### PR TITLE
[WIP] Add support for “smart” `PointSchedule` shrinking

### DIFF
--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup.hs
@@ -4,50 +4,64 @@
 {-# LANGUAGE LambdaCase                #-}
 {-# LANGUAGE NamedFieldPuns            #-}
 {-# LANGUAGE RankNTypes                #-}
-{-# LANGUAGE RecordWildCards           #-}
 {-# LANGUAGE ScopedTypeVariables       #-}
+{-# LANGUAGE TupleSections             #-}
 
 module Test.Consensus.Genesis.Setup (
     module Test.Consensus.Genesis.Setup.GenChains
   , exceptionCounterexample
-  , runTest
+  , runGenesisTest
+  , runGenesisTest'
+  , forAllGenesisTest
+  , forAllGenesisTest'
   ) where
 
 import           Control.Exception (AsyncException (ThreadKilled))
-import           Control.Monad.Class.MonadTime (MonadTime)
-import           Control.Monad.Class.MonadTimer.SI (MonadTimer)
+import           Control.Monad.IOSim (runSimOrThrow)
 import           Control.Tracer (debugTracer, traceWith)
 import           Data.Either (partitionEithers)
 import           Data.Foldable (for_)
+import           Data.Function ((&))
+import           Data.List (intercalate)
 import           Ouroboros.Consensus.Util.Condense
 import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Network.Protocol.ChainSync.Codec
                      (ChainSyncTimeout (..))
+import           System.Random.Stateful (runSTGen_)
 import           Test.Consensus.BlockTree (allFragments)
+import           Test.Consensus.Genesis.Setup.Classifiers
 import           Test.Consensus.Genesis.Setup.GenChains
 import           Test.Consensus.PeerSimulator.Run
 import           Test.Consensus.PeerSimulator.StateView
 import           Test.Consensus.PeerSimulator.Trace (traceLinesWith, terseFrag)
 import           Test.Consensus.PointSchedule
+import           Test.Consensus.PointSchedule.Shrink (shrinkPointSchedule)
 import           Test.QuickCheck
+import           Test.QuickCheck.Random (QCGen)
+import           Test.QuickCheck.Extras (unsafeMapSuchThatJust)
 import           Test.Util.Orphans.IOLike ()
+import           Test.Util.QuickCheck (forAllGenRunShrinkCheck)
 import           Test.Util.Tracer (recordingTracerTVar)
+
+data RunGenesisTestResult = RunGenesisTestResult {
+  rgtrTrace :: String,
+  rgtrStateView :: StateView
+  }
 
 -- | Runs the given point schedule and evaluates the given property on the final
 -- state view.
-runTest ::
-  (IOLike m, MonadTime m, MonadTimer m, Testable a) =>
+runGenesisTest ::
   SchedulerConfig ->
   GenesisTest ->
   PointSchedule ->
-  (StateView -> a) ->
-  m Property
-runTest schedulerConfig genesisTest schedule makeProperty = do
+  RunGenesisTestResult
+runGenesisTest schedulerConfig genesisTest schedule =
+  runSimOrThrow $ do
     (recordingTracer, getTrace) <- recordingTracerTVar
     let tracer = if scDebug schedulerConfig then debugTracer else recordingTracer
 
     -- FIXME: should also go in 'prettyGenesisTest' (or 'prettyBlockTree')
-    for_ (allFragments gtBlockTree) \ bt -> traceWith tracer (terseFrag bt)
+    for_ (allFragments gtBlockTree) (traceWith tracer . terseFrag)
 
     traceLinesWith tracer $ [
       "SchedulerConfig:",
@@ -61,10 +75,24 @@ runTest schedulerConfig genesisTest schedule makeProperty = do
     traceWith tracer (condense finalStateView)
     trace <- unlines <$> getTrace
 
-    pure $ counterexample trace $ makeProperty finalStateView
+    pure $ RunGenesisTestResult trace finalStateView
   where
     SchedulerConfig {scChainSyncTimeouts} = schedulerConfig
     GenesisTest {gtBlockTree} = genesisTest
+
+-- | Simple wrapper around 'runGenesisTest' that also takes a property to apply
+-- to the resulting state view.
+runGenesisTest' ::
+  Testable prop =>
+  SchedulerConfig ->
+  GenesisTest ->
+  PointSchedule ->
+  (StateView -> prop) ->
+  Property
+runGenesisTest' schedulerConfig genesisTest schedule makeProperty = do
+  runGenesisTest schedulerConfig genesisTest schedule
+    & \RunGenesisTestResult {rgtrTrace, rgtrStateView} ->
+      counterexample rgtrTrace $ makeProperty rgtrStateView
 
 -- | Print counterexamples if the test result contains exceptions.
 exceptionCounterexample :: Testable a => (StateView -> [PeerId] -> a) -> StateView -> Property
@@ -78,3 +106,51 @@ exceptionCounterexample makeProperty stateView =
     genesisException = \case
       (ChainSyncException peer e) | Just ThreadKilled <- fromException e -> Right peer
       exc -> Left exc
+
+-- | All-in-one helper that generates a 'GenesisTest' and a point schedule, runs
+-- them with 'runGenesisTest', check whether the given property holds on the
+-- resulting 'StateView' and attempts to shrink if it does not.
+forAllGenesisTest ::
+  Testable prop =>
+  Gen (GenesisTest, PointSchedule) ->
+  SchedulerConfig ->
+  (StateView -> prop) ->
+  Property
+forAllGenesisTest generator schedulerConfig mkProperty =
+  forAllGenRunShrinkCheck generator runner shrinker
+    $ \(genesisTest, _) RunGenesisTestResult{rgtrTrace, rgtrStateView} ->
+      let cls = classifiers genesisTest in
+      classify (allAdversariesSelectable cls) "All adversaries selectable" $
+      classify (genesisWindowAfterIntersection cls) "Full genesis window after intersection" $
+      counterexample rgtrTrace $
+      exceptionCounterexample
+        (\stateView' killed ->
+          killCounterexample killed $
+          mkProperty stateView')
+        rgtrStateView
+
+  where
+    runner = uncurry (runGenesisTest schedulerConfig)
+    shrinker (gt, ps) _ = (gt,) <$> shrinkPointSchedule (gtBlockTree gt) ps
+    killCounterexample [] = property
+    killCounterexample killed = counterexample ("Some peers were killed: " ++ intercalate ", " (condense <$> killed))
+
+-- | Variant of 'forAllGenesisTest' that generate a 'GenesisTest' and a
+-- 'PointSchedule' given a number of alternative branches in the block tree and
+-- a schedule type.
+forAllGenesisTest' ::
+  Testable prop =>
+  Gen Word -> -- ^ number of alternative branches in the block tree
+  ScheduleType ->
+  SchedulerConfig ->
+  (StateView -> prop) ->
+  Property
+forAllGenesisTest' numBranches scheduleType schedulerConfig@SchedulerConfig{scSchedule} =
+    forAllGenesisTest genChainsAndSchedule schedulerConfig
+  where
+    genChainsAndSchedule :: Gen (GenesisTest, PointSchedule)
+    genChainsAndSchedule =
+      unsafeMapSuchThatJust do
+        gt@GenesisTest{gtBlockTree} <- genChains =<< numBranches
+        seed :: QCGen <- arbitrary
+        pure $ (gt,) <$> runSTGen_ seed (\g -> genSchedule g scSchedule scheduleType gtBlockTree)

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup.hs
@@ -36,7 +36,7 @@ import           Test.Consensus.PeerSimulator.Run
 import           Test.Consensus.PeerSimulator.StateView
 import           Test.Consensus.PeerSimulator.Trace (traceLinesWith, terseFrag)
 import           Test.Consensus.PointSchedule
-import           Test.Consensus.PointSchedule.Shrink (shrinkPointSchedule)
+import           Test.Consensus.PointSchedule.Shrink (smartShrinkAlertPointSchedule)
 import           Test.QuickCheck
 import           Test.QuickCheck.Random (QCGen)
 import           Test.QuickCheck.Extras (unsafeMapSuchThatJust)
@@ -132,7 +132,8 @@ forAllGenesisTest generator schedulerConfig mkProperty =
 
   where
     runner = uncurry (runGenesisTest schedulerConfig)
-    shrinker (gt, ps) _ = (gt,) <$> shrinkPointSchedule (gtBlockTree gt) ps
+    shrinker (gt, ps) RunGenesisTestResult{rgtrStateView=sv} =
+      (gt,) <$> smartShrinkAlertPointSchedule (gtBlockTree gt) ps sv
     killCounterexample [] = property
     killCounterexample killed = counterexample ("Some peers were killed: " ++ intercalate ", " (condense <$> killed))
 

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LongRangeAttack.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LongRangeAttack.hs
@@ -27,17 +27,8 @@ tests =
 prop_longRangeAttack :: Property
 prop_longRangeAttack =
   forAllGenesisTest'
-
-    -- number of alternative branches in the block tree
-    (pure 1)
-
-    -- type of schedule
-    NewLRA
-
-    -- scheduler config
+    (pure $ NumBranches 1) NewLRA
     (noTimeoutsSchedulerConfig defaultPointScheduleConfig)
-
-    -- property
     (isHonestImmutableTip . svSelectedChain)
 
   where

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
@@ -54,16 +54,19 @@ prop_rollback wantRollback = do
     wantRollback == canRollbackFromTrunkTip (gtSecurityParam genesisTest) (gtBlockTree genesisTest)
     ==>
       runGenesisTest' schedulerConfig genesisTest schedule $ \StateView{svSelectedChain} ->
-        let headOnAlternativeChain = case AF.headHash svSelectedChain of
-              GenesisHash    -> False
-              BlockHash hash -> any (0 /=) $ unTestHash hash
-        in
         -- The test passes if we want a rollback and we actually end up on the
         -- alternative chain or if we want no rollback and end up on the trunk.
-        wantRollback == headOnAlternativeChain
+        wantRollback == headOnAlternativeChain svSelectedChain
 
   where
     schedulerConfig = noTimeoutsSchedulerConfig defaultPointScheduleConfig
+
+    -- | Check whether the head of the given fragment is on an alternative chain
+    -- of the block tree.
+    headOnAlternativeChain fragment =
+      case AF.headHash fragment of
+        GenesisHash    -> False
+        BlockHash hash -> any (0 /=) $ unTestHash hash
 
     -- A schedule that advertises all the points of the trunk, then switches to
     -- the first alternative chain of the given block tree.

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
@@ -5,7 +5,6 @@
 
 module Test.Consensus.PeerSimulator.Tests.Rollback (tests) where
 
-import           Control.Monad.IOSim (runSimOrThrow)
 import           Data.Maybe (fromJust)
 import           Ouroboros.Consensus.Block (ChainHash (..))
 import           Ouroboros.Consensus.Config.SecurityParam
@@ -54,7 +53,7 @@ prop_rollback wantRollback = do
   pure $
     wantRollback == canRollbackFromTrunkTip (gtSecurityParam genesisTest) (gtBlockTree genesisTest)
     ==>
-      runSimOrThrow $ runTest schedulerConfig genesisTest schedule $ \StateView{svSelectedChain} ->
+      runGenesisTest' schedulerConfig genesisTest schedule $ \StateView{svSelectedChain} ->
         let headOnAlternativeChain = case AF.headHash svSelectedChain of
               GenesisHash    -> False
               BlockHash hash -> any (0 /=) $ unTestHash hash

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
@@ -1,6 +1,3 @@
-{-# LANGUAGE LambdaCase     #-}
-{-# LANGUAGE NamedFieldPuns #-}
-
 module Test.Consensus.PeerSimulator.Tests.Timeouts (tests) where
 
 import           Data.List.NonEmpty (NonEmpty ((:|)))
@@ -35,13 +32,13 @@ prop_timeouts = do
   genesisTest <- genChains 0
 
   -- Use higher tick duration to avoid the test taking really long
-  let scSchedule = PointScheduleConfig {pscTickDuration = 1}
+  let scheduleConfig = PointScheduleConfig {pscTickDuration = 1}
 
-      schedulerConfig = defaultSchedulerConfig scSchedule (gtHonestAsc genesisTest)
+      schedulerConfig = defaultSchedulerConfig scheduleConfig (gtHonestAsc genesisTest)
 
       schedule =
         dullSchedule
-          scSchedule
+          scheduleConfig
           (fromJust $ mustReplyTimeout (scChainSyncTimeouts schedulerConfig))
           (btTrunk $ gtBlockTree genesisTest)
 

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
@@ -3,7 +3,6 @@
 
 module Test.Consensus.PeerSimulator.Tests.Timeouts (tests) where
 
-import           Control.Monad.IOSim (runSimOrThrow)
 import           Data.List.NonEmpty (NonEmpty ((:|)))
 import           Data.Maybe (fromJust)
 import           Ouroboros.Consensus.Block (getHeader)
@@ -46,8 +45,7 @@ prop_timeouts = do
           (fromJust $ mustReplyTimeout (scChainSyncTimeouts schedulerConfig))
           (btTrunk $ gtBlockTree genesisTest)
 
-  pure $ runSimOrThrow $
-    runTest schedulerConfig genesisTest schedule $ \stateView ->
+  pure $ runGenesisTest' schedulerConfig genesisTest schedule $ \stateView ->
       case svChainSyncExceptions stateView of
         [] ->
           counterexample ("result: " ++ condense (svSelectedChain stateView)) False

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
@@ -288,7 +288,7 @@ prettyPointSchedule PointSchedule{ticks} =
 
 -- | Parameters that are significant for components outside of generators, like the peer
 -- simulator.
-data PointScheduleConfig =
+newtype PointScheduleConfig =
   PointScheduleConfig {
     -- | Duration of a tick, for timeouts in the scheduler.
     pscTickDuration :: DiffTime


### PR DESCRIPTION
Obsolete. Extract information and close. Refer to https://github.com/IntersectMBO/ouroboros-consensus/pull/856 for new work on shrinking.

-----

This PR builds on top of #817, which adds “basic” shrinking. In this context, we call _basic_ shrinking the default shrinking that comes with QuickCheck, where shrinkers have type `Input -> [Input]` for some `Input` type. This makes sense in many contexts, but we might want more in ours, and hence we introduce _smart_ shrinking. (I am very unattached to the terms _basic_ and _smart_ so feel free to find better ones.)

_Smart_ shrinking is a generalised form of shrinking where the shrinkers get access to more information than just the input. This makes sense when properties that we want to check require a lot of computation and we would want to use the information gained during this computation. We introduce the pattern “gen-run-check” which fits quite well our use case:

- `gen :: Gen Input` is a standard QuickCheck generator of `Input`s. In our case, those are pairs `(GenesisTest, PointSchedule)`.
- `run :: Input -> Output` contains the expensive part of the computation; it does a lot of things to `Input` until it gathered enough information to produce an `Output`. In our case, this is a `StateView` and `run` is basically our `PeerSimulator`.
- `check :: Output -> Bool` then only has to check a few things on this `Output` to decide whether the test passes.

In this context, we want our shrinkers to not have the usual type `Input -> [Input]` but the richer type `Input -> Output -> [Input]`. In this PR, we therefore:

- Add a QuickCheck helper `forAllGenRunShrinkCheck` providing exactly this functionality. There would be other approaches or more general versions of this helper; see [this private thread on Tweag's Slack](https://moduscreate.slack.com/archives/C02EU5SFBTN/p1701885748346819) for some examples.
- Split the previous `runTest` into two `runGenesisTest` and `runGenesisTest'` functions giving us access to more information.
- Add two Genesis testing-specific helpers `forAllGenesisTest` and `forAllGenesisTest'` that provide a QuickCheck's `forAll`-like interface specific to tests based on generating `(GenesisTest, PointSchedule)`, then running the `PeerSimulator`, then shrinking.
- Rewrite the long range attack and the rollback tests using this new helper.