### PR TITLE
Homogenize Shelley versions in Cardano NTC versions

### DIFF
--- a/docs/website/contents/for-developers/QueryVersioning.md
+++ b/docs/website/contents/for-developers/QueryVersioning.md
@@ -40,6 +40,8 @@ Our code does not use the negotiated [`NodeToClientVersion`][n2c] directly, but 
    ```
    This tells us that in Shelley, Allegra, Mary, Alonzo and Babbage, we use `ShelleyNodeToClientVersion6`, and Conway is disabled. This means that no queries that were introduced in `ShelleyNodeToClientVersion7` can be used, and no queries in the Conway era are possible at all.
 
+   In order to reduce the number of possible version combinations, we currently follow the convention that all `ShelleyNodeToClientVersion`s in one `CardanoNodeToClientVersionX` are equal. This means that users (like `cardano-api`) can rely on the fact that once a `NodeToClient` version has been negotiated, all enabled Shelley-based eras support exactly the same queries.[^conway-queries] We might weaken this guarantee in the future, see [#864](https://github.com/IntersectMBO/ouroboros-consensus/issues/864).
+
 The mapping from `NodeToClientVersion`s to `CardanoNodeToClientVersion`s is [`supportedNodeToClientVersions`][supportedNodeToClientVersions]. Additionally, all versions larger than a certain `NodeToClientVersion` (see [`latestReleasedNodeVersion`][latestReleasedNodeVersion]) are considered experimental, which means that queries newly enabled by them can be added and changed at will, without compatibility guarantees. They are only offered in the initial version negotiation when a flag (currently, `ExperimentalProtocolsEnabled`) is set; also see [`limitToLatestReleasedVersion`][limitToLatestReleasedVersion] and its call/usage sites.
 
 #### Shelly node-to-client version
@@ -106,3 +108,5 @@ Old pull-requests that added new queries serve as good reference material when a
 [network-repo]: https://github.com/IntersectMBO/ouroboros-network
 [shelley-supportedNodeToClientVersions]: https://github.com/IntersectMBO/ouroboros-consensus/blob/35e444f1440cef34e0989519f025231241397674/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/NetworkProtocolVersion.hs#L56-L65
 [decodeShelleyResult]: https://github.com/IntersectMBO/ouroboros-consensus/blob/3d55ae3ca7a9e1c63a19266d35ef5512bbef13ab/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Query.hs#L733
+
+[^conway-queries]: There are already queries that morally are Conway-specific, but still work in older eras, returning something along the lines of `mempty` in that case.

--- a/ouroboros-consensus-cardano/changelog.d/20240104_195829_alexander.esgen_homogenous_cardano_n2c_versions.md
+++ b/ouroboros-consensus-cardano/changelog.d/20240104_195829_alexander.esgen_homogenous_cardano_n2c_versions.md
@@ -1,0 +1,6 @@
+### Non-Breaking
+
+- `CardanoNodeToClientVersion12` now implies `ShelleyNodeToClientVersion8` in
+  all Shelley-based eras instead of just in `Conway`. This means that downstream
+  logic determining query availablity (eg in `cardano-api`) can (continue to)
+  simply branch on the negotiated `NodeToClientVersion`.

--- a/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/Node.hs
+++ b/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/Node.hs
@@ -532,11 +532,11 @@ pattern CardanoNodeToClientVersion12 =
     HardForkNodeToClientEnabled
       HardForkSpecificNodeToClientVersion2
       (  EraNodeToClientEnabled ByronNodeToClientVersion1
-      :* EraNodeToClientEnabled ShelleyNodeToClientVersion7
-      :* EraNodeToClientEnabled ShelleyNodeToClientVersion7
-      :* EraNodeToClientEnabled ShelleyNodeToClientVersion7
-      :* EraNodeToClientEnabled ShelleyNodeToClientVersion7
-      :* EraNodeToClientEnabled ShelleyNodeToClientVersion7
+      :* EraNodeToClientEnabled ShelleyNodeToClientVersion8
+      :* EraNodeToClientEnabled ShelleyNodeToClientVersion8
+      :* EraNodeToClientEnabled ShelleyNodeToClientVersion8
+      :* EraNodeToClientEnabled ShelleyNodeToClientVersion8
+      :* EraNodeToClientEnabled ShelleyNodeToClientVersion8
       :* EraNodeToClientEnabled ShelleyNodeToClientVersion8
       :* Nil
       )


### PR DESCRIPTION
Closes #862 

Note that `CardanoNodeToClientVersion12` is experimental, so this change does not impact backwards-compatibility.