### PR TITLE
Bump flake inputs and tools

### DIFF
--- a/docs/website/contents/for-developers/ReleaseProcess.md
+++ b/docs/website/contents/for-developers/ReleaseProcess.md
@@ -231,12 +231,12 @@ A - ...
 # Installing `scriv`
 
 To manage the workflow described above, we will use the `scriv` tool slightly
-modified to support cabal files.. If you use `nix` then you will find `scriv` in
+modified to support cabal files. If you use `nix` then you will find `scriv` in
 the Nix shell. Otherwise, the way to install it from source is:
 
-1. Clone [our fork of scriv](https://github.com/IntersectMBO/scriv/) and `cd`
-   into it.
-2. Run `pip install -e $(pwd)`
+```
+pip install scriv
+```
 
 If you encounter an error mentioning:
 `pkg_resources.extern.packaging.version.InvalidVersion: Invalid version: ...` we
@@ -248,7 +248,7 @@ installation complains with the error `error: externally-managed-environment`,
 pass in the flag `--break-system-packages`:
 
 ```
-pip install --break-system-packages -e $(pwd)
+pip install --break-system-packages scriv
 ```
 
 # Adding a changelog fragment

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1702906471,
-        "narHash": "sha256-br+hVo3R6nfmiSEPXcLKhIX4Kg5gcK2PjzjmvQsuUp8=",
+        "lastModified": 1704194205,
+        "narHash": "sha256-DVaL6dBqgGOOjr3kyHi3NgtD4UrwTVsSMLkpUToyPt4=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "48a359ac3f1d437ebaa91126b20e15a65201f004",
+        "rev": "aad2fe5dcccc7eb0402aed0093dffc0f01c2a435",
         "type": "github"
       },
       "original": {
@@ -155,11 +155,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1694529238,
-        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "lastModified": 1701680307,
+        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
         "type": "github"
       },
       "original": {
@@ -207,11 +207,11 @@
     "ghc99": {
       "flake": false,
       "locked": {
-        "lastModified": 1697054644,
-        "narHash": "sha256-kKarOuXUaAH3QWv7ASx+gGFMHaHKe0pK5Zu37ky2AL4=",
+        "lastModified": 1701580282,
+        "narHash": "sha256-drA01r3JrXnkKyzI+owMZGxX0JameMzjK0W5jJE/+V4=",
         "ref": "refs/heads/master",
-        "rev": "f383a242c76f90bcca8a4d7ee001dcb49c172a9a",
-        "revCount": 62040,
+        "rev": "f5eb0f2982e9cf27515e892c4bdf634bcfb28459",
+        "revCount": 62197,
         "submodules": true,
         "type": "git",
         "url": "https://gitlab.haskell.org/ghc/ghc"
@@ -225,11 +225,11 @@
     "hackageNix": {
       "flake": false,
       "locked": {
-        "lastModified": 1702859030,
-        "narHash": "sha256-W5IMCeXNvFV8YUIuYh+VTE5zRhCIdodg8inKUwwQGjg=",
+        "lastModified": 1704154975,
+        "narHash": "sha256-hD3WePXz4TvPVAHKvXN1xn6yFyWWSTPJGa/B9WVfrMQ=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "998fd3cc7447726ad57b28b7270c2b4b51b7af18",
+        "rev": "ab6b0b7741bd85f4209eb6a9af54e148e440c419",
         "type": "github"
       },
       "original": {
@@ -270,16 +270,17 @@
         "nixpkgs-2205": "nixpkgs-2205",
         "nixpkgs-2211": "nixpkgs-2211",
         "nixpkgs-2305": "nixpkgs-2305",
+        "nixpkgs-2311": "nixpkgs-2311",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "old-ghc-nix": "old-ghc-nix",
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1700182189,
-        "narHash": "sha256-h9M8kgf27DCRjl+Q8L5MtiaNDuNPIQSeYMEeLjJCaEM=",
+        "lastModified": 1704156612,
+        "narHash": "sha256-JOAIVXNh5UNryoJHEQ0TGWWkyBq5f/F5ITFjOzXLXW0=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "a643374524cd1d367731d07fce0c52b84ac91b6e",
+        "rev": "651cfbaf9effe950fbd9a52cb39fcbab2aa0dbbe",
         "type": "github"
       },
       "original": {
@@ -359,16 +360,16 @@
     "hls-2.4": {
       "flake": false,
       "locked": {
-        "lastModified": 1696939266,
-        "narHash": "sha256-VOMf5+kyOeOmfXTHlv4LNFJuDGa7G3pDnOxtzYR40IU=",
+        "lastModified": 1699862708,
+        "narHash": "sha256-YHXSkdz53zd0fYGIYOgLt6HrA0eaRJi9mXVqDgmvrjk=",
         "owner": "haskell",
         "repo": "haskell-language-server",
-        "rev": "362fdd1293efb4b82410b676ab1273479f6d17ee",
+        "rev": "54507ef7e85fa8e9d0eb9a669832a3287ffccd57",
         "type": "github"
       },
       "original": {
         "owner": "haskell",
-        "ref": "2.4.0.0",
+        "ref": "2.4.0.1",
         "repo": "haskell-language-server",
         "type": "github"
       }
@@ -422,11 +423,11 @@
         "sodium": "sodium"
       },
       "locked": {
-        "lastModified": 1698999258,
-        "narHash": "sha256-42D1BMbdyZD+lT+pWUzb5zDQyasNbMJtH/7stuPuPfE=",
+        "lastModified": 1702362799,
+        "narHash": "sha256-cU8cZXNuo5GRwrSvWqdaqoW5tJ2HWwDEOvWwIVPDPmo=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "73dc2bb45af6f20cfe1d962f1334eed5e84ae764",
+        "rev": "b426fb9e0b109a9d1dd2e1476f9e0bd8bb715142",
         "type": "github"
       },
       "original": {
@@ -587,16 +588,32 @@
     },
     "nixpkgs-2305": {
       "locked": {
-        "lastModified": 1695416179,
-        "narHash": "sha256-610o1+pwbSu+QuF3GE0NU5xQdTHM3t9wyYhB9l94Cd8=",
+        "lastModified": 1701362232,
+        "narHash": "sha256-GVdzxL0lhEadqs3hfRLuj+L1OJFGiL/L7gCcelgBlsw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "715d72e967ec1dd5ecc71290ee072bcaf5181ed6",
+        "rev": "d2332963662edffacfddfad59ff4f709dde80ffe",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "ref": "nixpkgs-23.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2311": {
+      "locked": {
+        "lastModified": 1701386440,
+        "narHash": "sha256-xI0uQ9E7JbmEy/v8kR9ZQan6389rHug+zOtZeZFiDJk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "293822e55ec1872f715a66d0eda9e592dc14419f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-23.11-darwin",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -619,17 +636,17 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1695318763,
-        "narHash": "sha256-FHVPDRP2AfvsxAdc+AsgFJevMz5VBmnZglFUMlxBkcY=",
+        "lastModified": 1694822471,
+        "narHash": "sha256-6fSDCj++lZVMZlyqOe9SIOL8tYSBz1bI8acwovRwoX8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e12483116b3b51a185a33a272bf351e357ba9a99",
+        "rev": "47585496bcb13fb72e4a90daeea2f434e2501998",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
+        "rev": "47585496bcb13fb72e4a90daeea2f434e2501998",
         "type": "github"
       }
     },
@@ -701,11 +718,11 @@
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1700179756,
-        "narHash": "sha256-xj/rBkxLVXMYb8MhhEfJAd8AmprEulnwxfi69n1i9nE=",
+        "lastModified": 1704154190,
+        "narHash": "sha256-qbB89x4v4Qf2XgfmN4iKmmKNULFaMyU6gbIyPj4RcgI=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "27cee8e925b64ad493c7a30e124493f0d6274c15",
+        "rev": "a0e554abda5ba94926d5bf522958f22d212260ec",
         "type": "github"
       },
       "original": {

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -22,7 +22,7 @@ hsPkgs.shellFor {
   # This is the place for tools that are required to be built with the same GHC
   # version as used in hsPkgs.
   tools = lib.mapAttrs (_: t: t // { index-state = pkgs.tool-index-state; }) {
-    haskell-language-server = { version = "2.4.0.0"; };
+    haskell-language-server = { version = "2.5.0.0"; };
   };
 
   shellHook = ''

--- a/nix/tools.nix
+++ b/nix/tools.nix
@@ -2,7 +2,7 @@ inputs: final: prev:
 
 let
   inherit (final) lib;
-  tool-index-state = "2023-11-16T00:00:00Z";
+  tool-index-state = "2024-01-01T00:00:00Z";
   tool = name: version: other:
     final.haskell-nix.tool final.hsPkgs.args.compiler-nix-name name ({
       version = version;
@@ -51,16 +51,6 @@ in
   stylish-haskell = tool "stylish-haskell" "0.14.5.0" { };
 
   cabal-fmt = tool "cabal-fmt" "0.1.9" { };
-
-  scriv = prev.scriv.overrideAttrs (_: {
-    version = "1.2.0-custom-iog";
-    src = final.fetchFromGitHub {
-      owner = "input-output-hk";
-      repo = "scriv";
-      rev = "567a1aa3f6df77d1a531290f10a261ec6a49c75a";
-      hash = "sha256-wpWDuZ3c8JJKVWPw9PHgcpneRWYjd/0z4oAIirPa0/E=";
-    };
-  });
 
   haskellBuildUtils = prev.haskellBuildUtils.override {
     inherit (final.hsPkgs.args) compiler-nix-name;


### PR DESCRIPTION
 - Update flake inputs
 - Update HLS to 2.5
 - Use upstream scriv as https://github.com/nedbat/scriv/pull/91 was merged and released in 1.4.0 (latest is 1.5.1 already).