### PR TITLE
Add profiled Nix shells

### DIFF
--- a/docs/website/contents/for-developers/ProfilingTipsAndTricks.md
+++ b/docs/website/contents/for-developers/ProfilingTipsAndTricks.md
@@ -196,4 +196,23 @@ package plutus-core
 ...
 ```
 
+## Entering a profiled Nix shell
 
+We have cached profiled Nix shells built on CI so you don't have to locally recompile all dependencies with profiling.
+To use them, enter the `.#ghc96-profiled` shell, eg via
+```shell
+nix develop .#ghc96-profiled
+```
+and create a `cabal.project.local` like this:
+```cabal
+profiling: True
+-- https://well-typed.com/blog/2023/03/prof-late/
+profiling-detail: late
+```
+Now, any built executable will have profiling support.
+
+For example, to find out where time is spent in some test, you could use
+```shell
+cabal run ouroboros-consensus:test:storage-test -- -p 'ChainDB q-s-m' +RTS -pj
+```
+and eg load the resulting `.prof` file into [speedscope](https://speedscope.app).

--- a/flake.nix
+++ b/flake.nix
@@ -63,6 +63,8 @@
         devShells = rec {
           default = ghc96;
           ghc96 = hydraJobs.native.haskell96.devShell;
+          ghc96-profiled = hydraJobs.native.haskell96.devShellProfiled;
+
           website = pkgs.mkShell {
             packages = [ pkgs.nodejs pkgs.yarn ];
           };

--- a/nix/ci.nix
+++ b/nix/ci.nix
@@ -31,6 +31,8 @@ let
     } // lib.optionalAttrs noCross {
       devShell =
         import ./shell.nix { inherit pkgs hsPkgs; };
+      devShellProfiled =
+        import ./shell.nix { inherit pkgs; hsPkgs = hsPkgs.projectVariants.profiled; };
     };
 
   jobs = lib.filterAttrsRecursive (n: v: n != "recurseForDerivations") ({
@@ -43,7 +45,7 @@ let
       # ensure we can still build on 8.10, can be removed soon
       haskell810 = builtins.removeAttrs
         (mkHaskellJobsFor pkgs.hsPkgs.projectVariants.ghc810)
-        [ "checks" "devShell" ];
+        [ "checks" "devShell" "devShellProfiled" ];
     };
   } // lib.optionalAttrs (buildSystem == "x86_64-linux") {
     windows = {

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -38,12 +38,22 @@ let
         reinstallableLibGhc = false;
       })
     ];
-    flake.variants.noAsserts = {
-      src = lib.mkForce (final.applyPatches {
-        name = "consensus-src-no-asserts";
-        src = ./..;
-        postPatch = ''echo > asserts.cabal'';
-      });
+    flake.variants = {
+      noAsserts = {
+        src = lib.mkForce (final.applyPatches {
+          name = "consensus-src-no-asserts";
+          src = ./..;
+          postPatch = ''echo > asserts.cabal'';
+        });
+      };
+      profiled = {
+        modules = [{
+          enableLibraryProfiling = true;
+          enableProfiling = true;
+          # https://well-typed.com/blog/2023/03/prof-late/
+          profilingDetail = "late";
+        }];
+      };
     };
   };
 in


### PR DESCRIPTION
One annoying aspect of profiling is that you have to rebuild all dependencies in order to use it. At least for Nix users, we can instead do most of that work on CI.

Also includes a short paragraph on how to use this.