### PR TITLE
Consolidate Cardano protocol versions

### DIFF
--- a/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
+++ b/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
@@ -80,6 +80,9 @@ library
     Ouroboros.Consensus.Cardano.CanHardFork
     Ouroboros.Consensus.Cardano.Condense
     Ouroboros.Consensus.Cardano.Node
+    Ouroboros.Consensus.Cardano.Node.HasPartialProtocolParams
+    Ouroboros.Consensus.Cardano.Node.ProtocolVersions
+    Ouroboros.Consensus.Cardano.Node.ProtocolVersions.Internal
     Ouroboros.Consensus.Shelley.Crypto
     Ouroboros.Consensus.Shelley.Eras
     Ouroboros.Consensus.Shelley.HFEras

--- a/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano.hs
+++ b/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano.hs
@@ -9,6 +9,7 @@ module Ouroboros.Consensus.Cardano (
   , ProtocolShelley
     -- * Abstract over the various protocols
   , CardanoHardForkTriggers (..)
+  , PartialProtocolParams (..)
   , ProtocolParams (..)
   , module X
   ) where

--- a/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/Node/HasPartialProtocolParams.hs
+++ b/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/Node/HasPartialProtocolParams.hs
@@ -1,0 +1,114 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE TypeFamilies      #-}
+
+-- | Complete protocol parameters from partial protocol parameters.
+module Ouroboros.Consensus.Cardano.Node.HasPartialProtocolParams (
+    HasPartialProtocolParams (..)
+  , PartialProtocolParams (..)
+  ) where
+
+import qualified Cardano.Chain.Genesis as Genesis
+import qualified Cardano.Chain.Update as Update
+import           Data.Kind (Type)
+import           Ouroboros.Consensus.Byron.Ledger.Block (ByronBlock)
+import           Ouroboros.Consensus.Byron.Node (ByronLeaderCredentials,
+                     PBftSignatureThreshold, ProtocolParams (..))
+import           Ouroboros.Consensus.Cardano.Node.ProtocolVersions
+                     (ProtocolVersion)
+import qualified Ouroboros.Consensus.Mempool.Capacity as Mempool
+import           Ouroboros.Consensus.Protocol.Praos (Praos)
+import           Ouroboros.Consensus.Protocol.TPraos (TPraos)
+import           Ouroboros.Consensus.Shelley.Eras (AllegraEra, AlonzoEra,
+                     BabbageEra, ConwayEra, MaryEra, ShelleyEra)
+import           Ouroboros.Consensus.Shelley.Ledger.Block (ShelleyBlock)
+import           Ouroboros.Consensus.Shelley.Node (ProtocolParams (..))
+
+{-------------------------------------------------------------------------------
+  Class
+-------------------------------------------------------------------------------}
+
+class HasPartialProtocolParams blk where
+  data PartialProtocolParams blk :: Type
+
+  completeProtocolParams ::
+       ProtocolVersion blk
+    -> PartialProtocolParams blk
+    -> ProtocolParams blk
+
+{-------------------------------------------------------------------------------
+  Instances
+-------------------------------------------------------------------------------}
+
+instance HasPartialProtocolParams ByronBlock where
+  data instance PartialProtocolParams ByronBlock =
+    PartialProtocolParamsByron {
+        pbyronGenesis                :: Genesis.Config
+      , pbyronPbftSignatureThreshold :: Maybe PBftSignatureThreshold
+      , pbyronSoftwareVersion        :: Update.SoftwareVersion
+      , pbyronLeaderCredentials      :: Maybe ByronLeaderCredentials
+      , pbyronMaxTxCapacityOverrides :: Mempool.TxOverrides ByronBlock
+      }
+
+  completeProtocolParams byronProtVer partialParamsByron =
+      ProtocolParamsByron {
+          byronGenesis = pbyronGenesis partialParamsByron
+        , byronPbftSignatureThreshold = pbyronPbftSignatureThreshold partialParamsByron
+        , byronProtocolVersion = byronProtVer
+        , byronSoftwareVersion = pbyronSoftwareVersion partialParamsByron
+        , byronLeaderCredentials = pbyronLeaderCredentials partialParamsByron
+        , byronMaxTxCapacityOverrides = pbyronMaxTxCapacityOverrides partialParamsByron
+        }
+
+instance HasPartialProtocolParams (ShelleyBlock (TPraos c) (ShelleyEra c)) where
+  newtype instance PartialProtocolParams (ShelleyBlock (TPraos c) (ShelleyEra c)) =
+    PartialProtocolParamsShelley {
+        pshelleyMaxTxCapacityOverrides :: Mempool.TxOverrides (ShelleyBlock (TPraos c) (ShelleyEra c))
+      }
+
+  completeProtocolParams protVer (PartialProtocolParamsShelley txOverrides) =
+    ProtocolParamsShelley protVer txOverrides
+
+instance HasPartialProtocolParams (ShelleyBlock (TPraos c) (AllegraEra c)) where
+  newtype instance PartialProtocolParams (ShelleyBlock (TPraos c) (AllegraEra c)) =
+    PartialProtocolParamsAllegra {
+        pallegraMaxTxCapacityOverrides :: Mempool.TxOverrides (ShelleyBlock (TPraos c) (AllegraEra c))
+      }
+
+  completeProtocolParams protVer (PartialProtocolParamsAllegra txOverrides) =
+    ProtocolParamsAllegra protVer txOverrides
+
+instance HasPartialProtocolParams (ShelleyBlock (TPraos c) (MaryEra c)) where
+  newtype instance PartialProtocolParams (ShelleyBlock (TPraos c) (MaryEra c)) =
+    PartialProtocolParamsMary {
+        pmaryMaxTxCapacityOverrides :: Mempool.TxOverrides (ShelleyBlock (TPraos c) (MaryEra c))
+      }
+
+  completeProtocolParams protVer (PartialProtocolParamsMary txOverrides) =
+    ProtocolParamsMary protVer txOverrides
+
+instance HasPartialProtocolParams (ShelleyBlock (TPraos c) (AlonzoEra c)) where
+  newtype instance PartialProtocolParams (ShelleyBlock (TPraos c) (AlonzoEra c)) =
+    PartialProtocolParamsAlonzo {
+        palonzoMaxTxCapacityOverrides :: Mempool.TxOverrides (ShelleyBlock (TPraos c) (AlonzoEra c))
+      }
+
+  completeProtocolParams protVer (PartialProtocolParamsAlonzo txOverrides) =
+    ProtocolParamsAlonzo protVer txOverrides
+
+instance HasPartialProtocolParams (ShelleyBlock (Praos c) (BabbageEra c)) where
+  newtype instance PartialProtocolParams (ShelleyBlock (Praos c) (BabbageEra c)) =
+    PartialProtocolParamsBabbage {
+        pbabbageMaxTxCapacityOverrides :: Mempool.TxOverrides (ShelleyBlock (Praos c) (BabbageEra c))
+      }
+
+  completeProtocolParams protVer (PartialProtocolParamsBabbage txOverrides) =
+    ProtocolParamsBabbage protVer txOverrides
+
+instance HasPartialProtocolParams (ShelleyBlock (Praos c) (ConwayEra c)) where
+  newtype instance PartialProtocolParams (ShelleyBlock (Praos c) (ConwayEra c)) =
+    PartialProtocolParamsConway {
+        pconwayMaxTxCapacityOverrides :: Mempool.TxOverrides (ShelleyBlock (Praos c) (ConwayEra c))
+      }
+
+  completeProtocolParams protVer (PartialProtocolParamsConway txOverrides) =
+    ProtocolParamsConway protVer txOverrides

--- a/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/Node/ProtocolVersions.hs
+++ b/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/Node/ProtocolVersions.hs
@@ -1,0 +1,12 @@
+-- | Consolidated protocol versions for cardano eras.
+module Ouroboros.Consensus.Cardano.Node.ProtocolVersions (
+    -- * Cardano protocol versions
+    CardanoProtocolVersions (CardanoProtocolVersions, protVerByron, protVerShelley, protVerAllegra, protVerMary, protVerAlonzo, protVerBabbage, protVerConway)
+  , cardanoMainnetProtocolVersions
+  , cardanoMaxProtocolVersion
+    -- * HasProtocolVersion
+  , HasProtocolVersion (..)
+  , ProtocolVersion
+  ) where
+
+import           Ouroboros.Consensus.Cardano.Node.ProtocolVersions.Internal

--- a/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/Node/ProtocolVersions/Internal.hs
+++ b/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/Node/ProtocolVersions/Internal.hs
@@ -1,0 +1,189 @@
+{-# LANGUAGE DataKinds                #-}
+{-# LANGUAGE FlexibleContexts         #-}
+{-# LANGUAGE FlexibleInstances        #-}
+{-# LANGUAGE PatternSynonyms          #-}
+{-# LANGUAGE PolyKinds                #-}
+{-# LANGUAGE ScopedTypeVariables      #-}
+{-# LANGUAGE StandaloneKindSignatures #-}
+{-# LANGUAGE TypeApplications         #-}
+{-# LANGUAGE TypeFamilies             #-}
+{-# LANGUAGE TypeOperators            #-}
+
+-- | See "Ouroboros.Consensus.Cardano.Node.ProtocolVersions".
+module Ouroboros.Consensus.Cardano.Node.ProtocolVersions.Internal (
+    -- * Cardano protocol versions
+    CardanoProtocolVersions (CardanoProtocolVersions_, getCardanoProtocolVersions, CardanoProtocolVersions, protVerByron, protVerShelley, protVerAllegra, protVerMary, protVerAlonzo, protVerBabbage, protVerConway)
+  , cardanoMainnetProtocolVersions
+  , cardanoMaxProtocolVersion
+    -- * HasProtocolVersion
+  , HasProtocolVersion (..)
+  , ProtocolVersion
+    -- * Value for /each/ era
+  , PerEraProtocolVersion (..)
+  , WrapProtocolVersion (..)
+    -- * Maximum protocol versions
+  , Last
+  , lastNP
+  , maxProtocolVersion
+  ) where
+
+import Data.Proxy (Proxy (..))
+import qualified Cardano.Chain.Update as Byron.Update
+import qualified Cardano.Ledger.BaseTypes as SL (natVersion)
+import qualified Cardano.Ledger.Shelley.API as SL
+import           Data.Kind (Constraint, Type)
+import           Data.SOP.NonEmpty (IsNonEmpty (..), ProofEmpty (ProofEmpty),
+                     ProofNonEmpty (ProofNonEmpty), checkEmptiness)
+import           Data.SOP.Strict (NP (..))
+import Data.SOP (SListI)
+import           Ouroboros.Consensus.Byron.Ledger.Block (ByronBlock)
+import           Ouroboros.Consensus.Byron.Node (ProtocolParams (..))
+import           Ouroboros.Consensus.Cardano.Block (CardanoBlock, CardanoEras)
+import           Ouroboros.Consensus.Protocol.Praos (Praos)
+import           Ouroboros.Consensus.Protocol.TPraos (TPraos)
+import           Ouroboros.Consensus.Shelley.Eras (AllegraEra, AlonzoEra,
+                     BabbageEra, ConwayEra, MaryEra, ShelleyEra)
+import           Ouroboros.Consensus.Shelley.Ledger.Block (ShelleyBlock)
+import           Ouroboros.Consensus.Shelley.Node (ProtocolParams (..))
+
+{-------------------------------------------------------------------------------
+  Cardano protocol versions
+-------------------------------------------------------------------------------}
+
+newtype CardanoProtocolVersions c = CardanoProtocolVersions_ {
+    getCardanoProtocolVersions :: PerEraProtocolVersion (CardanoEras c)
+  }
+
+{-# COMPLETE CardanoProtocolVersions #-}
+pattern CardanoProtocolVersions ::
+     ProtocolVersion ByronBlock
+  -> ProtocolVersion (ShelleyBlock (TPraos c) (ShelleyEra c))
+  -> ProtocolVersion (ShelleyBlock (TPraos c) (AllegraEra c))
+  -> ProtocolVersion (ShelleyBlock (TPraos c) (MaryEra    c))
+  -> ProtocolVersion (ShelleyBlock (TPraos c) (AlonzoEra  c))
+  -> ProtocolVersion (ShelleyBlock (Praos  c) (BabbageEra c))
+  -> ProtocolVersion (ShelleyBlock (Praos  c) (ConwayEra  c))
+  -> CardanoProtocolVersions c
+pattern CardanoProtocolVersions {
+      protVerByron
+    , protVerShelley
+    , protVerAllegra
+    , protVerMary
+    , protVerAlonzo
+    , protVerBabbage
+    , protVerConway
+    } =
+  CardanoProtocolVersions_ {
+      getCardanoProtocolVersions = PerEraProtocolVersion {
+          getPerEraProtocolVersion =
+               WrapProtocolVersion protVerByron
+            :* WrapProtocolVersion protVerShelley
+            :* WrapProtocolVersion protVerAllegra
+            :* WrapProtocolVersion protVerMary
+            :* WrapProtocolVersion protVerAlonzo
+            :* WrapProtocolVersion protVerBabbage
+            :* WrapProtocolVersion protVerConway
+            :* Nil
+        }
+    }
+
+cardanoMainnetProtocolVersions :: Bool -> CardanoProtocolVersions c
+cardanoMainnetProtocolVersions experimentalHardForksEnabled =
+    CardanoProtocolVersions {
+        protVerByron   = Byron.Update.ProtocolVersion 3 0 0
+      , protVerShelley = SL.ProtVer (SL.natVersion @3) 0
+      , protVerAllegra = SL.ProtVer (SL.natVersion @4) 0
+      , protVerMary    = SL.ProtVer (SL.natVersion @5) 0
+      , protVerAlonzo  = SL.ProtVer (SL.natVersion @7) 0
+      , protVerBabbage = if experimentalHardForksEnabled then
+                           SL.ProtVer (SL.natVersion @9) 0
+                         else
+                           SL.ProtVer (SL.natVersion @8) 0
+      , protVerConway  = SL.ProtVer (SL.natVersion @9) 0
+      }
+
+cardanoMaxProtocolVersion :: CardanoProtocolVersions c -> SL.ProtVer
+cardanoMaxProtocolVersion = maxProtocolVersion . getCardanoProtocolVersions
+
+{-------------------------------------------------------------------------------
+  HasProtocolVersion
+-------------------------------------------------------------------------------}
+
+-- | This type family is not an associated type of the 'HasProtocolVersion'
+-- class, as it reduces duplication: all Shelley blocks have the same
+-- 'ProtocolVersion' type.
+type ProtocolVersion :: Type -> Type
+type family ProtocolVersion blk where
+  ProtocolVersion ByronBlock               = Byron.Update.ProtocolVersion
+  ProtocolVersion (ShelleyBlock proto era) = SL.ProtVer
+  ProtocolVersion (CardanoBlock c)         = CardanoProtocolVersions c
+
+type HasProtocolVersion :: Type -> Constraint
+class HasProtocolVersion blk where
+  extractProtocolVersion :: ProtocolParams blk -> ProtocolVersion blk
+
+{-------------------------------------------------------------------------------
+  HasProtocolVersion: block instances
+-------------------------------------------------------------------------------}
+
+instance HasProtocolVersion ByronBlock where
+  extractProtocolVersion = byronProtocolVersion
+
+instance HasProtocolVersion (ShelleyBlock (TPraos c) (ShelleyEra c)) where
+  extractProtocolVersion = shelleyProtVer
+
+instance HasProtocolVersion (ShelleyBlock (TPraos c) (AllegraEra c)) where
+  extractProtocolVersion = allegraProtVer
+
+instance HasProtocolVersion (ShelleyBlock (TPraos c) (MaryEra c)) where
+  extractProtocolVersion = maryProtVer
+
+instance HasProtocolVersion (ShelleyBlock (TPraos c) (AlonzoEra c)) where
+  extractProtocolVersion = alonzoProtVer
+
+instance HasProtocolVersion (ShelleyBlock (Praos c) (BabbageEra c)) where
+  extractProtocolVersion = babbageProtVer
+
+instance HasProtocolVersion (ShelleyBlock (Praos c) (ConwayEra c)) where
+  extractProtocolVersion = conwayProtVer
+
+{-------------------------------------------------------------------------------
+  Value for /each/ era
+-------------------------------------------------------------------------------}
+
+type PerEraProtocolVersion :: [Type] -> Type
+newtype PerEraProtocolVersion xs = PerEraProtocolVersion {
+    getPerEraProtocolVersion :: NP WrapProtocolVersion xs
+  }
+
+type WrapProtocolVersion :: Type -> Type
+newtype WrapProtocolVersion blk = WrapProtocolVersion {
+    unwrapProtocolVersion :: ProtocolVersion blk
+  }
+
+{-------------------------------------------------------------------------------
+  Maximum protocol version
+-------------------------------------------------------------------------------}
+
+maxProtocolVersion ::
+     (IsNonEmpty xs, SListI xs)
+  => PerEraProtocolVersion xs
+  -> ProtocolVersion (Last xs)
+maxProtocolVersion = unwrapProtocolVersion . lastNP . getPerEraProtocolVersion
+
+type Last :: [k] -> k
+type family Last xs where
+  Last '[x]    = x
+  Last (x:xs) = Last xs
+
+lastNP :: forall f xs. (IsNonEmpty xs, SListI xs) => NP f xs -> f (Last xs)
+lastNP xs0 =
+    case isNonEmpty (Proxy @xs) of
+      ProofNonEmpty Proxy (Proxy :: Proxy xs') ->
+        case checkEmptiness (Proxy @xs') of
+          Left ProofEmpty ->
+            case xs0 of
+              x :* Nil -> x
+          Right (ProofNonEmpty Proxy (Proxy :: Proxy xs'')) ->
+            case xs0 of
+              _ :* xs -> lastNP xs

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Node/TPraos.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Node/TPraos.hs
@@ -175,25 +175,25 @@ validateGenesis = first errsToString . SL.validateGenesis
 -- | Parameters needed to run Shelley
 data instance ProtocolParams (ShelleyBlock (TPraos c) (ShelleyEra c)) = ProtocolParamsShelley {
       shelleyProtVer                :: SL.ProtVer
-    , shelleyMaxTxCapacityOverrides :: Mempool.TxOverrides (ShelleyBlock(TPraos c) (ShelleyEra c) )
+    , shelleyMaxTxCapacityOverrides :: Mempool.TxOverrides (ShelleyBlock (TPraos c) (ShelleyEra c))
     }
 
 -- | Parameters needed to run Allegra
 data instance ProtocolParams (ShelleyBlock (TPraos c) (AllegraEra c)) = ProtocolParamsAllegra {
       allegraProtVer                :: SL.ProtVer
-    , allegraMaxTxCapacityOverrides :: Mempool.TxOverrides (ShelleyBlock (TPraos c) (AllegraEra c) )
+    , allegraMaxTxCapacityOverrides :: Mempool.TxOverrides (ShelleyBlock (TPraos c) (AllegraEra c))
     }
 
 -- | Parameters needed to run Mary
 data instance ProtocolParams (ShelleyBlock (TPraos c) (MaryEra c)) = ProtocolParamsMary {
       maryProtVer                :: SL.ProtVer
-    , maryMaxTxCapacityOverrides :: Mempool.TxOverrides (ShelleyBlock (TPraos c) (MaryEra c) )
+    , maryMaxTxCapacityOverrides :: Mempool.TxOverrides (ShelleyBlock (TPraos c) (MaryEra c))
     }
 
 -- | Parameters needed to run Alonzo
 data instance ProtocolParams (ShelleyBlock (TPraos c) (AlonzoEra c)) = ProtocolParamsAlonzo {
       alonzoProtVer                :: SL.ProtVer
-    , alonzoMaxTxCapacityOverrides :: Mempool.TxOverrides (ShelleyBlock (TPraos c) (AlonzoEra c) )
+    , alonzoMaxTxCapacityOverrides :: Mempool.TxOverrides (ShelleyBlock (TPraos c) (AlonzoEra c))
     }
 
 protocolInfoShelley ::

--- a/sop-extras/src/Data/SOP/NonEmpty.hs
+++ b/sop-extras/src/Data/SOP/NonEmpty.hs
@@ -15,8 +15,12 @@
 module Data.SOP.NonEmpty (
     NonEmpty (..)
     -- * Proofs
+  , IsEmpty (..)
   , IsNonEmpty (..)
+  , ProofEmpty (..)
   , ProofNonEmpty (..)
+  , checkEmptiness
+  , checkIsEmpty
   , checkIsNonEmpty
     -- * Working with 'NonEmpty'
   , nonEmptyFromList
@@ -159,6 +163,14 @@ nonEmptyMapTwo f g = go
   Proofs
 -------------------------------------------------------------------------------}
 
+checkEmptiness ::
+     forall xs. SListI xs
+  => Proxy xs
+  -> Either (ProofEmpty xs) (ProofNonEmpty xs)
+checkEmptiness _ = case sList @xs of
+    SNil  -> Left ProofEmpty
+    SCons -> Right $ ProofNonEmpty Proxy Proxy
+
 type ProofNonEmpty :: [a] -> Type
 data ProofNonEmpty xs where
   ProofNonEmpty :: Proxy x -> Proxy xs -> ProofNonEmpty (x ': xs)
@@ -173,3 +185,17 @@ checkIsNonEmpty :: forall xs. SListI xs => Proxy xs -> Maybe (ProofNonEmpty xs)
 checkIsNonEmpty _ = case sList @xs of
     SNil  -> Nothing
     SCons -> Just $ ProofNonEmpty Proxy Proxy
+
+data ProofEmpty :: [a] -> Type where
+  ProofEmpty :: ProofEmpty '[]
+
+class IsEmpty xs where
+  isEmpty :: Proxy xs -> ProofEmpty xs
+
+instance IsEmpty '[] where
+  isEmpty _ = ProofEmpty
+
+checkIsEmpty :: forall xs. SListI xs => Proxy xs -> Maybe (ProofEmpty xs)
+checkIsEmpty _ = case sList @xs of
+    SNil  -> Just ProofEmpty
+    SCons -> Nothing


### PR DESCRIPTION
# Description

Closes #276.

Currently, protocol versions for Cardano eras are redefined in a number of places, among which `cardano-node`, `db-analyser` and `db-synthesiser`. This is not ideal, since mistakes often creep into the code that redefines these versions (see the description of #276).

This PR provides the `Ouroboros.Consensus.Cardano.Node.ProtocolVersions` module, where protocol versions for each of the Cardano eras are consolidated in a single `CardanoProtocolVersions` datatype. `cardanoMainnetProtocolVersions` is a constant that defines the protocol versions of the Cardano eras on mainnet. `cardanoMaxProtocolVersion` can be used to extract the maximum protocol version across the Cardano eras (equivalently, it is the protocol version of the last era), which is information that is required by the `TPraos` and `Praos` protocols.

Since protocol versions are currently defined as part of `ProtocolParams` datatypes for each era, downstream code would have to pattern match on the `CardanoProtocolVersions` datatype, retrieving protocol versions for each era, and filling in the protocol versions in the `ProtocolParams` for each era. To facilitate easily using `CardanoProtocolVersions`, the `Ouroboros.Consensus.Cardano.Node.HasPartialProtocolParams` module provides a `HasPartialProtocolParams` class: instances of this class can create a `ProtocolParams` datatype from a `ProtocolVersion` and `PartialProtocolParams` (i.e., a `ProtocolParams` without any `ProtocolVersion`). As such, partial protocol parameters for Cardano and protocol versions for each era can be passed in separately, and combined using the `completeProtocolParams` function. `protocolInfoCardano'` is a variant of `protocolInfoCardano` that automates this. A usage example of `protocolInfoCardano'` can be found in the `Cardano.Tools.DBAnalyser.Block.Cardano` module.

### Todos
- [ ] Rename commits
- [ ] Add changelog fragments
- [ ] Re-evaluate public exports. What should marked as internal?
- [ ] Re-evaluate module hierarchy. Can some functionality be moved to `ouroboros-consensus`?
