### PR TITLE
Ensure lower density in adversarial schemas

### DIFF
--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Consensus/ChainGenerator/Adversarial.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Consensus/ChainGenerator/Adversarial.hs
@@ -678,11 +678,11 @@ uniformAdversarialChain mbAsc recipe g0 = wrap $ C.createV $ do
         -- intersection.
         stablePrefixWindowsContaining w =
           let
-            stableSlotsAfterIntersection =
-              min s (C.getCount (C.lengthMV mv) - C.getCount (C.windowStart w))
-            n = stableSlotsAfterIntersection - C.getCount (C.windowSize w)
-          in
-            take n $ drop 1 $ iterate increaseSizeW w
+            start = C.windowStart w
+            size  = C.getCount (C.windowSize w)
+            end   = s `min` C.getCount (C.lengthMV mv)
+           in
+            [ C.UnsafeContains start (C.Count size') | size' <- [ size+1 .. end ] ]
 
         -- Updates mv to ensure the density of the adversarial schema is lower
         -- than the density of the honest schema in @increaseSizeW w@.
@@ -707,10 +707,6 @@ uniformAdversarialChain mbAsc recipe g0 = wrap $ C.createV $ do
                 pure ac'
 
           return (hc', ac'')
-
-    -- | Increase the size of a window by one slot
-    increaseSizeW (C.UnsafeContains start size) =
-        C.UnsafeContains start (size C.+ 1)
 
     -- | Ensure the density of the adversarial schema is less than the density
     -- of the honest schema in the given window.

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Consensus/ChainGenerator/Adversarial.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Consensus/ChainGenerator/Adversarial.hs
@@ -287,7 +287,7 @@ checkAdversarialChain recipe adv = do
           -- window after the intersection
           hwSum = Vector.toList $ Vector.drop (C.getCount $ C.windowSize w0') $ Vector.take (s + 1) hSum
           awSum = Vector.toList $ Vector.drop (C.getCount $ C.windowSize w0') $ Vector.take (s + 1) aSum
-        case filter (\(x, y) -> x < y) (zip hwSum awSum) of
+        case filter (\(x, y) -> x <= y) (zip hwSum awSum) of
           []         -> pure ()
           ((x, y):_) -> Exn.throwError $ BadDensity x y
 

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Consensus/ChainGenerator/Adversarial.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Consensus/ChainGenerator/Adversarial.hs
@@ -265,7 +265,7 @@ checkAdversarialChain recipe adv = do
           winHAfterIntersection =
               C.UnsafeContains
                   (fromJust $ C.toWindow winH $ C.windowStart winA)
-                  (C.Count $ C.getCount (C.windowSize winA))
+                  (C.windowSize winA)
           -- honest schema after the intersection
           vHAfterIntersection = C.sliceV winHAfterIntersection vH
           iterH :: RI.Race adv

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Consensus/ChainGenerator/Adversarial.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Consensus/ChainGenerator/Adversarial.hs
@@ -277,7 +277,7 @@ checkAdversarialChain recipe adv = do
         C.SomeWindow pw0 w0 <- let RI.Race x = iterH in pure x
 
         let
-          w0' = C.UnsafeContains (C.windowStart w0) (min (C.Count s) (C.windowSize w0))
+          w0' = C.truncateWin w0 (C.Count s)
           vvH = C.getVector vHAfterIntersection
           vvA = C.getVector vA
           -- cumulative sums of active slots per slot after the intersection
@@ -660,7 +660,7 @@ uniformAdversarialChain mbAsc recipe g0 = wrap $ C.createV $ do
         let
           -- A window after the intersection as short as the shortest of the
           -- stability window or the first race to the k+1st block.
-          w0' = C.UnsafeContains (C.windowStart w0) (min (C.Count s) (C.windowSize w0))
+          w0' = C.truncateWin w0 (C.Count s)
           hCount = C.toVar $ BV.countActivesInV S.notInverted (C.sliceV w0' vA)
 
         aCount <- ensureLowerDensityInWindow w0' g mv hCount

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Consensus/ChainGenerator/Adversarial.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Consensus/ChainGenerator/Adversarial.hs
@@ -697,13 +697,13 @@ uniformAdversarialChain mbAsc recipe g0 = wrap $ C.createV $ do
     ensureLowerDensityInWindow w g mv hCount = do
         let emptyCountTarget = C.toVar $ S.complementActive S.notInverted (C.windowSize w) hCount C.+ 1
 
-        ec <- BV.fillInWindow
+        emptyCount <- BV.fillInWindow
             S.inverted
             (BV.SomeDensityWindow emptyCountTarget (C.windowSize w))
             g
             (C.sliceMV w mv)
 
-        pure $ C.toVar $ S.complementActive S.inverted (C.windowSize w) ec
+        pure $ C.toVar $ S.complementActive S.inverted (C.windowSize w) emptyCount
 
 
 -- | The youngest stable slot

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Consensus/ChainGenerator/Adversarial.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Consensus/ChainGenerator/Adversarial.hs
@@ -262,12 +262,12 @@ checkAdversarialChain recipe adv = do
     checkDensity = do
         let
           -- window of the honest schema after the intersection
-          winHAfterIntersection =
+          carWin =
               C.UnsafeContains
                   (fromJust $ C.toWindow winH $ C.windowStart winA)
                   (C.windowSize winA)
           -- honest schema after the intersection
-          vHAfterIntersection = C.sliceV winHAfterIntersection vH
+          vHAfterIntersection = C.sliceV carWin vH
           iterH :: RI.Race adv
           iterH =
               maybe (RI.initConservative vHAfterIntersection) id

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Consensus/ChainGenerator/Adversarial.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Consensus/ChainGenerator/Adversarial.hs
@@ -513,6 +513,9 @@ uniformAdversarialChain mbAsc recipe g0 = wrap $ C.createV $ do
 
     ensureLowerDensityInWindows iterH g mv
 
+    -- While densities are lower in the adversarial schema, the adversarial
+    -- schema could still win races to the k+1st block by less than 1+delta
+    -- slots. Therefore, we call @unfillRaces@ to deactivate further slots.
     unfillRaces kPlus1st (C.Count 0) UnknownYS iterH g mv
 
     pure mv

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Consensus/ChainGenerator/Adversarial.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Consensus/ChainGenerator/Adversarial.hs
@@ -255,7 +255,7 @@ checkAdversarialChain recipe adv = do
 
     -- | Check that the density of the adversarial schema is less than the
     -- density of the honest schema in the first stability window after the
-    -- intersection and in any subwindow that contains the first race to the
+    -- intersection and in any prefix that contains the first race to the
     -- k+1st block.
     --
     -- See description of @ensureLowerDensityInWindows@
@@ -629,9 +629,9 @@ uniformAdversarialChain mbAsc recipe g0 = wrap $ C.createV $ do
 
     -- | Ensure the density of the adversarial schema is less than the density
     -- of the honest schema in the first stability window after the intersection
-    -- and in any subwindow that contains the first race to the k+1st block.
+    -- and in any prefix window that contains the first race to the k+1st block.
     --
-    -- Ensuring lower density of the subwindows is necessary to avoid chains like
+    -- Ensuring lower density of the prefix windows is necessary to avoid chains like
     --
     -- > k: 3
     -- > s: 9

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Consensus/ChainGenerator/Counting.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Consensus/ChainGenerator/Counting.hs
@@ -39,6 +39,7 @@ module Test.Ouroboros.Consensus.ChainGenerator.Counting (
   , joinWin
   , toWindow
   , toWindowVar
+  , truncateWin
   , windowLast
   , windowSize
   , windowStart
@@ -224,6 +225,9 @@ windowStart win = fromWindow win (Count 0)
 
 windowLast :: Contains elem outer inner -> Index outer elem
 windowLast win = fromWindow win $ lastIndex $ windowSize win
+
+truncateWin :: Contains elem outer inner -> Size inner elem -> Contains elem outer inner
+truncateWin (UnsafeContains start len) x = UnsafeContains start (min len x)
 
 -- | 'Contains' is a 'Data.Semigroupoid.Semigroupoid'
 joinWin :: Contains elem outer mid -> Contains elem mid inner -> Contains elem outer inner


### PR DESCRIPTION
This commit ensures lower density in the first stability window after the intersection, and in any other subwindow that extends the first race window after the intersection.

Ensuring lower density of the subwindows is necessary to avoid chains like
```
k: 3
s: 9
H: 0111100
A: 1110011
```
where the honest chain wins the race to the k+1st block, might win the density comparison if the chains are extended to include a full stability window after the intersection, but loses the density comparison if the chains aren't extended.                                                                                                                                                                

For the sake of shrinking test inputs, we also prevent the above scenario to occur in any intersection, not just the intersections near the end of the chains.