### PR TITLE
Use SizeInBytes

### DIFF
--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -323,6 +323,7 @@ library unstable-consensus-testlib
     Test.Util.Orphans.Arbitrary
     Test.Util.Orphans.IOLike
     Test.Util.Orphans.NoThunks
+    Test.Util.Orphans.Serialise
     Test.Util.Orphans.SignableRepresentation
     Test.Util.Orphans.ToExpr
     Test.Util.Paths
@@ -439,6 +440,7 @@ library unstable-mock-block
     , ouroboros-network-mock
     , serialise
     , time
+    , unstable-consensus-testlib
 
 library unstable-mempool-test-utils
   import:          common-lib

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/Common.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/Common.hs
@@ -156,7 +156,7 @@ data BlockComponent blk a where
   GetSlot          :: BlockComponent blk SlotNo
   GetIsEBB         :: BlockComponent blk IsEBB
   -- TODO: use `SizeInBytes` rather than Word32
-  GetBlockSize     :: BlockComponent blk Word32
+  GetBlockSize     :: BlockComponent blk SizeInBytes
   GetHeaderSize    :: BlockComponent blk Word16
   GetNestedCtxt    :: BlockComponent blk (SomeSecond (NestedCtxt Header) blk)
   GetPure          :: a

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ImmutableDB/Impl/Iterator.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ImmutableDB/Impl/Iterator.hs
@@ -582,7 +582,7 @@ extractBlockComponent hasFS chunkInfo chunk ccfg checkIntegrity eHnd
         GetHash          -> return headerHash
         GetSlot          -> return slotNo
         GetIsEBB         -> return $ isBlockOrEBB blockOrEBB
-        GetBlockSize     -> return blockSize
+        GetBlockSize     -> return $ SizeInBytes blockSize
         GetHeaderSize    -> return $ fromIntegral $ Secondary.unHeaderSize headerSize
         GetRawBlock      -> readBlock
         GetRawHeader     -> readHeader

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/Orphans/Arbitrary.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/Orphans/Arbitrary.hs
@@ -1,14 +1,15 @@
-{-# LANGUAGE DataKinds            #-}
-{-# LANGUAGE DerivingVia          #-}
-{-# LANGUAGE FlexibleContexts     #-}
-{-# LANGUAGE FlexibleInstances    #-}
-{-# LANGUAGE GADTs                #-}
-{-# LANGUAGE NumericUnderscores   #-}
-{-# LANGUAGE ScopedTypeVariables  #-}
-{-# LANGUAGE StandaloneDeriving   #-}
-{-# LANGUAGE TypeApplications     #-}
-{-# LANGUAGE TypeOperators        #-}
-{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE DataKinds                  #-}
+{-# LANGUAGE DerivingVia                #-}
+{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE FlexibleInstances          #-}
+{-# LANGUAGE GADTs                      #-}
+{-# LANGUAGE GeneralisedNewtypeDeriving #-}
+{-# LANGUAGE NumericUnderscores         #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE StandaloneDeriving         #-}
+{-# LANGUAGE TypeApplications           #-}
+{-# LANGUAGE TypeOperators              #-}
+{-# LANGUAGE UndecidableInstances       #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Test.Util.Orphans.Arbitrary (
@@ -54,6 +55,7 @@ import           Ouroboros.Consensus.Storage.ImmutableDB.Chunks.Internal
                      (ChunkNo (..), ChunkSize (..), RelativeSlot (..))
 import           Ouroboros.Consensus.Storage.ImmutableDB.Chunks.Layout
 import           Ouroboros.Consensus.TypeFamilyWrappers
+import           Ouroboros.Network.SizeInBytes
 import           Test.Cardano.Ledger.Binary.Arbitrary ()
 import           Test.QuickCheck hiding (Fixed (..))
 import           Test.Util.Time (dawnOfTime)
@@ -152,6 +154,8 @@ instance Arbitrary ClockSkew where
       skew0, skew1 :: ClockSkew
       skew0 = InFuture.clockSkewInSeconds 0
       skew1 = InFuture.clockSkewInSeconds 1
+
+deriving newtype instance Arbitrary SizeInBytes
 
 {-------------------------------------------------------------------------------
   SmallDiffTime

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/Orphans/Serialise.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/Orphans/Serialise.hs
@@ -1,0 +1,13 @@
+{-# LANGUAGE DerivingVia                #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE StandaloneDeriving         #-}
+
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Test.Util.Orphans.Serialise () where
+
+import           Codec.Serialise (Serialise)
+import           Ouroboros.Network.SizeInBytes
+
+deriving newtype instance Serialise SizeInBytes
+

--- a/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Ledger/Block.hs
+++ b/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Ledger/Block.hs
@@ -94,11 +94,12 @@ import           Ouroboros.Consensus.Ledger.SupportsPeerSelection
 import           Ouroboros.Consensus.Mock.Ledger.Address
 import           Ouroboros.Consensus.Mock.Ledger.State
 import qualified Ouroboros.Consensus.Mock.Ledger.UTxO as Mock
-import           Ouroboros.Consensus.Storage.Common (BinaryBlockInfo (..))
+import           Ouroboros.Consensus.Storage.Common (BinaryBlockInfo (..),
+                     SizeInBytes)
 import           Ouroboros.Consensus.Util (ShowProxy (..), hashFromBytesShortE,
                      (..:), (.:))
 import           Ouroboros.Consensus.Util.Condense
-import           Ouroboros.Consensus.Util.Orphans ()
+import           Test.Util.Orphans.Serialise ()
 
 {-------------------------------------------------------------------------------
   Definition of a block
@@ -168,8 +169,7 @@ data SimpleStdHeader c ext = SimpleStdHeader {
     , simpleSlotNo   :: SlotNo
     , simpleBlockNo  :: BlockNo
     , simpleBodyHash :: Hash (SimpleHash c) SimpleBody
-      -- TODO: use SizeInBytes
-    , simpleBodySize :: Word32
+    , simpleBodySize :: SizeInBytes
     }
   deriving stock    (Generic, Show, Eq)
   deriving anyclass (Serialise, NoThunks)

--- a/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Ledger/Forge.hs
+++ b/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Ledger/Forge.hs
@@ -14,12 +14,12 @@ import           Cardano.Binary (toCBOR)
 import           Cardano.Crypto.Hash (hashWithSerialiser)
 import           Codec.Serialise (Serialise (..), serialise)
 import qualified Data.ByteString.Lazy as Lazy
-import           Data.Word
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Mock.Ledger.Block
 import           Ouroboros.Consensus.Protocol.Abstract
+import           Ouroboros.Network.SizeInBytes
 
 -- | Construct the protocol specific part of the block
 --
@@ -65,5 +65,5 @@ forgeSimple ForgeExt { forgeExt } cfg curBlock curSlot tickedLedger txs proof =
         , simpleBodySize = bodySize
         }
 
-    bodySize :: Word32
-    bodySize = fromIntegral $ Lazy.length $ serialise body
+    bodySize :: SizeInBytes
+    bodySize = SizeInBytes $ fromIntegral $ Lazy.length $ serialise body

--- a/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Node/Serialisation.hs
+++ b/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Node/Serialisation.hs
@@ -72,7 +72,7 @@ instance Serialise ext => SerialiseNodeToNodeConstraints (MockBlock ext) where
       7 {- CBOR-in-CBOR -} + 1 {- encodeListLen 2 -} + hdrSize + bodySize
     where
       hdrSize  = fromIntegral (Lazy.length (serialise hdr))
-      bodySize = fromIntegral (simpleBodySize (simpleHeaderStd hdr))
+      bodySize = simpleBodySize (simpleHeaderStd hdr)
 
 instance Serialise ext => SerialiseNodeToNode (MockBlock ext) (MockBlock ext) where
   encodeNodeToNode _ _ = defaultEncodeCBORinCBOR

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
@@ -97,7 +97,7 @@ import           Data.Ord (Down (..))
 import           Data.Proxy
 import           Data.Typeable
 import           Data.Void (Void)
-import           Data.Word (Word16, Word32, Word64)
+import           Data.Word (Word16, Word64)
 import qualified Generics.SOP as SOP
 import           GHC.Generics (Generic)
 import           NoThunks.Class (AllowThunk (..))
@@ -116,6 +116,7 @@ import           Ouroboros.Consensus.Storage.ChainDB hiding
                      (TraceFollowerEvent (..))
 import qualified Ouroboros.Consensus.Storage.ChainDB as ChainDB
 import qualified Ouroboros.Consensus.Storage.ChainDB.API.Types.InvalidBlockPunishment as InvalidBlockPunishment
+import           Ouroboros.Consensus.Storage.Common (SizeInBytes)
 import qualified Ouroboros.Consensus.Storage.ImmutableDB as ImmutableDB
 import           Ouroboros.Consensus.Storage.ImmutableDB.Chunks.Internal
                      (unsafeChunkNoToEpochNo)
@@ -305,7 +306,7 @@ type AllComponents blk =
   , HeaderHash blk
   , SlotNo
   , IsEBB
-  , Word32
+  , SizeInBytes
   , Word16
   , SomeSecond (NestedCtxt Header) blk
   )

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ImmutableDB/StateMachine.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ImmutableDB/StateMachine.hs
@@ -61,7 +61,7 @@ import qualified Data.Map.Strict as Map
 import           Data.Maybe (listToMaybe)
 import           Data.TreeDiff (Expr (App), defaultExprViaShow)
 import           Data.Typeable (Typeable)
-import           Data.Word (Word16, Word32, Word64)
+import           Data.Word (Word16, Word64)
 import qualified Generics.SOP as SOP
 import           GHC.Generics (Generic, Generic1)
 import           GHC.Stack (HasCallStack)
@@ -193,7 +193,7 @@ type AllComponents blk =
   , HeaderHash blk
   , SlotNo
   , IsEBB
-  , Word32
+  , SizeInBytes
   , Word16
   , SomeSecond (NestedCtxt Header) blk
   )

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/VolatileDB/StateMachine.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/VolatileDB/StateMachine.hs
@@ -116,7 +116,7 @@ type AllComponents blk =
   , HeaderHash blk
   , SlotNo
   , IsEBB
-  , Word32
+  , SizeInBytes
   , Word16
   , SomeSecond (NestedCtxt Header) blk
   )


### PR DESCRIPTION
# Description

This PR replaces the use of `Word32` with `SizeInBytes` for `BlockComponents` and `SimpleStdHeader`, as per in #532. 