### PR TITLE
Prototype lightweight checkpointing (non-combinator approach)

### DIFF
--- a/ouroboros-consensus-cardano/changelog.d/20240111_195320_facundo.dominguez_lightweight_checkpointing.md
+++ b/ouroboros-consensus-cardano/changelog.d/20240111_195320_facundo.dominguez_lightweight_checkpointing.md
@@ -1,0 +1,23 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Patch
+
+- A bullet item for the Patch category.
+
+-->
+<!--
+### Non-Breaking
+
+- A bullet item for the Non-Breaking category.
+
+-->
+### Breaking
+
+- Implement lightweigth checkpointing [#449](https://github.com/IntersectMBO/ouroboros-consensus/issues/449).
+  A validation to help Genesis nodes follow the historical chain.
+

--- a/ouroboros-consensus-cardano/src/byron/Ouroboros/Consensus/Byron/Ledger/Config.hs
+++ b/ouroboros-consensus-cardano/src/byron/Ouroboros/Consensus/Byron/Ledger/Config.hs
@@ -26,6 +26,7 @@ import qualified Cardano.Chain.Genesis as CC.Genesis
 import qualified Cardano.Chain.Slotting as CC.Slot
 import qualified Cardano.Chain.Update as CC.Update
 import qualified Cardano.Crypto as Crypto
+import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           GHC.Generics (Generic)
 import           NoThunks.Class (NoThunks (..))
@@ -52,6 +53,8 @@ data instance BlockConfig ByronBlock = ByronConfig {
       --
       -- Like 'byronProtocolVersion', this is independent from the chain.
     , byronSoftwareVersion :: !CC.Update.SoftwareVersion
+
+    , byronCheckpoints     :: !(Map BlockNo ByronHash)
     }
   deriving (Generic, NoThunks)
 

--- a/ouroboros-consensus-cardano/src/byron/Ouroboros/Consensus/Byron/Ledger/HeaderValidation.hs
+++ b/ouroboros-consensus-cardano/src/byron/Ouroboros/Consensus/Byron/Ledger/HeaderValidation.hs
@@ -37,7 +37,7 @@ instance HasAnnTip ByronBlock where
 
 data ByronOtherHeaderEnvelopeError =
     UnexpectedEBBInSlot !SlotNo
-  | InvalidCheckpoint -- TODO args
+  | CheckpointMismatch -- TODO args
   deriving (Eq, Show, Generic, NoThunks)
 
 instance BasicEnvelopeValidation ByronBlock where
@@ -65,7 +65,7 @@ instance ValidateEnvelope ByronBlock where
       when (not (fromIsEBB newIsEBB)) $ -- TODO fine to ignore EBBs?
         whenJust (Map.lookup (blockNo hdr) checkpoints) $ \checkpoint ->
           when (checkpoint /= blockHash hdr) $
-            throwError InvalidCheckpoint
+            throwError CheckpointMismatch
     where
       actualSlotNo :: SlotNo
       actualSlotNo = blockSlot hdr

--- a/ouroboros-consensus-cardano/src/byron/Ouroboros/Consensus/Byron/Ledger/HeaderValidation.hs
+++ b/ouroboros-consensus-cardano/src/byron/Ouroboros/Consensus/Byron/Ledger/HeaderValidation.hs
@@ -11,7 +11,7 @@ module Ouroboros.Consensus.Byron.Ledger.HeaderValidation (
   ) where
 
 import qualified Cardano.Chain.Slotting as CC
-import           Control.Monad (unless, when)
+import           Control.Monad (when)
 import           Control.Monad.Except (throwError)
 import qualified Data.Map.Strict as Map
 import           Data.Word
@@ -62,9 +62,9 @@ instance ValidateEnvelope ByronBlock where
   additionalEnvelopeChecks cfg _ledgerView hdr = do
       when (fromIsEBB newIsEBB && not (canBeEBB actualSlotNo)) $
         throwError $ UnexpectedEBBInSlot actualSlotNo
-      unless (fromIsEBB newIsEBB) $ -- TODO fine to ignore EBBs?
+      when (not (fromIsEBB newIsEBB)) $ -- TODO fine to ignore EBBs?
         whenJust (Map.lookup (blockNo hdr) checkpoints) $ \checkpoint ->
-          unless (checkpoint == blockHash hdr) $
+          when (checkpoint /= blockHash hdr) $
             throwError InvalidCheckpoint
     where
       actualSlotNo :: SlotNo

--- a/ouroboros-consensus-cardano/src/byron/Ouroboros/Consensus/Byron/Node.hs
+++ b/ouroboros-consensus-cardano/src/byron/Ouroboros/Consensus/Byron/Node.hs
@@ -31,6 +31,7 @@ import qualified Cardano.Chain.Update as Update
 import qualified Cardano.Crypto as Crypto
 import           Control.Monad (guard)
 import           Data.Coerce (coerce)
+import           Data.Map.Strict (Map)
 import           Data.Maybe
 import           Data.Text (Text)
 import           Data.Void (Void)
@@ -180,13 +181,15 @@ data instance ProtocolParams ByronBlock = ProtocolParamsByron {
     }
 
 protocolInfoByron :: ProtocolParams ByronBlock
+                  -> Map BlockNo ByronHash -- ^ Checkpoints.
                   -> ProtocolInfo ByronBlock
 protocolInfoByron ProtocolParamsByron {
                       byronGenesis                = genesisConfig
                     , byronPbftSignatureThreshold = mSigThresh
                     , byronProtocolVersion        = pVer
                     , byronSoftwareVersion        = sVer
-                    } =
+                    }
+                  checkpoints =
     ProtocolInfo {
         pInfoConfig = TopLevelConfig {
             topLevelConfigProtocol = PBftConfig {
@@ -208,7 +211,7 @@ protocolInfoByron ProtocolParamsByron {
   where
     compactedGenesisConfig = compactGenesisConfig genesisConfig
 
-    blockConfig = mkByronConfig compactedGenesisConfig pVer sVer
+    blockConfig = mkByronConfig compactedGenesisConfig pVer sVer checkpoints
 
 protocolClientInfoByron :: EpochSlots -> ProtocolClientInfo ByronBlock
 protocolClientInfoByron epochSlots =
@@ -228,11 +231,13 @@ byronPBftParams cfg threshold = PBftParams {
 mkByronConfig :: Genesis.Config
               -> Update.ProtocolVersion
               -> Update.SoftwareVersion
+              -> Map BlockNo ByronHash
               -> BlockConfig ByronBlock
-mkByronConfig genesisConfig pVer sVer = ByronConfig {
+mkByronConfig genesisConfig pVer sVer checkpoints = ByronConfig {
       byronGenesisConfig   = genesisConfig
     , byronProtocolVersion = pVer
     , byronSoftwareVersion = sVer
+    , byronCheckpoints     = checkpoints
     }
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Config.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Config.hs
@@ -48,6 +48,7 @@ data instance BlockConfig (ShelleyBlock proto era) = ShelleyConfig {
       -- block producing nodes, this can be set to the empty map.
     , shelleyBlockIssuerVKeys :: !(Map (SL.KeyHash 'SL.BlockIssuer (EraCrypto era))
                                        (SL.VKey 'SL.BlockIssuer (EraCrypto era)))
+    , shelleyCheckpoints      :: !(Map BlockNo (HeaderHash (ShelleyBlock proto era)))
     }
   deriving stock (Generic)
 
@@ -59,8 +60,9 @@ mkShelleyBlockConfig ::
   => SL.ProtVer
   -> SL.ShelleyGenesis (EraCrypto era)
   -> [SL.VKey 'SL.BlockIssuer (EraCrypto era)]
+  -> Map BlockNo (HeaderHash (ShelleyBlock proto era))
   -> BlockConfig (ShelleyBlock proto era)
-mkShelleyBlockConfig protVer genesis blockIssuerVKeys = ShelleyConfig {
+mkShelleyBlockConfig protVer genesis blockIssuerVKeys checkpoints = ShelleyConfig {
       shelleyProtocolVersion  = protVer
     , shelleySystemStart      = SystemStart  $ SL.sgSystemStart  genesis
     , shelleyNetworkMagic     = NetworkMagic $ SL.sgNetworkMagic genesis
@@ -68,6 +70,7 @@ mkShelleyBlockConfig protVer genesis blockIssuerVKeys = ShelleyConfig {
         [ (SL.hashKey k, k)
         | k <- blockIssuerVKeys
         ]
+    , shelleyCheckpoints      = checkpoints
     }
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Ledger.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Ledger.hs
@@ -474,7 +474,9 @@ instance ShelleyCompatible proto era => ValidateEnvelope (ShelleyBlock proto era
     EnvelopeCheckError proto
 
   additionalEnvelopeChecks cfg lv hdr =
-    envelopeChecks (configConsensus cfg) lv (shelleyHeaderRaw hdr)
+      envelopeChecks (configConsensus cfg) checkpoints lv (shelleyHeaderRaw hdr)
+    where
+      checkpoints = shelleyCheckpoints (configBlock cfg)
 
 {-------------------------------------------------------------------------------
   Auxiliary

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Node/TPraos.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Node/TPraos.hs
@@ -331,6 +331,7 @@ protocolInfoTPraosShelleyBased ProtocolParamsShelleyBased {
           protVer
           genesis
           (shelleyBlockIssuerVKey <$> credentialss)
+          mempty -- TODO propagate?
 
     storageConfig :: StorageConfig (ShelleyBlock (TPraos c) era)
     storageConfig = ShelleyStorageConfig {

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Protocol/Abstract.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Protocol/Abstract.hs
@@ -42,6 +42,7 @@ import           Cardano.Slotting.Slot (SlotNo)
 import           Codec.Serialise (Serialise (..))
 import           Control.Monad.Except (Except)
 import           Data.Kind (Type)
+import           Data.Map.Strict (Map)
 import           Data.Typeable (Typeable)
 import           Data.Word (Word64)
 import           GHC.Generics (Generic)
@@ -117,6 +118,7 @@ class
   -- check things like maximum header size.
   envelopeChecks ::
     ConsensusConfig proto ->
+    Map BlockNo (ShelleyHash (ProtoCrypto proto)) ->
     LedgerView proto ->
     ShelleyProtocolHeader proto ->
     Except (EnvelopeCheckError proto) ()

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Protocol/Praos.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Protocol/Praos.hs
@@ -19,7 +19,7 @@ import           Cardano.Ledger.Slot (SlotNo (unSlotNo))
 import           Cardano.Protocol.TPraos.OCert
                      (OCert (ocertKESPeriod, ocertVkHot))
 import qualified Cardano.Protocol.TPraos.OCert as SL
-import           Control.Monad (unless)
+import           Control.Monad (unless, when)
 import           Control.Monad.Except (throwError)
 import           Data.Either (isRight)
 import qualified Data.Map.Strict as Map
@@ -115,7 +115,7 @@ instance PraosCrypto c => ProtocolHeaderSupportsEnvelope (Praos c) where
       throwError $
         BlockSizeTooLarge (bhviewBSize bhv) maxBodySize
     whenJust (Map.lookup (pHeaderBlock hdr) checkpoints) $ \checkpoint ->
-      unless (checkpoint == pHeaderHash hdr) $
+      when (checkpoint /= pHeaderHash hdr) $
         throwError InvalidCheckpoint
     where
       pp = praosParams cfg

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Protocol/Praos.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Protocol/Praos.hs
@@ -90,7 +90,7 @@ data PraosEnvelopeError
     -- <https://github.com/IntersectMBO/ouroboros-consensus/issues/325>.
   | HeaderSizeTooLarge Int Word16
   | BlockSizeTooLarge Word32 Word32
-  | InvalidCheckpoint -- TODO args
+  | CheckpointMismatch -- TODO args
   deriving (Eq, Generic, Show)
 
 instance NoThunks PraosEnvelopeError
@@ -116,7 +116,7 @@ instance PraosCrypto c => ProtocolHeaderSupportsEnvelope (Praos c) where
         BlockSizeTooLarge (bhviewBSize bhv) maxBodySize
     whenJust (Map.lookup (pHeaderBlock hdr) checkpoints) $ \checkpoint ->
       when (checkpoint /= pHeaderHash hdr) $
-        throwError InvalidCheckpoint
+        throwError CheckpointMismatch
     where
       pp = praosParams cfg
       (MaxMajorProtVer maxpv) = praosMaxMajorPV pp

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Protocol/TPraos.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Protocol/TPraos.hs
@@ -19,7 +19,7 @@ import qualified Cardano.Protocol.TPraos.BHeader as SL
 import           Cardano.Protocol.TPraos.OCert (ocertKESPeriod, ocertVkHot)
 import qualified Cardano.Protocol.TPraos.OCert as SL
 import           Cardano.Slotting.Slot (unSlotNo)
-import           Control.Monad (unless)
+import           Control.Monad (when)
 import           Control.Monad.Except (liftEither, throwError)
 import           Data.Bifunctor (first)
 import           Data.Either (isRight)
@@ -71,7 +71,7 @@ instance PraosCrypto c => ProtocolHeaderSupportsEnvelope (TPraos c) where
         (SL.lvChainChecks lv)
         (SL.makeHeaderView $ protocolHeaderView @(TPraos c) hdr)
     whenJust (Map.lookup (pHeaderBlock hdr) checkpoints) $ \checkpoint ->
-      unless (checkpoint == pHeaderHash hdr) $
+      when (checkpoint /= pHeaderHash hdr) $
         throwError InvalidCheckpoint
     where
       MaxMajorProtVer maxPV = tpraosMaxMajorPV $ tpraosParams cfg

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Protocol/TPraos.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Protocol/TPraos.hs
@@ -47,9 +47,9 @@ type instance ProtoCrypto (TPraos c) = c
 
 type instance ShelleyProtocolHeader (TPraos c) = SL.BHeader c
 
-data TPraosEnvelopeError
+data TPraosEnvelopeError c
   = ChainPredicateFailure ChainPredicateFailure
-  | CheckpointMismatch -- TODO args
+  | CheckpointMismatch (ShelleyHash c) (ShelleyHash c)
   deriving stock (Show, Eq, Generic)
   deriving anyclass (NoThunks)
 
@@ -62,7 +62,7 @@ instance PraosCrypto c => ProtocolHeaderSupportsEnvelope (TPraos c) where
   pHeaderSize = fromIntegral . SL.bHeaderSize
   pHeaderBlockSize = fromIntegral @Word32 @Natural . SL.bsize . SL.bhbody
 
-  type EnvelopeCheckError _ = TPraosEnvelopeError
+  type EnvelopeCheckError (TPraos c) = TPraosEnvelopeError c
 
   envelopeChecks cfg checkpoints lv hdr = do
     liftEither . first ChainPredicateFailure $
@@ -72,7 +72,8 @@ instance PraosCrypto c => ProtocolHeaderSupportsEnvelope (TPraos c) where
         (SL.makeHeaderView $ protocolHeaderView @(TPraos c) hdr)
     whenJust (Map.lookup (pHeaderBlock hdr) checkpoints) $ \checkpoint ->
       when (checkpoint /= pHeaderHash hdr) $
-        throwError CheckpointMismatch
+        throwError $
+          CheckpointMismatch (pHeaderHash hdr) checkpoint
     where
       MaxMajorProtVer maxPV = tpraosMaxMajorPV $ tpraosParams cfg
 

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Protocol/TPraos.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Protocol/TPraos.hs
@@ -49,7 +49,7 @@ type instance ShelleyProtocolHeader (TPraos c) = SL.BHeader c
 
 data TPraosEnvelopeError
   = ChainPredicateFailure ChainPredicateFailure
-  | InvalidCheckpoint -- TODO args
+  | CheckpointMismatch -- TODO args
   deriving stock (Show, Eq, Generic)
   deriving anyclass (NoThunks)
 
@@ -72,7 +72,7 @@ instance PraosCrypto c => ProtocolHeaderSupportsEnvelope (TPraos c) where
         (SL.makeHeaderView $ protocolHeaderView @(TPraos c) hdr)
     whenJust (Map.lookup (pHeaderBlock hdr) checkpoints) $ \checkpoint ->
       when (checkpoint /= pHeaderHash hdr) $
-        throwError InvalidCheckpoint
+        throwError CheckpointMismatch
     where
       MaxMajorProtVer maxPV = tpraosMaxMajorPV $ tpraosParams cfg
 

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Protocol/TPraos.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Protocol/TPraos.hs
@@ -23,11 +23,11 @@ import           Control.Monad (when)
 import           Control.Monad.Except (liftEither, throwError)
 import           Data.Bifunctor (first)
 import           Data.Either (isRight)
-import           Data.Word (Word32)
-import           Numeric.Natural (Natural)
 import qualified Data.Map.Strict as Map
+import           Data.Word (Word32)
 import           GHC.Generics (Generic)
 import           NoThunks.Class (NoThunks)
+import           Numeric.Natural (Natural)
 import           Ouroboros.Consensus.Protocol.Signed (Signed,
                      SignedHeader (headerSigned))
 import           Ouroboros.Consensus.Protocol.TPraos

--- a/ouroboros-consensus-cardano/src/unstable-byron-testlib/Ouroboros/Consensus/ByronDual/Node.hs
+++ b/ouroboros-consensus-cardano/src/unstable-byron-testlib/Ouroboros/Consensus/ByronDual/Node.hs
@@ -156,6 +156,7 @@ protocolInfoDualByron abstractGenesis@ByronSpecGenesis{..} params credss =
                        concreteGenesis
                        protocolVersion
                        softwareVersion
+                       mempty
       where
         -- TODO: Take (spec) protocol version and (spec) software version
         -- as arguments instead, and then translate /those/ to Impl types.

--- a/ouroboros-consensus-cardano/src/unstable-byron-testlib/Test/Consensus/Byron/Examples.hs
+++ b/ouroboros-consensus-cardano/src/unstable-byron-testlib/Test/Consensus/Byron/Examples.hs
@@ -71,6 +71,7 @@ cfg = ByronConfig {
       byronGenesisConfig   = CC.dummyConfig
     , byronProtocolVersion = CC.exampleProtocolVersion
     , byronSoftwareVersion = CC.exampleSoftwareVersion
+    , byronCheckpoints     = mempty
     }
 
 codecConfig :: CodecConfig ByronBlock

--- a/ouroboros-consensus-cardano/src/unstable-byron-testlib/Test/ThreadNet/Infra/Byron/ProtocolInfo.hs
+++ b/ouroboros-consensus-cardano/src/unstable-byron-testlib/Test/ThreadNet/Infra/Byron/ProtocolInfo.hs
@@ -54,7 +54,7 @@ mkProtocolByron params coreNodeId genesisConfig genesisSecrets =
     PBftParams { pbftSignatureThreshold } = params
 
     protocolInfo :: ProtocolInfo ByronBlock
-    protocolInfo = protocolInfoByron protocolParams
+    protocolInfo = protocolInfoByron protocolParams mempty
 
     blockForging :: [BlockForging m ByronBlock]
     blockForging = blockForgingByron protocolParams

--- a/ouroboros-consensus-cardano/src/unstable-cardano-testlib/Test/Consensus/Cardano/ProtocolInfo.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-testlib/Test/Consensus/Cardano/ProtocolInfo.hs
@@ -326,6 +326,7 @@ mkTestProtocolInfo
               SL.exampleAlonzoGenesis
               SL.exampleConwayGenesis
           )
+          mempty
         )
 
   where

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Api/Protocol/Types.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Api/Protocol/Types.hs
@@ -60,7 +60,7 @@ class RunNode blk => ProtocolClient blk where
 -- | Run PBFT against the Byron ledger
 instance IOLike m => Protocol m ByronBlockHFC where
   data ProtocolInfoArgs m ByronBlockHFC = ProtocolInfoArgsByron (ProtocolParams Consensus.ByronBlock)
-  protocolInfo (ProtocolInfoArgsByron params) = ( inject $ protocolInfoByron params
+  protocolInfo (ProtocolInfoArgsByron params) = ( inject $ protocolInfoByron params mempty
                                                 , pure . map inject $ blockForgingByron params
                                                 )
 

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Node/Protocol/Cardano.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Node/Protocol/Cardano.hs
@@ -296,6 +296,7 @@ mkSomeConsensusProtocolCardano NodeByronProtocolConfiguration {
                   Just epochNo -> Consensus.TriggerHardForkAtEpoch epochNo
           }
           transitionLedgerConfig
+          mempty
         )
 
 ------------------------------------------------------------------------------

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Block/Byron.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Block/Byron.hs
@@ -106,7 +106,7 @@ mkByronProtocolInfo :: Genesis.Config
                     -> Maybe PBftSignatureThreshold
                     -> ProtocolInfo ByronBlock
 mkByronProtocolInfo genesisConfig signatureThreshold =
-    protocolInfoByron $ ProtocolParamsByron {
+    protocolInfoByron ProtocolParamsByron {
         byronGenesis                = genesisConfig
       , byronPbftSignatureThreshold = signatureThreshold
       , byronProtocolVersion        = Update.ProtocolVersion 1 0 0
@@ -114,3 +114,4 @@ mkByronProtocolInfo genesisConfig signatureThreshold =
       , byronLeaderCredentials      = Nothing
       , byronMaxTxCapacityOverrides = Mempool.mkOverrides Mempool.noOverridesMeasure
       }
+      mempty

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Block/Cardano.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Block/Cardano.hs
@@ -322,6 +322,7 @@ mkCardanoProtocolInfo genesisByron signatureThreshold transitionConfig initialNo
           }
         triggers
         transitionConfig
+        mempty
       )
   where
 

--- a/ouroboros-consensus-cardano/test/byron-test/Test/Consensus/Byron/Serialisation.hs
+++ b/ouroboros-consensus-cardano/test/byron-test/Test/Consensus/Byron/Serialisation.hs
@@ -94,7 +94,7 @@ testCfg = pInfoConfig protocolInfo
   where
     protocolInfo :: ProtocolInfo ByronBlock
     protocolInfo =
-      protocolInfoByron $ ProtocolParamsByron {
+      protocolInfoByron ProtocolParamsByron {
           byronGenesis                = CC.dummyConfig
         , byronPbftSignatureThreshold = Just (PBftSignatureThreshold 0.5)
         , byronProtocolVersion        = CC.Update.ProtocolVersion 1 0 0
@@ -102,6 +102,7 @@ testCfg = pInfoConfig protocolInfo
         , byronLeaderCredentials      = Nothing
         , byronMaxTxCapacityOverrides = Mempool.mkOverrides Mempool.noOverridesMeasure
         }
+        mempty
 
 -- | Matches the values used for the generators.
 testCodecCfg :: CodecConfig ByronBlock


### PR DESCRIPTION
Prototype of lightweight checkpointing, see #448

To be merged, this would need more polish (Haddocks, addressing the inline TODOs) and tests.

Notably, this PR adds a new field to `ProtocolParams (CardanoBlock c)`:
```haskell
data instance ProtocolParams (CardanoBlock c) = ProtocolParamsCardano {
  ...
  , cardanoCheckpoints            :: Map BlockNo (HeaderHash (CardanoBlock c))
  }
```
with the semantics described in https://github.com/input-output-hk/ouroboros-consensus/issues/447#issuecomment-1775300165.

Note that this is *not* the approach described in https://github.com/input-output-hk/ouroboros-consensus/issues/447#issuecomment-1775306156; the approach of this PR is likely less invasive/has a smaller diff, but less elegant than the combinator-based appraoch.