### PR TITLE
Add a query for vote delegatees

### DIFF
--- a/ouroboros-consensus-cardano/changelog.d/20231110_165234_carl.hammann_vote_delegatee_query.md
+++ b/ouroboros-consensus-cardano/changelog.d/20231110_165234_carl.hammann_vote_delegatee_query.md
@@ -1,0 +1,23 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Patch
+
+- A bullet item for the Patch category.
+
+-->
+
+<!--
+### Non-Breaking
+
+- A bullet item for the Non-Breaking category.
+
+-->
+
+### Breaking
+
+- Add a query for vote delegatees: GetFilteredVoteDelegatees

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/NetworkProtocolVersion.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/NetworkProtocolVersion.hs
@@ -35,7 +35,7 @@ data ShelleyNodeToClientVersion =
     -- | New queries introduced: GetStakeDelegDeposits
   | ShelleyNodeToClientVersion7
 
-    -- | New queries introduced: GetConstitutionHash
+    -- | New queries introduced: GetConstitutionHash, GetFilteredVoteDelegatees
   | ShelleyNodeToClientVersion8
   deriving (Show, Eq, Ord, Enum, Bounded)
 


### PR DESCRIPTION
For context, see [this issue on `cardano-cli`](https://github.com/input-output-hk/cardano-cli/issues/423): We want to have a query returns the vote delegatees, given staking credentials. This functionality is currently missing (here, and thus in the `cardano-api`, which I want to use in the CLI).