### PR TITLE
Express tests in terms of schedules and not the block tree

### DIFF
--- a/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
+++ b/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
@@ -210,6 +210,7 @@ test-suite consensus-test
     Test.Consensus.Genesis.Setup.GenChains
     Test.Consensus.Genesis.Tests
     Test.Consensus.Genesis.Tests.LongRangeAttack
+    Test.Consensus.Genesis.Tests.Uniform
     Test.Consensus.HardFork.Combinator
     Test.Consensus.HardFork.Combinator.A
     Test.Consensus.HardFork.Combinator.B

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup/GenChains.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup/GenChains.hs
@@ -66,7 +66,7 @@ genAlternativeChainSchema (testRecipeH, arHonest) =
     let H.HonestRecipe kcp scg delta _len = testRecipeH
 
     (seedPrefix :: QCGen) <- QC.arbitrary
-    let arPrefix = genPrefixBlockCount seedPrefix arHonest
+    let arPrefix = genPrefixBlockCount kcp seedPrefix arHonest
 
     let testRecipeA = A.AdversarialRecipe {
       A.arPrefix,
@@ -81,6 +81,7 @@ genAlternativeChainSchema (testRecipeH, arHonest) =
         A.NoSuchAdversarialBlock -> pure Nothing
         A.NoSuchCompetitor       -> error $ "impossible! " <> show e
         A.NoSuchIntersection     -> error $ "impossible! " <> show e
+        A.KcpIs1                 -> error $ "impossible! " <> show e
 
       Right (A.SomeCheckedAdversarialRecipe _ testRecipeA'') -> do
         let Count prefixCount = arPrefix

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests.hs
@@ -1,9 +1,11 @@
 module Test.Consensus.Genesis.Tests (tests) where
 
 import qualified Test.Consensus.Genesis.Tests.LongRangeAttack as LongRangeAttack
+import qualified Test.Consensus.Genesis.Tests.Uniform as Uniform
 import           Test.Tasty
 
 tests :: TestTree
 tests = testGroup "Genesis tests"
     [ LongRangeAttack.tests
+    , Uniform.tests
     ]

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
@@ -24,12 +24,12 @@ import           Ouroboros.Network.Block (blockNo, unBlockNo)
 import           Test.Consensus.BlockTree (BlockTree (..))
 import           Test.Consensus.Genesis.Setup
 import           Test.Consensus.Genesis.Setup.Classifiers
-import           Test.Consensus.PeerSimulator.Run (noTimeoutsSchedulerConfig,
-                     scTraceState)
+import           Test.Consensus.PeerSimulator.Run (SchedulerConfig (scTrace),
+                     noTimeoutsSchedulerConfig, scTraceState)
 import           Test.Consensus.PeerSimulator.StateView
 import           Test.Consensus.PointSchedule
 import           Test.Consensus.PointSchedule.SinglePeer
-  (SchedulePoint(ScheduleBlockPoint, ScheduleTipPoint))
+                     (SchedulePoint (ScheduleBlockPoint, ScheduleTipPoint))
 import           Test.Ouroboros.Consensus.ChainGenerator.Params (Delta (Delta))
 import qualified Test.QuickCheck as QC
 import           Test.QuickCheck
@@ -124,7 +124,7 @@ prop_serveAdversarialBranches = QC.expectFailure <$> do
     makeProperty genesisTest (length (peerIds schedule) - 1)
 
   where
-    schedulerConfig = (noTimeoutsSchedulerConfig scheduleConfig) {scTraceState = False}
+    schedulerConfig = (noTimeoutsSchedulerConfig scheduleConfig) {scTraceState = False, scTrace = False}
 
     scheduleConfig = defaultPointScheduleConfig
 
@@ -168,7 +168,8 @@ prop_leashingAttackStalling = QC.expectFailure <$> do
     makeProperty genesisTest (length (peerIds schedule) - 1)
 
   where
-    schedulerConfig = (noTimeoutsSchedulerConfig scheduleConfig) {scEnableGdd = True}
+    schedulerConfig = (noTimeoutsSchedulerConfig scheduleConfig)
+      { scTrace = False }
 
     scheduleConfig = defaultPointScheduleConfig
 
@@ -214,7 +215,8 @@ prop_leashingAttackTimeLimited = QC.expectFailure <$> do
     makeProperty genesisTest (length (peerIds schedule) - 1)
 
   where
-    schedulerConfig = (noTimeoutsSchedulerConfig scheduleConfig) {scEnableGdd = True}
+    schedulerConfig = (noTimeoutsSchedulerConfig scheduleConfig)
+      { scTrace = False }
 
     scheduleConfig = defaultPointScheduleConfig
 
@@ -248,10 +250,10 @@ prop_leashingAttackTimeLimited = QC.expectFailure <$> do
               0.020 * lastBlockNo + 5 * fromIntegral peerCount)
 
     fromTipPoint (t, ScheduleTipPoint bp) = Just (t, bp)
-    fromTipPoint _ = Nothing
+    fromTipPoint _                        = Nothing
 
     fromBlockPoint (t, ScheduleBlockPoint bp) = Just (t, bp)
-    fromBlockPoint _ = Nothing
+    fromBlockPoint _                          = Nothing
 
 headCallStack :: HasCallStack => [a] -> a
 headCallStack xs = if null xs then error "headCallStack: empty list" else head xs

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
@@ -11,10 +11,16 @@
 module Test.Consensus.Genesis.Tests.Uniform (tests) where
 
 import           Cardano.Slotting.Slot (SlotNo (SlotNo), WithOrigin (..))
+import           Control.Monad (replicateM)
 import           Control.Monad.IOSim (runSimOrThrow)
-import           Data.List (intercalate)
-import           Ouroboros.Consensus.Util.Condense (Condense (condense))
+import           Data.List (group, intercalate, sort)
+import qualified Data.Map.Strict as Map
+import           Data.Maybe (mapMaybe)
+import           Data.Time.Clock (DiffTime)
+import           GHC.Stack (HasCallStack)
+import           Ouroboros.Consensus.Util.Condense (condense)
 import qualified Ouroboros.Network.AnchoredFragment as AF
+import           Ouroboros.Network.Block (blockNo, unBlockNo)
 import           Test.Consensus.BlockTree (BlockTree (..))
 import           Test.Consensus.Genesis.Setup
 import           Test.Consensus.Genesis.Setup.Classifiers
@@ -22,6 +28,8 @@ import           Test.Consensus.PeerSimulator.Run (noTimeoutsSchedulerConfig,
                      scTraceState)
 import           Test.Consensus.PeerSimulator.StateView
 import           Test.Consensus.PointSchedule
+import           Test.Consensus.PointSchedule.SinglePeer
+  (SchedulePoint(ScheduleBlockPoint, ScheduleTipPoint))
 import           Test.Ouroboros.Consensus.ChainGenerator.Params (Delta (Delta))
 import qualified Test.QuickCheck as QC
 import           Test.QuickCheck
@@ -35,9 +43,15 @@ import           Text.Printf (printf)
 
 tests :: TestTree
 tests =
+  adjustQuickCheckTests (* 10) $
+  adjustQuickCheckMaxSize (`div` 5) $
+  testGroup "uniform" [
+    -- See Note [Leashing attacks]
+    testProperty "stalling leashing attack" prop_leashingAttackStalling,
+    testProperty "time limited leashing attack" prop_leashingAttackTimeLimited,
   adjustQuickCheckTests (`div` 10) $
-  adjustQuickCheckMaxSize (`div` 10) $
-  testProperty "serve adversarial branches" prop_serveAdversarialBranches
+    testProperty "serve adversarial branches" prop_serveAdversarialBranches
+    ]
 
 makeProperty ::
   GenesisTest ->
@@ -116,3 +130,128 @@ prop_serveAdversarialBranches = QC.expectFailure <$> do
 
 genUniformSchedulePoints :: GenesisTest -> QC.Gen (Peers PeerSchedule)
 genUniformSchedulePoints gt = stToGen (uniformPoints (gtBlockTree gt))
+
+-- Note [Leashing attacks]
+--
+-- A leashing attack would be rehearsed by a point schedule meeting either of
+-- two conditions:
+--
+-- 1) it causes the node under test to stop making progress (i.e. the immutable
+--    tip doesn't get close to the last genesis window of the honest chain), or
+-- 2) it causes the node under test to still make progress but it is too slow
+--    (in some sense of slow)
+--
+-- We produce schedules meeting the first condition by dropping random points
+-- from the schedule of adversarial peers. If peers don't send the headers or
+-- the blocks that they promised with a tip point, the node under test could
+-- wait indefinitely without advancing the immutable tip.
+--
+-- We produce schedules meeting the second condition by stopping the execution
+-- of the schedule after an amount of time that depends on the amount of blocks
+-- to sync up and the timeouts allowed by Limit of Patience.
+-- If the adversarial peers succeed in delaying the immutable tip, interrupting
+-- the test at this point should cause the immutable tip to be too far behind
+-- the last genesis window of the honest chain.
+
+-- | Test that the leashing attacks do not delay the immutable tip
+--
+-- This test is expected to fail because we don't test a genesis implementation
+-- yet.
+prop_leashingAttackStalling :: QC.Gen QC.Property
+prop_leashingAttackStalling = QC.expectFailure <$> do
+  genesisTest <- genChains (QC.choose (1, 4))
+  schedule <- fromSchedulePoints <$> genLeashingSchedule genesisTest
+  pure $
+    runSimOrThrow $
+    runTest schedulerConfig genesisTest schedule $
+    exceptionCounterexample $
+    makeProperty genesisTest (length (peerIds schedule) - 1)
+
+  where
+    schedulerConfig = (noTimeoutsSchedulerConfig scheduleConfig) {scEnableGdd = True}
+
+    scheduleConfig = defaultPointScheduleConfig
+
+    -- | Produces schedules that might cause the node under test to stall.
+    --
+    -- This is achieved by dropping random points from the schedule of each peer
+    genLeashingSchedule :: GenesisTest -> QC.Gen (Peers PeerSchedule)
+    genLeashingSchedule genesisTest = do
+      Peers honest advs0 <- genUniformSchedulePoints genesisTest
+      advs <- mapM (mapM dropRandomPoints) advs0
+      pure (Peers honest advs)
+
+    dropRandomPoints :: [(DiffTime, SchedulePoint)] -> QC.Gen [(DiffTime, SchedulePoint)]
+    dropRandomPoints ps = do
+      let lenps = length ps
+      dropCount <- QC.choose (0, max 1 $ div lenps 5)
+      let dedup = map head . group
+      is <- fmap (dedup . sort) $ replicateM dropCount $ QC.choose (0, lenps - 1)
+      pure $ dropElemsAt ps is
+
+    dropElemsAt :: [a] -> [Int] -> [a]
+    dropElemsAt xs [] = xs
+    dropElemsAt xs (i:is) =
+      let (ys, zs) = splitAt i xs
+       in ys ++ dropElemsAt (drop 1 zs) is
+
+-- | Test that the leashing attacks do not delay the immutable tip after. The
+-- immutable tip needs to be advanced enough when the honest peer has offered
+-- all of its ticks.
+--
+-- This test is expected to fail because we don't test a genesis implementation
+-- yet.
+--
+-- See Note [Leashing attacks]
+prop_leashingAttackTimeLimited :: QC.Gen QC.Property
+prop_leashingAttackTimeLimited = QC.expectFailure <$> do
+  genesisTest <- genChains (QC.choose (1, 4))
+  schedule <- fromSchedulePoints <$> genTimeLimitedSchedule genesisTest
+  pure $
+    runSimOrThrow $
+    runTest schedulerConfig genesisTest schedule $
+    exceptionCounterexample $
+    makeProperty genesisTest (length (peerIds schedule) - 1)
+
+  where
+    schedulerConfig = (noTimeoutsSchedulerConfig scheduleConfig) {scEnableGdd = True}
+
+    scheduleConfig = defaultPointScheduleConfig
+
+    -- | A schedule which doesn't run past the last event of the honest peer
+    genTimeLimitedSchedule :: GenesisTest -> QC.Gen (Peers PeerSchedule)
+    genTimeLimitedSchedule genesisTest = do
+      Peers honest advs0 <- genUniformSchedulePoints genesisTest
+      let timeLimit = estimateTimeBound (value honest) (Map.size advs0 + 1)
+          advs = fmap (fmap (takePointsUntil timeLimit)) advs0
+      pure (Peers honest advs)
+
+    takePointsUntil limit = takeWhile ((<= limit) . fst)
+
+    estimateTimeBound :: [(DiffTime, SchedulePoint)] -> Int -> DiffTime
+    estimateTimeBound honest peerCount =
+      let firstTipPointBlock = headCallStack (mapMaybe fromTipPoint honest)
+          lastBlockPoint = last (mapMaybe fromBlockPoint honest)
+          lastBlockNo = fromIntegral $ unBlockNo $ blockNo $ snd lastBlockPoint
+          -- 0.020s is the amount of time LoP returns per interesting header
+          -- 5s is the initial fill of the LoP bucket
+          --
+          -- Since the moment the honest peer offers the first tip, LoP should
+          -- start ticking. Syncing all the blocks might take longer than it
+          -- takes to dispatch all ticks to the honest peer. In this case
+          -- the syncing time is the time bound for the test. If dispatching
+          -- all the ticks takes longer, then the dispatching time becomes
+          -- the time bound.
+      in max
+          (fst lastBlockPoint)
+          (fst firstTipPointBlock +
+              0.020 * lastBlockNo + 5 * fromIntegral peerCount)
+
+    fromTipPoint (t, ScheduleTipPoint bp) = Just (t, bp)
+    fromTipPoint _ = Nothing
+
+    fromBlockPoint (t, ScheduleBlockPoint bp) = Just (t, bp)
+    fromBlockPoint _ = Nothing
+
+headCallStack :: HasCallStack => [a] -> a
+headCallStack xs = if null xs then error "headCallStack: empty list" else head xs

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
@@ -1,0 +1,118 @@
+{-# LANGUAGE BlockArguments      #-}
+{-# LANGUAGE DerivingStrategies  #-}
+{-# LANGUAGE LambdaCase          #-}
+{-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE RecordWildCards     #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections       #-}
+{-# LANGUAGE TypeFamilies        #-}
+{-# LANGUAGE TypeOperators       #-}
+
+module Test.Consensus.Genesis.Tests.Uniform (tests) where
+
+import           Cardano.Slotting.Slot (SlotNo (SlotNo), WithOrigin (..))
+import           Control.Monad.IOSim (runSimOrThrow)
+import           Data.List (intercalate)
+import           Ouroboros.Consensus.Util.Condense (Condense (condense))
+import qualified Ouroboros.Network.AnchoredFragment as AF
+import           Test.Consensus.BlockTree (BlockTree (..))
+import           Test.Consensus.Genesis.Setup
+import           Test.Consensus.Genesis.Setup.Classifiers
+import           Test.Consensus.PeerSimulator.Run (noTimeoutsSchedulerConfig,
+                     scTraceState)
+import           Test.Consensus.PeerSimulator.StateView
+import           Test.Consensus.PointSchedule
+import           Test.Ouroboros.Consensus.ChainGenerator.Params (Delta (Delta))
+import qualified Test.QuickCheck as QC
+import           Test.QuickCheck
+import           Test.Tasty
+import           Test.Tasty.QuickCheck
+import           Test.Util.Orphans.IOLike ()
+import           Test.Util.QuickCheck (le)
+import           Test.Util.TestEnv (adjustQuickCheckMaxSize,
+                     adjustQuickCheckTests)
+import           Text.Printf (printf)
+
+tests :: TestTree
+tests =
+  adjustQuickCheckTests (`div` 10) $
+  adjustQuickCheckMaxSize (`div` 10) $
+  testProperty "serve adversarial branches" prop_serveAdversarialBranches
+
+makeProperty ::
+  GenesisTest ->
+  Int ->
+  StateView ->
+  [PeerId] ->
+  Property
+makeProperty genesisTest advCount StateView {svSelectedChain} killed =
+  classify genesisWindowAfterIntersection "Full genesis window after intersection" $
+  classify (isOrigin immutableTipHash) "Immutable tip is Origin" $
+  label disconnected $
+  classify (advCount < length (btBranches gtBlockTree)) "Some adversaries performed rollbacks" $
+  counterexample killedPeers $
+  -- We require the honest chain to fit a Genesis window, because otherwise its tip may suggest
+  -- to the governor that the density is too low.
+  longerThanGenesisWindow ==>
+  conjoin [
+    counterexample "The honest peer was disconnected" (not (HonestPeer `elem` killed)),
+    counterexample ("The immutable tip is not honest: " ++ show immutableTip) $
+    property (isHonest immutableTipHash),
+    immutableTipIsRecent
+  ]
+  where
+    immutableTipIsRecent =
+      counterexample ("Age of the immutable tip: " ++ show immutableTipAge) $
+      immutableTipAge `le` s + fromIntegral d + 1
+
+    SlotNo immutableTipAge = case (honestTipSlot, immutableTipSlot) of
+      (At h, At i)   -> h - i
+      (At h, Origin) -> h
+      _              -> 0
+
+    isOrigin = null
+
+    isHonest = all (0 ==)
+
+    immutableTipHash = simpleHash (AF.anchorToHash immutableTip)
+
+    immutableTip = AF.anchor svSelectedChain
+
+    immutableTipSlot = AF.anchorToSlotNo (AF.anchor svSelectedChain)
+
+    disconnected =
+      printf "disconnected %.1f%% of adversaries" disconnectedPercent
+
+    disconnectedPercent :: Double
+    disconnectedPercent =
+      100 * fromIntegral (length killed) / fromIntegral advCount
+
+    killedPeers = case killed of
+      [] -> "No peers were killed"
+      peers -> "Some peers were killed: " ++ intercalate ", " (condense <$> peers)
+
+    honestTipSlot = AF.headSlot (btTrunk gtBlockTree)
+
+    GenesisTest {gtBlockTree, gtGenesisWindow = GenesisWindow s, gtDelay = Delta d} = genesisTest
+
+    Classifiers {genesisWindowAfterIntersection, longerThanGenesisWindow} = classifiers genesisTest
+
+-- | Tests that the immutable tip is not delayed and stays honest with the
+-- adversarial peers serving adversarial branches.
+prop_serveAdversarialBranches :: QC.Gen QC.Property
+prop_serveAdversarialBranches = QC.expectFailure <$> do
+  genesisTest <- genChains (QC.choose (1, 4))
+  schedule <- fromSchedulePoints <$> genUniformSchedulePoints genesisTest
+  pure $
+    runSimOrThrow $
+    runTest schedulerConfig genesisTest schedule $
+    exceptionCounterexample $
+    makeProperty genesisTest (length (peerIds schedule) - 1)
+
+  where
+    schedulerConfig = (noTimeoutsSchedulerConfig scheduleConfig) {scTraceState = False}
+
+    scheduleConfig = defaultPointScheduleConfig
+
+genUniformSchedulePoints :: GenesisTest -> QC.Gen (Peers PeerSchedule)
+genUniformSchedulePoints gt = stToGen (uniformPoints (gtBlockTree gt))

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
@@ -6,7 +6,6 @@
 module Test.Consensus.PeerSimulator.Tests.Rollback (tests) where
 
 import           Control.Monad.IOSim (runSimOrThrow)
-import           Data.Maybe (fromJust)
 import           Ouroboros.Consensus.Block (ChainHash (..))
 import           Ouroboros.Consensus.Config.SecurityParam
 import qualified Ouroboros.Network.AnchoredFragment as AF
@@ -45,7 +44,7 @@ tests = testGroup "rollback" [
 -- blocks before the current selection.
 prop_rollback :: Bool -> QC.Gen QC.Property
 prop_rollback wantRollback = do
-  genesisTest <- genChains 1
+  genesisTest <- genChains (pure 1)
 
   let schedule = rollbackSchedule (gtBlockTree genesisTest)
 
@@ -77,7 +76,7 @@ prop_rollback wantRollback = do
           states = banalStates trunk ++ banalStates branch
           peers = peersOnlyHonest states
           pointSchedule = balanced defaultPointScheduleConfig peers
-       in fromJust pointSchedule
+       in pointSchedule
 
     -- | Whether it is possible to roll back from the trunk after having served
     -- it fully, that is whether there is an alternative chain that forks of the

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
@@ -71,8 +71,6 @@ prop_cannotRollback = do
   -- the implementation doesn't
   pure $
     alternativeChainIsLongEnough (gtSecurityParam genesisTest) (gtBlockTree genesisTest)
-      &&
-    honestChainIsLongEnough (gtSecurityParam genesisTest) (gtBlockTree genesisTest)
     ==>
       runSimOrThrow $ runTest schedulerConfig genesisTest schedule $ \StateView{svSelectedChain} ->
         let headOnAlternativeChain = case AF.headHash svSelectedChain of
@@ -102,18 +100,6 @@ rollbackSchedule n blockTree =
       peers = peersOnlyHonest states
       pointSchedule = balanced defaultPointScheduleConfig peers
    in pointSchedule
-
--- | Whether the honest chain has more than 'k' blocks after the
--- intersection with the alternative chain.
---
--- PRECONDITION: Block tree with exactly one alternative chain, otherwise
--- this property does not make sense. With no alternative chain, this will
--- even crash.
-honestChainIsLongEnough :: SecurityParam -> BlockTree TestBlock -> Bool
-honestChainIsLongEnough (SecurityParam k) blockTree =
-  let BlockTreeBranch{btbTrunkSuffix} = head $ btBranches blockTree
-      lengthTrunkSuffix = AF.length btbTrunkSuffix
-   in lengthTrunkSuffix > fromIntegral k
 
 -- | Whether the alternative chain has more than 'k' blocks after the
 -- intersection with the honest chain.

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
@@ -24,74 +24,105 @@ import           Test.Util.TestEnv (adjustQuickCheckTests)
 
 tests :: TestTree
 tests = testGroup "rollback" [
-  -- NOTE: The property @prop_rollback True@ discards a lot of inputs, making
-  -- it quite flakey. We increase the maximum number of discarded tests per
-  -- successful ones so as to make this test more reliable.
   adjustQuickCheckTests (`div` 10) $
   localOption (QuickCheckMaxRatio 100) $
-  testProperty "can rollback" (prop_rollback True)
+  testProperty "can rollback" prop_rollback
   ,
   adjustQuickCheckTests (`div` 10) $
-  testProperty "cannot rollback" (prop_rollback False)
+  testProperty "cannot rollback" prop_cannotRollback
   ]
 
--- | @prop_rollback True@ tests that the selection of the node under test
+-- | @prop_rollback@ tests that the selection of the node under test
 -- changes branches when sent a rollback to a block no older than 'k' blocks
 -- before the current selection.
---
--- @prop_rollback False@ tests that the selection of the node under test *does
--- not* change branches when sent a rollback to a block strictly older than 'k'
--- blocks before the current selection.
-prop_rollback :: Bool -> QC.Gen QC.Property
-prop_rollback wantRollback = do
+prop_rollback :: QC.Gen QC.Property
+prop_rollback = do
   genesisTest <- genChains (pure 1)
 
-  let schedule = rollbackSchedule (gtBlockTree genesisTest)
+  let SecurityParam k = gtSecurityParam genesisTest
+      schedule = rollbackSchedule (fromIntegral k) (gtBlockTree genesisTest)
 
-  -- | We consider the test case interesting if we want a rollback and we can
-  -- actually get one, or if we want no rollback and we cannot actually get one.
+  -- We consider the test case interesting if we can rollback
   pure $
-    wantRollback == canRollbackFromTrunkTip (gtSecurityParam genesisTest) (gtBlockTree genesisTest)
+    alternativeChainIsLongEnough (gtSecurityParam genesisTest) (gtBlockTree genesisTest)
     ==>
       runSimOrThrow $ runTest schedulerConfig genesisTest schedule $ \StateView{svSelectedChain} ->
         let headOnAlternativeChain = case AF.headHash svSelectedChain of
               GenesisHash    -> False
               BlockHash hash -> any (0 /=) $ unTestHash hash
         in
-        -- The test passes if we want a rollback and we actually end up on the
-        -- alternative chain or if we want no rollback and end up on the trunk.
-        wantRollback == headOnAlternativeChain
+        -- The test passes if we end up on the alternative chain
+        headOnAlternativeChain
 
   where
     schedulerConfig = noTimeoutsSchedulerConfig defaultPointScheduleConfig
 
-    -- A schedule that advertises all the points of the trunk, then switches to
-    -- the first alternative chain of the given block tree.
-    --
-    -- PRECONDITION: Block tree with at least one alternative chain.
-    rollbackSchedule :: BlockTree TestBlock -> PointSchedule
-    rollbackSchedule blockTree =
-      let trunk = btTrunk blockTree
-          branch = btbSuffix $ head $ btBranches blockTree
-          states = banalStates trunk ++ banalStates branch
-          peers = peersOnlyHonest states
-          pointSchedule = balanced defaultPointScheduleConfig peers
-       in pointSchedule
+-- @prop_cannotRollback@ tests that the selection of the node under test *does
+-- not* change branches when sent a rollback to a block strictly older than 'k'
+-- blocks before the current selection.
+prop_cannotRollback :: QC.Gen QC.Property
+prop_cannotRollback = do
+  genesisTest <- genChains (pure 1)
 
-    -- | Whether it is possible to roll back from the trunk after having served
-    -- it fully, that is whether there is an alternative chain that forks of the
-    -- trunk no more than 'k' blocks from the tip and that is longer than the
-    -- trunk.
-    --
-    -- PRECONDITION: Block tree with exactly one alternative chain, otherwise
-    -- this property does not make sense. With no alternative chain, this will
-    -- even crash.
-    --
-    -- REVIEW: Why does 'existsSelectableAdversary' get to be a classifier and
-    -- not this? (or a generalised version of this)
-    canRollbackFromTrunkTip :: SecurityParam -> BlockTree TestBlock -> Bool
-    canRollbackFromTrunkTip (SecurityParam k) blockTree =
-      let BlockTreeBranch{btbSuffix, btbTrunkSuffix} = head $ btBranches blockTree
-          lengthSuffix = AF.length btbSuffix
-          lengthTrunkSuffix = AF.length btbTrunkSuffix
-       in lengthTrunkSuffix <= fromIntegral k && lengthSuffix > lengthTrunkSuffix
+  let SecurityParam k = gtSecurityParam genesisTest
+      schedule = rollbackSchedule (fromIntegral (k + 1)) (gtBlockTree genesisTest)
+
+  -- We consider the test case interesting if it allows to rollback even if
+  -- the implementation doesn't
+  pure $
+    alternativeChainIsLongEnough (gtSecurityParam genesisTest) (gtBlockTree genesisTest)
+      &&
+    honestChainIsLongEnough (gtSecurityParam genesisTest) (gtBlockTree genesisTest)
+    ==>
+      runSimOrThrow $ runTest schedulerConfig genesisTest schedule $ \StateView{svSelectedChain} ->
+        let headOnAlternativeChain = case AF.headHash svSelectedChain of
+              GenesisHash    -> False
+              BlockHash hash -> any (0 /=) $ unTestHash hash
+        in
+        -- The test passes if we end up on the trunk.
+        not headOnAlternativeChain
+
+  where
+    schedulerConfig = noTimeoutsSchedulerConfig defaultPointScheduleConfig
+
+-- | A schedule that advertises all the points of the trunk up until the nth
+-- block after the intersection, then switches to the first alternative
+-- chain of the given block tree.
+--
+-- PRECONDITION: Block tree with at least one alternative chain.
+rollbackSchedule :: Int -> BlockTree TestBlock -> PointSchedule
+rollbackSchedule n blockTree =
+  let branch = head $ btBranches blockTree
+      trunkSuffix = AF.takeOldest n (btbTrunkSuffix branch)
+      states = concat
+        [ banalStates (btbPrefix branch)
+        , banalStates trunkSuffix
+        , banalStates (btbSuffix branch)
+        ]
+      peers = peersOnlyHonest states
+      pointSchedule = balanced defaultPointScheduleConfig peers
+   in pointSchedule
+
+-- | Whether the honest chain has more than 'k' blocks after the
+-- intersection with the alternative chain.
+--
+-- PRECONDITION: Block tree with exactly one alternative chain, otherwise
+-- this property does not make sense. With no alternative chain, this will
+-- even crash.
+honestChainIsLongEnough :: SecurityParam -> BlockTree TestBlock -> Bool
+honestChainIsLongEnough (SecurityParam k) blockTree =
+  let BlockTreeBranch{btbTrunkSuffix} = head $ btBranches blockTree
+      lengthTrunkSuffix = AF.length btbTrunkSuffix
+   in lengthTrunkSuffix > fromIntegral k
+
+-- | Whether the alternative chain has more than 'k' blocks after the
+-- intersection with the honest chain.
+--
+-- PRECONDITION: Block tree with exactly one alternative chain, otherwise
+-- this property does not make sense. With no alternative chain, this will
+-- even crash.
+alternativeChainIsLongEnough :: SecurityParam -> BlockTree TestBlock -> Bool
+alternativeChainIsLongEnough (SecurityParam k) blockTree =
+  let BlockTreeBranch{btbSuffix} = head $ btBranches blockTree
+      lengthSuffix = AF.length btbSuffix
+   in lengthSuffix > fromIntegral k

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
@@ -33,7 +33,7 @@ tests = adjustQuickCheckTests (`div` 10) $ testProperty "timeouts" prop_timeouts
 
 prop_timeouts :: QC.Gen QC.Property
 prop_timeouts = do
-  genesisTest <- genChains 0
+  genesisTest <- genChains (pure 0)
 
   -- Use higher tick duration to avoid the test taking really long
   let scSchedule = PointScheduleConfig {pscTickDuration = 1}
@@ -69,7 +69,7 @@ prop_timeouts = do
           headerPoint = HeaderPoint $ At (getHeader tipBlock)
           blockPoint = BlockPoint (At tipBlock)
           state = Peer HonestPeer $ NodeOnline $ AdvertisedPoints tipPoint headerPoint blockPoint
-          tick = Tick { active = state, duration = pscTickDuration scheduleConfig }
+          tick = Tick { active = state, duration = pscTickDuration scheduleConfig, number = 0 }
           maximumNumberOfTicks = round $ timeout / pscTickDuration scheduleConfig
       in
       PointSchedule (tick :| replicate maximumNumberOfTicks tick) (HonestPeer :| [])

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Trace.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Trace.hs
@@ -36,9 +36,9 @@ import           Ouroboros.Consensus.Util.Condense (Condense (..))
 import           Ouroboros.Consensus.Util.IOLike (IOLike, MonadMonotonicTime,
                      Time (Time), getMonotonicTime)
 import           Ouroboros.Network.AnchoredFragment
-                     (Anchor (Anchor, AnchorGenesis), AnchoredSeq (Empty),
-                     anchor, mapAnchoredFragment, toOldestFirst)
-import           Test.Consensus.PointSchedule (TestFrag, TestFragH)
+                     (Anchor (Anchor, AnchorGenesis), AnchoredFragment,
+                     AnchoredSeq (Empty), anchor, mapAnchoredFragment,
+                     toOldestFirst)
 import           Test.Util.TestBlock (Header (TestHeader), TestBlock,
                      TestHash (TestHash), unTestHash)
 import           Text.Printf (printf)
@@ -122,7 +122,7 @@ tersePoint = \case
   BlockPoint slot hash -> terseSlotBlockFork slot (BlockNo (fromIntegral (length (unTestHash hash)))) hash
   GenesisPoint -> "G"
 
-terseFragH :: TestFragH -> String
+terseFragH :: AnchoredFragment (Header TestBlock) -> String
 terseFragH frag =
   renderAnchor ++ renderBlocks
   where
@@ -136,6 +136,6 @@ terseFragH frag =
       | all (== 0) (unTestHash hash) = ""
       | otherwise = condense hash
 
-terseFrag :: TestFrag -> String
+terseFrag :: AnchoredFragment TestBlock -> String
 terseFrag =
   terseFragH . mapAnchoredFragment getHeader

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
@@ -4,6 +4,8 @@
 {-# LANGUAGE LambdaCase            #-}
 {-# LANGUAGE NamedFieldPuns        #-}
 {-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE RankNTypes            #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
 
 -- | Data types and generators that convert a 'BlockTree' to a 'PointSchedule'.
 --
@@ -32,10 +34,10 @@ module Test.Consensus.PointSchedule (
   , NodeState (..)
   , Peer (..)
   , PeerId (..)
+  , PeerSchedule
   , Peers (..)
   , PointSchedule (..)
   , PointScheduleConfig (..)
-  , ScheduleType (..)
   , TestFrag
   , TestFragH
   , Tick (..)
@@ -44,19 +46,23 @@ module Test.Consensus.PointSchedule (
   , banalStates
   , defaultPointScheduleConfig
   , fromSchedulePoints
-  , genSchedule
+  , genesisAdvertisedPoints
+  , longRangeAttack
   , mkPeers
-  , onlyHonestWithMintingPointSchedule
   , peersOnlyHonest
   , pointSchedulePeers
   , prettyGenesisTest
   , prettyPointSchedule
+  , stToGen
+  , uniformPoints
   ) where
 
+import           Control.Monad.ST (ST)
 import           Data.Foldable (toList)
 import           Data.Hashable (Hashable)
-import           Data.List (mapAccumL, scanl', sortOn, transpose)
-import           Data.List.NonEmpty (NonEmpty ((:|)), nonEmpty)
+import           Data.List (mapAccumL, partition, scanl', transpose)
+import           Data.List.NonEmpty (NonEmpty ((:|)))
+import qualified Data.List.NonEmpty as NonEmpty
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           Data.Maybe (fromMaybe, listToMaybe)
@@ -64,25 +70,32 @@ import           Data.String (IsString (fromString))
 import           Data.Time (DiffTime)
 import           Data.Word (Word64)
 import           GHC.Generics (Generic)
-import           Ouroboros.Consensus.Block.Abstract (HasHeader,
-                     WithOrigin (Origin), getHeader)
-import           Ouroboros.Consensus.Protocol.Abstract (SecurityParam)
+import           Ouroboros.Consensus.Block.Abstract (WithOrigin (..), getHeader)
+import           Ouroboros.Consensus.Protocol.Abstract (SecurityParam,
+                     maxRollbacks)
 import           Ouroboros.Consensus.Util.Condense (Condense (condense))
 import           Ouroboros.Network.AnchoredFragment (AnchoredFragment,
-                     AnchoredSeq (Empty, (:>)), anchorFromBlock)
+                     AnchoredSeq (Empty, (:>)))
 import qualified Ouroboros.Network.AnchoredFragment as AF
-import           Ouroboros.Network.Block (SlotNo, Tip (Tip, TipGenesis),
-                     blockNo, blockSlot, getTipSlotNo, tipFromHeader)
+import           Ouroboros.Network.Block (Tip (Tip, TipGenesis), blockNo,
+                     blockSlot, tipFromHeader)
 import           Ouroboros.Network.Point (WithOrigin (At))
-import           System.Random.Stateful (StatefulGen)
+import qualified System.Random.Stateful as Random
+import           System.Random.Stateful (STGenM, StatefulGen, runSTGen_)
 import           Test.Consensus.BlockTree (BlockTree (..), BlockTreeBranch (..),
                      prettyBlockTree)
 import           Test.Consensus.PointSchedule.SinglePeer
                      (IsTrunk (IsBranch, IsTrunk), PeerScheduleParams (..),
                      SchedulePoint (..), defaultPeerScheduleParams, mergeOn,
                      peerScheduleFromTipPoints)
-import           Test.Ouroboros.Consensus.ChainGenerator.Params (Asc)
+import           Test.Consensus.PointSchedule.SinglePeer.Indices
+                     (uniformRMDiffTime)
+import           Test.Ouroboros.Consensus.ChainGenerator.Params (Asc,
+                     Delta (Delta), ascVal)
+import           Test.QuickCheck (Gen, arbitrary)
+import           Test.QuickCheck.Random (QCGen)
 import           Test.Util.TestBlock (Header (TestHeader), TestBlock)
+import           Text.Printf (printf)
 
 ----------------------------------------------------------------------------------------------------
 -- Data types
@@ -148,6 +161,14 @@ instance Condense AdvertisedPoints where
     "TP " ++ condense tip ++
     " | HP " ++ condense header ++
     " | BP " ++ condense block
+
+genesisAdvertisedPoints :: AdvertisedPoints
+genesisAdvertisedPoints =
+  AdvertisedPoints {
+    tip = TipPoint TipGenesis,
+    header = HeaderPoint Origin,
+    block = BlockPoint Origin
+  }
 
 -- | The state of a peer in a single tick.
 --
@@ -230,16 +251,24 @@ data Tick =
   Tick {
     active   :: Peer NodeState,
     -- | The duration of this tick, for the scheduler to pass to @threadDelay@.
-    duration :: DiffTime
+    duration :: DiffTime,
+    number   :: Word
   }
   deriving (Eq, Show)
 
 instance Condense Tick where
-  condense Tick {active, duration} = condense active ++ " | " ++ show duration
+  condense Tick {active, duration, number} =
+    show number ++ ": " ++ condense active ++ " | " ++ showDT duration
+    where
+      showDT t = printf "%.6f" (realToFrac t :: Double)
 
-tickDefault :: PointScheduleConfig -> Peer NodeState -> Tick
-tickDefault PointScheduleConfig {pscTickDuration} active =
-  Tick {active, duration = pscTickDuration}
+tickDefault :: PointScheduleConfig -> Word -> Peer NodeState -> Tick
+tickDefault PointScheduleConfig {pscTickDuration} number active =
+  Tick {active, duration = pscTickDuration, number}
+
+tickDefaults :: PointScheduleConfig -> [Peer NodeState] -> [Tick]
+tickDefaults psc states =
+  uncurry (tickDefault psc) <$> zip [0 ..] states
 
 -- | A set of peers with only one honest peer carrying the given value.
 peersOnlyHonest :: a -> Peers a
@@ -291,24 +320,6 @@ defaultPointScheduleConfig =
 getPeerIds :: Peers a -> NonEmpty PeerId
 getPeerIds peers = HonestPeer :| Map.keys (others peers)
 
--- | Extract the trunk and all the branches from the 'BlockTree' and store them in
--- an honest 'Peer' and several adversarial ones, respectively.
-blockTreePeers :: BlockTree TestBlock -> Peers TestFrag
-blockTreePeers BlockTree {btTrunk, btBranches} =
-  Peers {
-    honest = Peer HonestPeer btTrunk,
-    others = Map.fromList (branches btBranches)
-  }
-  where
-    branches = \case
-      [b] -> [peer "adversary" b]
-      bs -> uncurry branch <$> zip [1 :: Int ..] bs
-
-    branch num =
-      peer (PeerId ("adversary " <> show num))
-
-    peer pid BlockTreeBranch {btbFull} = (pid, Peer pid btbFull)
-
 -- | Get the names of the peers involved in this point schedule.
 -- This is the main motivation for requiring the point schedule to be
 -- nonempty, so we don't have to carry around another value for the
@@ -336,9 +347,10 @@ mkPeers h as =
 -- Conversion to 'PointSchedule'
 ----------------------------------------------------------------------------------------------------
 
--- | Ensure that a 'PointSchedule' isn't empty.
-pointSchedule :: [Tick] -> NonEmpty PeerId -> Maybe PointSchedule
-pointSchedule ticks nePeerIds = (`PointSchedule` nePeerIds) <$> nonEmpty ticks
+-- | Create a point schedule from a list of ticks
+pointSchedule :: [Tick] -> NonEmpty PeerId -> PointSchedule
+pointSchedule [] _nePeerIds = error "pointSchedule: no ticks"
+pointSchedule ticks nePeerIds = PointSchedule (NonEmpty.fromList ticks) nePeerIds
 
 -- | Convert a @SinglePeer@ schedule to a 'NodeState' schedule.
 --
@@ -350,9 +362,13 @@ pointSchedule ticks nePeerIds = (`PointSchedule` nePeerIds) <$> nonEmpty ticks
 -- This is a preliminary measure to make the long range attack test work, since that relies on the
 -- honest node sending headers later than the adversary, which is not possible if the adversary's
 -- first tip point is delayed by 20 or more seconds due to being in a later slot.
-peerStates :: PeerId -> [(DiffTime, SchedulePoint)] -> [(DiffTime, Peer NodeState)]
-peerStates peerId pts =
-  zip (0 : (shiftTime <$> times)) (Peer peerId . NodeOnline <$> scanl' modPoint zero points)
+--
+-- Finally, drops the first state, since all points being 'Origin' (in particular the tip) has no
+-- useful effects in the simulator, but it could set the tip in the GDD governor to 'Origin', which
+-- causes slow nodes to be disconnected right away.
+peerStates :: Peer PeerSchedule -> [(DiffTime, Peer NodeState)]
+peerStates Peer {name, value = schedulePoints} =
+  drop 1 (zip (0 : (shiftTime <$> times)) (Peer name . NodeOnline <$> scanl' modPoint genesisAdvertisedPoints points))
   where
     shiftTime t = t - firstTipOffset
 
@@ -361,44 +377,25 @@ peerStates peerId pts =
       ScheduleHeaderPoint h -> z {header = HeaderPoint (At (getHeader h))}
       ScheduleBlockPoint b -> z {block = BlockPoint (At b)}
 
-    zero = AdvertisedPoints {
-      tip = TipPoint TipGenesis,
-      header = HeaderPoint Origin,
-      block = BlockPoint Origin
-    }
-
     firstTipOffset = fromMaybe 0 (listToMaybe times)
 
-    (times, points) = unzip pts
+    (times, points) = unzip schedulePoints
+
+type PeerSchedule = [(DiffTime, SchedulePoint)]
 
 -- | Convert a set of @SinglePeer@ schedules to a 'PointSchedule'.
 --
 -- Call 'peerStates' for each peer, then merge all of them sorted by tick start times, then convert
 -- start times to relative tick durations.
-fromSchedulePoints :: Map PeerId [(DiffTime, SchedulePoint)] -> Maybe PointSchedule
+fromSchedulePoints :: Peers PeerSchedule -> PointSchedule
 fromSchedulePoints peers = do
-  peerIds <- nonEmpty (Map.keys peers)
-  pointSchedule (zipWith Tick states durations) peerIds
+  pointSchedule (zipWith3 Tick states durations [0 ..]) peerIds
   where
-    durations = drop 1 (snd (mapAccumL (\ prev start -> (start, start - prev)) 0 (drop 1 starts))) ++ [0]
+    peerIds = getPeerIds peers
 
-    (starts, states) = unzip $ foldr (mergeOn fst) [] [peerStates p sch | (p, sch) <- Map.toList peers]
+    durations = snd (mapAccumL (\ prev start -> (start, start - prev)) 0 (drop 1 starts)) ++ [0.1]
 
-----------------------------------------------------------------------------------------------------
--- Folding functions
-----------------------------------------------------------------------------------------------------
-
--- | Combine two 'Peers' by creating tuples of the two honest 'Peer's and of each pair
--- of 'others' with the same 'PeerId', dropping any 'Peer' that is present in only one
--- of the 'Map's.
-zipPeers :: Peers a -> Peers b -> Peers (a, b)
-zipPeers a b =
-  Peers {
-    honest = Peer HonestPeer (value (honest a), value (honest b)),
-    others = Map.intersectionWith zp (others a) (others b)
-  }
-  where
-    zp p1 p2 = Peer (name p1) (value p1, value p2)
+    (starts, states) = unzip $ foldr (mergeOn fst) [] (peerStates <$> toList (peersList peers))
 
 ----------------------------------------------------------------------------------------------------
 -- Schedule generators
@@ -428,156 +425,13 @@ banalStates frag@(_ :> tipBlock) =
 balanced ::
   PointScheduleConfig ->
   Peers [NodeState] ->
-  Maybe PointSchedule
+  PointSchedule
 balanced config states =
-  pointSchedule (map (tickDefault config) activeSeq) (getPeerIds states)
+  pointSchedule (tickDefaults config activeSeq) (getPeerIds states)
   where
     -- Sequence containing the first state of all the nodes in order, then the
     -- second in order, etc.
     activeSeq = concat $ transpose $ sequenceA (honest states) : (sequenceA <$> Map.elems (others states))
-
--- | Generate a point schedule that serves a single header in each tick for each
--- peer in turn. See 'blockTreePeers' for peers generation.
-banalPointSchedule ::
-  PointScheduleConfig ->
-  BlockTree TestBlock ->
-  Maybe PointSchedule
-banalPointSchedule config blockTree =
-  balanced config (banalStates <$> blockTreePeers blockTree)
-
--- | Generate a point schedule for the scenario in which adversaries send blocks much faster
--- than the honest node.
---
--- This is intended to test the Limit on Eagerness, which prevents the selection from advancing
--- far enough into a fork that the immutable tip moves into the fork as well (i.e. more than k
--- blocks).
---
--- The LoE is only resolved when all peers with forks at that block have been disconnected from,
--- in particular due to a decision based on the Genesis density criterion.
---
--- This is implemented by initializing each peer's schedule with 'banalStates' (which advances by
--- one block per tick) and assigning interval lengths to each peer tick based on the frequency
--- config in the first argument, then sorting the resulting absolute times.
-frequencyPointSchedule ::
-  -- | A set of relative frequencies.
-  -- If peer A has a value of @2@ and peer B has @6@, peer B will get three turns in the schedule
-  -- for each turn of A.
-  --
-  -- Given @Peers { honest = 1, others = [("A", 2), ("B", 10)] }@, we get a schedule like
-  --
-  -- @BBBBABBBBBHAB BBBBABBBBBHAB...@
-  --
-  -- with the intermediate interval representation:
-  --
-  -- B(1/10) B(2/10) B(3/10) B(4/10) A(1/2) B(5/10) B(6/10) B(7/10) B(8/10) B(9/10) H(1/1) (2/2) B(10/10)
-  --
-  -- With the order of equal values determined by the @PeerId@s.
-  PointScheduleConfig ->
-  Peers Int ->
-  BlockTree TestBlock ->
-  Maybe PointSchedule
-frequencyPointSchedule config freqs blockTree =
-  pointSchedule (map (tickDefault config . fmap snd) (sortOn (fst . value) catted)) (getPeerIds freqs)
-  where
-    catted = sequenceA =<< toList (peersList intvals)
-
-    intvals = uncurry mkIntvals <$> zipPeers freqs states
-
-    mkIntvals freq ss = zip (peerIntervals (length ss) freq) ss
-
-    states = banalStates <$> frags
-
-    frags = blockTreePeers blockTree
-
-    peerIntervals :: Int -> Int -> [Double]
-    peerIntervals count freq =
-      (* intvalLen) <$> [1 .. fromIntegral count]
-      where
-        intvalLen = 1 / fromIntegral freq
-
--- | Generate a point schedule that consist of a single tick in which the honest peer advertises
--- its entire chain immediately.
-onlyHonestPointSchedule ::
-  PointScheduleConfig ->
-  BlockTree TestBlock ->
-  Maybe PointSchedule
-onlyHonestPointSchedule _ BlockTree {btTrunk = Empty _} = Nothing
-onlyHonestPointSchedule config BlockTree {btTrunk = _ :> tipBlock} =
-  Just $ PointSchedule (pure tick) (HonestPeer :| [])
-  where
-    tick = tickDefault config honestPeerState
-    honestPeerState = Peer HonestPeer (NodeOnline points)
-    points = AdvertisedPoints tipPoint headerPoint blockPoint
-    tipPoint = TipPoint (tipFromHeader tipBlock)
-    headerPoint = HeaderPoint $ At (getHeader tipBlock)
-    blockPoint = BlockPoint (At tipBlock)
-
--- | Generate a point schedule that consist of a single tick in which the honest peer advertises
--- its entire chain as it becomes available.
---
--- No idea what the point of this is.
-onlyHonestWithMintingPointSchedule ::
-  PointScheduleConfig ->
-  SlotNo ->
-  Int ->
-  TestFrag ->
-  Maybe PointSchedule
-onlyHonestWithMintingPointSchedule config initialSlotNo _ticksPerSlot fullFragment@(_ :> finalBlock) =
-  pointSchedule (map tickAtSlotNo [initialSlotNo .. finalSlotNo]) (HonestPeer :| [])
-  where
-    -- If we hold a block, we are guaranteed that the slot number cannot be
-    -- origin?
-    finalSlotNo = case getTipSlotNo $ tipFromHeader finalBlock of
-      At s -> s
-      _    -> error "unexpected alternative"
-
-    advertisedPointsAtSlotNo :: SlotNo -> AdvertisedPoints
-    advertisedPointsAtSlotNo slotNo =
-      case fst $ splitFragmentAtSlotNo slotNo fullFragment of
-        Empty _ -> error "onlyHonestWithMintingPointSchedule: there should be a block at that slot"
-        (_ :> tipBlock) ->
-          let tipPoint = TipPoint $ tipFromHeader tipBlock
-              headerPoint = HeaderPoint $ At (getHeader tipBlock)
-              blockPoint = BlockPoint (At tipBlock)
-           in AdvertisedPoints tipPoint headerPoint blockPoint
-
-    tickAtSlotNo :: SlotNo -> Tick
-    tickAtSlotNo slotNo =
-      let honestPeerState =
-            Peer HonestPeer $
-              NodeOnline $
-              advertisedPointsAtSlotNo slotNo
-       in
-          tickDefault config honestPeerState
-onlyHonestWithMintingPointSchedule _ _initialSlotNo _ticksPerSlot _fullFragment =
-    error "unexpected alternative"
-
--- onlyHonestWithMintingPointSchedule' :: SlotNo -> Int -> TestFrag -> PointSchedule
--- onlyHonestWithMintingPointSchedule' initialSlotNo ticksPerSlot fullFragment =
---   let (availFragment, futureFragment) = splitFragmentAtSlotNo (At initialSlotNo) fullFragment
---       blockSlotNos = map blockSlotNo toOldestFirst futureFragment
-
--- | Given a slot number and an anchored fragment 'a', splits the fragment into
--- two 'b' and 'c' such that:
---
--- - 'b' is anchored in the same place as 'a' and contains all the blocks of 'a'
---   that have a slot number smaller than (or equal to) the given one.
---
--- - 'c' is anchored at the last block of 'b' and contains all the blocks of 'a'
---   that have a slot number strictly greater than the given one.
-splitFragmentAtSlotNo ::
-  HasHeader b =>
-  SlotNo ->
-  AnchoredFragment b ->
-  (AnchoredFragment b, AnchoredFragment b)
-splitFragmentAtSlotNo slotNo (fragment :> block) =
-  if blockSlot block <= slotNo then
-    (fragment :> block, Empty $ anchorFromBlock block)
-  else
-    let (firstPart, secondPart) = splitFragmentAtSlotNo slotNo fragment in
-      (firstPart, secondPart :> block)
-splitFragmentAtSlotNo _ (Empty anchor) =
-  (Empty anchor, Empty anchor)
 
 -- | Produce a schedule similar to @Frequencies (Peers 1 [10])@, using the new @SinglePeer@
 -- generator.
@@ -585,34 +439,89 @@ splitFragmentAtSlotNo _ (Empty anchor) =
 -- We hardcode the two schedules to use the latest block as the initial tip point.
 -- The honest peer gets a substantially larger (and disconnected) delay interval to ensure
 -- that k+1 blocks are sent fast enough to trigger selection of a fork.
-newLongRangeAttack ::
+longRangeAttack ::
   StatefulGen g m =>
-  g ->
   BlockTree TestBlock ->
-  m (Maybe PointSchedule)
-newLongRangeAttack g BlockTree {btTrunk, btBranches = [branch]} = do
+  g ->
+  m (Peers PeerSchedule)
+longRangeAttack BlockTree {btTrunk, btBranches = [branch]} g = do
   honest <- peerScheduleFromTipPoints g honParams [(IsTrunk, [AF.length btTrunk - 1])] btTrunk []
   adv <- peerScheduleFromTipPoints g advParams [(IsBranch, [AF.length (btbFull branch) - 1])] btTrunk [btbFull branch]
-  pure (fromSchedulePoints (Map.fromList [(HonestPeer, honest), ("adversary 1", adv)]))
+  pure (mkPeers honest [adv])
   where
     honParams = defaultPeerScheduleParams {pspHeaderDelayInterval = (0.3, 0.4)}
     advParams = defaultPeerScheduleParams {pspTipDelayInterval = (0, 0.1)}
 
-newLongRangeAttack _ _ =
-  pure Nothing
+longRangeAttack _ _ =
+  error "longRangeAttack can only deal with single adversary"
 
--- | Encodes the different scheduling styles for use with quickcheck generators.
-data ScheduleType =
-  Frequencies (Peers Int)
-  |
-  Banal
-  |
-  OnlyHonest
-  |
-  NewLRA
-  deriving (Eq, Show)
+-- | Generate a schedule in which the trunk and branches are served by one peer each, using
+-- a single tip point, without specifically assigned delay intervals like in
+-- 'newLongRangeAttack'.
+--
+-- Include rollbacks in a percentage of adversaries, in which case that peer uses two branchs.
+--
+uniformPoints ::
+  StatefulGen g m =>
+  BlockTree TestBlock ->
+  g ->
+  m (Peers PeerSchedule)
+uniformPoints BlockTree {btTrunk, btBranches} g = do
+  honestTip0 <- firstTip btTrunk
+  honest <- mkSchedule [(IsTrunk, [honestTip0 .. AF.length btTrunk - 1])] []
+  advs <- takeBranches btBranches
+  pure (mkPeers honest advs)
+  where
+    takeBranches = \case
+        [] -> pure []
+        [b] -> pure <$> withoutRollback b
+        b1 : b2 : branches -> do
+          a <- Random.uniformDouble01M g
+          if a < rollbackProb
+          then do
+            this <- withRollback b1 b2
+            rest <- takeBranches branches
+            pure (this : rest)
+          else do
+            this <- withoutRollback b1
+            rest <- takeBranches (b2 : branches)
+            pure (this : rest)
 
-newtype GenesisWindow = GenesisWindow { getGenesisWindow :: Word64 }
+    withoutRollback branch = do
+      tips <- mkTips branch
+      mkSchedule tips [btbSuffix branch]
+
+    withRollback b1 b2 = do
+      firstTips <- mkTips b1
+      let secondTips = [AF.length (btbSuffix b2) - 1]
+      mkSchedule (firstTips ++ [(IsBranch, secondTips)]) [btbSuffix b1, btbSuffix b2]
+
+    mkSchedule tips branches = do
+      params <- mkParams
+      peerScheduleFromTipPoints g params tips btTrunk branches
+
+    mkTips branch = do
+      tip0 <- firstTip (btbFull branch)
+      let (pre, post) = partition (< firstSuffixBlock) [tip0 .. lastBlock]
+      pure ((if null pre then [] else [(IsTrunk, pre)]) ++ [(IsBranch, (shift <$> post))])
+      where
+        shift i = i - firstSuffixBlock
+        firstSuffixBlock = lastBlock - AF.length (btbSuffix branch) + 1
+        lastBlock = AF.length full - 1
+        full = btbFull branch
+
+    firstTip frag = pure (AF.length frag - 1)
+
+    mkParams = do
+      tipL <- uniformRMDiffTime (0, 0.5) g
+      tipU <- uniformRMDiffTime (1, 2) g
+      headerL <- uniformRMDiffTime (0.018, 0.03) g
+      headerU <- uniformRMDiffTime (0.021, 0.04) g
+      pure defaultPeerScheduleParams {pspTipDelayInterval = (tipL, tipU), pspHeaderDelayInterval = (headerL, headerU)}
+
+    rollbackProb = 0.2
+
+newtype GenesisWindow = GenesisWindow { unGenesisWindow :: Word64 }
   deriving (Show)
 
 -- | All the data used by point schedule tests.
@@ -620,30 +529,24 @@ data GenesisTest = GenesisTest {
   gtHonestAsc     :: Asc,
   gtSecurityParam :: SecurityParam,
   gtGenesisWindow :: GenesisWindow,
+  gtDelay         :: Delta,
   gtBlockTree     :: BlockTree TestBlock
   }
 
 prettyGenesisTest :: GenesisTest -> [String]
-prettyGenesisTest GenesisTest{gtHonestAsc, gtSecurityParam, gtGenesisWindow, gtBlockTree} =
+prettyGenesisTest GenesisTest{gtHonestAsc, gtSecurityParam, gtGenesisWindow, gtDelay = Delta delta, gtBlockTree} =
   [ "GenesisTest:"
-  , "  gtHonestAsc: " ++ show gtHonestAsc
-  , "  gtSecurityParam: " ++ show gtSecurityParam
-  , "  gtGenesisWindow: " ++ show gtGenesisWindow
+  , "  gtHonestAsc: " ++ show (ascVal gtHonestAsc)
+  , "  gtSecurityParam: " ++ show (maxRollbacks gtSecurityParam)
+  , "  gtGenesisWindow: " ++ show (unGenesisWindow gtGenesisWindow)
+  , "  gtDelay: " ++ show delta
   , "  gtBlockTree:"
   ] ++ (("    " ++) <$> prettyBlockTree gtBlockTree)
 
--- | Create a point schedule from the given block tree.
---
--- The first argument determines the scheduling style.
-genSchedule ::
-  StatefulGen g m =>
-  g ->
-  PointScheduleConfig ->
-  ScheduleType ->
-  BlockTree TestBlock ->
-  m (Maybe PointSchedule)
-genSchedule g config = \case
-  Frequencies fs -> pure . frequencyPointSchedule config fs
-  Banal -> pure . banalPointSchedule config
-  OnlyHonest -> pure . onlyHonestPointSchedule config
-  NewLRA -> newLongRangeAttack g
+-- | Wrap a 'ST' generator in 'Gen'.
+stToGen ::
+  (forall s . STGenM QCGen s -> ST s a) ->
+  Gen a
+stToGen gen = do
+  seed :: QCGen <- arbitrary
+  pure (runSTGen_ seed gen)

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/SinglePeer/Indices.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/SinglePeer/Indices.hs
@@ -18,6 +18,7 @@ module Test.Consensus.PointSchedule.SinglePeer.Indices (
   , rollbacksTipPoints
   , singleJumpTipPoints
   , tipPointSchedule
+  , uniformRMDiffTime
   ) where
 
 import           Control.Monad (forM, replicateM)

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Consensus/ChainGenerator/Adversarial.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Consensus/ChainGenerator/Adversarial.hs
@@ -14,7 +14,7 @@ module Test.Ouroboros.Consensus.ChainGenerator.Adversarial (
     -- * Generating
     AdversarialRecipe (AdversarialRecipe, arHonest, arParams, arPrefix)
   , CheckedAdversarialRecipe (UnsafeCheckedAdversarialRecipe, carHonest, carParams, carWin)
-  , NoSuchAdversarialChainSchema (NoSuchAdversarialBlock, NoSuchCompetitor, NoSuchIntersection)
+  , NoSuchAdversarialChainSchema (NoSuchAdversarialBlock, NoSuchCompetitor, NoSuchIntersection, KcpIs1)
   , SomeCheckedAdversarialRecipe (SomeCheckedAdversarialRecipe)
   , checkAdversarialRecipe
   , uniformAdversarialChain
@@ -355,6 +355,12 @@ data NoSuchAdversarialChainSchema =
   |
     -- | @not (0 <= 'arPrefix' <= C)@ where @C@ is the number of active slots in 'arHonest'
     NoSuchIntersection
+  |
+    -- | @k=1@
+    --
+    -- This may technically be viable, but our current specification for
+    -- 'uniformAdversarialChain' requires @k>1@.
+    KcpIs1
   deriving (Eq, Show)
 
 -----
@@ -374,6 +380,8 @@ checkAdversarialRecipe ::
          (SomeCheckedAdversarialRecipe base hon)
 checkAdversarialRecipe recipe = do
     when (0 == k) $ Exn.throwError NoSuchAdversarialBlock
+
+    when (1 == k) $ Exn.throwError KcpIs1
 
     -- validate 'arPrefix'
     firstAdvSlot <- case compare arPrefix 0 of
@@ -631,15 +639,18 @@ withinYS (Delta d) !mbYS !(RI.Race (C.SomeWindow Proxy win)) = case mbYS of
 --
 -- The count will be strictly smaller than the number of active slots in the given 'ChainSchema'.
 --
--- REVIEW: why do we not allow forking off the block number 1?
-genPrefixBlockCount :: R.RandomGen g => g -> ChainSchema base hon -> C.Var hon 'ActiveSlotE
-genPrefixBlockCount g schedH =
-    if C.toVar numChoices < 2 then C.Count 0 {- can always pick genesis -} else do
+-- The result is guaranteed to leave more than k active slots after the
+-- intersection.
+genPrefixBlockCount :: R.RandomGen g => Kcp -> g -> ChainSchema base hon -> C.Var hon 'ActiveSlotE
+genPrefixBlockCount (Kcp k) g schedH
+    | C.getCount numChoices <= 0 = error "there should be at least k+1 blocks in the honest schema"
+    | otherwise =
+        -- uniformIndex is going to pick a number between 0 and numChoices-1
         C.toVar $ R.runSTGen_ g $ C.uniformIndex numChoices
   where
     ChainSchema _slots v = schedH
 
-    numChoices = pc C.- 1   -- can't pick the last active slot
+    numChoices = actives C.- k
 
-    -- 'H.uniformTheHonestChain' ensures 0 < pc
-    pc = BV.countActivesInV S.notInverted v
+    -- 'H.uniformTheHonestChain' ensures k < active
+    actives = BV.countActivesInV S.notInverted v

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Consensus/ChainGenerator/Honest.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Consensus/ChainGenerator/Honest.hs
@@ -104,10 +104,12 @@ data NoSuchHonestChainSchema =
 
 genHonestRecipe :: QC.Gen HonestRecipe
 genHonestRecipe = sized1 $ \sz -> do
-  (kcp, Scg s, delta) <- genKSD
-  -- s <= l, most of the time
-  l <- QC.frequency [(9, (+ s) <$> QC.choose (0, 5 * sz)), (1, QC.choose (1, s))]
-  pure $ HonestRecipe kcp (Scg s) delta (Len l)
+    (Kcp k, Scg s, Delta d) <- genKSD
+    -- 2s slots has at least 2k blocks. But that is ensuring k-1 more blocks
+    -- than we actually need. Thus it's safe to remove the k-1 last slots.
+    -- Therefore we set for a length of at least 2s - (k - 1).
+    l <- (+ (2*s - (k - 1))) <$> QC.choose (0, 5 * sz)
+    pure $ HonestRecipe (Kcp k) (Scg s) (Delta d) (Len l)
 
 -- | Checks whether the given 'HonestRecipe' determines a valid input to
 -- 'uniformTheHonestChain'

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Consensus/ChainGenerator/Params.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Consensus/ChainGenerator/Params.hs
@@ -98,7 +98,9 @@ genAsc = ascFromBits <$> QC.choose (1 :: Word8, maxBound - 1)
 
 genKSD :: QC.Gen (Kcp, Scg, Delta)
 genKSD = sized1 $ \sz -> do
-    d <- QC.choose (0, div sz 4)
+    -- k > 1 so we can ensure an alternative schema loses the density comparison
+    -- without having to deactivate the first active slot
     k <- (+ 2) <$> QC.choose (0, 2 * sz)
     s <- (+ k) <$> QC.choose (0, 3 * sz)   -- ensures @k / s <= 1@
+    d <- QC.choose (0, max 0 $ min (div sz 4) (s-1)) -- ensures @d < s@
     pure (Kcp k, Scg s, Delta d)

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/TestEnv.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/TestEnv.hs
@@ -3,6 +3,7 @@
 -- | A @tasty@ command-line option for enabling nightly tests
 module Test.Util.TestEnv (
     TestEnv (..)
+  , adjustQuickCheckMaxSize
   , adjustQuickCheckTests
   , askTestEnv
   , defaultMainWithTestEnv
@@ -85,3 +86,16 @@ adjustQuickCheckTests :: (Int -> Int) -> TestTree -> TestTree
 adjustQuickCheckTests f =
   adjustOption $ \(QuickCheckTests n) ->
     QuickCheckTests $ if n == 0 then 0 else max 1 (f n)
+
+-- | Locally adjust the maximum size parameter of QuickCheck tests for the given
+-- test subtree, similar to 'adjustQuickCheckTests'.
+--
+-- The size parameter is varied across test runs from 0 to @maxSize - 1@
+-- cyclically, influencing the result of generators that make use of it, like
+-- those that call 'Test.QuickCheck.sized'.
+--
+-- The default is 100.
+adjustQuickCheckMaxSize :: (Int -> Int) -> TestTree -> TestTree
+adjustQuickCheckMaxSize f =
+  adjustOption $ \(QuickCheckMaxSize n) ->
+    QuickCheckMaxSize $ if n == 0 then 0 else max 1 (f n)

--- a/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/ChainGenerator/Tests/Adversarial.hs
+++ b/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/ChainGenerator/Tests/Adversarial.hs
@@ -31,16 +31,19 @@ import qualified Test.Ouroboros.Consensus.ChainGenerator.Slot as S
 import           Test.Ouroboros.Consensus.ChainGenerator.Slot (E (SlotE))
 import qualified Test.Ouroboros.Consensus.ChainGenerator.Some as Some
 import qualified Test.Ouroboros.Consensus.ChainGenerator.Tests.Honest as H
-import qualified Test.QuickCheck as QC
+import qualified Test.QuickCheck as QC hiding (elements)
 import           Test.QuickCheck.Extras (unsafeMapSuchThatJust)
 import           Test.QuickCheck.Random (QCGen)
 import qualified Test.Tasty as TT
 import qualified Test.Tasty.QuickCheck as TT
+import qualified Test.Util.QuickCheck as QC
 
 -----
 
 tests :: [TT.TestTree]
 tests = [
+    TT.testProperty "k+1 blocks after the intersection" prop_kPlus1BlocksAfterIntersection
+  ,
     TT.testProperty "Adversarial chains lose density and race comparisons" prop_adversarialChain
   ,
     TT.localOption (TT.QuickCheckMaxSize 14) $ TT.testProperty "Adversarial chains win if checked with relaxed parameters" prop_adversarialChainMutation
@@ -106,9 +109,9 @@ instance QC.Arbitrary SomeTestAdversarial where
 
         testSeedPrefix <- QC.arbitrary @QCGen
 
-        let arPrefix = genPrefixBlockCount testSeedPrefix arHonest
+        let arPrefix = genPrefixBlockCount kcp testSeedPrefix arHonest
 
-        let H.HonestRecipe kcp scg delta _len = testRecipeH
+            H.HonestRecipe kcp scg delta _len = testRecipeH
 
             testRecipeA = A.AdversarialRecipe {
                 A.arPrefix
@@ -125,6 +128,7 @@ instance QC.Arbitrary SomeTestAdversarial where
                 A.NoSuchAdversarialBlock -> pure Nothing
                 A.NoSuchCompetitor       -> error $ "impossible! " <> show e
                 A.NoSuchIntersection     -> error $ "impossible! " <> show e
+                A.KcpIs1                 -> error $ "impossible! " <> show e
 
             Right testRecipeA' -> do
                 pure $ Just $ SomeTestAdversarial Proxy Proxy $ TestAdversarial {
@@ -142,6 +146,45 @@ instance QC.Arbitrary SomeTestAdversarial where
                   ,
                     testSeedH
                   }
+
+-- | The honest schema has k+1 blocks after the intersection.
+prop_kPlus1BlocksAfterIntersection :: SomeTestAdversarial -> QCGen -> QC.Property
+prop_kPlus1BlocksAfterIntersection someTestAdversarial testSeedA = runIdentity $ do
+    SomeTestAdversarial Proxy Proxy TestAdversarial {
+        testAscA
+      ,
+        testRecipeA
+      ,
+        testRecipeA'
+      } <- pure someTestAdversarial
+    A.SomeCheckedAdversarialRecipe Proxy recipeA' <- pure testRecipeA'
+
+    let A.AdversarialRecipe { A.arHonest = schedH } = testRecipeA
+        schedA = A.uniformAdversarialChain (Just testAscA) recipeA' testSeedA
+        H.ChainSchema winA _vA = schedA
+        H.ChainSchema _winH vH = schedH
+        A.AdversarialRecipe { A.arParams = (Kcp k, scg, _delta) } = testRecipeA
+
+    C.SomeWindow Proxy stabWin <- do
+        pure $ calculateStability scg schedA
+
+    pure $
+      QC.counterexample (unlines $
+                            H.prettyChainSchema schedH "H"
+                            ++ H.prettyChainSchema schedA "A"
+                          )
+      $ QC.counterexample ("arPrefix = " <> show (A.arPrefix testRecipeA))
+      $ QC.counterexample ("stabWin  = " <> show stabWin)
+      $ QC.counterexample ("stabWin' = " <> show (C.joinWin winA stabWin))
+      $ QC.counterexample ("The honest chain should have k+1 blocks after the intersection")
+          (BV.countActivesInV S.notInverted vH
+            `QC.ge` C.toSize (C.Count (k + 1) + A.arPrefix testRecipeA)
+          )
+-- TODO: uncomment this after ensuring the same for the alternative schema
+--        QC..&&.
+--        QC.counterexample ("The alternative chain should have k+1 blocks after the intersection")
+--          (BV.countActivesInV S.notInverted vA `QC.ge` C.Count (k + 1))
+
 
 -- | No seed exists such that each 'A.checkAdversarialChain' rejects the result of 'A.uniformAdversarialChain'
 prop_adversarialChain :: SomeTestAdversarial -> QCGen -> QC.Property
@@ -308,7 +351,7 @@ instance QC.Arbitrary SomeTestAdversarialMutation where
 
             testSeedPrefix <- QC.arbitrary @QCGen
 
-            let arPrefix = genPrefixBlockCount testSeedPrefix arHonest
+            let arPrefix = genPrefixBlockCount kcp testSeedPrefix arHonest
 
             let recipeA = A.AdversarialRecipe {
                     A.arPrefix
@@ -323,6 +366,7 @@ instance QC.Arbitrary SomeTestAdversarialMutation where
                     A.NoSuchAdversarialBlock -> Nothing
                     A.NoSuchCompetitor       -> error $ "impossible! " <> show e
                     A.NoSuchIntersection     -> error $ "impossible! " <> show e
+                    A.KcpIs1                 -> error $ "impossible! " <> show e
 
                 Right recipeA' -> case Exn.runExcept $ A.checkAdversarialRecipe $ mutateAdversarial recipeA mut of
                     Left{} -> Nothing

--- a/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/ChainGenerator/Tests/Adversarial.hs
+++ b/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/ChainGenerator/Tests/Adversarial.hs
@@ -25,15 +25,14 @@ import qualified Test.Ouroboros.Consensus.ChainGenerator.BitVector as BV
 import qualified Test.Ouroboros.Consensus.ChainGenerator.Counting as C
 import qualified Test.Ouroboros.Consensus.ChainGenerator.Honest as H
 import           Test.Ouroboros.Consensus.ChainGenerator.Params (Asc,
-                     Delta (Delta), Kcp (Kcp), Len (Len), Scg (Scg), genAsc,
-                     genKSD)
+                     Delta (Delta), Kcp (Kcp), Len (Len), Scg (Scg), genAsc)
 import qualified Test.Ouroboros.Consensus.ChainGenerator.RaceIterator as RI
 import qualified Test.Ouroboros.Consensus.ChainGenerator.Slot as S
 import           Test.Ouroboros.Consensus.ChainGenerator.Slot (E (SlotE))
 import qualified Test.Ouroboros.Consensus.ChainGenerator.Some as Some
 import qualified Test.Ouroboros.Consensus.ChainGenerator.Tests.Honest as H
 import qualified Test.QuickCheck as QC
-import           Test.QuickCheck.Extras (sized1, unsafeMapSuchThatJust)
+import           Test.QuickCheck.Extras (unsafeMapSuchThatJust)
 import           Test.QuickCheck.Random (QCGen)
 import qualified Test.Tasty as TT
 import qualified Test.Tasty.QuickCheck as TT
@@ -42,9 +41,9 @@ import qualified Test.Tasty.QuickCheck as TT
 
 tests :: [TT.TestTree]
 tests = [
-    TT.testProperty "prop_adversarialChain" prop_adversarialChain
+    TT.testProperty "Adversarial chains lose density and race comparisons" prop_adversarialChain
   ,
-    TT.localOption (TT.QuickCheckMaxSize 14) $ TT.testProperty "prop_adversarialChainMutation" prop_adversarialChainMutation
+    TT.localOption (TT.QuickCheckMaxSize 14) $ TT.testProperty "Adversarial chains win if checked with relaxed parameters" prop_adversarialChainMutation
   ]
 
 -----
@@ -295,14 +294,7 @@ instance QC.Arbitrary SomeTestAdversarialMutation where
     arbitrary = do
         mut <- QC.elements [minBound .. maxBound :: AdversarialMutation]
         unsafeMapSuchThatJust $ do
-            (kcp, scg, delta, len) <- sized1 $ \sz -> do
-                (kcp, Scg s, delta) <- genKSD
-
-                l <- (+ s) <$> QC.choose (0, 5 * sz)
-
-                pure (kcp, Scg s, delta, Len l)
-
-            let recipeH = H.HonestRecipe kcp scg delta len
+            recipeH@(H.HonestRecipe kcp scg delta len) <- H.genHonestRecipe
 
             someTestRecipeH' <- case Exn.runExcept $ H.checkHonestRecipe recipeH of
                 Left e  -> error $ "impossible! " <> show (recipeH, e)


### PR DESCRIPTION
This PR allows to prune a suffix of the schedule of the honest peer and still get a valid input.