### PR TITLE
Turn off caching of the dist-newstyle folder in GitHub actions (for now)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,18 +113,23 @@ jobs:
     - name: Store week number as environment variable
       run: echo "WEEKNUM=$(/usr/bin/date -u '+%W')" >> $GITHUB_ENV
 
-    # When we restore a previous cache and store a new key, we also store files
-    # that were part of the last restoration but were not actually used. To
-    # prevent the cache from growing too quickly we only store a new cache every
-    # week.
-    - uses: actions/cache@v3
-      name: "Cache `dist-newstyle`"
-      with:
-        path: |
-          dist-newstyle
-          !dist-newstyle/**/.git
-        key: cache-dist-${{ env.CABAL_CACHE_VERSION }}-${{ runner.os }}-${{ matrix.ghc }}-${{ env.WEEKNUM }}
-        restore-keys: cache-dist-${{ env.CABAL_CACHE_VERSION }}-${{ runner.os }}-${{ matrix.ghc }}
+    # NOTE: We skip caching of the dist-newstyle folder for now, since we're
+    # often getting the following cabal warning, which leads to compilation
+    # failures: "Warning: This package indirectly depends on multiple versions
+    # of the same package. This is very likely to cause a compile failure.".
+    #
+    # # When we restore a previous cache and store a new key, we also store files
+    # # that were part of the last restoration but were not actually used. To
+    # # prevent the cache from growing too quickly we only store a new cache every
+    # # week.
+    # - uses: actions/cache@v3
+    #   name: "Cache `dist-newstyle`"
+    #   with:
+    #     path: |
+    #       dist-newstyle
+    #       !dist-newstyle/**/.git
+    #     key: cache-dist-${{ env.CABAL_CACHE_VERSION }}-${{ runner.os }}-${{ matrix.ghc }}-${{ env.WEEKNUM }}
+    #     restore-keys: cache-dist-${{ env.CABAL_CACHE_VERSION }}-${{ runner.os }}-${{ matrix.ghc }}
 
     - name: Build dependencies
       run: cabal build --only-dependencies all -j


### PR DESCRIPTION
# Description

We skip caching of the dist-newstyle folder for now, since we're often getting the following cabal warning, which leads to compilation failures in GitHub actions CI.
```
Warning: 
  This package indirectly depends on multiple versions of the same package. This is very likely to cause a compile failure.
  ...
```
    
See, for example the following [run](https://github.com/input-output-hk/ouroboros-consensus/actions/runs/5265271178/jobs/9517679368).
