### PR TITLE
Change the minimum chain schema length

### DIFF
--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup/GenChains.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup/GenChains.hs
@@ -15,6 +15,7 @@ import qualified Control.Monad.Except as Exn
 import           Data.List (foldl')
 import           Data.Proxy (Proxy (Proxy))
 import qualified Data.Vector.Unboxed as Vector
+import           Data.Word (Word8)
 import           Ouroboros.Consensus.Block.Abstract hiding (Header)
 import           Ouroboros.Consensus.Protocol.Abstract
                      (SecurityParam (SecurityParam))
@@ -42,8 +43,8 @@ import           Test.Util.TestBlock hiding (blockTree)
 -- | Random generator for an honest chain recipe and schema.
 genHonestChainSchema :: QC.Gen (Asc, H.HonestRecipe, H.SomeHonestChainSchema)
 genHonestChainSchema = do
-  honestRecipe <- H.genHonestRecipe
   asc <- genAsc
+  honestRecipe <- H.genHonestRecipe
 
   H.SomeCheckedHonestRecipe Proxy Proxy honestRecipe' <-
     case Exn.runExcept $ H.checkHonestRecipe honestRecipe of
@@ -73,7 +74,7 @@ genAlternativeChainSchema (testRecipeH, arHonest) =
       A.arHonest
     }
 
-    alternativeAsc <- genAscWithKcp kcp scg
+    alternativeAsc <- ascFromBits <$> QC.choose (1 :: Word8, maxBound - 1)
 
     case Exn.runExcept $ A.checkAdversarialRecipe testRecipeA of
       Left e -> case e of

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup/GenChains.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup/GenChains.hs
@@ -15,7 +15,6 @@ import qualified Control.Monad.Except as Exn
 import           Data.List (foldl')
 import           Data.Proxy (Proxy (Proxy))
 import qualified Data.Vector.Unboxed as Vector
-import           Data.Word (Word8)
 import           Ouroboros.Consensus.Block.Abstract hiding (Header)
 import           Ouroboros.Consensus.Protocol.Abstract
                      (SecurityParam (SecurityParam))
@@ -43,8 +42,8 @@ import           Test.Util.TestBlock hiding (blockTree)
 -- | Random generator for an honest chain recipe and schema.
 genHonestChainSchema :: QC.Gen (Asc, H.HonestRecipe, H.SomeHonestChainSchema)
 genHonestChainSchema = do
-  asc <- genAsc
   honestRecipe <- H.genHonestRecipe
+  asc <- genAsc
 
   H.SomeCheckedHonestRecipe Proxy Proxy honestRecipe' <-
     case Exn.runExcept $ H.checkHonestRecipe honestRecipe of
@@ -74,7 +73,7 @@ genAlternativeChainSchema (testRecipeH, arHonest) =
       A.arHonest
     }
 
-    alternativeAsc <- ascFromBits <$> QC.choose (1 :: Word8, maxBound - 1)
+    alternativeAsc <- genAscWithKcp kcp scg
 
     case Exn.runExcept $ A.checkAdversarialRecipe testRecipeA of
       Left e -> case e of

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup/GenChains.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup/GenChains.hs
@@ -66,7 +66,7 @@ genAlternativeChainSchema (testRecipeH, arHonest) =
     let H.HonestRecipe kcp scg delta _len = testRecipeH
 
     (seedPrefix :: QCGen) <- QC.arbitrary
-    let arPrefix = genPrefixBlockCount seedPrefix arHonest
+    let arPrefix = genPrefixBlockCount seedPrefix testRecipeH arHonest
 
     let testRecipeA = A.AdversarialRecipe {
       A.arPrefix,

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
@@ -81,19 +81,20 @@ prop_cannotRollback = do
   where
     schedulerConfig = noTimeoutsSchedulerConfig defaultPointScheduleConfig
 
--- A schedule that advertises all the points of the trunk up until the kth
+-- | A schedule that advertises all the points of the trunk up until the nth
 -- block after the intersection, then switches to the first alternative
 -- chain of the given block tree.
 --
 -- PRECONDITION: Block tree with at least one alternative chain.
 rollbackSchedule :: Int -> BlockTree TestBlock -> PointSchedule
-rollbackSchedule k blockTree =
+rollbackSchedule n blockTree =
   let branch = head $ btBranches blockTree
-      trunk = btTrunk blockTree
-      prefixLen = AF.length $ btbPrefix branch
-      trunkPrefix = AF.takeOldest (k + prefixLen) trunk
-      branchSuffix = btbSuffix branch
-      states = banalStates trunkPrefix ++ banalStates branchSuffix
+      trunkSuffix = AF.takeOldest n (btbTrunkSuffix branch)
+      states = concat
+        [ banalStates (btbPrefix branch)
+        , banalStates trunkSuffix
+        , banalStates (btbSuffix branch)
+        ]
       peers = peersOnlyHonest states
       pointSchedule = balanced peers
    in fromJust pointSchedule

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
@@ -63,43 +63,43 @@ prop_rollback wantRollback = do
   where
     schedulerConfig = noTimeoutsSchedulerConfig defaultPointScheduleConfig
 
-    -- A schedule that advertises all the points of the trunk up until the kth
-    -- block after the intersection, then switches to the first alternative
-    -- chain of the given block tree.
-    --
-    -- PRECONDITION: Block tree with at least one alternative chain.
-    rollbackSchedule :: Int -> BlockTree TestBlock -> PointSchedule
-    rollbackSchedule k blockTree =
-      let branch = head $ btBranches blockTree
-          trunk = btTrunk blockTree
-          prefixLen = AF.length $ btbPrefix branch
-          trunkPrefix = AF.takeOldest (k + prefixLen) trunk
-          branchSuffix = btbSuffix branch
-          states = banalStates trunkPrefix ++ banalStates branchSuffix
-          peers = peersOnlyHonest states
-          pointSchedule = balanced peers
-       in fromJust pointSchedule
+-- A schedule that advertises all the points of the trunk up until the kth
+-- block after the intersection, then switches to the first alternative
+-- chain of the given block tree.
+--
+-- PRECONDITION: Block tree with at least one alternative chain.
+rollbackSchedule :: Int -> BlockTree TestBlock -> PointSchedule
+rollbackSchedule k blockTree =
+  let branch = head $ btBranches blockTree
+      trunk = btTrunk blockTree
+      prefixLen = AF.length $ btbPrefix branch
+      trunkPrefix = AF.takeOldest (k + prefixLen) trunk
+      branchSuffix = btbSuffix branch
+      states = banalStates trunkPrefix ++ banalStates branchSuffix
+      peers = peersOnlyHonest states
+      pointSchedule = balanced peers
+   in fromJust pointSchedule
 
-    -- | Whether the honest chain has more than 'k' blocks after the
-    -- intersection with the alternative chain.
-    --
-    -- PRECONDITION: Block tree with exactly one alternative chain, otherwise
-    -- this property does not make sense. With no alternative chain, this will
-    -- even crash.
-    honestChainIsLongEnough :: SecurityParam -> BlockTree TestBlock -> Bool
-    honestChainIsLongEnough (SecurityParam k) blockTree =
-      let BlockTreeBranch{btbTrunkSuffix} = head $ btBranches blockTree
-          lengthTrunkSuffix = AF.length btbTrunkSuffix
-       in lengthTrunkSuffix > fromIntegral k
+-- | Whether the honest chain has more than 'k' blocks after the
+-- intersection with the alternative chain.
+--
+-- PRECONDITION: Block tree with exactly one alternative chain, otherwise
+-- this property does not make sense. With no alternative chain, this will
+-- even crash.
+honestChainIsLongEnough :: SecurityParam -> BlockTree TestBlock -> Bool
+honestChainIsLongEnough (SecurityParam k) blockTree =
+  let BlockTreeBranch{btbTrunkSuffix} = head $ btBranches blockTree
+      lengthTrunkSuffix = AF.length btbTrunkSuffix
+   in lengthTrunkSuffix > fromIntegral k
 
-    -- | Whether the alternative chain has more than 'k' blocks after the
-    -- intersection with the honest chain.
-    --
-    -- PRECONDITION: Block tree with exactly one alternative chain, otherwise
-    -- this property does not make sense. With no alternative chain, this will
-    -- even crash.
-    alternativeChainIsLongEnough :: SecurityParam -> BlockTree TestBlock -> Bool
-    alternativeChainIsLongEnough (SecurityParam k) blockTree =
-      let BlockTreeBranch{btbSuffix} = head $ btBranches blockTree
-          lengthSuffix = AF.length btbSuffix
-       in lengthSuffix > fromIntegral k
+-- | Whether the alternative chain has more than 'k' blocks after the
+-- intersection with the honest chain.
+--
+-- PRECONDITION: Block tree with exactly one alternative chain, otherwise
+-- this property does not make sense. With no alternative chain, this will
+-- even crash.
+alternativeChainIsLongEnough :: SecurityParam -> BlockTree TestBlock -> Bool
+alternativeChainIsLongEnough (SecurityParam k) blockTree =
+  let BlockTreeBranch{btbSuffix} = head $ btBranches blockTree
+      lengthSuffix = AF.length btbSuffix
+   in lengthSuffix > fromIntegral k

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
@@ -16,7 +16,6 @@ import           Test.Consensus.PeerSimulator.Run (noTimeoutsSchedulerConfig)
 import           Test.Consensus.PeerSimulator.StateView
 import           Test.Consensus.PointSchedule
 import qualified Test.QuickCheck as QC
-import           Test.QuickCheck
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
 import           Test.Util.Orphans.IOLike ()
@@ -38,10 +37,7 @@ prop_rollback = do
   let SecurityParam k = gtSecurityParam genesisTest
       schedule = rollbackSchedule (fromIntegral k) (gtBlockTree genesisTest)
 
-  -- We consider the test case interesting if we can rollback
   pure $
-    alternativeChainIsLongEnough (gtSecurityParam genesisTest) (gtBlockTree genesisTest)
-    ==>
       runSimOrThrow $ runTest schedulerConfig genesisTest schedule $ \StateView{svSelectedChain} ->
         let headOnAlternativeChain = case AF.headHash svSelectedChain of
               GenesisHash    -> False
@@ -63,13 +59,7 @@ prop_cannotRollback = do
   let SecurityParam k = gtSecurityParam genesisTest
       schedule = rollbackSchedule (fromIntegral (k + 1)) (gtBlockTree genesisTest)
 
-  -- We consider the test case interesting if it allows to rollback even if
-  -- the implementation doesn't
   pure $
-    alternativeChainIsLongEnough (gtSecurityParam genesisTest) (gtBlockTree genesisTest)
-      &&
-    honestChainIsLongEnough (gtSecurityParam genesisTest) (gtBlockTree genesisTest)
-    ==>
       runSimOrThrow $ runTest schedulerConfig genesisTest schedule $ \StateView{svSelectedChain} ->
         let headOnAlternativeChain = case AF.headHash svSelectedChain of
               GenesisHash    -> False
@@ -98,27 +88,3 @@ rollbackSchedule n blockTree =
       peers = peersOnlyHonest states
       pointSchedule = balanced peers
    in fromJust pointSchedule
-
--- | Whether the honest chain has more than 'k' blocks after the
--- intersection with the alternative chain.
---
--- PRECONDITION: Block tree with exactly one alternative chain, otherwise
--- this property does not make sense. With no alternative chain, this will
--- even crash.
-honestChainIsLongEnough :: SecurityParam -> BlockTree TestBlock -> Bool
-honestChainIsLongEnough (SecurityParam k) blockTree =
-  let BlockTreeBranch{btbTrunkSuffix} = head $ btBranches blockTree
-      lengthTrunkSuffix = AF.length btbTrunkSuffix
-   in lengthTrunkSuffix > fromIntegral k
-
--- | Whether the alternative chain has more than 'k' blocks after the
--- intersection with the honest chain.
---
--- PRECONDITION: Block tree with exactly one alternative chain, otherwise
--- this property does not make sense. With no alternative chain, this will
--- even crash.
-alternativeChainIsLongEnough :: SecurityParam -> BlockTree TestBlock -> Bool
-alternativeChainIsLongEnough (SecurityParam k) blockTree =
-  let BlockTreeBranch{btbSuffix} = head $ btBranches blockTree
-      lengthSuffix = AF.length btbSuffix
-   in lengthSuffix > fromIntegral k

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
@@ -24,41 +24,59 @@ import           Test.Util.TestBlock (TestBlock, unTestHash)
 
 tests :: TestTree
 tests = testGroup "rollback" [
-  testProperty "can rollback" (prop_rollback True),
-  testProperty "cannot rollback" (prop_rollback False)
+  testProperty "can rollback" prop_rollback,
+  testProperty "cannot rollback" prop_cannotRollback
   ]
 
--- | @prop_rollback True@ tests that the selection of the node under test
+-- | @prop_rollback@ tests that the selection of the node under test
 -- changes branches when sent a rollback to a block no older than 'k' blocks
 -- before the current selection.
---
--- @prop_rollback False@ tests that the selection of the node under test *does
--- not* change branches when sent a rollback to a block strictly older than 'k'
--- blocks before the current selection.
-prop_rollback :: Bool -> QC.Gen QC.Property
-prop_rollback wantRollback = do
+prop_rollback :: QC.Gen QC.Property
+prop_rollback = do
   genesisTest <- genChains 1
 
   let SecurityParam k = gtSecurityParam genesisTest
-      schedule =
-        if wantRollback then rollbackSchedule (fromIntegral k) (gtBlockTree genesisTest)
-        else rollbackSchedule (fromIntegral (k + 1)) (gtBlockTree genesisTest)
+      schedule = rollbackSchedule (fromIntegral k) (gtBlockTree genesisTest)
 
-  -- | We consider the test case interesting if we want a rollback and we can
-  -- actually get one, or if we want no rollback and we cannot actually get one.
+  -- We consider the test case interesting if we can rollback
   pure $
     alternativeChainIsLongEnough (gtSecurityParam genesisTest) (gtBlockTree genesisTest)
-      &&
-    (wantRollback || honestChainIsLongEnough (gtSecurityParam genesisTest) (gtBlockTree genesisTest))
     ==>
       runSimOrThrow $ runTest schedulerConfig genesisTest schedule $ \StateView{svSelectedChain} ->
         let headOnAlternativeChain = case AF.headHash svSelectedChain of
               GenesisHash    -> False
               BlockHash hash -> any (0 /=) $ unTestHash hash
         in
-        -- The test passes if we want a rollback and we actually end up on the
-        -- alternative chain or if we want no rollback and end up on the trunk.
-        wantRollback == headOnAlternativeChain
+        -- The test passes if we end up on the alternative chain
+        headOnAlternativeChain
+
+  where
+    schedulerConfig = noTimeoutsSchedulerConfig defaultPointScheduleConfig
+
+-- @prop_cannotRollback@ tests that the selection of the node under test *does
+-- not* change branches when sent a rollback to a block strictly older than 'k'
+-- blocks before the current selection.
+prop_cannotRollback :: QC.Gen QC.Property
+prop_cannotRollback = do
+  genesisTest <- genChains 1
+
+  let SecurityParam k = gtSecurityParam genesisTest
+      schedule = rollbackSchedule (fromIntegral (k + 1)) (gtBlockTree genesisTest)
+
+  -- We consider the test case interesting if it allows to rollback even if
+  -- the implementation doesn't
+  pure $
+    alternativeChainIsLongEnough (gtSecurityParam genesisTest) (gtBlockTree genesisTest)
+      &&
+    honestChainIsLongEnough (gtSecurityParam genesisTest) (gtBlockTree genesisTest)
+    ==>
+      runSimOrThrow $ runTest schedulerConfig genesisTest schedule $ \StateView{svSelectedChain} ->
+        let headOnAlternativeChain = case AF.headHash svSelectedChain of
+              GenesisHash    -> False
+              BlockHash hash -> any (0 /=) $ unTestHash hash
+        in
+        -- The test passes if we end up on the trunk.
+        not headOnAlternativeChain
 
   where
     schedulerConfig = noTimeoutsSchedulerConfig defaultPointScheduleConfig

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Consensus/ChainGenerator/Adversarial.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Consensus/ChainGenerator/Adversarial.hs
@@ -655,8 +655,8 @@ genPrefixBlockCount g (HonestRecipe (Kcp k) (Scg s) (Delta d) _len) schedH
 
     -- 'H.uniformTheHonestChain' ensures there is at least one block in the
     -- first s slots.
-    -- By leaving on block after the intersection in the first s slots, we
-    -- ensure there is are k+1 active slots in the honest chain after the
+    -- By leaving one block after the intersection in the first s slots, we
+    -- ensure there are k+1 active slots in the honest chain after the
     -- intersection.
     numChoices = numBlocks C.- 1
     numBlocks = BV.countActivesInV S.notInverted $

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Consensus/ChainGenerator/Adversarial.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Consensus/ChainGenerator/Adversarial.hs
@@ -664,11 +664,12 @@ withinYS (Delta d) !mbYS !(RI.Race (C.SomeWindow Proxy win)) = case mbYS of
 -- REVIEW: why do we not allow forking off the block number 1?
 genPrefixBlockCount :: R.RandomGen g => g -> HonestRecipe -> ChainSchema base hon -> C.Var hon 'ActiveSlotE
 genPrefixBlockCount g (HonestRecipe (Kcp k) (Scg s) (Delta d) _len) schedH
-    | C.getCount validIntersections >= 0 =
-    if C.toVar numChoices < 2 then C.Count 0 {- can always pick genesis -} else do
-        C.toVar $ R.runSTGen_ g $ C.uniformIndex numChoices
-    | otherwise =
+    | C.getCount validIntersections < 0 =
         error "size of schema is smaller than s + k + d + 1"
+    |  C.toVar numChoices < 2 =
+        C.Count 0 {- can always pick genesis -}
+    | otherwise =
+        C.toVar $ R.runSTGen_ g $ C.uniformIndex numChoices
   where
     ChainSchema _slots v = schedH
 

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Consensus/ChainGenerator/Adversarial.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Consensus/ChainGenerator/Adversarial.hs
@@ -35,7 +35,7 @@ import qualified System.Random.Stateful as R
 import qualified Test.Ouroboros.Consensus.ChainGenerator.BitVector as BV
 import qualified Test.Ouroboros.Consensus.ChainGenerator.Counting as C
 import           Test.Ouroboros.Consensus.ChainGenerator.Honest
-                     (ChainSchema (ChainSchema), HonestRecipe(HonestRecipe))
+                     (ChainSchema (ChainSchema), HonestRecipe (HonestRecipe))
 import           Test.Ouroboros.Consensus.ChainGenerator.Params (Asc,
                      Delta (Delta), Kcp (Kcp), Scg (Scg))
 import qualified Test.Ouroboros.Consensus.ChainGenerator.RaceIterator as RI

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Consensus/ChainGenerator/Adversarial.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Consensus/ChainGenerator/Adversarial.hs
@@ -637,8 +637,9 @@ withinYS (Delta d) !mbYS !(RI.Race (C.SomeWindow Proxy win)) = case mbYS of
 --
 -- The count will be strictly smaller than the number of active slots in the given 'ChainSchema'.
 --
--- The following precondition ensures that there are enough slots to produce an
--- alternative chain schema with at least k+1 slots.
+-- The precondition allows the intersection to occur early enough (earlier than
+-- s+k+d+1 slots from the end), which should allow the generation algorithm to
+-- fit k+1 active slots in the alternative schema after the intersection.
 --
 -- PRECONDITION: @schemaSize schedH >= s + k + d + 1@
 --
@@ -658,6 +659,8 @@ genPrefixBlockCount g (HonestRecipe (Kcp k) (Scg s) (Delta d) _len) schedH
     -- By leaving one block after the intersection in the first s slots, we
     -- ensure there are k+1 active slots in the honest chain after the
     -- intersection.
+    --
+    -- numChoices might be smaller than 0, in which case we just pick genesis
     numChoices = numBlocks C.- 1
     numBlocks = BV.countActivesInV S.notInverted $
            C.sliceV (C.UnsafeContains (C.Count 0) validIntersections) v

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Consensus/ChainGenerator/Adversarial.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Consensus/ChainGenerator/Adversarial.hs
@@ -653,8 +653,13 @@ genPrefixBlockCount g (HonestRecipe (Kcp k) (Scg s) (Delta d) _len) schedH
   where
     ChainSchema _slots v = schedH
 
-    -- 'H.uniformTheHonestChain' ensures 0 < pc
-    numChoices = BV.countActivesInV S.notInverted $
+    -- 'H.uniformTheHonestChain' ensures there is at least one block in the
+    -- first s slots.
+    -- By leaving on block after the intersection in the first s slots, we
+    -- ensure there is are k+1 active slots in the honest chain after the
+    -- intersection.
+    numChoices = numBlocks C.- 1
+    numBlocks = BV.countActivesInV S.notInverted $
            C.sliceV (C.UnsafeContains (C.Count 0) validIntersections) v
 
     validIntersections = C.lengthV v C.- (s + k + d + 1)

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Consensus/ChainGenerator/Adversarial.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Consensus/ChainGenerator/Adversarial.hs
@@ -451,11 +451,18 @@ uniformAdversarialChain mbAsc recipe g0 = wrap $ C.createV $ do
         Just asc -> S.genS asc `R.applySTGen` g
 
     -- ensure the adversarial leader schedule is not empty
-    do  void $ BV.fillInWindow
+    do -- Since the first active slot in the adversarial chain might determine
+       -- the position of the acceleration bound, we ensure it is early enough
+       -- so we can always fit k+1 blocks in the alternative schema.
+       let trailingSlots = s + k + d + 1
+           szFirstActive = sz C.- trailingSlots C.+ 1
+       when (szFirstActive <= C.Count 0) $
+         error "the adversarial schema is smaller than s+k+d+1"
+       void $ BV.fillInWindow
             S.notInverted
-            (BV.SomeDensityWindow (C.Count 1) (C.windowSize carWin))
+            (BV.SomeDensityWindow (C.Count 1) szFirstActive)
             g
-            mv
+            (C.sliceMV (C.UnsafeContains (C.Count 0) szFirstActive) mv)
 
     -- find the slot of the k+1 honest block
     let kPlus1st :: C.Index adv SlotE

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Consensus/ChainGenerator/Honest.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Consensus/ChainGenerator/Honest.hs
@@ -104,10 +104,16 @@ data NoSuchHonestChainSchema =
 
 genHonestRecipe :: QC.Gen HonestRecipe
 genHonestRecipe = sized1 $ \sz -> do
-  (kcp, Scg s, delta) <- genKSD
-  -- s <= l, most of the time
-  l <- QC.frequency [(9, (+ s) <$> QC.choose (0, 5 * sz)), (1, QC.choose (1, s))]
-  pure $ HonestRecipe kcp (Scg s) delta (Len l)
+  (Kcp k, Scg s, Delta d) <- genKSD
+  -- Ensure that there are k + 1 slots in the chain:
+  -- 2s has 2k blocks, but if the windows overlap as in 2s-k, then
+  -- only k blocks might be present.
+  -- Therefore we enlarge the schema by one slot to get the size 2s-k+1
+  --
+  -- If we then add k+d slots, we get enough room for alternative chains
+  -- to have k+1 blocks when they branch of blocks in the first s slots.
+  l <- (+ (2*s + d + 1)) <$> QC.choose (0, 5 * sz)
+  pure $ HonestRecipe (Kcp k) (Scg s) (Delta d) (Len l)
 
 -- | Checks whether the given 'HonestRecipe' determines a valid input to
 -- 'uniformTheHonestChain'

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Consensus/ChainGenerator/Honest.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Consensus/ChainGenerator/Honest.hs
@@ -110,8 +110,9 @@ genHonestRecipe = sized1 $ \sz -> do
   -- only k blocks might be present.
   -- Therefore we enlarge the schema by one slot to get the size 2s-k+1
   --
-  -- If we then add k+d slots, we get enough room for alternative chains
-  -- to have k+1 blocks when they branch of blocks in the first s slots.
+  -- If we then add k+d slots (to get a total size of 2s+d+1), we get enough
+  -- room for alternative chains to have k+1 blocks when they branch before
+  -- the last s+d slots.
   l <- (+ (2*s + d + 1)) <$> QC.choose (0, 5 * sz)
   pure $ HonestRecipe (Kcp k) (Scg s) (Delta d) (Len l)
 

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Consensus/ChainGenerator/Params.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Consensus/ChainGenerator/Params.hs
@@ -10,7 +10,6 @@ module Test.Ouroboros.Consensus.ChainGenerator.Params (
   , ascFromDouble
   , ascVal
   , genAsc
-  , genAscWithKcp
   , genKSD
   ) where
 
@@ -93,14 +92,6 @@ ascFromBits w = ascFromDouble $ toEnum (fromEnum w) / (2 ^ B.finiteBitSize w)
 -- | Interpret 'Asc' as a 'Double'
 ascVal :: Asc -> Double
 ascVal (Asc x) = x
-
--- | Provides an Asc with high probability to produce k slots in
--- a window of size s. Therefore, we chose @Asc >= 3k/s@.
-genAscWithKcp :: Kcp -> Scg -> QC.Gen Asc
-genAscWithKcp (Kcp k) (Scg s) =
-    let word8Max = fromEnum (maxBound :: Word8)
-        asc0Min = toEnum $ min (word8Max - 1) $ word8Max * 3 * k `div` s :: Word8
-     in ascFromBits <$> QC.choose (asc0Min, maxBound - 1)
 
 genAsc :: QC.Gen Asc
 genAsc = ascFromBits <$> QC.choose (1 :: Word8, maxBound - 1)

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Consensus/ChainGenerator/Params.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Consensus/ChainGenerator/Params.hs
@@ -10,6 +10,7 @@ module Test.Ouroboros.Consensus.ChainGenerator.Params (
   , ascFromDouble
   , ascVal
   , genAsc
+  , genAscWithKcp
   , genKSD
   ) where
 
@@ -92,6 +93,14 @@ ascFromBits w = ascFromDouble $ toEnum (fromEnum w) / (2 ^ B.finiteBitSize w)
 -- | Interpret 'Asc' as a 'Double'
 ascVal :: Asc -> Double
 ascVal (Asc x) = x
+
+-- | Provides an Asc with high probability to produce k slots in
+-- a window of size s. Therefore, we chose @Asc >= 3k/s@.
+genAscWithKcp :: Kcp -> Scg -> QC.Gen Asc
+genAscWithKcp (Kcp k) (Scg s) =
+    let word8Max = fromEnum (maxBound :: Word8)
+        asc0Min = toEnum $ min (word8Max - 1) $ word8Max * 3 * k `div` s :: Word8
+     in ascFromBits <$> QC.choose (asc0Min, maxBound - 1)
 
 genAsc :: QC.Gen Asc
 genAsc = ascFromBits <$> QC.choose (1 :: Word8, maxBound - 1)

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Consensus/ChainGenerator/Params.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Consensus/ChainGenerator/Params.hs
@@ -98,7 +98,7 @@ genAsc = ascFromBits <$> QC.choose (1 :: Word8, maxBound - 1)
 
 genKSD :: QC.Gen (Kcp, Scg, Delta)
 genKSD = sized1 $ \sz -> do
-    d <- QC.choose (0, div sz 4)
     k <- (+ 2) <$> QC.choose (0, 2 * sz)
     s <- (+ k) <$> QC.choose (0, 3 * sz)   -- ensures @k / s <= 1@
+    d <- QC.choose (0, max 0 $ min (div sz 4) (s-1)) -- ensures @d < s@
     pure (Kcp k, Scg s, Delta d)

--- a/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/ChainGenerator/Tests/Adversarial.hs
+++ b/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/ChainGenerator/Tests/Adversarial.hs
@@ -25,15 +25,14 @@ import qualified Test.Ouroboros.Consensus.ChainGenerator.BitVector as BV
 import qualified Test.Ouroboros.Consensus.ChainGenerator.Counting as C
 import qualified Test.Ouroboros.Consensus.ChainGenerator.Honest as H
 import           Test.Ouroboros.Consensus.ChainGenerator.Params (Asc,
-                     Delta (Delta), Kcp (Kcp), Len (Len), Scg (Scg), genAsc,
-                     genKSD)
+                     Delta (Delta), Kcp (Kcp), Len (Len), Scg (Scg), genAsc)
 import qualified Test.Ouroboros.Consensus.ChainGenerator.RaceIterator as RI
 import qualified Test.Ouroboros.Consensus.ChainGenerator.Slot as S
 import           Test.Ouroboros.Consensus.ChainGenerator.Slot (E (SlotE))
 import qualified Test.Ouroboros.Consensus.ChainGenerator.Some as Some
 import qualified Test.Ouroboros.Consensus.ChainGenerator.Tests.Honest as H
 import qualified Test.QuickCheck as QC
-import           Test.QuickCheck.Extras (sized1, unsafeMapSuchThatJust)
+import           Test.QuickCheck.Extras (unsafeMapSuchThatJust)
 import           Test.QuickCheck.Random (QCGen)
 import qualified Test.Tasty as TT
 import qualified Test.Tasty.QuickCheck as TT
@@ -107,7 +106,7 @@ instance QC.Arbitrary SomeTestAdversarial where
 
         testSeedPrefix <- QC.arbitrary @QCGen
 
-        let arPrefix = genPrefixBlockCount testSeedPrefix arHonest
+        let arPrefix = genPrefixBlockCount testSeedPrefix testRecipeH arHonest
 
         let H.HonestRecipe kcp scg delta _len = testRecipeH
 
@@ -295,14 +294,7 @@ instance QC.Arbitrary SomeTestAdversarialMutation where
     arbitrary = do
         mut <- QC.elements [minBound .. maxBound :: AdversarialMutation]
         unsafeMapSuchThatJust $ do
-            (kcp, scg, delta, len) <- sized1 $ \sz -> do
-                (kcp, Scg s, delta) <- genKSD
-
-                l <- (+ s) <$> QC.choose (0, 5 * sz)
-
-                pure (kcp, Scg s, delta, Len l)
-
-            let recipeH = H.HonestRecipe kcp scg delta len
+            recipeH@(H.HonestRecipe kcp scg delta len) <- H.genHonestRecipe
 
             someTestRecipeH' <- case Exn.runExcept $ H.checkHonestRecipe recipeH of
                 Left e  -> error $ "impossible! " <> show (recipeH, e)
@@ -316,7 +308,7 @@ instance QC.Arbitrary SomeTestAdversarialMutation where
 
             testSeedPrefix <- QC.arbitrary @QCGen
 
-            let arPrefix = genPrefixBlockCount testSeedPrefix arHonest
+            let arPrefix = genPrefixBlockCount testSeedPrefix recipeH arHonest
 
             let recipeA = A.AdversarialRecipe {
                     A.arPrefix

--- a/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/ChainGenerator/Tests/Adversarial.hs
+++ b/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/ChainGenerator/Tests/Adversarial.hs
@@ -25,7 +25,8 @@ import qualified Test.Ouroboros.Consensus.ChainGenerator.BitVector as BV
 import qualified Test.Ouroboros.Consensus.ChainGenerator.Counting as C
 import qualified Test.Ouroboros.Consensus.ChainGenerator.Honest as H
 import           Test.Ouroboros.Consensus.ChainGenerator.Params (Asc,
-                     Delta (Delta), Kcp (Kcp), Len (Len), Scg (Scg), genAscWithKcp)
+                     Delta (Delta), Kcp (Kcp), Len (Len), Scg (Scg),
+                     genAscWithKcp)
 import qualified Test.Ouroboros.Consensus.ChainGenerator.RaceIterator as RI
 import qualified Test.Ouroboros.Consensus.ChainGenerator.Slot as S
 import           Test.Ouroboros.Consensus.ChainGenerator.Slot (E (SlotE))

--- a/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/ChainGenerator/Tests/Adversarial.hs
+++ b/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/ChainGenerator/Tests/Adversarial.hs
@@ -25,7 +25,7 @@ import qualified Test.Ouroboros.Consensus.ChainGenerator.BitVector as BV
 import qualified Test.Ouroboros.Consensus.ChainGenerator.Counting as C
 import qualified Test.Ouroboros.Consensus.ChainGenerator.Honest as H
 import           Test.Ouroboros.Consensus.ChainGenerator.Params (Asc,
-                     Delta (Delta), Kcp (Kcp), Len (Len), Scg (Scg), genAsc)
+                     Delta (Delta), Kcp (Kcp), Len (Len), Scg (Scg), genAscWithKcp)
 import qualified Test.Ouroboros.Consensus.ChainGenerator.RaceIterator as RI
 import qualified Test.Ouroboros.Consensus.ChainGenerator.Slot as S
 import           Test.Ouroboros.Consensus.ChainGenerator.Slot (E (SlotE))
@@ -120,7 +120,7 @@ instance QC.Arbitrary SomeTestAdversarial where
                 A.arHonest
               }
 
-        testAscA <- genAsc
+        testAscA <- genAscWithKcp kcp scg
 
         case Exn.runExcept $ A.checkAdversarialRecipe testRecipeA of
             Left e -> case e of

--- a/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/ChainGenerator/Tests/Adversarial.hs
+++ b/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/ChainGenerator/Tests/Adversarial.hs
@@ -44,9 +44,9 @@ tests :: [TT.TestTree]
 tests = [
     TT.testProperty "k+1 blocks after the intersection" prop_kPlus1BlocksAfterIntersection
   ,
-    TT.testProperty "prop_adversarialChain" prop_adversarialChain
+    TT.testProperty "Adversarial chains lose density and race comparisons" prop_adversarialChain
   ,
-    TT.localOption (TT.QuickCheckMaxSize 14) $ TT.testProperty "prop_adversarialChainMutation" prop_adversarialChainMutation
+    TT.localOption (TT.QuickCheckMaxSize 14) $ TT.testProperty "Adversarial chains win if checked with relaxed parameters" prop_adversarialChainMutation
   ]
 
 -----

--- a/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/ChainGenerator/Tests/Adversarial.hs
+++ b/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/ChainGenerator/Tests/Adversarial.hs
@@ -168,17 +168,19 @@ prop_kPlus1BlocksAfterIntersection someTestAdversarial testSeedA = runIdentity $
     C.SomeWindow Proxy stabWin <- do
         pure $ calculateStability scg schedA
 
-    pure
-      $ QC.counterexample (unlines $
+    pure $
+      (BV.countActivesInV S.notInverted vA >= C.Count (k + 1))
+      QC.==>
+      (QC.counterexample (unlines $
                             H.prettyChainSchema schedH "H"
                             ++ H.prettyChainSchema schedA "A"
                           )
       $ QC.counterexample ("arPrefix = " <> show (A.arPrefix testRecipeA))
       $ QC.counterexample ("stabWin  = " <> show stabWin)
       $ QC.counterexample ("stabWin' = " <> show (C.joinWin winA stabWin))
-      $ BV.countActivesInV S.notInverted vA  >= C.Count (k + 1)
-        && BV.countActivesInV S.notInverted vH
-             >= C.toSize (C.Count (k + 1) + A.arPrefix testRecipeA)
+      $ BV.countActivesInV S.notInverted vH
+          >= C.toSize (C.Count (k + 1) + A.arPrefix testRecipeA)
+      )
 
 -- | No seed exists such that each 'A.checkAdversarialChain' rejects the result of 'A.uniformAdversarialChain'
 prop_adversarialChain :: SomeTestAdversarial -> QCGen -> QC.Property

--- a/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/ChainGenerator/Tests/Adversarial.hs
+++ b/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/ChainGenerator/Tests/Adversarial.hs
@@ -25,8 +25,7 @@ import qualified Test.Ouroboros.Consensus.ChainGenerator.BitVector as BV
 import qualified Test.Ouroboros.Consensus.ChainGenerator.Counting as C
 import qualified Test.Ouroboros.Consensus.ChainGenerator.Honest as H
 import           Test.Ouroboros.Consensus.ChainGenerator.Params (Asc,
-                     Delta (Delta), Kcp (Kcp), Len (Len), Scg (Scg),
-                     genAscWithKcp)
+                     Delta (Delta), Kcp (Kcp), Len (Len), Scg (Scg), genAsc)
 import qualified Test.Ouroboros.Consensus.ChainGenerator.RaceIterator as RI
 import qualified Test.Ouroboros.Consensus.ChainGenerator.Slot as S
 import           Test.Ouroboros.Consensus.ChainGenerator.Slot (E (SlotE))
@@ -121,7 +120,7 @@ instance QC.Arbitrary SomeTestAdversarial where
                 A.arHonest
               }
 
-        testAscA <- genAscWithKcp kcp scg
+        testAscA <- genAsc
 
         case Exn.runExcept $ A.checkAdversarialRecipe testRecipeA of
             Left e -> case e of


### PR DESCRIPTION
This PR causes chain schemas to have more than k blocks after intersections.

Having more than k blocks after intersections makes the inputs interesting for the long range attack, and for testing that rollbacks of more than `k` can't happen in caught up nodes.

This guarantee comes from the generation algorithm, which ensures that every s window has exactly `k` blocks in the honest chain.

For alternative chains, we ensure that the chains have more than `s+k+d+1` slots, and we choose the first active slot before this many slots from the end. Then the acceleration bound is before the last `k` blocks of the alternative chain, which we always set to active.

Race windows do not push the acceleration bound to the last `k` blocks because the intersections with the honest chain are always behind the last block preceding the last `s+k+d+1` slots.