### PR TITLE
Extract peer-related code to own module

### DIFF
--- a/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
+++ b/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
@@ -233,6 +233,7 @@ test-suite consensus-test
     Test.Consensus.PeerSimulator.Tests.Timeouts
     Test.Consensus.PeerSimulator.Trace
     Test.Consensus.PointSchedule
+    Test.Consensus.PointSchedule.Peers
     Test.Consensus.PointSchedule.SinglePeer
     Test.Consensus.PointSchedule.SinglePeer.Indices
     Test.Consensus.PointSchedule.Tests

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup.hs
@@ -26,6 +26,7 @@ import           Test.Consensus.PeerSimulator.Run
 import           Test.Consensus.PeerSimulator.StateView
 import           Test.Consensus.PeerSimulator.Trace (traceLinesWith)
 import           Test.Consensus.PointSchedule
+import           Test.Consensus.PointSchedule.Peers (Peers)
 import           Test.QuickCheck
 import           Test.Util.Orphans.IOLike ()
 import           Test.Util.TersePrinting (terseFragment)

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
@@ -24,6 +24,8 @@ import           Test.Consensus.PeerSimulator.Run (SchedulerConfig (scTrace),
                      noTimeoutsSchedulerConfig, scTraceState)
 import           Test.Consensus.PeerSimulator.StateView
 import           Test.Consensus.PointSchedule
+import           Test.Consensus.PointSchedule.Peers (PeerId (..), Peers (..),
+                     value)
 import           Test.Consensus.PointSchedule.SinglePeer
                      (SchedulePoint (ScheduleBlockPoint, ScheduleTipPoint))
 import           Test.Ouroboros.Consensus.ChainGenerator.Params (Delta (Delta))

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/ChainSync.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/ChainSync.hs
@@ -37,7 +37,8 @@ import           Test.Consensus.PeerSimulator.StateView
                      StateViewTracers (StateViewTracers, svtChainSyncExceptionsTracer))
 import           Test.Consensus.PeerSimulator.Trace (mkChainSyncClientTracer,
                      traceUnitWith)
-import           Test.Consensus.PointSchedule (PeerId, TestFragH)
+import           Test.Consensus.PointSchedule (TestFragH)
+import           Test.Consensus.PointSchedule.Peers (PeerId)
 import           Test.Util.Orphans.IOLike ()
 import           Test.Util.TestBlock (TestBlock)
 

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Resources.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Resources.hs
@@ -41,6 +41,7 @@ import           Test.Consensus.PeerSimulator.ScheduledBlockFetchServer
                      runScheduledBlockFetchServer)
 import           Test.Consensus.PeerSimulator.ScheduledChainSyncServer
 import           Test.Consensus.PointSchedule
+import           Test.Consensus.PointSchedule.Peers (PeerId)
 import           Test.Util.Orphans.IOLike ()
 import           Test.Util.TestBlock (TestBlock)
 

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Run.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Run.hs
@@ -52,9 +52,10 @@ import           Test.Consensus.PeerSimulator.StateView
 import           Test.Consensus.PeerSimulator.Trace
 import qualified Test.Consensus.PointSchedule as PointSchedule
 import           Test.Consensus.PointSchedule (GenesisTest (GenesisTest),
-                     Peer (Peer), PeerId, PointSchedule (PointSchedule),
-                     PointScheduleConfig, TestFragH, Tick (Tick),
-                     pointSchedulePeers, prettyPointSchedule)
+                     PointSchedule (PointSchedule), PointScheduleConfig,
+                     TestFragH, Tick (Tick), pointSchedulePeers,
+                     prettyPointSchedule)
+import           Test.Consensus.PointSchedule.Peers (Peer (..), PeerId)
 import           Test.Ouroboros.Consensus.ChainGenerator.Params (Asc)
 import           Test.Util.ChainDB
 import           Test.Util.Orphans.IOLike ()

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/StateDiagram.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/StateDiagram.hs
@@ -54,8 +54,9 @@ import           Ouroboros.Network.Block (HeaderHash, Tip (Tip))
 import           Test.Consensus.BlockTree (BlockTree (btBranches, btTrunk),
                      BlockTreeBranch (btbSuffix), prettyBlockTree)
 import qualified Test.Consensus.PointSchedule as PS
-import           Test.Consensus.PointSchedule (AdvertisedPoints, PeerId (..),
-                     TestFrag, TestFragH, genesisAdvertisedPoints)
+import           Test.Consensus.PointSchedule (AdvertisedPoints, TestFrag,
+                     TestFragH, genesisAdvertisedPoints)
+import           Test.Consensus.PointSchedule.Peers (PeerId (..))
 import           Test.Util.TestBlock (TestBlock, TestHash (TestHash))
 
 enableDebug :: Bool

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/StateView.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/StateView.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE LambdaCase     #-}
 {-# LANGUAGE NamedFieldPuns #-}
 
 module Test.Consensus.PeerSimulator.StateView (
@@ -19,7 +18,8 @@ import qualified Ouroboros.Consensus.Storage.ChainDB as ChainDB
 import           Ouroboros.Consensus.Util.Condense (Condense (condense))
 import           Ouroboros.Consensus.Util.IOLike (IOLike, SomeException,
                      atomically)
-import           Test.Consensus.PointSchedule (PeerId, TestFragH)
+import           Test.Consensus.PointSchedule (TestFragH)
+import           Test.Consensus.PointSchedule.Peers (PeerId)
 import           Test.Util.TersePrinting (terseHFragment)
 import           Test.Util.TestBlock (TestBlock)
 import           Test.Util.Tracer (recordingTracerTVar)

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
@@ -13,6 +13,7 @@ import           Test.Consensus.Genesis.Setup
 import           Test.Consensus.PeerSimulator.Run (noTimeoutsSchedulerConfig)
 import           Test.Consensus.PeerSimulator.StateView
 import           Test.Consensus.PointSchedule
+import           Test.Consensus.PointSchedule.Peers (peersOnlyHonest)
 import           Test.QuickCheck
 import           Test.Tasty
 import           Test.Tasty.QuickCheck

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
@@ -17,6 +17,7 @@ import           Test.Consensus.PeerSimulator.Run (SchedulerConfig (..),
                      defaultSchedulerConfig)
 import           Test.Consensus.PeerSimulator.StateView
 import           Test.Consensus.PointSchedule
+import           Test.Consensus.PointSchedule.Peers (Peer (..), PeerId (..))
 import           Test.QuickCheck
 import           Test.Tasty
 import           Test.Tasty.QuickCheck

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveGeneric         #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE LambdaCase            #-}
@@ -32,10 +31,7 @@ module Test.Consensus.PointSchedule (
   , GenesisWindow (..)
   , HeaderPoint (..)
   , NodeState (..)
-  , Peer (..)
-  , PeerId (..)
   , PeerSchedule
-  , Peers (..)
   , PointSchedule (..)
   , PointScheduleConfig (..)
   , TestFrag
@@ -48,8 +44,6 @@ module Test.Consensus.PointSchedule (
   , fromSchedulePoints
   , genesisAdvertisedPoints
   , longRangeAttack
-  , mkPeers
-  , peersOnlyHonest
   , pointSchedulePeers
   , prettyGenesisTest
   , prettyPointSchedule
@@ -59,17 +53,13 @@ module Test.Consensus.PointSchedule (
 
 import           Control.Monad.ST (ST)
 import           Data.Foldable (toList)
-import           Data.Hashable (Hashable)
 import           Data.List (mapAccumL, partition, scanl', transpose)
-import           Data.List.NonEmpty (NonEmpty ((:|)))
+import           Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NonEmpty
-import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           Data.Maybe (fromMaybe, listToMaybe)
-import           Data.String (IsString (fromString))
 import           Data.Time (DiffTime)
 import           Data.Word (Word64)
-import           GHC.Generics (Generic)
 import           Ouroboros.Consensus.Block.Abstract (WithOrigin (..), getHeader)
 import           Ouroboros.Consensus.Protocol.Abstract (SecurityParam,
                      maxRollbacks)
@@ -83,6 +73,8 @@ import qualified System.Random.Stateful as Random
 import           System.Random.Stateful (STGenM, StatefulGen, runSTGen_)
 import           Test.Consensus.BlockTree (BlockTree (..), BlockTreeBranch (..),
                      prettyBlockTree)
+import           Test.Consensus.PointSchedule.Peers (Peer (..), PeerId (..),
+                     Peers (..), getPeerIds, mkPeers, peersList)
 import           Test.Consensus.PointSchedule.SinglePeer
                      (IsTrunk (IsBranch, IsTrunk), PeerScheduleParams (..),
                      SchedulePoint (..), defaultPeerScheduleParams, mergeOn,
@@ -180,62 +172,6 @@ instance Condense NodeState where
     NodeOnline points -> condense points
     NodeOffline -> "*chrrrk* <signal lost>"
 
--- | Identifier used to index maps and specify which peer is active during a tick.
-data PeerId =
-  HonestPeer
-  |
-  PeerId String
-  deriving (Eq, Generic, Show, Ord)
-
-instance IsString PeerId where
-  fromString "honest" = HonestPeer
-  fromString i        = PeerId i
-
-instance Condense PeerId where
-  condense = \case
-    HonestPeer -> "honest"
-    PeerId name -> name
-
-instance Hashable PeerId
-
--- | General-purpose functor associated with a peer.
-data Peer a =
-  Peer {
-    name  :: PeerId,
-    value :: a
-  }
-  deriving (Eq, Show)
-
-instance Functor Peer where
-  fmap f Peer {name, value} = Peer {name, value = f value}
-
-instance Foldable Peer where
-  foldr step z (Peer _ a) = step a z
-
-instance Traversable Peer where
-  sequenceA (Peer name fa) =
-    Peer name <$> fa
-
-instance Condense a => Condense (Peer a) where
-  condense Peer {name, value} = condense name ++ ": " ++ condense value
-
--- | General-purpose functor for a set of peers.
---
--- REVIEW: There is a duplicate entry for the honest peer, here. We should
--- probably either have only the 'Map' or have the keys of the map be 'String'?
---
--- Alternatively, we could just have 'newtype PeerId = PeerId String' with an
--- alias for 'HonestPeer = PeerId "honest"'?
-data Peers a =
-  Peers {
-    honest :: Peer a,
-    others :: Map PeerId (Peer a)
-  }
-  deriving (Eq, Show)
-
-instance Functor Peers where
-  fmap f Peers {honest, others} = Peers {honest = f <$> honest, others = fmap f <$> others}
-
 -- | A tick is an entry in a 'PointSchedule', containing the peer that is
 -- going to change state.
 data Tick =
@@ -260,14 +196,6 @@ tickDefault PointScheduleConfig {pscTickDuration} number active =
 tickDefaults :: PointScheduleConfig -> [Peer NodeState] -> [Tick]
 tickDefaults psc states =
   uncurry (tickDefault psc) <$> zip [0 ..] states
-
--- | A set of peers with only one honest peer carrying the given value.
-peersOnlyHonest :: a -> Peers a
-peersOnlyHonest value =
-  Peers {
-    honest = Peer {name = HonestPeer, value},
-    others = Map.empty
-    }
 
 -- | A point schedule is a series of states for a set of peers.
 --
@@ -307,32 +235,12 @@ defaultPointScheduleConfig =
 -- Accessors
 ----------------------------------------------------------------------------------------------------
 
--- | Extract all 'PeerId's.
-getPeerIds :: Peers a -> NonEmpty PeerId
-getPeerIds peers = HonestPeer :| Map.keys (others peers)
-
 -- | Get the names of the peers involved in this point schedule.
 -- This is the main motivation for requiring the point schedule to be
 -- nonempty, so we don't have to carry around another value for the
 -- 'PeerId's.
 pointSchedulePeers :: PointSchedule -> NonEmpty PeerId
 pointSchedulePeers = peerIds
-
--- | Convert 'Peers' to a list of 'Peer'.
-peersList :: Peers a -> NonEmpty (Peer a)
-peersList Peers {honest, others} =
-  honest :| Map.elems others
-
--- | Construct 'Peers' from values, adding adversary names based on the default schema.
--- A single adversary gets the ID @adversary@, multiple get enumerated as @adversary N@.
-mkPeers :: a -> [a] -> Peers a
-mkPeers h as =
-  Peers (Peer HonestPeer h) (Map.fromList (mkPeer <$> advs as))
-  where
-    mkPeer (pid, a) = (pid, Peer pid a)
-    advs [a] = [("adversary", a)]
-    advs _   = zip enumAdvs as
-    enumAdvs = (\ n -> PeerId ("adversary " ++ show n)) <$> [1 :: Int ..]
 
 ----------------------------------------------------------------------------------------------------
 -- Conversion to 'PointSchedule'

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Peers.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Peers.hs
@@ -14,6 +14,8 @@ module Test.Consensus.PointSchedule.Peers (
     Peer (..)
   , PeerId (..)
   , Peers (..)
+  , fromMap
+  , fromMap'
   , getPeerIds
   , mkPeers
   , mkPeers'
@@ -22,6 +24,8 @@ module Test.Consensus.PointSchedule.Peers (
   , peersFromPeerList
   , peersList
   , peersOnlyHonest
+  , toMap
+  , toMap'
   ) where
 
 import           Data.Hashable (Hashable)
@@ -149,3 +153,20 @@ peersFromPeerIdList = flip $ \val -> peersFromPeerList . fmap (flip Peer val)
 -- | Like 'peersFromPeerIdList' with @()@.
 peersFromPeerIdList' :: NonEmpty PeerId -> Peers ()
 peersFromPeerIdList' = flip peersFromPeerIdList ()
+
+toMap :: Peers a -> Map PeerId (Peer a)
+toMap Peers{honest, others} = Map.insert HonestPeer honest others
+
+-- | Same as 'toMap' but the map contains unwrapped values.
+toMap' :: Peers a -> Map PeerId a
+toMap' = fmap (\(Peer _ v) -> v) . toMap
+
+fromMap :: Map PeerId (Peer a) -> Peers a
+fromMap peers = Peers{
+    honest = peers Map.! HonestPeer,
+    others = Map.delete HonestPeer peers
+  }
+
+-- | Same as 'fromMap' but the map contains unwrapped values.
+fromMap' :: Map PeerId a -> Peers a
+fromMap' = fromMap . Map.mapWithKey Peer

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Peers.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Peers.hs
@@ -1,0 +1,113 @@
+{-# LANGUAGE DeriveGeneric         #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE LambdaCase            #-}
+{-# LANGUAGE NamedFieldPuns        #-}
+{-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE RankNTypes            #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
+
+-- | This module contains the definition of point schedule _peers_ as well as
+-- all kind of utilities to manipulate them.
+
+module Test.Consensus.PointSchedule.Peers (
+    Peer (..)
+  , PeerId (..)
+  , Peers (..)
+  , getPeerIds
+  , mkPeers
+  , peersList
+  , peersOnlyHonest
+  ) where
+
+import           Data.Hashable (Hashable)
+import           Data.List.NonEmpty (NonEmpty ((:|)))
+import           Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import           Data.String (IsString (fromString))
+import           GHC.Generics (Generic)
+import           Ouroboros.Consensus.Util.Condense (Condense (condense))
+
+-- | Identifier used to index maps and specify which peer is active during a tick.
+data PeerId =
+  HonestPeer
+  |
+  PeerId String
+  deriving (Eq, Generic, Show, Ord)
+
+instance IsString PeerId where
+  fromString "honest" = HonestPeer
+  fromString i        = PeerId i
+
+instance Condense PeerId where
+  condense = \case
+    HonestPeer -> "honest"
+    PeerId name -> name
+
+instance Hashable PeerId
+
+-- | General-purpose functor associated with a peer.
+data Peer a =
+  Peer {
+    name  :: PeerId,
+    value :: a
+  }
+  deriving (Eq, Show)
+
+instance Functor Peer where
+  fmap f Peer {name, value} = Peer {name, value = f value}
+
+instance Foldable Peer where
+  foldr step z (Peer _ a) = step a z
+
+instance Traversable Peer where
+  sequenceA (Peer name fa) =
+    Peer name <$> fa
+
+instance Condense a => Condense (Peer a) where
+  condense Peer {name, value} = condense name ++ ": " ++ condense value
+
+-- | General-purpose functor for a set of peers.
+--
+-- REVIEW: There is a duplicate entry for the honest peer, here. We should
+-- probably either have only the 'Map' or have the keys of the map be 'String'?
+--
+-- Alternatively, we could just have 'newtype PeerId = PeerId String' with an
+-- alias for 'HonestPeer = PeerId "honest"'?
+data Peers a =
+  Peers {
+    honest :: Peer a,
+    others :: Map PeerId (Peer a)
+  }
+  deriving (Eq, Show)
+
+instance Functor Peers where
+  fmap f Peers {honest, others} = Peers {honest = f <$> honest, others = fmap f <$> others}
+
+-- | A set of peers with only one honest peer carrying the given value.
+peersOnlyHonest :: a -> Peers a
+peersOnlyHonest value =
+  Peers {
+    honest = Peer {name = HonestPeer, value},
+    others = Map.empty
+    }
+
+-- | Extract all 'PeerId's.
+getPeerIds :: Peers a -> NonEmpty PeerId
+getPeerIds peers = HonestPeer :| Map.keys (others peers)
+
+-- | Convert 'Peers' to a list of 'Peer'.
+peersList :: Peers a -> NonEmpty (Peer a)
+peersList Peers {honest, others} =
+  honest :| Map.elems others
+
+-- | Construct 'Peers' from values, adding adversary names based on the default schema.
+-- A single adversary gets the ID @adversary@, multiple get enumerated as @adversary N@.
+mkPeers :: a -> [a] -> Peers a
+mkPeers h as =
+  Peers (Peer HonestPeer h) (Map.fromList (mkPeer <$> advs as))
+  where
+    mkPeer (pid, a) = (pid, Peer pid a)
+    advs [a] = [("adversary", a)]
+    advs _   = zip enumAdvs as
+    enumAdvs = (\ n -> PeerId ("adversary " ++ show n)) <$> [1 :: Int ..]


### PR DESCRIPTION
This is a cherry pick from https://github.com/IntersectMBO/ouroboros-consensus/pull/856. I believe those commits would be useful in general. They extract code related to the `Peers` type from `Test.Consensus.PointSchedule` to `Test.Consensus.PointSchedule.Peers`, making the code clearer. It also adds a bunch of new helpers for peers.