### PR TITLE
First tests for the genesis implementation

### DIFF
--- a/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
+++ b/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
@@ -237,6 +237,7 @@ test-suite consensus-test
     Test.Consensus.PeerSimulator.ScheduledBlockFetchServer
     Test.Consensus.PeerSimulator.ScheduledChainSyncServer
     Test.Consensus.PeerSimulator.ScheduledServer
+    Test.Consensus.PeerSimulator.StateDiagram
     Test.Consensus.PeerSimulator.StateView
     Test.Consensus.PeerSimulator.Tests
     Test.Consensus.PeerSimulator.Tests.Rollback

--- a/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
+++ b/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
@@ -219,6 +219,7 @@ test-suite consensus-test
     Test.Consensus.Genesis.Setup.GenChains
     Test.Consensus.Genesis.Tests
     Test.Consensus.Genesis.Tests.LongRangeAttack
+    Test.Consensus.Genesis.Tests.Uniform
     Test.Consensus.GSM
     Test.Consensus.GSM.Model
     Test.Consensus.HardFork.Combinator

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/BlockTree.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/BlockTree.hs
@@ -21,7 +21,7 @@ module Test.Consensus.BlockTree (
   , findFragment
   , findPath
   , mkTrunk
-  , prettyPrint
+  , prettyBlockTree
   ) where
 
 import           Cardano.Slotting.Slot (SlotNo (unSlotNo))
@@ -161,10 +161,9 @@ findPath source target blockTree = do
 --                      ╰─────3──4─────5
 --
 -- Returns a list of strings intended to be catenated with a newline.
-prettyPrint :: AF.HasHeader blk => BlockTree blk -> [String]
-prettyPrint blockTree = do
-  ["Block tree:"]
-    ++ ["  slots:   " ++ unwords (map (printf "%2d" . unSlotNo) [veryFirstSlot .. veryLastSlot])]
+prettyBlockTree :: AF.HasHeader blk => BlockTree blk -> [String]
+prettyBlockTree blockTree =
+  ["slots:   " ++ unwords (map (printf "%2d" . unSlotNo) [veryFirstSlot .. veryLastSlot])]
     ++ [printTrunk honestFragment]
     ++ (map printBranch adversarialFragments)
 
@@ -181,11 +180,11 @@ prettyPrint blockTree = do
           (honestFragment : adversarialFragments)
 
     printTrunk :: AF.HasHeader blk => AF.AnchoredFragment blk -> String
-    printTrunk = printLine (\_ -> "  trunk:  ─")
+    printTrunk = printLine (\_ -> "trunk:  -")
 
     printBranch :: AF.HasHeader blk => AF.AnchoredFragment blk -> String
     printBranch = printLine $ \firstSlot ->
-      "        " ++ replicate (3 * fromIntegral (unSlotNo (firstSlot - veryFirstSlot))) ' ' ++ " ╰─"
+      "      " ++ replicate (3 * fromIntegral (unSlotNo (firstSlot - veryFirstSlot))) ' ' ++ " `-"
 
     printLine :: AF.HasHeader blk => (SlotNo -> String) -> AF.AnchoredFragment blk -> String
     printLine printHeader fragment =
@@ -203,7 +202,7 @@ prettyPrint blockTree = do
         & Vector.toList . (slotRange Vector.//)
         & map (maybe "  " (printf "%2d"))
         & unwords
-        & map (\c -> if c == ' ' then '─' else c)
+        & map (\c -> if c == ' ' then '-' else c)
       where
         -- Initialize a Vector with the length of the fragment containing only Nothings
         slotRange = Vector.replicate (fromIntegral (unSlotNo lastSlot - unSlotNo firstSlot + 1)) Nothing

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup.hs
@@ -19,19 +19,16 @@ import           Control.Monad.Class.MonadTimer.SI (MonadTimer)
 import           Control.Tracer (debugTracer, traceWith)
 import           Data.Either (partitionEithers)
 import           Data.Foldable (for_)
-import           Ouroboros.Consensus.Config (maxRollbacks)
 import           Ouroboros.Consensus.Util.Condense
 import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Network.Protocol.ChainSync.Codec
                      (ChainSyncTimeout (..))
-import qualified Test.Consensus.BlockTree as BT
 import           Test.Consensus.BlockTree (allFragments)
 import           Test.Consensus.Genesis.Setup.GenChains
 import           Test.Consensus.PeerSimulator.Run
 import           Test.Consensus.PeerSimulator.StateView
 import           Test.Consensus.PeerSimulator.Trace (traceLinesWith, terseFrag)
 import           Test.Consensus.PointSchedule
-import           Test.Ouroboros.Consensus.ChainGenerator.Params (ascVal)
 import           Test.QuickCheck
 import           Test.Util.Orphans.IOLike ()
 import           Test.Util.Tracer (recordingTracerTVar)
@@ -48,20 +45,17 @@ runTest ::
 runTest schedulerConfig genesisTest schedule makeProperty = do
     (recordingTracer, getTrace) <- recordingTracerTVar
     let tracer = if scDebug schedulerConfig then debugTracer else recordingTracer
+
+    -- FIXME: should also go in 'prettyGenesisTest' (or 'prettyBlockTree')
     for_ (allFragments gtBlockTree) \ bt -> traceWith tracer (terseFrag bt)
 
-    traceLinesWith tracer [
+    traceLinesWith tracer $ [
       "SchedulerConfig:",
       "  ChainSyncTimeouts:",
       "    canAwait = " ++ show (canAwaitTimeout scChainSyncTimeouts),
       "    intersect = " ++ show (intersectTimeout scChainSyncTimeouts),
-      "    mustReply = " ++ show (mustReplyTimeout scChainSyncTimeouts),
-      "Security param k = " ++ show (maxRollbacks gtSecurityParam),
-      "Honest active slot coefficient asc = " ++ show (ascVal gtHonestAsc),
-      "Genesis window scg = " ++ show (getGenesisWindow gtGenesisWindow)
-      ]
-
-    mapM_ (traceWith tracer) $ BT.prettyPrint gtBlockTree
+      "    mustReply = " ++ show (mustReplyTimeout scChainSyncTimeouts)
+      ] ++ prettyGenesisTest genesisTest
 
     finalStateView <- runPointSchedule schedulerConfig genesisTest schedule tracer
     traceWith tracer (condense finalStateView)
@@ -70,7 +64,7 @@ runTest schedulerConfig genesisTest schedule makeProperty = do
     pure $ counterexample trace $ makeProperty finalStateView
   where
     SchedulerConfig {scChainSyncTimeouts} = schedulerConfig
-    GenesisTest {gtSecurityParam, gtHonestAsc, gtGenesisWindow, gtBlockTree} = genesisTest
+    GenesisTest {gtBlockTree} = genesisTest
 
 -- | Print counterexamples if the test result contains exceptions.
 exceptionCounterexample :: Testable a => (StateView -> [PeerId] -> a) -> StateView -> Property

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup.hs
@@ -46,7 +46,7 @@ runTest schedulerConfig genesisTest schedule makeProperty = do
     (recordingTracer, getTrace) <- recordingTracerTVar
     let tracer = if scDebug schedulerConfig then debugTracer else recordingTracer
 
-    -- FIXME: should also go in 'prettyGenesisTest' (or 'prettyBlockTree')
+    -- TODO: should also go in 'prettyGenesisTest' (or 'prettyBlockTree')
     for_ (allFragments gtBlockTree) \ bt -> traceWith tracer (terseFrag bt)
 
     traceLinesWith tracer $ [

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup/GenChains.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup/GenChains.hs
@@ -66,7 +66,7 @@ genAlternativeChainSchema (testRecipeH, arHonest) =
     let H.HonestRecipe kcp scg delta _len = testRecipeH
 
     (seedPrefix :: QCGen) <- QC.arbitrary
-    let arPrefix = genPrefixBlockCount seedPrefix arHonest
+    let arPrefix = genPrefixBlockCount kcp seedPrefix arHonest
 
     let testRecipeA = A.AdversarialRecipe {
       A.arPrefix,
@@ -81,6 +81,7 @@ genAlternativeChainSchema (testRecipeH, arHonest) =
         A.NoSuchAdversarialBlock -> pure Nothing
         A.NoSuchCompetitor       -> error $ "impossible! " <> show e
         A.NoSuchIntersection     -> error $ "impossible! " <> show e
+        A.KcpIs1                 -> error $ "impossible! " <> show e
 
       Right (A.SomeCheckedAdversarialRecipe _ testRecipeA'') -> do
         let Count prefixCount = arPrefix

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests.hs
@@ -1,9 +1,11 @@
 module Test.Consensus.Genesis.Tests (tests) where
 
 import qualified Test.Consensus.Genesis.Tests.LongRangeAttack as LongRangeAttack
+import qualified Test.Consensus.Genesis.Tests.Uniform as Uniform
 import           Test.Tasty
 
 tests :: TestTree
 tests = testGroup "Genesis tests"
     [ LongRangeAttack.tests
+    , Uniform.tests
     ]

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LongRangeAttack.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LongRangeAttack.hs
@@ -41,7 +41,10 @@ tests =
 
 prop_longRangeAttack :: QC.Gen QC.Property
 prop_longRangeAttack = do
+  -- | Create a block tree with @1@ alternative chain.
   genesisTest <- genChains (pure 1)
+
+  -- | Create a 'longRangeAttack' schedule based on the generated chains.
   schedule <- fromSchedulePoints <$> stToGen (longRangeAttack (gtBlockTree genesisTest))
   let cls = classifiers genesisTest
 

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LongRangeAttack.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LongRangeAttack.hs
@@ -28,10 +28,12 @@ import           Test.Tasty
 import           Test.Tasty.QuickCheck
 import           Test.Util.Orphans.IOLike ()
 import           Test.Util.TestBlock (TestBlock, unTestHash)
+import           Test.Util.TestEnv (adjustQuickCheckTests)
 
 tests :: TestTree
 tests =
   testGroup "long range attack" [
+    adjustQuickCheckTests (`div` 10) $
     testProperty "one adversary" (prop_longRangeAttack 1 [10])
     -- TODO we don't have useful classification logic for multiple adversaries yet – if a selectable
     -- adversary is slow, it might be discarded before it reaches critical length because the faster
@@ -57,7 +59,7 @@ prop_longRangeAttack honestFreq advFreqs = do
 
   -- TODO: not existsSelectableAdversary ==> immutableTipBeforeFork svSelectedChain
 
-  pure $ withMaxSuccess 10 $
+  pure $
     classify (genesisWindowAfterIntersection cls) "Full genesis window after intersection" $
     allAdversariesSelectable cls
     ==>

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
@@ -8,6 +8,11 @@
 {-# LANGUAGE TypeFamilies        #-}
 {-# LANGUAGE TypeOperators       #-}
 
+-- | Peer simulator tests based on randomly generated schedules. They share the
+-- same property stating that the immutable tip should be on the trunk of the
+-- block tree with the right age (roughly @k@ blocks from the tip). Contrary to
+-- other tests cases (eg. long range attack), the schedules are not particularly
+-- biased towards a specific situation.
 module Test.Consensus.Genesis.Tests.Uniform (tests) where
 
 import           Cardano.Slotting.Slot (SlotNo (SlotNo), WithOrigin (..))
@@ -142,8 +147,8 @@ genUniformSchedulePoints gt = stToGen (uniformPoints (gtBlockTree gt))
 
 -- Note [Leashing attacks]
 --
--- A leashing attack would be rehearsed by a point schedule meeting either of
--- two conditions:
+-- A leashing attack would be successfully conducted by a point schedule meeting
+-- either of two conditions:
 --
 -- 1) it causes the node under test to stop making progress (i.e. the immutable
 --    tip doesn't get close to the last genesis window of the honest chain), or

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
@@ -1,0 +1,125 @@
+{-# LANGUAGE BlockArguments      #-}
+{-# LANGUAGE DerivingStrategies  #-}
+{-# LANGUAGE LambdaCase          #-}
+{-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE RecordWildCards     #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections       #-}
+{-# LANGUAGE TypeFamilies        #-}
+{-# LANGUAGE TypeOperators       #-}
+
+module Test.Consensus.Genesis.Tests.Uniform (tests) where
+
+import           Cardano.Slotting.Slot (SlotNo (SlotNo), WithOrigin (..))
+import           Control.Monad.IOSim (runSimOrThrow)
+import           Data.List (intercalate)
+import           Ouroboros.Consensus.Util.Condense (Condense (condense))
+import qualified Ouroboros.Network.AnchoredFragment as AF
+import           Test.Consensus.BlockTree (BlockTree (..))
+import           Test.Consensus.Genesis.Setup
+import           Test.Consensus.Genesis.Setup.Classifiers
+import           Test.Consensus.PeerSimulator.Run (noTimeoutsSchedulerConfig,
+                     scTraceState)
+import           Test.Consensus.PeerSimulator.StateView
+import           Test.Consensus.PointSchedule
+import           Test.Ouroboros.Consensus.ChainGenerator.Params (Delta (Delta))
+import qualified Test.QuickCheck as QC
+import           Test.QuickCheck
+import           Test.Tasty
+import           Test.Tasty.QuickCheck
+import           Test.Util.Orphans.IOLike ()
+import           Test.Util.QuickCheck (le)
+import           Test.Util.TestBlock (TestBlock, tbSlot)
+import           Test.Util.TestEnv (adjustQuickCheckMaxSize,
+                     adjustQuickCheckTests)
+import           Text.Printf (printf)
+
+tests :: TestTree
+tests =
+  adjustQuickCheckTests (`div` 10) $
+  adjustQuickCheckMaxSize (`div` 10) $
+  testProperty "serve adversarial branches" prop_serveAdversarialBranches
+
+makeProperty ::
+  GenesisTest ->
+  Peers PeerSchedule ->
+  StateView ->
+  [PeerId] ->
+  Property
+makeProperty genesisTest schedule StateView {svSelectedChain} killed =
+  classify genesisWindowAfterIntersection "Full genesis window after intersection" $
+  classify (isOrigin immutableTipHash) "Immutable tip is Origin" $
+  label disconnected $
+  classify (advCount < length (btBranches gtBlockTree)) "Some adversaries performed rollbacks" $
+  counterexample killedPeers $
+  -- We require the honest chain to fit a Genesis window, because otherwise its tip may suggest
+  -- to the governor that the density is too low.
+  longerThanGenesisWindow ==>
+  conjoin [
+    counterexample "The honest peer was disconnected" (not (HonestPeer `elem` killed)),
+    counterexample ("The immutable tip is not honest: " ++ show immutableTip) $
+    property (isHonest immutableTipHash),
+    immutableTipIsRecent
+  ]
+  where
+    advCount = Map.size (others schedule)
+
+    immutableTipIsRecent =
+      counterexample ("Age of the immutable tip: " ++ show immutableTipAge) $
+      immutableTipAge `le` s + fromIntegral d + 1
+
+    SlotNo immutableTipAge = case (honestTipSlot, immutableTipSlot) of
+      (At h, At i)   -> h - i
+      (At h, Origin) -> h
+      _              -> 0
+
+    isOrigin = null
+
+    isHonest = all (0 ==)
+
+    immutableTipHash = simpleHash (AF.anchorToHash immutableTip)
+
+    immutableTip = AF.anchor svSelectedChain
+
+    immutableTipSlot = AF.anchorToSlotNo (AF.anchor svSelectedChain)
+
+    disconnected =
+      printf "disconnected %.1f%% of adversaries" disconnectedPercent
+
+    disconnectedPercent :: Double
+    disconnectedPercent =
+      100 * fromIntegral (length killed) / fromIntegral advCount
+
+    killedPeers = case killed of
+      [] -> "No peers were killed"
+      peers -> "Some peers were killed: " ++ intercalate ", " (condense <$> peers)
+
+    honestTipSlot = At $ tbSlot $ snd $ last $ mapMaybe fromBlockPoint $ value $ honest schedule
+
+    GenesisTest {gtBlockTree, gtGenesisWindow = GenesisWindow s, gtDelay = Delta d} = genesisTest
+
+    Classifiers {genesisWindowAfterIntersection, longerThanGenesisWindow} = classifiers genesisTest
+
+fromBlockPoint :: (DiffTime, SchedulePoint) -> Maybe (DiffTime, TestBlock)
+fromBlockPoint (t, ScheduleBlockPoint bp) = Just (t, bp)
+fromBlockPoint _                          = Nothing
+
+-- | Tests that the immutable tip is not delayed and stays honest with the
+-- adversarial peers serving adversarial branches.
+prop_serveAdversarialBranches :: QC.Gen QC.Property
+prop_serveAdversarialBranches = QC.expectFailure <$> do
+  genesisTest <- genChains (QC.choose (1, 4))
+  schedulePoints <- genUniformSchedulePoints genesisTest
+  pure $
+    runSimOrThrow $
+    runTest schedulerConfig genesisTest (fromSchedulePoints schedulePoints) $
+    exceptionCounterexample $
+    makeProperty genesisTest schedulePoints
+
+  where
+    schedulerConfig = (noTimeoutsSchedulerConfig scheduleConfig) {scTraceState = False}
+
+    scheduleConfig = defaultPointScheduleConfig
+
+genUniformSchedulePoints :: GenesisTest -> QC.Gen (Peers PeerSchedule)
+genUniformSchedulePoints gt = stToGen (uniformPoints (gtBlockTree gt))

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
@@ -11,10 +11,18 @@
 module Test.Consensus.Genesis.Tests.Uniform (tests) where
 
 import           Cardano.Slotting.Slot (SlotNo (SlotNo), WithOrigin (..))
+import           Control.Monad (replicateM)
 import           Control.Monad.IOSim (runSimOrThrow)
-import           Data.List (intercalate)
-import           Ouroboros.Consensus.Util.Condense (Condense (condense))
+import           Data.List (intercalate, sort)
+import qualified Data.List.NonEmpty as NE
+import qualified Data.Map.Strict as Map
+import           Data.Maybe (mapMaybe)
+import           Data.Time.Clock (DiffTime)
+import           Data.Word (Word64)
+import           GHC.Stack (HasCallStack)
+import           Ouroboros.Consensus.Util.Condense (condense)
 import qualified Ouroboros.Network.AnchoredFragment as AF
+import           Ouroboros.Network.Block (blockNo, unBlockNo)
 import           Test.Consensus.BlockTree (BlockTree (..))
 import           Test.Consensus.Genesis.Setup
 import           Test.Consensus.Genesis.Setup.Classifiers
@@ -22,6 +30,8 @@ import           Test.Consensus.PeerSimulator.Run (noTimeoutsSchedulerConfig,
                      scTraceState)
 import           Test.Consensus.PeerSimulator.StateView
 import           Test.Consensus.PointSchedule
+import           Test.Consensus.PointSchedule.SinglePeer
+                     (SchedulePoint (ScheduleBlockPoint, ScheduleTipPoint))
 import           Test.Ouroboros.Consensus.ChainGenerator.Params (Delta (Delta))
 import qualified Test.QuickCheck as QC
 import           Test.QuickCheck
@@ -36,9 +46,15 @@ import           Text.Printf (printf)
 
 tests :: TestTree
 tests =
+  adjustQuickCheckTests (* 10) $
+  adjustQuickCheckMaxSize (`div` 5) $
+  testGroup "uniform" [
+    -- See Note [Leashing attacks]
+    testProperty "stalling leashing attack" prop_leashingAttackStalling,
+    testProperty "time limited leashing attack" prop_leashingAttackTimeLimited,
   adjustQuickCheckTests (`div` 10) $
-  adjustQuickCheckMaxSize (`div` 10) $
-  testProperty "serve adversarial branches" prop_serveAdversarialBranches
+    testProperty "serve adversarial branches" prop_serveAdversarialBranches
+    ]
 
 makeProperty ::
   GenesisTest ->
@@ -123,3 +139,137 @@ prop_serveAdversarialBranches = QC.expectFailure <$> do
 
 genUniformSchedulePoints :: GenesisTest -> QC.Gen (Peers PeerSchedule)
 genUniformSchedulePoints gt = stToGen (uniformPoints (gtBlockTree gt))
+
+-- Note [Leashing attacks]
+--
+-- A leashing attack would be rehearsed by a point schedule meeting either of
+-- two conditions:
+--
+-- 1) it causes the node under test to stop making progress (i.e. the immutable
+--    tip doesn't get close to the last genesis window of the honest chain), or
+-- 2) it causes the node under test to still make progress but it is too slow
+--    (in some sense of slow)
+--
+-- We produce schedules meeting the first condition by dropping random points
+-- from the schedule of adversarial peers. If peers don't send the headers or
+-- the blocks that they promised with a tip point, the node under test could
+-- wait indefinitely without advancing the immutable tip.
+--
+-- We produce schedules meeting the second condition by stopping the execution
+-- of the schedule after an amount of time that depends on the amount of blocks
+-- to sync up and the timeouts allowed by Limit of Patience.
+-- If the adversarial peers succeed in delaying the immutable tip, interrupting
+-- the test at this point should cause the immutable tip to be too far behind
+-- the last genesis window of the honest chain.
+
+-- | Test that the leashing attacks do not delay the immutable tip
+--
+-- This test is expected to fail because we don't test a genesis implementation
+-- yet.
+prop_leashingAttackStalling :: QC.Gen QC.Property
+prop_leashingAttackStalling = QC.expectFailure <$> do
+  genesisTest <- genChains (QC.choose (1, 4))
+  schedulePoints <- genLeashingSchedule genesisTest
+  pure $
+    runSimOrThrow $
+    runTest schedulerConfig genesisTest (fromSchedulePoints schedulePoints) $
+    exceptionCounterexample $
+    makeProperty genesisTest schedulePoints
+
+  where
+    schedulerConfig = (noTimeoutsSchedulerConfig scheduleConfig) {scEnableGdd = True}
+
+    scheduleConfig = defaultPointScheduleConfig
+
+    -- | Produces schedules that might cause the node under test to stall.
+    --
+    -- This is achieved by dropping random points from the schedule of each peer
+    genLeashingSchedule :: GenesisTest -> QC.Gen (Peers PeerSchedule)
+    genLeashingSchedule genesisTest = do
+      Peers honest advs0 <- genUniformSchedulePoints genesisTest
+      advs <- mapM (mapM dropRandomPoints) advs0
+      pure (Peers honest advs)
+
+    dropRandomPoints :: [(DiffTime, SchedulePoint)] -> QC.Gen [(DiffTime, SchedulePoint)]
+    dropRandomPoints ps = do
+      let lenps = length ps
+      dropCount <- QC.choose (0, max 1 $ div lenps 5)
+      let dedup = map NE.head . NE.group
+      is <- fmap (dedup . sort) $ replicateM dropCount $ QC.choose (0, lenps - 1)
+      pure $ dropElemsAt ps is
+
+    dropElemsAt :: [a] -> [Int] -> [a]
+    dropElemsAt xs [] = xs
+    dropElemsAt xs (i:is) =
+      let (ys, zs) = splitAt i xs
+       in ys ++ dropElemsAt (drop 1 zs) is
+
+-- | Test that the leashing attacks do not delay the immutable tip after. The
+-- immutable tip needs to be advanced enough when the honest peer has offered
+-- all of its ticks.
+--
+-- This test is expected to fail because we don't test a genesis implementation
+-- yet.
+--
+-- See Note [Leashing attacks]
+prop_leashingAttackTimeLimited :: QC.Gen QC.Property
+prop_leashingAttackTimeLimited = QC.expectFailure <$> do
+  genesisTest <- genChains (QC.choose (1, 4))
+  schedulePoints <- genTimeLimitedSchedule genesisTest
+  pure $
+    runSimOrThrow $
+    runTest schedulerConfig genesisTest (fromSchedulePoints schedulePoints) $
+    exceptionCounterexample $
+    makeProperty genesisTest schedulePoints
+
+  where
+    schedulerConfig = (noTimeoutsSchedulerConfig scheduleConfig) {scEnableGdd = True}
+
+    scheduleConfig = defaultPointScheduleConfig
+
+    -- | A schedule which doesn't run past the last event of the honest peer
+    genTimeLimitedSchedule :: GenesisTest -> QC.Gen (Peers PeerSchedule)
+    genTimeLimitedSchedule genesisTest = do
+      Peers honest advs0 <- genUniformSchedulePoints genesisTest
+      let timeLimit = estimateTimeBound (value honest) (map value $ Map.elems advs0)
+          advs = fmap (fmap (takePointsUntil timeLimit)) advs0
+      pure (Peers honest advs)
+
+    takePointsUntil limit = takeWhile ((<= limit) . fst)
+
+    estimateTimeBound :: PeerSchedule -> [PeerSchedule] -> DiffTime
+    estimateTimeBound honest advs =
+      let firstTipPointBlock = headCallStack (mapMaybe fromTipPoint honest)
+          lastBlockPoint = last (mapMaybe fromBlockPoint honest)
+          peerCount = length advs + 1
+          maxBlockNo = maximum $ 0 : blockPointNos honest ++ concatMap blockPointNos advs
+          -- 0.020s is the amount of time LoP grants per interesting header
+          -- 5s is the initial fill of the LoP bucket
+          --
+          -- Since the moment the honest peer offers the first tip, LoP should
+          -- start ticking. Syncing all the blocks might take longer than it
+          -- takes to dispatch all ticks to the honest peer. In this case
+          -- the syncing time is the time bound for the test. If dispatching
+          -- all the ticks takes longer, then the dispatching time becomes
+          -- the time bound.
+          --
+          -- Adversarial peers might cause more ticks to be sent as well. We
+          -- bound it all by considering the highest block number that is ever
+          -- sent.
+      in max
+          (fst lastBlockPoint)
+          (fst firstTipPointBlock +
+              0.020 * fromIntegral maxBlockNo + 5 * fromIntegral peerCount)
+
+    blockPointNos :: [(DiffTime, SchedulePoint)] -> [Word64]
+    blockPointNos =
+      map (unBlockNo . blockNo . snd) .
+      mapMaybe fromBlockPoint
+
+    fromTipPoint (t, ScheduleTipPoint bp) = Just (t, bp)
+    fromTipPoint _                        = Nothing
+
+headCallStack :: HasCallStack => [a] -> a
+headCallStack = \case
+  x:_ -> x
+  _   -> error "headCallStack: empty list"

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
@@ -26,8 +26,8 @@ import           Ouroboros.Network.Block (blockNo, unBlockNo)
 import           Test.Consensus.BlockTree (BlockTree (..))
 import           Test.Consensus.Genesis.Setup
 import           Test.Consensus.Genesis.Setup.Classifiers
-import           Test.Consensus.PeerSimulator.Run (noTimeoutsSchedulerConfig,
-                     scTraceState)
+import           Test.Consensus.PeerSimulator.Run (SchedulerConfig (scTrace),
+                     noTimeoutsSchedulerConfig, scTraceState)
 import           Test.Consensus.PeerSimulator.StateView
 import           Test.Consensus.PointSchedule
 import           Test.Consensus.PointSchedule.SinglePeer
@@ -133,7 +133,7 @@ prop_serveAdversarialBranches = QC.expectFailure <$> do
     makeProperty genesisTest schedulePoints
 
   where
-    schedulerConfig = (noTimeoutsSchedulerConfig scheduleConfig) {scTraceState = False}
+    schedulerConfig = (noTimeoutsSchedulerConfig scheduleConfig) {scTraceState = False, scTrace = False}
 
     scheduleConfig = defaultPointScheduleConfig
 
@@ -177,7 +177,8 @@ prop_leashingAttackStalling = QC.expectFailure <$> do
     makeProperty genesisTest schedulePoints
 
   where
-    schedulerConfig = (noTimeoutsSchedulerConfig scheduleConfig) {scEnableGdd = True}
+    schedulerConfig = (noTimeoutsSchedulerConfig scheduleConfig)
+      { scTrace = False }
 
     scheduleConfig = defaultPointScheduleConfig
 
@@ -223,7 +224,8 @@ prop_leashingAttackTimeLimited = QC.expectFailure <$> do
     makeProperty genesisTest schedulePoints
 
   where
-    schedulerConfig = (noTimeoutsSchedulerConfig scheduleConfig) {scEnableGdd = True}
+    schedulerConfig = (noTimeoutsSchedulerConfig scheduleConfig)
+      { scTrace = False }
 
     scheduleConfig = defaultPointScheduleConfig
 

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Handlers.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Handlers.hs
@@ -14,19 +14,24 @@ module Test.Consensus.PeerSimulator.Handlers (
     handlerBlockFetch
   , handlerFindIntersection
   , handlerRequestNext
+  , handlerSendBlocks
   ) where
 
-import           Cardano.Slotting.Slot (WithOrigin)
+import           Cardano.Slotting.Slot (WithOrigin (..))
 import           Control.Monad.Trans (lift)
 import           Control.Monad.Writer.Strict (MonadWriter (tell),
                      WriterT (runWriterT))
 import           Data.Coerce (coerce)
+import           Data.List (isSuffixOf)
+import qualified Data.List.NonEmpty as NonEmpty
 import           Data.Maybe (fromJust, fromMaybe)
 import           Ouroboros.Consensus.Block (HasHeader, Header, HeaderHash,
-                     Point (GenesisPoint), castPoint, getHeader, withOrigin)
+                     Point (GenesisPoint), blockHash, castPoint, getHeader,
+                     withOrigin)
 import           Ouroboros.Consensus.Util.Condense (Condense (..))
 import           Ouroboros.Consensus.Util.IOLike (IOLike, STM, StrictTVar,
                      readTVar, writeTVar)
+import           Ouroboros.Network.AnchoredFragment (AnchoredFragment)
 import qualified Ouroboros.Network.AnchoredFragment as AF
 import           Ouroboros.Network.Block (blockPoint, getTipPoint)
 import           Ouroboros.Network.BlockFetch.ClientState
@@ -35,18 +40,40 @@ import qualified Test.Consensus.BlockTree as BT
 import           Test.Consensus.BlockTree (BlockTree)
 import           Test.Consensus.Network.AnchoredFragment.Extras (intersectWith)
 import           Test.Consensus.PeerSimulator.ScheduledBlockFetchServer
-                     (BlockFetch (..))
+                     (BlockFetch (..), SendBlocks (..))
 import           Test.Consensus.PeerSimulator.ScheduledChainSyncServer
                      (FindIntersect (..),
                      RequestNext (AwaitReply, RollBackward, RollForward))
-import           Test.Consensus.PeerSimulator.Trace (terseFrag, tersePoint)
+import           Test.Consensus.PeerSimulator.Trace (terseBlock, terseFrag,
+                     tersePoint)
 import           Test.Consensus.PointSchedule
 import           Test.Util.Orphans.IOLike ()
-import           Test.Util.TestBlock (TestBlock, TestHash)
+import           Test.Util.TestBlock (TestBlock, TestHash (TestHash))
 
 
 toPoint :: (HasHeader block, HeaderHash block ~ TestHash) => WithOrigin block -> Point TestBlock
 toPoint = castPoint . withOrigin GenesisPoint blockPoint
+
+-- | More efficient implementation of a check used in some of the handlers,
+-- determining whether the first argument is on the chain that ends in the
+-- second argument.
+-- We would usually call @withinFragmentBounds@ for this, but since we're
+-- using 'TestBlock', looking at the hash is cheaper.
+isAncestorOf ::
+  HasHeader blk1 =>
+  HasHeader blk2 =>
+  HeaderHash blk1 ~ TestHash =>
+  HeaderHash blk2 ~ TestHash =>
+  WithOrigin blk1 ->
+  WithOrigin blk2 ->
+  Bool
+isAncestorOf (At ancestor) (At descendant) =
+  isSuffixOf (NonEmpty.toList hashA) (NonEmpty.toList hashD)
+  where
+    TestHash hashA = blockHash ancestor
+    TestHash hashD = blockHash descendant
+isAncestorOf (At _) Origin = False
+isAncestorOf Origin _ = True
 
 -- | Handle a @MsgFindIntersect@ message.
 --
@@ -148,6 +175,16 @@ handlerRequestNext currentIntersection blockTree points =
 
     trace = tell . pure
 
+-- REVIEW: We call this a lot, and I assume it creates some significant overhead.
+-- We should figure out a cheaper way to achieve what we're doing with the result.
+-- Since we're in TestBlock, we can at least check whether a block can extend another block,
+-- but then we won't be able to generalize later.
+fragmentUpTo :: BlockTree TestBlock -> String -> Point TestBlock -> AnchoredFragment TestBlock
+fragmentUpTo blockTree desc b =
+  fromMaybe fatal (BT.findFragment b blockTree)
+  where
+    fatal = error ("BlockFetch: Could not find " ++ desc ++ " in the block tree")
+
 -- | Handle the BlockFetch message (it actually has only one unnamed entry point).
 --
 -- If the requested range ends not after the block point, send them. If the
@@ -166,48 +203,149 @@ handlerBlockFetch ::
   -- ^ The current advertised points (tip point, header point and block point).
   -- They are in the block tree.
   STM m (Maybe BlockFetch, [String])
-handlerBlockFetch blockTree (ChainRange from to) AdvertisedPoints {header = HeaderPoint hp, block = BlockPoint bp} =
-  runWriterT (serveFromBpFragment (AF.sliceRange bpChain from to))
+handlerBlockFetch blockTree (ChainRange from to) AdvertisedPoints {header = HeaderPoint hp} =
+  runWriterT (serveFromBpFragment (AF.sliceRange hpChain from to))
   where
-    -- Check whether the requested range is contained in the fragment before the block point.
-    -- We may only serve the full range; if the server has only some of the blocks, it must refuse.
+    -- Check whether the requested range is contained in the fragment before the header point.
+    -- We may only initiate batch serving if the full range is available; if the server has only some of the blocks, it
+    -- must refuse.
     serveFromBpFragment = \case
       Just slice -> do
-        trace ("Sending slice " ++ terseFrag slice)
+        trace ("Starting batch for slice " ++ terseFrag slice)
         pure (Just (StartBatch (AF.toOldestFirst slice)))
       Nothing    -> do
-        -- If we cannot serve blocks from the block point chain (that is the
-        -- chain on which the block point is), decide whether to yield control
-        -- to the scheduler or serve blocks anyway.
-        --
-        -- If the @to@ point is not part of the header point chain but the block
-        -- point is, we must have switched to a fork without ensuring that the
-        -- block point advances to the last header point advertised on the old
-        -- chain. This should be a precondition violation, but because it would
-        -- make the schedule generator more complex, we simply serve the missing
-        -- blocks anyway here.
-        --
-        -- Otherwise, we simply have to wait for the block point to advance
-        -- sufficiently, and we block without sending a message, to simulate a
-        -- slow response.
-        case not (AF.withinFragmentBounds to hpChain) && AF.withinFragmentBounds (toPoint bp) hpChain of
-          True ->
-            case AF.sliceRange (fragmentUpTo "requested point" to) from to of
-              Just slice -> do
-                trace "Sending range due to incomplete fork switch"
-                pure (Just (StartBatch (AF.toOldestFirst slice)))
-              Nothing    -> error "BlockFetch: Client requested blocks that aren't in the block tree"
-          False  -> do
-            trace ("Waiting for next tick for range: " ++ tersePoint from ++ " -> " ++ tersePoint to)
-            pure Nothing
+        trace ("Waiting for next tick for range: " ++ tersePoint from ++ " -> " ++ tersePoint to)
+        pure Nothing
 
-    bpChain = fragmentUpTo "block point" (toPoint bp)
-
-    hpChain = fragmentUpTo "header point" (toPoint hp)
+    hpChain = fragmentUpTo blockTree "header point" (toPoint hp)
 
     trace = tell . pure
 
-    fragmentUpTo sort b =
-      fromMaybe (fatal sort) (BT.findFragment b blockTree)
+{-
+If we cannot serve blocks from the block point chain (that is the chain on which
+the block point is), decide whether to yield control to the scheduler or serve
+blocks anyway.
 
-    fatal sort = error ("BlockFetch: Could not find " ++ sort ++ " in the block tree")
+If the next block to deliver is part of the header point chain, we have to wait
+for the block point to advance sufficiently, and we block without sending a
+message, to simulate a slow response.
+
+If the next block to deliver is not part of the header point chain, but the
+block point is, we must have switched to a fork without ensuring that the block
+point advances to the last header point advertised on the old chain.
+
+While the block point is not on the same chain as the header point we wait,
+because the block point might still advance to allow the next block to be sent.
+If the block point is in the same chain as the header point, we interpret that
+the block point has left the old branch, and the requested blocks should be sent
+at this time.
+
+The cases to consider follow:
+
+ 0 1 2 3 4 5 6
+ x-x-x-x-x-x-x
+         ^BP ^HP
+       \-x-x-x
+         ^next
+✅ send the blocks because a rollback happened
+
+ 0 1 2 3 4 5 6
+ x-x-x-x-x-x-x
+   ^BP       ^HP
+       \-x-x-x
+         ^next
+
+❌ BP might still go on the fork where next is, so don't send the blocks yet
+
+ 0 1 2 3 4 5 6
+ x-x-x-x-x-x-x
+   ^BP
+     \-x-x-x-x
+       ^next ^HP
+
+❌ BP could still go on the fork where next is, don't send the blocks yet
+
+ 0 1 2 3 4 5 6
+ x-x-x-x-x-x-x
+     ^BP
+   \-x-x-x-x-x
+     ^next   ^HP
+
+❌ BP could still go on the fork where next is, don't send the blocks yet
+
+ 0 1 2 3 4 5 6
+ x-x-x-x-x-x-x
+     ^BP
+   \-x-x-x-x-x
+     ^next
+   \-x-x-x-x-x
+       ^HP
+
+❌ BP could still go on the fork where next is, don't send the blocks yet
+
+ 0 1 2 3 4 5 6
+ x-x-x-x-x-x-x
+     ^HP
+   \-x-x-x-x-x
+     ^next   ^BP
+
+✅ send the blocks because BP is after next
+
+ 0 1 2 3 4 5 6
+ x-x-x-x-x-x-x
+     ^HP
+   \-x-x-x-x-x
+     ^BP   ^next
+
+❌ BP could still advance past next, don't send the blocks yet
+
+-}
+handlerSendBlocks ::
+  forall m .
+  IOLike m =>
+  [TestBlock] ->
+  AdvertisedPoints ->
+  STM m (Maybe SendBlocks, [String])
+handlerSendBlocks blocks AdvertisedPoints {header = HeaderPoint hp, block = BlockPoint bp} =
+  runWriterT (checkDone blocks)
+  where
+    checkDone = \case
+      [] -> do
+        trace "Batch done"
+        pure (Just BatchDone)
+      (next : future) ->
+        blocksLeft next future
+
+    blocksLeft next future
+      | isAncestorOf (At next) bp
+      || compensateForScheduleRollback next
+      = do
+        trace ("Sending " ++ terseBlock next)
+        pure (Just (SendBlock next future))
+
+      | otherwise
+      = do
+        trace "BP is behind"
+        pure Nothing
+
+    -- Here we encode the conditions for the special situation mentioned above.
+    -- These use aliases for @withinFragmentBounds@ to illustrate what we're testing.
+    -- The names don't precisely match semantically, but it's difficult to understand the
+    -- circumstances otherwise.
+    --
+    -- The involved points are BP, HP, and @next@, which is the block we're deciding whether to
+    -- send or not.
+    --
+    -- Remember that at this point, we already know that we cannot send @next@ regularly, i.e.
+    -- @next@ is not on the chain leading up to BP.
+    -- The conditions in which we send @next@ to compensate for rollbacks are:
+    --
+    -- * @next@ is not on the chain leading up to HP – HP moved to another chain, and
+    --
+    -- * BP is in the same chain as HP and is not an ancestor of @next@ - BP also moved away from the chain of @next@.
+    --
+    -- Precondition: @not (isAncestorOf (At next) bp)@
+    compensateForScheduleRollback next =
+      not (isAncestorOf (At next) hp) && isAncestorOf bp hp && not (isAncestorOf bp (At next))
+
+    trace = tell . pure

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/ScheduledBlockFetchServer.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/ScheduledBlockFetchServer.hs
@@ -4,7 +4,9 @@
 
 module Test.Consensus.PeerSimulator.ScheduledBlockFetchServer (
     BlockFetch (..)
+  , BlockFetchServerHandlers (..)
   , ScheduledBlockFetchServer (..)
+  , SendBlocks (..)
   , runScheduledBlockFetchServer
   ) where
 
@@ -20,6 +22,13 @@ import           Test.Consensus.PeerSimulator.ScheduledServer
 import           Test.Consensus.PeerSimulator.Trace
 import           Test.Util.TestBlock (TestBlock)
 
+-- | Return values for the 'handlerSendBlocks'.
+data SendBlocks =
+  SendBlock TestBlock [TestBlock]
+  |
+  BatchDone
+  deriving (Eq, Show)
+
 -- | Return values for the 'handlerBlockFetch'.
 data BlockFetch =
   StartBatch [TestBlock]
@@ -30,12 +39,19 @@ data BlockFetch =
   -- ^ Negative response to the client's request for blocks.
   deriving (Eq, Show)
 
+-- | Handlers for the scheduled BlockFetch server.
+data BlockFetchServerHandlers m a =
+  BlockFetchServerHandlers {
+    bfshBlockFetch :: ChainRange (Point TestBlock) -> a -> STM m (Maybe BlockFetch, [String]),
+    bfshSendBlocks :: [TestBlock] -> a -> STM m (Maybe SendBlocks, [String])
+  }
+
 -- | Resources used by a scheduled BlockFetch server. This comprises a generic
 -- 'ScheduledServer' and BlockFetch-specific handlers.
 data ScheduledBlockFetchServer m a =
   ScheduledBlockFetchServer {
-    sbfsServer  :: ScheduledServer m a,
-    sbfsHandler :: ChainRange (Point TestBlock) -> a -> STM m (Maybe BlockFetch, [String])
+    sbfsServer   :: ScheduledServer m a,
+    sbfsHandlers :: BlockFetchServerHandlers m a
   }
 
 -- | Make a 'BlockFetchServer' able to run with the normal infrastructure from a
@@ -46,13 +62,15 @@ scheduledBlockFetchServer ::
   IOLike m =>
   ScheduledBlockFetchServer m a ->
   BlockFetchServer TestBlock (Point TestBlock) m ()
-scheduledBlockFetchServer ScheduledBlockFetchServer {sbfsServer, sbfsHandler} =
+scheduledBlockFetchServer ScheduledBlockFetchServer {sbfsServer, sbfsHandlers} =
   server
   where
     server = BlockFetchServer blockFetch ()
 
+    BlockFetchServerHandlers {bfshBlockFetch, bfshSendBlocks} = sbfsHandlers
+
     blockFetch range =
-      runHandler sbfsServer "BlockFetch" (sbfsHandler range) $ \case
+      runHandler sbfsServer "BlockFetch" (bfshBlockFetch range) $ \case
         StartBatch blocks -> do
           trace $ "  sending blocks: " ++ intercalate " " (terseBlock <$> blocks)
           trace "done handling BlockFetch"
@@ -62,14 +80,10 @@ scheduledBlockFetchServer ScheduledBlockFetchServer {sbfsServer, sbfsHandler} =
           trace "done handling BlockFetch"
           pure (SendMsgNoBlocks (server <$ awaitOnlineState sbfsServer))
 
-    sendBlocks :: [TestBlock] -> m (BlockFetchSendBlocks TestBlock (Point TestBlock) m ())
-    sendBlocks = \case
-      []         -> do
-        trace "Batch done"
-        pure (SendMsgBatchDone (pure server))
-      blk : blks -> do
-        trace ("Sending " ++ terseBlock blk)
-        pure (SendMsgBlock blk (sendBlocks blks))
+    sendBlocks bs =
+      runHandler sbfsServer "SendBlocks" (bfshSendBlocks bs) $ \case
+        SendBlock blk blks -> pure (SendMsgBlock blk (sendBlocks blks))
+        BatchDone -> pure (SendMsgBatchDone (pure server))
 
     trace = traceWith (ssTracer sbfsServer)
 
@@ -83,9 +97,9 @@ runScheduledBlockFetchServer ::
   STM m () ->
   STM m (Maybe a) ->
   Tracer m String ->
-  (ChainRange (Point TestBlock) -> a -> STM m (Maybe BlockFetch, [String])) ->
+  BlockFetchServerHandlers m a ->
   BlockFetchServer TestBlock (Point TestBlock) m ()
-runScheduledBlockFetchServer ssPeerId ssTickStarted ssCurrentState tracer sbfsHandler =
+runScheduledBlockFetchServer ssPeerId ssTickStarted ssCurrentState tracer sbfsHandlers =
   scheduledBlockFetchServer ScheduledBlockFetchServer {
     sbfsServer = ScheduledServer {
       ssPeerId,
@@ -93,5 +107,5 @@ runScheduledBlockFetchServer ssPeerId ssTickStarted ssCurrentState tracer sbfsHa
       ssCurrentState,
       ssTracer = Tracer (traceUnitWith tracer ("ScheduledBlockFetchServer " ++ ssPeerId))
     },
-    sbfsHandler
+    sbfsHandlers
   }

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/StateDiagram.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/StateDiagram.hs
@@ -1,0 +1,863 @@
+{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase                 #-}
+{-# LANGUAGE NamedFieldPuns             #-}
+{-# LANGUAGE OverloadedStrings          #-}
+{-# LANGUAGE TypeFamilies               #-}
+
+-- | A pretty-printer and tracer that shows the current peer simulator state in
+-- a block tree, highlighting the candidate fragments, selection, and forks in
+-- different colors, omitting uninteresting segments.
+module Test.Consensus.PeerSimulator.StateDiagram (
+    PeerSimState (..)
+  , RenderConfig (..)
+  , defaultRenderConfig
+  , peerSimStateDiagram
+  , peerSimStateDiagramSTMTracer
+  , peerSimStateDiagramSTMTracerDebug
+  , peerSimStateDiagramTracer
+  , peerSimStateDiagramWith
+  ) where
+
+import           Cardano.Slotting.Block (BlockNo (BlockNo))
+import           Cardano.Slotting.Slot (SlotNo (SlotNo), WithOrigin (..),
+                     fromWithOrigin, withOrigin)
+import           Control.Monad (guard)
+import           Control.Monad.State.Strict (State, gets, modify', runState,
+                     state)
+import           Control.Tracer (Tracer (Tracer), debugTracer, traceWith)
+import           Data.Bifunctor (first)
+import           Data.Foldable (foldl', foldr')
+import           Data.List (intersperse, mapAccumL, sort, transpose)
+import           Data.List.NonEmpty (NonEmpty ((:|)), nonEmpty, (<|))
+import qualified Data.List.NonEmpty as NonEmpty
+import           Data.Map (Map)
+import           Data.Map.Strict ((!?))
+import qualified Data.Map.Strict as Map
+import           Data.Maybe (mapMaybe)
+import           Data.String (IsString (fromString))
+import           Data.Vector (Vector)
+import qualified Data.Vector as Vector
+import qualified Data.Vector.Mutable as MV
+import           Data.Word (Word64)
+import qualified Debug.Trace as Debug
+import           GHC.Exts (IsList (..))
+import           Ouroboros.Consensus.Block (blockNo, blockSlot, getHeader)
+import           Ouroboros.Consensus.Util (eitherToMaybe)
+import           Ouroboros.Consensus.Util.Condense (Condense (..))
+import           Ouroboros.Consensus.Util.IOLike (IOLike, MonadSTM (STM),
+                     atomically, modifyTVar, readTVar, uncheckedNewTVarM)
+import           Ouroboros.Network.AnchoredFragment (anchor, anchorToSlotNo)
+import qualified Ouroboros.Network.AnchoredFragment as AF
+import           Test.Consensus.BlockTree (BlockTree (btBranches, btTrunk),
+                     BlockTreeBranch (btbSuffix), prettyBlockTree)
+import           Test.Consensus.PointSchedule (PeerId (..), TestFrag, TestFragH)
+import           Test.Util.TestBlock (TestBlock)
+
+enableDebug :: Bool
+enableDebug = False
+
+debugRender :: String -> a -> a
+debugRender
+  | enableDebug
+  = Debug.trace
+  | otherwise
+  = const id
+
+----------------------------------------------------------------------------------------------------
+-- Colors
+----------------------------------------------------------------------------------------------------
+
+data SGR =
+  Color Word64
+  |
+  BgColor Word64
+  |
+  Bold
+  |
+  Reset
+  |
+  Keep
+
+renderSgr :: [SGR] -> String
+renderSgr =
+  foldMap $ \case
+    Color n -> sgr ("38;5;" ++ show n)
+    BgColor n -> sgr ("48;5;" ++ show n)
+    Bold -> sgr "1"
+    Reset -> sgr "0"
+    Keep -> ""
+  where
+    sgr x = "\ESC[" ++ x ++ "m"
+
+data Col =
+  ColAspect (NonEmpty Aspect) Col
+  |
+  Col [SGR] Col
+  |
+  ColString String
+  |
+  ColCat [Col]
+
+instance IsString Col where
+  fromString = ColString
+
+instance IsList Col where
+  type Item Col = Col
+  fromList = ColCat
+  toList = \case
+    ColCat cols -> cols
+    c -> [c]
+
+instance Semigroup Col where
+  l <> r = ColCat [l, r]
+
+instance Monoid Col where
+  mempty = ""
+
+colLength :: Col -> Int
+colLength = \case
+  ColAspect _ c -> colLength c
+  Col _ c -> colLength c
+  ColString s -> length s
+  ColCat cs -> sum (colLength <$> cs)
+
+data Colors =
+  Colors {
+    candidates :: [Word64],
+    selection  :: Maybe Word64,
+    slotNumber :: Word64,
+    cache      :: Map PeerId Word64,
+    stack      :: [[SGR]]
+  }
+
+candidateColor :: PeerId -> Colors -> (Maybe Word64, Colors)
+candidateColor pid s@Colors {candidates, cache}
+  | Just c <- cached
+  = (Just c, s)
+
+  | h : t <- filter unused candidates
+  = (Just h, s {candidates = t, cache = Map.insert pid h cache})
+
+  | otherwise
+  = (Nothing, s)
+  where
+    cached = cache !? pid
+    unused c = not (elem c cache)
+
+getColor :: Bool -> Aspect -> State Colors (Maybe [SGR])
+getColor bg = \case
+  Selection -> do
+    c <- gets selection
+    pure (Just (Bold : maybe [] (pure . mkColor) c))
+  Candidate pid ->
+    fmap (pure . mkColor) <$> state (candidateColor pid)
+  Fork -> pure Nothing
+  SlotNumber -> do
+    c <- gets slotNumber
+    pure (Just [mkColor c])
+  where
+    mkColor | bg = BgColor
+            | otherwise = Color
+
+getColors :: NonEmpty Aspect -> State Colors [SGR]
+getColors aspects = do
+  (main, rest) <- findColor False (NonEmpty.toList aspects)
+  (bg, _) <- findColor True rest
+  pure (main ++ bg)
+  where
+    findColor bg (h : t) =
+      getColor bg h >>= \case
+        Just c -> pure (c, t)
+        Nothing -> findColor bg t
+    findColor _ [] = pure ([], [])
+
+renderCol :: Col -> State Colors String
+renderCol col =
+  spin col
+  where
+    spin = \case
+      ColAspect aspects sub -> do
+        sgr <- getColors aspects
+        withSgr sgr sub
+      Col sgr sub ->
+        withSgr sgr sub
+      ColString s -> pure s
+      ColCat cols -> concat <$> traverse spin cols
+
+    withSgr sgr sub = do
+      pre <- push sgr
+      s <- spin sub
+      pop
+      pure (renderSgr sgr ++ s ++ renderSgr pre)
+
+    push sgr =
+      state $ \case
+        s@Colors {stack = []} -> ([Reset], s {stack = [sgr, [Reset]]})
+        s@Colors {stack = h : t} -> ([Reset], s {stack = sgr : h : t})
+
+    pop = modify' $ \ s@Colors {stack} -> s {stack = drop 1 stack}
+
+runCol :: [Word64] -> Maybe Word64 -> Word64 -> Map PeerId Word64 -> State Colors a -> (a, Colors)
+runCol cand selection slotNumber cache s =
+  runState s Colors {candidates = cand, selection, slotNumber, cache, stack = []}
+
+----------------------------------------------------------------------------------------------------
+-- Slots
+----------------------------------------------------------------------------------------------------
+
+slotInt :: SlotNo -> Int
+slotInt (SlotNo s) = fromIntegral s
+
+blockInt :: BlockNo -> Int
+blockInt (BlockNo s) = fromIntegral s
+
+data Range =
+  Range {
+    from :: Int,
+    to   :: Int
+  }
+  deriving (Show, Eq, Ord)
+
+instance Condense Range where
+  condense (Range from to) = "[" ++ condense from ++ "," ++ condense to ++ "]"
+
+data Aspect =
+  Fork
+  |
+  Selection
+  |
+  Candidate PeerId
+  |
+  SlotNumber
+  deriving (Eq, Show, Ord)
+
+instance Condense Aspect where
+  condense = \case
+    Selection -> "s"
+    Candidate _ -> "c"
+    Fork -> "f"
+    SlotNumber -> "n"
+
+data AspectEdge =
+  EdgeLeft
+  |
+  EdgeRight
+  |
+  NoEdge
+  deriving (Show)
+
+data SlotAspect =
+  SlotAspect {
+    slotAspect :: Aspect,
+    edge       :: AspectEdge
+  }
+  deriving (Show)
+
+data SlotCapacity =
+  SlotOutside
+  |
+  SlotBlock Int
+  |
+  SlotEmpty
+  deriving (Show)
+
+instance Condense SlotCapacity where
+  condense = \case
+    SlotOutside -> ""
+    SlotBlock n -> "-" ++ condense n
+    SlotEmpty -> ""
+
+data Slot =
+  Slot {
+    num      :: WithOrigin Int,
+    capacity :: SlotCapacity,
+    aspects  :: [SlotAspect]
+  }
+  deriving (Show)
+
+instance Condense Slot where
+  condense Slot {num, capacity} =
+    sn ++ condense capacity
+    where
+      sn = case num of
+        Origin -> "G"
+        At n   -> show n
+
+----------------------------------------------------------------------------------------------------
+-- Slots vectors
+----------------------------------------------------------------------------------------------------
+
+data BranchSlots =
+  BranchSlots {
+    frag  :: TestFragH,
+    slots :: Vector Slot,
+    cands :: [PeerId]
+  }
+  deriving (Show)
+
+addAspect :: Aspect -> Range -> Bool -> Vector Slot -> Vector Slot
+addAspect slotAspect (Range l u) overFork slots =
+  debugRender (show (l, u, slotAspect)) $
+  debugRender (condense (Vector.toList (ins <$> sub))) $
+  Vector.update slots (ins <$> sub)
+  where
+    ins (i, slot) =
+      (i, slot {aspects = newAspect : aspects slot})
+      where
+        newAspect = SlotAspect {slotAspect, edge = mkEdge i}
+
+    mkEdge i | i == l && not overFork = EdgeLeft
+             | i == u = EdgeRight
+             | otherwise = NoEdge
+
+    sub = Vector.slice l count (Vector.indexed slots)
+
+    count | u == l = 1
+          | otherwise = u - l + 1
+
+initSlots :: Int -> Range -> TestFrag -> Vector Slot
+initSlots lastSlot (Range l u) blocks =
+  Vector.fromList (snd (mapAccumL step (AF.toOldestFirst blocks) [-1 .. lastSlot]))
+  where
+    step bs cur
+      | cur == -1
+      = (bs, Slot {num = Origin, capacity = SlotOutside, aspects = []})
+
+      | b : rest <- bs
+      , s <- slotInt (blockSlot b)
+      , s == cur
+      = (rest, mkSlot cur (SlotBlock (blockInt (blockNo b))))
+
+      | cur >= l - 1 && cur <= u
+      = (bs, mkSlot cur SlotEmpty)
+
+      | otherwise
+      = (bs, mkSlot cur SlotOutside)
+
+    mkSlot num capacity =
+      Slot {num = At num, capacity, aspects = []}
+
+initBranch :: Int -> Range -> TestFrag -> BranchSlots
+initBranch lastSlot fragRange fragment =
+  BranchSlots {
+    frag = AF.mapAnchoredFragment getHeader fragment,
+    slots = initSlots lastSlot fragRange fragment,
+    cands = []
+  }
+
+data TreeSlots =
+  TreeSlots {
+    lastSlot :: Int,
+    branches :: [BranchSlots]
+  }
+  deriving (Show)
+
+initTree :: BlockTree TestBlock -> TreeSlots
+initTree blockTree =
+  TreeSlots {lastSlot, branches = trunk : branches}
+  where
+    trunk = initFR trunkRange
+
+    branches = initFR <$> branchRanges
+
+    initFR = uncurry (initBranch lastSlot)
+
+    lastSlot = foldr' (max . (to . fst)) 0 (trunkRange : branchRanges)
+
+    trunkRange = withRange (btTrunk blockTree)
+
+    branchRanges = withRange . btbSuffix <$> btBranches blockTree
+
+    withRange f = (mkRange f, f)
+
+    mkRange f =
+      Range l u
+      where
+        l = withOrigin 0 slotInt (AF.lastSlot f)
+        u = withOrigin 0 slotInt (AF.headSlot f)
+
+commonRange :: TestFragH -> TestFragH -> Maybe (Range, Bool)
+commonRange branch segment = do
+  (preB, preS, _, _) <- AF.intersect branch segment
+  lower <- findLower (AF.toNewestFirst preB) (AF.toNewestFirst preS)
+  upper <- eitherToMaybe (AF.head preB)
+  let
+    aB = anchor preB
+    aS = anchor preS
+    asB = anchorToSlotNo aB
+    asS = anchorToSlotNo aS
+    l = blockSlot lower
+    u = blockSlot upper
+    overFork = asS < asB && aB == anchor branch
+  guard (u >= l)
+  pure (Range (slotInt l + (if overFork then 0 else 1)) (slotInt u + 1), overFork)
+  where
+    findLower preB preS =
+      foldl' step Nothing (zip preB preS)
+    step prev (b1, b2) | b1 == b2 = Just b1
+                       | otherwise = prev
+
+addFragRange :: Aspect -> TestFragH -> TreeSlots -> TreeSlots
+addFragRange aspect selection TreeSlots {lastSlot, branches} =
+  TreeSlots {lastSlot, branches = forBranch <$> branches}
+  where
+    forBranch branch@BranchSlots {frag, slots, cands} =
+      case commonRange frag selection of
+        Just (range, overFork) -> branch {slots = addAspect aspect range overFork slots, cands = addCandidate cands}
+        _          -> branch
+
+    addCandidate old | Candidate peerId <- aspect = peerId : old
+                     | otherwise = old
+
+addCandidateRange :: TreeSlots -> (PeerId, TestFragH) -> TreeSlots
+addCandidateRange ranges (pid, candidate) =
+  addFragRange (Candidate pid) candidate ranges
+
+updateSlot :: Int -> (Slot -> Slot) -> Vector Slot -> Vector Slot
+updateSlot i f =
+  Vector.modify (\ mv -> MV.modify mv f i)
+
+addForks :: TreeSlots -> TreeSlots
+addForks ranges@TreeSlots {branches} =
+  ranges {branches = addFork <$> branches}
+  where
+    addFork fr@BranchSlots {frag, slots} =
+      fr {slots = updateSlot s update slots}
+      where
+        update slot =
+          slot {
+            capacity = SlotEmpty,
+            aspects = SlotAspect {slotAspect = Fork, edge = NoEdge} : aspects slot
+          }
+        s = slotInt (withOrigin 0 (+ 1) (anchorToSlotNo (anchor frag)))
+
+----------------------------------------------------------------------------------------------------
+-- Cells
+----------------------------------------------------------------------------------------------------
+
+data CellSort =
+  CellHere (NonEmpty Aspect)
+  |
+  CellOther
+  deriving (Show)
+
+instance Condense CellSort where
+  condense = \case
+    CellHere a -> "h" ++ condense (toList a)
+    CellOther -> "o"
+
+data FragCell =
+  FragCell {
+    fcLabel       :: Maybe String,
+    fcSort        :: CellSort,
+    fcLineAspects :: [Aspect]
+  }
+  deriving (Show)
+
+instance Condense FragCell where
+  condense (FragCell l s a) =
+    lb ++ " " ++ condense s ++ condense a
+    where
+      lb = case l of
+        Just x  -> x
+        Nothing -> "-"
+
+data Cell =
+  Cell FragCell
+  |
+  CellEmpty
+  |
+  CellSlotNo (WithOrigin Int)
+  |
+  CellLabels [PeerId]
+  deriving (Show)
+
+instance Condense Cell where
+  condense = \case
+    Cell c -> condense c
+    CellEmpty -> "E"
+    CellSlotNo n -> "S" ++ show n
+    CellLabels _ -> "L"
+
+mainAspects :: [SlotAspect] -> Maybe (NonEmpty Aspect)
+mainAspects =
+  nonEmpty . sort . fmap slotAspect
+
+lineAspects :: [SlotAspect] -> [Aspect]
+lineAspects =
+  sort . mapMaybe check
+  where
+    check SlotAspect {edge, slotAspect}
+      | EdgeLeft <- edge
+      = Nothing
+      | otherwise
+      = Just slotAspect
+
+prependList :: [a] -> NonEmpty a -> NonEmpty a
+prependList = \case
+  [] -> id
+  h : t -> ((h :| t) <>)
+
+branchCells :: BranchSlots -> NonEmpty Cell
+branchCells BranchSlots {cands, slots} =
+  prependList (fragCell <$> Vector.toList slots) (pure labels)
+  where
+    fragCell Slot {capacity, aspects}
+      | SlotOutside <- capacity
+      = CellEmpty
+
+      | otherwise
+      , cellSort <- maybe CellOther CellHere (mainAspects aspects)
+      = Cell (FragCell (content capacity) cellSort (lineAspects aspects))
+
+    content = \case
+      SlotBlock num -> Just (show num)
+      _ -> Nothing
+
+    labels = CellLabels cands
+
+slotNoCells :: Int -> NonEmpty Cell
+slotNoCells lastSlot =
+  CellSlotNo Origin :| (CellSlotNo . At <$> [0 .. lastSlot]) ++ [CellEmpty]
+
+treeCells :: TreeSlots -> NonEmpty (NonEmpty Cell)
+treeCells TreeSlots {lastSlot, branches} =
+  slotNoCells lastSlot :| (branchCells <$> branches)
+
+----------------------------------------------------------------------------------------------------
+-- Render cells
+----------------------------------------------------------------------------------------------------
+
+newtype SlotWidth =
+  SlotWidth Int
+  deriving (Eq, Show, Ord, Num)
+
+data RenderSlot =
+  SlotEllipsis Int
+  |
+  RenderSlot Int SlotWidth (NonEmpty Cell)
+  deriving (Show)
+
+data RenderCell =
+  CellEllipsis
+  |
+  RenderCell SlotWidth Cell
+  deriving (Show)
+
+instance Condense RenderCell where
+  condense = \case
+    CellEllipsis -> " .. "
+    RenderCell _ cell -> condense cell
+
+renderPeerId :: PeerId -> String
+renderPeerId = \case
+  HonestPeer -> "honest"
+  PeerId p -> p
+
+slotWidth :: NonEmpty Cell -> SlotWidth
+slotWidth =
+  maximum . fmap cellWidth
+  where
+    cellWidth = \case
+      Cell FragCell {fcLabel = Just label} -> SlotWidth (length label)
+      CellLabels peerIds -> SlotWidth (sum (labelWidth <$> peerIds))
+      _ -> 1
+
+    labelWidth pid = 2 + length (renderPeerId pid)
+
+contiguous :: [(Int, Bool, a)] -> [[(Int, a)]]
+contiguous ((i0, _, a0) : rest) =
+  result (foldl' step (pure (i0, a0), []) rest)
+  where
+    result (cur, res) = reverse (reverse (toList cur) : res)
+
+    step (cur@((prev, _) :| _), res) (i, force, a)
+      | i == prev + 1 || force
+      = ((i, a) <| cur, res)
+      | otherwise
+      = (pure (i, a), reverse (toList cur) : res)
+contiguous [] = []
+
+cellSlots :: Int -> [(Int, Bool, NonEmpty Cell)] -> [RenderSlot]
+cellSlots branches =
+  concat . intersperse [SlotEllipsis branches] . fmap (fmap (uncurry withMaxSize)) . contiguous
+  where
+    withMaxSize slot cells = RenderSlot slot (slotWidth cells) cells
+
+pruneCells :: NonEmpty (NonEmpty Cell) -> [RenderSlot]
+pruneCells branches =
+  -- debugRender (unlines (condense <$> branches)) $
+  cellSlots (length branches) (mapMaybe cellSlot (zip slotRange (NonEmpty.toList (NonEmpty.transpose branches))))
+  where
+    cellSlot :: (WithOrigin Int, NonEmpty Cell) -> Maybe (Int, Bool, NonEmpty Cell)
+    cellSlot (num, frags)
+      | let noEll = any forceNoEllipsis frags
+      , noEll || any essential frags
+      = keep num noEll frags
+      | otherwise
+      = Nothing
+
+    keep num noEll frags = Just (fromWithOrigin (-1) num, noEll, frags)
+
+    essential = \case
+      Cell FragCell {fcSort = CellHere _} -> True
+      _ -> False
+
+    forceNoEllipsis = \case
+      CellLabels _ -> True
+      _ -> False
+
+    slotRange = Origin : (At <$> [0 ..])
+
+----------------------------------------------------------------------------------------------------
+-- Render
+----------------------------------------------------------------------------------------------------
+
+data RenderConfig =
+  RenderConfig {
+    lineWidth       :: Int,
+    ellipsis        :: String,
+    slotDistance    :: Int,
+    boringChar      :: Char,
+    candidateChar   :: Char,
+    selectionChar   :: Char,
+    forkChar        :: Char,
+    candidateColors :: [Word64],
+    cachedPeers     :: Map PeerId Word64,
+    selectionColor  :: Maybe Word64,
+    slotNumberColor :: Word64
+  }
+
+padCell :: RenderConfig -> Char -> SlotWidth -> String -> String
+padCell RenderConfig {slotDistance} padChar (SlotWidth w) s
+  | pad <= 0 = s
+  |otherwise = replicate pad padChar ++ s
+  where
+    pad = w - length s + slotDistance
+
+lineChar :: RenderConfig -> [Aspect] -> Char
+lineChar config aspects
+  | elem Selection aspects
+  = selectionChar config
+
+  | any isCandidate aspects
+  = candidateChar config
+
+  | otherwise
+  = boringChar config
+  where
+    isCandidate = \case
+      Candidate _ -> True
+      _ -> False
+
+colorAspects :: [Aspect] -> [Aspect]
+colorAspects =
+  filter $ \case
+    Fork -> False
+    Selection -> False
+    _ -> True
+
+renderLine :: RenderConfig -> SlotWidth -> [Aspect] -> Int -> Col
+renderLine config@RenderConfig {slotDistance, forkChar} (SlotWidth width) aspects labelWidth =
+  case colorAspects aspects of
+    [] -> ColString lineString
+    colors -> ColCat [ColAspect (pure color) (ColString [c]) | (c, color) <- zip lineString (cycle colors)]
+  where
+    lineString | elem Fork aspects = replicate (lineWidth - 1) ' ' ++ [forkChar]
+               | otherwise = replicate lineWidth lc
+    lineWidth = max 0 (width - labelWidth + slotDistance)
+    lc = lineChar config aspects
+
+labelColor :: CellSort -> Maybe (NonEmpty Aspect)
+labelColor = \case
+  CellOther -> Nothing
+  CellHere aspects ->
+    nonEmpty (colorAspects (toList aspects))
+
+renderSpecifiedLabel :: String -> CellSort -> Col
+renderSpecifiedLabel label srt =
+  case labelColor srt of
+    Nothing -> text
+    Just as -> ColAspect as text
+  where
+    text = ColString label
+
+renderLabel :: Maybe String -> CellSort -> Col
+renderLabel label srt
+  | Just specified <- label
+  = renderSpecifiedLabel specified srt
+  | otherwise
+  = ""
+
+renderFragCell :: RenderConfig -> SlotWidth -> FragCell -> Col
+renderFragCell config width FragCell {fcLabel, fcSort, fcLineAspects} =
+  renderLine config width fcLineAspects (colLength label) <> label
+  where
+    label = renderLabel fcLabel fcSort
+
+renderSlotNo :: RenderConfig -> SlotWidth -> WithOrigin Int -> Col
+renderSlotNo config width num =
+  ColAspect (pure SlotNumber) (ColString (padCell config ' ' width label))
+  where
+    label = case num of
+      Origin -> "G"
+      At s   -> show s
+
+renderLabels :: [PeerId] -> Col
+renderLabels peers =
+  ColCat [ColAspect (pure (Candidate p)) (ColString ("  " ++ renderPeerId p)) | p <- peers]
+
+renderCell :: RenderConfig -> RenderCell -> Col
+renderCell config@RenderConfig {ellipsis} = \case
+  RenderCell width (Cell cell) -> renderFragCell config width cell
+  RenderCell width (CellEmpty) -> ColString (padCell config ' ' width "")
+  RenderCell width (CellSlotNo n) -> renderSlotNo config width n
+  RenderCell _ (CellLabels peers) -> renderLabels peers
+  CellEllipsis -> ColString ellipsis
+
+renderBranch :: RenderConfig -> [RenderCell] -> Col
+renderBranch config cells =
+  debugRender (condense cells) $
+  foldMap (renderCell config) cells
+
+-- | Use w + 2 because we want the effective width, which includes the line segment.
+renderSlotWidth :: Int -> RenderSlot -> Int
+renderSlotWidth ellipsisWidth = \case
+  SlotEllipsis _ -> ellipsisWidth
+  RenderSlot _ (SlotWidth w) _ -> w + 2
+
+breakLines :: RenderConfig -> [RenderSlot] -> [[RenderSlot]]
+breakLines RenderConfig {lineWidth, ellipsis} =
+  result . foldl' step (0, [], [])
+  where
+    result (_, cur, res) = reverse (reverse cur : res)
+    step (w, cur, res) slot
+      | new <= lineWidth = (new, slot : cur, res)
+      | otherwise = (curW, [slot], reverse cur : res)
+      where
+        new = w + curW
+        curW = renderSlotWidth (length ellipsis) slot
+
+renderCells :: [RenderSlot] -> [[RenderCell]]
+renderCells =
+  transpose . fmap toCells
+  where
+    toCells = \case
+      RenderSlot _ width cells -> RenderCell width <$> toList cells
+      SlotEllipsis n -> replicate n CellEllipsis
+
+renderSlotSequence :: RenderConfig -> [RenderSlot] -> [Col]
+renderSlotSequence config =
+  fmap (renderBranch config) . renderCells
+
+renderSlots :: RenderConfig -> [RenderSlot] -> [[Col]]
+renderSlots config slots =
+  renderSlotSequence config <$> breakLines config slots
+
+renderColBlocks :: RenderConfig -> [[Col]] -> ([String], Colors)
+renderColBlocks RenderConfig {candidateColors, selectionColor, slotNumberColor, cachedPeers} cols =
+  first (fmap unlines) (runCol candidateColors selectionColor slotNumberColor cachedPeers (traverse (traverse renderCol) cols))
+
+------------------------------------------------------------------------------------------------------
+---- API
+------------------------------------------------------------------------------------------------------
+
+-- | All inputs for the state diagram printer.
+data PeerSimState =
+  PeerSimState {
+    pssBlockTree  :: BlockTree TestBlock,
+    pssSelection  :: TestFragH,
+    pssCandidates :: Map PeerId TestFragH
+  }
+
+-- TODO add an aspect for the last block of each branch?
+
+-- | Pretty-print the current peer simulator state in a block tree, highlighting
+-- the candidate fragments, selection, and forks in different colors, omitting
+-- uninteresting segments.
+peerSimStateDiagramWith :: RenderConfig -> PeerSimState -> (String, Map PeerId Word64)
+peerSimStateDiagramWith config PeerSimState {pssBlockTree, pssSelection, pssCandidates} =
+  debugRender (unlines (prettyBlockTree pssBlockTree)) $
+  (unlines blocks, cache)
+  where
+    (blocks, Colors {cache}) = renderColBlocks config (renderSlots config frags)
+
+    frags =
+      pruneCells $
+      treeCells $
+      addForks $
+      flip (foldl' addCandidateRange) (Map.toList pssCandidates) $
+      addFragRange Selection pssSelection $
+      initTree pssBlockTree
+
+defaultRenderConfig :: RenderConfig
+defaultRenderConfig =
+  RenderConfig {
+    lineWidth = 80,
+    ellipsis = " .. ",
+    slotDistance = 2,
+    boringChar = '·',
+    candidateChar = '-',
+    selectionChar = '*',
+    forkChar = '`',
+    candidateColors = [164, 113, 142, 81, 33],
+    cachedPeers = mempty,
+    selectionColor = Just 123,
+    slotNumberColor = 166
+  }
+
+peerSimStateDiagram :: PeerSimState -> String
+peerSimStateDiagram =
+  fst . peerSimStateDiagramWith defaultRenderConfig
+
+-- | Construct a tracer that prints the current peer simulator state in
+-- a block tree, highlighting the candidate fragments, selection, and forks in
+-- different colors, omitting uninteresting segments.
+peerSimStateDiagramTracer ::
+  Tracer m String ->
+  Tracer m PeerSimState
+peerSimStateDiagramTracer tracer =
+  Tracer (traceWith tracer . peerSimStateDiagram)
+
+-- | Construct a stateful tracer that prints the current peer simulator state in
+-- a block tree, highlighting the candidate fragments, selection, and forks in
+-- different colors, omitting uninteresting segments.
+--
+-- Since the tracer gets its input from concurrent state, it takes only a dummy
+-- @()@ value as its argument.
+peerSimStateDiagramSTMTracer ::
+  IOLike m =>
+  Tracer m String ->
+  BlockTree TestBlock ->
+  STM m TestFragH ->
+  STM m (Map PeerId TestFragH) ->
+  m (Tracer m ())
+peerSimStateDiagramSTMTracer stringTracer pssBlockTree selectionVar candidatesVar = do
+  peerCache <- uncheckedNewTVarM mempty
+  pure $ Tracer $ const $ do
+    (s, cachedPeers) <- atomically $ do
+      pssSelection <- selectionVar
+      pssCandidates <- candidatesVar
+      cachedPeers <- readTVar peerCache
+      pure (PeerSimState {pssBlockTree, pssSelection, pssCandidates}, cachedPeers)
+    let (blocks, newPeers) = peerSimStateDiagramWith (defaultRenderConfig {cachedPeers}) s
+    atomically (modifyTVar peerCache (newPeers <>))
+    traceWith stringTracer blocks
+
+-- | Construct a stateful tracer that prints the current peer simulator state in
+-- a block tree, highlighting the candidate fragments, selection, and forks in
+-- different colors, omitting uninteresting segments.
+--
+-- Since the tracer gets its input from concurrent state, it takes only a dummy
+-- @()@ value as its argument.
+--
+-- This variant uses the global debug tracer.
+peerSimStateDiagramSTMTracerDebug ::
+  IOLike m =>
+  BlockTree TestBlock ->
+  STM m TestFragH ->
+  STM m (Map PeerId TestFragH) ->
+  m (Tracer m ())
+peerSimStateDiagramSTMTracerDebug =
+  peerSimStateDiagramSTMTracer debugTracer

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
@@ -21,10 +21,18 @@ import           Test.Tasty
 import           Test.Tasty.QuickCheck
 import           Test.Util.Orphans.IOLike ()
 import           Test.Util.TestBlock (TestBlock, unTestHash)
+import           Test.Util.TestEnv (adjustQuickCheckTests)
 
 tests :: TestTree
 tests = testGroup "rollback" [
-  testProperty "can rollback" (prop_rollback True),
+  -- NOTE: The property @prop_rollback True@ discards a lot of inputs, making
+  -- it quite flakey. We increase the maximum number of discarded tests per
+  -- successful ones so as to make this test more reliable.
+  adjustQuickCheckTests (`div` 10) $
+  localOption (QuickCheckMaxRatio 100) $
+  testProperty "can rollback" (prop_rollback True)
+  ,
+  adjustQuickCheckTests (`div` 10) $
   testProperty "cannot rollback" (prop_rollback False)
   ]
 

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
@@ -6,7 +6,6 @@
 module Test.Consensus.PeerSimulator.Tests.Rollback (tests) where
 
 import           Control.Monad.IOSim (runSimOrThrow)
-import           Data.Maybe (fromJust)
 import           Ouroboros.Consensus.Block (ChainHash (..))
 import           Ouroboros.Consensus.Config.SecurityParam
 import qualified Ouroboros.Network.AnchoredFragment as AF
@@ -47,7 +46,7 @@ prop_rollback :: Bool -> QC.Gen QC.Property
 prop_rollback wantRollback = do
   -- | Create a block tree with @1@ alternative chain, such that we can rollback
   -- from the trunk to that chain.
-  genesisTest <- genChains 1
+  genesisTest <- genChains (pure 1)
 
   let schedule = rollbackSchedule (gtBlockTree genesisTest)
 
@@ -81,7 +80,7 @@ prop_rollback wantRollback = do
           states = banalStates trunk ++ banalStates branch
           peers = peersOnlyHonest states
           pointSchedule = balanced defaultPointScheduleConfig peers
-       in fromJust pointSchedule
+       in pointSchedule
 
     -- | Whether it is possible to roll back from the trunk after having served
     -- it fully, that is whether there is an alternative chain that forks of the

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
@@ -24,80 +24,113 @@ import           Test.Util.TestEnv (adjustQuickCheckTests)
 
 tests :: TestTree
 tests = testGroup "rollback" [
-  -- NOTE: The property @prop_rollback True@ discards a lot of inputs, making
-  -- it quite flakey. We increase the maximum number of discarded tests per
-  -- successful ones so as to make this test more reliable.
   adjustQuickCheckTests (`div` 10) $
   localOption (QuickCheckMaxRatio 100) $
-  testProperty "can rollback" (prop_rollback True)
+  testProperty "can rollback" prop_rollback
   ,
   adjustQuickCheckTests (`div` 10) $
-  testProperty "cannot rollback" (prop_rollback False)
+  testProperty "cannot rollback" prop_cannotRollback
   ]
 
--- | @prop_rollback True@ tests that the selection of the node under test
+-- | @prop_rollback@ tests that the selection of the node under test
 -- changes branches when sent a rollback to a block no older than 'k' blocks
 -- before the current selection.
---
--- @prop_rollback False@ tests that the selection of the node under test *does
--- not* change branches when sent a rollback to a block strictly older than 'k'
--- blocks before the current selection.
-prop_rollback :: Bool -> QC.Gen QC.Property
-prop_rollback wantRollback = do
-  -- | Create a block tree with @1@ alternative chain, such that we can rollback
+prop_rollback :: QC.Gen QC.Property
+prop_rollback = do
+  -- Create a block tree with @1@ alternative chain, such that we can rollback
   -- from the trunk to that chain.
   genesisTest <- genChains (pure 1)
 
-  let schedule = rollbackSchedule (gtBlockTree genesisTest)
+  let SecurityParam k = gtSecurityParam genesisTest
+      schedule = rollbackSchedule (fromIntegral k) (gtBlockTree genesisTest)
 
-  -- | We consider the test case interesting if we want a rollback and we can
-  -- actually get one, or if we want no rollback and we cannot actually get one.
+  -- We consider the test case interesting if we can rollback
   pure $
-    wantRollback == canRollbackFromTrunkTip (gtSecurityParam genesisTest) (gtBlockTree genesisTest)
+    alternativeChainIsLongEnough (gtSecurityParam genesisTest) (gtBlockTree genesisTest)
     ==>
       runSimOrThrow $ runTest schedulerConfig genesisTest schedule $ \StateView{svSelectedChain} ->
         let headOnAlternativeChain = case AF.headHash svSelectedChain of
               GenesisHash    -> False
               BlockHash hash -> any (0 /=) $ unTestHash hash
         in
-        -- The test passes if we want a rollback and we actually end up on the
-        -- alternative chain or if we want no rollback and end up on the trunk.
-        wantRollback == headOnAlternativeChain
+        -- The test passes if we end up on the alternative chain
+        headOnAlternativeChain
 
   where
     schedulerConfig = noTimeoutsSchedulerConfig defaultPointScheduleConfig
 
-    -- A schedule that advertises all the points of the trunk, then switches to
-    -- the first alternative chain of the given block tree.
-    --
-    -- PRECONDITION: Block tree with at least one alternative chain.
-    rollbackSchedule :: BlockTree TestBlock -> PointSchedule
-    rollbackSchedule blockTree =
-      let trunk = btTrunk blockTree
-          branch = case btBranches blockTree of
-            [b] -> btbSuffix b
-            _   -> error "The block tree must have exactly one alternative branch"
-          states = banalStates trunk ++ banalStates branch
-          peers = peersOnlyHonest states
-          pointSchedule = balanced defaultPointScheduleConfig peers
-       in pointSchedule
+-- @prop_cannotRollback@ tests that the selection of the node under test *does
+-- not* change branches when sent a rollback to a block strictly older than 'k'
+-- blocks before the current selection.
+prop_cannotRollback :: QC.Gen QC.Property
+prop_cannotRollback = do
+  genesisTest <- genChains (pure 1)
 
-    -- | Whether it is possible to roll back from the trunk after having served
-    -- it fully, that is whether there is an alternative chain that forks of the
-    -- trunk no more than 'k' blocks from the tip and that is longer than the
-    -- trunk.
-    --
-    -- PRECONDITION: Block tree with exactly one alternative chain, otherwise
-    -- this property does not make sense. With no alternative chain, this will
-    -- even crash.
-    --
-    -- REVIEW: Why does 'existsSelectableAdversary' get to be a classifier and
-    -- not this? (or a generalised version of this)
-    canRollbackFromTrunkTip :: SecurityParam -> BlockTree TestBlock -> Bool
-    canRollbackFromTrunkTip (SecurityParam k) blockTree =
-      let BlockTreeBranch{btbSuffix, btbTrunkSuffix} = case btBranches blockTree of
-            [b] -> b
-            _   -> error "The block tree must have exactly one alternative branch"
-          lengthSuffix = AF.length btbSuffix
-          lengthTrunkSuffix = AF.length btbTrunkSuffix
-       in lengthTrunkSuffix <= fromIntegral k && lengthSuffix > lengthTrunkSuffix
+  let SecurityParam k = gtSecurityParam genesisTest
+      schedule = rollbackSchedule (fromIntegral (k + 1)) (gtBlockTree genesisTest)
+
+  -- We consider the test case interesting if it allows to rollback even if
+  -- the implementation doesn't
+  pure $
+    alternativeChainIsLongEnough (gtSecurityParam genesisTest) (gtBlockTree genesisTest)
+      &&
+    honestChainIsLongEnough (gtSecurityParam genesisTest) (gtBlockTree genesisTest)
+    ==>
+      runSimOrThrow $ runTest schedulerConfig genesisTest schedule $ \StateView{svSelectedChain} ->
+        let headOnAlternativeChain = case AF.headHash svSelectedChain of
+              GenesisHash    -> False
+              BlockHash hash -> any (0 /=) $ unTestHash hash
+        in
+        -- The test passes if we end up on the trunk.
+        not headOnAlternativeChain
+
+  where
+    schedulerConfig = noTimeoutsSchedulerConfig defaultPointScheduleConfig
+
+-- | A schedule that advertises all the points of the trunk up until the nth
+-- block after the intersection, then switches to the first alternative
+-- chain of the given block tree.
+--
+-- PRECONDITION: Block tree with at least one alternative chain.
+rollbackSchedule :: Int -> BlockTree TestBlock -> PointSchedule
+rollbackSchedule n blockTree =
+  let branch = case btBranches blockTree of
+        [b] -> b
+        _   -> error "The block tree must have exactly one alternative branch"
+      trunkSuffix = AF.takeOldest n (btbTrunkSuffix branch)
+      states = concat
+        [ banalStates (btbPrefix branch)
+        , banalStates trunkSuffix
+        , banalStates (btbSuffix branch)
+        ]
+      peers = peersOnlyHonest states
+      pointSchedule = balanced defaultPointScheduleConfig peers
+   in pointSchedule
+
+-- | Whether the honest chain has more than 'k' blocks after the
+-- intersection with the alternative chain.
+--
+-- PRECONDITION: Block tree with exactly one alternative chain, otherwise
+-- this property does not make sense. With no alternative chain, this will
+-- even crash.
+honestChainIsLongEnough :: SecurityParam -> BlockTree TestBlock -> Bool
+honestChainIsLongEnough (SecurityParam k) blockTree =
+  let BlockTreeBranch{btbTrunkSuffix} = case btBranches blockTree of
+        [b] -> b
+        _   -> error "The block tree must have exactly one alternative branch"
+      lengthTrunkSuffix = AF.length btbTrunkSuffix
+   in lengthTrunkSuffix > fromIntegral k
+
+-- | Whether the alternative chain has more than 'k' blocks after the
+-- intersection with the honest chain.
+--
+-- PRECONDITION: Block tree with exactly one alternative chain, otherwise
+-- this property does not make sense. With no alternative chain, this will
+-- even crash.
+alternativeChainIsLongEnough :: SecurityParam -> BlockTree TestBlock -> Bool
+alternativeChainIsLongEnough (SecurityParam k) blockTree =
+  let BlockTreeBranch{btbSuffix} = case btBranches blockTree of
+        [b] -> b
+        _   -> error "The block tree must have exactly one alternative branch"
+      lengthSuffix = AF.length btbSuffix
+   in lengthSuffix > fromIntegral k

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
@@ -73,8 +73,6 @@ prop_cannotRollback = do
   -- the implementation doesn't
   pure $
     alternativeChainIsLongEnough (gtSecurityParam genesisTest) (gtBlockTree genesisTest)
-      &&
-    honestChainIsLongEnough (gtSecurityParam genesisTest) (gtBlockTree genesisTest)
     ==>
       runSimOrThrow $ runTest schedulerConfig genesisTest schedule $ \StateView{svSelectedChain} ->
         let headOnAlternativeChain = case AF.headHash svSelectedChain of
@@ -106,20 +104,6 @@ rollbackSchedule n blockTree =
       peers = peersOnlyHonest states
       pointSchedule = balanced defaultPointScheduleConfig peers
    in pointSchedule
-
--- | Whether the honest chain has more than 'k' blocks after the
--- intersection with the alternative chain.
---
--- PRECONDITION: Block tree with exactly one alternative chain, otherwise
--- this property does not make sense. With no alternative chain, this will
--- even crash.
-honestChainIsLongEnough :: SecurityParam -> BlockTree TestBlock -> Bool
-honestChainIsLongEnough (SecurityParam k) blockTree =
-  let BlockTreeBranch{btbTrunkSuffix} = case btBranches blockTree of
-        [b] -> b
-        _   -> error "The block tree must have exactly one alternative branch"
-      lengthTrunkSuffix = AF.length btbTrunkSuffix
-   in lengthTrunkSuffix > fromIntegral k
 
 -- | Whether the alternative chain has more than 'k' blocks after the
 -- intersection with the honest chain.

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
@@ -33,7 +33,7 @@ tests = adjustQuickCheckTests (`div` 10) $ testProperty "timeouts" prop_timeouts
 
 prop_timeouts :: QC.Gen QC.Property
 prop_timeouts = do
-  genesisTest <- genChains 0
+  genesisTest <- genChains (pure 0)
 
   -- Use higher tick duration to avoid the test taking really long
   let scSchedule = PointScheduleConfig {pscTickDuration = 1}
@@ -69,7 +69,7 @@ prop_timeouts = do
           headerPoint = HeaderPoint $ At (getHeader tipBlock)
           blockPoint = BlockPoint (At tipBlock)
           state = Peer HonestPeer $ NodeOnline $ AdvertisedPoints tipPoint headerPoint blockPoint
-          tick = Tick { active = state, duration = pscTickDuration scheduleConfig }
+          tick = Tick { active = state, duration = pscTickDuration scheduleConfig, number = 0 }
           maximumNumberOfTicks = round $ timeout / pscTickDuration scheduleConfig
       in
       PointSchedule (tick :| replicate maximumNumberOfTicks tick) (HonestPeer :| [])

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
@@ -26,9 +26,10 @@ import           Test.QuickCheck
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
 import           Test.Util.Orphans.IOLike ()
+import           Test.Util.TestEnv (adjustQuickCheckTests)
 
 tests :: TestTree
-tests = testProperty "timeouts" prop_timeouts
+tests = adjustQuickCheckTests (`div` 10) $ testProperty "timeouts" prop_timeouts
 
 prop_timeouts :: QC.Gen QC.Property
 prop_timeouts = do
@@ -45,7 +46,7 @@ prop_timeouts = do
           (fromJust $ mustReplyTimeout (scChainSyncTimeouts schedulerConfig))
           (btTrunk $ gtBlockTree genesisTest)
 
-  pure $ withMaxSuccess 10 $ runSimOrThrow $
+  pure $ runSimOrThrow $
     runTest schedulerConfig genesisTest schedule $ \stateView ->
       case svChainSyncExceptions stateView of
         [] ->

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Trace.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Trace.hs
@@ -36,9 +36,9 @@ import           Ouroboros.Consensus.Util.Condense (Condense (..))
 import           Ouroboros.Consensus.Util.IOLike (IOLike, MonadMonotonicTime,
                      Time (Time), getMonotonicTime)
 import           Ouroboros.Network.AnchoredFragment
-                     (Anchor (Anchor, AnchorGenesis), AnchoredSeq (Empty),
-                     anchor, mapAnchoredFragment, toOldestFirst)
-import           Test.Consensus.PointSchedule (TestFrag, TestFragH)
+                     (Anchor (Anchor, AnchorGenesis), AnchoredFragment,
+                     AnchoredSeq (Empty), anchor, mapAnchoredFragment,
+                     toOldestFirst)
 import           Test.Util.TestBlock (Header (TestHeader), TestBlock,
                      TestHash (TestHash), unTestHash)
 import           Text.Printf (printf)
@@ -122,7 +122,7 @@ tersePoint = \case
   BlockPoint slot hash -> terseSlotBlockFork slot (BlockNo (fromIntegral (length (unTestHash hash)))) hash
   GenesisPoint -> "G"
 
-terseFragH :: TestFragH -> String
+terseFragH :: AnchoredFragment (Header TestBlock) -> String
 terseFragH frag =
   renderAnchor ++ renderBlocks
   where
@@ -136,6 +136,6 @@ terseFragH frag =
       | all (== 0) (unTestHash hash) = ""
       | otherwise = condense hash
 
-terseFrag :: TestFrag -> String
+terseFrag :: AnchoredFragment TestBlock -> String
 terseFrag =
   terseFragH . mapAnchoredFragment getHeader

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Trace.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Trace.hs
@@ -128,7 +128,7 @@ terseFragH frag =
   where
     renderBlocks = case frag of
       Empty _ -> ""
-      _       -> " ⚓ " ++ intercalate " " (terseHeader <$> toOldestFirst frag)
+      _       -> " | " ++ intercalate " " (terseHeader <$> toOldestFirst frag)
     renderAnchor = case anchor frag of
       AnchorGenesis -> "G"
       Anchor slot hash block -> terseSlotBlock slot block ++ renderAnchorHash hash

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
@@ -49,6 +49,8 @@ module Test.Consensus.PointSchedule (
   , onlyHonestWithMintingPointSchedule
   , peersOnlyHonest
   , pointSchedulePeers
+  , prettyGenesisTest
+  , prettyPointSchedule
   ) where
 
 import           Data.Foldable (toList)
@@ -73,7 +75,8 @@ import           Ouroboros.Network.Block (SlotNo, Tip (Tip, TipGenesis),
                      blockNo, blockSlot, getTipSlotNo, tipFromHeader)
 import           Ouroboros.Network.Point (WithOrigin (At))
 import           System.Random.Stateful (StatefulGen)
-import           Test.Consensus.BlockTree (BlockTree (..), BlockTreeBranch (..))
+import           Test.Consensus.BlockTree (BlockTree (..), BlockTreeBranch (..),
+                     prettyBlockTree)
 import           Test.Consensus.PointSchedule.SinglePeer
                      (IsTrunk (IsBranch, IsTrunk), PeerScheduleParams (..),
                      SchedulePoint (..), defaultPeerScheduleParams, mergeOn,
@@ -262,6 +265,10 @@ data PointSchedule =
 
 instance Condense PointSchedule where
   condense (PointSchedule ticks _) = unlines (condense <$> toList ticks)
+
+prettyPointSchedule :: PointSchedule -> [String]
+prettyPointSchedule PointSchedule{ticks} =
+  "PointSchedule:" : (("  " ++) <$> (condense <$> toList ticks))
 
 -- | Parameters that are significant for components outside of generators, like the peer
 -- simulator.
@@ -624,6 +631,15 @@ data GenesisTest = GenesisTest {
   gtGenesisWindow :: GenesisWindow,
   gtBlockTree     :: BlockTree TestBlock
   }
+
+prettyGenesisTest :: GenesisTest -> [String]
+prettyGenesisTest GenesisTest{gtHonestAsc, gtSecurityParam, gtGenesisWindow, gtBlockTree} =
+  [ "GenesisTest:"
+  , "  gtHonestAsc: " ++ show gtHonestAsc
+  , "  gtSecurityParam: " ++ show gtSecurityParam
+  , "  gtGenesisWindow: " ++ show gtGenesisWindow
+  , "  gtBlockTree:"
+  ] ++ (("    " ++) <$> prettyBlockTree gtBlockTree)
 
 -- | Create a point schedule from the given block tree.
 --

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/SinglePeer.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/SinglePeer.hs
@@ -202,15 +202,18 @@ singleJumpRawPeerSchedule g psp slotOfB chainv = do
 data IsTrunk = IsTrunk | IsBranch
   deriving (Eq, Show)
 
--- | @peerScheduleFromTipPoints g params tps trunk branches@ generates a schedule for
--- a single peer that follows the given tip points.
+-- | @peerScheduleFromTipPoints g params tps trunk branches@ generates a
+-- schedule for a single peer that follows the given tip points.
 --
--- @tps@ contains the tip points for each fragment.
+-- @tps@ contains the tip points for each fragment. The indices correspond to
+-- the fragments in branches and go from @0@ to @length branch - 1@.
 --
 -- @trunk@ is the fragment for the honest chain
 --
 -- @branches@ contains the fragments for the alternative chains in ascending
--- order of their intersections with the honest chain.
+-- order of their intersections with the honest chain. Each fragment is anchored
+-- at the intersection, and therefore their first block must be the first block
+-- after the intersection.
 --
 peerScheduleFromTipPoints
   :: R.StatefulGen g m

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/SinglePeer/Indices.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/SinglePeer/Indices.hs
@@ -19,6 +19,7 @@ module Test.Consensus.PointSchedule.SinglePeer.Indices (
   , rollbacksTipPoints
   , singleJumpTipPoints
   , tipPointSchedule
+  , uniformRMDiffTime
   ) where
 
 import           Control.Monad (forM, replicateM)

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Consensus/ChainGenerator/Adversarial.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Consensus/ChainGenerator/Adversarial.hs
@@ -14,7 +14,7 @@ module Test.Ouroboros.Consensus.ChainGenerator.Adversarial (
     -- * Generating
     AdversarialRecipe (AdversarialRecipe, arHonest, arParams, arPrefix)
   , CheckedAdversarialRecipe (UnsafeCheckedAdversarialRecipe, carHonest, carParams, carWin)
-  , NoSuchAdversarialChainSchema (NoSuchAdversarialBlock, NoSuchCompetitor, NoSuchIntersection)
+  , NoSuchAdversarialChainSchema (NoSuchAdversarialBlock, NoSuchCompetitor, NoSuchIntersection, KcpIs1)
   , SomeCheckedAdversarialRecipe (SomeCheckedAdversarialRecipe)
   , checkAdversarialRecipe
   , uniformAdversarialChain
@@ -355,6 +355,12 @@ data NoSuchAdversarialChainSchema =
   |
     -- | @not (0 <= 'arPrefix' <= C)@ where @C@ is the number of active slots in 'arHonest'
     NoSuchIntersection
+  |
+    -- | @k=1@
+    --
+    -- This may technically be viable, but our current specification for
+    -- 'uniformAdversarialChain' requires @k>1@.
+    KcpIs1
   deriving (Eq, Show)
 
 -----
@@ -374,6 +380,8 @@ checkAdversarialRecipe ::
          (SomeCheckedAdversarialRecipe base hon)
 checkAdversarialRecipe recipe = do
     when (0 == k) $ Exn.throwError NoSuchAdversarialBlock
+
+    when (1 == k) $ Exn.throwError KcpIs1
 
     -- validate 'arPrefix'
     firstAdvSlot <- case compare arPrefix 0 of
@@ -631,15 +639,18 @@ withinYS (Delta d) !mbYS !(RI.Race (C.SomeWindow Proxy win)) = case mbYS of
 --
 -- The count will be strictly smaller than the number of active slots in the given 'ChainSchema'.
 --
--- REVIEW: why do we not allow forking off the block number 1?
-genPrefixBlockCount :: R.RandomGen g => g -> ChainSchema base hon -> C.Var hon 'ActiveSlotE
-genPrefixBlockCount g schedH =
-    if C.toVar numChoices < 2 then C.Count 0 {- can always pick genesis -} else do
+-- The result is guaranteed to leave more than k active slots after the
+-- intersection.
+genPrefixBlockCount :: R.RandomGen g => Kcp -> g -> ChainSchema base hon -> C.Var hon 'ActiveSlotE
+genPrefixBlockCount (Kcp k) g schedH
+    | C.getCount numChoices <= 0 = error "there should be at least k+1 blocks in the honest schema"
+    | otherwise =
+        -- uniformIndex is going to pick a number between 0 and numChoices-1
         C.toVar $ R.runSTGen_ g $ C.uniformIndex numChoices
   where
     ChainSchema _slots v = schedH
 
-    numChoices = pc C.- 1   -- can't pick the last active slot
+    numChoices = actives C.- k
 
-    -- 'H.uniformTheHonestChain' ensures 0 < pc
-    pc = BV.countActivesInV S.notInverted v
+    -- 'H.uniformTheHonestChain' ensures k < active
+    actives = BV.countActivesInV S.notInverted v

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Consensus/ChainGenerator/Honest.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Consensus/ChainGenerator/Honest.hs
@@ -104,10 +104,12 @@ data NoSuchHonestChainSchema =
 
 genHonestRecipe :: QC.Gen HonestRecipe
 genHonestRecipe = sized1 $ \sz -> do
-  (kcp, Scg s, delta) <- genKSD
-  -- s <= l, most of the time
-  l <- QC.frequency [(9, (+ s) <$> QC.choose (0, 5 * sz)), (1, QC.choose (1, s))]
-  pure $ HonestRecipe kcp (Scg s) delta (Len l)
+    (Kcp k, Scg s, Delta d) <- genKSD
+    -- 2s slots has at least 2k blocks. But that is ensuring k-1 more blocks
+    -- than we actually need. Thus it's safe to remove the k-1 last slots.
+    -- Therefore we set for a length of at least 2s - (k - 1).
+    l <- (+ (2*s - (k - 1))) <$> QC.choose (0, 5 * sz)
+    pure $ HonestRecipe (Kcp k) (Scg s) (Delta d) (Len l)
 
 -- | Checks whether the given 'HonestRecipe' determines a valid input to
 -- 'uniformTheHonestChain'

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Consensus/ChainGenerator/Params.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Consensus/ChainGenerator/Params.hs
@@ -98,7 +98,9 @@ genAsc = ascFromBits <$> QC.choose (1 :: Word8, maxBound - 1)
 
 genKSD :: QC.Gen (Kcp, Scg, Delta)
 genKSD = sized1 $ \sz -> do
-    d <- QC.choose (0, div sz 4)
+    -- k > 1 so we can ensure an alternative schema loses the density comparison
+    -- without having to deactivate the first active slot
     k <- (+ 2) <$> QC.choose (0, 2 * sz)
     s <- (+ k) <$> QC.choose (0, 3 * sz)   -- ensures @k / s <= 1@
+    d <- QC.choose (0, max 0 $ min (div sz 4) (s-1)) -- ensures @d < s@
     pure (Kcp k, Scg s, Delta d)

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/TestEnv.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/TestEnv.hs
@@ -3,6 +3,7 @@
 -- | A @tasty@ command-line option for enabling nightly tests
 module Test.Util.TestEnv (
     TestEnv (..)
+  , adjustQuickCheckMaxSize
   , adjustQuickCheckTests
   , askTestEnv
   , defaultMainWithTestEnv
@@ -88,3 +89,16 @@ adjustQuickCheckTests :: (Int -> Int) -> TestTree -> TestTree
 adjustQuickCheckTests f =
   adjustOption $ \(QuickCheckTests n) ->
     QuickCheckTests $ if n == 0 then 0 else max 1 (f n)
+
+-- | Locally adjust the maximum size parameter of QuickCheck tests for the given
+-- test subtree, similar to 'adjustQuickCheckTests'.
+--
+-- The size parameter is varied across test runs from 0 to @maxSize - 1@
+-- cyclically, influencing the result of generators that make use of it, like
+-- those that call 'Test.QuickCheck.sized'.
+--
+-- The default is 100.
+adjustQuickCheckMaxSize :: (Int -> Int) -> TestTree -> TestTree
+adjustQuickCheckMaxSize f =
+  adjustOption $ \(QuickCheckMaxSize n) ->
+    QuickCheckMaxSize $ if n == 0 then 0 else max 1 (f n)

--- a/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/ChainGenerator/Tests/Adversarial.hs
+++ b/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/ChainGenerator/Tests/Adversarial.hs
@@ -36,16 +36,19 @@ import qualified Test.Ouroboros.Consensus.ChainGenerator.Slot as S
 import           Test.Ouroboros.Consensus.ChainGenerator.Slot (E (SlotE))
 import qualified Test.Ouroboros.Consensus.ChainGenerator.Some as Some
 import qualified Test.Ouroboros.Consensus.ChainGenerator.Tests.Honest as H
-import qualified Test.QuickCheck as QC
+import qualified Test.QuickCheck as QC hiding (elements)
 import           Test.QuickCheck.Extras (unsafeMapSuchThatJust)
 import           Test.QuickCheck.Random (QCGen)
 import qualified Test.Tasty as TT
 import qualified Test.Tasty.QuickCheck as TT
+import qualified Test.Util.QuickCheck as QC
 
 -----
 
 tests :: [TT.TestTree]
 tests = [
+    TT.testProperty "k+1 blocks after the intersection" prop_kPlus1BlocksAfterIntersection
+  ,
     TT.testProperty "Adversarial chains lose density and race comparisons" prop_adversarialChain
   ,
     TT.localOption (TT.QuickCheckMaxSize 14) $ TT.testProperty "Adversarial chains win if checked with relaxed parameters" prop_adversarialChainMutation
@@ -111,9 +114,9 @@ instance QC.Arbitrary SomeTestAdversarial where
 
         testSeedPrefix <- QC.arbitrary @QCGen
 
-        let arPrefix = genPrefixBlockCount testSeedPrefix arHonest
+        let arPrefix = genPrefixBlockCount kcp testSeedPrefix arHonest
 
-        let H.HonestRecipe kcp scg delta _len = testRecipeH
+            H.HonestRecipe kcp scg delta _len = testRecipeH
 
             testRecipeA = A.AdversarialRecipe {
                 A.arPrefix
@@ -130,6 +133,7 @@ instance QC.Arbitrary SomeTestAdversarial where
                 A.NoSuchAdversarialBlock -> pure Nothing
                 A.NoSuchCompetitor       -> error $ "impossible! " <> show e
                 A.NoSuchIntersection     -> error $ "impossible! " <> show e
+                A.KcpIs1                 -> error $ "impossible! " <> show e
 
             Right testRecipeA' -> do
                 pure $ Just $ SomeTestAdversarial Proxy Proxy $ TestAdversarial {
@@ -147,6 +151,45 @@ instance QC.Arbitrary SomeTestAdversarial where
                   ,
                     testSeedH
                   }
+
+-- | The honest schema has k+1 blocks after the intersection.
+prop_kPlus1BlocksAfterIntersection :: SomeTestAdversarial -> QCGen -> QC.Property
+prop_kPlus1BlocksAfterIntersection someTestAdversarial testSeedA = runIdentity $ do
+    SomeTestAdversarial Proxy Proxy TestAdversarial {
+        testAscA
+      ,
+        testRecipeA
+      ,
+        testRecipeA'
+      } <- pure someTestAdversarial
+    A.SomeCheckedAdversarialRecipe Proxy recipeA' <- pure testRecipeA'
+
+    let A.AdversarialRecipe { A.arHonest = schedH } = testRecipeA
+        schedA = A.uniformAdversarialChain (Just testAscA) recipeA' testSeedA
+        H.ChainSchema winA _vA = schedA
+        H.ChainSchema _winH vH = schedH
+        A.AdversarialRecipe { A.arParams = (Kcp k, scg, _delta) } = testRecipeA
+
+    C.SomeWindow Proxy stabWin <- do
+        pure $ calculateStability scg schedA
+
+    pure $
+      QC.counterexample (unlines $
+                            H.prettyChainSchema schedH "H"
+                            ++ H.prettyChainSchema schedA "A"
+                          )
+      $ QC.counterexample ("arPrefix = " <> show (A.arPrefix testRecipeA))
+      $ QC.counterexample ("stabWin  = " <> show stabWin)
+      $ QC.counterexample ("stabWin' = " <> show (C.joinWin winA stabWin))
+      $ QC.counterexample ("The honest chain should have k+1 blocks after the intersection")
+          (BV.countActivesInV S.notInverted vH
+            `QC.ge` C.toSize (C.Count (k + 1) + A.arPrefix testRecipeA)
+          )
+-- TODO: uncomment this after ensuring the same for the alternative schema
+--        QC..&&.
+--        QC.counterexample ("The alternative chain should have k+1 blocks after the intersection")
+--          (BV.countActivesInV S.notInverted vA `QC.ge` C.Count (k + 1))
+
 
 -- | No seed exists such that each 'A.checkAdversarialChain' rejects the result of 'A.uniformAdversarialChain'
 prop_adversarialChain :: SomeTestAdversarial -> QCGen -> QC.Property
@@ -313,7 +356,7 @@ instance QC.Arbitrary SomeTestAdversarialMutation where
 
             testSeedPrefix <- QC.arbitrary @QCGen
 
-            let arPrefix = genPrefixBlockCount testSeedPrefix arHonest
+            let arPrefix = genPrefixBlockCount kcp testSeedPrefix arHonest
 
             let recipeA = A.AdversarialRecipe {
                     A.arPrefix
@@ -328,6 +371,7 @@ instance QC.Arbitrary SomeTestAdversarialMutation where
                     A.NoSuchAdversarialBlock -> Nothing
                     A.NoSuchCompetitor       -> error $ "impossible! " <> show e
                     A.NoSuchIntersection     -> error $ "impossible! " <> show e
+                    A.KcpIs1                 -> error $ "impossible! " <> show e
 
                 Right recipeA' -> case Exn.runExcept $ A.checkAdversarialRecipe $ mutateAdversarial recipeA mut of
                     Left{} -> Nothing


### PR DESCRIPTION
This PR contributes three tests that rehearse the genesis implementation in different ways.

Please, note that this PR targets the branch of #536. 

All the tests check that the immutable tip of the node under test ends up in the honest chain, at a block that is recent enough from the tip of the honest chain. Recent enough is defined as within s+d+1 slots of the tip of the honest chain, where s is the genesis window and d is the maximum Praos delay.

The tests differ in the inputs that they rehearse:
* "serve adversarial branches": tests schedules that provide as much time as necessary for the node under test to reach the expected immutable tip.
* "stalling leashing attack": tests schedules where adversarial peers sometimes omit sending random blocks or headers, which would cause the node under test to delay 
* "timed leashing attack": tests schedules where the schedules are executed up to a given time bound by which the node under test is expected to reach a recent immutable tip.

All tests are expected to fail at the moment since they depend on having a working genesis implementation.

Contents of the PR:
* The new genesis tests in commits https://github.com/IntersectMBO/ouroboros-consensus/pull/840/commits/6ab827720f1aeba1a7915a3bd4580658c7a06828 and https://github.com/IntersectMBO/ouroboros-consensus/pull/840/commits/01641f77c04807866d7bfea556a13f3db1b0065c
* Improvements to the peer simulator and the schedule generator in commits https://github.com/IntersectMBO/ouroboros-consensus/pull/840/commits/065614cbebbdfa9bed158d590c56e0902b8eee58, https://github.com/IntersectMBO/ouroboros-consensus/pull/840/commits/343695cde9eb7f7119042ce0dbf05a97400e8ec5, https://github.com/IntersectMBO/ouroboros-consensus/pull/840/commits/e7ef3833c299b91415a4694fc61e7334ef3b036a, and https://github.com/IntersectMBO/ouroboros-consensus/pull/840/commits/3714105301d6b485149f4325689041d7672b79fc
* Improvements to the schema generator in https://github.com/IntersectMBO/ouroboros-consensus/pull/840/commits/441092ab7ebdfe58a76ab014e71612d18aa585e7 and https://github.com/IntersectMBO/ouroboros-consensus/pull/840/commits/692c099597e5dd0ea320210cbf09824b163f7147
* Improvements to peer simulator tests in https://github.com/IntersectMBO/ouroboros-consensus/pull/840/commits/e3c0f5e7060752f6147a95896486b57e3475d510