### PR TITLE
A generator of schedules for Genesis tests

### DIFF
--- a/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
+++ b/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
@@ -234,6 +234,7 @@ test-suite consensus-test
     Test.Consensus.PeerSimulator.Resources
     Test.Consensus.PeerSimulator.Run
     Test.Consensus.PeerSimulator.ScheduledChainSyncServer
+    Test.Consensus.PeerSimulator.StateView
     Test.Consensus.PeerSimulator.Trace
     Test.Consensus.PointSchedule
 

--- a/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
+++ b/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
@@ -240,6 +240,9 @@ test-suite consensus-test
     Test.Consensus.PeerSimulator.Tests.Timeouts
     Test.Consensus.PeerSimulator.Trace
     Test.Consensus.PointSchedule
+    Test.Consensus.PointSchedule.SinglePeer
+    Test.Consensus.PointSchedule.SinglePeer.Indices
+    Test.Consensus.PointSchedule.Tests
 
   build-depends:
     , base
@@ -268,6 +271,7 @@ test-suite consensus-test
     , QuickCheck
     , quickcheck-state-machine:no-vendored-treediff
     , quiet
+    , random
     , serialise
     , si-timers
     , sop-extras

--- a/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
+++ b/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
@@ -229,11 +229,14 @@ test-suite consensus-test
     Test.Consensus.Network.Driver.Limits.Extras
     Test.Consensus.Node
     Test.Consensus.PeerSimulator.BlockFetch
+    Test.Consensus.PeerSimulator.ChainSync
     Test.Consensus.PeerSimulator.Config
     Test.Consensus.PeerSimulator.Handlers
     Test.Consensus.PeerSimulator.Resources
     Test.Consensus.PeerSimulator.Run
+    Test.Consensus.PeerSimulator.ScheduledBlockFetchServer
     Test.Consensus.PeerSimulator.ScheduledChainSyncServer
+    Test.Consensus.PeerSimulator.ScheduledServer
     Test.Consensus.PeerSimulator.StateView
     Test.Consensus.PeerSimulator.Tests
     Test.Consensus.PeerSimulator.Tests.Rollback

--- a/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
+++ b/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
@@ -235,6 +235,8 @@ test-suite consensus-test
     Test.Consensus.PeerSimulator.Run
     Test.Consensus.PeerSimulator.ScheduledChainSyncServer
     Test.Consensus.PeerSimulator.StateView
+    Test.Consensus.PeerSimulator.Tests
+    Test.Consensus.PeerSimulator.Tests.Timeouts
     Test.Consensus.PeerSimulator.Trace
     Test.Consensus.PointSchedule
 

--- a/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
+++ b/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
@@ -236,6 +236,7 @@ test-suite consensus-test
     Test.Consensus.PeerSimulator.ScheduledChainSyncServer
     Test.Consensus.PeerSimulator.StateView
     Test.Consensus.PeerSimulator.Tests
+    Test.Consensus.PeerSimulator.Tests.Rollback
     Test.Consensus.PeerSimulator.Tests.Timeouts
     Test.Consensus.PeerSimulator.Trace
     Test.Consensus.PointSchedule

--- a/ouroboros-consensus-diffusion/test/consensus-test/Main.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Main.hs
@@ -4,6 +4,7 @@ import qualified Test.Consensus.Genesis.Tests (tests)
 import qualified Test.Consensus.GSM (tests)
 import qualified Test.Consensus.HardFork.Combinator (tests)
 import qualified Test.Consensus.Node (tests)
+import qualified Test.Consensus.PeerSimulator.Tests (tests)
 import           Test.Tasty
 import           Test.Util.TestEnv (defaultMainWithTestEnv,
                      defaultTestEnvConfig)
@@ -22,4 +23,5 @@ tests =
       ]
   , Test.Consensus.Genesis.Tests.tests
   , testGroup "GSM" Test.Consensus.GSM.tests
+  , Test.Consensus.PeerSimulator.Tests.tests
   ]

--- a/ouroboros-consensus-diffusion/test/consensus-test/Main.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Main.hs
@@ -5,6 +5,7 @@ import qualified Test.Consensus.GSM (tests)
 import qualified Test.Consensus.HardFork.Combinator (tests)
 import qualified Test.Consensus.Node (tests)
 import qualified Test.Consensus.PeerSimulator.Tests (tests)
+import qualified Test.Consensus.PointSchedule.Tests (tests)
 import           Test.Tasty
 import           Test.Util.TestEnv (defaultMainWithTestEnv,
                      defaultTestEnvConfig)
@@ -24,4 +25,5 @@ tests =
   , Test.Consensus.Genesis.Tests.tests
   , testGroup "GSM" Test.Consensus.GSM.tests
   , Test.Consensus.PeerSimulator.Tests.tests
+  , Test.Consensus.PointSchedule.Tests.tests
   ]

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/BlockTree.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/BlockTree.hs
@@ -43,9 +43,10 @@ import           Text.Printf (printf)
 --
 -- INVARIANT: @btbFull == fromJust $ AF.join btbPrefix btbSuffix@.
 data BlockTreeBranch blk = BlockTreeBranch {
-    btbPrefix :: AF.AnchoredFragment blk,
-    btbSuffix :: AF.AnchoredFragment blk,
-    btbFull   :: AF.AnchoredFragment blk
+    btbPrefix      :: AF.AnchoredFragment blk,
+    btbSuffix      :: AF.AnchoredFragment blk,
+    btbTrunkSuffix :: AF.AnchoredFragment blk,
+    btbFull        :: AF.AnchoredFragment blk
   }
   deriving (Show)
 
@@ -88,7 +89,7 @@ mkTrunk btTrunk = BlockTree { btTrunk, btBranches = [] }
 -- block in common with an existing branch.
 addBranch :: AF.HasHeader blk => AF.AnchoredFragment blk -> BlockTree blk -> Maybe (BlockTree blk)
 addBranch branch bt = do
-  (_, btbPrefix, _, btbSuffix) <- AF.intersect (btTrunk bt) branch
+  (btbPrefix, _, btbTrunkSuffix, btbSuffix) <- AF.intersect (btTrunk bt) branch
   -- NOTE: We could use the monadic bind for @Maybe@ here but we would rather
   -- catch bugs quicker.
   let btbFull = fromJust $ AF.join btbPrefix btbSuffix

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup/Classifiers.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup/Classifiers.hs
@@ -20,8 +20,10 @@ import           Test.Util.Orphans.IOLike ()
 -- | Interesting categories to classify test inputs
 data Classifiers =
   Classifiers {
-    -- | There are more than k blocks in the alternative chain after the intersection
+    -- | There are more than k blocks in at least one alternative chain after the intersection
     existsSelectableAdversary      :: Bool,
+    -- | There are more than k blocks in all alternative chains after the intersection
+    allAdversariesSelectable       :: Bool,
     -- | There are at least scg slots after the intesection on both the honest
     -- and the alternative chain
     --
@@ -34,7 +36,7 @@ data Classifiers =
 
 classifiers :: GenesisTest -> Classifiers
 classifiers GenesisTest {gtBlockTree, gtSecurityParam = SecurityParam k, gtGenesisWindow = GenesisWindow scg} =
-  Classifiers {existsSelectableAdversary, genesisWindowAfterIntersection}
+  Classifiers {existsSelectableAdversary, allAdversariesSelectable, genesisWindowAfterIntersection}
   where
     genesisWindowAfterIntersection =
       any fragmentHasGenesis branches
@@ -47,6 +49,9 @@ classifiers GenesisTest {gtBlockTree, gtSecurityParam = SecurityParam k, gtGenes
 
     existsSelectableAdversary =
       any isSelectable branches
+
+    allAdversariesSelectable =
+      all isSelectable branches
 
     isSelectable bt = AF.length (btbSuffix bt) > fromIntegral k
 

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LongRangeAttack.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LongRangeAttack.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE BlockArguments      #-}
 {-# LANGUAGE DerivingStrategies  #-}
+{-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE NamedFieldPuns      #-}
 {-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -8,11 +9,15 @@
 module Test.Consensus.Genesis.Tests.LongRangeAttack (tests) where
 
 import           Control.Monad.IOSim (runSimOrThrow)
+import           Data.List (intercalate)
 import           Ouroboros.Consensus.Block.Abstract (HeaderHash)
+import           Ouroboros.Consensus.Util.Condense (condense)
 import           Ouroboros.Network.AnchoredFragment (headAnchor)
 import qualified Ouroboros.Network.AnchoredFragment as AF
 import           Test.Consensus.Genesis.Setup
 import           Test.Consensus.Genesis.Setup.Classifiers
+import           Test.Consensus.PeerSimulator.Run (noTimeoutsSchedulerConfig)
+import           Test.Consensus.PeerSimulator.StateView
 import           Test.Consensus.PointSchedule
 import qualified Test.QuickCheck as QC
 import           Test.QuickCheck
@@ -23,28 +28,51 @@ import           Test.Util.Orphans.IOLike ()
 import           Test.Util.TestBlock (TestBlock, unTestHash)
 
 tests :: TestTree
-tests = testProperty "long range attack" prop_longRangeAttack
+tests =
+  testGroup "long range attack" [
+    testProperty "one adversary" (prop_longRangeAttack 1 [10])
+    -- TODO we don't have useful classification logic for multiple adversaries yet – if a selectable
+    -- adversary is slow, it might be discarded before it reaches critical length because the faster
+    -- ones have served k blocks off the honest chain if their fork anchor is further down the line.
+    -- ,
+    -- testProperty "three adversaries" (prop_longRangeAttack 1 [2, 5, 10])
+  ]
 
-genChainsAndSchedule :: Word -> ScheduleType -> QC.Gen (GenesisTest, PointSchedule)
-genChainsAndSchedule numAdversaries scheduleType =
+genChainsAndSchedule :: PointScheduleConfig -> Word -> ScheduleType -> QC.Gen (GenesisTest, PointSchedule)
+genChainsAndSchedule scheduleConfig numAdversaries scheduleType =
   unsafeMapSuchThatJust do
     gt <- genChains numAdversaries
-    pure $ ((gt,) <$> genSchedule scheduleType (gtBlockTree gt))
+    pure $ ((gt,) <$> genSchedule scheduleConfig scheduleType (gtBlockTree gt))
 
-prop_longRangeAttack :: QC.Gen QC.Property
-prop_longRangeAttack = do
-  (genesisTest, schedule) <- genChainsAndSchedule 1 FastAdversary
+prop_longRangeAttack :: Int -> [Int] -> QC.Gen QC.Property
+prop_longRangeAttack honestFreq advFreqs = do
+  (genesisTest, schedule) <- genChainsAndSchedule scheduleConfig (fromIntegral (length advFreqs)) (Frequencies freqs)
   let cls = classifiers genesisTest
 
-  pure $ withMaxSuccess 10 $ runSimOrThrow $
-    runTest genesisTest schedule $ \fragment ->
-        classify (genesisWindowAfterIntersection cls) "Full genesis window after intersection"
-        -- This is the expected behavior of Praos to be reversed with Genesis.
-        -- But we are testing Praos for the moment
-        $ existsSelectableAdversary cls ==> not $ isHonestTestFragH fragment
-        -- TODO
-        -- $ not (existsSelectableAdversary cls) ==> immutableTipBeforeFork fragment
+  -- TODO: not existsSelectableAdversary ==> immutableTipBeforeFork svSelectedChain
+
+  pure $ withMaxSuccess 10 $
+    classify (genesisWindowAfterIntersection cls) "Full genesis window after intersection" $
+    allAdversariesSelectable cls
+    ==>
+    runSimOrThrow $
+      runTest
+        (noTimeoutsSchedulerConfig scheduleConfig)
+        genesisTest
+        schedule
+        $ exceptionCounterexample $ \StateView{svSelectedChain} killed ->
+            killCounterexample killed $
+            -- This is the expected behavior of Praos to be reversed with Genesis.
+            -- But we are testing Praos for the moment
+            not (isHonestTestFragH svSelectedChain)
+
   where
+    freqs = mkPeers honestFreq advFreqs
+
+    killCounterexample = \case
+      [] -> property
+      killed -> counterexample ("Some peers were killed: " ++ intercalate ", " (condense <$> killed))
+
     isHonestTestFragH :: TestFragH -> Bool
     isHonestTestFragH frag = case headAnchor frag of
         AF.AnchorGenesis   -> True
@@ -52,3 +80,5 @@ prop_longRangeAttack = do
 
     isHonestTestHeaderHash :: HeaderHash TestBlock -> Bool
     isHonestTestHeaderHash = all (0 ==) . unTestHash
+
+    scheduleConfig = defaultPointScheduleConfig

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/BlockFetch.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/BlockFetch.hs
@@ -22,7 +22,6 @@ import           Data.Map.Strict (Map)
 import           Network.TypedProtocol.Channel (createConnectedChannels)
 import           Network.TypedProtocol.Driver.Simple
                      (runConnectedPeersPipelined)
-import           Ouroboros.Consensus.Block (HasHeader)
 import           Ouroboros.Consensus.Block.Abstract (Header, Point (..))
 import qualified Ouroboros.Consensus.MiniProtocol.BlockFetch.ClientInterface as BlockFetchClientInterface
 import           Ouroboros.Consensus.Node.ProtocolInfo
@@ -32,7 +31,6 @@ import           Ouroboros.Consensus.Util.IOLike (IOLike, STM, atomically,
                      retry)
 import           Ouroboros.Consensus.Util.ResourceRegistry
 import           Ouroboros.Network.AnchoredFragment (AnchoredFragment)
-import qualified Ouroboros.Network.AnchoredFragment as AF
 import           Ouroboros.Network.BlockFetch (BlockFetchConfiguration (..),
                      FetchClientRegistry, FetchMode (..), blockFetchLogic,
                      bracketFetchClient, bracketKeepAliveClient)
@@ -42,10 +40,7 @@ import           Ouroboros.Network.NodeToNode.Version (NodeToNodeVersion,
                      isPipeliningEnabled)
 import           Ouroboros.Network.Protocol.BlockFetch.Codec (codecBlockFetchId)
 import           Ouroboros.Network.Protocol.BlockFetch.Server
-                     (BlockFetchBlockSender (SendMsgNoBlocks, SendMsgStartBatch),
-                     BlockFetchSendBlocks (SendMsgBatchDone, SendMsgBlock),
-                     BlockFetchServer (..), blockFetchServerPeer)
-import           Ouroboros.Network.Protocol.BlockFetch.Type (ChainRange (..))
+                     (BlockFetchServer (..), blockFetchServerPeer)
 import           Test.Util.Orphans.IOLike ()
 import           Test.Util.TestBlock (BlockConfig (TestBlockConfig), TestBlock)
 import           Test.Util.Time (dawnOfTime)
@@ -109,12 +104,12 @@ runBlockFetchClient ::
   => peer
   -> FetchClientRegistry peer (Header TestBlock) TestBlock m
   -> ControlMessageSTM m
-  -> m (AnchoredFragment TestBlock)
+  -> BlockFetchServer TestBlock (Point TestBlock) m ()
   -> m ()
-runBlockFetchClient peerId fetchClientRegistry controlMsgSTM getCurrentServerChain =
+runBlockFetchClient peerId fetchClientRegistry controlMsgSTM server =
     bracketFetchClient fetchClientRegistry ntnVersion isPipeliningEnabled peerId $ \clientCtx -> do
       let bfClient = blockFetchClient ntnVersion controlMsgSTM nullTracer clientCtx
-          bfServer = blockFetchServerPeer $ mockBlockFetchServer getCurrentServerChain
+          bfServer = blockFetchServerPeer server
 
       fst <$> runConnectedPeersPipelined
               createConnectedChannels
@@ -125,22 +120,3 @@ runBlockFetchClient peerId fetchClientRegistry controlMsgSTM getCurrentServerCha
   where
     ntnVersion :: NodeToNodeVersion
     ntnVersion = maxBound
-
-mockBlockFetchServer ::
-     forall m blk.
-     (Monad m, HasHeader blk)
-  => m (AnchoredFragment blk)
-  -> BlockFetchServer blk (Point blk) m ()
-mockBlockFetchServer getCurrentChain = idle
-  where
-    idle :: BlockFetchServer blk (Point blk) m ()
-    idle = flip BlockFetchServer () $ \(ChainRange from to) -> do
-        curChain <- getCurrentChain
-        pure $ case AF.sliceRange curChain from to of
-          Nothing    -> SendMsgNoBlocks (pure idle)
-          Just slice -> SendMsgStartBatch $ sendBlocks (AF.toOldestFirst slice)
-
-    sendBlocks :: [blk] -> m (BlockFetchSendBlocks blk (Point blk) m ())
-    sendBlocks = pure . \case
-      []         -> SendMsgBatchDone (pure idle)
-      blk : blks -> SendMsgBlock blk (sendBlocks blks)

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/ChainSync.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/ChainSync.hs
@@ -1,0 +1,130 @@
+{-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Test.Consensus.PeerSimulator.ChainSync (runChainSyncClient) where
+
+import           Control.Exception (AsyncException (ThreadKilled))
+import           Control.Monad.Class.MonadTimer.SI (MonadTimer)
+import           Control.Tracer (Tracer, nullTracer, traceWith)
+import           Data.Map.Strict (Map)
+import           Data.Proxy (Proxy (..))
+import           Ouroboros.Consensus.Block (Header, Point)
+import           Ouroboros.Consensus.Config (TopLevelConfig (..))
+import           Ouroboros.Consensus.MiniProtocol.ChainSync.Client (ChainDbView,
+                     Consensus, bracketChainSyncClient, chainSyncClient)
+import qualified Ouroboros.Consensus.MiniProtocol.ChainSync.Client as CSClient
+import qualified Ouroboros.Consensus.MiniProtocol.ChainSync.Client.InFutureCheck as InFutureCheck
+import           Ouroboros.Consensus.Util.Condense (Condense (..))
+import           Ouroboros.Consensus.Util.IOLike (Exception (fromException),
+                     IOLike, MonadCatch (try), StrictTVar)
+import           Ouroboros.Network.Block (Tip)
+import           Ouroboros.Network.Channel (createConnectedChannels)
+import           Ouroboros.Network.ControlMessage (ControlMessage (..))
+import           Ouroboros.Network.Driver.Limits
+                     (ProtocolLimitFailure (ExceededSizeLimit, ExceededTimeLimit))
+import           Ouroboros.Network.NodeToNode.Version (NodeToNodeVersion)
+import           Ouroboros.Network.Protocol.ChainSync.ClientPipelined
+                     (ChainSyncClientPipelined, chainSyncClientPeerPipelined)
+import           Ouroboros.Network.Protocol.ChainSync.Codec (ChainSyncTimeout,
+                     codecChainSyncId, timeLimitsChainSync)
+import           Ouroboros.Network.Protocol.ChainSync.PipelineDecision
+                     (pipelineDecisionLowHighMark)
+import           Ouroboros.Network.Protocol.ChainSync.Server (ChainSyncServer,
+                     chainSyncServerPeer)
+import           Test.Consensus.Network.Driver.Limits.Extras
+                     (chainSyncNoSizeLimits,
+                     runConnectedPeersPipelinedWithLimits)
+import           Test.Consensus.PeerSimulator.StateView
+                     (ChainSyncException (ChainSyncException),
+                     StateViewTracers (StateViewTracers, svtChainSyncExceptionsTracer))
+import           Test.Consensus.PeerSimulator.Trace (mkChainSyncClientTracer,
+                     traceUnitWith)
+import           Test.Consensus.PointSchedule (PeerId, TestFragH)
+import           Test.Util.Orphans.IOLike ()
+import           Test.Util.TestBlock (TestBlock)
+
+
+basicChainSyncClient :: forall m.
+  IOLike m =>
+  Tracer m String ->
+  TopLevelConfig TestBlock ->
+  ChainDbView m TestBlock ->
+  StrictTVar m TestFragH ->
+  Consensus ChainSyncClientPipelined TestBlock m
+basicChainSyncClient tracer cfg chainDbView varCandidate =
+  chainSyncClient
+    CSClient.ConfigEnv {
+        CSClient.mkPipelineDecision0     = pipelineDecisionLowHighMark 10 20
+      , CSClient.tracer                  = mkChainSyncClientTracer tracer
+      , CSClient.cfg
+      , CSClient.chainDbView
+      , CSClient.someHeaderInFutureCheck = dummyHeaderInFutureCheck
+      }
+    CSClient.DynamicEnv {
+        CSClient.version             = maxBound
+      , CSClient.controlMessageSTM   = return Continue
+      , CSClient.headerMetricsTracer = nullTracer
+      , CSClient.varCandidate
+      , CSClient.startIdling         = pure ()
+      , CSClient.stopIdling          = pure ()
+      }
+  where
+    dummyHeaderInFutureCheck ::
+      InFutureCheck.SomeHeaderInFutureCheck m TestBlock
+    dummyHeaderInFutureCheck =
+      InFutureCheck.SomeHeaderInFutureCheck InFutureCheck.HeaderInFutureCheck
+      { InFutureCheck.proxyArrival = Proxy
+      , InFutureCheck.recordHeaderArrival = \_ -> pure ()
+      , InFutureCheck.judgeHeaderArrival = \_ _ _ -> pure ()
+      , InFutureCheck.handleHeaderArrival = \_ -> pure Nothing
+      }
+
+runChainSyncClient ::
+  (IOLike m, MonadTimer m) =>
+  Tracer m String ->
+  TopLevelConfig TestBlock ->
+  ChainDbView m TestBlock ->
+  PeerId ->
+  ChainSyncServer (Header TestBlock) (Point TestBlock) (Tip TestBlock) m () ->
+  ChainSyncTimeout ->
+  StateViewTracers m ->
+  StrictTVar m (Map PeerId (StrictTVar m TestFragH)) ->
+  m ()
+runChainSyncClient
+  tracer
+  cfg
+  chainDbView
+  peerId
+  server
+  chainSyncTimeouts
+  StateViewTracers {svtChainSyncExceptionsTracer}
+  varCandidates
+  =
+    bracketChainSyncClient nullTracer chainDbView varCandidates peerId ntnVersion $ \ varCandidate -> do
+      res <- try $ runConnectedPeersPipelinedWithLimits
+        createConnectedChannels
+        nullTracer
+        codecChainSyncId
+        chainSyncNoSizeLimits
+        (timeLimitsChainSync chainSyncTimeouts)
+        (chainSyncClientPeerPipelined (basicChainSyncClient tracer cfg chainDbView varCandidate))
+        (chainSyncServerPeer server)
+      case res of
+        Left exn -> do
+          traceWith svtChainSyncExceptionsTracer $ ChainSyncException peerId exn
+          case fromException exn of
+            Just (ExceededSizeLimit _) ->
+              traceUnitWith tracer ("ChainSyncClient " ++ condense peerId) "Terminating because of size limit exceeded."
+            Just (ExceededTimeLimit _) ->
+              traceUnitWith tracer ("ChainSyncClient " ++ condense peerId) "Terminating because of time limit exceeded."
+            Nothing ->
+              pure ()
+          case fromException exn of
+            Just ThreadKilled ->
+              traceUnitWith tracer ("ChainSyncClient " ++ condense peerId) "Terminated by GDD governor."
+            _ ->
+              pure ()
+        Right _ -> pure ()
+  where
+    ntnVersion :: NodeToNodeVersion
+    ntnVersion = maxBound

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/ChainSync.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/ChainSync.hs
@@ -86,16 +86,26 @@ basicChainSyncClient tracer cfg chainDbView varCandidate (startIdling, stopIdlin
       , InFutureCheck.handleHeaderArrival = \_ -> pure Nothing
       }
 
+-- | Create and run a ChainSync client using 'bracketChainSyncClient' and
+-- 'basicChainSyncClient', synchronously. Exceptions are caught, sent to the
+-- 'StateViewTracers' and logged.
 runChainSyncClient ::
   (IOLike m, MonadTimer m) =>
   Tracer m String ->
   TopLevelConfig TestBlock ->
   ChainDbView m TestBlock ->
   PeerId ->
+  -- ^ The id of the peer to which the client connects.
   ChainSyncServer (Header TestBlock) (Point TestBlock) (Tip TestBlock) m () ->
+  -- ^ The ChainSync server to which the client connects.
   ChainSyncTimeout ->
+  -- ^ Timeouts for this client.
   StateViewTracers m ->
+  -- ^ Tracers used to record information for the future 'StateView'.
   StrictTVar m (Map PeerId (StrictTVar m TestFragH)) ->
+  -- ^ A TVar containing a map of fragments of headers for each peer. This
+  -- function will (via 'bracketChainSyncClient') register and de-register a
+  -- TVar for the fragment of the peer.
   m ()
 runChainSyncClient
   tracer

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/ChainSync.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/ChainSync.hs
@@ -44,14 +44,19 @@ import           Test.Consensus.PointSchedule (PeerId, TestFragH)
 import           Test.Util.Orphans.IOLike ()
 import           Test.Util.TestBlock (TestBlock)
 
-
+-- | A basic ChainSync client. It wraps around 'chainSyncClient', but simplifies
+-- quite a few aspects. In particular, the size of the pipeline cannot exceed 20
+-- messages and the “in future” checks are disabled.
 basicChainSyncClient :: forall m.
   IOLike m =>
   Tracer m String ->
   TopLevelConfig TestBlock ->
   ChainDbView m TestBlock ->
   StrictTVar m TestFragH ->
+  -- ^ A TVar containing the fragment of headers for that peer, kept up to date
+  -- by the ChainSync client.
   (m (), m ()) ->
+  -- ^ Two monadic actions called when reaching and leaving @StIdle@.
   Consensus ChainSyncClientPipelined TestBlock m
 basicChainSyncClient tracer cfg chainDbView varCandidate (startIdling, stopIdling) =
   chainSyncClient

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Handlers.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Handlers.hs
@@ -1,41 +1,52 @@
 {-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies        #-}
+{-# LANGUAGE TypeOperators       #-}
 
--- | Business logic of the SyncChain protocol handlers that operates
+-- | Business logic of the ChainSync and BlockFetch protocol handlers that operate
 -- on the 'AdvertisedPoints' of a point schedule.
 --
 -- These are separated from the scheduling related mechanics of the
--- ChainSync server mock that the peer simulator uses, in
--- "Test.Consensus.PeerSimulator.ScheduledChainSyncServer".
+-- server mocks that the peer simulator uses, in
+-- "Test.Consensus.PeerSimulator.ScheduledChainSyncServer" and
+-- "Test.Consensus.PeerSimulator.ScheduledBlockFetchServer".
 module Test.Consensus.PeerSimulator.Handlers (
-    handlerFindIntersection
+    handlerBlockFetch
+  , handlerFindIntersection
   , handlerRequestNext
   ) where
 
+import           Cardano.Slotting.Slot (WithOrigin)
 import           Control.Monad.Trans (lift)
 import           Control.Monad.Writer.Strict (MonadWriter (tell),
                      WriterT (runWriterT))
 import           Data.Coerce (coerce)
-import           Data.Maybe (fromJust)
-import           Ouroboros.Consensus.Block.Abstract (Header, Point (..),
-                     getHeader, withOrigin)
+import           Data.Maybe (fromJust, fromMaybe)
+import           Ouroboros.Consensus.Block (HasHeader, Header, HeaderHash,
+                     Point (GenesisPoint), castPoint, getHeader, withOrigin)
 import           Ouroboros.Consensus.Util.Condense (Condense (..))
 import           Ouroboros.Consensus.Util.IOLike (IOLike, STM, StrictTVar,
                      readTVar, writeTVar)
 import qualified Ouroboros.Network.AnchoredFragment as AF
 import           Ouroboros.Network.Block (blockPoint, getTipPoint)
+import           Ouroboros.Network.BlockFetch.ClientState
+                     (ChainRange (ChainRange))
 import qualified Test.Consensus.BlockTree as BT
 import           Test.Consensus.BlockTree (BlockTree)
 import           Test.Consensus.Network.AnchoredFragment.Extras (intersectWith)
+import           Test.Consensus.PeerSimulator.ScheduledBlockFetchServer
+                     (BlockFetch (..))
 import           Test.Consensus.PeerSimulator.ScheduledChainSyncServer
                      (FindIntersect (..),
                      RequestNext (AwaitReply, RollBackward, RollForward))
-import           Test.Consensus.PeerSimulator.Trace (terseFrag)
-import           Test.Consensus.PointSchedule (AdvertisedPoints (header, tip),
-                     HeaderPoint (HeaderPoint), TipPoint (TipPoint))
+import           Test.Consensus.PeerSimulator.Trace (terseFrag, tersePoint)
+import           Test.Consensus.PointSchedule
 import           Test.Util.Orphans.IOLike ()
-import           Test.Util.TestBlock (TestBlock)
+import           Test.Util.TestBlock (TestBlock, TestHash)
 
+
+toPoint :: (HasHeader block, HeaderHash block ~ TestHash) => WithOrigin block -> Point TestBlock
+toPoint = castPoint . withOrigin GenesisPoint blockPoint
 
 -- | Handle a @MsgFindIntersect@ message.
 --
@@ -45,20 +56,19 @@ handlerFindIntersection ::
   IOLike m =>
   StrictTVar m (Point TestBlock) ->
   BlockTree TestBlock ->
-  AdvertisedPoints ->
   [Point TestBlock] ->
-  STM m (FindIntersect, [String])
-handlerFindIntersection currentIntersection blockTree points clientPoints = do
+  AdvertisedPoints ->
+  STM m (Maybe FindIntersect, [String])
+handlerFindIntersection currentIntersection blockTree clientPoints points = do
   let TipPoint tip' = tip points
       tipPoint = getTipPoint tip'
       fragment = fromJust $ BT.findFragment tipPoint blockTree
   case intersectWith fragment clientPoints of
     Nothing ->
-      pure (IntersectNotFound tip', [])
+      pure (Just (IntersectNotFound tip'), [])
     Just intersection -> do
       writeTVar currentIntersection intersection
-      pure (IntersectFound intersection tip', [])
-  where
+      pure (Just (IntersectFound intersection tip'), [])
 
 -- | Handle a @MsgRequestNext@ message.
 --
@@ -80,26 +90,24 @@ handlerRequestNext currentIntersection blockTree points =
   runWriterT $ do
     intersection <- lift $ readTVar currentIntersection
     trace $ "  last intersection is " ++ condense intersection
-    withOrigin headerIsOrigin (withHeader intersection) (coerce (header points))
+    withHeader intersection (coerce (header points))
   where
-    headerIsOrigin = pure Nothing
-
-    withHeader :: Point TestBlock -> Header TestBlock -> WriterT [String] (STM m) (Maybe RequestNext)
+    withHeader :: Point TestBlock -> WithOrigin (Header TestBlock) -> WriterT [String] (STM m) (Maybe RequestNext)
     withHeader intersection h =
       maybe noPathError (analysePath hp) (BT.findPath intersection hp blockTree)
       where
-        hp = AF.castPoint $ blockPoint h
+        hp = toPoint h
 
     noPathError = error "serveHeader: intersection and headerPoint should always be in the block tree"
 
-    analysePath headerPoint = \case
+    analysePath hp = \case
       -- If the anchor is the intersection (the source of the path-finding) but
       -- the fragment is empty, then the intersection is exactly our header
       -- point and there is nothing to do. If additionally the header point is
       -- also the tip point (because we served our whole chain, or we are
       -- stalling as an adversarial behaviour), then we ask the client to wait;
       -- otherwise we just do nothing.
-      (BT.PathAnchoredAtSource True, AF.Empty _) | getTipPoint tip' == headerPoint -> do
+      (BT.PathAnchoredAtSource True, AF.Empty _) | getTipPoint tip' == hp -> do
         trace "  chain has been fully served"
         pure (Just AwaitReply)
       (BT.PathAnchoredAtSource True, AF.Empty _) -> do
@@ -139,3 +147,57 @@ handlerRequestNext currentIntersection blockTree points =
     TipPoint tip' = tip points
 
     trace = tell . pure
+
+-- | Handle the BlockFetch message (it actually has only one unnamed entry point).
+--
+-- If the requested range ends not after BP, send them.
+-- If BP moved to a fork without serving all blocks corresponding to advertised headers, serve them.
+-- Otherwise, stall.
+handlerBlockFetch ::
+  forall m .
+  IOLike m =>
+  BlockTree TestBlock ->
+  ChainRange (Point TestBlock) ->
+  AdvertisedPoints ->
+  STM m (Maybe BlockFetch, [String])
+handlerBlockFetch blockTree (ChainRange from to) AdvertisedPoints {header = HeaderPoint hp, block = BlockPoint bp} =
+  runWriterT (serveFromBpFragment (AF.sliceRange bpChain from to))
+  where
+    -- Check whether the requested range is contained in the fragment before the block point.
+    -- We may only serve the full range; if the server has only some of the blocks, it must refuse.
+    serveFromBpFragment = \case
+      Just slice -> do
+        trace ("Sending slice " ++ terseFrag slice)
+        pure (Just (StartBatch (AF.toOldestFirst slice)))
+      Nothing    -> do
+        -- If we cannot serve blocks from the BP chain, decide whether to yield control to the scheduler
+        -- or serve blocks anyway.
+        --
+        -- If the @to@ point is not part of the HP chain but BP is, we must have switched to a fork without ensuring
+        -- that BP advances to the last HP advertised on the old chain.
+        -- This should be a precondition violation, but because it would make the schedule generator more complex, we
+        -- simply serve the missing blocks anyway here.
+        --
+        -- Otherwise, we simply have to wait for BP to advance sufficiently, and we block without sending
+        -- a message, to simulate a slow response.
+        case not (AF.withinFragmentBounds to hpChain) && AF.withinFragmentBounds (toPoint bp) hpChain of
+          True ->
+            case AF.sliceRange (fragmentUpTo "requested point" to) from to of
+              Just slice -> do
+                trace "Sending range due to incomplete fork switch"
+                pure (Just (StartBatch (AF.toOldestFirst slice)))
+              Nothing    -> error "BlockFetch: Client requested blocks that aren't in the block tree"
+          False  -> do
+            trace ("Waiting for next tick for range: " ++ tersePoint from ++ " -> " ++ tersePoint to)
+            pure Nothing
+
+    bpChain = fragmentUpTo "block point" (toPoint bp)
+
+    hpChain = fragmentUpTo "header point" (toPoint hp)
+
+    trace = tell . pure
+
+    fragmentUpTo sort b =
+      fromMaybe (fatal sort) (BT.findFragment b blockTree)
+
+    fatal sort = error ("BlockFetch: Could not find " ++ sort ++ " in the block tree")

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Handlers.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Handlers.hs
@@ -28,6 +28,7 @@ import           Test.Consensus.Network.AnchoredFragment.Extras (intersectWith)
 import           Test.Consensus.PeerSimulator.ScheduledChainSyncServer
                      (FindIntersect (..),
                      RequestNext (AwaitReply, RollBackward, RollForward))
+import           Test.Consensus.PeerSimulator.Trace (terseFrag)
 import           Test.Consensus.PointSchedule (AdvertisedPoints (header, tip),
                      HeaderPoint (HeaderPoint), TipPoint (TipPoint))
 import           Test.Util.Orphans.IOLike ()
@@ -97,7 +98,7 @@ handlerRequestNext currentIntersection blockTree points =
       -- we have something to serve.
       (BT.PathAnchoredAtSource True, fragmentAhead@(next AF.:< _)) -> do
         trace "  intersection is before our header point"
-        trace $ "  fragment ahead: " ++ condense fragmentAhead
+        trace $ "  fragment ahead: " ++ terseFrag fragmentAhead
         lift $ writeTVar currentIntersection $ blockPoint next
         pure $ Just (RollForward (getHeader next) (coerce (tip points)))
       -- If the anchor is not the intersection but the fragment is empty, then

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Handlers.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Handlers.hs
@@ -157,8 +157,14 @@ handlerBlockFetch ::
   forall m .
   IOLike m =>
   BlockTree TestBlock ->
+  -- ^ The tree of blocks in this scenario -- aka. the “universe”.
   ChainRange (Point TestBlock) ->
+  -- ^ A requested range of blocks. If the client behaves correctly, they
+  -- correspond to headers that have been sent before, and if the scheduled
+  -- ChainSync server behaves correctly, then they are all in the block tree.
   AdvertisedPoints ->
+  -- ^ The current advertised points (tip point, header point and block point).
+  -- They are in the block tree.
   STM m (Maybe BlockFetch, [String])
 handlerBlockFetch blockTree (ChainRange from to) AdvertisedPoints {header = HeaderPoint hp, block = BlockPoint bp} =
   runWriterT (serveFromBpFragment (AF.sliceRange bpChain from to))

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Resources.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Resources.hs
@@ -6,7 +6,8 @@
 -- primitives used by ChainSync and BlockFetch in the handlers that implement
 -- the block tree analysis specific to our peer simulator.
 module Test.Consensus.PeerSimulator.Resources (
-    ChainSyncResources (..)
+    BlockFetchResources (..)
+  , ChainSyncResources (..)
   , PeerResources (..)
   , PeerSimulatorResources (..)
   , SharedResources (..)
@@ -15,8 +16,8 @@ module Test.Consensus.PeerSimulator.Resources (
   , makePeerSimulatorResources
   ) where
 
-import           Control.Concurrent.Class.MonadSTM.Strict (newEmptyTMVarIO,
-                     takeTMVar)
+import           Control.Concurrent.Class.MonadSTM.Strict (atomically, dupTChan,
+                     newBroadcastTChan, readTChan, writeTChan)
 import           Control.Tracer (Tracer)
 import           Data.Foldable (toList)
 import           Data.List.NonEmpty (NonEmpty)
@@ -27,14 +28,16 @@ import           Ouroboros.Consensus.Block (WithOrigin (Origin))
 import           Ouroboros.Consensus.Block.Abstract (Header, Point (..))
 import           Ouroboros.Consensus.Util.Condense (Condense (..))
 import           Ouroboros.Consensus.Util.IOLike (IOLike, MonadSTM (STM),
-                     StrictTMVar, StrictTVar, readTVar, uncheckedNewTVarM,
-                     writeTVar)
+                     StrictTVar, readTVar, uncheckedNewTVarM, writeTVar)
 import qualified Ouroboros.Network.AnchoredFragment as AF
 import           Ouroboros.Network.Block (Tip (..))
+import           Ouroboros.Network.Protocol.BlockFetch.Server (BlockFetchServer)
 import           Ouroboros.Network.Protocol.ChainSync.Server
                      (ChainSyncServer (..))
 import           Test.Consensus.BlockTree (BlockTree)
 import           Test.Consensus.PeerSimulator.Handlers
+import           Test.Consensus.PeerSimulator.ScheduledBlockFetchServer
+                     (runScheduledBlockFetchServer)
 import           Test.Consensus.PeerSimulator.ScheduledChainSyncServer
 import           Test.Consensus.PointSchedule
 import           Test.Util.Orphans.IOLike ()
@@ -63,25 +66,43 @@ data SharedResources m =
 -- "Test.Consensus.PeerSimulator.ScheduledChainSyncServer".
 data ChainSyncResources m =
   ChainSyncResources {
-    -- | A mailbox of node states that is updated by the scheduler in the peer's active tick,
-    -- waking up the chain sync server.
-    csrNextState :: StrictTMVar m NodeState,
-
     -- | The current known intersection with the chain of the client.
     csrCurrentIntersection :: StrictTVar m (Point TestBlock),
 
     -- | The final server passed to typed-protocols.
-    csrServer :: ChainSyncServer (Header TestBlock) (Point TestBlock) (Tip TestBlock) m ()
+    csrServer :: ChainSyncServer (Header TestBlock) (Point TestBlock) (Tip TestBlock) m (),
+
+    -- | This action blocks while this peer is inactive in the point schedule.
+    csrTickStarted :: STM m ()
   }
 
--- | The totality of resources used by a single peer in ChainSync and BlockFetch.
+-- | The data used by the point scheduler to interact with the mocked protocol handler in
+-- "Test.Consensus.PeerSimulator.BlockFetch".
+data BlockFetchResources m =
+  BlockFetchResources {
+    -- | The final server passed to typed-protocols.
+    bfrServer      :: BlockFetchServer TestBlock (Point TestBlock) m (),
+
+    -- | This action blocks while this peer is inactive in the point schedule.
+    bfrTickStarted :: STM m ()
+  }
+
+-- | The totality of resources used by a single peer in ChainSync and BlockFetch and by
+-- the scheduler to interact with it.
 data PeerResources m =
   PeerResources {
     -- | Resources used by ChainSync and BlockFetch.
-    prShared    :: SharedResources m,
+    prShared      :: SharedResources m,
 
     -- | Resources used by ChainSync only.
-    prChainSync :: ChainSyncResources m
+    prChainSync   :: ChainSyncResources m,
+
+    -- | Resources used by BlockFetch only.
+    prBlockFetch  :: BlockFetchResources m,
+
+    -- | An action used by the scheduler to update the peer's advertised points and
+    -- resume processing for the ChainSync and BlockFetch servers.
+    prUpdateState :: NodeState -> STM m ()
   }
 
 -- | Resources for the peer simulator.
@@ -106,41 +127,57 @@ makeChainSyncServerHandlers currentIntersection blockTree =
     csshRequestNext = handlerRequestNext currentIntersection blockTree
   }
 
--- | Transaction that blocks until the next turn of the current peer, when the
--- scheduler puts the new state into the TMVar, and updates the TVar that is
--- read by all of the ChainSync and BlockFetch handlers.
---
--- The ChainSync protocol handler mock is agnostic of our state type,
--- 'NodeState', so we convert it to 'Maybe'.
-waitForNextState ::
-  IOLike m =>
-  StrictTMVar m NodeState ->
-  StrictTVar m (Maybe AdvertisedPoints) ->
-  STM m (Maybe AdvertisedPoints)
-waitForNextState nextState currentState =
-  takeTMVar nextState >>= \ newState -> do
-    let
-      a = case newState of
-        NodeOffline     -> Nothing
-        NodeOnline tick -> Just tick
-    writeTVar currentState a
-    pure a
-
 -- | Create all the resources used exclusively by the ChainSync handlers, and
 -- the ChainSync protocol server that uses the handlers to interface with the
 -- typed-protocols engine.
+--
+-- TODO move server construction to Run?
 makeChainSyncResources ::
   IOLike m =>
+  STM m () ->
   SharedResources m ->
   m (ChainSyncResources m)
-makeChainSyncResources SharedResources {srPeerId, srTracer, srBlockTree, srCurrentState} = do
-  csrNextState <- newEmptyTMVarIO
+makeChainSyncResources csrTickStarted SharedResources {srPeerId, srTracer, srBlockTree, srCurrentState} = do
   csrCurrentIntersection <- uncheckedNewTVarM $ AF.Point Origin
   let
-    wait = waitForNextState csrNextState srCurrentState
     handlers = makeChainSyncServerHandlers csrCurrentIntersection srBlockTree
-    csrServer = runScheduledChainSyncServer (condense srPeerId) wait (readTVar srCurrentState) srTracer handlers
-  pure ChainSyncResources {csrServer, csrNextState, csrCurrentIntersection}
+    csrServer = runScheduledChainSyncServer (condense srPeerId) csrTickStarted (readTVar srCurrentState) srTracer handlers
+  pure ChainSyncResources {csrTickStarted, csrServer, csrCurrentIntersection}
+
+-- | Create the concurrency transactions for communicating the begin of a peer's
+-- tick and its new state to the ChainSync and BlockFetch servers.
+--
+-- We use a 'TChan' with two consumers and return only an action that takes a
+-- 'NodeState', which should be called by the scheduler in each of this peer's
+-- ticks.
+--
+-- The action writes the new state (converted to 'Maybe') to the shared TVar,
+-- and publishes an item to the channel _only if_ the state is 'NodeOnline'.
+--
+-- If the peer's servers block on the channel whenever they have exhausted the
+-- possible actions for a tick, the scheduler will be resumed.
+-- When the scheduler then calls the update action in this peer's next tick,
+-- both consumers will be unblocked and able to fetch the new state from the
+-- TVar.
+updateState ::
+  IOLike m =>
+  StrictTVar m (Maybe AdvertisedPoints) ->
+  m (NodeState -> STM m (), STM m (), STM m ())
+updateState srCurrentState =
+  atomically $ do
+    publisher <- newBroadcastTChan
+    consumer1 <- dupTChan publisher
+    consumer2 <- dupTChan publisher
+    let
+      newState s = do
+        writeTVar srCurrentState =<< case s of
+          NodeOffline     -> pure Nothing
+          NodeOnline tick -> do
+            -- REVIEW: Is it ok to only unblock the peer when it is online?
+            -- So far we've handled Nothing in the ChainSync server by skipping the tick.
+            writeTChan publisher ()
+            pure (Just tick)
+    pure (newState, readTChan consumer1, readTChan consumer2)
 
 -- | Create all concurrency resources and the ChainSync protocol server used
 -- for a single peer.
@@ -149,6 +186,8 @@ makeChainSyncResources SharedResources {srPeerId, srTracer, srBlockTree, srCurre
 -- type 'AdvertisedPoints' that is updated by a separate scheduler, waking up
 -- the protocol handlers to process messages until the conditions of the new
 -- state are satisfied.
+--
+-- TODO pass BFR and CSR to runScheduled... rather than passing the individual resources in and storing the result
 makePeerResources ::
   IOLike m =>
   Tracer m String ->
@@ -157,9 +196,11 @@ makePeerResources ::
   m (PeerResources m)
 makePeerResources srTracer srBlockTree srPeerId = do
   srCurrentState <- uncheckedNewTVarM Nothing
+  (prUpdateState, csrTickStarted, bfrTickStarted) <- updateState srCurrentState
   let prShared = SharedResources {srTracer, srBlockTree, srPeerId, srCurrentState}
-  prChainSync <- makeChainSyncResources prShared
-  pure PeerResources {prChainSync, prShared}
+      prBlockFetch = BlockFetchResources {bfrTickStarted, bfrServer = runScheduledBlockFetchServer (condense srPeerId) bfrTickStarted (readTVar srCurrentState) srTracer (handlerBlockFetch srBlockTree)}
+  prChainSync <- makeChainSyncResources csrTickStarted prShared
+  pure PeerResources {prShared, prChainSync, prBlockFetch, prUpdateState}
 
 -- | Create resources for all given peers operating on the given block tree.
 makePeerSimulatorResources ::

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Run.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Run.hs
@@ -12,6 +12,7 @@ module Test.Consensus.PeerSimulator.Run (
   , runPointSchedule
   ) where
 
+import           Cardano.Slotting.Slot (WithOrigin (At, Origin))
 import           Cardano.Slotting.Time (SlotLength, slotLengthFromSec)
 import           Control.Exception (AsyncException (ThreadKilled))
 import           Control.Monad.Class.MonadTime (MonadTime)
@@ -24,7 +25,8 @@ import qualified Data.Map.Strict as Map
 import           Data.Proxy (Proxy (..))
 import           Ouroboros.Consensus.Config (TopLevelConfig (..))
 import           Ouroboros.Consensus.MiniProtocol.ChainSync.Client (ChainDbView,
-                     Consensus, bracketChainSyncClient, chainSyncClient)
+                     Consensus, bracketChainSyncClient, chainSyncClient,
+                     defaultChainDbView)
 import qualified Ouroboros.Consensus.MiniProtocol.ChainSync.Client as CSClient
 import qualified Ouroboros.Consensus.MiniProtocol.ChainSync.Client.InFutureCheck as InFutureCheck
 import           Ouroboros.Consensus.Storage.ChainDB.API
@@ -62,10 +64,12 @@ import           Test.Consensus.PeerSimulator.Resources
 import           Test.Consensus.PeerSimulator.StateView
 import           Test.Consensus.PeerSimulator.Trace
 import qualified Test.Consensus.PointSchedule as PointSchedule
-import           Test.Consensus.PointSchedule (GenesisTest (GenesisTest),
+import           Test.Consensus.PointSchedule
+                     (AdvertisedPoints (AdvertisedPoints),
+                     BlockPoint (BlockPoint), GenesisTest (GenesisTest),
                      Peer (Peer), PeerId, PointSchedule (PointSchedule),
                      PointScheduleConfig, TestFragH, Tick (Tick),
-                     pointSchedulePeers, pscTickDuration)
+                     pointSchedulePeers)
 import           Test.Ouroboros.Consensus.ChainGenerator.Params (Asc)
 import           Test.Util.ChainDB
 import           Test.Util.Orphans.IOLike ()
@@ -239,11 +243,12 @@ startBlockFetchConnectionThread registry fetchClientRegistry controlMsgSTM Share
       nodeState <- readTVar srCurrentState
       case nodeState of
         Nothing -> retry
-        Just aps -> do
-          let PointSchedule.BlockPoint b = PointSchedule.block aps
+        Just AdvertisedPoints {block = BlockPoint (At b)} -> do
           case BT.findFragment (blockPoint b) srBlockTree of
             Just f  -> pure f
             Nothing -> error "block tip is not in the block tree"
+        Just AdvertisedPoints {block = BlockPoint Origin} ->
+          retry
 
 -- | The 'Tick' contains a state update for a specific peer.
 -- If the peer has not terminated by protocol rules, this will update its TMVar
@@ -251,22 +256,21 @@ startBlockFetchConnectionThread registry fetchClientRegistry controlMsgSTM Share
 -- for new instructions.
 dispatchTick ::
   IOLike m =>
-  SchedulerConfig ->
   Tracer m String ->
   Map PeerId (PeerResources m) ->
   Tick ->
   m ()
-dispatchTick config tracer peers Tick {active = Peer pid state} =
+dispatchTick tracer peers Tick {active = Peer pid state, duration} =
   case peers Map.!? pid of
     Just PeerResources {prChainSync = ChainSyncResources {csrNextState}} -> do
+      -- REVIEW: It would be worth sanity-checking that our understanding of
+      -- `threadDelay` is correct; and maybe getting explicit information from
+      -- both ChainSync & BlockFetch servers that they are done.
+      threadDelay duration
       trace $ "Writing state " ++ condense state
       atomically (tryPutTMVar csrNextState state) >>= \case
         True -> trace $ "Waiting for full resolution of " ++ condense pid ++ "'s tick..."
         False -> trace $ "Client for " ++ condense pid ++ " has ceased operation."
-      -- REVIEW: It would be worth sanity-checking that our understanding of
-      -- `threadDelay` is correct; and maybe getting explicit information from
-      -- both ChainSync & BlockFetch servers that they are done.
-      threadDelay (pscTickDuration (scSchedule config))
       trace $ condense pid ++ "'s tick is now done."
     Nothing -> error "“The impossible happened,” as GHC would say."
   where
@@ -279,16 +283,15 @@ dispatchTick config tracer peers Tick {active = Peer pid state} =
 -- client.
 runScheduler ::
   IOLike m =>
-  SchedulerConfig ->
   Tracer m String ->
   PointSchedule ->
   Map PeerId (PeerResources m) ->
   m ()
-runScheduler config tracer PointSchedule {ticks=ps} peers = do
+runScheduler tracer PointSchedule {ticks=ps} peers = do
   traceWith tracer "Schedule is:"
   for_ ps  $ \tick -> traceWith tracer $ "  " ++ condense tick
   traceStartOfTime
-  for_ ps (dispatchTick config tracer peers)
+  for_ ps (dispatchTick tracer peers)
   traceEndOfTime
   where
     traceStartOfTime =
@@ -331,7 +334,7 @@ runPointSchedule schedulerConfig GenesisTest {gtSecurityParam = k, gtBlockTree} 
     -- peer fragments than registered clients.
     let getCandidates = traverse readTVar =<< readTVar (psrCandidates resources)
     PeerSimulator.BlockFetch.startBlockFetchLogic registry chainDb fetchClientRegistry getCandidates
-    runScheduler schedulerConfig tracer pointSchedule (psrPeers resources)
+    runScheduler tracer pointSchedule (psrPeers resources)
     snapshotStateView stateViewTracers chainDb
   where
     config = defaultCfg k

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Run.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Run.hs
@@ -12,61 +12,44 @@ module Test.Consensus.PeerSimulator.Run (
   , runPointSchedule
   ) where
 
-import           Cardano.Slotting.Slot (WithOrigin (At, Origin))
 import           Cardano.Slotting.Time (SlotLength, slotLengthFromSec)
-import           Control.Exception (AsyncException (ThreadKilled))
 import           Control.Monad.Class.MonadTime (MonadTime)
 import           Control.Monad.Class.MonadTimer.SI (MonadTimer)
-import           Control.Tracer (Tracer, nullTracer, traceWith)
+import           Control.Tracer (Tracer, traceWith)
 import           Data.Foldable (for_)
 import           Data.Functor (void)
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import           Data.Proxy (Proxy (..))
 import           Ouroboros.Consensus.Config (TopLevelConfig (..))
-import           Ouroboros.Consensus.MiniProtocol.ChainSync.Client (ChainDbView,
-                     Consensus, bracketChainSyncClient, chainSyncClient,
-                     defaultChainDbView)
+import           Ouroboros.Consensus.MiniProtocol.ChainSync.Client (ChainDbView)
 import qualified Ouroboros.Consensus.MiniProtocol.ChainSync.Client as CSClient
-import qualified Ouroboros.Consensus.MiniProtocol.ChainSync.Client.InFutureCheck as InFutureCheck
 import           Ouroboros.Consensus.Storage.ChainDB.API
 import qualified Ouroboros.Consensus.Storage.ChainDB.API as ChainDB
 import           Ouroboros.Consensus.Storage.ChainDB.Impl
                      (ChainDbArgs (cdbTracer))
 import qualified Ouroboros.Consensus.Storage.ChainDB.Impl as ChainDB.Impl
 import           Ouroboros.Consensus.Util.Condense (Condense (..))
-import           Ouroboros.Consensus.Util.IOLike (Exception (fromException),
-                     IOLike, MonadCatch (try), MonadDelay (threadDelay),
-                     MonadSTM (atomically, retry), StrictTVar, readTVar,
-                     tryPutTMVar)
+import           Ouroboros.Consensus.Util.IOLike (IOLike,
+                     MonadDelay (threadDelay), MonadSTM (atomically),
+                     StrictTVar, readTVar)
 import           Ouroboros.Consensus.Util.ResourceRegistry
-import           Ouroboros.Network.Block (blockPoint)
 import           Ouroboros.Network.BlockFetch (FetchClientRegistry,
                      bracketSyncWithFetchClient, newFetchClientRegistry)
-import           Ouroboros.Network.Channel (createConnectedChannels)
 import           Ouroboros.Network.ControlMessage (ControlMessage (..),
                      ControlMessageSTM)
-import           Ouroboros.Network.Driver.Limits
-import           Ouroboros.Network.NodeToNode.Version (NodeToNodeVersion)
-import           Ouroboros.Network.Protocol.ChainSync.ClientPipelined
-                     (ChainSyncClientPipelined, chainSyncClientPeerPipelined)
 import           Ouroboros.Network.Protocol.ChainSync.Codec
-import           Ouroboros.Network.Protocol.ChainSync.PipelineDecision
-                     (pipelineDecisionLowHighMark)
-import           Ouroboros.Network.Protocol.ChainSync.Server
-                     (chainSyncServerPeer)
-import qualified Test.Consensus.BlockTree as BT
 import           Test.Consensus.Genesis.Setup.GenChains (GenesisTest)
 import           Test.Consensus.Network.Driver.Limits.Extras
 import qualified Test.Consensus.PeerSimulator.BlockFetch as PeerSimulator.BlockFetch
+import           Test.Consensus.PeerSimulator.BlockFetch (runBlockFetchClient,
+                     startBlockFetchLogic)
+import           Test.Consensus.PeerSimulator.ChainSync (runChainSyncClient)
 import           Test.Consensus.PeerSimulator.Config
 import           Test.Consensus.PeerSimulator.Resources
 import           Test.Consensus.PeerSimulator.StateView
 import           Test.Consensus.PeerSimulator.Trace
 import qualified Test.Consensus.PointSchedule as PointSchedule
-import           Test.Consensus.PointSchedule
-                     (AdvertisedPoints (AdvertisedPoints),
-                     BlockPoint (BlockPoint), GenesisTest (GenesisTest),
+import           Test.Consensus.PointSchedule (GenesisTest (GenesisTest),
                      Peer (Peer), PeerId, PointSchedule (PointSchedule),
                      PointScheduleConfig, TestFragH, Tick (Tick),
                      pointSchedulePeers)
@@ -127,41 +110,6 @@ noTimeoutsSchedulerConfig scSchedule =
 debugScheduler :: SchedulerConfig -> SchedulerConfig
 debugScheduler conf = conf { scDebug = True }
 
-basicChainSyncClient :: forall m.
-  IOLike m =>
-  Tracer m String ->
-  TopLevelConfig TestBlock ->
-  ChainDbView m TestBlock ->
-  StrictTVar m TestFragH ->
-  Consensus ChainSyncClientPipelined TestBlock m
-basicChainSyncClient tracer cfg chainDbView varCandidate =
-  chainSyncClient
-    CSClient.ConfigEnv {
-        CSClient.mkPipelineDecision0     = pipelineDecisionLowHighMark 10 20
-      , CSClient.tracer                  = mkChainSyncClientTracer tracer
-      , CSClient.cfg
-      , CSClient.chainDbView
-      , CSClient.someHeaderInFutureCheck = dummyHeaderInFutureCheck
-      }
-    CSClient.DynamicEnv {
-        CSClient.version             = maxBound
-      , CSClient.controlMessageSTM   = return Continue
-      , CSClient.headerMetricsTracer = nullTracer
-      , CSClient.varCandidate
-      , CSClient.startIdling         = pure ()
-      , CSClient.stopIdling          = pure ()
-      }
-  where
-    dummyHeaderInFutureCheck ::
-      InFutureCheck.SomeHeaderInFutureCheck m TestBlock
-    dummyHeaderInFutureCheck =
-      InFutureCheck.SomeHeaderInFutureCheck InFutureCheck.HeaderInFutureCheck
-      { InFutureCheck.proxyArrival = Proxy
-      , InFutureCheck.recordHeaderArrival = \_ -> pure ()
-      , InFutureCheck.judgeHeaderArrival = \_ _ _ -> pure ()
-      , InFutureCheck.handleHeaderArrival = \_ -> pure Nothing
-      }
-
 -- | Run a ChainSync protocol for one peer, consisting of a server and client.
 --
 -- The connection uses timeouts based on the ASC.
@@ -192,39 +140,12 @@ startChainSyncConnectionThread
   SharedResources {srPeerId}
   ChainSyncResources {csrServer}
   SchedulerConfig {scChainSyncTimeouts}
-  StateViewTracers {svtChainSyncExceptionsTracer}
-  varCandidates
-  =
-  void $ forkLinkedThread registry ("ChainSyncClient" <> condense srPeerId) $
-    bracketSyncWithFetchClient fetchClientRegistry srPeerId $ do
-      bracketChainSyncClient nullTracer chainDbView varCandidates srPeerId ntnVersion $ \ varCandidate -> do
-        res <- try $ runConnectedPeersPipelinedWithLimits
-          createConnectedChannels
-          nullTracer
-          codecChainSyncId
-          chainSyncNoSizeLimits
-          (timeLimitsChainSync scChainSyncTimeouts)
-          (chainSyncClientPeerPipelined (basicChainSyncClient tracer cfg chainDbView varCandidate))
-          (chainSyncServerPeer csrServer)
-        case res of
-          Left exn -> do
-            traceWith svtChainSyncExceptionsTracer $ ChainSyncException srPeerId exn
-            case fromException exn of
-              Just (ExceededSizeLimit _) ->
-                traceUnitWith tracer ("ChainSyncClient " ++ condense srPeerId) "Terminating because of size limit exceeded."
-              Just (ExceededTimeLimit _) ->
-                traceUnitWith tracer ("ChainSyncClient " ++ condense srPeerId) "Terminating because of time limit exceeded."
-              Nothing ->
-                pure ()
-            case fromException exn of
-              Just ThreadKilled ->
-                traceUnitWith tracer ("ChainSyncClient " ++ condense srPeerId) "Terminated by GDD governor."
-              _ ->
-                pure ()
-          Right _ -> pure ()
-  where
-    ntnVersion :: NodeToNodeVersion
-    ntnVersion = maxBound
+  tracers
+  varCandidates =
+    void $
+    forkLinkedThread registry ("ChainSyncClient" <> condense srPeerId) $
+    bracketSyncWithFetchClient fetchClientRegistry srPeerId $
+    runChainSyncClient tracer cfg chainDbView srPeerId csrServer scChainSyncTimeouts tracers varCandidates
 
 -- | Start the BlockFetch client, using the supplied 'FetchClientRegistry' to
 -- register it for synchronization with the ChainSync client.
@@ -234,21 +155,17 @@ startBlockFetchConnectionThread ::
   FetchClientRegistry PeerId (Header TestBlock) TestBlock m ->
   ControlMessageSTM m ->
   SharedResources m ->
+  BlockFetchResources m ->
   m ()
-startBlockFetchConnectionThread registry fetchClientRegistry controlMsgSTM SharedResources {srPeerId, srBlockTree, srCurrentState} =
-  void $ forkLinkedThread registry ("BlockFetchClient" <> condense srPeerId) $
-    PeerSimulator.BlockFetch.runBlockFetchClient srPeerId fetchClientRegistry controlMsgSTM getCurrentChain
-  where
-    getCurrentChain = atomically $ do
-      nodeState <- readTVar srCurrentState
-      case nodeState of
-        Nothing -> retry
-        Just AdvertisedPoints {block = BlockPoint (At b)} -> do
-          case BT.findFragment (blockPoint b) srBlockTree of
-            Just f  -> pure f
-            Nothing -> error "block tip is not in the block tree"
-        Just AdvertisedPoints {block = BlockPoint Origin} ->
-          retry
+startBlockFetchConnectionThread
+  registry
+  fetchClientRegistry
+  controlMsgSTM
+  SharedResources {srPeerId}
+  BlockFetchResources {bfrServer} =
+    void $
+    forkLinkedThread registry ("BlockFetchClient" <> condense srPeerId) $
+    runBlockFetchClient srPeerId fetchClientRegistry controlMsgSTM bfrServer
 
 -- | The 'Tick' contains a state update for a specific peer.
 -- If the peer has not terminated by protocol rules, this will update its TMVar
@@ -262,15 +179,11 @@ dispatchTick ::
   m ()
 dispatchTick tracer peers Tick {active = Peer pid state, duration} =
   case peers Map.!? pid of
-    Just PeerResources {prChainSync = ChainSyncResources {csrNextState}} -> do
-      -- REVIEW: It would be worth sanity-checking that our understanding of
-      -- `threadDelay` is correct; and maybe getting explicit information from
-      -- both ChainSync & BlockFetch servers that they are done.
-      threadDelay duration
+    Just PeerResources {prUpdateState} -> do
       trace $ "Writing state " ++ condense state
-      atomically (tryPutTMVar csrNextState state) >>= \case
-        True -> trace $ "Waiting for full resolution of " ++ condense pid ++ "'s tick..."
-        False -> trace $ "Client for " ++ condense pid ++ " has ceased operation."
+      atomically (prUpdateState state)
+      trace $ "Waiting for full resolution of " ++ condense pid ++ "'s tick..."
+      threadDelay duration
       trace $ condense pid ++ "'s tick is now done."
     Nothing -> error "“The impossible happened,” as GHC would say."
   where
@@ -327,13 +240,13 @@ runPointSchedule schedulerConfig GenesisTest {gtSecurityParam = k, gtBlockTree} 
     for_ (psrPeers resources) $ \PeerResources {prShared, prChainSync} -> do
       startChainSyncConnectionThread registry tracer config chainDbView fetchClientRegistry prShared prChainSync schedulerConfig stateViewTracers (psrCandidates resources)
       PeerSimulator.BlockFetch.startKeepAliveThread registry fetchClientRegistry (srPeerId prShared)
-    for_ (psrPeers resources) $ \PeerResources {prShared} ->
-      startBlockFetchConnectionThread registry fetchClientRegistry (pure Continue) prShared
+    for_ (psrPeers resources) $ \PeerResources {prShared, prBlockFetch} ->
+      startBlockFetchConnectionThread registry fetchClientRegistry (pure Continue) prShared prBlockFetch
     -- The block fetch logic needs to be started after the block fetch clients
     -- otherwise, an internal assertion fails because getCandidates yields more
     -- peer fragments than registered clients.
     let getCandidates = traverse readTVar =<< readTVar (psrCandidates resources)
-    PeerSimulator.BlockFetch.startBlockFetchLogic registry chainDb fetchClientRegistry getCandidates
+    startBlockFetchLogic registry chainDb fetchClientRegistry getCandidates
     runScheduler tracer pointSchedule (psrPeers resources)
     snapshotStateView stateViewTracers chainDb
   where

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Run.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Run.hs
@@ -5,27 +5,26 @@
 {-# LANGUAGE TypeFamilies        #-}
 
 module Test.Consensus.PeerSimulator.Run (
-    ChainSyncException (..)
-  , SchedulerConfig (..)
+    SchedulerConfig (..)
+  , debugScheduler
+  , defaultSchedulerConfig
+  , noTimeoutsSchedulerConfig
   , runPointSchedule
   ) where
 
-import           Control.Monad.Class.MonadAsync
-                     (AsyncCancelled (AsyncCancelled))
+import           Cardano.Slotting.Time (SlotLength, slotLengthFromSec)
+import           Control.Exception (AsyncException (ThreadKilled))
 import           Control.Monad.Class.MonadTime (MonadTime)
 import           Control.Monad.Class.MonadTimer.SI (MonadTimer)
 import           Control.Tracer (Tracer, nullTracer, traceWith)
 import           Data.Foldable (for_)
 import           Data.Functor (void)
-import           Data.List.NonEmpty (NonEmpty, nonEmpty)
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           Data.Proxy (Proxy (..))
-import           Data.Traversable (for)
 import           Ouroboros.Consensus.Config (TopLevelConfig (..))
-import qualified Ouroboros.Consensus.HardFork.History.EraParams as HardFork
 import           Ouroboros.Consensus.MiniProtocol.ChainSync.Client (ChainDbView,
-                     Consensus, chainSyncClient)
+                     Consensus, bracketChainSyncClient, chainSyncClient)
 import qualified Ouroboros.Consensus.MiniProtocol.ChainSync.Client as CSClient
 import qualified Ouroboros.Consensus.MiniProtocol.ChainSync.Client.InFutureCheck as InFutureCheck
 import           Ouroboros.Consensus.Storage.ChainDB.API
@@ -36,9 +35,8 @@ import qualified Ouroboros.Consensus.Storage.ChainDB.Impl as ChainDB.Impl
 import           Ouroboros.Consensus.Util.Condense (Condense (..))
 import           Ouroboros.Consensus.Util.IOLike (Exception (fromException),
                      IOLike, MonadCatch (try), MonadDelay (threadDelay),
-                     MonadSTM (atomically, retry), MonadThrow (throwIO),
-                     SomeException, StrictTVar, readTVar, readTVarIO,
-                     tryPutTMVar, uncheckedNewTVarM, writeTVar)
+                     MonadSTM (atomically, retry), StrictTVar, readTVar,
+                     tryPutTMVar)
 import           Ouroboros.Consensus.Util.ResourceRegistry
 import           Ouroboros.Network.Block (blockPoint)
 import           Ouroboros.Network.BlockFetch (FetchClientRegistry,
@@ -47,6 +45,7 @@ import           Ouroboros.Network.Channel (createConnectedChannels)
 import           Ouroboros.Network.ControlMessage (ControlMessage (..),
                      ControlMessageSTM)
 import           Ouroboros.Network.Driver.Limits
+import           Ouroboros.Network.NodeToNode.Version (NodeToNodeVersion)
 import           Ouroboros.Network.Protocol.ChainSync.ClientPipelined
                      (ChainSyncClientPipelined, chainSyncClientPeerPipelined)
 import           Ouroboros.Network.Protocol.ChainSync.Codec
@@ -60,11 +59,13 @@ import           Test.Consensus.Network.Driver.Limits.Extras
 import qualified Test.Consensus.PeerSimulator.BlockFetch as PeerSimulator.BlockFetch
 import           Test.Consensus.PeerSimulator.Config
 import           Test.Consensus.PeerSimulator.Resources
+import           Test.Consensus.PeerSimulator.StateView
 import           Test.Consensus.PeerSimulator.Trace
 import qualified Test.Consensus.PointSchedule as PointSchedule
 import           Test.Consensus.PointSchedule (GenesisTest (GenesisTest),
                      Peer (Peer), PeerId, PointSchedule (PointSchedule),
-                     TestFragH, Tick (Tick), pointSchedulePeers)
+                     PointScheduleConfig, TestFragH, Tick (Tick),
+                     pointSchedulePeers, pscTickDuration)
 import           Test.Ouroboros.Consensus.ChainGenerator.Params (Asc)
 import           Test.Util.ChainDB
 import           Test.Util.Orphans.IOLike ()
@@ -73,14 +74,54 @@ import           Test.Util.TestBlock (Header (..), TestBlock, testInitExtLedger)
 -- | Behavior config for the scheduler.
 data SchedulerConfig =
   SchedulerConfig {
-    -- | Whether to use timouts for the ChainSync protocol.
-    -- These apply when the client sends a MsgRequestNext and the server doesn't reply.
-    -- Because the point schedule cannot yet handle the case where a slow peer has a
-    -- header point that's behind the latest header that another peer has sent, we need
-    -- to be able to disable them.
-    enableTimeouts :: Bool
+    -- | Timeouts for the ChainSync protocol. These apply when the client sends
+    -- a 'MsgRequestNext' or a 'MsgFindIntersect' and the server doesn't reply.
+    -- Because the point schedule cannot yet handle the case where a slow peer
+    -- has a header point that's behind the latest header that another peer has
+    -- sent, we need to be able to control or disable them.
+    scChainSyncTimeouts :: ChainSyncTimeout
+
+    -- | The duration of a single slot, used by the peer simulator to wait
+    -- between ticks.
+    , scSlotLength      :: SlotLength
+
+    -- | Config shared with point schedule generators.
+    , scSchedule        :: PointScheduleConfig
+
+    -- | If 'True', 'Test.Consensus.Genesis.Setup.runTest' will enable full
+    -- tracing during the test.
+    --
+    -- Use 'debugScheduler' to toggle it conveniently.
+    , scDebug           :: Bool
   }
-  deriving (Show)
+
+-- | Determine timeouts based on the 'Asc' and a slot length of 20 seconds.
+defaultSchedulerConfig :: PointScheduleConfig -> Asc -> SchedulerConfig
+defaultSchedulerConfig scSchedule asc =
+  SchedulerConfig {
+    scChainSyncTimeouts = chainSyncTimeouts scSlotLength asc,
+    scSlotLength,
+    scSchedule,
+    scDebug = False
+  }
+  where
+    scSlotLength = slotLengthFromSec 20
+
+-- | Config with no timeouts and a slot length of 20 seconds.
+noTimeoutsSchedulerConfig :: PointScheduleConfig -> SchedulerConfig
+noTimeoutsSchedulerConfig scSchedule =
+  SchedulerConfig {
+    scChainSyncTimeouts = chainSyncNoTimeouts,
+    scSlotLength,
+    scSchedule,
+    scDebug = False
+  }
+  where
+    scSlotLength = slotLengthFromSec 20
+
+-- | Enable debug tracing during a scheduler test.
+debugScheduler :: SchedulerConfig -> SchedulerConfig
+debugScheduler conf = conf { scDebug = True }
 
 basicChainSyncClient :: forall m.
   IOLike m =>
@@ -117,14 +158,6 @@ basicChainSyncClient tracer cfg chainDbView varCandidate =
       , InFutureCheck.handleHeaderArrival = \_ -> pure Nothing
       }
 
--- | A record to associate an exception thrown by the ChainSync
--- thread with the peer that it was running for.
-data ChainSyncException = ChainSyncException
-       { csePeerId    :: PeerId
-       , cseException :: SomeException
-       }
-    deriving Show
-
 -- | Run a ChainSync protocol for one peer, consisting of a server and client.
 --
 -- The connection uses timeouts based on the ASC.
@@ -138,46 +171,56 @@ startChainSyncConnectionThread ::
   ResourceRegistry m ->
   Tracer m String ->
   TopLevelConfig TestBlock ->
-  Asc ->
   ChainDbView m TestBlock ->
   FetchClientRegistry PeerId (Header TestBlock) TestBlock m ->
   SharedResources m ->
   ChainSyncResources m ->
   SchedulerConfig ->
-  m (StrictTVar m (Maybe ChainSyncException))
-startChainSyncConnectionThread registry tracer cfg activeSlotCoefficient chainDbView fetchClientRegistry SharedResources {srPeerId, srCandidateFragment} ChainSyncResources {csrServer} SchedulerConfig {enableTimeouts} = do
-  let
-    slotLength = HardFork.eraSlotLength . topLevelConfigLedger $ cfg
-    timeouts | enableTimeouts = chainSyncTimeouts slotLength activeSlotCoefficient
-             | otherwise = chainSyncNoTimeouts
-  traceWith tracer $ "timeouts:"
-  traceWith tracer $ "  canAwait = " ++ show (canAwaitTimeout timeouts)
-  traceWith tracer $ "  intersect = " ++ show (intersectTimeout timeouts)
-  traceWith tracer $ "  mustReply = " ++ show (mustReplyTimeout timeouts)
-  chainSyncException <- uncheckedNewTVarM Nothing
-  _ <- forkLinkedThread registry ("ChainSyncClient" <> condense srPeerId) $
+  StateViewTracers m ->
+  StrictTVar m (Map PeerId (StrictTVar m TestFragH)) ->
+  m ()
+startChainSyncConnectionThread
+  registry
+  tracer
+  cfg
+  chainDbView
+  fetchClientRegistry
+  SharedResources {srPeerId}
+  ChainSyncResources {csrServer}
+  SchedulerConfig {scChainSyncTimeouts}
+  StateViewTracers {svtChainSyncExceptionsTracer}
+  varCandidates
+  =
+  void $ forkLinkedThread registry ("ChainSyncClient" <> condense srPeerId) $
     bracketSyncWithFetchClient fetchClientRegistry srPeerId $ do
-      res <- try $ runConnectedPeersPipelinedWithLimits
-        createConnectedChannels
-        nullTracer
-        codecChainSyncId
-        chainSyncNoSizeLimits
-        (timeLimitsChainSync timeouts)
-        (chainSyncClientPeerPipelined (basicChainSyncClient tracer cfg chainDbView srCandidateFragment))
-        (chainSyncServerPeer csrServer)
-      case res of
-        Left exn -> do
-          atomically $ writeTVar chainSyncException $ Just $ ChainSyncException srPeerId exn
-          case fromException exn of
-            Just (ExceededSizeLimit _) ->
-              traceUnitWith tracer ("ChainSyncClient " ++ condense srPeerId) "Terminating because of size limit exceeded."
-            Just (ExceededTimeLimit _) ->
-              traceUnitWith tracer ("ChainSyncClient " ++ condense srPeerId) "Terminating because of time limit exceeded."
-            Nothing ->
-              pure ()
-          throwIO exn
-        Right res' -> pure res'
-  pure chainSyncException
+      bracketChainSyncClient nullTracer chainDbView varCandidates srPeerId ntnVersion $ \ varCandidate -> do
+        res <- try $ runConnectedPeersPipelinedWithLimits
+          createConnectedChannels
+          nullTracer
+          codecChainSyncId
+          chainSyncNoSizeLimits
+          (timeLimitsChainSync scChainSyncTimeouts)
+          (chainSyncClientPeerPipelined (basicChainSyncClient tracer cfg chainDbView varCandidate))
+          (chainSyncServerPeer csrServer)
+        case res of
+          Left exn -> do
+            traceWith svtChainSyncExceptionsTracer $ ChainSyncException srPeerId exn
+            case fromException exn of
+              Just (ExceededSizeLimit _) ->
+                traceUnitWith tracer ("ChainSyncClient " ++ condense srPeerId) "Terminating because of size limit exceeded."
+              Just (ExceededTimeLimit _) ->
+                traceUnitWith tracer ("ChainSyncClient " ++ condense srPeerId) "Terminating because of time limit exceeded."
+              Nothing ->
+                pure ()
+            case fromException exn of
+              Just ThreadKilled ->
+                traceUnitWith tracer ("ChainSyncClient " ++ condense srPeerId) "Terminated by GDD governor."
+              _ ->
+                pure ()
+          Right _ -> pure ()
+  where
+    ntnVersion :: NodeToNodeVersion
+    ntnVersion = maxBound
 
 -- | Start the BlockFetch client, using the supplied 'FetchClientRegistry' to
 -- register it for synchronization with the ChainSync client.
@@ -208,18 +251,22 @@ startBlockFetchConnectionThread registry fetchClientRegistry controlMsgSTM Share
 -- for new instructions.
 dispatchTick ::
   IOLike m =>
+  SchedulerConfig ->
   Tracer m String ->
   Map PeerId (PeerResources m) ->
   Tick ->
   m ()
-dispatchTick tracer peers Tick {active = Peer pid state} =
+dispatchTick config tracer peers Tick {active = Peer pid state} =
   case peers Map.!? pid of
     Just PeerResources {prChainSync = ChainSyncResources {csrNextState}} -> do
       trace $ "Writing state " ++ condense state
       atomically (tryPutTMVar csrNextState state) >>= \case
         True -> trace $ "Waiting for full resolution of " ++ condense pid ++ "'s tick..."
         False -> trace $ "Client for " ++ condense pid ++ " has ceased operation."
-      threadDelay 0.100
+      -- REVIEW: It would be worth sanity-checking that our understanding of
+      -- `threadDelay` is correct; and maybe getting explicit information from
+      -- both ChainSync & BlockFetch servers that they are done.
+      threadDelay (pscTickDuration (scSchedule config))
       trace $ condense pid ++ "'s tick is now done."
     Nothing -> error "“The impossible happened,” as GHC would say."
   where
@@ -232,19 +279,30 @@ dispatchTick tracer peers Tick {active = Peer pid state} =
 -- client.
 runScheduler ::
   IOLike m =>
+  SchedulerConfig ->
   Tracer m String ->
   PointSchedule ->
   Map PeerId (PeerResources m) ->
   m ()
-runScheduler tracer (PointSchedule ps) peers = do
+runScheduler config tracer PointSchedule {ticks=ps} peers = do
   traceWith tracer "Schedule is:"
   for_ ps  $ \tick -> traceWith tracer $ "  " ++ condense tick
-  traceWith tracer "--------------------------------------------------------------------------------"
-  traceWith tracer "Running point schedule ..."
-  traceWith tracer "--------------------------------------------------------------------------------"
-  for_ ps (dispatchTick tracer peers)
-  traceWith tracer "--------------------------------------------------------------------------------"
-  traceWith tracer "Finished running point schedule"
+  traceStartOfTime
+  for_ ps (dispatchTick config tracer peers)
+  traceEndOfTime
+  where
+    traceStartOfTime =
+      traceLinesWith tracer [
+        hline,
+        "Running point schedule ...",
+        hline
+        ]
+    traceEndOfTime =
+      traceLinesWith tracer [
+        hline,
+        "Finished running point schedule"
+        ]
+    hline = "--------------------------------------------------------------------------------"
 
 -- | Construct STM resources, set up ChainSync and BlockFetch threads, and
 -- send all ticks in a 'PointSchedule' to all given peers in turn.
@@ -255,53 +313,38 @@ runPointSchedule ::
   GenesisTest ->
   PointSchedule ->
   Tracer m String ->
-  m (Either (NonEmpty ChainSyncException) TestFragH)
-runPointSchedule schedulerConfig GenesisTest {gtSecurityParam = k, gtHonestAsc = asc, gtBlockTree} pointSchedule tracer =
+  m StateView
+runPointSchedule schedulerConfig GenesisTest {gtSecurityParam = k, gtBlockTree} pointSchedule tracer =
   withRegistry $ \registry -> do
-    resources <- makePeersResources tracer gtBlockTree (pointSchedulePeers pointSchedule)
-    let candidates = srCandidateFragment . prShared <$> resources
-    traceWith tracer $ "Security param k = " ++ show k
-    chainDb <- mkChainDb tracer candidates config registry
+    stateViewTracers <- defaultStateViewTracers
+    resources <- makePeerSimulatorResources tracer gtBlockTree (pointSchedulePeers pointSchedule)
+    chainDb <- mkChainDb tracer config registry
     fetchClientRegistry <- newFetchClientRegistry
     let chainDbView = CSClient.defaultChainDbView chainDb
-    chainSyncRess <- for resources $ \PeerResources {prShared, prChainSync} -> do
-      chainSyncRes <- startChainSyncConnectionThread registry tracer config asc chainDbView fetchClientRegistry prShared prChainSync schedulerConfig
+    for_ (psrPeers resources) $ \PeerResources {prShared, prChainSync} -> do
+      startChainSyncConnectionThread registry tracer config chainDbView fetchClientRegistry prShared prChainSync schedulerConfig stateViewTracers (psrCandidates resources)
       PeerSimulator.BlockFetch.startKeepAliveThread registry fetchClientRegistry (srPeerId prShared)
-      pure chainSyncRes
-    for_ resources $ \PeerResources {prShared} ->
+    for_ (psrPeers resources) $ \PeerResources {prShared} ->
       startBlockFetchConnectionThread registry fetchClientRegistry (pure Continue) prShared
     -- The block fetch logic needs to be started after the block fetch clients
     -- otherwise, an internal assertion fails because getCandidates yields more
     -- peer fragments than registered clients.
-    let getCandidates = traverse readTVar candidates
+    let getCandidates = traverse readTVar =<< readTVar (psrCandidates resources)
     PeerSimulator.BlockFetch.startBlockFetchLogic registry chainDb fetchClientRegistry getCandidates
-    runScheduler tracer pointSchedule resources
-    chainSyncExceptions <- collectExceptions (Map.elems chainSyncRess)
-    b <- atomically $ ChainDB.getCurrentChain chainDb
-    pure $ maybe (Right b) Left chainSyncExceptions
+    runScheduler schedulerConfig tracer pointSchedule (psrPeers resources)
+    snapshotStateView stateViewTracers chainDb
   where
     config = defaultCfg k
-
-    collectExceptions :: [StrictTVar m (Maybe ChainSyncException)] -> m (Maybe (NonEmpty ChainSyncException))
-    collectExceptions vars = do
-      res <- mapM readTVarIO vars
-      pure $ nonEmpty [ e | Just e <- res, not (isAsyncCancelled e) ]
-
-    isAsyncCancelled :: ChainSyncException -> Bool
-    isAsyncCancelled e = case fromException $ cseException e of
-      Just AsyncCancelled -> True
-      _                   -> False
 
 -- | Create a ChainDB and start a BlockRunner that operate on the peers'
 -- candidate fragments.
 mkChainDb ::
   IOLike m =>
   Tracer m String ->
-  Map PeerId (StrictTVar m TestFragH) ->
   TopLevelConfig TestBlock ->
   ResourceRegistry m ->
   m (ChainDB m TestBlock)
-mkChainDb tracer _candidateVars nodeCfg registry = do
+mkChainDb tracer nodeCfg registry = do
     chainDbArgs <- do
       mcdbNodeDBs <- emptyNodeDBs
       pure $ (

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/ScheduledBlockFetchServer.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/ScheduledBlockFetchServer.hs
@@ -33,8 +33,8 @@ data BlockFetch =
 -- | Resources used by a BlockFetch server mock.
 data ScheduledBlockFetchServer m a =
   ScheduledBlockFetchServer {
-    sbfsServer :: ScheduledServer m a,
-    sbfsHandler       :: ChainRange (Point TestBlock) -> a -> STM m (Maybe BlockFetch, [String])
+    sbfsServer  :: ScheduledServer m a,
+    sbfsHandler :: ChainRange (Point TestBlock) -> a -> STM m (Maybe BlockFetch, [String])
   }
 
 scheduledBlockFetchServer ::

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/ScheduledBlockFetchServer.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/ScheduledBlockFetchServer.hs
@@ -20,12 +20,6 @@ import           Test.Consensus.PeerSimulator.ScheduledServer
 import           Test.Consensus.PeerSimulator.Trace
 import           Test.Util.TestBlock (TestBlock)
 
-data SendBlocks =
-  Block TestBlock
-  |
-  BatchDone
-  deriving (Eq, Show)
-
 data BlockFetch =
   StartBatch [TestBlock]
   |

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/ScheduledBlockFetchServer.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/ScheduledBlockFetchServer.hs
@@ -30,13 +30,16 @@ data BlockFetch =
   -- ^ Negative response to the client's request for blocks.
   deriving (Eq, Show)
 
--- | Resources used by a BlockFetch server mock.
+-- | Resources used by a scheduled BlockFetch server. This comprises a generic
+-- 'ScheduledServer' and BlockFetch-specific handlers.
 data ScheduledBlockFetchServer m a =
   ScheduledBlockFetchServer {
     sbfsServer  :: ScheduledServer m a,
     sbfsHandler :: ChainRange (Point TestBlock) -> a -> STM m (Maybe BlockFetch, [String])
   }
 
+-- | Make a 'BlockFetchServer' able to run with the normal infrastructure from a
+-- 'ScheduledBlockFetchServer'.
 scheduledBlockFetchServer ::
   forall m a .
   Condense a =>

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/ScheduledBlockFetchServer.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/ScheduledBlockFetchServer.hs
@@ -20,10 +20,14 @@ import           Test.Consensus.PeerSimulator.ScheduledServer
 import           Test.Consensus.PeerSimulator.Trace
 import           Test.Util.TestBlock (TestBlock)
 
+-- | Return values for the 'handlerBlockFetch'.
 data BlockFetch =
   StartBatch [TestBlock]
+  -- ^ As a response to the client request, we should send the blocks in the
+  -- given batch.
   |
   NoBlocks
+  -- ^ Negative response to the client's request for blocks.
   deriving (Eq, Show)
 
 -- | Resources used by a BlockFetch server mock.

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/ScheduledBlockFetchServer.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/ScheduledBlockFetchServer.hs
@@ -1,0 +1,96 @@
+{-# LANGUAGE LambdaCase          #-}
+{-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Test.Consensus.PeerSimulator.ScheduledBlockFetchServer (
+    BlockFetch (..)
+  , ScheduledBlockFetchServer (..)
+  , runScheduledBlockFetchServer
+  ) where
+
+import           Control.Tracer
+import           Data.List (intercalate)
+import           Ouroboros.Consensus.Block (Point)
+import           Ouroboros.Consensus.Util.Condense (Condense)
+import           Ouroboros.Consensus.Util.IOLike (IOLike, MonadSTM (STM))
+import           Ouroboros.Network.BlockFetch.ClientState (ChainRange)
+import           Ouroboros.Network.Protocol.BlockFetch.Server
+import           Test.Consensus.PeerSimulator.ScheduledServer
+                     (ScheduledServer (..), awaitOnlineState, runHandler)
+import           Test.Consensus.PeerSimulator.Trace
+import           Test.Util.TestBlock (TestBlock)
+
+data SendBlocks =
+  Block TestBlock
+  |
+  BatchDone
+  deriving (Eq, Show)
+
+data BlockFetch =
+  StartBatch [TestBlock]
+  |
+  NoBlocks
+  deriving (Eq, Show)
+
+-- | Resources used by a BlockFetch server mock.
+data ScheduledBlockFetchServer m a =
+  ScheduledBlockFetchServer {
+    sbfsServer :: ScheduledServer m a,
+    sbfsHandler       :: ChainRange (Point TestBlock) -> a -> STM m (Maybe BlockFetch, [String])
+  }
+
+scheduledBlockFetchServer ::
+  forall m a .
+  Condense a =>
+  IOLike m =>
+  ScheduledBlockFetchServer m a ->
+  BlockFetchServer TestBlock (Point TestBlock) m ()
+scheduledBlockFetchServer ScheduledBlockFetchServer {sbfsServer, sbfsHandler} =
+  server
+  where
+    server = BlockFetchServer blockFetch ()
+
+    blockFetch range =
+      runHandler sbfsServer "BlockFetch" (sbfsHandler range) $ \case
+        StartBatch blocks -> do
+          trace $ "  sending blocks: " ++ intercalate " " (terseBlock <$> blocks)
+          trace "done handling BlockFetch"
+          pure $ SendMsgStartBatch (sendBlocks blocks)
+        NoBlocks -> do
+          trace "  no blocks available"
+          trace "done handling BlockFetch"
+          pure (SendMsgNoBlocks (server <$ awaitOnlineState sbfsServer))
+
+    sendBlocks :: [TestBlock] -> m (BlockFetchSendBlocks TestBlock (Point TestBlock) m ())
+    sendBlocks = \case
+      []         -> do
+        trace "Batch done"
+        pure (SendMsgBatchDone (pure server))
+      blk : blks -> do
+        trace ("Sending " ++ terseBlock blk)
+        pure (SendMsgBlock blk (sendBlocks blks))
+
+    trace = traceWith (ssTracer sbfsServer)
+
+-- | Construct a BlockFetch server for the peer simulator.
+--
+-- See 'scheduledBlockFetchServer'.
+runScheduledBlockFetchServer ::
+  Condense a =>
+  IOLike m =>
+  String ->
+  STM m () ->
+  STM m (Maybe a) ->
+  Tracer m String ->
+  (ChainRange (Point TestBlock) -> a -> STM m (Maybe BlockFetch, [String])) ->
+  BlockFetchServer TestBlock (Point TestBlock) m ()
+runScheduledBlockFetchServer ssPeerId ssTickStarted ssCurrentState tracer sbfsHandler =
+  scheduledBlockFetchServer ScheduledBlockFetchServer {
+    sbfsServer = ScheduledServer {
+      ssPeerId,
+      ssTickStarted,
+      ssCurrentState,
+      ssTracer = Tracer (traceUnitWith tracer ("ScheduledBlockFetchServer " ++ ssPeerId))
+    },
+    sbfsHandler
+  }

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/ScheduledChainSyncServer.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/ScheduledChainSyncServer.hs
@@ -24,7 +24,7 @@ import           Ouroboros.Network.Protocol.ChainSync.Server
                      ServerStIdle (ServerStIdle, recvMsgDoneClient, recvMsgFindIntersect, recvMsgRequestNext),
                      ServerStIntersect (SendMsgIntersectFound, SendMsgIntersectNotFound),
                      ServerStNext (SendMsgRollBackward, SendMsgRollForward))
-import           Test.Consensus.PeerSimulator.Trace (traceUnitWith)
+import           Test.Consensus.PeerSimulator.Trace (terseHeader, traceUnitWith)
 import           Test.Util.TestBlock (Header (..), TestBlock)
 
 -- | Pure representation of the messages produced by the handler for the @StNext@
@@ -144,7 +144,7 @@ scheduledChainSyncServer server@ScheduledChainSyncServer {scssHandlers, scssTrac
       trace $ "  state is " ++ condense currentState
       runHandlerWithTrace requestNextTracer (csshRequestNext currentState) >>= \case
         Just (RollForward header tip) -> do
-          trace $ "  gotta serve " ++ condense header
+          trace $ "  gotta serve " ++ terseHeader header
           trace $ "  tip is      " ++ condense tip
           trace "done handling MsgRequestNext"
           pure $ Left $ SendMsgRollForward header tip go

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/ScheduledServer.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/ScheduledServer.hs
@@ -1,0 +1,98 @@
+{-# LANGUAGE LambdaCase     #-}
+{-# LANGUAGE NamedFieldPuns #-}
+
+module Test.Consensus.PeerSimulator.ScheduledServer (
+    ScheduledServer (..)
+  , awaitOnlineState
+  , ensureCurrentState
+  , runHandler
+  , runHandlerWithTrace
+  ) where
+import           Control.Tracer (Tracer (Tracer), traceWith)
+import           Data.Foldable (traverse_)
+import           Ouroboros.Consensus.Util.Condense (Condense (condense))
+import           Ouroboros.Consensus.Util.IOLike (IOLike,
+                     MonadSTM (STM, atomically))
+
+data ScheduledServer m a =
+  ScheduledServer {
+    ssPeerId       :: String,
+    ssCurrentState :: STM m (Maybe a),
+    ssTickStarted  :: STM m (),
+    ssTracer       :: Tracer m String
+  }
+
+nextTickState :: IOLike m => ScheduledServer m a -> m (Maybe a)
+nextTickState ScheduledServer {ssCurrentState, ssTickStarted} =
+  atomically (ssTickStarted >> ssCurrentState)
+
+retryOffline :: IOLike m => ScheduledServer m a -> Maybe a -> m a
+retryOffline server = maybe (awaitOnlineState server) pure
+
+-- | Block until the peer simulator has updated the concurrency primitive that
+-- indicates that it's this peer's server's turn in the point schedule.
+-- If the new state is 'Nothing', the point schedule has declared this peer as
+-- offline for the current tick, so it will not resume operation and wait for
+-- the next update.
+awaitOnlineState :: IOLike m => ScheduledServer m a -> m a
+awaitOnlineState server =
+  retryOffline server =<< nextTickState server
+
+-- | Fetch the current state from the STM action, and if it is 'Nothing',
+-- wait for the next tick to be triggered in 'awaitOnlineState'.
+--
+-- Since processing of a tick always ends when the handler finishes
+-- after serving the last point, this function is only relevant for the
+-- initial state update.
+ensureCurrentState :: IOLike m => ScheduledServer m a -> m a
+ensureCurrentState server =
+  retryOffline server =<< atomically (ssCurrentState server)
+
+-- | Handler functions are STM actions for the usual race condition reasons,
+-- which means that they cannot emit trace messages.
+--
+-- For that reason, we allow them to return their messages alongside the
+-- protocol result and emit them here.
+runHandlerWithTrace ::
+  IOLike m =>
+  Tracer m String ->
+  STM m (a, [String]) ->
+  m a
+runHandlerWithTrace tracer handler = do
+  (result, handlerMessages) <- atomically handler
+  traverse_ (traceWith tracer) handlerMessages
+  pure result
+
+-- | Run a peer server's message handler by fetching state from the scheduler's STM interface.
+--
+-- The handler is an STM action that returns a protocol result and log messages.
+--
+-- If the result is 'Nothing', the server's activity for the current tick is complete
+-- and we listen for the scheduler's signal to start the next tick, which we continue without
+-- updating the protocol handler (in @restart@).
+--
+-- Otherwise, the result is passed to @dispatchMessage@, which produces a native protocol handler
+-- message with the server's continuation in it.
+runHandler ::
+  IOLike m =>
+  Condense a =>
+  ScheduledServer m a ->
+  String ->
+  (a -> STM m (Maybe msg, [String])) ->
+  (msg -> m h) ->
+  m h
+runHandler server@ScheduledServer{ssTracer} handlerName handler dispatchMessage =
+  run
+  where
+    run = do
+      currentState <- ensureCurrentState server
+      trace ("handling " ++ handlerName)
+      trace ("  state is " ++ condense currentState)
+      maybe restart dispatchMessage =<< runHandlerWithTrace handlerTracer (handler currentState)
+
+    restart = do
+      trace "  cannot serve at this point; waiting for node state and starting again"
+      awaitOnlineState server *> run
+
+    trace = traceWith ssTracer
+    handlerTracer = Tracer $ \ msg -> traceWith ssTracer (handlerName ++ " | " ++ msg)

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/ScheduledServer.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/ScheduledServer.hs
@@ -1,6 +1,13 @@
 {-# LANGUAGE LambdaCase     #-}
 {-# LANGUAGE NamedFieldPuns #-}
 
+-- | This module contains code that is generic to any “scheduled server” (think
+-- scheduled ChainSync or BlockFetch server). A scheduled server keeps track of
+-- the current state of a point schedule and wakes up when new ticks arise. It
+-- processes as many messages there are via its domain-specific handlers; once
+-- there is nothing new to process, or what needs to process requires a
+-- different state of the point schedule, the scheduled server goes back to
+-- sleep, awaiting another tick.
 module Test.Consensus.PeerSimulator.ScheduledServer (
     ScheduledServer (..)
   , awaitOnlineState

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/StateView.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/StateView.hs
@@ -1,0 +1,73 @@
+{-# LANGUAGE NamedFieldPuns #-}
+
+module Test.Consensus.PeerSimulator.StateView (
+    ChainSyncException (..)
+  , StateView (..)
+  , StateViewTracers (..)
+  , defaultStateViewTracers
+  , snapshotStateView
+  ) where
+
+import           Control.Tracer (Tracer)
+import           Ouroboros.Consensus.Storage.ChainDB (ChainDB)
+import qualified Ouroboros.Consensus.Storage.ChainDB as ChainDB
+import           Ouroboros.Consensus.Util.Condense (Condense (condense))
+import           Ouroboros.Consensus.Util.IOLike (IOLike, SomeException,
+                     atomically)
+import           Test.Consensus.PeerSimulator.Trace (terseFragH)
+import           Test.Consensus.PointSchedule (PeerId, TestFragH)
+import           Test.Util.TestBlock (TestBlock)
+import           Test.Util.Tracer (recordingTracerTVar)
+
+-- | A record to associate an exception thrown by the ChainSync
+-- thread with the peer that it was running for.
+data ChainSyncException = ChainSyncException
+       { csePeerId    :: PeerId
+       , cseException :: SomeException
+       }
+    deriving Show
+
+-- | A state view is a partial view of the state of the whole peer simulator.
+-- This includes information about the part of the code that is being tested
+-- (for instance the fragment that is selected by the ChainDB) but also
+-- information about the mocked peers (for instance the exceptions raised in the
+-- mocked ChainSync server threads).
+data StateView = StateView {
+    svSelectedChain       :: TestFragH,
+    svChainSyncExceptions :: [ChainSyncException]
+  }
+  deriving Show
+
+instance Condense StateView where
+  condense StateView {svSelectedChain, svChainSyncExceptions} =
+    "SelectedChain: " ++ terseFragH svSelectedChain ++ "\nChainSyncExceptions: " ++ show svChainSyncExceptions
+
+-- | State view tracers are a lightweight mechanism to record information that
+-- can later be used to produce a state view. This mechanism relies on
+-- contra-tracers which we already use in a pervasives way.
+data StateViewTracers m = StateViewTracers {
+    svtChainSyncExceptionsTracer :: Tracer m ChainSyncException
+  , svtGetChainSyncExceptions    :: m [ChainSyncException]
+  }
+
+-- | Make default state view tracers. The tracers are all freshly initialised
+-- and contain no information.
+defaultStateViewTracers ::
+  IOLike m =>
+  m (StateViewTracers m)
+defaultStateViewTracers = do
+  (svtChainSyncExceptionsTracer, svtGetChainSyncExceptions) <- recordingTracerTVar
+  pure StateViewTracers {svtChainSyncExceptionsTracer, svtGetChainSyncExceptions}
+
+-- | Use the state view tracers as well as some extra information to produce a
+-- state view. This mostly consists in reading and storing the current state of
+-- the tracers.
+snapshotStateView ::
+  IOLike m =>
+  StateViewTracers m ->
+  ChainDB m TestBlock ->
+  m StateView
+snapshotStateView StateViewTracers{svtGetChainSyncExceptions} chainDb = do
+  svChainSyncExceptions <- svtGetChainSyncExceptions
+  svSelectedChain <- atomically $ ChainDB.getCurrentChain chainDb
+  pure StateView {svSelectedChain, svChainSyncExceptions}

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests.hs
@@ -1,0 +1,9 @@
+module Test.Consensus.PeerSimulator.Tests (tests) where
+
+import qualified Test.Consensus.PeerSimulator.Tests.Timeouts as Timeouts
+import           Test.Tasty
+
+tests :: TestTree
+tests = testGroup "PeerSimulator" [
+    Timeouts.tests
+  ]

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests.hs
@@ -1,9 +1,11 @@
 module Test.Consensus.PeerSimulator.Tests (tests) where
 
+import qualified Test.Consensus.PeerSimulator.Tests.Rollback as Rollback
 import qualified Test.Consensus.PeerSimulator.Tests.Timeouts as Timeouts
 import           Test.Tasty
 
 tests :: TestTree
 tests = testGroup "PeerSimulator" [
+    Rollback.tests,
     Timeouts.tests
   ]

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
@@ -1,0 +1,90 @@
+{-# LANGUAGE BlockArguments      #-}
+{-# LANGUAGE DerivingStrategies  #-}
+{-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Test.Consensus.PeerSimulator.Tests.Rollback (tests) where
+
+import           Control.Monad.IOSim (runSimOrThrow)
+import           Data.Maybe (fromJust)
+import           Ouroboros.Consensus.Block (ChainHash (..))
+import           Ouroboros.Consensus.Config.SecurityParam
+import qualified Ouroboros.Network.AnchoredFragment as AF
+import           Test.Consensus.BlockTree (BlockTree (..), BlockTreeBranch (..))
+import           Test.Consensus.Genesis.Setup
+import           Test.Consensus.PeerSimulator.Run (noTimeoutsSchedulerConfig)
+import           Test.Consensus.PeerSimulator.StateView
+import           Test.Consensus.PointSchedule
+import qualified Test.QuickCheck as QC
+import           Test.QuickCheck
+import           Test.Tasty
+import           Test.Tasty.QuickCheck
+import           Test.Util.Orphans.IOLike ()
+import           Test.Util.TestBlock (TestBlock, unTestHash)
+
+tests :: TestTree
+tests = testGroup "rollback" [
+  testProperty "can rollback" (prop_rollback True),
+  testProperty "cannot rollback" (prop_rollback False)
+  ]
+
+-- | @prop_rollback True@ tests that the selection of the node under test
+-- changes branches when sent a rollback to a block no older than 'k' blocks
+-- before the current selection.
+--
+-- @prop_rollback False@ tests that the selection of the node under test *does
+-- not* change branches when sent a rollback to a block strictly older than 'k'
+-- blocks before the current selection.
+prop_rollback :: Bool -> QC.Gen QC.Property
+prop_rollback wantRollback = do
+  genesisTest <- genChains 1
+
+  let schedule = rollbackSchedule (gtBlockTree genesisTest)
+
+  -- | We consider the test case interesting if we want a rollback and we can
+  -- actually get one, or if we want no rollback and we cannot actually get one.
+  pure $
+    wantRollback == canRollbackFromTrunkTip (gtSecurityParam genesisTest) (gtBlockTree genesisTest)
+    ==>
+      runSimOrThrow $ runTest schedulerConfig genesisTest schedule $ \StateView{svSelectedChain} ->
+        let headOnAlternativeChain = case AF.headHash svSelectedChain of
+              GenesisHash    -> False
+              BlockHash hash -> any (0 /=) $ unTestHash hash
+        in
+        -- The test passes if we want a rollback and we actually end up on the
+        -- alternative chain or if we want no rollback and end up on the trunk.
+        wantRollback == headOnAlternativeChain
+
+  where
+    schedulerConfig = noTimeoutsSchedulerConfig defaultPointScheduleConfig
+
+    -- A schedule that advertises all the points of the trunk, then switches to
+    -- the first alternative chain of the given block tree.
+    --
+    -- PRECONDITION: Block tree with at least one alternative chain.
+    rollbackSchedule :: BlockTree TestBlock -> PointSchedule
+    rollbackSchedule blockTree =
+      let trunk = btTrunk blockTree
+          branch = btbSuffix $ head $ btBranches blockTree
+          states = banalStates trunk ++ banalStates branch
+          peers = peersOnlyHonest states
+          pointSchedule = balanced peers
+       in fromJust pointSchedule
+
+    -- | Whether it is possible to roll back from the trunk after having served
+    -- it fully, that is whether there is an alternative chain that forks of the
+    -- trunk no more than 'k' blocks from the tip and that is longer than the
+    -- trunk.
+    --
+    -- PRECONDITION: Block tree with exactly one alternative chain, otherwise
+    -- this property does not make sense. With no alternative chain, this will
+    -- even crash.
+    --
+    -- REVIEW: Why does 'existsSelectableAdversary' get to be a classifier and
+    -- not this? (or a generalised version of this)
+    canRollbackFromTrunkTip :: SecurityParam -> BlockTree TestBlock -> Bool
+    canRollbackFromTrunkTip (SecurityParam k) blockTree =
+      let BlockTreeBranch{btbSuffix, btbTrunkSuffix} = head $ btBranches blockTree
+          lengthSuffix = AF.length btbSuffix
+          lengthTrunkSuffix = AF.length btbTrunkSuffix
+       in lengthTrunkSuffix <= fromIntegral k && lengthSuffix > lengthTrunkSuffix

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
@@ -68,7 +68,7 @@ prop_rollback wantRollback = do
           branch = btbSuffix $ head $ btBranches blockTree
           states = banalStates trunk ++ banalStates branch
           peers = peersOnlyHonest states
-          pointSchedule = balanced peers
+          pointSchedule = balanced defaultPointScheduleConfig peers
        in fromJust pointSchedule
 
     -- | Whether it is possible to roll back from the trunk after having served

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
@@ -37,6 +37,8 @@ tests = testGroup "rollback" [
 -- blocks before the current selection.
 prop_rollback :: Bool -> QC.Gen QC.Property
 prop_rollback wantRollback = do
+  -- | Create a block tree with @1@ alternative chain, such that we can rollback
+  -- from the trunk to that chain.
   genesisTest <- genChains 1
 
   let schedule = rollbackSchedule (gtBlockTree genesisTest)

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
@@ -65,7 +65,9 @@ prop_rollback wantRollback = do
     rollbackSchedule :: BlockTree TestBlock -> PointSchedule
     rollbackSchedule blockTree =
       let trunk = btTrunk blockTree
-          branch = btbSuffix $ head $ btBranches blockTree
+          branch = case btBranches blockTree of
+            [b] -> btbSuffix b
+            _   -> error "The block tree must have exactly one alternative branch"
           states = banalStates trunk ++ banalStates branch
           peers = peersOnlyHonest states
           pointSchedule = balanced defaultPointScheduleConfig peers
@@ -84,7 +86,9 @@ prop_rollback wantRollback = do
     -- not this? (or a generalised version of this)
     canRollbackFromTrunkTip :: SecurityParam -> BlockTree TestBlock -> Bool
     canRollbackFromTrunkTip (SecurityParam k) blockTree =
-      let BlockTreeBranch{btbSuffix, btbTrunkSuffix} = head $ btBranches blockTree
+      let BlockTreeBranch{btbSuffix, btbTrunkSuffix} = case btBranches blockTree of
+            [b] -> b
+            _   -> error "The block tree must have exactly one alternative branch"
           lengthSuffix = AF.length btbSuffix
           lengthTrunkSuffix = AF.length btbTrunkSuffix
        in lengthTrunkSuffix <= fromIntegral k && lengthSuffix > lengthTrunkSuffix

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
@@ -13,6 +13,7 @@ import qualified Ouroboros.Network.AnchoredFragment as AF
 import           Ouroboros.Network.Block (tipFromHeader)
 import           Ouroboros.Network.Driver.Limits
                      (ProtocolLimitFailure (ExceededTimeLimit))
+import           Ouroboros.Network.Point (WithOrigin (At))
 import           Ouroboros.Network.Protocol.ChainSync.Codec (mustReplyTimeout)
 import           Test.Consensus.BlockTree (btTrunk)
 import           Test.Consensus.Genesis.Setup
@@ -64,8 +65,8 @@ prop_timeouts = do
     dullSchedule _ _ (AF.Empty _) = error "requires a non-empty block tree"
     dullSchedule scheduleConfig timeout (_ AF.:> tipBlock) =
       let tipPoint = TipPoint $ tipFromHeader tipBlock
-          headerPoint = HeaderPoint $ getHeader tipBlock
-          blockPoint = BlockPoint tipBlock
+          headerPoint = HeaderPoint $ At (getHeader tipBlock)
+          blockPoint = BlockPoint (At tipBlock)
           state = Peer HonestPeer $ NodeOnline $ AdvertisedPoints tipPoint headerPoint blockPoint
           tick = Tick { active = state, duration = pscTickDuration scheduleConfig }
           maximumNumberOfTicks = round $ timeout / pscTickDuration scheduleConfig

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
@@ -67,7 +67,7 @@ prop_timeouts = do
           headerPoint = HeaderPoint $ getHeader tipBlock
           blockPoint = BlockPoint tipBlock
           state = Peer HonestPeer $ NodeOnline $ AdvertisedPoints tipPoint headerPoint blockPoint
-          tick = Tick { active = state }
+          tick = Tick { active = state, duration = pscTickDuration scheduleConfig }
           maximumNumberOfTicks = round $ timeout / pscTickDuration scheduleConfig
       in
       PointSchedule (tick :| replicate maximumNumberOfTicks tick) (HonestPeer :| [])

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
@@ -1,0 +1,73 @@
+{-# LANGUAGE LambdaCase     #-}
+{-# LANGUAGE NamedFieldPuns #-}
+
+module Test.Consensus.PeerSimulator.Tests.Timeouts (tests) where
+
+import           Control.Monad.IOSim (runSimOrThrow)
+import           Data.List.NonEmpty (NonEmpty ((:|)))
+import           Data.Maybe (fromJust)
+import           Ouroboros.Consensus.Block (getHeader)
+import           Ouroboros.Consensus.Util.Condense
+import           Ouroboros.Consensus.Util.IOLike (DiffTime, fromException)
+import qualified Ouroboros.Network.AnchoredFragment as AF
+import           Ouroboros.Network.Block (tipFromHeader)
+import           Ouroboros.Network.Driver.Limits
+                     (ProtocolLimitFailure (ExceededTimeLimit))
+import           Ouroboros.Network.Protocol.ChainSync.Codec (mustReplyTimeout)
+import           Test.Consensus.BlockTree (btTrunk)
+import           Test.Consensus.Genesis.Setup
+import           Test.Consensus.PeerSimulator.Run (SchedulerConfig (..),
+                     defaultSchedulerConfig)
+import           Test.Consensus.PeerSimulator.StateView
+import           Test.Consensus.PointSchedule
+import qualified Test.QuickCheck as QC
+import           Test.QuickCheck
+import           Test.Tasty
+import           Test.Tasty.QuickCheck
+import           Test.Util.Orphans.IOLike ()
+
+tests :: TestTree
+tests = testProperty "timeouts" prop_timeouts
+
+prop_timeouts :: QC.Gen QC.Property
+prop_timeouts = do
+  genesisTest <- genChains 0
+
+  -- Use higher tick duration to avoid the test taking really long
+  let scSchedule = PointScheduleConfig {pscTickDuration = 1}
+
+      schedulerConfig = defaultSchedulerConfig scSchedule (gtHonestAsc genesisTest)
+
+      schedule =
+        dullSchedule
+          scSchedule
+          (fromJust $ mustReplyTimeout (scChainSyncTimeouts schedulerConfig))
+          (btTrunk $ gtBlockTree genesisTest)
+
+  pure $ withMaxSuccess 10 $ runSimOrThrow $
+    runTest schedulerConfig genesisTest schedule $ \stateView ->
+      case svChainSyncExceptions stateView of
+        [] ->
+          counterexample ("result: " ++ condense (svSelectedChain stateView)) False
+        [exn] ->
+          case fromException $ cseException exn of
+            Just (ExceededTimeLimit _) -> property True
+            _ -> counterexample ("exception: " ++ show exn) False
+        exns ->
+          counterexample ("exceptions: " ++ show exns) False
+
+  where
+
+    -- A schedule that advertises all the points of the chain from the start but
+    -- contains just one too many ticks, therefore reaching the timeouts.
+    dullSchedule :: PointScheduleConfig -> DiffTime -> TestFrag -> PointSchedule
+    dullSchedule _ _ (AF.Empty _) = error "requires a non-empty block tree"
+    dullSchedule scheduleConfig timeout (_ AF.:> tipBlock) =
+      let tipPoint = TipPoint $ tipFromHeader tipBlock
+          headerPoint = HeaderPoint $ getHeader tipBlock
+          blockPoint = BlockPoint tipBlock
+          state = Peer HonestPeer $ NodeOnline $ AdvertisedPoints tipPoint headerPoint blockPoint
+          tick = Tick { active = state }
+          maximumNumberOfTicks = round $ timeout / pscTickDuration scheduleConfig
+      in
+      PointSchedule (tick :| replicate maximumNumberOfTicks tick) (HonestPeer :| [])

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
@@ -32,6 +32,7 @@ module Test.Consensus.PointSchedule (
   , NodeState (..)
   , Peer (..)
   , PeerId (..)
+  , Peers (..)
   , PointSchedule (..)
   , PointScheduleConfig (..)
   , ScheduleType (..)

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
@@ -597,12 +597,21 @@ newLongRangeAttack _ _ =
 -- | Encodes the different scheduling styles for use with quickcheck generators.
 data ScheduleType =
   Frequencies (Peers Int)
+  -- ^ A schedule where each peer serves their own chain. The frequency at which
+  -- they serve blocks is given as a map from peers to integers.
   |
   Banal
+  -- ^ A schedule where each peer serves their own chain, one header at a time.
+  -- This is similar to 'Frequencies' with all peers having frequency 1.
   |
   OnlyHonest
+  -- ^ A schedule with only an honest node serving the trunk of the tree
+  -- immediately in one tick.
   |
   NewLRA
+  -- ^ “New long-range attack”. Similar to @Frequencies (Peers 1 [10])@ but
+  -- relies on the 'SinglePeer' generator, and therefore contains
+  -- randomly-chosen delays between messages.
   deriving (Eq, Show)
 
 newtype GenesisWindow = GenesisWindow { getGenesisWindow :: Word64 }

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
@@ -345,7 +345,7 @@ pointSchedule ticks nePeerIds = (`PointSchedule` nePeerIds) <$> nonEmpty ticks
 -- first tip point is delayed by 20 or more seconds due to being in a later slot.
 peerStates :: PeerId -> [(DiffTime, SchedulePoint)] -> [(DiffTime, Peer NodeState)]
 peerStates peerId pts =
-  zip (shiftTime <$> times) (Peer peerId . NodeOnline <$> scanl' modPoint zero points)
+  zip (0 : (shiftTime <$> times)) (Peer peerId . NodeOnline <$> scanl' modPoint zero points)
   where
     shiftTime t = t - firstTipOffset
 

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/SinglePeer.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/SinglePeer.hs
@@ -1,0 +1,324 @@
+-- | This module contains functions for generating random point schedules.
+--
+-- A point schedule is a set of tables, having one table per simulated peer.
+-- Each row of a table correspond to a point in time, also called a tick.
+--
+-- Each tick has a timestamp and a state to set for the corresponding peer at
+-- that time. The state of each peer is described by three blocks points
+-- related to the peer's hypothetical chain selection:
+--
+-- * Tip Point: the tip of the hypothetical chain selection. This tip is
+--       advertised to the node under test in ChainSync client exchanges.
+-- * Header Point: the most recent header that the peer should send to the
+--       node under test. Any newer headers should wait until the Header
+--       Point is updated to newer headers.
+-- * Block Point: the most recent block that the peer should send to the
+--       node under test. Any newer blocks should wait until the Block Point
+--       is updated to newer headers.
+--
+-- Given a chain selection like this:
+--
+-- > Genesis -> A -> B -> C -> D
+--
+-- The point schedule of a peer might look like this:
+--
+-- > +--------+----------------+----------------+----------------+
+-- > | Tick   | Tip Point      | Header Point   | Block Point    |
+-- > +--------+----------------+----------------+----------------+
+-- > |   0.0s | Genesis        | Genesis        | Genesis        |
+-- > +--------+----------------+----------------+----------------+
+-- > |   1.2s | D              | Genesis        | Genesis        |
+-- > +--------+----------------+----------------+----------------+
+-- > |   1.3s | D              | C              | Genesis        |
+-- > +--------+----------------+----------------+----------------+
+-- > |   1.6s | D              | C              | B              |
+-- > +--------+----------------+----------------+----------------+
+-- > |   2.0s | D              | C              | C              |
+-- > +--------+----------------+----------------+----------------+
+-- > |   2.2s | D              | D              | D              |
+-- > +--------+----------------+----------------+----------------+
+--
+-- Some rules apply to how the point schedule progresses, although
+-- exceptions might be tested occasionally. In general,
+--
+-- * The Tip Point is set first
+-- * Header points are not allowed to point to newer blocks than the tip point
+-- * Block points are not allowed to point to newer blocks than the header point
+--
+-- The following is an example with rollbacks:
+--
+-- > Genesis -> A -> B -> C -> D
+-- >                   \-> C' -> D' -> E
+--
+-- > +--------+----------------+----------------+----------------+
+-- > | Tick   | Tip Point      | Header Point   | Block Point    |
+-- > +--------+----------------+----------------+----------------+
+-- > |   0.0s | Genesis        | Genesis        | Genesis        |
+-- > +--------+----------------+----------------+----------------+
+-- > |   1.2s | D              | Genesis        | Genesis        |
+-- > +--------+----------------+----------------+----------------+
+-- > |   1.3s | D              | C              | Genesis        |
+-- > +--------+----------------+----------------+----------------+
+-- > |   1.6s | D              | C              | B              |
+-- > +--------+----------------+----------------+----------------+
+-- > |   2.0s | D              | C              | C              |
+-- > +--------+----------------+----------------+----------------+
+-- > |   2.1s | D              | D              | C              |
+-- > +--------+----------------+----------------+----------------+
+-- > |   2.3s | D              | D              | D              |
+-- > +--------+----------------+----------------+----------------+
+-- > |   2.4s | E              | D              | D              |
+-- > +--------+----------------+----------------+----------------+
+-- > |   2.6s | E              | D'             | D              |
+-- > +--------+----------------+----------------+----------------+
+-- > |   2.7s | E              | D'             | C'             |
+-- > +--------+----------------+----------------+----------------+
+-- > |   2.9s | E              | D'             | D'             |
+-- > +--------+----------------+----------------+----------------+
+-- > |   3.0s | E              | E              | D'             |
+-- > +--------+----------------+----------------+----------------+
+-- > |   3.1s | E              | E              | E              |
+-- > +--------+----------------+----------------+----------------+
+--
+module Test.Consensus.PointSchedule.SinglePeer (
+    IsTrunk (..)
+  , PeerScheduleParams (..)
+  , SchedulePoint (..)
+  , defaultPeerScheduleParams
+  , peerScheduleFromTipPoints
+  , schedulePointToBlock
+  , singleJumpPeerSchedule
+    -- * Exposed for testing
+  , zipMany
+  ) where
+
+import           Cardano.Slotting.Slot (WithOrigin (At, Origin), withOrigin)
+import           Control.Arrow (second)
+import           Data.List (mapAccumL)
+import           Data.Time.Clock (DiffTime)
+import           Data.Vector (Vector)
+import qualified Data.Vector as Vector
+import qualified Ouroboros.Network.AnchoredFragment as AF
+import           Ouroboros.Network.Block (BlockNo (unBlockNo), SlotNo)
+import qualified System.Random.Stateful as R (StatefulGen)
+import           Test.Consensus.PointSchedule.SinglePeer.Indices
+                     (HeaderPointSchedule (hpsBranch, hpsTrunk),
+                     headerPointSchedule, singleJumpTipPoints, tipPointSchedule)
+import           Test.Util.TestBlock (TestBlock, tbSlot)
+
+
+-- | A point in the schedule of a single peer.
+data SchedulePoint
+  = ScheduleTipPoint TestBlock
+  | ScheduleHeaderPoint TestBlock
+  | ScheduleBlockPoint TestBlock
+  deriving (Eq, Show)
+
+schedulePointToBlock :: SchedulePoint -> TestBlock
+schedulePointToBlock (ScheduleTipPoint b)    = b
+schedulePointToBlock (ScheduleHeaderPoint b) = b
+schedulePointToBlock (ScheduleBlockPoint b)  = b
+
+-- | Parameters for generating a schedule for a single peer.
+--
+-- In the most general form, the caller provides a list of tip points and the
+-- schedule is generated by following the given tip points. All headers points
+-- and block points are sent eventually, but the points are delayed according
+-- to these parameters.
+data PeerScheduleParams = PeerScheduleParams
+  { pspSlotLength          :: DiffTime
+    -- | Each of these pairs specifies a range of delays for a point. The
+    -- actual delay is chosen uniformly at random from the range.
+    --
+    -- For tip points, the delay is relative to the slot of the tip point.
+  , pspTipDelayInterval    :: (DiffTime, DiffTime)
+    -- | For header points, the delay is relative to the previous header point
+    -- or the tip point that advertises the existence of the header (whichever
+    -- happened most recently).
+  , pspHeaderDelayInterval :: (DiffTime, DiffTime)
+    -- | For block points, the delay is relative to the previous block point or
+    -- the header point that advertises the existence of the block (whichever
+    -- happened most recently).
+  , pspBlockDelayInterval  :: (DiffTime, DiffTime)
+  }
+  deriving (Show)
+
+defaultPeerScheduleParams :: PeerScheduleParams
+defaultPeerScheduleParams = PeerScheduleParams
+  { pspSlotLength = 20
+  , pspTipDelayInterval = (0, 1)
+  , pspHeaderDelayInterval = (0.018, 0.021)
+  , pspBlockDelayInterval = (0.050, 0.055)
+  }
+
+-- | Generate a schedule for a single peer that jumps once to the middle of a
+-- sequence of blocks.
+--
+--  See 'peerScheduleFromTipPoints' for generation of schedules with rollbacks
+singleJumpPeerSchedule
+  :: R.StatefulGen g m
+  => g
+  -> PeerScheduleParams
+  -> AF.AnchoredFragment TestBlock
+  -> m [(DiffTime, SchedulePoint)]
+singleJumpPeerSchedule g psp chain = do
+    let chainv = Vector.fromList $ AF.toOldestFirst chain
+    (tps, hps, bps) <- singleJumpRawPeerSchedule g psp tbSlot chainv
+    let tipPoints = map (second ScheduleTipPoint) tps
+        headerPoints = map (second ScheduleHeaderPoint) hps
+        blockPoints = map (second ScheduleBlockPoint) bps
+    -- merge the schedules
+    pure $
+      mergeOn fst tipPoints $
+      mergeOn fst headerPoints blockPoints
+
+singleJumpRawPeerSchedule
+  :: R.StatefulGen g m
+  => g
+  -> PeerScheduleParams
+  -> (b -> SlotNo)
+  -> Vector b
+  -> m ([(DiffTime, b)], [(DiffTime, b)], [(DiffTime, b)])
+singleJumpRawPeerSchedule g psp slotOfB chainv = do
+    -- generate the tip points
+    ixs <- singleJumpTipPoints g 0 (Vector.length chainv - 1)
+    let tipPointBlks = map (chainv Vector.!) ixs
+        tipPointSlots = map slotOfB tipPointBlks
+    -- generate the tip point schedule
+    ts <- tipPointSchedule g (pspSlotLength psp) (pspTipDelayInterval psp) tipPointSlots
+    -- generate the header point schedule
+    hpss <- headerPointSchedule g (pspHeaderDelayInterval psp) [(Nothing, zip ts ixs)]
+    let hps = concatMap hpsTrunk hpss
+    -- generate the block point schedule
+    bpss <- headerPointSchedule g (pspBlockDelayInterval psp) [(Nothing, hps)]
+    -- collect the blocks for each schedule
+    let bps = concatMap hpsTrunk bpss
+        tipPointTips = zip ts tipPointBlks
+        hpsHeaders = map (second (chainv Vector.!)) hps
+        bpsBlks = map (second (chainv Vector.!)) bps
+    pure (tipPointTips, hpsHeaders, bpsBlks)
+
+data IsTrunk = IsTrunk | IsBranch
+  deriving (Eq, Show)
+
+-- | @peerScheduleFromTipPoints g params tps trunk branches@ generates a schedule for
+-- a single peer that follows the given tip points.
+--
+-- @tps@ contains the tip points for each fragment.
+--
+-- @trunk@ is the fragment for the honest chain
+--
+-- @branches@ contains the fragments for the alternative chains in ascending
+-- order of their intersections with the honest chain.
+--
+peerScheduleFromTipPoints
+  :: R.StatefulGen g m
+  => g
+  -> PeerScheduleParams
+  -> [(IsTrunk, [Int])]
+  -> AF.AnchoredFragment TestBlock
+  -> [AF.AnchoredFragment TestBlock]
+  -> m [(DiffTime, SchedulePoint)]
+peerScheduleFromTipPoints g psp tipPoints trunk0 branches0 = do
+    let trunk0v = Vector.fromList $ AF.toOldestFirst trunk0
+        firstTrunkBlockNo = withOrigin 1 (+1) $ AF.anchorBlockNo trunk0
+        branches0v = map (Vector.fromList . AF.toOldestFirst) branches0
+        anchorBlockIndices =
+          [ fromIntegral $ unBlockNo $ fragmentAnchorBlockNo b - firstTrunkBlockNo
+          | b <- branches0
+          ]
+        isTrunks = map fst tipPoints
+        intersections = intersperseTrunkFragments anchorBlockIndices isTrunks
+    (tps, hps, bps) <- rawPeerScheduleFromTipPoints g psp tbSlot tipPoints trunk0v branches0v intersections
+    let tipPoints' = map (second ScheduleTipPoint) tps
+        headerPoints = map (second ScheduleHeaderPoint) hps
+        blockPoints = map (second ScheduleBlockPoint) bps
+    -- merge the schedules
+    pure $
+      mergeOn fst tipPoints' $
+      mergeOn fst headerPoints blockPoints
+  where
+    fragmentAnchorBlockNo :: AF.AnchoredFragment TestBlock -> BlockNo
+    fragmentAnchorBlockNo f = case AF.anchorBlockNo f of
+      At s   -> s
+      Origin -> 0
+
+    intersperseTrunkFragments :: [Int] -> [IsTrunk] -> [Maybe Int]
+    intersperseTrunkFragments [] [] = []
+    intersperseTrunkFragments iis (IsTrunk:isTrunks) = Nothing : intersperseTrunkFragments iis isTrunks
+    intersperseTrunkFragments (i:is) (IsBranch:isTrunks) = Just i : intersperseTrunkFragments is isTrunks
+    intersperseTrunkFragments _ [] = error "intersperseTrunkFragments: not enough isTrunk flags"
+    intersperseTrunkFragments [] _ = error "intersperseTrunkFragments: not enough intersections"
+
+rawPeerScheduleFromTipPoints
+  :: R.StatefulGen g m
+  => g
+  -> PeerScheduleParams
+  -> (b -> SlotNo)
+  -> [(IsTrunk, [Int])]
+  -> Vector b
+  -> [Vector b]
+  -> [Maybe Int]
+  -> m ([(DiffTime, b)], [(DiffTime, b)], [(DiffTime, b)])
+rawPeerScheduleFromTipPoints g psp slotOfB tipPoints trunk0v branches0v intersections = do
+    let (isTrunks, tpIxs) = unzip tipPoints
+        pairedVectors = pairVectorsWithChunks trunk0v branches0v isTrunks
+        tipPointBlks = concat $ zipWith indicesToBlocks pairedVectors tpIxs
+        tipPointSlots = map slotOfB tipPointBlks
+    -- generate the tip point schedule
+    ts <- tipPointSchedule g (pspSlotLength psp) (pspTipDelayInterval psp) tipPointSlots
+    -- generate the header point schedule
+    let tpSchedules = zipMany ts tpIxs
+    hpss <- headerPointSchedule g (pspHeaderDelayInterval psp) $ zip intersections tpSchedules
+    -- generate the block point schedule
+    let (hpsPerBranch, vs) = unzip $ filter (not . null . snd .fst) $ concat
+          [ [((Nothing, hpsTrunk hps), trunk0v), ((mi, hpsBranch hps), v)]
+          | (mi, hps, v) <- zip3 intersections hpss pairedVectors
+          ]
+    bpss <- headerPointSchedule g (pspBlockDelayInterval psp) hpsPerBranch
+    let tipPointTips = zip ts tipPointBlks
+        hpsHeaders = concat $ zipWith (scheduleIndicesToBlocks trunk0v) pairedVectors hpss
+        bpsBlks = concat $ zipWith (scheduleIndicesToBlocks trunk0v) vs bpss
+    pure (tipPointTips, hpsHeaders, bpsBlks)
+
+  where
+    pairVectorsWithChunks
+      :: Vector b
+      -> [Vector b]
+      -> [IsTrunk]
+      -> [Vector b]
+    pairVectorsWithChunks trunk branches =
+       snd . mapAccumL pairVectors branches
+      where
+        pairVectors brs IsTrunk       = (brs, trunk)
+        pairVectors (br:brs) IsBranch = (brs, br)
+        pairVectors [] IsBranch       = error "not enough branches"
+
+    -- | Replaces block indices with the actual blocks
+    scheduleIndicesToBlocks :: Vector b -> Vector b -> HeaderPointSchedule -> [(DiffTime, b)]
+    scheduleIndicesToBlocks trunk v hps =
+        map (second (trunk Vector.!)) (hpsTrunk hps)
+          ++ map (second (v Vector.!)) (hpsBranch hps)
+
+    indicesToBlocks :: Vector b -> [Int] -> [b]
+    indicesToBlocks v ixs = map (v Vector.!) ixs
+
+
+-- | Merge two sorted lists.
+--
+-- PRECONDITION: The lists are sorted.
+--
+mergeOn :: Ord b => (a -> b) -> [a] -> [a] -> [a]
+mergeOn _f [] ys = ys
+mergeOn _f xs [] = xs
+mergeOn f xxs@(x:xs) yys@(y:ys) =
+    if f x <= f y
+      then x : mergeOn f xs yys
+      else y : mergeOn f xxs ys
+
+zipMany :: [a] -> [[b]] -> [[(a, b)]]
+zipMany xs0 = snd . mapAccumL (go []) xs0
+  where
+    go acc xs []         = (xs, reverse acc)
+    go _acc [] _ys       = error "zipMany: lengths don't match"
+    go acc (x:xs) (y:ys) = go ((x, y) : acc) xs ys

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/SinglePeer.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/SinglePeer.hs
@@ -89,6 +89,7 @@ module Test.Consensus.PointSchedule.SinglePeer (
   , schedulePointToBlock
   , singleJumpPeerSchedule
     -- * Exposed for testing
+  , mergeOn
   , zipMany
   ) where
 

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/SinglePeer/Indices.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/SinglePeer/Indices.hs
@@ -1,0 +1,316 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+-- | Schedule generators for a single peer
+--
+-- These functions generate schedules for the tip points, the header points and
+-- the block points of a single peer. All of them are expressed in terms of
+-- block indices rather than actual block points.
+--
+-- The tip points are to be generated first with either of 'singleJumpTipPoints'
+-- or 'rollbacksTipPoints'. Then the tip points can be assigned times at which
+-- to announce them with 'tipPointSchedule'. Then, the header points can be
+-- generated with 'headerPointSchedule'. Finally, the block points can be
+-- generated with 'headerPointSchedule' as well. See the implementation of
+-- 'Test.Consensus.PointSchedule.Random.singleJumpPeerSchedule' for an example.
+--
+module Test.Consensus.PointSchedule.SinglePeer.Indices (
+    HeaderPointSchedule (..)
+  , headerPointSchedule
+  , rollbacksTipPoints
+  , singleJumpTipPoints
+  , tipPointSchedule
+  ) where
+
+import           Control.Monad (forM, replicateM)
+import           Data.List (sort)
+import           Data.Time.Clock (DiffTime, diffTimeToPicoseconds,
+                     picosecondsToDiffTime)
+import           GHC.Stack (HasCallStack)
+import           Ouroboros.Network.Block (SlotNo (SlotNo))
+import qualified System.Random.Stateful as R
+
+
+-- | @singleJumpTipPoints g m n@ generates a list of tip points for a single peer
+-- serving a single branch between block indices @m@ and @n@. The schedule is a
+-- list of block indices for the tip point of the peer state.
+--
+-- The first tip jumps to a block in the middle of the index range, and
+-- then updates the tip one block at a time.
+--
+-- > singleJumpTipPoints
+-- >   :: g
+-- >   -> {m:Int | m >= 0}
+-- >   -> {n:Int | n >= 0}
+-- >   -> m {v:[Int]
+-- >        | isSorted v &&
+-- >          all (m<=) v &&
+-- >          all (<=n) v &&
+-- >          not (hasDuplicates v)
+-- >        }
+--
+singleJumpTipPoints :: R.StatefulGen g m => g -> Int -> Int -> m [Int]
+singleJumpTipPoints _g m n
+    | n < m = pure []
+singleJumpTipPoints g m n = do
+    jump <- R.uniformRM (m, n) g
+    pure [jump..n]
+
+-- | @rollbacksTipPoints k bs g@ generates a schedule for a single peer
+-- serving from multiple alternative branches. The schedule is a list of block
+-- indices for the tip point of the peer state. Here the block indices are
+-- separated per branch in the result. Each index is relative to the branch it
+-- belongs to.
+--
+-- @k@ is the security parameter.
+--
+-- @bs@ are the length in blocks of the alternative branches of the block tree.
+-- The lengths need to be provided in the order in which the branches intersect
+-- with the trunk.
+--
+-- > rollbacksTipPoints
+-- >   :: g
+-- >   -> {k:Int | k > 0}
+-- >   -> {bs:[Int] | all (0<=) bs}
+-- >   -> m {v:[Int]
+-- >        | isSorted v &&
+-- >          all (all (0<=)) v &&
+-- >          all (all (<k)) v &&
+-- >          all isSorted v &&
+-- >          all (not . hasDuplicates) v &&
+-- >          and [all (<bn) bbs | (bn, bbs) <- zip bs v] &&
+-- >          length v == length bs bracketChainSyncClient
+-- >        }
+--
+rollbacksTipPoints
+  :: R.StatefulGen g m => g -> Int -> [Int] -> m [[Int]]
+rollbacksTipPoints g k = mapM walkBranch
+  where
+    walkBranch bn = singleJumpTipPoints g 0 (min (k-1) (bn - 1))
+
+
+-- | @tipPointSchedule g slotLengh msgDelayInterval slots@ attaches times to a
+-- sequence of tip points. These times are the times at which the tip points
+-- should be offered to the node under test. Times are expressed as an offset
+-- from the time of slot 0.
+--
+-- @slotLength@ is the length of a slot in seconds.
+--
+-- @msgDelayInterval@ is the interval from which to sample the delay of
+-- each tip point after the slot in which it was minted.
+--
+-- @slots@ are the slot numbers of the blocks in the tip point schedule.
+-- Because the slots might belong to different branches, they might be
+-- duplicated or not monotonically increasing. e.g.
+--
+-- If 0s and 1s signal the tip points that we want to announce
+--
+-- > slot number: 0123456
+-- > trunk  :     011001
+-- > alternative:   01101
+--
+-- The slots of the tip points to serve could be @[1, 2, 5, 3, 4, 6]@
+-- Then the generated times could be close to
+--
+-- > [1*20, 2*20, 5*20, t3, t4, 6*20]
+--
+-- where @t3@ and @t4@ are chosen randomly in the interval between the
+-- branch tips, that is between 5*20 and 6*20.
+--
+-- > tipPointSchedule
+-- >   :: g
+-- >   -> {slotLength:DiffTime | slotLength >= 0}
+-- >   -> {msgDelayInterval:(DiffTime, DiffTime)
+-- >      | fst msgDelayInterval <= snd msgDelayInterval
+-- >      }
+-- >   -> {slots:[SlotNo] | all (0<=) slots}
+-- >   -> m {v:[DiffTime] | isSorted v && length v == length slots}
+--
+tipPointSchedule
+  :: forall g m. R.StatefulGen g m => g -> DiffTime -> (DiffTime, DiffTime) -> [SlotNo] -> m [DiffTime]
+tipPointSchedule _g slotLength (a, b) _slots
+    | slotLength <= b = error "tipPointSchedule: slotLength <= maximum delay"
+    | b < a = error "tipPointSchedule: empty delay interval"
+tipPointSchedule g slotLength msgDelayInterval slots = do
+    let -- pairs of times corresponding to the start and end of each interval
+        -- between tip points
+        slotTimes = map toDiffTime slots
+        timePairs = zip slotTimes $ tail slotTimes ++ [last slotTimes + 1]
+    go timePairs
+  where
+    go :: [(DiffTime, DiffTime)] -> m [DiffTime]
+    go [] = pure []
+    go xs = do
+      -- While the slots are increasing, assign a time to each point
+      -- by choosing a random time in the delay interval after the
+      -- slot start
+      let (pointSeq, newBranch) = span (\(a, b) -> a < b) xs
+      times <- forM pointSeq $ \(s, _) -> do
+                 delay <- uniformRMDiffTime msgDelayInterval g
+                 pure $ s + delay
+      (times', xss) <- case newBranch of
+        [] -> pure ([], [])
+        ((seqLast, _) : branches) -> do
+          delay <- uniformRMDiffTime msgDelayInterval g
+          let lastTime = seqLast + delay
+          (times', xss) <- handleDelayedTipPoints lastTime branches
+          pure (lastTime : times', xss)
+      -- When the slots are not increasing, we must be doing a rollback.
+      -- We might have tip points in past slots.
+      times'' <- go xss
+      pure $ times ++ times' ++ times''
+
+    -- | The start of each slot in the schedule
+    toDiffTime :: SlotNo -> DiffTime
+    toDiffTime (SlotNo s) = fromIntegral s * slotLength
+
+    -- | Assign times to tip points in past slots. A past slots is
+    -- any earlier slot than the first parameter.
+    --
+    -- Yields the assigned times and the remaining tip points which
+    -- aren't in the past.
+    handleDelayedTipPoints :: DiffTime -> [(DiffTime, DiffTime)] -> m ([DiffTime], [(DiffTime, DiffTime)])
+    handleDelayedTipPoints lastTime xss = do
+      let (pointSeq, newBranch) = span (\(a, _) -> a + fst msgDelayInterval <= lastTime) xss
+          nseq = length pointSeq
+          -- The first point in xss that is not in the past
+          firstLater = case newBranch of
+            -- If there is no later point, pick an arbitrary later time interval
+            -- to sample from
+            []           -> lastTime + toDiffTime (toEnum nseq)
+            ((a, _) : _) -> a + fst msgDelayInterval
+      times <- replicateM nseq (uniformRMDiffTime (lastTime, firstLater) g)
+      pure (sort times, newBranch)
+
+uniformRMDiffTime :: R.StatefulGen g m => (DiffTime, DiffTime) -> g -> m DiffTime
+uniformRMDiffTime (a, b) g =
+    picosecondsToDiffTime <$>
+      R.uniformRM (diffTimeToPicoseconds a, diffTimeToPicoseconds b) g
+
+data HeaderPointSchedule = HeaderPointSchedule {
+    hpsTrunk  :: [(DiffTime, Int)] -- ^ header points up to the intersection
+  , hpsBranch :: [(DiffTime, Int)] -- ^ header points after the intersection
+                                   -- indices are relative to the branch
+  }
+  deriving (Show)
+
+-- | @headerPointSchedule g msgDelayInterval tpSchedule@ generates a
+-- schedule of header points for a single peer.
+--
+-- @msgDelayInterval@ is the interval from which to sample the delay of
+-- each header after offering the previous header.
+--
+-- @tpSchedule@ is the tip point schedule for the peer.
+-- Tip points are grouped by the branch they point to. Each group has
+-- the index of the intersection block with the trunk. Then each group
+-- has a list of tip point block indices relative to the branch. Groups
+-- corresponding to tip points in trunk use 'Nothing' as the intersection.
+--
+-- For each group of tip points, the schedule generates a HeaderPointSchedule,
+-- which provides the time at which each header should be offered.
+--
+-- If scheduled, header points are guaranteed to be scheduled after the tip
+-- point that enables them. They might not be generated if they cannot be
+-- delivered before a tip point of a different branch is announced.  The
+-- header points on a same chain are never announced out of order.
+--
+-- > headerPointSchedule
+-- >   :: g
+-- >   -> {msgDelayInterval:(DiffTime, DiffTime)
+-- >      | fst msgDelayInterval <= snd msgDelayInterval
+-- >      }
+-- >   -> {tpSchedule:[(Maybe Int, [(DiffTime, Int)]]
+-- >      | isSorted (catMaybes (map fst tpSchedule)) &&
+-- >        all (\(_, xs) -> isSorted xs) tpSchedule &&
+-- >        all (\(_, xs) -> all (0<=) (map snd xs)) tpSchedule &&
+-- >        all (\(_, xs) -> not (hasDuplicates (map snd xs))) tpSchedule &&
+-- >        all (\(_, xs) -> not (null xs)) tpSchedule &&
+-- >        all (\(_, xs) -> all (0<=) (map snd xs)) tpSchedule
+-- >      }
+-- >   -> m {v:[HeaderPointSchedule]
+-- >        | length v == length tpSchedule &&
+-- >          isSorted [ map fst (hpsTrunk hps) ++ map fst (hpsBranch hps) | hps <- v ] &&
+-- >          isSorted [ map snd (hpsTrunk hps) | hps <- v ] &&
+-- >          all (\hps -> isSorted (map snd $ hpsBranch hps)) v &&
+-- >          all (\hps -> all (0<=) (map snd (hpsTrunk hps))) v &&
+-- >          all (\hps -> all (0<=) (map snd (hpsBranch hps))) v &&
+-- >          all (\hps -> not (hasDuplicates (map snd (hpsTrunk hps)))) v &&
+-- >          all (\hps -> not (hasDuplicates (map snd (hpsBranch hps)))) v
+-- >        }
+headerPointSchedule
+  :: forall g m. (HasCallStack, R.StatefulGen g m)
+  => g
+  -> (DiffTime, DiffTime)
+  -> [(Maybe Int, [(DiffTime, Int)])]
+  -> m [HeaderPointSchedule]
+headerPointSchedule g msgDelayInterval xs =
+   let -- Pair each  branch with the maximum time at which its header points
+       -- should be offered
+       xs' = zip xs $ map (Just . fst . headCallStack . snd) (tail xs) ++ [Nothing]
+    in snd <$> mapAccumM genHPBranchSchedule (0, 0) xs'
+
+  where
+    -- | @genHPBranchSchedule (tNext, trunkNextHp) ((mi, tps), mtMax)@ generates
+    -- a schedule for a single branch.
+    --
+    -- @tNext@ is the time at which the next header point should be offered.
+    --
+    -- @trunkNextHp@ is the index of the next header point that was offered
+    -- from the trunk.
+    --
+    -- @mi@ is the index of the intersection block with the trunk. Nothing
+    -- means this group has tip points from the trunk.
+    --
+    -- @tps@ is the list of tip point indices relative to the branch.
+    --
+    -- @mtMax@ is the maximum time at which the last header point can be
+    -- offered. 'Nothing' stands for infinity.
+    --
+    -- Returns the time at which the last header point was offered, the next
+    -- header point to offer and the schedule for the branch.
+    genHPBranchSchedule
+      :: (DiffTime, Int)
+      -> ((Maybe Int, [(DiffTime, Int)]), Maybe DiffTime)
+      -> m ((DiffTime, Int), HeaderPointSchedule)
+    genHPBranchSchedule (tNext, trunkNextHp) ((_mi, []), _mtMax) =
+      pure ((tNext, trunkNextHp), HeaderPointSchedule [] [])
+    genHPBranchSchedule (tNext, trunkNextHp) ((Nothing, tps), mtMax) = do
+      (p, tsTrunk) <- mapAccumM (generatePerTipPointTimes mtMax) (tNext, trunkNextHp) tps
+      pure (p, HeaderPointSchedule (concat tsTrunk) [])
+    genHPBranchSchedule (tNext, trunkNextHp) ((Just iLast, tps@((firstTipTime, _):_)), mtMax) = do
+      ((tNext', trunkNextHp'), tsTrunk) <- generatePerTipPointTimes mtMax (tNext, trunkNextHp) (firstTipTime, iLast)
+      ((tNext'', _), tsBranch) <- mapAccumM (generatePerTipPointTimes mtMax) (tNext', 0) tps
+      pure ((tNext'', trunkNextHp'), HeaderPointSchedule tsTrunk (concat tsBranch))
+
+    -- | @generatePerTipPointTimes mtMax (tNext, nextHp) (tTip, tp)@ schedules the header
+    -- points from @nextHp@ to @tp@ in ascending order starting from the maximum
+    -- of @tNext@ and @tTip + t@ where t is sampled from @msgDelayInterval@.
+    --
+    -- Less header points are scheduled if they would be scheduled after @mtMax@.
+    --
+    -- The delay of each tipPoint is sampled from @msgDelayInterval@.
+    --
+    generatePerTipPointTimes
+      :: Maybe DiffTime
+      -> (DiffTime, Int)
+      -> (DiffTime, Int)
+      -> m ((DiffTime, Int), [(DiffTime, Int)])
+    generatePerTipPointTimes mtMax (tNext0, nextHp0) (tTip, tp) = do
+       t <- uniformRMDiffTime msgDelayInterval g
+       go (max tNext0 (tTip + t)) nextHp0 []
+      where
+        go :: DiffTime -> Int -> [(DiffTime, Int)] -> m ((DiffTime, Int), [(DiffTime, Int)])
+        go tNext nextHp acc = do
+          if maybe False (tNext >) mtMax || nextHp > tp then
+            pure ((tNext, nextHp), reverse acc)
+          else do
+            t <- (+tNext) <$> uniformRMDiffTime msgDelayInterval g
+            go t (nextHp+1) ((tNext, nextHp) : acc)
+
+mapAccumM :: Monad m => (s -> x -> m (s, y)) -> s -> [x] -> m (s, [y])
+mapAccumM _ acc [] = pure (acc, [])
+mapAccumM f acc (x:xs) = do
+    (acc', y) <- f acc x
+    (acc'', ys) <- mapAccumM f acc' xs
+    pure (acc'', y:ys)
+
+headCallStack :: HasCallStack => [a] -> a
+headCallStack xs = if null xs then error "headCallStack: empty list" else head xs

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/SinglePeer/Indices.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/SinglePeer/Indices.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 -- | Schedule generators for a single peer
 --
@@ -133,7 +134,7 @@ tipPointSchedule g slotLength msgDelayInterval slots = do
     let -- pairs of times corresponding to the start and end of each interval
         -- between tip points
         slotTimes = map toDiffTime slots
-        timePairs = zip slotTimes $ tail slotTimes ++ [last slotTimes + 1]
+        timePairs = zip slotTimes $ (drop 1 slotTimes) ++ [last slotTimes + 1]
     go timePairs
   where
     go :: [(DiffTime, DiffTime)] -> m [DiffTime]
@@ -244,7 +245,7 @@ headerPointSchedule
 headerPointSchedule g msgDelayInterval xs =
    let -- Pair each  branch with the maximum time at which its header points
        -- should be offered
-       xs' = zip xs $ map (Just . fst . headCallStack . snd) (tail xs) ++ [Nothing]
+       xs' = zip xs $ map (Just . fst . headCallStack . snd) (drop 1 xs) ++ [Nothing]
     in snd <$> mapAccumM genHPBranchSchedule (0, 0) xs'
 
   where
@@ -313,4 +314,6 @@ mapAccumM f acc (x:xs) = do
     pure (acc'', y:ys)
 
 headCallStack :: HasCallStack => [a] -> a
-headCallStack xs = if null xs then error "headCallStack: empty list" else head xs
+headCallStack = \case
+  x:_ -> x
+  _   -> error "headCallStack: empty list"

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Tests.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Tests.hs
@@ -331,7 +331,9 @@ dedupSorted :: Eq a => [a] -> [a]
 dedupSorted = map headCallStack . group
 
 headCallStack :: HasCallStack => [a] -> a
-headCallStack xs = if null xs then error "headCallStack: empty list" else head xs
+headCallStack = \case
+  x:_ -> x
+  _   -> error "headCallStack: empty list"
 
 headerPointsFollowTipPoints :: Show a => (a -> a -> Maybe Ordering) -> [(DiffTime, a)] -> [(DiffTime, a)] -> QC.Property
 headerPointsFollowTipPoints _ [] [] = QC.property True

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Tests.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Tests.hs
@@ -1,0 +1,382 @@
+{-# LANGUAGE LambdaCase       #-}
+{-# LANGUAGE NamedFieldPuns   #-}
+{-# LANGUAGE TypeApplications #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Test.Consensus.PointSchedule.Tests (tests) where
+
+import           Cardano.Slotting.Slot (SlotNo (..), WithOrigin (..),
+                     withOrigin)
+import           Control.Monad (forM, replicateM)
+import           Data.Bifunctor (second)
+import           Data.List (foldl', group, isSuffixOf, partition, sort)
+import qualified Data.List.NonEmpty as NonEmpty
+import           Data.Maybe (isNothing)
+import           Data.Time.Clock (DiffTime, diffTimeToPicoseconds,
+                     picosecondsToDiffTime)
+import           GHC.Stack (HasCallStack)
+import qualified Ouroboros.Network.AnchoredFragment as AF
+import           Ouroboros.Network.Block (blockHash)
+import           System.Random.Stateful (runSTGen_)
+import           Test.Consensus.PointSchedule.SinglePeer
+import           Test.Consensus.PointSchedule.SinglePeer.Indices
+import qualified Test.QuickCheck as QC hiding (elements)
+import           Test.QuickCheck
+import           Test.QuickCheck.Random
+import           Test.Tasty
+import           Test.Tasty.QuickCheck
+import qualified Test.Util.QuickCheck as QC
+import           Test.Util.TestBlock (TestBlock, TestHash (unTestHash),
+                     firstBlock, modifyFork, successorBlock, tbSlot)
+import           Test.Util.TestEnv
+
+
+tests :: TestTree
+tests =
+    adjustQuickCheckTests (* 100) $
+    adjustOption (\(QuickCheckMaxSize n) -> QuickCheckMaxSize (n `div` 10)) $
+    testGroup "PointSchedule"
+      [ testProperty "zipMany" prop_zipMany
+      , testProperty "singleJumpTipPoints" prop_singleJumpTipPoints
+      , testProperty "tipPointSchedule" prop_tipPointSchedule
+      , testProperty "headerPointSchedule" prop_headerPointSchedule
+      , testProperty "peerScheduleFromTipPoints" prop_peerScheduleFromTipPoints
+      ]
+
+prop_zipMany :: [[Int]] -> QC.Property
+prop_zipMany xss =
+    let xs :: [Int]
+        xs = concatMap (map (+1)) xss
+        ys :: [[(Int, Int)]]
+        ys = zipMany xs xss
+     in
+          length xss QC.=== length ys
+        QC..&&.
+          map (map snd) ys QC.=== xss
+        QC..&&.
+          concatMap (map fst) ys QC.=== xs
+
+
+data SingleJumpTipPointsInput = SingleJumpTipPointsInput
+  { sjtpMin :: Int
+  , sjtpMax :: Int
+  } deriving (Show)
+
+instance QC.Arbitrary SingleJumpTipPointsInput where
+  arbitrary = do
+    QC.NonNegative a <- QC.arbitrary
+    QC.NonNegative b <- QC.arbitrary
+    pure $ SingleJumpTipPointsInput (min a b) (max a b)
+
+prop_singleJumpTipPoints :: QCGen -> SingleJumpTipPointsInput -> QC.Property
+prop_singleJumpTipPoints seed (SingleJumpTipPointsInput m n) =
+    runSTGen_ seed $ \g -> do
+      xs <- singleJumpTipPoints g m n
+      pure $ isSorted QC.le xs
+        QC..&&.
+         (QC.counterexample ("length xs = " ++ show (length xs)) $
+           length xs `QC.le` n - m + 1
+         )
+        QC..&&.
+         (QC.counterexample ("head xs = " ++ show (headCallStack xs)) $
+             headCallStack xs `QC.le` n
+           QC..&&.
+             m `QC.le` headCallStack xs
+         )
+
+data TipPointScheduleInput = TipPointScheduleInput
+  { tpsSlotLength  :: DiffTime
+  , tpsMsgInterval :: (DiffTime, DiffTime)
+  , tpsSlots       :: [SlotNo]
+  } deriving (Show)
+
+instance QC.Arbitrary TipPointScheduleInput where
+  arbitrary = do
+    slotLength <- chooseDiffTime (1, 20)
+    msgInterval <- genTimeInterval (slotLength - 0.1)
+    slots0 <- dedupSorted . map (SlotNo . QC.getNonNegative) <$> QC.orderedList
+    slots1 <- dedupSorted . map (SlotNo . QC.getNonNegative) <$> QC.orderedList
+    pure $ TipPointScheduleInput slotLength msgInterval (slots0 ++ slots1)
+
+prop_tipPointSchedule :: QCGen -> TipPointScheduleInput -> QC.Property
+prop_tipPointSchedule seed (TipPointScheduleInput slotLength msgInterval slots) =
+    runSTGen_ seed $ \g -> do
+      ts <- tipPointSchedule g slotLength msgInterval slots
+      pure $
+          (QC.counterexample ("length slots = " ++ show (length slots)) $
+           QC.counterexample ("length ts = " ++ show (length ts)) $
+             length slots QC.=== length ts
+          )
+        QC..&&.
+          isSorted QC.le ts
+
+data HeaderPointScheduleInput = HeaderPointScheduleInput
+  { hpsMsgInterval :: (DiffTime, DiffTime)
+  , hpsTipPoints   :: [(Maybe Int, [(DiffTime, Int)])]
+  } deriving (Show)
+
+instance QC.Arbitrary HeaderPointScheduleInput where
+  arbitrary = do
+    msgInterval <- genTimeInterval 10
+    branchTips <- genTipPoints
+    let branchCount = length branchTips
+        tpCount = sum $ map length branchTips
+    ts <- scanl1 (+) . sort <$> replicateM tpCount (chooseDiffTime (7, 12))
+    let tpts = zipMany ts branchTips
+    intersectionBlocks <- genIntersections branchCount
+    maybes <- QC.infiniteList @(Maybe Int)
+    let intersections = zipWith (>>) maybes $ map Just intersectionBlocks
+    pure $ HeaderPointScheduleInput msgInterval (zip intersections tpts)
+
+prop_headerPointSchedule :: QCGen -> HeaderPointScheduleInput -> QC.Property
+prop_headerPointSchedule g (HeaderPointScheduleInput msgDelayInterval xs) =
+    runSTGen_ g $ \g' -> do
+      hpss <- headerPointSchedule g' msgDelayInterval xs
+      pure $
+          (QC.counterexample ("length xs = " ++ show (length xs)) $
+           QC.counterexample ("length hpss = " ++ show (length hpss)) $
+            length xs QC.=== length hpss
+          )
+        QC..&&.
+          (QC.counterexample ("header points are sorted in each branch") $
+            foldr (QC..&&.) (QC.property True)
+              [ QC.counterexample ("branch = " ++ show hps) $
+                isSorted QC.lt (map snd trunk) QC..&&. isSorted QC.lt (map snd branch)
+              | hps@(HeaderPointSchedule trunk branch) <- hpss
+              ]
+          )
+         QC..&&.
+          (QC.counterexample ("times are sorted accross branches") $
+           QC.counterexample ("branches = " ++ show hpss) $
+            isSorted QC.le $ concat
+              [ map fst trunk ++ map fst branch
+              | HeaderPointSchedule trunk branch <- hpss
+              ]
+          )
+        QC..&&.
+          (QC.counterexample ("trunk header points are sorted accross branches") $
+           QC.counterexample ("branches = " ++ show hpss) $
+            isSorted QC.lt $ concat
+              [ map snd trunk | HeaderPointSchedule trunk _ <- hpss ]
+          )
+        QC..&&.
+          (QC.counterexample "branch header points follow tip points" $
+           QC.counterexample ("branches = " ++ show hpss) $
+             foldr (QC..&&.) (QC.property True) $
+               zipWith (\hps x ->
+                 case x of
+                   (Just _, b) -> headerPointsFollowTipPoints leMaybe (hpsBranch hps) b
+                   _ -> QC.property True
+                ) hpss xs
+          )
+  where
+    leMaybe :: Ord a => a -> a -> Maybe Ordering
+    leMaybe a b = Just $ compare a b
+
+data PeerScheduleFromTipPointsInput = PeerScheduleFromTipPointsInput
+       PeerScheduleParams
+       [(IsTrunk, [Int])]
+       (AF.AnchoredFragment TestBlock)
+       [AF.AnchoredFragment TestBlock]
+
+instance Show PeerScheduleFromTipPointsInput where
+  show (PeerScheduleFromTipPointsInput psp tps trunk branches) =
+    unlines
+      [ "PeerScheduleFromTipPointsInput"
+      , "  params = "  ++ show psp
+      , "  tipPoints = " ++ show tps
+      , "  trunk = " ++ show (AF.toOldestFirst trunk)
+      , "  branches = " ++ show [ (AF.anchorBlockNo b, AF.toOldestFirst b) | b <- branches ]
+      ]
+
+instance QC.Arbitrary PeerScheduleFromTipPointsInput where
+  arbitrary = do
+    slotLength <- chooseDiffTime (1, 20)
+    tipDelayInterval <- genTimeInterval (slotLength - 0.1)
+    headerDelayInterval <- genTimeInterval (min 2 (slotLength - 0.1))
+    blockDelayInterval <- genTimeInterval (min 2 (slotLength - 0.1))
+    tipPoints <- genTipPoints
+    isTrunks <- QC.infiniteList
+    intersections <- genIntersections (length tipPoints)
+    let tstps = zip isTrunks tipPoints
+        tsi = zip isTrunks intersections
+        -- The maximum block number in the tip points and the intersections.
+        maxBlock =
+          maximum $ concat [ b | (IsTrunk, b) <- tstps ] ++
+                           [ i | (IsBranch, i) <- tsi ]
+    trunkSlots <- map SlotNo <$> genSortedVectorWithoutDuplicates (maxBlock + 1)
+    let branchesTipPoints = [ b | (IsBranch, b) <- tstps ]
+    branchesSlots <- forM branchesTipPoints $ \b -> do
+      let maxBranchBlock = maximum b
+      map SlotNo <$> genSortedVectorWithoutDuplicates (maxBranchBlock + 1)
+    let trunk = mkFragment Origin trunkSlots 0
+        branchIntersections = [ i | (IsBranch, i) <- tsi ]
+        branches =
+          [ genAdversarialFragment trunk fNo i branchSlots
+          | (fNo, branchSlots, i)  <- zip3 [1..] branchesSlots branchIntersections
+          ]
+        psp = PeerScheduleParams
+          { pspSlotLength = slotLength
+          , pspTipDelayInterval = tipDelayInterval
+          , pspHeaderDelayInterval = headerDelayInterval
+          , pspBlockDelayInterval = blockDelayInterval
+          }
+
+    pure $ PeerScheduleFromTipPointsInput psp tstps trunk branches
+
+instance QC.Arbitrary IsTrunk where
+  arbitrary = QC.elements [IsTrunk, IsBranch]
+
+prop_peerScheduleFromTipPoints :: QCGen -> PeerScheduleFromTipPointsInput -> QC.Property
+prop_peerScheduleFromTipPoints seed (PeerScheduleFromTipPointsInput psp tps trunk branches) =
+    runSTGen_ seed $ \g -> do
+      ss <- peerScheduleFromTipPoints g psp tps trunk branches
+      let (tps', (hps, _bps)) =
+            partition (isHeaderPoint . snd) <$> partition (isTipPoint . snd) ss
+      pure $
+          (QC.counterexample ("hps = " ++ show (map (second showPoint) hps)) $
+           QC.counterexample ("tps' = " ++ show (map (second showPoint) tps')) $
+             headerPointsFollowTipPoints isAncestorBlock
+               (map (second schedulePointToBlock) hps)
+               (map (second schedulePointToBlock) tps')
+          )
+        QC..&&.
+          (QC.counterexample ("schedule = " ++ show (map (second showPoint) ss)) $
+            isSorted QC.le (map fst ss))
+        QC..&&.
+          (QC.counterexample ("schedule = " ++ show (map (second showPoint) ss)) $
+           QC.counterexample ("header points don't decrease or repeat") $
+            noReturnToAncestors (filter isHeaderPoint $ map snd ss)
+          )
+        QC..&&.
+          (QC.counterexample ("schedule = " ++ show (map (second showPoint) ss)) $
+           QC.counterexample ("block points don't decrease or repeat") $
+            noReturnToAncestors (filter isBlockPoint $ map snd ss)
+          )
+  where
+    showPoint :: SchedulePoint -> String
+    showPoint (ScheduleTipPoint b)    = "TP " ++ show (blockHash b)
+    showPoint (ScheduleHeaderPoint b) = "HP " ++ show (blockHash b)
+    showPoint (ScheduleBlockPoint b)  = "BP " ++ show (blockHash b)
+
+    isTipPoint :: SchedulePoint -> Bool
+    isTipPoint (ScheduleTipPoint _) = True
+    isTipPoint _                    = False
+
+    isHeaderPoint :: SchedulePoint -> Bool
+    isHeaderPoint (ScheduleHeaderPoint _) = True
+    isHeaderPoint _                       = False
+
+    isBlockPoint :: SchedulePoint -> Bool
+    isBlockPoint (ScheduleBlockPoint _) = True
+    isBlockPoint _                      = False
+
+isAncestorBlock :: TestBlock -> TestBlock -> Maybe Ordering
+isAncestorBlock b0 b1 =
+    if isSuffixOf
+         (NonEmpty.toList (unTestHash (blockHash b0)))
+         (NonEmpty.toList (unTestHash (blockHash b1)))
+    then if blockHash b0 == blockHash b1
+      then Just EQ
+      else Just LT
+    else Nothing
+
+noReturnToAncestors :: [SchedulePoint] -> QC.Property
+noReturnToAncestors = go []
+  where
+    go _ [] = QC.property True
+    go ancestors (p : ss) =
+      let b = schedulePointToBlock p
+       in   foldr (QC..&&.) (QC.property True)
+              (map (isNotAncestorOf b) ancestors)
+          QC..&&.
+            go (b : ancestors) ss
+
+    isNotAncestorOf :: TestBlock -> TestBlock -> QC.Property
+    isNotAncestorOf b0 b1 =
+      QC.counterexample ("return to ancestor: " ++ show (blockHash b0) ++ " -> " ++ show (blockHash b1)) $
+        QC.property $ isNothing $ isAncestorBlock b0 b1
+
+genTimeInterval :: DiffTime -> QC.Gen (DiffTime, DiffTime)
+genTimeInterval trange = do
+    a <- chooseDiffTime (1, trange)
+    b <- chooseDiffTime (1, trange)
+    pure (min a b, max a b)
+
+genTipPoints :: QC.Gen [[Int]]
+genTipPoints = do
+    branchCount <- QC.choose (1, 5)
+    xss <- QC.vector branchCount
+    pure $ map (dedupSorted . sort . map QC.getNonNegative . QC.getNonEmpty) xss
+
+-- | @genIntersections n@ generates a list of @n@ intersections as block numbers.
+genIntersections :: Int -> QC.Gen [Int]
+genIntersections n =
+    -- Intersection with the genesis block is represented by @Just (-1)@.
+    map (\x -> x - 1) . sort . map QC.getNonNegative <$> QC.vector n
+
+isSorted :: Show a => (a -> a -> QC.Property) -> [a] -> QC.Property
+isSorted cmp xs =
+    QC.counterexample ("isSorted " ++ show xs) $
+    foldr (QC..&&.) (QC.property True)
+      [ cmp a b | (a, b) <- zip xs (drop 1 xs) ]
+
+chooseDiffTime :: (DiffTime, DiffTime) -> QC.Gen DiffTime
+chooseDiffTime (a, b) = do
+    let aInt = diffTimeToPicoseconds a
+        bInt = diffTimeToPicoseconds b
+    picosecondsToDiffTime <$> QC.chooseInteger (aInt, bInt)
+
+dedupSorted :: Eq a => [a] -> [a]
+dedupSorted = map headCallStack . group
+
+headCallStack :: HasCallStack => [a] -> a
+headCallStack xs = if null xs then error "headCallStack: empty list" else head xs
+
+headerPointsFollowTipPoints :: Show a => (a -> a -> Maybe Ordering) -> [(DiffTime, a)] -> [(DiffTime, a)] -> QC.Property
+headerPointsFollowTipPoints _ [] [] = QC.property True
+headerPointsFollowTipPoints isAncestor ((t0, i0) : ss) ((t1, i1) : ps) =
+      QC.counterexample "schedule times follow tip points" (QC.ge t0 t1)
+    QC..&&.
+      (case isAncestor i0 i1 of
+         Just LT -> headerPointsFollowTipPoints isAncestor ss ((t1, i1) : ps)
+         Just EQ -> headerPointsFollowTipPoints isAncestor ss ps
+         _       -> headerPointsFollowTipPoints isAncestor ((t0, i0) : ss) ps
+      )
+headerPointsFollowTipPoints _ [] _ps =
+--      There can be unscheduled header points if they would be produced so
+--      late that they would come after the tip point has moved to another branch.
+--
+--      QC.counterexample ("schedule times are sufficient for: " ++ show ps) $
+--        QC.property False
+      QC.property True
+headerPointsFollowTipPoints _ ss [] =
+      QC.counterexample ("schedule times finish after last tip point: " ++ show ss) $
+        QC.property False
+
+-- | @genAdversarialFragment goodBlocks forkNo prefixCount slotsA@ generates
+-- a fragment for a chain that forks off the given chain.
+genAdversarialFragment :: AF.AnchoredFragment TestBlock -> Int -> Int -> [SlotNo] -> AF.AnchoredFragment TestBlock
+genAdversarialFragment goodBlocks forkNo prefixCount slotsA
+      = mkFragment intersectionBlock slotsA forkNo
+  where
+    -- blocks in the common prefix in reversed order
+    intersectionBlock = case AF.head $ AF.takeOldest (prefixCount + 1) goodBlocks of
+        Left _  -> Origin
+        Right b -> At b
+
+-- | @mkFragment pre active forkNo@ generates a list of blocks at the given slots.
+mkFragment :: WithOrigin TestBlock -> [SlotNo] -> Int -> AF.AnchoredFragment TestBlock
+mkFragment pre active forkNo = AF.fromNewestFirst anchor $ foldl' issue [] active
+  where
+    anchor = withOrigin AF.AnchorGenesis AF.anchorFromBlock pre
+    issue (h : t) s = (successorBlock h) {tbSlot = s} : h : t
+    issue [] s | Origin <- pre = [(firstBlock (fromIntegral forkNo)) {tbSlot = s}]
+               | At h <- pre = [(modifyFork (const (fromIntegral forkNo)) (successorBlock h)) {tbSlot = s}]
+
+-- | @genVectorWithoutDuplicates n@ generates a vector of length @n@
+-- without duplicates.
+genSortedVectorWithoutDuplicates :: (QC.Arbitrary a, Num a, Ord a) => Int -> QC.Gen [a]
+genSortedVectorWithoutDuplicates n = do
+    x0 <- QC.arbitrary
+    scanl (+) x0 . map ((+1) . QC.getNonNegative) <$> QC.vector (n - 1)

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Consensus/ChainGenerator/Params.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Consensus/ChainGenerator/Params.hs
@@ -99,6 +99,6 @@ genAsc = ascFromBits <$> QC.choose (1 :: Word8, maxBound - 1)
 genKSD :: QC.Gen (Kcp, Scg, Delta)
 genKSD = sized1 $ \sz -> do
     d <- QC.choose (0, div sz 4)
-    k <- QC.choose (1, 2 * sz)
+    k <- (+ 2) <$> QC.choose (0, 2 * sz)
     s <- (+ k) <$> QC.choose (0, 3 * sz)   -- ensures @k / s <= 1@
     pure (Kcp k, Scg s, Delta d)

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/Corruption.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/Corruption.hs
@@ -31,7 +31,9 @@ applyCorruption (Corruption n) bs
     | Lazy.null bs
     = bs
     | otherwise
-    = before <> Lazy.cons (Lazy.head atAfter + 1) (Lazy.tail atAfter)
+    = before <> case Lazy.uncons atAfter of
+      Nothing       -> error "split bytestring after last byte"
+      Just (hd, tl) -> Lazy.cons (hd + 1) tl
   where
     offset = fromIntegral n `mod` Lazy.length bs
     (before, atAfter) = Lazy.splitAt offset bs

--- a/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/ChainGenerator/Tests/Adversarial.hs
+++ b/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/ChainGenerator/Tests/Adversarial.hs
@@ -176,6 +176,7 @@ prop_adversarialChain someTestAdversarial testSeedA = runIdentity $ do
         Left e   -> case e of
             A.BadAnchor{} -> QC.counterexample (show e) False
             A.BadCount{}  -> QC.counterexample (show e) False
+            A.BadDensity{}  -> QC.counterexample (show e) False
             A.BadRace rv  -> case rv of
                 A.AdversaryWonRace {
                     A.rvAdv = RI.Race (C.SomeWindow Proxy rAdv)
@@ -235,7 +236,11 @@ data AdversarialMutation =
     -- | Increasing 'Delta' by one may cause the adversary to win a race
     AdversarialMutateDelta
   |
-    -- | Decreasing 'Kcp' by one may cause the adversary to win a race
+    -- | Decreasing 'Kcp' by two may cause the adversary to win a race
+    --
+    -- NOTE: decreasing 'Kcp' by one does not guarantee a lost race since the
+    -- alternative chain already has one slot less in the first window after the
+    -- intersection.
     AdversarialMutateKcp
 {-
   |
@@ -287,7 +292,7 @@ mutateAdversarial recipe mut =
 
     (k', s', d') = case mut of
         AdversarialMutateDelta -> (k,     s,     d + 1)
-        AdversarialMutateKcp   -> (k - 1, s,     d    )
+        AdversarialMutateKcp   -> (k - 2, s,     d    )
 --        AdversarialMutateScgNeg -> (k,     s - 1, d    )
 --        AdversarialMutateScgPos -> (k,     s + 1, d    )
 
@@ -422,9 +427,10 @@ prop_adversarialChainMutation (SomeTestAdversarialMutation Proxy Proxy testAdver
                 writeIORef catch (testSeedA,  H.prettyChainSchema schedA "A" <> pretty)
                 go catch counter recipeA' testSeedAsSeed'
             Left e   -> case e of
-                A.BadAnchor{} -> error $ "impossible! " <> show e
-                A.BadCount{}  -> error $ "impossible! " <> show e
-                A.BadRace{}   -> pure $ QC.property ()
+                A.BadAnchor{}  -> error $ "impossible! " <> show e
+                A.BadCount{}   -> error $ "impossible! " <> show e
+                A.BadDensity{} -> pure $ QC.property ()
+                A.BadRace{}    -> pure $ QC.property ()
 
 -----
 

--- a/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/ChainGenerator/Tests/BitVector.hs
+++ b/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/ChainGenerator/Tests/BitVector.hs
@@ -126,7 +126,7 @@ class POL pol => TestPOL (pol :: S.Pol) where showPol :: proxy pol -> String
 instance TestPOL S.Inverted             where showPol _pol = "Inverted"
 instance TestPOL S.NotInverted          where showPol _pol = "NotInverted"
 
--- | Check that when @findIthZeroInV i bv@ yields 'JustFound'
+-- | Check that when @findIthEmptyInV pol bv i@ yields 'JustFound'
 --
 -- 1. it yields the index of an inactive slot
 -- 2. there are exactly @i@ inactive slots in the preceding slots

--- a/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/ChainGenerator/Tests/BitVector.hs
+++ b/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/ChainGenerator/Tests/BitVector.hs
@@ -126,6 +126,11 @@ class POL pol => TestPOL (pol :: S.Pol) where showPol :: proxy pol -> String
 instance TestPOL S.Inverted             where showPol _pol = "Inverted"
 instance TestPOL S.NotInverted          where showPol _pol = "NotInverted"
 
+-- | Check that when @findIthZeroInV i bv@ yields 'JustFound'
+--
+-- 1. it yields the index of an inactive slot
+-- 2. there are exactly @i@ inactive slots in the preceding slots
+--
 prop_findIthZeroInV :: SomeFindTestSetup -> QC.Property
 prop_findIthZeroInV testSetup = case testSetup of
     SomeFindTestSetup FindTestSetup {
@@ -198,6 +203,13 @@ instance QC.Arbitrary FillInWindowSetup where
       ss <- QC.vectorOf szV QC.arbitrary
       pure $ FillInWindowSetup pol k szW qcGen (V.fromList ss)
 
+-- | Check that 'fillInWindow'
+--
+-- 1. does not decrease the count of active slots in the given window
+-- 2. returns exactly the amount of activated slots
+-- 3. never leaves less than the requested amount of slots in the given
+--    window
+--
 prop_fillInWindow :: FillInWindowSetup -> QC.Property
 prop_fillInWindow
         (FillInWindowSetup

--- a/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/ChainGenerator/Tests/BitVector.hs
+++ b/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/ChainGenerator/Tests/BitVector.hs
@@ -29,7 +29,7 @@ import qualified Test.Util.QuickCheck as QC
 
 tests :: [TT.TestTree]
 tests = [
-    TT.testProperty "prop_findIthZeroInV" prop_findIthZeroInV,
+    TT.testProperty "prop_findIthEmptyInV" prop_findIthEmptyInV,
     TT.testProperty "prop_fillInWindow" prop_fillInWindow
   ]
 
@@ -131,8 +131,8 @@ instance TestPOL S.NotInverted          where showPol _pol = "NotInverted"
 -- 1. it yields the index of an inactive slot
 -- 2. there are exactly @i@ inactive slots in the preceding slots
 --
-prop_findIthZeroInV :: SomeFindTestSetup -> QC.Property
-prop_findIthZeroInV testSetup = case testSetup of
+prop_findIthEmptyInV :: SomeFindTestSetup -> QC.Property
+prop_findIthEmptyInV testSetup = case testSetup of
     SomeFindTestSetup FindTestSetup {
         testIndex
       ,


### PR DESCRIPTION
The main motivation of this PR is to implement a generator of schedules for genesis tests.
It can be found in commit https://github.com/IntersectMBO/ouroboros-consensus/pull/536/commits/6636fa5f83282762cdf330feb4a58e1dce607905, and a first file to look at could be 
`ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/SinglePeer.hs`

Unit tests are provided in `ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Tests.hs` which look for flaws in the generated schedules.

The generators have been integrated in commit https://github.com/IntersectMBO/ouroboros-consensus/pull/536/commits/6c829e5dbc95762ce5ac8bcdb43e6e96b3cd5e2e with the provisional Praos/Genesis test of a long range attack.

For the rest, this PR includes:
* commits https://github.com/IntersectMBO/ouroboros-consensus/pull/536/commits/1ccb06303874fac8f5b8f1f16591514acb235821 and https://github.com/IntersectMBO/ouroboros-consensus/pull/536/commits/a7d6e64ae7bdf5f6d281b2e01714228660fc83c2 with tests to check that our materialization of a Praos node enforces timeouts and follows rollbacks,
* commit https://github.com/IntersectMBO/ouroboros-consensus/pull/536/commits/2cf4c3942a3f5d53bdf589448cd304940ec5c949 which fixes the chain schema generator so alternative chains are guaranteed to be less dense than the honest chain
* commits https://github.com/IntersectMBO/ouroboros-consensus/pull/536/commits/d562c3373d9d0af3eafff0847394c68da92584bb, https://github.com/IntersectMBO/ouroboros-consensus/pull/536/commits/072d4afe9b6a48f68a75c933c96acca2cd7712f7, and https://github.com/IntersectMBO/ouroboros-consensus/pull/536/commits/0c9adb6803213f98e69b08838949133d609a663d with various improvements to the peer simulator and the chain schema generator.

