### PR TITLE
Introduce shrinking of peer schedules

### DIFF
--- a/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
+++ b/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
@@ -234,6 +234,7 @@ test-suite consensus-test
     Test.Consensus.PeerSimulator.Trace
     Test.Consensus.PointSchedule
     Test.Consensus.PointSchedule.Peers
+    Test.Consensus.PointSchedule.Shrinking
     Test.Consensus.PointSchedule.SinglePeer
     Test.Consensus.PointSchedule.SinglePeer.Indices
     Test.Consensus.PointSchedule.Tests

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LongRangeAttack.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LongRangeAttack.hs
@@ -29,10 +29,10 @@ tests =
 
 prop_longRangeAttack :: Property
 prop_longRangeAttack =
-  forAllGenesisTest
+  forAllGenesisTest'
 
     (do gt@GenesisTest{gtBlockTree} <- genChains (pure 1)
-        ps <- fromSchedulePoints <$> stToGen (longRangeAttack gtBlockTree)
+        ps <- stToGen (longRangeAttack gtBlockTree)
         if allAdversariesSelectable (classifiers gt)
           then pure (gt, ps)
           else discard)

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LongRangeAttack.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LongRangeAttack.hs
@@ -14,6 +14,7 @@ import           Test.Consensus.Genesis.Setup.Classifiers
 import           Test.Consensus.PeerSimulator.Run (noTimeoutsSchedulerConfig)
 import           Test.Consensus.PeerSimulator.StateView
 import           Test.Consensus.PointSchedule
+import           Test.Consensus.PointSchedule.Shrinking (shrinkPeerSchedules)
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
 import           Test.Util.Orphans.IOLike ()
@@ -39,7 +40,7 @@ prop_longRangeAttack =
 
     (noTimeoutsSchedulerConfig defaultPointScheduleConfig)
 
-    (\_ _ _ -> [])
+    shrinkPeerSchedules
 
     -- NOTE: This is the expected behaviour of Praos to be reversed with
     -- Genesis. But we are testing Praos for the moment

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
@@ -26,6 +26,7 @@ import           Test.Consensus.PeerSimulator.StateView
 import           Test.Consensus.PointSchedule
 import           Test.Consensus.PointSchedule.Peers (PeerId (..), Peers (..),
                      value)
+import           Test.Consensus.PointSchedule.Shrinking (shrinkPeerSchedules)
 import           Test.Consensus.PointSchedule.SinglePeer
                      (SchedulePoint (ScheduleBlockPoint, ScheduleTipPoint))
 import           Test.Ouroboros.Consensus.ChainGenerator.Params (Delta (Delta))
@@ -130,7 +131,7 @@ prop_serveAdversarialBranches =
     ((noTimeoutsSchedulerConfig defaultPointScheduleConfig)
        {scTraceState = False, scTrace = False})
 
-    (\_ _ _ -> [])
+    shrinkPeerSchedules
 
     theProperty
 
@@ -174,7 +175,7 @@ prop_leashingAttackStalling =
     ((noTimeoutsSchedulerConfig defaultPointScheduleConfig)
       {scTrace = False})
 
-    (\_ _ _ -> [])
+    shrinkPeerSchedules
 
     theProperty
 
@@ -221,7 +222,7 @@ prop_leashingAttackTimeLimited =
     ((noTimeoutsSchedulerConfig defaultPointScheduleConfig)
       {scTrace = False})
 
-    (\_ _ _ -> [])
+    shrinkPeerSchedules
 
     theProperty
 

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
@@ -46,6 +46,7 @@ module Test.Consensus.PointSchedule (
   , genesisAdvertisedPoints
   , headerPointBlock
   , longRangeAttack
+  , peerSchedulesBlocks
   , pointScheduleBlocks
   , pointSchedulePeers
   , prettyGenesisTest
@@ -82,7 +83,7 @@ import           Test.Consensus.PointSchedule.Peers (Peer (..), PeerId (..),
 import           Test.Consensus.PointSchedule.SinglePeer
                      (IsTrunk (IsBranch, IsTrunk), PeerScheduleParams (..),
                      SchedulePoint (..), defaultPeerScheduleParams, mergeOn,
-                     peerScheduleFromTipPoints)
+                     peerScheduleFromTipPoints, schedulePointToBlock)
 import           Test.Consensus.PointSchedule.SinglePeer.Indices
                      (uniformRMDiffTime)
 import           Test.Ouroboros.Consensus.ChainGenerator.Params (Asc,
@@ -327,6 +328,14 @@ fromSchedulePoints peers = do
     durations = snd (mapAccumL (\ prev start -> (start, start - prev)) 0 (drop 1 starts)) ++ [0.1]
 
     (starts, states) = unzip $ foldr (mergeOn fst) [] (peerStates <$> toList (peersList peers))
+
+-- | List of all blocks appearing in the schedule.
+peerScheduleBlocks :: PeerSchedule -> [TestBlock]
+peerScheduleBlocks = map (schedulePointToBlock . snd)
+
+-- | List of all blocks appearing in the schedules.
+peerSchedulesBlocks :: Peers PeerSchedule -> [TestBlock]
+peerSchedulesBlocks = concatMap (peerScheduleBlocks . value) . toList . peersList
 
 ----------------------------------------------------------------------------------------------------
 -- Schedule generators

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Shrinking.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Shrinking.hs
@@ -1,0 +1,13 @@
+module Test.Consensus.PointSchedule.Shrinking (shrinkPeerSchedules) where
+
+import           Test.Consensus.PeerSimulator.StateView (StateView)
+import           Test.Consensus.PointSchedule (GenesisTest, PeerSchedule)
+import           Test.Consensus.PointSchedule.Peers (Peers (..))
+
+-- | Shrink a 'Peers PeerSchedule'.
+shrinkPeerSchedules ::
+  GenesisTest ->
+  Peers PeerSchedule ->
+  StateView ->
+  [(GenesisTest, Peers PeerSchedule)]
+shrinkPeerSchedules _genesisTest _schedule _stateView = []

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Shrinking.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Shrinking.hs
@@ -21,17 +21,23 @@ import           Test.QuickCheck (shrinkList)
 import           Test.Util.TestBlock (TestBlock, TestHash (unTestHash))
 
 -- | Shrink a 'Peers PeerSchedule'. This does not affect the honest peer; it
--- does, however, attempt to remove other peers. The block tree is trimmed to
--- keep only parts that are necessary for the shrunk schedule.
+-- does, however, attempt to remove other peers or ticks of other peers. The
+-- block tree is trimmed to keep only parts that are necessary for the shrunk
+-- schedule.
 shrinkPeerSchedules ::
   GenesisTest ->
   Peers PeerSchedule ->
   StateView ->
   [(GenesisTest, Peers PeerSchedule)]
 shrinkPeerSchedules genesisTest schedule _stateView =
-  shrinkOtherPeers (const []) schedule <&> \shrunkSchedule ->
+  shrinkOtherPeers shrinkPeerSchedule schedule <&> \shrunkSchedule ->
     let trimmedBlockTree = trimBlockTree (gtBlockTree genesisTest) (fromSchedulePoints shrunkSchedule)
      in (genesisTest{gtBlockTree = trimmedBlockTree}, shrunkSchedule)
+
+-- | Shrink a 'PeerSchedule' by removing ticks from it. The other ticks are kept
+-- unchanged.
+shrinkPeerSchedule :: PeerSchedule -> [PeerSchedule]
+shrinkPeerSchedule = shrinkList (const [])
 
 -- | Shrink the 'others' field of a 'Peers' structure by attempting to remove
 -- peers or by shrinking their values using the given shrinking function.

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Shrinking.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Shrinking.hs
@@ -54,9 +54,9 @@ trimBlockTree' = keepOnlyAncestorsOf . peerSchedulesBlocks
 -- that contains ancestors of the given blocks.
 keepOnlyAncestorsOf :: [TestBlock] -> BlockTree TestBlock -> BlockTree TestBlock
 keepOnlyAncestorsOf blocks bt =
-    let leafs = blocksWithoutDescendents blocks
-        trunk = keepOnlyAncestorsOf' leafs (btTrunk bt)
-        branches = mapMaybe (fragmentToMaybe . keepOnlyAncestorsOf' leafs . btbSuffix) (btBranches bt)
+    let leaves = blocksWithoutDescendents blocks
+        trunk = keepOnlyAncestorsOf' leaves (btTrunk bt)
+        branches = mapMaybe (fragmentToMaybe . keepOnlyAncestorsOf' leaves . btbSuffix) (btBranches bt)
      in foldr addBranch' (mkTrunk trunk) branches
   where
     fragmentToMaybe (Empty _) = Nothing
@@ -65,7 +65,7 @@ keepOnlyAncestorsOf blocks bt =
     -- | Given some blocks and a fragment, keep only the prefix of the fragment
     -- that contains ancestors of the given blocks.
     keepOnlyAncestorsOf' :: [TestBlock] -> AnchoredFragment TestBlock -> AnchoredFragment TestBlock
-    keepOnlyAncestorsOf' leafs = takeWhileOldest (\block -> (block `isAncestorOf`) `any` leafs)
+    keepOnlyAncestorsOf' leaves = takeWhileOldest (\block -> (block `isAncestorOf`) `any` leaves)
 
     -- | Return a subset of the given blocks containing only the ones that do
     -- not have any other descendents in the set.
@@ -78,8 +78,8 @@ keepOnlyAncestorsOf blocks bt =
         -- | Blocks that do not have any descendents earlier in the list.
         blocksWithoutPreviousDescendents =
           foldl
-            (\leafs block ->
-               if (block `isAncestorOf`) `any` leafs
-                 then leafs
-                 else block : leafs)
+            (\leaves block ->
+               if (block `isAncestorOf`) `any` leaves
+                 then leaves
+                 else block : leaves)
             []

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Shrinking.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Shrinking.hs
@@ -1,13 +1,24 @@
 {-# LANGUAGE NamedFieldPuns #-}
-{-# LANGUAGE TupleSections  #-}
 
 module Test.Consensus.PointSchedule.Shrinking (shrinkPeerSchedules) where
 
+import           Data.Functor ((<&>))
+import           Data.List (isSuffixOf, sortOn)
+import qualified Data.List.NonEmpty as NonEmpty
 import qualified Data.Map.Strict as Map
+import           Data.Maybe (mapMaybe)
+import           Ouroboros.Network.AnchoredFragment (AnchoredFragment,
+                     AnchoredSeq (Empty, (:>)))
+import           Ouroboros.Network.Block (blockHash, blockSlot)
+import           Test.Consensus.BlockTree (BlockTree (..), BlockTreeBranch (..),
+                     addBranch', mkTrunk)
 import           Test.Consensus.PeerSimulator.StateView (StateView)
-import           Test.Consensus.PointSchedule (GenesisTest, PeerSchedule)
+import           Test.Consensus.PointSchedule (GenesisTest (gtBlockTree),
+                     PeerSchedule, PointSchedule, fromSchedulePoints,
+                     pointScheduleBlocks)
 import           Test.Consensus.PointSchedule.Peers (Peers (..))
 import           Test.QuickCheck (shrinkList)
+import           Test.Util.TestBlock (TestBlock, TestHash (unTestHash))
 
 -- | Shrink a 'Peers PeerSchedule'. This does not affect the honest peer; it
 -- does, however, attempt to remove other peers. The block tree is trimmed to
@@ -18,7 +29,9 @@ shrinkPeerSchedules ::
   StateView ->
   [(GenesisTest, Peers PeerSchedule)]
 shrinkPeerSchedules genesisTest schedule _stateView =
-  map (genesisTest,) $ shrinkOtherPeers (const []) schedule
+  shrinkOtherPeers (const []) schedule <&> \shrunkSchedule ->
+    let trimmedBlockTree = trimBlockTree (gtBlockTree genesisTest) (fromSchedulePoints shrunkSchedule)
+     in (genesisTest{gtBlockTree = trimmedBlockTree}, shrunkSchedule)
 
 -- | Shrink the 'others' field of a 'Peers' structure by attempting to remove
 -- peers or by shrinking their values using the given shrinking function.
@@ -26,3 +39,52 @@ shrinkOtherPeers :: (a -> [a]) -> Peers a -> [Peers a]
 shrinkOtherPeers shrink Peers{honest, others} =
   map (Peers honest . Map.fromList) $
     shrinkList (traverse (traverse shrink)) $ Map.toList others
+
+-- | Remove blocks from the given block tree that are not necessary for the
+-- given point schedule. If entire branches are unused, they are removed. If the
+-- trunk is unused, then it remains as an empty anchored fragment.
+trimBlockTree :: BlockTree TestBlock -> PointSchedule -> BlockTree TestBlock
+trimBlockTree bt ps =
+    let youngest = selectYoungest (pointScheduleBlocks ps)
+        trunk = trimFragment youngest (btTrunk bt)
+        branches = mapMaybe (fragmentToMaybe . trimFragment youngest . btbSuffix) (btBranches bt)
+     in foldr addBranch' (mkTrunk trunk) branches
+  where
+    fragmentToMaybe (Empty _) = Nothing
+    fragmentToMaybe fragment  = Just fragment
+
+    -- | Given a list of blocks and a fragment, cut the fragment such that it
+    -- contains only blocks that are ancestors of blocks in the list.
+    trimFragment :: [TestBlock] -> AnchoredFragment TestBlock -> AnchoredFragment TestBlock
+    trimFragment _ fragment@(Empty _) = fragment
+    trimFragment youngest (fragment :> block)
+      | any (block `isOlderThan`) youngest = fragment :> block
+      | otherwise = trimFragment youngest fragment
+
+    -- | Return a subset of the given block containing youngest elements. It is
+    -- not guaranteed that this set is minimal. It is however guaranteed that
+    -- any block in the input list is an ancestor of a block in the output list.
+    selectYoungest :: [TestBlock] -> [TestBlock]
+    selectYoungest =
+        -- NOTE: We process blocks from the biggest slot to the smallest; this
+        -- should make us select only the tip of each chain.
+        go [] . reverse . sortOn blockSlot
+      where
+        go youngest [] = youngest
+        go youngest (block : blocks)
+          | any (`isYoungerThan` block) youngest = go youngest blocks
+          | otherwise = go (block : youngest) blocks
+
+    -- | Partial comparison of blocks. A block is older than another block if it
+    -- is its ancestor. For test blocks, this can be seen in the hash.
+    isOlderThan :: TestBlock -> TestBlock -> Bool
+    isOlderThan b1 b2 =
+      -- NOTE: 'unTestHash' returns the list of hash components _in reverse
+      -- order_ so we need to test that one hash is the _suffix_ of the other.
+      NonEmpty.toList (unTestHash (blockHash b1))
+        `isSuffixOf`
+      NonEmpty.toList (unTestHash (blockHash b2))
+
+    -- | Partial comparison of blocks. @isYoungerThan = flip isOlderThan@.
+    isYoungerThan :: TestBlock -> TestBlock -> Bool
+    isYoungerThan = flip isOlderThan

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Shrinking.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Shrinking.hs
@@ -1,13 +1,28 @@
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE TupleSections  #-}
+
 module Test.Consensus.PointSchedule.Shrinking (shrinkPeerSchedules) where
 
+import qualified Data.Map.Strict as Map
 import           Test.Consensus.PeerSimulator.StateView (StateView)
 import           Test.Consensus.PointSchedule (GenesisTest, PeerSchedule)
 import           Test.Consensus.PointSchedule.Peers (Peers (..))
+import           Test.QuickCheck (shrinkList)
 
--- | Shrink a 'Peers PeerSchedule'.
+-- | Shrink a 'Peers PeerSchedule'. This does not affect the honest peer; it
+-- does, however, attempt to remove other peers. The block tree is trimmed to
+-- keep only parts that are necessary for the shrunk schedule.
 shrinkPeerSchedules ::
   GenesisTest ->
   Peers PeerSchedule ->
   StateView ->
   [(GenesisTest, Peers PeerSchedule)]
-shrinkPeerSchedules _genesisTest _schedule _stateView = []
+shrinkPeerSchedules genesisTest schedule _stateView =
+  map (genesisTest,) $ shrinkOtherPeers (const []) schedule
+
+-- | Shrink the 'others' field of a 'Peers' structure by attempting to remove
+-- peers or by shrinking their values using the given shrinking function.
+shrinkOtherPeers :: (a -> [a]) -> Peers a -> [Peers a]
+shrinkOtherPeers shrink Peers{honest, others} =
+  map (Peers honest . Map.fromList) $
+    shrinkList (traverse (traverse shrink)) $ Map.toList others

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Shrinking.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Shrinking.hs
@@ -3,13 +3,12 @@
 module Test.Consensus.PointSchedule.Shrinking (shrinkPeerSchedules) where
 
 import           Data.Functor ((<&>))
-import           Data.List (isSuffixOf, sortOn)
-import qualified Data.List.NonEmpty as NonEmpty
+import           Data.List (sortOn)
 import qualified Data.Map.Strict as Map
 import           Data.Maybe (mapMaybe)
 import           Ouroboros.Network.AnchoredFragment (AnchoredFragment,
                      AnchoredSeq (Empty), takeWhileOldest)
-import           Ouroboros.Network.Block (blockHash, blockSlot)
+import           Ouroboros.Network.Block (blockSlot)
 import           Test.Consensus.BlockTree (BlockTree (..), BlockTreeBranch (..),
                      addBranch', mkTrunk)
 import           Test.Consensus.PeerSimulator.StateView (StateView)
@@ -17,7 +16,7 @@ import           Test.Consensus.PointSchedule (GenesisTest (gtBlockTree),
                      PeerSchedule, peerSchedulesBlocks)
 import           Test.Consensus.PointSchedule.Peers (Peers (..))
 import           Test.QuickCheck (shrinkList)
-import           Test.Util.TestBlock (TestBlock, TestHash (unTestHash))
+import           Test.Util.TestBlock (TestBlock, isAncestorOf)
 
 -- | Shrink a 'Peers PeerSchedule'. This does not affect the honest peer; it
 -- does, however, attempt to remove other peers or ticks of other peers. The
@@ -84,13 +83,3 @@ keepOnlyAncestorsOf blocks bt =
                  then leafs
                  else block : leafs)
             []
-
-    -- | Partial comparison of blocks. A block is older than another block if it
-    -- is its ancestor. For test blocks, this can be seen in the hash.
-    isAncestorOf :: TestBlock -> TestBlock -> Bool
-    isAncestorOf b1 b2 =
-      -- NOTE: 'unTestHash' returns the list of hash components _in reverse
-      -- order_ so we need to test that one hash is the _suffix_ of the other.
-      NonEmpty.toList (unTestHash (blockHash b1))
-        `isSuffixOf`
-      NonEmpty.toList (unTestHash (blockHash b2))

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Shrinking.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Shrinking.hs
@@ -64,7 +64,7 @@ trimBlockTree bt ps =
     trimFragment :: [TestBlock] -> AnchoredFragment TestBlock -> AnchoredFragment TestBlock
     trimFragment _ fragment@(Empty _) = fragment
     trimFragment youngest (fragment :> block)
-      | any (block `isOlderThan`) youngest = fragment :> block
+      | any (block `isAncestorOf`) youngest = fragment :> block
       | otherwise = trimFragment youngest fragment
 
     -- | Return a subset of the given block containing youngest elements. It is
@@ -78,19 +78,19 @@ trimBlockTree bt ps =
       where
         go youngest [] = youngest
         go youngest (block : blocks)
-          | any (`isYoungerThan` block) youngest = go youngest blocks
+          | any (`isDescendentOf` block) youngest = go youngest blocks
           | otherwise = go (block : youngest) blocks
 
     -- | Partial comparison of blocks. A block is older than another block if it
     -- is its ancestor. For test blocks, this can be seen in the hash.
-    isOlderThan :: TestBlock -> TestBlock -> Bool
-    isOlderThan b1 b2 =
+    isAncestorOf :: TestBlock -> TestBlock -> Bool
+    isAncestorOf b1 b2 =
       -- NOTE: 'unTestHash' returns the list of hash components _in reverse
       -- order_ so we need to test that one hash is the _suffix_ of the other.
       NonEmpty.toList (unTestHash (blockHash b1))
         `isSuffixOf`
       NonEmpty.toList (unTestHash (blockHash b2))
 
-    -- | Partial comparison of blocks. @isYoungerThan = flip isOlderThan@.
-    isYoungerThan :: TestBlock -> TestBlock -> Bool
-    isYoungerThan = flip isOlderThan
+    -- | Partial comparison of blocks. @isDescendentOf = flip isAncestorOf@.
+    isDescendentOf :: TestBlock -> TestBlock -> Bool
+    isDescendentOf = flip isAncestorOf

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/TestBlock.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/TestBlock.hs
@@ -72,6 +72,8 @@ module Test.Util.TestBlock (
   , Permutation (..)
   , isAncestorOf
   , isDescendentOf
+  , isStrictAncestorOf
+  , isStrictDescendentOf
   , permute
   , unsafeTestBlockWithPayload
   ) where
@@ -266,6 +268,11 @@ isAncestorOf b1 b2 =
     `isSuffixOf`
   NE.toList (unTestHash (blockHash b2))
 
+-- | Variant of 'isAncestorOf' that returns @False@ when the two blocks are
+-- equal.
+isStrictAncestorOf :: TestBlock -> TestBlock -> Bool
+isStrictAncestorOf b1 b2 = b1 `isAncestorOf` b2 && b1 /= b2
+
 -- | A block @b1@ is the descendent of another block @b2@ if there exists a
 -- chain of blocks from @b2@ to @b1@. For test blocks in particular, this can be
 -- seen in the hash: the hash of @b2@ should be a prefix of the hash of @b1@.
@@ -276,6 +283,11 @@ isAncestorOf b1 b2 =
 -- not (b1 `isAncestorOf` b2) || b1 == b2@.
 isDescendentOf :: TestBlock -> TestBlock -> Bool
 isDescendentOf = flip isAncestorOf
+
+-- | Variant of 'isDescendentOf' that returns @False@ when the two blocks are
+-- equal.
+isStrictDescendentOf :: TestBlock -> TestBlock -> Bool
+isStrictDescendentOf b1 b2 = b1 `isDescendentOf` b2 && b1 /= b2
 
 instance ShowProxy TestBlock where
 

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/TestBlock.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/TestBlock.hs
@@ -71,6 +71,7 @@ module Test.Util.TestBlock (
     -- * Support for tests
   , Permutation (..)
   , permute
+  , unsafeTestBlockWithPayload
   ) where
 
 import           Cardano.Crypto.DSIGN
@@ -217,6 +218,12 @@ data TestBlockWith ptype = TestBlockWith {
     }
   deriving stock    (Show, Eq, Ord, Generic)
   deriving anyclass (Serialise, NoThunks, ToExpr)
+
+-- | Create a block directly with the given parameters. This allows creating
+-- inconsistent blocks; prefer 'firstBlockWithPayload' or 'successorBlockWithPayload'.
+unsafeTestBlockWithPayload :: TestHash -> SlotNo -> Validity -> ptype -> TestBlockWith ptype
+unsafeTestBlockWithPayload tbHash tbSlot tbValid tbPayload =
+  TestBlockWith{tbHash, tbSlot, tbValid, tbPayload}
 
 -- | Create the first block in the given fork, @[fork]@, with the given payload.
 -- The 'SlotNo' will be 1.


### PR DESCRIPTION
_Supersedes https://github.com/IntersectMBO/ouroboros-consensus/pull/817, https://github.com/IntersectMBO/ouroboros-consensus/pull/826 and https://github.com/IntersectMBO/ouroboros-consensus/pull/828 apart from the checks of alertness of the honest peer, but we might take a different approach and the commits of these PRs are too old to be reapplied easily anyways._

### Overview

This PR introduces shrinking for `Peers PeerSchedule`, in a careful way, based on what we have learned so far.

The first four commits are logistical ones. ee37753e5ad2a1d586bd41605f9b2f996f1e53a5 and b70a36f52da342de99e70ca5253f54d384c9202c introduce helpers to manipulate point schedules. 7cf053cb7b095e8cafede94c29f5cb0f5bc7fe13 introduces a minor irrelevant change to long change attack. e3528776c1101fdaa3ca8f56a4d66760e49ad101 introduces a `Test.Consensus.PointSchedule.Shrinking` module with a dummy shrinking function. 

The first interesting commit is 32d67e562350ee7a0ff1121ee652bc5243c1a39e. It introduces basic shrinking of `Peers PeerSchedule` by simply attempting to remove non-honest peers. df2e8570fc1f4307604820ad029d112d8b4505c6 then introduces trimming of block trees, removing all blocks in a block tree that are not necessary for the execution of a point schedule. Since our point schedules so far tend to advertise the whole chain immediately, this trimming only consists in removing unused branches so far. It was surprisingly tricky to get right but I think it works now. Finally, 7c46ffcc832cfeff30a1e0d33997468832ead48e also adds shrinking of one `PeerSchedule` by removing its ticks. This is only applied to non-honest peers.

### Discussion

For now, I avoided touching the honest peer altogether. Shrinking the non-honest peers is easier because it does not matter really what we remove as long as they still win over the honest peer. For the honest peer, we have to be careful not to make it too weak. I do wonder if there is such a thing as a too strong adversary, though. For instance, I have been playing around with:

```
cabal run ouroboros-consensus-diffusion:consensus-test -- -p '/stalling leashing attack/' --quickcheck-replay=512008
```

Before this PR (on 27f63dec1ee3f4fb14e7682dea46b65cd365b2f5), it would find the following test case:

<details>
  <summary><i>Block tree with 1 trunk and 4 branches; point schedule with 197 ticks.</i></summary>

```
gtBlockTree:
  slots:    0  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29
  trunk:  -----1--2--3--4-----5--6--7--8--9----10-11-12-13----14-15----------16-17-18----19-20-21
                                       `-----9-------------------10-------11----12-------------13-14
                                       `-----9-10-11-12----------------13-14-15-16----17-18
               `--2--3-----4-----5--6-----7--8-----9-10-11----12-13-14-15-16----17-18-19-20-21-22-23
         `--1-----2--3--------4--5--6--7-----8--9-10-11-12-13-14-15-16-17-18-19-20-21----22-23-24-25

PointSchedule:
  0: honest: TP 21-28 | HP G | BP G | 0.000000
  1: adversary 1: TP 14-29[8x0,4,5x0] | HP G | BP G | 0.000000
  2: adversary 2: TP 18-26[8x0,3,9x0] | HP G | BP G | 0.000000
  3: adversary 3: TP 23-29[0,2,21x0] | HP G | BP G | 0.000000
  4: adversary 4: TP 25-29[1,24x0] | HP G | BP G | 0.021074
  5: adversary 3: TP 23-29[0,2,21x0] | HP 1-1 | BP G | 0.002591
  6: honest: TP 21-28 | HP 1-1 | BP G | 0.000810
  7: adversary 1: TP 14-29[8x0,4,5x0] | HP 1-1 | BP G | 0.002086
  8: adversary 4: TP 25-29[1,24x0] | HP 1-0[1] | BP G | 0.008475
  9: adversary 2: TP 18-26[8x0,3,9x0] | HP 1-1 | BP G | 0.007123
  10: adversary 3: TP 23-29[0,2,21x0] | HP 2-2[0,2] | BP G | 0.003542
  11: honest: TP 21-28 | HP 2-2 | BP G | 0.002234
  12: adversary 1: TP 14-29[8x0,4,5x0] | HP 2-2 | BP G | 0.006318
  13: adversary 4: TP 25-29[1,24x0] | HP 2-2[1,0] | BP G | 0.007728
  14: adversary 3: TP 23-29[0,2,21x0] | HP 3-3[0,2,0] | BP G | 0.005688
  15: honest: TP 21-28 | HP 3-3 | BP G | 0.000804
  16: adversary 2: TP 18-26[8x0,3,9x0] | HP 2-2 | BP G | 0.005681
  17: honest: TP 21-28 | HP 3-3 | BP 1-1 | 0.001544
  18: adversary 1: TP 14-29[8x0,4,5x0] | HP 2-2 | BP 1-1 | 0.001798
  19: adversary 1: TP 14-29[8x0,4,5x0] | HP 3-3 | BP 1-1 | 0.002981
  20: adversary 4: TP 25-29[1,24x0] | HP 2-2[1,0] | BP 1-0[1] | 0.001346
  21: adversary 3: TP 23-29[0,2,21x0] | HP 4-5[0,2,2x0] | BP G | 0.006391
  22: adversary 2: TP 18-26[8x0,3,9x0] | HP 2-2 | BP 1-1 | 0.006266
  23: honest: TP 21-28 | HP 4-4 | BP 1-1 | 0.000282
  24: adversary 3: TP 23-29[0,2,21x0] | HP 4-5[0,2,2x0] | BP 1-1 | 0.005611
  25: adversary 2: TP 18-26[8x0,3,9x0] | HP 3-3 | BP 1-1 | 0.002113
  26: adversary 3: TP 23-29[0,2,21x0] | HP 5-7[0,2,3x0] | BP 1-1 | 0.005281
  27: adversary 4: TP 25-29[1,24x0] | HP 4-6[1,3x0] | BP 1-0[1] | 0.013719
  28: honest: TP 21-28 | HP 5-6 | BP 1-1 | 0.000463
  29: adversary 3: TP 23-29[0,2,21x0] | HP 6-8[0,2,4x0] | BP 1-1 | 0.003993
  30: honest: TP 21-28 | HP 5-6 | BP 2-2 | 0.000009
  31: adversary 1: TP 14-29[8x0,4,5x0] | HP 5-6 | BP 1-1 | 0.003374
  32: adversary 2: TP 18-26[8x0,3,9x0] | HP 4-4 | BP 1-1 | 0.000763
  33: adversary 1: TP 14-29[8x0,4,5x0] | HP 5-6 | BP 2-2 | 0.003322
  34: adversary 4: TP 25-29[1,24x0] | HP 5-7[1,4x0] | BP 1-0[1] | 0.000218
  35: adversary 4: TP 25-29[1,24x0] | HP 5-7[1,4x0] | BP 2-2[1,0] | 0.004786
  36: adversary 2: TP 18-26[8x0,3,9x0] | HP 4-4 | BP 2-2 | 0.003279
  37: honest: TP 21-28 | HP 6-7 | BP 2-2 | 0.000697
  38: adversary 3: TP 23-29[0,2,21x0] | HP 7-10[0,2,5x0] | BP 1-1 | 0.004346
  39: adversary 3: TP 23-29[0,2,21x0] | HP 7-10[0,2,5x0] | BP 2-2[0,2] | 0.003710
  40: adversary 1: TP 14-29[8x0,4,5x0] | HP 6-7 | BP 2-2 | 0.010613
  41: adversary 4: TP 25-29[1,24x0] | HP 6-8[1,5x0] | BP 2-2[1,0] | 0.000554
  42: adversary 3: TP 23-29[0,2,21x0] | HP 8-11[0,2,6x0] | BP 2-2[0,2] | 0.004809
  43: honest: TP 21-28 | HP 7-8 | BP 2-2 | 0.010189
  44: adversary 1: TP 14-29[8x0,4,5x0] | HP 7-8 | BP 2-2 | 0.003692
  45: honest: TP 21-28 | HP 7-8 | BP 3-3 | 0.001730
  46: adversary 3: TP 23-29[0,2,21x0] | HP 9-13[0,2,7x0] | BP 2-2[0,2] | 0.002486
  47: adversary 1: TP 14-29[8x0,4,5x0] | HP 7-8 | BP 3-3 | 0.000585
  48: adversary 4: TP 25-29[1,24x0] | HP 7-9[1,6x0] | BP 2-2[1,0] | 0.003276
  49: adversary 4: TP 25-29[1,24x0] | HP 7-9[1,6x0] | BP 3-3[1,2x0] | 0.000201
  50: honest: TP 21-28 | HP 8-9 | BP 3-3 | 0.000902
  51: adversary 2: TP 18-26[8x0,3,9x0] | HP 4-4 | BP 3-3 | 0.003239
  52: adversary 2: TP 18-26[8x0,3,9x0] | HP 6-7 | BP 3-3 | 0.005268
  53: adversary 3: TP 23-29[0,2,21x0] | HP 9-13[0,2,7x0] | BP 3-3[0,2,0] | 0.002312
  54: adversary 1: TP 14-29[8x0,4,5x0] | HP 8-9 | BP 3-3 | 0.002087
  55: adversary 3: TP 23-29[0,2,21x0] | HP 10-14[0,2,8x0] | BP 3-3[0,2,0] | 0.011612
  56: adversary 4: TP 25-29[1,24x0] | HP 8-11[1,7x0] | BP 3-3[1,2x0] | 0.001105
  57: honest: TP 21-28 | HP 9-10 | BP 3-3 | 0.006998
  58: adversary 2: TP 18-26[8x0,3,9x0] | HP 7-8 | BP 3-3 | 0.000938
  59: adversary 3: TP 23-29[0,2,21x0] | HP 11-15[0,2,9x0] | BP 3-3[0,2,0] | 0.006302
  60: adversary 1: TP 14-29[8x0,4,5x0] | HP 9-11[8x0,4] | BP 3-3 | 0.001910
  61: honest: TP 21-28 | HP 9-10 | BP 4-4 | 0.005941
  62: honest: TP 21-28 | HP 10-12 | BP 4-4 | 0.002718
  63: adversary 4: TP 25-29[1,24x0] | HP 9-12[1,8x0] | BP 3-3[1,2x0] | 0.002291
  64: adversary 2: TP 18-26[8x0,3,9x0] | HP 7-8 | BP 4-4 | 0.002285
  65: adversary 3: TP 23-29[0,2,21x0] | HP 12-17[0,2,10x0] | BP 3-3[0,2,0] | 0.004519
  66: adversary 3: TP 23-29[0,2,21x0] | HP 12-17[0,2,10x0] | BP 4-5[0,2,2x0] | 0.002513
  67: adversary 2: TP 18-26[8x0,3,9x0] | HP 8-9 | BP 4-4 | 0.005105
  68: adversary 1: TP 14-29[8x0,4,5x0] | HP 10-18[8x0,4,0] | BP 3-3 | 0.007429
  69: honest: TP 21-28 | HP 11-13 | BP 4-4 | 0.000392
  70: adversary 4: TP 25-29[1,24x0] | HP 10-13[1,9x0] | BP 3-3[1,2x0] | 0.001207
  71: adversary 3: TP 23-29[0,2,21x0] | HP 13-18[0,2,11x0] | BP 4-5[0,2,2x0] | 0.013827
  72: adversary 1: TP 14-29[8x0,4,5x0] | HP 10-18[8x0,4,0] | BP 4-4 | 0.004778
  73: honest: TP 21-28 | HP 11-13 | BP 5-6 | 0.000574
  74: adversary 3: TP 23-29[0,2,21x0] | HP 14-19[0,2,12x0] | BP 4-5[0,2,2x0] | 0.001223
  75: adversary 2: TP 18-26[8x0,3,9x0] | HP 9-11[8x0,3] | BP 4-4 | 0.003546
  76: adversary 4: TP 25-29[1,24x0] | HP 11-14[1,10x0] | BP 3-3[1,2x0] | 0.000111
  77: honest: TP 21-28 | HP 12-14 | BP 5-6 | 0.004486
  78: adversary 4: TP 25-29[1,24x0] | HP 11-14[1,10x0] | BP 5-7[1,4x0] | 0.008204
  79: adversary 3: TP 23-29[0,2,21x0] | HP 14-19[0,2,12x0] | BP 5-7[0,2,3x0] | 0.002932
  80: adversary 3: TP 23-29[0,2,21x0] | HP 15-20[0,2,13x0] | BP 5-7[0,2,3x0] | 0.002656
  81: adversary 1: TP 14-29[8x0,4,5x0] | HP 12-23[8x0,4,3x0] | BP 4-4 | 0.008052
  82: adversary 2: TP 18-26[8x0,3,9x0] | HP 10-12[8x0,3,0] | BP 4-4 | 0.001799
  83: honest: TP 21-28 | HP 13-15 | BP 5-6 | 0.000662
  84: adversary 4: TP 25-29[1,24x0] | HP 12-15[1,11x0] | BP 5-7[1,4x0] | 0.006375
  85: adversary 3: TP 23-29[0,2,21x0] | HP 16-21[0,2,14x0] | BP 5-7[0,2,3x0] | 0.007123
  86: adversary 1: TP 14-29[8x0,4,5x0] | HP 12-23[8x0,4,3x0] | BP 5-6 | 0.003369
  87: honest: TP 21-28 | HP 13-15 | BP 6-7 | 0.000027
  88: adversary 1: TP 14-29[8x0,4,5x0] | HP 13-28[8x0,4,4x0] | BP 5-6 | 0.002921
  89: adversary 2: TP 18-26[8x0,3,9x0] | HP 10-12[8x0,3,0] | BP 5-6 | 0.002520
  90: honest: TP 21-28 | HP 14-17 | BP 6-7 | 0.003187
  91: adversary 3: TP 23-29[0,2,21x0] | HP 17-23[0,2,15x0] | BP 5-7[0,2,3x0] | 0.002003
  92: adversary 4: TP 25-29[1,24x0] | HP 13-16[1,12x0] | BP 5-7[1,4x0] | 0.000686
  93: adversary 4: TP 25-29[1,24x0] | HP 13-16[1,12x0] | BP 6-8[1,5x0] | 0.004077
  94: adversary 2: TP 18-26[8x0,3,9x0] | HP 11-13[8x0,3,2x0] | BP 5-6 | 0.006321
  95: adversary 3: TP 23-29[0,2,21x0] | HP 17-23[0,2,15x0] | BP 6-8[0,2,4x0] | 0.005933
  96: adversary 1: TP 14-29[8x0,4,5x0] | HP 14-29[8x0,4,5x0] | BP 5-6 | 0.000858
  97: honest: TP 21-28 | HP 15-18 | BP 6-7 | 0.001160
  98: adversary 3: TP 23-29[0,2,21x0] | HP 18-24[0,2,16x0] | BP 6-8[0,2,4x0] | 0.007469
  99: adversary 4: TP 25-29[1,24x0] | HP 14-17[1,13x0] | BP 6-8[1,5x0] | 0.012226
  100: adversary 2: TP 18-26[8x0,3,9x0] | HP 12-14[8x0,3,3x0] | BP 5-6 | 0.000475
  101: adversary 1: TP 14-29[8x0,4,5x0] | HP 14-29[8x0,4,5x0] | BP 6-7 | 0.000016
  102: adversary 3: TP 23-29[0,2,21x0] | HP 19-25[0,2,17x0] | BP 6-8[0,2,4x0] | 0.000660
  103: honest: TP 21-28 | HP 16-22 | BP 6-7 | 0.002669
  104: honest: TP 21-28 | HP 16-22 | BP 7-8 | 0.010563
  105: adversary 4: TP 25-29[1,24x0] | HP 14-17[1,13x0] | BP 7-9[1,6x0] | 0.000925
  106: adversary 4: TP 25-29[1,24x0] | HP 15-18[1,14x0] | BP 7-9[1,6x0] | 0.005537
  107: adversary 3: TP 23-29[0,2,21x0] | HP 20-26[0,2,18x0] | BP 6-8[0,2,4x0] | 0.006424
  108: adversary 3: TP 23-29[0,2,21x0] | HP 20-26[0,2,18x0] | BP 7-10[0,2,5x0] | 0.000558
  109: honest: TP 21-28 | HP 17-23 | BP 7-8 | 0.001554
  110: adversary 2: TP 18-26[8x0,3,9x0] | HP 13-20[8x0,3,4x0] | BP 5-6 | 0.010150
  111: adversary 4: TP 25-29[1,24x0] | HP 16-19[1,15x0] | BP 7-9[1,6x0] | 0.001638
  112: adversary 3: TP 23-29[0,2,21x0] | HP 21-27[0,2,19x0] | BP 7-10[0,2,5x0] | 0.011992
  113: adversary 1: TP 14-29[8x0,4,5x0] | HP 14-29[8x0,4,5x0] | BP 7-8 | 0.000067
  114: honest: TP 21-28 | HP 18-24 | BP 7-8 | 0.000638
  115: honest: TP 21-28 | HP 18-24 | BP 8-9 | 0.004260
  116: adversary 2: TP 18-26[8x0,3,9x0] | HP 13-20[8x0,3,4x0] | BP 7-8 | 0.003328
  117: adversary 3: TP 23-29[0,2,21x0] | HP 22-28[0,2,20x0] | BP 7-10[0,2,5x0] | 0.002219
  118: adversary 4: TP 25-29[1,24x0] | HP 17-20[1,16x0] | BP 7-9[1,6x0] | 0.000391
  119: adversary 2: TP 18-26[8x0,3,9x0] | HP 14-21[8x0,3,5x0] | BP 7-8 | 0.003057
  120: adversary 4: TP 25-29[1,24x0] | HP 17-20[1,16x0] | BP 8-11[1,7x0] | 0.012958
  121: honest: TP 21-28 | HP 19-26 | BP 8-9 | 0.001833
  122: adversary 3: TP 23-29[0,2,21x0] | HP 23-29[0,2,21x0] | BP 7-10[0,2,5x0] | 0.005594
  123: adversary 4: TP 25-29[1,24x0] | HP 18-21[1,17x0] | BP 8-11[1,7x0] | 0.011205
  124: adversary 2: TP 18-26[8x0,3,9x0] | HP 15-22[8x0,3,6x0] | BP 7-8 | 0.005753
  125: honest: TP 21-28 | HP 20-27 | BP 8-9 | 0.000742
  126: honest: TP 21-28 | HP 20-27 | BP 9-10 | 0.000542
  127: adversary 1: TP 14-29[8x0,4,5x0] | HP 14-29[8x0,4,5x0] | BP 8-9 | 0.002799
  128: adversary 2: TP 18-26[8x0,3,9x0] | HP 15-22[8x0,3,6x0] | BP 8-9 | 0.012946
  129: adversary 4: TP 25-29[1,24x0] | HP 18-21[1,17x0] | BP 9-12[1,8x0] | 0.003981
  130: honest: TP 21-28 | HP 21-28 | BP 9-10 | 0.001580
  131: adversary 2: TP 18-26[8x0,3,9x0] | HP 16-23[8x0,3,7x0] | BP 8-9 | 0.004469
  132: adversary 3: TP 23-29[0,2,21x0] | HP 23-29[0,2,21x0] | BP 9-13[0,2,7x0] | 0.010442
  133: adversary 4: TP 25-29[1,24x0] | HP 20-23[1,19x0] | BP 9-12[1,8x0] | 0.013374
  134: honest: TP 21-28 | HP 21-28 | BP 10-12 | 0.002805
  135: adversary 2: TP 18-26[8x0,3,9x0] | HP 17-25[8x0,3,8x0] | BP 8-9 | 0.002433
  136: adversary 1: TP 14-29[8x0,4,5x0] | HP 14-29[8x0,4,5x0] | BP 9-11[8x0,4] | 0.001040
  137: adversary 2: TP 18-26[8x0,3,9x0] | HP 17-25[8x0,3,8x0] | BP 9-11[8x0,3] | 0.007968
  138: adversary 4: TP 25-29[1,24x0] | HP 21-24[1,20x0] | BP 9-12[1,8x0] | 0.003863
  139: adversary 4: TP 25-29[1,24x0] | HP 21-24[1,20x0] | BP 10-13[1,9x0] | 0.010629
  140: adversary 3: TP 23-29[0,2,21x0] | HP 23-29[0,2,21x0] | BP 10-14[0,2,8x0] | 0.008896
  141: adversary 2: TP 18-26[8x0,3,9x0] | HP 18-26[8x0,3,9x0] | BP 9-11[8x0,3] | 0.000571
  142: adversary 4: TP 25-29[1,24x0] | HP 22-26[1,21x0] | BP 10-13[1,9x0] | 0.015499
  143: honest: TP 21-28 | HP 21-28 | BP 11-13 | 0.001972
  144: adversary 1: TP 14-29[8x0,4,5x0] | HP 14-29[8x0,4,5x0] | BP 10-18[8x0,4,0] | 0.004262
  145: adversary 2: TP 18-26[8x0,3,9x0] | HP 18-26[8x0,3,9x0] | BP 10-12[8x0,3,0] | 0.003977
  146: adversary 4: TP 25-29[1,24x0] | HP 23-27[1,22x0] | BP 10-13[1,9x0] | 0.006040
  147: adversary 4: TP 25-29[1,24x0] | HP 23-27[1,22x0] | BP 11-14[1,10x0] | 0.009934
  148: adversary 3: TP 23-29[0,2,21x0] | HP 23-29[0,2,21x0] | BP 11-15[0,2,9x0] | 0.011305
  149: adversary 4: TP 25-29[1,24x0] | HP 24-28[1,23x0] | BP 11-14[1,10x0] | 0.012958
  150: honest: TP 21-28 | HP 21-28 | BP 12-14 | 0.002526
  151: adversary 1: TP 14-29[8x0,4,5x0] | HP 14-29[8x0,4,5x0] | BP 11-21[8x0,4,2x0] | 0.003591
  152: adversary 2: TP 18-26[8x0,3,9x0] | HP 18-26[8x0,3,9x0] | BP 11-13[8x0,3,2x0] | 0.005288
  153: adversary 4: TP 25-29[1,24x0] | HP 25-29[1,24x0] | BP 11-14[1,10x0] | 0.009204
  154: adversary 4: TP 25-29[1,24x0] | HP 25-29[1,24x0] | BP 12-15[1,11x0] | 0.008948
  155: adversary 3: TP 23-29[0,2,21x0] | HP 23-29[0,2,21x0] | BP 12-17[0,2,10x0] | 0.023885
  156: honest: TP 21-28 | HP 21-28 | BP 13-15 | 0.002106
  157: adversary 1: TP 14-29[8x0,4,5x0] | HP 14-29[8x0,4,5x0] | BP 12-23[8x0,4,3x0] | 0.000622
  158: adversary 2: TP 18-26[8x0,3,9x0] | HP 18-26[8x0,3,9x0] | BP 12-14[8x0,3,3x0] | 0.019304
  159: adversary 4: TP 25-29[1,24x0] | HP 25-29[1,24x0] | BP 13-16[1,12x0] | 0.006148
  160: adversary 3: TP 23-29[0,2,21x0] | HP 23-29[0,2,21x0] | BP 13-18[0,2,11x0] | 0.026023
  161: honest: TP 21-28 | HP 21-28 | BP 14-17 | 0.002333
  162: adversary 1: TP 14-29[8x0,4,5x0] | HP 14-29[8x0,4,5x0] | BP 13-28[8x0,4,4x0] | 0.000519
  163: adversary 2: TP 18-26[8x0,3,9x0] | HP 18-26[8x0,3,9x0] | BP 13-20[8x0,3,4x0] | 0.017942
  164: adversary 4: TP 25-29[1,24x0] | HP 25-29[1,24x0] | BP 14-17[1,13x0] | 0.005885
  165: adversary 3: TP 23-29[0,2,21x0] | HP 23-29[0,2,21x0] | BP 14-19[0,2,12x0] | 0.026541
  166: honest: TP 21-28 | HP 21-28 | BP 15-18 | 0.003981
  167: adversary 2: TP 18-26[8x0,3,9x0] | HP 18-26[8x0,3,9x0] | BP 14-21[8x0,3,5x0] | 0.017362
  168: adversary 4: TP 25-29[1,24x0] | HP 25-29[1,24x0] | BP 15-18[1,14x0] | 0.005167
  169: adversary 3: TP 23-29[0,2,21x0] | HP 23-29[0,2,21x0] | BP 15-20[0,2,13x0] | 0.023852
  170: honest: TP 21-28 | HP 21-28 | BP 16-22 | 0.008219
  171: adversary 2: TP 18-26[8x0,3,9x0] | HP 18-26[8x0,3,9x0] | BP 15-22[8x0,3,6x0] | 0.016840
  172: adversary 4: TP 25-29[1,24x0] | HP 25-29[1,24x0] | BP 16-19[1,15x0] | 0.004027
  173: adversary 3: TP 23-29[0,2,21x0] | HP 23-29[0,2,21x0] | BP 16-21[0,2,14x0] | 0.023861
  174: honest: TP 21-28 | HP 21-28 | BP 17-23 | 0.007980
  175: adversary 2: TP 18-26[8x0,3,9x0] | HP 18-26[8x0,3,9x0] | BP 16-23[8x0,3,7x0] | 0.015107
  176: adversary 4: TP 25-29[1,24x0] | HP 25-29[1,24x0] | BP 17-20[1,16x0] | 0.006999
  177: adversary 3: TP 23-29[0,2,21x0] | HP 23-29[0,2,21x0] | BP 17-23[0,2,15x0] | 0.023008
  178: honest: TP 21-28 | HP 21-28 | BP 18-24 | 0.005698
  179: adversary 2: TP 18-26[8x0,3,9x0] | HP 18-26[8x0,3,9x0] | BP 17-25[8x0,3,8x0] | 0.016054
  180: adversary 4: TP 25-29[1,24x0] | HP 25-29[1,24x0] | BP 18-21[1,17x0] | 0.009345
  181: adversary 3: TP 23-29[0,2,21x0] | HP 23-29[0,2,21x0] | BP 18-24[0,2,16x0] | 0.020298
  182: honest: TP 21-28 | HP 21-28 | BP 19-26 | 0.021089
  183: adversary 4: TP 25-29[1,24x0] | HP 25-29[1,24x0] | BP 19-22[1,18x0] | 0.009099
  184: adversary 3: TP 23-29[0,2,21x0] | HP 23-29[0,2,21x0] | BP 19-25[0,2,17x0] | 0.024622
  185: honest: TP 21-28 | HP 21-28 | BP 20-27 | 0.016407
  186: adversary 4: TP 25-29[1,24x0] | HP 25-29[1,24x0] | BP 20-23[1,19x0] | 0.011643
  187: adversary 3: TP 23-29[0,2,21x0] | HP 23-29[0,2,21x0] | BP 20-26[0,2,18x0] | 0.022973
  188: honest: TP 21-28 | HP 21-28 | BP 21-28 | 0.018473
  189: adversary 4: TP 25-29[1,24x0] | HP 25-29[1,24x0] | BP 21-24[1,20x0] | 0.009232
  190: adversary 3: TP 23-29[0,2,21x0] | HP 23-29[0,2,21x0] | BP 21-27[0,2,19x0] | 0.044886
  191: adversary 4: TP 25-29[1,24x0] | HP 25-29[1,24x0] | BP 22-26[1,21x0] | 0.006918
  192: adversary 3: TP 23-29[0,2,21x0] | HP 23-29[0,2,21x0] | BP 22-28[0,2,20x0] | 0.045388
  193: adversary 4: TP 25-29[1,24x0] | HP 25-29[1,24x0] | BP 23-27[1,22x0] | 0.006991
  194: adversary 3: TP 23-29[0,2,21x0] | HP 23-29[0,2,21x0] | BP 23-29[0,2,21x0] | 0.043651
  195: adversary 4: TP 25-29[1,24x0] | HP 25-29[1,24x0] | BP 24-28[1,23x0] | 0.052588
  196: adversary 4: TP 25-29[1,24x0] | HP 25-29[1,24x0] | BP 25-29[1,24x0] | 0.100000
```
</details>

while after this PR (7c46ffcc832cfeff30a1e0d33997468832ead48e) it would shrink it to:

<details>
  <summary><i>Block tree with 1 trunk and 1 branch; point schedule with 44 ticks.</i></summary>

```
gtBlockTree:
  slots:    0  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29
  trunk:  -----1--2--3--4-----5--6--7--8--9----10-11-12-13----14-15----------16-17-18----19-20-21
               `--2--3-----4-----5--6-----7--8-----9-10-11----12-13-14-15-16----17-18-19-20-21-22-23

PointSchedule:
  0: honest: TP 21-28 | HP G | BP G | 0.000000
  1: adversary 3: TP G | HP 23-29[0,2,21x0] | BP G | 0.023664
  2: honest: TP 21-28 | HP 1-1 | BP G | 0.022036
  3: honest: TP 21-28 | HP 2-2 | BP G | 0.021968
  4: honest: TP 21-28 | HP 3-3 | BP G | 0.006485
  5: honest: TP 21-28 | HP 3-3 | BP 1-1 | 0.020327
  6: honest: TP 21-28 | HP 4-4 | BP 1-1 | 0.027007
  7: honest: TP 21-28 | HP 5-6 | BP 1-1 | 0.004456
  8: honest: TP 21-28 | HP 5-6 | BP 2-2 | 0.015750
  9: honest: TP 21-28 | HP 6-7 | BP 2-2 | 0.024731
  10: honest: TP 21-28 | HP 7-8 | BP 2-2 | 0.013882
  11: honest: TP 21-28 | HP 7-8 | BP 3-3 | 0.008278
  12: honest: TP 21-28 | HP 8-9 | BP 3-3 | 0.026525
  13: honest: TP 21-28 | HP 9-10 | BP 3-3 | 0.016148
  14: honest: TP 21-28 | HP 9-10 | BP 4-4 | 0.005941
  15: honest: TP 21-28 | HP 10-12 | BP 4-4 | 0.026861
  16: honest: TP 21-28 | HP 11-13 | BP 4-4 | 0.020205
  17: honest: TP 21-28 | HP 11-13 | BP 5-6 | 0.005454
  18: honest: TP 21-28 | HP 12-14 | BP 5-6 | 0.028128
  19: honest: TP 21-28 | HP 13-15 | BP 5-6 | 0.017529
  20: honest: TP 21-28 | HP 13-15 | BP 6-7 | 0.005468
  21: honest: TP 21-28 | HP 14-17 | BP 6-7 | 0.023064
  22: honest: TP 21-28 | HP 15-18 | BP 6-7 | 0.022006
  23: honest: TP 21-28 | HP 16-22 | BP 6-7 | 0.002669
  24: honest: TP 21-28 | HP 16-22 | BP 7-8 | 0.024007
  25: honest: TP 21-28 | HP 17-23 | BP 7-8 | 0.025400
  26: honest: TP 21-28 | HP 18-24 | BP 7-8 | 0.000638
  27: honest: TP 21-28 | HP 18-24 | BP 8-9 | 0.026213
  28: honest: TP 21-28 | HP 19-26 | BP 8-9 | 0.024385
  29: honest: TP 21-28 | HP 20-27 | BP 8-9 | 0.000742
  30: honest: TP 21-28 | HP 20-27 | BP 9-10 | 0.020268
  31: honest: TP 21-28 | HP 21-28 | BP 9-10 | 0.029865
  32: honest: TP 21-28 | HP 21-28 | BP 10-12 | 0.053703
  33: honest: TP 21-28 | HP 21-28 | BP 11-13 | 0.050448
  34: honest: TP 21-28 | HP 21-28 | BP 12-14 | 0.053442
  35: honest: TP 21-28 | HP 21-28 | BP 13-15 | 0.054202
  36: honest: TP 21-28 | HP 21-28 | BP 14-17 | 0.053220
  37: honest: TP 21-28 | HP 21-28 | BP 15-18 | 0.050363
  38: honest: TP 21-28 | HP 21-28 | BP 16-22 | 0.052947
  39: honest: TP 21-28 | HP 21-28 | BP 17-23 | 0.053094
  40: honest: TP 21-28 | HP 21-28 | BP 18-24 | 0.051395
  41: honest: TP 21-28 | HP 21-28 | BP 19-26 | 0.054811
  42: honest: TP 21-28 | HP 21-28 | BP 20-27 | 0.051023
  43: honest: TP 21-28 | HP 21-28 | BP 21-28 | 0.100000
```

</details>

We can already notice a non-negligible improvement of the size of the test! But more importantly, we can see that the resulting test is in fact all the ticks of the honest peer and only _one_ tick of the adversary. In the second tick, we have:

```
  1: adversary 3: TP G | HP 23-29[0,2,21x0] | BP G | 0.023664
```

meaning that the adversary serves 23 blocks in 0.02s. Of course, on much bigger test cases, we could imagine an adversary serving thousands of blocks right at the beginning of the test. My understanding is that it is OK and that the Genesis design will also work against absurdly strong adversaries. Can we confirm this?

We can also note that, by removing random ticks in a `PeerSchedule`, we arrive in a somewhat inconsistent state where the tip point is Genesis while the header point is not. Shrinking a `PointSchedule` has the advantage that we keep a form of consistency between those two points. However, when shrinking adversaries, it is not a problem: if an adversary wins by behaving like that, then that is still a bug.

### Future work

1. Shrinking of the honest peer's schedule. This is a non-trivial matter as we have discussed many times.

2. A shrinker that makes the tip point as old as possible (possibly as old as the youngest header point, something like that?) so as to remove blocks at leaves of the block tree.

3. A shrinker that skips the beginning of the test so as to remove the prefix of the block tree. This one impacts the honest peer's schedule and therefore should happen after we have figured out something convincing for point 1.

4. A “shrinker” that enforces consistency of a peer's points. For instance, in the example above, we would replace the tick by
   ```
     1: adversary 3: TP 23-29[0,2,21x0] | HP 23-29[0,2,21x0] | BP G | 0.023664
   ```
   The upside of this is that we avoid misleading a programmer by making them inspecting the code relating to the tip point when it has in fact nothing to do with the problem here. In general, I think we should try to have shrinkers that make the cases the least pathological possible.

... and more obviously!