### PR TITLE
Use upstream instances for basic blockchain types

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -31,3 +31,44 @@ tests: true
 benchmarks: true
 
 import: ./asserts.cabal
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/ouroboros-network
+  tag: 196bd57bfd023372feefefced0a9cff5a373abe3
+  subdir:
+    ouroboros-network-protocols
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/cardano-ledger
+  tag: c30207b554667c96df07c24d4ab0af3b61a12406
+  subdir:
+    eras/alonzo/impl
+    eras/alonzo/test-suite
+    eras/allegra/impl
+    eras/babbage/impl
+    eras/babbage/test-suite
+    eras/byron/chain/executable-spec
+    eras/byron/crypto
+    eras/byron/crypto/test
+    eras/byron/ledger/executable-spec
+    eras/byron/ledger/impl
+    eras/byron/ledger/impl/test
+    eras/conway/impl
+    eras/conway/test-suite
+    eras/mary/impl
+    eras/shelley-ma/test-suite
+    eras/shelley/impl
+    eras/shelley/test-suite
+    libs/cardano-data
+    libs/cardano-ledger-api
+    libs/cardano-ledger-binary
+    libs/cardano-ledger-core
+    libs/cardano-ledger-pretty
+    libs/cardano-protocol-tpraos
+    libs/non-integral
+    libs/set-algebra
+    libs/small-steps
+    libs/small-steps-test
+    libs/vector-map

--- a/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
+++ b/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
@@ -115,16 +115,16 @@ library
     , cardano-crypto
     , cardano-crypto-class
     , cardano-crypto-wrapper
-    , cardano-ledger-allegra        ^>=1.2.5
-    , cardano-ledger-alonzo         ^>=1.5.1
-    , cardano-ledger-api            ^>=1.7
-    , cardano-ledger-babbage        ^>=1.5.1
-    , cardano-ledger-binary         ^>=1.2.1
+    , cardano-ledger-allegra        ^>=1.3
+    , cardano-ledger-alonzo         ^>=1.6
+    , cardano-ledger-api            ^>=1.8
+    , cardano-ledger-babbage        ^>=1.6
+    , cardano-ledger-binary         ^>=1.3
     , cardano-ledger-byron          ^>=1.0.0.3
-    , cardano-ledger-conway         ^>=1.11
-    , cardano-ledger-core           ^>=1.9
-    , cardano-ledger-mary           ^>=1.4
-    , cardano-ledger-shelley        ^>=1.8
+    , cardano-ledger-conway         ^>=1.12
+    , cardano-ledger-core           ^>=1.10
+    , cardano-ledger-mary           ^>=1.5
+    , cardano-ledger-shelley        ^>=1.9
     , cardano-prelude
     , cardano-protocol-tpraos       ^>=1.0.3.7
     , cardano-slotting

--- a/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
+++ b/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
@@ -153,8 +153,10 @@ library unstable-mock-testlib
     , base
     , bytestring
     , cardano-crypto-class
+    , cardano-crypto-tests
     , containers
     , ouroboros-consensus:{ouroboros-consensus, unstable-consensus-testlib, unstable-mock-block}
+    , ouroboros-network-protocols:testlib
     , QuickCheck
     , serialise
     , unstable-diffusion-testlib

--- a/ouroboros-consensus-diffusion/src/unstable-mock-testlib/Test/Consensus/Ledger/Mock/Generators.hs
+++ b/ouroboros-consensus-diffusion/src/unstable-mock-testlib/Test/Consensus/Ledger/Mock/Generators.hs
@@ -1,11 +1,8 @@
 {-# LANGUAGE FlexibleContexts     #-}
 {-# LANGUAGE FlexibleInstances    #-}
-{-# LANGUAGE NamedFieldPuns       #-}
 {-# LANGUAGE OverloadedStrings    #-}
-{-# LANGUAGE PatternSynonyms      #-}
 {-# LANGUAGE RecordWildCards      #-}
 {-# LANGUAGE ScopedTypeVariables  #-}
-{-# LANGUAGE TypeApplications     #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 {-# OPTIONS_GHC -Wno-orphans #-}
@@ -28,6 +25,8 @@ import qualified Ouroboros.Consensus.Mock.Ledger.State as L
 import qualified Ouroboros.Consensus.Mock.Ledger.UTxO as L
 import           Ouroboros.Consensus.Mock.Node.Serialisation ()
 import           Ouroboros.Consensus.Protocol.BFT
+import           Test.ChainGenerators ()
+import           Test.Crypto.Hash ()
 import           Test.QuickCheck
 import           Test.Util.Orphans.Arbitrary ()
 import           Test.Util.Serialisation.Roundtrip
@@ -133,8 +132,8 @@ instance Arbitrary (TxId (GenTx (SimpleBlock c ext))) where
 
 instance Arbitrary L.Tx where
   arbitrary = L.Tx L.DoNotExpire
-         <$> pure mempty  -- For simplicity
-         <*> arbitrary
+             mempty -- for simplicity
+         <$> arbitrary
 
 instance Arbitrary L.Addr where
   arbitrary = elements ["a", "b", "c"]

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -342,9 +342,10 @@ library unstable-consensus-testlib
     , base16-bytestring
     , binary
     , bytestring
+    , cardano-binary:testlib
     , cardano-crypto-class
-    , cardano-ledger-binary:{cardano-ledger-binary, testlib}
     , cardano-prelude
+    , cardano-slotting:testlib
     , cardano-strict-containers
     , cborg
     , containers
@@ -366,6 +367,7 @@ library unstable-consensus-testlib
     , ouroboros-network-mock
     , pretty-simple
     , QuickCheck
+    , quickcheck-instances
     , quickcheck-state-machine                                ^>=0.7
     , quiet
     , random

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/Orphans/Arbitrary.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/Orphans/Arbitrary.hs
@@ -54,8 +54,9 @@ import           Ouroboros.Consensus.Storage.ImmutableDB.Chunks.Internal
                      (ChunkNo (..), ChunkSize (..), RelativeSlot (..))
 import           Ouroboros.Consensus.Storage.ImmutableDB.Chunks.Layout
 import           Ouroboros.Consensus.TypeFamilyWrappers
-import           Test.Cardano.Ledger.Binary.Arbitrary ()
+import           Test.Cardano.Slotting.Arbitrary ()
 import           Test.QuickCheck hiding (Fixed (..))
+import           Test.QuickCheck.Instances ()
 import           Test.Util.Time (dawnOfTime)
 
 minNumCoreNodes :: Word64

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/Orphans/ToExpr.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/Orphans/ToExpr.hs
@@ -5,13 +5,14 @@
 
 module Test.Util.Orphans.ToExpr () where
 
-import           Cardano.Ledger.TreeDiff
+import           Data.TreeDiff
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.HeaderValidation
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Network.Point
+import           Test.Cardano.Slotting.TreeDiff ()
 
 {-------------------------------------------------------------------------------
   ouroboros-network

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/Serialisation/Golden.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/Serialisation/Golden.hs
@@ -50,6 +50,7 @@ import qualified Data.ByteString.UTF8 as BS.UTF8
 import           Data.List (nub)
 import qualified Data.Map.Strict as Map
 import           Data.Proxy (Proxy (..))
+import           Data.TreeDiff
 import           GHC.Stack (HasCallStack)
 import           Ouroboros.Consensus.Block (CodecConfig)
 import           Ouroboros.Consensus.Ledger.Extended (encodeExtLedgerState)
@@ -69,7 +70,7 @@ import           Ouroboros.Consensus.Util.CBOR (decodeAsFlatTerm)
 import           Ouroboros.Consensus.Util.Condense (Condense (..))
 import           System.Directory (createDirectoryIfMissing)
 import           System.FilePath (takeDirectory, (</>))
-import           Test.Cardano.Ledger.Binary.TreeDiff (CBORBytes (..), diffExpr)
+import           Test.Cardano.Binary.TreeDiff (CBORBytes (..))
 import           Test.Tasty
 import           Test.Tasty.Golden.Advanced (goldenTest)
 import           Test.Util.Serialisation.Examples (Examples (..), Labelled)
@@ -152,7 +153,7 @@ goldenTestCBOR testName example enc goldenFile =
             | actual == golden -> Nothing
             | otherwise -> Just $ unlines [
                 "Golden term /= actual term, diff golden actual:"
-              , diffExpr (CBORBytes golden) (CBORBytes actual)
+              , show (ansiWlEditExpr (ediff (CBORBytes golden) (CBORBytes actual)))
               ]
 
           (Right actualFlatTerm, Left _) -> Just $ unlines [

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/VolatileDB/StateMachine.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/VolatileDB/StateMachine.hs
@@ -75,6 +75,7 @@ import qualified Test.StateMachine.Types.Rank2 as Rank2
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.QuickCheck (testProperty)
 import           Test.Util.Orphans.Arbitrary ()
+import           Test.Util.Orphans.ToExpr ()
 import           Test.Util.QuickCheck
 import           Test.Util.SOP
 import           Test.Util.Tracer (recordingTracerIORef)


### PR DESCRIPTION
# Description

Closes #517 

Pending input-output-hk/ouroboros-network#4732 and input-output-hk/cardano-ledger#3908 (and the respective releases in CHaP).
