### PR TITLE
Full-table shrinking

### DIFF
--- a/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
+++ b/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
@@ -239,6 +239,7 @@ test-suite consensus-test
     Test.Consensus.PointSchedule.SinglePeer
     Test.Consensus.PointSchedule.SinglePeer.Indices
     Test.Consensus.PointSchedule.Tests
+    Test.Consensus.PointSchedule.Tests.FullTable
     Test.Util.TersePrinting
 
   build-depends:

--- a/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
+++ b/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
@@ -233,6 +233,7 @@ test-suite consensus-test
     Test.Consensus.PeerSimulator.Tests.Timeouts
     Test.Consensus.PeerSimulator.Trace
     Test.Consensus.PointSchedule
+    Test.Consensus.PointSchedule.FullTable
     Test.Consensus.PointSchedule.Peers
     Test.Consensus.PointSchedule.SinglePeer
     Test.Consensus.PointSchedule.SinglePeer.Indices

--- a/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
+++ b/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
@@ -235,6 +235,7 @@ test-suite consensus-test
     Test.Consensus.PointSchedule
     Test.Consensus.PointSchedule.FullTable
     Test.Consensus.PointSchedule.Peers
+    Test.Consensus.PointSchedule.Shrinking
     Test.Consensus.PointSchedule.SinglePeer
     Test.Consensus.PointSchedule.SinglePeer.Indices
     Test.Consensus.PointSchedule.Tests

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LongRangeAttack.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LongRangeAttack.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DerivingStrategies  #-}
 {-# LANGUAGE NamedFieldPuns      #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections       #-}
 
 module Test.Consensus.Genesis.Tests.LongRangeAttack (tests) where
 
@@ -14,6 +15,8 @@ import           Test.Consensus.Genesis.Setup.Classifiers
 import           Test.Consensus.PeerSimulator.Run (noTimeoutsSchedulerConfig)
 import           Test.Consensus.PeerSimulator.StateView
 import           Test.Consensus.PointSchedule
+import           Test.Consensus.PointSchedule.Shrinking
+                     (shrinkFullTableExceptLast, shrinkViaFullTable)
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
 import           Test.Util.Orphans.IOLike ()
@@ -39,7 +42,7 @@ prop_longRangeAttack =
 
     (noTimeoutsSchedulerConfig defaultPointScheduleConfig)
 
-    (\_ _ _ -> [])
+    (\gt ps _ -> map (gt,) (shrinkViaFullTable shrinkFullTableExceptLast ps))
 
     -- NOTE: This is the expected behaviour of Praos to be reversed with
     -- Genesis. But we are testing Praos for the moment

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DerivingStrategies  #-}
 {-# LANGUAGE NamedFieldPuns      #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections       #-}
 
 module Test.Consensus.PeerSimulator.Tests.Rollback (tests) where
 
@@ -14,6 +15,8 @@ import           Test.Consensus.PeerSimulator.Run (noTimeoutsSchedulerConfig)
 import           Test.Consensus.PeerSimulator.StateView
 import           Test.Consensus.PointSchedule
 import           Test.Consensus.PointSchedule.Peers (peersOnlyHonest)
+import           Test.Consensus.PointSchedule.Shrinking
+                     (shrinkFullTableExceptLast, shrinkViaFullTable)
 import           Test.QuickCheck
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
@@ -45,7 +48,7 @@ prop_rollback = do
 
     (noTimeoutsSchedulerConfig defaultPointScheduleConfig)
 
-    (\_ _ _ -> [])
+    (\gt ps _ -> map (gt,) (shrinkViaFullTable shrinkFullTableExceptLast ps))
 
     (\_ _ -> not . hashOnTrunk . AF.headHash . svSelectedChain)
 
@@ -63,7 +66,7 @@ prop_cannotRollback =
 
     (noTimeoutsSchedulerConfig defaultPointScheduleConfig)
 
-    (\_ _ _ -> [])
+    (\gt ps _ -> map (gt,) (shrinkViaFullTable shrinkFullTableExceptLast ps))
 
     (\_ _ -> hashOnTrunk . AF.headHash . svSelectedChain)
 

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
@@ -68,7 +68,7 @@ prop_timeouts = do
           headerPoint = HeaderPoint $ At (getHeader tipBlock)
           blockPoint = BlockPoint (At tipBlock)
           state = Peer HonestPeer $ NodeOnline $ AdvertisedPoints tipPoint headerPoint blockPoint
-          tick = Tick { active = state, duration = pscTickDuration scheduleConfig, number = 0 }
+          tick = Tick { active = state, duration = pscTickDuration scheduleConfig }
           maximumNumberOfTicks = round $ timeout / pscTickDuration scheduleConfig
       in
       PointSchedule (tick :| replicate maximumNumberOfTicks tick) (HonestPeer :| [])

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
@@ -179,6 +179,7 @@ data Tick =
     active   :: Peer NodeState,
     -- | The duration of this tick, for the scheduler to pass to @threadDelay@.
     duration :: DiffTime,
+    -- | The number of this tick, starting at @0@.
     number   :: Word
   }
   deriving (Eq, Show)

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/FullTable.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/FullTable.hs
@@ -1,15 +1,22 @@
+{-# LANGUAGE NamedFieldPuns #-}
+
 -- | A 'full table' point schedule is a point schedule that shows the state of
 -- all the peers at each tick with absolute times.
 
 module Test.Consensus.PointSchedule.FullTable (
     FullTablePointSchedule (..)
   , FullTableRow (..)
+  , fullTableFromActivePointSchedule
   ) where
 
-import           Control.Monad.Class.MonadTime.SI (Time)
-import           Data.List.NonEmpty (NonEmpty)
-import           Test.Consensus.PointSchedule (NodeState (..))
-import           Test.Consensus.PointSchedule.Peers (PeerId (..), Peers (..))
+import           Control.Monad.Class.MonadTime.SI (Time (Time), addTime)
+import           Data.List.NonEmpty (NonEmpty ((:|)))
+import qualified Data.List.NonEmpty as NonEmpty
+import qualified Data.Map.Strict as Map
+import           Test.Consensus.PointSchedule (NodeState (..),
+                     PointSchedule (..), Tick (..))
+import           Test.Consensus.PointSchedule.Peers (Peer (..), PeerId (..),
+                     Peers (..), peersFromPeerIdList, peersList)
 
 -- | A row in a full-table point schedule. It contains states for all peers and
 -- an absolute time at which this state starts holding.
@@ -25,3 +32,38 @@ data FullTablePointSchedule = FullTablePointSchedule {
     ftpsPeerIds :: NonEmpty PeerId
   }
   deriving (Show, Eq)
+
+-- | Transform a regular “active” 'PointSchedule' into its full table equivalent.
+fullTableFromActivePointSchedule :: PointSchedule -> FullTablePointSchedule
+fullTableFromActivePointSchedule PointSchedule{ticks, peerIds} =
+    FullTablePointSchedule {
+      ftpsRows = go (Time 0) beginningOfTimeRow [] (NonEmpty.toList ticks),
+      ftpsPeerIds = peerIds
+    }
+  where
+    -- | A row where time is @0@ and where all peers are offline.
+    beginningOfTimeRow = FullTableRow (peersFromPeerIdList peerIds NodeOffline) (Time 0)
+
+    -- | Helper to process all the ticks and turn them into 'FullTableRow's. We
+    -- keep the last constructed row apart from the others because we merge
+    -- zero-duration ticks into it. We have to be careful with time because
+    -- 'PointSchedule' ticks carry durations while our rows carry absolute time
+    -- where a row starts being relevant.
+    go :: Time -> FullTableRow -> [FullTableRow] -> [Tick] -> NonEmpty FullTableRow
+    go _ row rows [] = NonEmpty.reverse (row :| rows)
+    go time row@FullTableRow{ftrStates, ftrTime} rows (Tick{active, duration} : otherTicks) =
+      let states' = updatePeer active ftrStates
+          time' = addTime duration time
+          rows' = if time == ftrTime || isDummyBeginningOfTime row then rows else row : rows
+       in go time' (FullTableRow states' time) rows' otherTicks
+
+    -- | Update a 'Peers' structure given a 'Peer'.
+    updatePeer :: Peer a -> Peers a -> Peers a
+    updatePeer peer@(Peer HonestPeer _) peers = peers { honest = peer }
+    updatePeer peer@(Peer peerId _) peers = peers { others = Map.insert peerId peer (others peers) }
+
+    -- | If it is a row at time 0 and with all nodes offline, then it is just a
+    -- dummy which can be safely ignored.
+    isDummyBeginningOfTime FullTableRow{ftrStates, ftrTime} =
+      ftrTime == Time 0 &&
+        all (\(Peer _ s) -> s == NodeOffline) (NonEmpty.toList (peersList ftrStates))

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/FullTable.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/FullTable.hs
@@ -19,8 +19,7 @@ import qualified Data.Map.Strict as Map
 import           Test.Consensus.PointSchedule (NodeState (..),
                      PointSchedule (..), Tick (..))
 import           Test.Consensus.PointSchedule.Peers (Peer (..), PeerId (..),
-                     Peers (..), peerValue, peersFromPeerIdList, peersList,
-                     toMap)
+                     Peers (..), peersFromPeerIdList, peersList, toMap)
 
 -- | A row in a full-table point schedule. It contains states for all peers and
 -- an absolute time at which this state starts holding.
@@ -97,7 +96,7 @@ activeFromFullTablePointSchedule FullTablePointSchedule{ftpsRows, ftpsPeerIds} =
         [] -> go (states, time) active ticks rows
         updatedPeer : otherUpdatedPeers ->
           let tick = Tick active (diffTime time' time)
-              ticks' = if duration tick == 0 && peerValue active == NodeOffline then ticks else tick : ticks
+              ticks' = if duration tick == 0 && value active == NodeOffline then ticks else tick : ticks
               zeroDurationTicks = map (\peer -> Tick peer 0) otherUpdatedPeers
            in go (states', time') updatedPeer (zeroDurationTicks ++ ticks') rows
 

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/FullTable.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/FullTable.hs
@@ -1,0 +1,27 @@
+-- | A 'full table' point schedule is a point schedule that shows the state of
+-- all the peers at each tick with absolute times.
+
+module Test.Consensus.PointSchedule.FullTable (
+    FullTablePointSchedule (..)
+  , FullTableRow (..)
+  ) where
+
+import           Control.Monad.Class.MonadTime.SI (Time)
+import           Data.List.NonEmpty (NonEmpty)
+import           Test.Consensus.PointSchedule (NodeState (..))
+import           Test.Consensus.PointSchedule.Peers (PeerId (..), Peers (..))
+
+-- | A row in a full-table point schedule. It contains states for all peers and
+-- an absolute time at which this state starts holding.
+data FullTableRow = FullTableRow {
+    ftrStates :: Peers NodeState,
+    ftrTime   :: Time
+  }
+  deriving (Show, Eq)
+
+-- | A full-table point schedule is a (non-empty) list of 'FullTableRow's.
+data FullTablePointSchedule = FullTablePointSchedule {
+    ftpsRows    :: NonEmpty FullTableRow,
+    ftpsPeerIds :: NonEmpty PeerId
+  }
+  deriving (Show, Eq)

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Peers.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Peers.hs
@@ -19,6 +19,7 @@ module Test.Consensus.PointSchedule.Peers (
   , getPeerIds
   , mkPeers
   , mkPeers'
+  , peerValue
   , peersFromPeerIdList
   , peersFromPeerIdList'
   , peersFromPeerList
@@ -75,6 +76,9 @@ instance Traversable Peer where
 
 instance Condense a => Condense (Peer a) where
   condense Peer {name, value} = condense name ++ ": " ++ condense value
+
+peerValue :: Peer a -> a
+peerValue (Peer _ x) = x
 
 -- | General-purpose functor for a set of peers.
 --

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Peers.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Peers.hs
@@ -171,10 +171,13 @@ toMap' :: Peers a -> Map PeerId a
 toMap' = fmap (\(Peer _ v) -> v) . toMap
 
 fromMap :: Map PeerId (Peer a) -> Peers a
-fromMap peers = Peers{
-    honest = peers Map.! HonestPeer,
-    others = Map.delete HonestPeer peers
-  }
+fromMap peers =
+  case Map.lookup HonestPeer peers of
+    Nothing -> error "Peers.fromMap: missing HonestPeer"
+    Just honestPeer -> Peers {
+      honest = honestPeer,
+      others = Map.delete HonestPeer peers
+      }
 
 -- | Same as 'fromMap' but the map contains unwrapped values.
 fromMap' :: Map PeerId a -> Peers a

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Peers.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Peers.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveFoldable        #-}
 {-# LANGUAGE DeriveGeneric         #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE FlexibleContexts      #-}
@@ -92,10 +93,14 @@ data Peers a =
     honest :: Peer a,
     others :: Map PeerId (Peer a)
   }
-  deriving (Eq, Show)
+  deriving (Eq, Show, Foldable)
 
 instance Functor Peers where
   fmap f Peers {honest, others} = Peers {honest = f <$> honest, others = fmap f <$> others}
+
+instance Traversable Peers where
+  sequenceA (Peers{honest, others}) =
+    (Peers <$> sequenceA honest) <*> traverse sequenceA others
 
 -- | A set of peers with only one honest peer carrying the given value.
 peersOnlyHonest :: a -> Peers a

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Peers.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Peers.hs
@@ -20,7 +20,6 @@ module Test.Consensus.PointSchedule.Peers (
   , getPeerIds
   , mkPeers
   , mkPeers'
-  , peerValue
   , peersFromPeerIdList
   , peersFromPeerIdList'
   , peersFromPeerList
@@ -77,9 +76,6 @@ instance Traversable Peer where
 
 instance Condense a => Condense (Peer a) where
   condense Peer {name, value} = condense name ++ ": " ++ condense value
-
-peerValue :: Peer a -> a
-peerValue (Peer _ x) = x
 
 -- | General-purpose functor for a set of peers.
 --

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Shrinking.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Shrinking.hs
@@ -41,7 +41,9 @@ shrinkViaFullTable shrinkFullTable ps@PointSchedule{ticks} =
 shrinkFullTableExceptLast :: FullTablePointSchedule -> [FullTablePointSchedule]
 shrinkFullTableExceptLast FullTablePointSchedule{ftpsRows, ftpsPeerIds} =
     let (rows, lastRow) = nonEmptyUnsnoc ftpsRows
-     in map (flip FullTablePointSchedule ftpsPeerIds . NonEmpty.fromList . (++ [lastRow])) (shrinkList (const []) rows)
+     in [ FullTablePointSchedule (NonEmpty.fromList (rows' ++ [lastRow])) ftpsPeerIds
+        | rows' <- shrinkList (const []) rows
+        ]
   where
     nonEmptyUnsnoc :: NonEmpty a -> ([a], a)
     nonEmptyUnsnoc = unsnoc . NonEmpty.toList

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Shrinking.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Shrinking.hs
@@ -40,13 +40,13 @@ shrinkViaFullTable shrinkFullTable ps@PointSchedule{ticks} =
 -- the peers, which makes it a safe “blind” shrinker.
 shrinkFullTableExceptLast :: FullTablePointSchedule -> [FullTablePointSchedule]
 shrinkFullTableExceptLast FullTablePointSchedule{ftpsRows, ftpsPeerIds} =
-    let (rows, lastRow) = extractLast ftpsRows
+    let (rows, lastRow) = nonEmptyUnsnoc ftpsRows
      in map (flip FullTablePointSchedule ftpsPeerIds . NonEmpty.fromList . (++ [lastRow])) (shrinkList (const []) rows)
   where
-    extractLast :: NonEmpty a -> ([a], a)
-    extractLast = go . NonEmpty.toList
+    nonEmptyUnsnoc :: NonEmpty a -> ([a], a)
+    nonEmptyUnsnoc = unsnoc . NonEmpty.toList
       where
-        go :: [a] -> ([a], a)
-        go []       = error "extractLast"
-        go [x]      = ([], x)
-        go (x : xs) = first (x :) (go xs)
+        unsnoc :: [a] -> ([a], a)
+        unsnoc []       = error "nonEmptyUnsnoc"
+        unsnoc [x]      = ([], x)
+        unsnoc (x : xs) = first (x :) (unsnoc xs)

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Shrinking.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Shrinking.hs
@@ -1,0 +1,52 @@
+{-# LANGUAGE NamedFieldPuns #-}
+
+-- | This module contains all kind of utilities related to shrinking point
+-- schedules. Some function allow shrinking generically while other require the
+-- properties to be written in a specific way. Be sure to read the documentation
+-- of the shrinking function that you use.
+
+module Test.Consensus.PointSchedule.Shrinking (
+    shrinkFullTableExceptLast
+  , shrinkViaFullTable
+  ) where
+
+import           Data.Bifunctor (first)
+import           Data.Function ((&))
+import           Data.List.NonEmpty (NonEmpty)
+import qualified Data.List.NonEmpty as NonEmpty
+import           Test.Consensus.PointSchedule (PointSchedule (..))
+import           Test.Consensus.PointSchedule.FullTable
+                     (FullTablePointSchedule (..),
+                     activeFromFullTablePointSchedule,
+                     fullTableFromActivePointSchedule)
+import           Test.QuickCheck (shrinkList)
+
+-- | Shrink a 'PointSchedule' by transforming it into a
+-- 'FullTablePointSchedule', shrinking that full-table point schedule, and
+-- transforming it back.
+shrinkViaFullTable ::
+  (FullTablePointSchedule -> [FullTablePointSchedule]) ->
+  PointSchedule ->
+  [PointSchedule]
+shrinkViaFullTable shrinkFullTable ps@PointSchedule{ticks} =
+    ps
+      & fullTableFromActivePointSchedule
+      & shrinkFullTable
+      & map activeFromFullTablePointSchedule
+      & filter (\PointSchedule{ticks=ticks'} -> length ticks' < length ticks)
+
+-- | Shrink a full-table point schedule randomly except for the last line that
+-- has to be constant. Keeping the last line guarantees the same final state of
+-- the peers, which makes it a safe “blind” shrinker.
+shrinkFullTableExceptLast :: FullTablePointSchedule -> [FullTablePointSchedule]
+shrinkFullTableExceptLast FullTablePointSchedule{ftpsRows, ftpsPeerIds} =
+    let (rows, lastRow) = extractLast ftpsRows
+     in map (flip FullTablePointSchedule ftpsPeerIds . NonEmpty.fromList . (++ [lastRow])) (shrinkList (const []) rows)
+  where
+    extractLast :: NonEmpty a -> ([a], a)
+    extractLast = go . NonEmpty.toList
+      where
+        go :: [a] -> ([a], a)
+        go []       = error "extractLast"
+        go [x]      = ([], x)
+        go (x : xs) = first (x :) (go xs)

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Tests.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Tests.hs
@@ -20,6 +20,7 @@ import           Ouroboros.Network.Block (blockHash)
 import           System.Random.Stateful (runSTGen_)
 import           Test.Consensus.PointSchedule.SinglePeer
 import           Test.Consensus.PointSchedule.SinglePeer.Indices
+import qualified Test.Consensus.PointSchedule.Tests.FullTable as FullTableTests
 import qualified Test.QuickCheck as QC hiding (elements)
 import           Test.QuickCheck
 import           Test.QuickCheck.Random
@@ -30,18 +31,19 @@ import           Test.Util.TestBlock (TestBlock, TestHash (unTestHash),
                      firstBlock, modifyFork, successorBlock, tbSlot)
 import           Test.Util.TestEnv
 
-
 tests :: TestTree
-tests =
-    adjustQuickCheckTests (* 100) $
+tests = testGroup "PointSchedule"
+  [ FullTableTests.tests
+  , adjustQuickCheckTests (* 100) $
     adjustOption (\(QuickCheckMaxSize n) -> QuickCheckMaxSize (n `div` 10)) $
-    testGroup "PointSchedule"
+    testGroup "SinglePeer"
       [ testProperty "zipMany" prop_zipMany
       , testProperty "singleJumpTipPoints" prop_singleJumpTipPoints
       , testProperty "tipPointSchedule" prop_tipPointSchedule
       , testProperty "headerPointSchedule" prop_headerPointSchedule
       , testProperty "peerScheduleFromTipPoints" prop_peerScheduleFromTipPoints
       ]
+  ]
 
 prop_zipMany :: [[Int]] -> QC.Property
 prop_zipMany xss =

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Tests/FullTable.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Tests/FullTable.hs
@@ -1,0 +1,314 @@
+{-# LANGUAGE FlexibleInstances  #-}
+{-# LANGUAGE NamedFieldPuns     #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE PatternSynonyms    #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Test.Consensus.PointSchedule.Tests.FullTable (tests) where
+
+import           Cardano.Slotting.Slot (SlotNo (..), WithOrigin (..))
+import           Control.Monad.Class.MonadTime.SI (DiffTime, Time (Time))
+import           Data.Bifunctor (first)
+import           Data.Functor ((<&>))
+import           Data.List (sortOn)
+import           Data.List.NonEmpty (NonEmpty ((:|)), fromList, nonEmpty,
+                     toList)
+import qualified Data.List.NonEmpty as NonEmpty
+import           Data.Map.Strict ((!))
+import qualified Data.Map.Strict as Map
+import           Data.Maybe (maybeToList)
+import           Data.Time.Clock (picosecondsToDiffTime)
+import           Ouroboros.Consensus.Block (HasHeader)
+import           Ouroboros.Network.Block (Tip (..), tipFromHeader)
+import           Test.Consensus.PointSchedule (AdvertisedPoints (..),
+                     BlockPoint (BlockPoint), HeaderPoint (HeaderPoint),
+                     NodeState (..), PointSchedule (..), Tick (..),
+                     TipPoint (TipPoint))
+import           Test.Consensus.PointSchedule.FullTable
+                     (FullTablePointSchedule (..), FullTableRow (..),
+                     activeFromFullTablePointSchedule,
+                     fullTableFromActivePointSchedule)
+import           Test.Consensus.PointSchedule.Peers (Peer (..), PeerId (..),
+                     Peers (..), peersFromPeerIdList')
+import           Test.QuickCheck (Arbitrary (arbitrary, shrink), Gen, Property,
+                     chooseInteger, counterexample, elements, forAllShrink,
+                     frequency, listOf, listOf1, shrinkList, suchThat)
+import           Test.Tasty (TestTree, testGroup)
+import           Test.Tasty.QuickCheck (testProperty)
+import           Test.Util.TestBlock (Header (TestHeader), TestBlock,
+                     TestBlockWith, TestHash, Validity (Valid),
+                     pattern TestHash, unsafeBlockWithPayload)
+import           Test.Util.TestEnv (adjustQuickCheckTests)
+
+tests :: TestTree
+tests = testGroup "FullTable" [
+    adjustQuickCheckTests (`div` 5) $
+    testProperty
+      "roundtrip: full-table -> active -> full-table"
+      prop_roundtripFromFullTable
+    ,
+    adjustQuickCheckTests (* 4) $
+    testProperty
+      "roundtrip: active -> full-table -> active"
+      prop_roundtripFromActive
+   ]
+
+--------------------------------------------------------------------------------
+-- Properties
+--------------------------------------------------------------------------------
+
+prop_roundtripFromFullTable :: Property
+prop_roundtripFromFullTable =
+  forAllShrink genFullTablePointSchedule shrinkFullTablePointSchedule $ \ps1 ->
+    let ps2 = activeFromFullTablePointSchedule ps1
+        ps3 = fullTableFromActivePointSchedule ps2
+     in counterexample ("Input:  " ++ show ps1) $
+        counterexample ("Output: " ++ show ps3) $
+        counterexample ("Intermediary: " ++ show ps2) $
+        ps1 == ps3
+
+prop_roundtripFromActive :: Property
+prop_roundtripFromActive =
+  forAllShrink genActivePointSchedule shrinkActivePointSchedule $ \ps1 ->
+    let ps2 = fullTableFromActivePointSchedule ps1
+        ps3 = activeFromFullTablePointSchedule ps2
+     in counterexample ("Input:  " ++ show ps1) $
+        counterexample ("Output: " ++ show ps3) $
+        counterexample ("Intermediary: " ++ show ps2) $
+        ps1 == ps3
+
+--------------------------------------------------------------------------------
+-- High-level generation/shrinking of full-table point schedules
+--------------------------------------------------------------------------------
+
+-- | Generator for the first row of a full-table point schedule, given a list of
+-- peer ids which must include the honest peer. This row always has time 0 and
+-- never has all peers offline simultaneously.
+genFirstFullTableRowFor :: NonEmpty PeerId -> Gen FullTableRow
+genFirstFullTableRowFor peerIds = do
+  ftrStates <- genPeersNotAllOfflineFor peerIds
+  pure FullTableRow{ftrStates, ftrTime = Time 0}
+
+-- | Generator for a normal row of a full-table point schedule, given a list of
+-- peer ids which must include the honest peer.
+genFullTableRowFor :: NonEmpty PeerId -> Gen FullTableRow
+genFullTableRowFor peerIds = do
+  ftrStates <- genPeersFor peerIds arbitrary
+  ftrTime <- arbitrary
+  pure FullTableRow{ftrStates, ftrTime}
+
+-- | Generator of full-table point schedules. Those schedules contain at least
+-- an honest peer, the first row has time 0, and there are no duplicate rows.
+genFullTablePointSchedule :: Gen FullTablePointSchedule
+genFullTablePointSchedule =
+  do
+    ftpsPeerIds <- (HonestPeer :|) <$> listOf arbitrary
+    row <- genFirstFullTableRowFor ftpsPeerIds
+    rows <- sortOn ftrTime <$> listOf (genFullTableRowFor ftpsPeerIds)
+    pure $ FullTablePointSchedule{ftpsRows = row :| rows, ftpsPeerIds}
+  `suchThat` noDuplicateStates
+
+-- | Shrink of full-table point schedules by trying to remove rows, remove
+-- non-honest peers, and by simplifying rows. The first row always has time 0,
+-- and there never are duplicate rows.
+shrinkFullTablePointSchedule :: FullTablePointSchedule -> [FullTablePointSchedule]
+shrinkFullTablePointSchedule ps =
+    filter noDuplicateStates $
+      shrinkRows ps
+      ++ shrinkColumns ps
+  where
+    -- | Remove as many rows as possible, but not the first one.
+    shrinkRows FullTablePointSchedule{ftpsRows = firstRow :| otherRows, ftpsPeerIds} =
+      (shrinkList shrinkRow otherRows <&> flip FullTablePointSchedule ftpsPeerIds . (firstRow :|))
+      ++ (shrinkRow firstRow <&> flip FullTablePointSchedule ftpsPeerIds . (:| otherRows))
+
+    -- | Remove non-honest peers.
+    shrinkColumns FullTablePointSchedule{ftpsRows, ftpsPeerIds} = do
+      otherPeers <- shrinkList (const []) $ filter (/= HonestPeer) $ toList ftpsPeerIds
+      ftpsRows' <- maybeToList $ nonEmpty $ map (shrinkOtherPeers otherPeers) (toList ftpsRows)
+      pure $ FullTablePointSchedule ftpsRows' (HonestPeer :| otherPeers)
+
+    -- | Shrink one row, making it carry more trivial content.
+    shrinkRow :: FullTableRow -> [FullTableRow]
+    shrinkRow FullTableRow{ftrStates, ftrTime} = do
+      ftrStates' <- shrinkPeers ftrStates
+      pure $ FullTableRow ftrStates' ftrTime
+
+    -- | Shrink a row, keeping only the given other peers.
+    shrinkOtherPeers :: [PeerId] -> FullTableRow -> FullTableRow
+    shrinkOtherPeers otherPeers FullTableRow{ftrStates=Peers{honest, others}, ftrTime} =
+      let others' = Map.fromList $ map (\peer -> (peer, others ! peer)) otherPeers
+          ftrStates' = Peers honest others'
+       in FullTableRow ftrStates' ftrTime
+
+-- | Predicate that checks whether the given full-table point schedule contains
+-- the same states in consecutive rows and returns @False@ if that is the case.
+noDuplicateStates :: FullTablePointSchedule -> Bool
+noDuplicateStates = all ((== 1) . length) . NonEmpty.group1 . fmap ftrStates . ftpsRows
+
+--------------------------------------------------------------------------------
+-- High-level generation/shrinking of active point schedules
+--------------------------------------------------------------------------------
+
+-- | Generator for an active point schedule tick, given a list of peer ids to
+-- choose from. The state generated is never 'NodeOffline'.
+genActiveTickFor :: NonEmpty PeerId -> Gen Tick
+genActiveTickFor peerIds = do
+  peerId <- elements (toList peerIds)
+  active <- Peer peerId <$> (NodeOnline <$> arbitrary)
+  duration <- arbitrary
+  pure Tick{active, duration}
+
+-- | Generator of active point schedules. States are never 'NodeOffline'.
+genActivePointSchedule :: Gen PointSchedule
+genActivePointSchedule = do
+  peerIds <- (HonestPeer :|) <$> listOf arbitrary
+  ticks' <- fromList <$> listOf1 (genActiveTickFor peerIds)
+  -- Always guarantee that the last duration is 1.
+  let ticks = mapLast (\Tick{active} -> Tick{active, duration = 1}) ticks'
+  pure $ PointSchedule{ticks, peerIds}
+
+-- | Shrink of active point schedules by trying to remove ticks, and by
+-- simplifying rows.
+shrinkActivePointSchedule :: PointSchedule -> [PointSchedule]
+shrinkActivePointSchedule = shrinkTicks
+  where
+    -- | Remove as many ticks as possible, but not the last one.
+    shrinkTicks PointSchedule{ticks=allTicks, peerIds} =
+      let (ticks, tick) = extractLast allTicks
+      in (shrinkList shrinkTick ticks <&> flip PointSchedule peerIds . (|: tick))
+         ++ (shrinkTick tick <&> flip PointSchedule peerIds . (ticks |:))
+
+    -- | Shrink one tick, making it carry more trivial content.
+    shrinkTick :: Tick -> [Tick]
+    shrinkTick Tick{active, duration} = do
+      active' <- shrink active
+      pure $ Tick active' duration
+
+--------------------------------------------------------------------------------
+-- Orphan 'Arbitrary' for all the point schedule components
+--------------------------------------------------------------------------------
+
+instance Arbitrary a => Arbitrary (NonEmpty a) where
+  arbitrary = do
+    x <- arbitrary
+    xs <- arbitrary
+    pure (x :| xs)
+
+instance Arbitrary SlotNo where
+  arbitrary = SlotNo <$> arbitrary
+
+instance Arbitrary TestHash where
+  arbitrary = TestHash <$> arbitrary
+
+instance Arbitrary a => Arbitrary (TestBlockWith a) where
+  arbitrary = do
+    hash <- arbitrary
+    slot <- arbitrary
+    payload <- arbitrary
+    pure $ unsafeBlockWithPayload hash slot Valid payload
+
+instance Arbitrary (Header TestBlock) where
+  arbitrary = TestHeader <$> arbitrary
+
+instance (Arbitrary blk, HasHeader blk) => Arbitrary (Tip blk) where
+  arbitrary =
+    frequency [
+      (1, pure TipGenesis),
+      (99, tipFromHeader <$> arbitrary)
+      ]
+  shrink TipGenesis = []
+  shrink (Tip {})   = [TipGenesis]
+
+instance Arbitrary a => Arbitrary (WithOrigin a) where
+  arbitrary =
+    frequency [
+      (1, pure Origin),
+      (99, At <$> arbitrary)
+      ]
+  shrink Origin = []
+  shrink (At a) = Origin : (At <$> shrink a)
+
+instance Arbitrary TipPoint where
+  arbitrary = TipPoint <$> arbitrary
+  shrink (TipPoint tip) = TipPoint <$> shrink tip
+
+instance Arbitrary HeaderPoint where
+  arbitrary = HeaderPoint <$> arbitrary
+  shrink (HeaderPoint header) = HeaderPoint <$> shrink header
+
+instance Arbitrary BlockPoint where
+  arbitrary = BlockPoint <$> arbitrary
+  shrink (BlockPoint block) = BlockPoint <$> shrink block
+
+instance Arbitrary AdvertisedPoints where
+  arbitrary = do
+    tip <- arbitrary
+    header <- arbitrary
+    block <- arbitrary
+    pure $ AdvertisedPoints {tip, header, block}
+  shrink AdvertisedPoints{tip, header, block} =
+    ((\tip' -> AdvertisedPoints tip' header block) <$> shrink tip)
+    ++ ((\header' -> AdvertisedPoints tip header' block) <$> shrink header)
+    ++ ((\block' -> AdvertisedPoints tip header block') <$> shrink block)
+
+instance Arbitrary NodeState where
+  arbitrary =
+    frequency [
+      (1, pure NodeOffline),
+      (19, NodeOnline <$> arbitrary)
+      ]
+  shrink NodeOffline         = []
+  shrink (NodeOnline points) = NodeOnline <$> shrink points
+
+-- | WARNING: Only non-honest peer ids.
+instance Arbitrary PeerId where
+  arbitrary = PeerId <$> arbitrary
+
+-- | WARNING: Only non-honest peers.
+instance Arbitrary a => Arbitrary (Peer a) where
+  arbitrary = do
+    peerId <- arbitrary
+    Peer peerId <$> arbitrary
+  shrink (Peer pid value) = Peer pid <$> shrink value
+
+genPeersFor :: NonEmpty PeerId -> Gen a -> Gen (Peers a)
+genPeersFor peerIds g = traverse (const g) (peersFromPeerIdList' peerIds)
+
+genPeersNotAllOfflineFor :: NonEmpty PeerId -> Gen (Peers NodeState)
+genPeersNotAllOfflineFor peerIds =
+    genPeersFor peerIds arbitrary `suchThat` \Peers{honest, others} ->
+       not (isOffline honest && all isOffline others)
+  where
+    isOffline (Peer _ NodeOffline) = True
+    isOffline _                    = False
+
+shrinkPeers :: Arbitrary a => Peers a -> [Peers a]
+shrinkPeers Peers{honest, others} = do
+  honest' <- shrink honest
+  others' <- shrink `mapM` others
+  pure $  Peers honest' others'
+
+instance Arbitrary DiffTime where
+  arbitrary = picosecondsToDiffTime <$> chooseInteger (1_000_000_000, 1_000_000_000_000)
+
+instance Arbitrary Time where
+  arbitrary = Time <$> arbitrary
+
+mapFirst :: (a -> a) -> NonEmpty a -> NonEmpty a
+mapFirst f (x :| xs) = f x :| xs
+
+mapLast :: (a -> a) -> NonEmpty a -> NonEmpty a
+mapLast f = NonEmpty.reverse . mapFirst f . NonEmpty.reverse
+
+extractLast :: NonEmpty a -> ([a], a)
+extractLast = go . NonEmpty.toList
+  where
+    go :: [a] -> ([a], a)
+    go []       = error "extractLast"
+    go [x]      = ([], x)
+    go (x : xs) = first (x :) (go xs)
+
+(|:) :: [a] -> a -> NonEmpty a
+(|:) [] z       = z :| []
+(|:) (x : xs) z = NonEmpty.cons x (xs |: z)

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/TestBlock.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/TestBlock.hs
@@ -38,6 +38,7 @@ module Test.Util.TestBlock (
   , successorBlockWithPayload
   , testHashFromList
   , unTestHash
+  , unsafeBlockWithPayload
     -- ** Test block without payload
   , TestBlock
   , firstBlock
@@ -217,6 +218,10 @@ data TestBlockWith ptype = TestBlockWith {
     }
   deriving stock    (Show, Eq, Ord, Generic)
   deriving anyclass (Serialise, NoThunks, ToExpr)
+
+unsafeBlockWithPayload :: TestHash -> SlotNo -> Validity -> ptype -> TestBlockWith ptype
+unsafeBlockWithPayload tbHash tbSlot tbValid tbPayload =
+  TestBlockWith{tbHash, tbSlot, tbValid, tbPayload}
 
 -- | Create the first block in the given fork, @[fork]@, with the given payload.
 -- The 'SlotNo' will be 1.


### PR DESCRIPTION
Builds on top of #842.

Brings generic shrinking based on a “full-table” point schedule (I also tend to call it “shrinking à la @nfrisby” because he's the one that made me realise this was a way to do it). I like this shrinking solution for its conceptual simplicity but I think we can achieve much better shrinking with random shrinking and properties that are supposed to hold at any point in time. Still, this can be merged, IMO.