### PR TITLE
Include point schedule in `GenesisTest`

### DIFF
--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup/Classifiers.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup/Classifiers.hs
@@ -45,7 +45,7 @@ data Classifiers =
     longerThanGenesisWindow        :: Bool
   }
 
-classifiers :: GenesisTest -> Classifiers
+classifiers :: GenesisTest schedule -> Classifiers
 classifiers GenesisTest {gtBlockTree, gtSecurityParam = SecurityParam k, gtGenesisWindow = GenesisWindow scg} =
   Classifiers {
     existsSelectableAdversary,

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup/GenChains.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup/GenChains.hs
@@ -98,7 +98,7 @@ genAlternativeChainSchema (testRecipeH, arHonest) =
 --     trunk: O─────1──2──3──4─────5──6──7
 --                     │           ╰─────6
 --                     ╰─────3──4─────5
-genChains :: QC.Gen Word -> QC.Gen GenesisTest
+genChains :: QC.Gen Word -> QC.Gen (GenesisTest ())
 genChains genNumForks = do
   (asc, honestRecipe, someHonestChainSchema) <- genHonestChainSchema
 
@@ -117,7 +117,8 @@ genChains genNumForks = do
     gtSecurityParam = SecurityParam (fromIntegral kcp),
     gtGenesisWindow = GenesisWindow (fromIntegral scg),
     gtDelay = delta,
-    gtBlockTree = foldl' (flip BT.addBranch') (BT.mkTrunk goodChain) $ zipWith (genAdversarialFragment goodBlocks) [1..] alternativeChainSchemas
+    gtBlockTree = foldl' (flip BT.addBranch') (BT.mkTrunk goodChain) $ zipWith (genAdversarialFragment goodBlocks) [1..] alternativeChainSchemas,
+    gtSchedule = ()
     }
 
   where

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LongRangeAttack.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LongRangeAttack.hs
@@ -5,6 +5,7 @@
 
 module Test.Consensus.Genesis.Tests.LongRangeAttack (tests) where
 
+import           Data.Functor (($>))
 import           Ouroboros.Consensus.Block.Abstract (HeaderHash)
 import           Ouroboros.Network.AnchoredFragment (headAnchor)
 import qualified Ouroboros.Network.AnchoredFragment as AF
@@ -35,7 +36,7 @@ prop_longRangeAttack =
     (do gt@GenesisTest{gtBlockTree} <- genChains (pure 1)
         ps <- stToGen (longRangeAttack gtBlockTree)
         if allAdversariesSelectable (classifiers gt)
-          then pure (gt, ps)
+          then pure $ gt $> ps
           else discard)
 
     (noTimeoutsSchedulerConfig defaultPointScheduleConfig)
@@ -44,7 +45,7 @@ prop_longRangeAttack =
 
     -- NOTE: This is the expected behaviour of Praos to be reversed with
     -- Genesis. But we are testing Praos for the moment
-    (\_ _ -> not . isHonestTestFragH . svSelectedChain)
+    (\_ -> not . isHonestTestFragH . svSelectedChain)
 
   where
     isHonestTestFragH :: TestFragH -> Bool

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
@@ -38,13 +38,13 @@ prop_rollback = do
   forAllGenesisTest
 
     (do gt@GenesisTest{gtSecurityParam, gtBlockTree} <- genChains (pure 1)
-        pure (gt, rollbackSchedule (fromIntegral (maxRollbacks gtSecurityParam)) gtBlockTree))
+        pure gt {gtSchedule =  rollbackSchedule (fromIntegral (maxRollbacks gtSecurityParam)) gtBlockTree})
 
     (noTimeoutsSchedulerConfig defaultPointScheduleConfig)
 
-    (\_ _ _ -> [])
+    (\_ _ -> [])
 
-    (\_ _ -> not . hashOnTrunk . AF.headHash . svSelectedChain)
+    (\_ -> not . hashOnTrunk . AF.headHash . svSelectedChain)
 
 -- @prop_cannotRollback@ tests that the selection of the node under test *does
 -- not* change branches when sent a rollback to a block strictly older than 'k'
@@ -54,13 +54,13 @@ prop_cannotRollback =
   forAllGenesisTest
 
     (do gt@GenesisTest{gtSecurityParam, gtBlockTree} <- genChains (pure 1)
-        pure (gt, rollbackSchedule (fromIntegral (maxRollbacks gtSecurityParam + 1)) gtBlockTree))
+        pure gt {gtSchedule = rollbackSchedule (fromIntegral (maxRollbacks gtSecurityParam + 1)) gtBlockTree})
 
     (noTimeoutsSchedulerConfig defaultPointScheduleConfig)
 
-    (\_ _ _ -> [])
+    (\_ _ -> [])
 
-    (\_ _ -> hashOnTrunk . AF.headHash . svSelectedChain)
+    (\_ -> hashOnTrunk . AF.headHash . svSelectedChain)
 
 -- | A schedule that advertises all the points of the trunk up until the nth
 -- block after the intersection, then switches to the first alternative

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
@@ -1,5 +1,6 @@
 module Test.Consensus.PeerSimulator.Tests.Timeouts (tests) where
 
+import           Data.Functor (($>))
 import           Data.List.NonEmpty (NonEmpty ((:|)))
 import           Data.Maybe (fromJust)
 import           Ouroboros.Consensus.Block (getHeader)
@@ -42,11 +43,13 @@ prop_timeouts = do
           (fromJust $ mustReplyTimeout (scChainSyncTimeouts schedulerConfig))
           (btTrunk $ gtBlockTree genesisTest)
 
+      genesisTest' = genesisTest $> schedule
+
   -- NOTE: Because the scheduler configuration depends on the generated
   -- 'GenesisTest' itself, we cannot rely on helpers such as
   -- 'forAllGenesisTest'.
   pure $
-    runGenesisTest' schedulerConfig genesisTest schedule $ \stateView ->
+    runGenesisTest' schedulerConfig genesisTest' $ \stateView ->
       case svChainSyncExceptions stateView of
         [] ->
           counterexample ("result: " ++ condense (svSelectedChain stateView)) False

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Shrinking.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Shrinking.hs
@@ -11,8 +11,9 @@ import           Ouroboros.Network.AnchoredFragment (AnchoredFragment,
 import           Test.Consensus.BlockTree (BlockTree (..), BlockTreeBranch (..),
                      addBranch', mkTrunk)
 import           Test.Consensus.PeerSimulator.StateView (StateView)
-import           Test.Consensus.PointSchedule (GenesisTest (gtBlockTree),
-                     PeerSchedule, peerSchedulesBlocks)
+import           Test.Consensus.PointSchedule
+                     (GenesisTest (gtBlockTree, gtSchedule), PeerSchedule,
+                     peerSchedulesBlocks)
 import           Test.Consensus.PointSchedule.Peers (Peers (..))
 import           Test.QuickCheck (shrinkList)
 import           Test.Util.TestBlock (TestBlock, isAncestorOf,
@@ -23,14 +24,13 @@ import           Test.Util.TestBlock (TestBlock, isAncestorOf,
 -- block tree is trimmed to keep only parts that are necessary for the shrunk
 -- schedule.
 shrinkPeerSchedules ::
-  GenesisTest ->
-  Peers PeerSchedule ->
+  GenesisTest (Peers PeerSchedule) ->
   StateView ->
-  [(GenesisTest, Peers PeerSchedule)]
-shrinkPeerSchedules genesisTest schedule _stateView =
-  shrinkOtherPeers shrinkPeerSchedule schedule <&> \shrunkSchedule ->
+  [GenesisTest (Peers PeerSchedule)]
+shrinkPeerSchedules genesisTest _stateView =
+  shrinkOtherPeers shrinkPeerSchedule (gtSchedule genesisTest) <&> \shrunkSchedule ->
     let trimmedBlockTree = trimBlockTree' shrunkSchedule (gtBlockTree genesisTest)
-     in (genesisTest{gtBlockTree = trimmedBlockTree}, shrunkSchedule)
+     in genesisTest{gtSchedule = shrunkSchedule, gtBlockTree = trimmedBlockTree}
 
 -- | Shrink a 'PeerSchedule' by removing ticks from it. The other ticks are kept
 -- unchanged.


### PR DESCRIPTION
Not super sure about this one.

I feel it makes sense to rework this type because I keep manipulating pairs of `GenesisTest` and point schedule (sometimes `PointSchedule` and sometimes `Peers PeerSchedule`). Considering that a point schedule does not make sense in itself but only within a context, which is what `GenesisTest` provides, I think it makes sense to have a type contain all the information. We could also decide that types such as `PointSchedule` must be self-contained, but I am not entirely convinced by this solution either. What do you guys think?

Also, this might be the right moment to rename this type or to move it. For now, it lives in `Test.Consensus.PointSchedule` and is called `GenesisTest`. My poor naming skills would make me want to rename it into something like `RichPointSchedule`, or just `Rich` so as to write `Rich PointSchedule` or `Rich (Peers PeerSchedule)` but I'm not convinced :p