### PR TITLE
Introduce a QuickCheck-like Genesis-specific `forAllGenesisTest` helper

### DIFF
--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup.hs
@@ -91,7 +91,7 @@ forAllGenesisTest ::
   Testable prop =>
   Gen (GenesisTest, PointSchedule) ->
   SchedulerConfig ->
-  (StateView -> prop) ->
+  (GenesisTest -> PointSchedule -> StateView -> prop) ->
   Property
 forAllGenesisTest generator schedulerConfig mkProperty =
   forAllBlind generator $ \(genesisTest, pointSchedule) ->
@@ -100,4 +100,4 @@ forAllGenesisTest generator schedulerConfig mkProperty =
      in classify (allAdversariesSelectable cls) "All adversaries selectable" $
         classify (genesisWindowAfterIntersection cls) "Full genesis window after intersection" $
         counterexample (rgtrTrace result) $
-        mkProperty (rgtrStateView result)
+        mkProperty genesisTest pointSchedule (rgtrStateView result)

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup.hs
@@ -85,27 +85,34 @@ runGenesisTest' schedulerConfig genesisTest schedule makeProperty =
     RunGenesisTestResult{rgtrTrace, rgtrStateView} =
       runGenesisTest schedulerConfig genesisTest schedule
 
-type ForAllGenesisTest schedule prop =
-  Gen (GenesisTest, schedule) ->
-  SchedulerConfig ->
-  (GenesisTest -> schedule -> StateView -> prop) ->
-  Property
-
 -- | All-in-one helper that generates a 'GenesisTest' and a 'PointSchedule',
 -- runs them with 'runGenesisTest', check whether the given property holds on
 -- the resulting 'StateView'.
-forAllGenesisTest :: Testable prop => ForAllGenesisTest PointSchedule prop
+forAllGenesisTest ::
+  Testable prop =>
+  Gen (GenesisTest, PointSchedule) ->
+  SchedulerConfig ->
+  (GenesisTest -> PointSchedule -> StateView -> prop) ->
+  Property
 forAllGenesisTest = mkForAllGenesisTest id
 
 -- | Same as 'forAllGenesisTest' but the schedule is a 'Peers PeerSchedule'.
-forAllGenesisTest' :: Testable prop => ForAllGenesisTest (Peers PeerSchedule) prop
+forAllGenesisTest' ::
+  Testable prop =>
+  Gen (GenesisTest, Peers PeerSchedule) ->
+  SchedulerConfig ->
+  (GenesisTest -> Peers PeerSchedule -> StateView -> prop) ->
+  Property
 forAllGenesisTest' = mkForAllGenesisTest fromSchedulePoints
 
 -- | Common code shared between flavours of 'forAllGenesisTest'.
 mkForAllGenesisTest ::
   Testable prop =>
   (schedule -> PointSchedule) ->
-  ForAllGenesisTest schedule prop
+  Gen (GenesisTest, schedule) ->
+  SchedulerConfig ->
+  (GenesisTest -> schedule -> StateView -> prop) ->
+  Property
 mkForAllGenesisTest mkPointSchedule generator schedulerConfig mkProperty =
   forAllBlind generator $ \(genesisTest, schedule) ->
     let cls = classifiers genesisTest

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LongRangeAttack.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LongRangeAttack.hs
@@ -41,7 +41,7 @@ prop_longRangeAttack =
 
     -- NOTE: This is the expected behaviour of Praos to be reversed with
     -- Genesis. But we are testing Praos for the moment
-    (not . isHonestTestFragH . svSelectedChain)
+    (\_ _ -> not . isHonestTestFragH . svSelectedChain)
 
   where
     isHonestTestFragH :: TestFragH -> Bool

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LongRangeAttack.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LongRangeAttack.hs
@@ -6,7 +6,6 @@
 
 module Test.Consensus.Genesis.Tests.LongRangeAttack (tests) where
 
-import           Control.Monad.IOSim (runSimOrThrow)
 import           Data.List (intercalate)
 import           Ouroboros.Consensus.Block.Abstract (HeaderHash)
 import           Ouroboros.Consensus.Util.Condense (condense)
@@ -49,8 +48,7 @@ prop_longRangeAttack = do
     classify (genesisWindowAfterIntersection cls) "Full genesis window after intersection" $
     allAdversariesSelectable cls
     ==>
-    runSimOrThrow $
-      runTest
+    runGenesisTest
         (noTimeoutsSchedulerConfig scheduleConfig)
         genesisTest
         schedule

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LongRangeAttack.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LongRangeAttack.hs
@@ -29,11 +29,6 @@ tests =
   testGroup "long range attack" [
     adjustQuickCheckTests (`div` 10) $
     testProperty "one adversary" prop_longRangeAttack
-    -- TODO we don't have useful classification logic for multiple adversaries yet – if a selectable
-    -- adversary is slow, it might be discarded before it reaches critical length because the faster
-    -- ones have served k blocks off the honest chain if their fork anchor is further down the line.
-    -- ,
-    -- testProperty "three adversaries" (prop_longRangeAttack 1 [2, 5, 10])
   ]
 
 prop_longRangeAttack :: QC.Gen QC.Property
@@ -48,7 +43,7 @@ prop_longRangeAttack = do
     classify (genesisWindowAfterIntersection cls) "Full genesis window after intersection" $
     allAdversariesSelectable cls
     ==>
-    runGenesisTest
+    runGenesisTest'
         (noTimeoutsSchedulerConfig scheduleConfig)
         genesisTest
         schedule

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
@@ -121,7 +121,7 @@ prop_serveAdversarialBranches = QC.expectFailure <$> do
   genesisTest <- genChains (QC.choose (1, 4))
   schedulePoints <- genUniformSchedulePoints genesisTest
   pure $
-    runGenesisTest schedulerConfig genesisTest (fromSchedulePoints schedulePoints) $
+    runGenesisTest' schedulerConfig genesisTest (fromSchedulePoints schedulePoints) $
     exceptionCounterexample $
     makeProperty genesisTest schedulePoints
 
@@ -164,7 +164,7 @@ prop_leashingAttackStalling = QC.expectFailure <$> do
   genesisTest <- genChains (QC.choose (1, 4))
   schedulePoints <- genLeashingSchedule genesisTest
   pure $
-    runGenesisTest schedulerConfig genesisTest (fromSchedulePoints schedulePoints) $
+    runGenesisTest' schedulerConfig genesisTest (fromSchedulePoints schedulePoints) $
     exceptionCounterexample $
     makeProperty genesisTest schedulePoints
 
@@ -210,7 +210,7 @@ prop_leashingAttackTimeLimited = QC.expectFailure <$> do
   genesisTest <- genChains (QC.choose (1, 4))
   schedulePoints <- genTimeLimitedSchedule genesisTest
   pure $
-    runGenesisTest schedulerConfig genesisTest (fromSchedulePoints schedulePoints) $
+    runGenesisTest' schedulerConfig genesisTest (fromSchedulePoints schedulePoints) $
     exceptionCounterexample $
     makeProperty genesisTest schedulePoints
 

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
@@ -54,9 +54,8 @@ makeProperty ::
   GenesisTest ->
   Peers PeerSchedule ->
   StateView ->
-  [PeerId] ->
   Property
-makeProperty genesisTest schedule StateView {svSelectedChain} killed =
+makeProperty genesisTest schedule stateView@StateView{svSelectedChain} =
   classify genesisWindowAfterIntersection "Full genesis window after intersection" $
   classify (isOrigin immutableTipHash) "Immutable tip is Origin" $
   label disconnected $
@@ -96,6 +95,8 @@ makeProperty genesisTest schedule StateView {svSelectedChain} killed =
     disconnected =
       printf "disconnected %.1f%% of adversaries" disconnectedPercent
 
+    killed = chainSyncKilled stateView
+
     disconnectedPercent :: Double
     disconnectedPercent =
       100 * fromIntegral (length killed) / fromIntegral advCount
@@ -122,7 +123,6 @@ prop_serveAdversarialBranches = QC.expectFailure <$> do
   schedulePoints <- genUniformSchedulePoints genesisTest
   pure $
     runGenesisTest' schedulerConfig genesisTest (fromSchedulePoints schedulePoints) $
-    exceptionCounterexample $
     makeProperty genesisTest schedulePoints
 
   where
@@ -165,7 +165,6 @@ prop_leashingAttackStalling = QC.expectFailure <$> do
   schedulePoints <- genLeashingSchedule genesisTest
   pure $
     runGenesisTest' schedulerConfig genesisTest (fromSchedulePoints schedulePoints) $
-    exceptionCounterexample $
     makeProperty genesisTest schedulePoints
 
   where
@@ -211,7 +210,6 @@ prop_leashingAttackTimeLimited = QC.expectFailure <$> do
   schedulePoints <- genTimeLimitedSchedule genesisTest
   pure $
     runGenesisTest' schedulerConfig genesisTest (fromSchedulePoints schedulePoints) $
-    exceptionCounterexample $
     makeProperty genesisTest schedulePoints
 
   where

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
@@ -8,7 +8,6 @@ module Test.Consensus.Genesis.Tests.Uniform (tests) where
 
 import           Cardano.Slotting.Slot (SlotNo (SlotNo), WithOrigin (..))
 import           Control.Monad (replicateM)
-import           Control.Monad.IOSim (runSimOrThrow)
 import           Data.List (group, intercalate, sort)
 import qualified Data.Map.Strict as Map
 import           Data.Maybe (mapMaybe)
@@ -122,8 +121,7 @@ prop_serveAdversarialBranches = QC.expectFailure <$> do
   genesisTest <- genChains (QC.choose (1, 4))
   schedulePoints <- genUniformSchedulePoints genesisTest
   pure $
-    runSimOrThrow $
-    runTest schedulerConfig genesisTest (fromSchedulePoints schedulePoints) $
+    runGenesisTest schedulerConfig genesisTest (fromSchedulePoints schedulePoints) $
     exceptionCounterexample $
     makeProperty genesisTest schedulePoints
 
@@ -166,8 +164,7 @@ prop_leashingAttackStalling = QC.expectFailure <$> do
   genesisTest <- genChains (QC.choose (1, 4))
   schedulePoints <- genLeashingSchedule genesisTest
   pure $
-    runSimOrThrow $
-    runTest schedulerConfig genesisTest (fromSchedulePoints schedulePoints) $
+    runGenesisTest schedulerConfig genesisTest (fromSchedulePoints schedulePoints) $
     exceptionCounterexample $
     makeProperty genesisTest schedulePoints
 
@@ -213,8 +210,7 @@ prop_leashingAttackTimeLimited = QC.expectFailure <$> do
   genesisTest <- genChains (QC.choose (1, 4))
   schedulePoints <- genTimeLimitedSchedule genesisTest
   pure $
-    runSimOrThrow $
-    runTest schedulerConfig genesisTest (fromSchedulePoints schedulePoints) $
+    runGenesisTest schedulerConfig genesisTest (fromSchedulePoints schedulePoints) $
     exceptionCounterexample $
     makeProperty genesisTest schedulePoints
 

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
@@ -5,7 +5,6 @@
 
 module Test.Consensus.PeerSimulator.Tests.Rollback (tests) where
 
-import           Control.Monad.IOSim (runSimOrThrow)
 import           Ouroboros.Consensus.Block (ChainHash (..))
 import           Ouroboros.Consensus.Config.SecurityParam
 import qualified Ouroboros.Network.AnchoredFragment as AF
@@ -46,7 +45,7 @@ prop_rollback = do
   pure $
     alternativeChainIsLongEnough (gtSecurityParam genesisTest) (gtBlockTree genesisTest)
     ==>
-      runSimOrThrow $ runTest schedulerConfig genesisTest schedule $ \StateView{svSelectedChain} ->
+      runGenesisTest schedulerConfig genesisTest schedule $ \StateView{svSelectedChain} ->
         let headOnAlternativeChain = case AF.headHash svSelectedChain of
               GenesisHash    -> False
               BlockHash hash -> any (0 /=) $ unTestHash hash
@@ -72,7 +71,7 @@ prop_cannotRollback = do
   pure $
     alternativeChainIsLongEnough (gtSecurityParam genesisTest) (gtBlockTree genesisTest)
     ==>
-      runSimOrThrow $ runTest schedulerConfig genesisTest schedule $ \StateView{svSelectedChain} ->
+      runGenesisTest schedulerConfig genesisTest schedule $ \StateView{svSelectedChain} ->
         let headOnAlternativeChain = case AF.headHash svSelectedChain of
               GenesisHash    -> False
               BlockHash hash -> any (0 /=) $ unTestHash hash

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
@@ -45,7 +45,7 @@ prop_rollback = do
   pure $
     alternativeChainIsLongEnough (gtSecurityParam genesisTest) (gtBlockTree genesisTest)
     ==>
-      runGenesisTest schedulerConfig genesisTest schedule $ \StateView{svSelectedChain} ->
+      runGenesisTest' schedulerConfig genesisTest schedule $ \StateView{svSelectedChain} ->
         let headOnAlternativeChain = case AF.headHash svSelectedChain of
               GenesisHash    -> False
               BlockHash hash -> any (0 /=) $ unTestHash hash
@@ -71,7 +71,7 @@ prop_cannotRollback = do
   pure $
     alternativeChainIsLongEnough (gtSecurityParam genesisTest) (gtBlockTree genesisTest)
     ==>
-      runGenesisTest schedulerConfig genesisTest schedule $ \StateView{svSelectedChain} ->
+      runGenesisTest' schedulerConfig genesisTest schedule $ \StateView{svSelectedChain} ->
         let headOnAlternativeChain = case AF.headHash svSelectedChain of
               GenesisHash    -> False
               BlockHash hash -> any (0 /=) $ unTestHash hash

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
@@ -44,7 +44,7 @@ prop_rollback = do
 
     (noTimeoutsSchedulerConfig defaultPointScheduleConfig)
 
-    (not . hashOnTrunk . AF.headHash . svSelectedChain)
+    (\_ _ -> not . hashOnTrunk . AF.headHash . svSelectedChain)
 
 -- @prop_cannotRollback@ tests that the selection of the node under test *does
 -- not* change branches when sent a rollback to a block strictly older than 'k'
@@ -60,7 +60,7 @@ prop_cannotRollback =
 
     (noTimeoutsSchedulerConfig defaultPointScheduleConfig)
 
-    (hashOnTrunk . AF.headHash . svSelectedChain)
+    (\_ _ -> hashOnTrunk . AF.headHash . svSelectedChain)
 
 -- | A schedule that advertises all the points of the trunk up until the nth
 -- block after the intersection, then switches to the first alternative

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
@@ -43,7 +43,7 @@ prop_timeouts = do
           (btTrunk $ gtBlockTree genesisTest)
 
   pure $
-    runGenesisTest schedulerConfig genesisTest schedule $ \stateView ->
+    runGenesisTest' schedulerConfig genesisTest schedule $ \stateView ->
       case svChainSyncExceptions stateView of
         [] ->
           counterexample ("result: " ++ condense (svSelectedChain stateView)) False

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
@@ -1,6 +1,5 @@
 module Test.Consensus.PeerSimulator.Tests.Timeouts (tests) where
 
-import           Control.Monad.IOSim (runSimOrThrow)
 import           Data.List.NonEmpty (NonEmpty ((:|)))
 import           Data.Maybe (fromJust)
 import           Ouroboros.Consensus.Block (getHeader)
@@ -43,8 +42,8 @@ prop_timeouts = do
           (fromJust $ mustReplyTimeout (scChainSyncTimeouts schedulerConfig))
           (btTrunk $ gtBlockTree genesisTest)
 
-  pure $ runSimOrThrow $
-    runTest schedulerConfig genesisTest schedule $ \stateView ->
+  pure $
+    runGenesisTest schedulerConfig genesisTest schedule $ \stateView ->
       case svChainSyncExceptions stateView of
         [] ->
           counterexample ("result: " ++ condense (svSelectedChain stateView)) False

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
@@ -17,7 +17,6 @@ import           Test.Consensus.PeerSimulator.Run (SchedulerConfig (..),
                      defaultSchedulerConfig)
 import           Test.Consensus.PeerSimulator.StateView
 import           Test.Consensus.PointSchedule
-import qualified Test.QuickCheck as QC
 import           Test.QuickCheck
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
@@ -27,7 +26,7 @@ import           Test.Util.TestEnv (adjustQuickCheckTests)
 tests :: TestTree
 tests = adjustQuickCheckTests (`div` 10) $ testProperty "timeouts" prop_timeouts
 
-prop_timeouts :: QC.Gen QC.Property
+prop_timeouts :: Gen Property
 prop_timeouts = do
   genesisTest <- genChains (pure 0)
 
@@ -42,6 +41,9 @@ prop_timeouts = do
           (fromJust $ mustReplyTimeout (scChainSyncTimeouts schedulerConfig))
           (btTrunk $ gtBlockTree genesisTest)
 
+  -- NOTE: Because the scheduler configuration depends on the generated
+  -- 'GenesisTest' itself, we cannot rely on helpers such as
+  -- 'forAllGenesisTest'.
   pure $
     runGenesisTest' schedulerConfig genesisTest schedule $ \stateView ->
       case svChainSyncExceptions stateView of

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
@@ -47,7 +47,6 @@ module Test.Consensus.PointSchedule (
   , defaultPointScheduleConfig
   , fromSchedulePoints
   , genesisAdvertisedPoints
-  , lastHonestBlockPoint
   , longRangeAttack
   , mkPeers
   , peersOnlyHonest
@@ -542,17 +541,3 @@ stToGen ::
 stToGen gen = do
   seed :: QCGen <- arbitrary
   pure (runSTGen_ seed gen)
-
--- | Return the last block point served by the honest peer. Fails if the honest
--- peer never sends a block, that is if they have no ticks or they only have
--- 'NodeOffline' ticks.
-lastHonestBlockPoint :: PointSchedule -> WithOrigin TestBlock
-lastHonestBlockPoint = go Nothing . toList . ticks
-  where
-    go :: Maybe (WithOrigin TestBlock) -> [Tick] -> WithOrigin TestBlock
-    go Nothing [] = error "lastHonestBlockPoint"
-    go (Just bp) [] = bp
-    go _ (Tick{active=Peer HonestPeer (NodeOnline points)} : ticks) =
-      let AdvertisedPoints{block = BlockPoint bp} = points
-       in go (Just bp) ticks
-    go bp (_ : ticks) = go bp ticks

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
@@ -47,6 +47,7 @@ module Test.Consensus.PointSchedule (
   , defaultPointScheduleConfig
   , fromSchedulePoints
   , genesisAdvertisedPoints
+  , lastHonestBlockPoint
   , longRangeAttack
   , mkPeers
   , peersOnlyHonest
@@ -541,3 +542,17 @@ stToGen ::
 stToGen gen = do
   seed :: QCGen <- arbitrary
   pure (runSTGen_ seed gen)
+
+-- | Return the last block point served by the honest peer. Fails if the honest
+-- peer never sends a block, that is if they have no ticks or they only have
+-- 'NodeOffline' ticks.
+lastHonestBlockPoint :: PointSchedule -> WithOrigin TestBlock
+lastHonestBlockPoint = go Nothing . toList . ticks
+  where
+    go :: Maybe (WithOrigin TestBlock) -> [Tick] -> WithOrigin TestBlock
+    go Nothing [] = error "lastHonestBlockPoint"
+    go (Just bp) [] = bp
+    go _ (Tick{active=Peer HonestPeer (NodeOnline points)} : ticks) =
+      let AdvertisedPoints{block = BlockPoint bp} = points
+       in go (Just bp) ticks
+    go bp (_ : ticks) = go bp ticks


### PR DESCRIPTION
In particular, this paves the way to adding shrinking in an easy way.