### PR TITLE
Golden tests: don't repeatedly test the same version combinations

### DIFF
--- a/ouroboros-consensus/src/consensus-testlib/Test/Util/Serialisation/Golden.hs
+++ b/ouroboros-consensus/src/consensus-testlib/Test/Util/Serialisation/Golden.hs
@@ -445,8 +445,10 @@ goldenTest_SerialiseNodeToClient ::
   -> TestTree
 goldenTest_SerialiseNodeToClient codecConfig goldenDir Examples {..} =
     testGroup "SerialiseNodeToClient" [
-        testVersion (nodeToClientVersionToQueryVersion version, blockVersion)
-      | (version, blockVersion) <- nub $ Map.toList $ supportedNodeToClientVersions $ Proxy @blk
+        testVersion (queryVersion, blockVersion)
+      | (queryVersion, blockVersion) <-
+          nub . fmap (first nodeToClientVersionToQueryVersion) . Map.toList $
+            supportedNodeToClientVersions (Proxy @blk)
       ]
   where
     testVersion :: (QueryVersion, BlockNodeToClientVersion blk) -> TestTree


### PR DESCRIPTION
With this, running e.g.
```console
cabal run shelley-test -- -p Golden
```
only reports 92 instead of 172 tests.