### PR TITLE
docs: draft MicroReadTVarIO.hs microbenchmark

### DIFF
--- a/docs/technical-reports/readTVarIO-optimization/MicroReadTVarIO.hs
+++ b/docs/technical-reports/readTVarIO-optimization/MicroReadTVarIO.hs
@@ -1,0 +1,139 @@
+{-# LANGUAGE LambdaCase #-}
+
+-- Execute these lines at the bash prompt.
+--
+-- > $ bash do-ticky MicroReadTVarIO
+-- > $ bash do-timing MicroReadTVarIO
+--
+-- And refer to
+-- <https://gitlab.haskell.org/ghc/ghc/-/wikis/debugging/ticky-ticky> for the
+-- semantics.
+
+-- My interpretation:
+--
+-- o The only meaningful difference is the MUT time.
+--
+-- o The ticky results indicates that's the result of eliminating one call to a
+--   dynamic target (aka ENT_DYN_FUN_DIRECT) and two stack checks (aka STK_CHK)
+--   per iteration.
+--
+-- o I /assume/ those are essentially unavoidable when using the @atomically#@
+--   primop.
+--
+-- o In the batch of 30 reps, we interleaved them so that cache warmness is
+--   less likely to matter.
+--
+-- o My averages at 10^2 were both less than 0, so the binary execution
+--   overhead is less than a millisecond. My averages at 10^8 were
+--   0.13653333333333337 seconds optimized and 2.1664333333333334 seconds
+--   unoptimized. So---if binary execution overhead is were actually 0---that'd
+--   imply 1.37 nanoseconds per call optimized and 21.7 nanoseconds per call
+--   unoptimized. That's a difference of merely 20 extra nanoseconds per
+--   call---and no allocation difference whatsoever!
+--
+-- This microbenchmark assesses removing an occurrence of @atomically@.
+-- HOWEVER, this microbenchmark compiles witwh the concrete 'IO' monad
+-- explicitly manifest, and so it's measuring exactly the @atomically#@ primop
+-- itself. In contrast, the actual Ouroboros Consensus code (at
+-- <https://github.com/input-output-hk/ouroboros-consensus/commit/ea76c4662743e129bf56d206fd212e2fe45685c9>),
+-- differs in two ways.
+--
+-- o It involves a layer of ad-hoc polymorphism. Thus removing the @atomically@
+--   call in that that context also eliminates a class method call
+--   (@atomically@ there is a method of the @io-sim-classes:MonadSTM@ class).
+--
+--   I think that approximately doubles the benefit, since I think a
+--   unspecialized class method call is an additional ENT_DYN_FUN_DIRECT. (The
+--   same @atomically@ is being used elsewhere in the real code's scope, so the
+--   optimization does not additionally eliminate the dictionary passing nor
+--   the method lookup.)
+--
+-- o The real code also has the shape @atomically (foo i <$> readTVar var)@.
+--   The @var@ could float out to be shared by each call to @atomically@, but
+--   the @i@ cannot. Moreover, because of the ad-hoc polymorphism, GHC cannot
+--   float the entire @(foo i <$> _)@ wrapper outside of the @atomically@, even
+--   though that'd be sound for the concrete 'IO'/'STM' monad (TODO I'm
+--   /assuming/ GHC does it in that case, but I have not checked).
+--
+--   This microbenchmark shared the argument of 'atomically' among all calls to
+--   it, but the real code cannot. Thus, I think the optimization also saves
+--   one heap allocation per call in the real code. HOWEVER, there are still
+--   some heap allocations per call after the optimization in the real code, so
+--   perhaps eg the heap check count wouldn't change.
+--
+-- Thus, in summary, this microbenchmark is essentially assessing exactly the
+-- cost of the @atomically#@ primop. I do think the diff has benefits beyond
+-- elminated that primop call in the real code. However, eliminating that
+-- primop call was the most mysterious to me, so this microbenchmark at least
+-- helps approximates its benefit: "hundreds of nanoseconds, no inherent change
+-- to heap allocation".
+
+module MicroReadTVarIO (main) where
+
+import Control.Concurrent.STM (TVar, atomically, newTVarIO, readTVar, readTVarIO)
+import System.Environment (getArgs)
+import Text.Read (readMaybe)
+
+-----
+
+-- We choose at run-time in order to avoid having two different binary files.
+-- Same reason for using argument strings of the same length.
+
+main :: IO ()
+main = getArgs >>= \case
+    [[c]]
+      | 'O' <- c ->   optimized
+      | 'U' <- c -> unoptimized
+    _    -> fail "$1 must be O or U"
+
+-- We do not parse 'numRepetitions' at run-time, because different input
+-- strings lead to variations in the +RTS -s bytes allocated metric, which is
+-- confusing/distracting.
+
+-- I chose one hundred million because it causes the faster one to take more
+-- than 99ms on my machine, since the RTS MUT time is not more granular than
+-- 1ms. Please increase it if your machine is faster than mine.
+--
+-- Furthermore, powers of 10 make the absolute durations and the ticky counts
+-- more legible than do eg powers of 2.
+
+numRepetitions :: Int
+numRepetitions = 10^8
+
+-----
+
+-- We use NOINLINE to prevent duplication in the resulting GHC Core.
+
+{-# NOINLINE unoptimized #-}
+unoptimized :: IO ()
+unoptimized = run (atomically . readTVar)
+
+{-# NOINLINE optimized #-}
+optimized :: IO ()
+optimized = run readTVarIO
+
+-----
+
+data Dummy = Dummy
+
+-- We did a Static-Argument Transform so that 'run' can be inlined.
+
+-- We use explicit lambdas so that it will definitely inline, since the GHC's
+-- inlining behavior directly depends on the number of arguments to the left of
+-- the equals sign.
+
+-- GHC's defaults do already inline 'run', but moreover: it is our explicit
+-- intention to do so.
+
+-- We are strict in f to eliminate noise in the resulting GHC Core. Same for
+-- -dsuppress-all.
+
+{-# INLINE run #-}
+run :: (TVar Dummy -> IO Dummy) -> IO ()
+run = \f -> f `seq` do
+    var <- newTVarIO Dummy
+    let
+        -- merely repeat the call to f n times
+        go 0 = pure ()
+        go i = do _ <- f var; go (i - 1)
+    go numRepetitions

--- a/docs/technical-reports/readTVarIO-optimization/MicroReadTVarIO2.hs
+++ b/docs/technical-reports/readTVarIO-optimization/MicroReadTVarIO2.hs
@@ -1,0 +1,107 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeFamilyDependencies #-}
+
+-- Execute these lines at the bash prompt.
+--
+-- > $ bash do-ticky MicroReadTVarIO2
+-- > $ bash do-timing MicroReadTVarIO2
+--
+-- And refer to
+-- <https://gitlab.haskell.org/ghc/ghc/-/wikis/debugging/ticky-ticky> for the
+-- semantics.
+
+-- This file is a follow-up to @MicroReadTVarIO.hs@. It addresses the
+-- discrepancies between that mircobenchmark---which is /extremely/ focused on
+-- the @atomically#@ primpop---and the actual Ouroboros Consensus code change
+-- (at
+-- <https://github.com/input-output-hk/ouroboros-consensus/commit/ea76c4662743e129bf56d206fd212e2fe45685c9>)
+-- that we're trying to assess.
+--
+-- In particular, it introduces ad-hoc polymorphism in the monad, as well as an
+-- @fmap@-ish context within the transaction.
+
+-- My interpretation:
+--
+-- In constrast to @MicroReadTVarIO.hs@, this microbenchmark does show an
+-- reduction in heap allocation. But it's exactly 48 bytes per call. Slightly
+-- more time is saved, but it's the same order of magnitude: approximately 40
+-- nanoseconds per call (70 nanoseconds unoptimized, 29 nanoseconds optimized).
+--
+-- One caveat: I disabled garbage collection during the ticky run by passing
+-- -A2.5G. On the other head, I did not pass -A2.5G in the batch of 30 runs,
+-- since both versions were significantly faster /without/ that flag. (I'm
+-- assuming it was OS overhead in fielding such a large allocation all at
+-- once?)
+
+module MicroReadTVarIO2 (main) where
+
+import qualified Control.Concurrent.STM as Real (STM, TVar, atomically, newTVarIO, readTVar, readTVarIO)
+import           Data.Kind (Type)
+import           GHC.Exts (Int(I#), Int#)
+import           System.Environment (getArgs)
+import           Text.Read (readMaybe)
+
+-----
+
+main :: IO ()
+main = getArgs >>= \case
+    [[c]]
+      | 'O' <- c -> run   optimized
+      | 'U' <- c -> run unoptimized
+    _    -> fail "$1 must be O or U"
+
+-- I chose ten million because it causes the faster one to take more than 99ms
+-- on my machine, since the RTS MUT time is not more granular than 1ms. Please
+-- increase it if your machine is faster than mine.
+--
+-- Furthermore, powers of 10 make the absolute durations and the ticky counts
+-- more legible than do eg powers of 2.
+
+numRepetitions :: Int
+numRepetitions = 10^7
+
+-----
+
+{-# NOINLINE unoptimized #-}
+unoptimized :: MonadSTM m => Int# -> TVar m Dummy -> m Dummy
+unoptimized = \i# var -> atomically (foo i# <$> readTVar var)
+
+{-# NOINLINE optimized #-}
+optimized :: MonadSTM m => Int# -> TVar m Dummy -> m Dummy
+optimized = \i# var -> foo i# <$> readTVarIO var
+
+-----
+
+data Dummy = Dummy | Dummy2
+
+foo :: Int# -> Dummy -> Dummy   -- an analog of @mkCurrentBlockContext@
+foo 999# d = d
+foo _i#  d = d `seq` Dummy2
+
+{-# INLINE run #-}
+run :: (Int# -> Real.TVar Dummy -> IO Dummy) -> IO ()
+run = \f -> do
+    var <- Real.newTVarIO Dummy
+    let
+        go 0 = return ()
+        go i@(I# i#) = do _ <- f i# var; go (i - 1)
+    go numRepetitions
+
+-----
+
+class (Monad m, Monad (STM m)) => MonadSTM m where
+  type STM  m = (stm :: Type -> Type) | stm -> m
+  type TVar m :: Type -> Type
+  atomically  :: STM m a -> m a
+  readTVar    :: TVar m a -> STM m a
+  readTVarIO  :: TVar m a -> m a
+
+instance MonadSTM IO where
+  type STM  IO = Real.STM
+  type TVar IO = Real.TVar
+  atomically   = Real.atomically
+  readTVar     = Real.readTVar
+  readTVarIO   = Real.readTVarIO

--- a/docs/technical-reports/readTVarIO-optimization/README.md
+++ b/docs/technical-reports/readTVarIO-optimization/README.md
@@ -1,0 +1,42 @@
+# Introduction
+
+The goal of the microbenchmarks in this directory is to demystify the consequences of replacing an `atomically . readTVar` with `readTVarIO`.
+In particular, a benchmarking run reported in [this #perf-announce message](https://input-output-rnd.slack.com/archives/C4Q7MF25U/p1698842470166369) on the IOG Slack shows that the system-level benchmarks indicate that [making that change in the `forkBlockForging` function](https://github.com/input-output-hk/ouroboros-consensus/commit/ea76c4662743e129bf56d206fd212e2fe45685c9) yields an improvement on the order of 10% CPU usage and 10% allocation compare to the baseline of `8.5.0-pre` (circa 2023 Nov 1).
+Those improvements are far greater than the Consensus Team was expecting, so we've begun investigating.
+These microbenchmarks are a first step.
+
+# Simple Case
+
+In the simplest possible case, the `atomically . readTVar` variant costs about 20 nanoseconds more to call (21.7 nanoseconds unoptimized, 1.37 nanoseconds optimized) than does the equivalent `readTVarIO`.
+It does not incur any extra allocation---which is unexpected.
+Duncan Coutts looked at the RTS code and remarked that the transaction log data structure has its own free-list, so I presume its allocator is working perfectly for these microbenchmarks, thus avoiding any extra heap allocation.
+I don't know whether that is happening in the real code or not (which does involve at least two STM transactions in sequence, in the typical case).
+
+# More Realistic Case
+
+The real code does not match that simplest case, for at least two reasons.
+
+- It's part of a top-level declaration that will neither be specialized nor inlined into a context in which the monad is monomorphic.
+  Hence its run-time behavior involves dictionary-passing.
+
+- The transaction of interset is actually of the shape `atomically (foo i <$> readTVar var)`, where the `i` cannot be floated out of the loop.
+  This means the closure allocated as the argument to `atomically` must be allocated fresh each time.
+  The optimized `foo i <$> readTVarIO var` avoids at least that closure.
+
+The second benchmark file is intended to replicate those two aspects of the real code.
+In contrast to the simplest case, this more realistic microbenchmark does show a reduction in heap allocation.
+It's exactly 48 bytes per call (as determined via [ticky ticky profiling](https://gitlab.haskell.org/ghc/ghc/-/wikis/debugging/ticky-ticky)).
+Slightly more time is saved per call, but it's the same order of magnitude: approximately 40 nanoseconds per call (70 nanoseconds unoptimized, 29 nanoseconds optimized).
+
+# Conclusion
+
+For a system-level benchmark that runs for a total of 54000 seconds, these microbenchmarks indicate that this particular manual optimization in a function that is called at most once per second cannot be directly responsible for a CPU usage/allocation savings on the order of 10%.
+In particular, _full_ blocks are allocated/parsed/propagated/etc fresh an average of once per 20 seconds.
+If the 48 bytes per second accounts for 10% of allocation, then blocks would have to be less than 20 * .90 * (48 / .10) = 8640 bytes.
+Even just their serialized bytes are are much greater than that, not to even consider their parsed heap footprint, etc.
+
+The system-level benchmarks are generally quite reproducible, as evidenced by occasional variance analaysis runs (repeats of the same run showing final stats within 1 millisecond, eg).
+So it seems likely that there is in fact a savings on the order of 10%.
+But our working hypothesis is that that savings is only indirectly cause by this particular manual optimization.
+
+Unfortunately, so far, we haven't come up with any possible explanations more specific than the usual suspects: the GHC garbage collector is complicated, work-stealing is complicated, instruction caches are powerful, and so on.

--- a/docs/technical-reports/readTVarIO-optimization/catch-compile1.txt
+++ b/docs/technical-reports/readTVarIO-optimization/catch-compile1.txt
@@ -1,0 +1,188 @@
+[1 of 1] Compiling MicroReadTVarIO  ( MicroReadTVarIO.hs, MicroReadTVarIO.o )
+
+==================== Tidy Core ====================
+Result size of Tidy Core
+  = {terms: 276, types: 298, coercions: 29, joins: 4/5}
+
+-- RHS size: {terms: 1, types: 0, coercions: 0, joins: 0/0}
+lvl_r32z = "Negative exponent"#
+
+-- RHS size: {terms: 3, types: 2, coercions: 0, joins: 0/0}
+$s^1 = errorWithoutStackTrace (unpackCString# lvl_r32z)
+
+-- RHS size: {terms: 1, types: 0, coercions: 0, joins: 0/0}
+$seven1 = 2
+
+-- RHS size: {terms: 1, types: 0, coercions: 0, joins: 0/0}
+lvl1_r32A = 1
+
+-- RHS size: {terms: 1, types: 0, coercions: 0, joins: 0/0}
+$s^2 = 0
+
+Rec {
+-- RHS size: {terms: 38, types: 5, coercions: 0, joins: 0/0}
+$wg1_r32B
+  = \ ww_s2YI w_s2YE ww1_s2YM ->
+      case eqInteger# (remInteger w_s2YE $seven1) $s^2 of {
+        __DEFAULT ->
+          case eqInteger# w_s2YE lvl1_r32A of {
+            __DEFAULT ->
+              $wg1_r32B
+                (*# ww_s2YI ww_s2YI)
+                (quotInteger w_s2YE $seven1)
+                (*# ww_s2YI ww1_s2YM);
+            1# -> *# ww_s2YI ww1_s2YM
+          };
+        1# ->
+          $wg1_r32B
+            (*# ww_s2YI ww_s2YI) (quotInteger w_s2YE $seven1) ww1_s2YM
+      }
+end Rec }
+
+Rec {
+-- RHS size: {terms: 32, types: 4, coercions: 0, joins: 0/0}
+$wf
+  = \ ww_s2YW w_s2YT ->
+      case eqInteger# (remInteger w_s2YT $seven1) $s^2 of {
+        __DEFAULT ->
+          case eqInteger# w_s2YT lvl1_r32A of {
+            __DEFAULT ->
+              $wg1_r32B
+                (*# ww_s2YW ww_s2YW) (quotInteger w_s2YT $seven1) ww_s2YW;
+            1# -> ww_s2YW
+          };
+        1# -> $wf (*# ww_s2YW ww_s2YW) (quotInteger w_s2YT $seven1)
+      }
+end Rec }
+
+-- RHS size: {terms: 23, types: 7, coercions: 0, joins: 0/0}
+$w$s^
+  = \ w_s2Z2 w1_s2Z3 ->
+      case ltInteger# w1_s2Z3 $s^2 of {
+        __DEFAULT ->
+          case eqInteger# w1_s2Z3 $s^2 of {
+            __DEFAULT ->
+              case w_s2Z2 of { I# ww1_s2YW -> $wf ww1_s2YW w1_s2Z3 };
+            1# -> 1#
+          };
+        1# -> case $s^1 of wild1_00 { }
+      }
+
+-- RHS size: {terms: 2, types: 0, coercions: 0, joins: 0/0}
+lvl2_r32C = I# 10#
+
+-- RHS size: {terms: 1, types: 0, coercions: 0, joins: 0/0}
+lvl3_r32D = 8
+
+-- RHS size: {terms: 7, types: 1, coercions: 0, joins: 0/0}
+numRepetitions_rkb
+  = case $w$s^ lvl2_r32C lvl3_r32D of ww_s2Z6 { __DEFAULT ->
+    I# ww_s2Z6
+    }
+
+-- RHS size: {terms: 43, types: 83, coercions: 0, joins: 2/3}
+unoptimized1_r32E
+  = \ s_a2qh ->
+      case newTVar# Dummy s_a2qh of { (# ipv_a2qq, ipv1_a2qr #) ->
+      let { lvl4_s2Uy = \ eta_a2rv -> readTVar# ipv1_a2qr eta_a2rv } in
+      joinrec {
+        $wgo_s2Ze ww_s2Zc w_s2Z9
+          = case ww_s2Zc of wild_XP {
+              __DEFAULT ->
+                case atomically# lvl4_s2Uy w_s2Z9 of
+                { (# ipv2_X2qL, ipv3_X2qN #) ->
+                jump $wgo_s2Ze (-# wild_XP 1#) ipv2_X2qL
+                };
+              0# -> (# w_s2Z9, () #)
+            }; } in
+      join {
+        go_s2SI w_s2Z8 w1_s2Z9
+          = case w_s2Z8 of { I# ww1_s2Zc ->
+            jump $wgo_s2Ze ww1_s2Zc w1_s2Z9
+            } } in
+      jump go_s2SI numRepetitions_rkb ipv_a2qq
+      }
+
+-- RHS size: {terms: 1, types: 0, coercions: 3, joins: 0/0}
+unoptimized = unoptimized1_r32E `cast` <Co:3>
+
+-- RHS size: {terms: 38, types: 70, coercions: 0, joins: 2/2}
+optimized1_r32F
+  = \ s_X2qz ->
+      case newTVar# Dummy s_X2qz of { (# ipv_a2qq, ipv1_a2qr #) ->
+      joinrec {
+        $wgo_s2Zm ww_s2Zk w_s2Zh
+          = case ww_s2Zk of wild_XP {
+              __DEFAULT ->
+                case readTVarIO# ipv1_a2qr w_s2Zh of
+                { (# ipv2_X2qL, ipv3_X2qN #) ->
+                jump $wgo_s2Zm (-# wild_XP 1#) ipv2_X2qL
+                };
+              0# -> (# w_s2Zh, () #)
+            }; } in
+      join {
+        go_s2SG w_s2Zg w1_s2Zh
+          = case w_s2Zg of { I# ww1_s2Zk ->
+            jump $wgo_s2Zm ww1_s2Zk w1_s2Zh
+            } } in
+      jump go_s2SG numRepetitions_rkb ipv_a2qq
+      }
+
+-- RHS size: {terms: 1, types: 0, coercions: 3, joins: 0/0}
+optimized = optimized1_r32F `cast` <Co:3>
+
+-- RHS size: {terms: 1, types: 0, coercions: 0, joins: 0/0}
+main4 = "$1 must be O or U"#
+
+-- RHS size: {terms: 2, types: 0, coercions: 0, joins: 0/0}
+main3 = unpackCString# main4
+
+-- RHS size: {terms: 3, types: 3, coercions: 0, joins: 0/0}
+main2 = noinline mkUserError main3
+
+-- RHS size: {terms: 51, types: 52, coercions: 14, joins: 0/0}
+main1
+  = \ s_X2qC ->
+      case ((allocaBytesAligned
+               $fStorableBool7 $fStorableBool7 (getArgs1 `cast` <Co:7>))
+            `cast` <Co:3>)
+             s_X2qC
+      of
+      { (# ipv_a2qj, ipv1_a2qk #) ->
+      case ipv1_a2qk of {
+        [] -> raiseIO# main2 ipv_a2qj;
+        : ds_d2pc ds2_d2pd ->
+          case ds_d2pc of {
+            [] -> raiseIO# main2 ipv_a2qj;
+            : c_aCi ds3_d2pe ->
+              case ds3_d2pe of {
+                [] ->
+                  case ds2_d2pd of {
+                    [] ->
+                      case c_aCi of { C# ds4_d2oC ->
+                      case ds4_d2oC of {
+                        __DEFAULT -> raiseIO# main2 ipv_a2qj;
+                        'O'# -> (optimized `cast` <Co:2>) ipv_a2qj;
+                        'U'# -> (unoptimized `cast` <Co:2>) ipv_a2qj
+                      }
+                      };
+                    : ipv2_s2DF ipv3_s2DJ -> raiseIO# main2 ipv_a2qj
+                  };
+                : ipv2_s2DD ipv3_s2DL -> raiseIO# main2 ipv_a2qj
+              }
+          }
+      }
+      }
+
+-- RHS size: {terms: 1, types: 0, coercions: 3, joins: 0/0}
+main = main1 `cast` <Co:3>
+
+-- RHS size: {terms: 2, types: 1, coercions: 3, joins: 0/0}
+main5 = runMainIO1 (main1 `cast` <Co:3>)
+
+-- RHS size: {terms: 1, types: 0, coercions: 3, joins: 0/0}
+main = main5 `cast` <Co:3>
+
+
+
+Linking MicroReadTVarIO ...

--- a/docs/technical-reports/readTVarIO-optimization/catch-compile2.txt
+++ b/docs/technical-reports/readTVarIO-optimization/catch-compile2.txt
@@ -1,0 +1,246 @@
+[1 of 1] Compiling MicroReadTVarIO2 ( MicroReadTVarIO2.hs, MicroReadTVarIO2.o )
+
+==================== Tidy Core ====================
+Result size of Tidy Core
+  = {terms: 357, types: 597, coercions: 130, joins: 4/6}
+
+-- RHS size: {terms: 6, types: 32, coercions: 0, joins: 0/0}
+$p1MonadSTM
+  = \ @ m_amB v_B1 ->
+      case v_B1 of v_B1 { C:MonadSTM v_B2 v_B3 v_B4 v_B5 v_B6 -> v_B2 }
+
+-- RHS size: {terms: 6, types: 32, coercions: 0, joins: 0/0}
+$p2MonadSTM
+  = \ @ m_amB v_B1 ->
+      case v_B1 of v_B1 { C:MonadSTM v_B2 v_B3 v_B4 v_B5 v_B6 -> v_B3 }
+
+-- RHS size: {terms: 6, types: 32, coercions: 0, joins: 0/0}
+atomically
+  = \ @ m_amB v_B1 ->
+      case v_B1 of v_B1 { C:MonadSTM v_B2 v_B3 v_B4 v_B5 v_B6 -> v_B4 }
+
+-- RHS size: {terms: 6, types: 32, coercions: 0, joins: 0/0}
+readTVar
+  = \ @ m_amB v_B1 ->
+      case v_B1 of v_B1 { C:MonadSTM v_B2 v_B3 v_B4 v_B5 v_B6 -> v_B5 }
+
+-- RHS size: {terms: 6, types: 32, coercions: 0, joins: 0/0}
+readTVarIO
+  = \ @ m_amB v_B1 ->
+      case v_B1 of v_B1 { C:MonadSTM v_B2 v_B3 v_B4 v_B5 v_B6 -> v_B6 }
+
+-- RHS size: {terms: 1, types: 0, coercions: 0, joins: 0/0}
+lvl_r3bV = "Negative exponent"#
+
+-- RHS size: {terms: 3, types: 2, coercions: 0, joins: 0/0}
+$s^1 = errorWithoutStackTrace (unpackCString# lvl_r3bV)
+
+-- RHS size: {terms: 1, types: 0, coercions: 0, joins: 0/0}
+$seven1 = 2
+
+-- RHS size: {terms: 1, types: 0, coercions: 0, joins: 0/0}
+lvl1_r3bW = 1
+
+-- RHS size: {terms: 1, types: 0, coercions: 0, joins: 0/0}
+$s^2 = 0
+
+Rec {
+-- RHS size: {terms: 38, types: 5, coercions: 0, joins: 0/0}
+$wg1_r3bX
+  = \ ww_s35T w_s35P ww1_s35X ->
+      case eqInteger# (remInteger w_s35P $seven1) $s^2 of {
+        __DEFAULT ->
+          case eqInteger# w_s35P lvl1_r3bW of {
+            __DEFAULT ->
+              $wg1_r3bX
+                (*# ww_s35T ww_s35T)
+                (quotInteger w_s35P $seven1)
+                (*# ww_s35T ww1_s35X);
+            1# -> *# ww_s35T ww1_s35X
+          };
+        1# ->
+          $wg1_r3bX
+            (*# ww_s35T ww_s35T) (quotInteger w_s35P $seven1) ww1_s35X
+      }
+end Rec }
+
+Rec {
+-- RHS size: {terms: 32, types: 4, coercions: 0, joins: 0/0}
+$wf
+  = \ ww_s367 w_s364 ->
+      case eqInteger# (remInteger w_s364 $seven1) $s^2 of {
+        __DEFAULT ->
+          case eqInteger# w_s364 lvl1_r3bW of {
+            __DEFAULT ->
+              $wg1_r3bX
+                (*# ww_s367 ww_s367) (quotInteger w_s364 $seven1) ww_s367;
+            1# -> ww_s367
+          };
+        1# -> $wf (*# ww_s367 ww_s367) (quotInteger w_s364 $seven1)
+      }
+end Rec }
+
+-- RHS size: {terms: 23, types: 7, coercions: 0, joins: 0/0}
+$w$s^
+  = \ w_s36d w1_s36e ->
+      case ltInteger# w1_s36e $s^2 of {
+        __DEFAULT ->
+          case eqInteger# w1_s36e $s^2 of {
+            __DEFAULT ->
+              case w_s36d of { I# ww1_s367 -> $wf ww1_s367 w1_s36e };
+            1# -> 1#
+          };
+        1# -> case $s^1 of wild1_00 { }
+      }
+
+-- RHS size: {terms: 6, types: 1, coercions: 42, joins: 0/0}
+$fMonadSTMIO
+  = C:MonadSTM
+      $fMonadIO
+      ($fMonadSTM `cast` <Co:3>)
+      (atomically# `cast` <Co:14>)
+      (readTVar1 `cast` <Co:15>)
+      (readTVarIO1 `cast` <Co:10>)
+
+-- RHS size: {terms: 18, types: 30, coercions: 0, joins: 0/0}
+$woptimized
+  = \ @ m_s36j ww_s36y ww1_s372 w_s36l w1_s36m ->
+      ww_s36y
+        (\ d_aJN ->
+           case w_s36l of {
+             __DEFAULT -> case d_aJN of { __DEFAULT -> Dummy2 };
+             999# -> d_aJN
+           })
+        (ww1_s372 w1_s36m)
+
+-- RHS size: {terms: 23, types: 37, coercions: 0, joins: 0/0}
+$wunoptimized
+  = \ @ m_s375 ww_s37c ww1_s37d ww2_s37e w_s377 w1_s378 ->
+      ww1_s37d
+        (fmap
+           ($p1Applicative ($p1Monad ww_s37c))
+           (\ d_aJN ->
+              case w_s377 of {
+                __DEFAULT -> case d_aJN of { __DEFAULT -> Dummy2 };
+                999# -> d_aJN
+              })
+           (ww2_s37e w1_s378))
+
+-- RHS size: {terms: 2, types: 0, coercions: 0, joins: 0/0}
+main3 = I# 10#
+
+-- RHS size: {terms: 1, types: 0, coercions: 0, joins: 0/0}
+main2 = 7
+
+-- RHS size: {terms: 7, types: 1, coercions: 0, joins: 0/0}
+numRepetitions
+  = case $w$s^ main3 main2 of ww_s36h { __DEFAULT -> I# ww_s36h }
+
+-- RHS size: {terms: 1, types: 0, coercions: 0, joins: 0/0}
+main6 = "$1 must be O or U"#
+
+-- RHS size: {terms: 2, types: 0, coercions: 0, joins: 0/0}
+main5 = unpackCString# main6
+
+-- RHS size: {terms: 3, types: 3, coercions: 0, joins: 0/0}
+main4 = noinline mkUserError main5
+
+-- RHS size: {terms: 134, types: 192, coercions: 79, joins: 4/6}
+main1
+  = \ s_a2yT ->
+      case ((allocaBytesAligned
+               $fStorableBool7 $fStorableBool7 (getArgs1 `cast` <Co:7>))
+            `cast` <Co:3>)
+             s_a2yT
+      of
+      { (# ipv_a2yV, ipv1_a2yW #) ->
+      case ipv1_a2yW of {
+        [] -> raiseIO# main4 ipv_a2yV;
+        : ds_d2xh ds2_d2xi ->
+          case ds_d2xh of {
+            [] -> raiseIO# main4 ipv_a2yV;
+            : c_aEJ ds3_d2xj ->
+              case ds3_d2xj of {
+                [] ->
+                  case ds2_d2xi of {
+                    [] ->
+                      case c_aEJ of { C# ds4_d2wH ->
+                      case ds4_d2wH of {
+                        __DEFAULT -> raiseIO# main4 ipv_a2yV;
+                        'O'# ->
+                          case newTVar# Dummy ipv_a2yV of { (# ipv2_a2z2, ipv3_a2z3 #) ->
+                          let { var_s307 = TVar ipv3_a2z3 } in
+                          joinrec {
+                            $wgo_s37p ww_s37n w_s37k
+                              = case ww_s37n of ds7_X28y {
+                                  __DEFAULT ->
+                                    case (($woptimized
+                                             ($fFunctorIO2 `cast` <Co:15>)
+                                             (readTVarIO1 `cast` <Co:10>)
+                                             ds7_X28y
+                                             (var_s307 `cast` <Co:4>))
+                                          `cast` <Co:2>)
+                                           w_s37k
+                                    of
+                                    { (# ipv4_X2zx, ipv5_X2zz #) ->
+                                    jump $wgo_s37p (-# ds7_X28y 1#) ipv4_X2zx
+                                    };
+                                  0# -> (# w_s37k, () #)
+                                }; } in
+                          join {
+                            go_s306 w_s37j w1_s37k
+                              = case w_s37j of { I# ww1_s37n ->
+                                jump $wgo_s37p ww1_s37n w1_s37k
+                                } } in
+                          jump go_s306 numRepetitions ipv2_a2z2
+                          };
+                        'U'# ->
+                          case newTVar# Dummy ipv_a2yV of { (# ipv2_a2z2, ipv3_a2z3 #) ->
+                          let { var_s30b = TVar ipv3_a2z3 } in
+                          joinrec {
+                            $wgo_s37w ww_s37u w_s37r
+                              = case ww_s37u of ds7_X28y {
+                                  __DEFAULT ->
+                                    case (($wunoptimized
+                                             ($fMonadSTM `cast` <Co:3>)
+                                             (atomically# `cast` <Co:14>)
+                                             (readTVar1 `cast` <Co:15>)
+                                             ds7_X28y
+                                             (var_s30b `cast` <Co:4>))
+                                          `cast` <Co:2>)
+                                           w_s37r
+                                    of
+                                    { (# ipv4_X2zx, ipv5_X2zz #) ->
+                                    jump $wgo_s37w (-# ds7_X28y 1#) ipv4_X2zx
+                                    };
+                                  0# -> (# w_s37r, () #)
+                                }; } in
+                          join {
+                            go_s30a w_s37q w1_s37r
+                              = case w_s37q of { I# ww1_s37u ->
+                                jump $wgo_s37w ww1_s37u w1_s37r
+                                } } in
+                          jump go_s30a numRepetitions ipv2_a2z2
+                          }
+                      }
+                      };
+                    : ipv2_s2La ipv3_s2Lo -> raiseIO# main4 ipv_a2yV
+                  };
+                : ipv2_s2L8 ipv3_s2Lq -> raiseIO# main4 ipv_a2yV
+              }
+          }
+      }
+      }
+
+-- RHS size: {terms: 1, types: 0, coercions: 3, joins: 0/0}
+main = main1 `cast` <Co:3>
+
+-- RHS size: {terms: 2, types: 1, coercions: 3, joins: 0/0}
+main7 = runMainIO1 (main1 `cast` <Co:3>)
+
+-- RHS size: {terms: 1, types: 0, coercions: 3, joins: 0/0}
+main = main7 `cast` <Co:3>
+
+
+
+Linking MicroReadTVarIO2 ...

--- a/docs/technical-reports/readTVarIO-optimization/do-ticky.sh
+++ b/docs/technical-reports/readTVarIO-optimization/do-ticky.sh
@@ -1,0 +1,8 @@
+(
+set -eu
+ghc -O --make -main-is "$1" "$1.hs" -rtsopts -fforce-recomp -ticky -ddump-simpl -dsuppress-all -dno-typeable-binds 2>&1 | cat >catch-compile.txt
+for w in U O; do
+    "./$1" "$w" +RTS -A2.5G -s -r"${w}.ticky" 2>"${w}.rts"
+done
+diff <(cat U.{ticky,rts}) <(cat O.{ticky,rts}) | tee catch-diff.txt
+)

--- a/docs/technical-reports/readTVarIO-optimization/do-timing.sh
+++ b/docs/technical-reports/readTVarIO-optimization/do-timing.sh
@@ -1,0 +1,9 @@
+(
+set -eu
+ghc -O --make -main-is "$1" "$1.hs" -rtsopts 2>&1 -fforce-recomp
+for i in $(seq 30); do
+    for w in U O; do
+        "./$1" "$w" +RTS -s 2>&1
+    done
+done | grep -e 'MUT     time'
+)


### PR DESCRIPTION
A microbenchmark investigation of the benefits of `readTVarIO` versus `atomically . readTVar`. See the directory's `README.md` for the motivation.