### PR TITLE
Enter Limit on Patience

### DIFF
--- a/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
+++ b/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
@@ -220,6 +220,7 @@ test-suite consensus-test
     Test.Consensus.Genesis.Tests
     Test.Consensus.Genesis.Tests.LoE
     Test.Consensus.Genesis.Tests.LongRangeAttack
+    Test.Consensus.Genesis.Tests.LoP
     Test.Consensus.Genesis.Tests.Uniform
     Test.Consensus.GSM
     Test.Consensus.GSM.Model

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToNode.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToNode.hs
@@ -540,10 +540,11 @@ mkApps ::
   -> (NodeToNodeVersion -> Codecs blk addrNTN e m bCS bCS bBF bBF bTX bKA bPS)
   -> ByteLimits bCS bBF bTX bKA
   -> m ChainSyncTimeout
+  -> CsClient.ChainSyncLoPBucketConfig
   -> ReportPeerMetrics m (ConnectionId addrNTN)
   -> Handlers m addrNTN blk
   -> Apps m addrNTN bCS bBF bTX bKA bPS NodeToNodeInitiatorResult ()
-mkApps kernel Tracers {..} mkCodecs ByteLimits {..} genChainSyncTimeout ReportPeerMetrics {..} Handlers {..} =
+mkApps kernel Tracers {..} mkCodecs ByteLimits {..} genChainSyncTimeout lopBucketConfig ReportPeerMetrics {..} Handlers {..} =
     Apps {..}
   where
     aChainSyncClient
@@ -571,7 +572,9 @@ mkApps kernel Tracers {..} mkCodecs ByteLimits {..} genChainSyncTimeout ReportPe
             (getNodeCandidates kernel)
             (getNodeIdlers     kernel)
             them
-            version $ \varCandidate (startIdling, stopIdling) -> do
+            version
+            lopBucketConfig
+            $ \varCandidate (startIdling, stopIdling) (pauseLoPBucket, resumeLoPBucket, grantLoPToken) -> do
               chainSyncTimeout <- genChainSyncTimeout
               (r, trailing) <-
                 runPipelinedPeerWithLimits
@@ -591,6 +594,9 @@ mkApps kernel Tracers {..} mkCodecs ByteLimits {..} genChainSyncTimeout ReportPe
                         , CsClient.varCandidate
                         , CsClient.startIdling
                         , CsClient.stopIdling
+                        , CsClient.pauseLoPBucket
+                        , CsClient.resumeLoPBucket
+                        , CsClient.grantLoPToken
                         }
               return (ChainSyncInitiatorResult r, trailing)
 

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Node.hs
@@ -77,6 +77,8 @@ import           Ouroboros.Consensus.Fragment.InFuture (CheckInFuture,
                      ClockSkew)
 import qualified Ouroboros.Consensus.Fragment.InFuture as InFuture
 import           Ouroboros.Consensus.Ledger.Extended (ExtLedgerState (..))
+import           Ouroboros.Consensus.MiniProtocol.ChainSync.Client
+                     (ChainSyncLoPBucketConfig (..))
 import qualified Ouroboros.Consensus.MiniProtocol.ChainSync.Client.InFutureCheck as InFutureCheck
 import qualified Ouroboros.Consensus.Network.NodeToClient as NTC
 import qualified Ouroboros.Consensus.Network.NodeToNode as NTN
@@ -243,6 +245,9 @@ data LowLevelRunNodeArgs m addrNTN addrNTC versionDataNTN versionDataNTC blk
 
       -- | See 'NTN.ChainSyncTimeout'
     , llrnChainSyncTimeout :: m NTN.ChainSyncTimeout
+
+      -- | See 'CsClient.ChainSyncLoPBucketConfig'
+    , llrnChainSyncLoPBucketConfig :: ChainSyncLoPBucketConfig
 
       -- | How to run the data diffusion applications
       --
@@ -480,6 +485,7 @@ runWith RunNodeArgs{..} encAddrNtN decAddrNtN LowLevelRunNodeArgs{..} =
           (NTN.defaultCodecs codecConfig version encAddrNTN decAddrNTN)
           NTN.byteLimits
           llrnChainSyncTimeout
+          llrnChainSyncLoPBucketConfig
           (reportMetric Diffusion.peerMetricsConfiguration peerMetrics)
           (NTN.mkHandlers nodeKernelArgs nodeKernel computePeers)
 
@@ -912,6 +918,7 @@ stdLowLevelRunNodeArgsIO RunNodeArgs{ rnProtocolInfo
     pure LowLevelRunNodeArgs
       { llrnBfcSalt
       , llrnChainSyncTimeout = fromMaybe stdChainSyncTimeout srnChainSyncTimeout
+      , llrnChainSyncLoPBucketConfig = ChainSyncLoPBucketDisabled
       , llrnCustomiseHardForkBlockchainTimeArgs = id
       , llrnGsmAntiThunderingHerd
       , llrnKeepAliveRng

--- a/ouroboros-consensus-diffusion/src/unstable-diffusion-testlib/Test/ThreadNet/Network.hs
+++ b/ouroboros-consensus-diffusion/src/unstable-diffusion-testlib/Test/ThreadNet/Network.hs
@@ -1035,6 +1035,7 @@ runThreadNetwork systemTime ThreadNetworkArgs
                      , mustReplyTimeout = waitForever
                      , idleTimeout      = waitForever
                      })
+                  CSClient.ChainSyncLoPBucketDisabled
                   nullMetric
                   -- The purpose of this test is not testing protocols, so
                   -- returning constant empty list is fine if we have thorough

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup/Classifiers.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup/Classifiers.hs
@@ -93,7 +93,11 @@ classifiers GenesisTest {gtBlockTree, gtSecurityParam = SecurityParam k, gtGenes
     isForecastable bt =
       -- FIXME: We are using `scg` here but what we really mean is `sfor`.
       -- Distinguish `scg` vs. `sgen` vs. `sfor` and use the latter here.
-      let slotNos = map blockSlot $ AF.toOldestFirst $ btbFull bt in
+      -- NOTE: We only care about the difference between slot numbers so it is
+      -- not a problem to add @1@ to all of them. However, we do care VERY MUCH
+      -- that this list includes the anchor.
+      let slotNos = (succWithOrigin $ anchorToSlotNo $ anchor $ btbFull bt)
+                    : (map ((+1) . blockSlot) $ AF.toOldestFirst $ btbFull bt) in
       all (\(SlotNo prev, SlotNo next) -> next - prev <= scg) (zip slotNos (drop 1 slotNos))
 
     allAdversariesKPlus1InForecast =

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup/GenChains.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup/GenChains.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DerivingStrategies        #-}
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE NamedFieldPuns            #-}
+{-# LANGUAGE NumericUnderscores        #-}
 {-# LANGUAGE RecordWildCards           #-}
 {-# LANGUAGE ScopedTypeVariables       #-}
 
@@ -121,6 +122,7 @@ genChains genNumForks = do
     gtDelay = delta,
     gtSlotLength,
     gtChainSyncTimeouts = chainSyncTimeouts gtSlotLength asc,
+    gtLoPBucketParams = LoPBucketParams { lbpCapacity = 10_000, lbpRate = 1_000 }, -- REVIEW: Do we want to generate those randomly?
     gtBlockTree = foldl' (flip BT.addBranch') (BT.mkTrunk goodChain) $ zipWith (genAdversarialFragment goodBlocks) [1..] alternativeChainSchemas,
     gtSchedule = ()
     }

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests.hs
@@ -2,6 +2,7 @@ module Test.Consensus.Genesis.Tests (tests) where
 
 import qualified Test.Consensus.Genesis.Tests.LoE as LoE
 import qualified Test.Consensus.Genesis.Tests.LongRangeAttack as LongRangeAttack
+import qualified Test.Consensus.Genesis.Tests.LoP as LoP
 import qualified Test.Consensus.Genesis.Tests.Uniform as Uniform
 import           Test.Tasty
 
@@ -9,5 +10,6 @@ tests :: TestTree
 tests = testGroup "Genesis tests"
     [ LongRangeAttack.tests
     , LoE.tests
+    , LoP.tests
     , Uniform.tests
     ]

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LoE.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LoE.hs
@@ -53,8 +53,7 @@ prop_adversaryHitsTimeouts timeoutsEnabled =
       -- NOTE: Crucially, there must be timeouts for this test, and no LoP.
       ( defaultSchedulerConfig
           { scEnableChainSyncTimeouts = timeoutsEnabled,
-            scEnableLoE = True,
-            scEnableLoP = False
+            scEnableLoE = True
           }
       )
       shrinkPeerSchedules

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LoE.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LoE.hs
@@ -7,18 +7,20 @@
 
 module Test.Consensus.Genesis.Tests.LoE (tests) where
 
-import           Ouroboros.Consensus.Block
-import           Ouroboros.Consensus.Util.IOLike (Time (Time))
+import           Ouroboros.Consensus.Util.IOLike (Time (Time), fromException)
 import qualified Ouroboros.Network.AnchoredFragment as AF
+import           Ouroboros.Network.Driver.Limits
+                     (ProtocolLimitFailure (ExceededTimeLimit))
 import           Test.Consensus.BlockTree (BlockTree (..), BlockTreeBranch (..))
 import           Test.Consensus.Genesis.Setup
 import           Test.Consensus.PeerSimulator.Run (SchedulerConfig (..),
                      defaultSchedulerConfig)
 import           Test.Consensus.PeerSimulator.StateView
 import           Test.Consensus.PointSchedule
-import           Test.Consensus.PointSchedule.Peers (mkPeers)
+import           Test.Consensus.PointSchedule.Peers (PeerId (..), mkPeers)
 import           Test.Consensus.PointSchedule.Shrinking (shrinkPeerSchedules)
-import           Test.Consensus.PointSchedule.SinglePeer (SchedulePoint (..))
+import           Test.Consensus.PointSchedule.SinglePeer (scheduleBlockPoint,
+                     scheduleHeaderPoint, scheduleTipPoint)
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
 import           Test.Util.Orphans.IOLike ()
@@ -32,13 +34,15 @@ tests =
     "LoE"
     [
       adjustQuickCheckTests (`div` 5) $
-        testProperty "adversary hits timeouts" prop_adversaryHitsTimeouts
+        testProperty "adversary does not hit timeouts" (prop_adversaryHitsTimeouts False),
+      adjustQuickCheckTests (`div` 5) $
+        testProperty "adversary hits timeouts" (prop_adversaryHitsTimeouts True)
     ]
 
 -- | Tests that the selection advances in presence of the LoE when a peer is
 -- killed by something that is not LoE-aware, eg. the timeouts.
-prop_adversaryHitsTimeouts :: Property
-prop_adversaryHitsTimeouts =
+prop_adversaryHitsTimeouts :: Bool -> Property
+prop_adversaryHitsTimeouts timeoutsEnabled =
   noShrinking $
     forAllGenesisTest
       ( do
@@ -46,17 +50,28 @@ prop_adversaryHitsTimeouts =
           let ps = delaySchedule gtBlockTree
           pure (ps <$ gt)
       )
-      -- NOTE: Crucially, there must be timeouts for this test.
+      -- NOTE: Crucially, there must be timeouts for this test, and no LoP.
       ( defaultSchedulerConfig
-          { scEnableChainSyncTimeouts = True,
-            scEnableLoE = True
+          { scEnableChainSyncTimeouts = timeoutsEnabled,
+            scEnableLoE = True,
+            scEnableLoP = False
           }
       )
       shrinkPeerSchedules
-      ( \GenesisTest {gtBlockTree} StateView {svSelectedChain} ->
+      ( \GenesisTest {gtBlockTree} StateView {svSelectedChain, svChainSyncExceptions} ->
         tabulate "binary log buckets of the length of the honest chain" [show (round @_ @Int (2 ** (realToFrac @_ @Double (round @_ @Int (logBase 2 (realToFrac @_ @Double (1 + AF.length (btTrunk gtBlockTree))))))))] $
         counterexample ("Selection is not the honest tip: " ++ tersePoint (AF.headPoint (btTrunk gtBlockTree)) ++ " / " ++ tersePoint (AF.castPoint (AF.headPoint svSelectedChain))) $
-          AF.headPoint (btTrunk gtBlockTree) == AF.castPoint (AF.headPoint svSelectedChain)
+          let treeTipPoint = AF.headPoint $ btTrunk gtBlockTree
+              selectedTipPoint = AF.castPoint $ AF.headPoint svSelectedChain
+              selectedCorrect = timeoutsEnabled == (treeTipPoint == selectedTipPoint)
+              exceptionsCorrect = case svChainSyncExceptions of
+                [] -> not timeoutsEnabled
+                [ChainSyncException (PeerId _) exn] ->
+                  case fromException exn of
+                    Just (ExceededTimeLimit _) -> timeoutsEnabled
+                    _                          -> False
+                _ -> False
+           in selectedCorrect && exceptionsCorrect
       )
   where
     getOnlyBranch :: BlockTree blk -> BlockTreeBranch blk
@@ -66,36 +81,40 @@ prop_adversaryHitsTimeouts =
 
     delaySchedule :: BlockTree TestBlock -> PeersSchedule TestBlock
     delaySchedule tree =
-      let trunkTip = NotOrigin $ case btTrunk tree of
+      let trunkTip = case btTrunk tree of
             (AF.Empty _)       -> error "tree must have at least one block"
             (_ AF.:> tipBlock) -> tipBlock
           branch = getOnlyBranch tree
           intersectM = case btbPrefix branch of
             (AF.Empty _)       -> Nothing
             (_ AF.:> tipBlock) -> Just tipBlock
-          branchTip = NotOrigin $ case btbFull branch of
+          branchTip = case btbFull branch of
             (AF.Empty _) -> error "alternate branch must have at least one block"
             (_ AF.:> tipBlock) -> tipBlock
        in mkPeers
-            -- The honest peer eagerly serves its chain after 5s so as not to
-            -- get disconnected by timeouts until @Time 15@.
-            [ (Time 0, ScheduleTipPoint trunkTip),
-              (Time 5, ScheduleHeaderPoint trunkTip),
-              (Time 5, ScheduleBlockPoint trunkTip),
-              (Time 16, ScheduleBlockPoint trunkTip),
-              (Time 16.1, ScheduleBlockPoint trunkTip),
-              (Time 16.2, ScheduleBlockPoint trunkTip)
-            ]
+            -- Eagerly serve the honest tree, but after the adversary has
+            -- advertised its chain.
+            ( (Time 0, scheduleTipPoint trunkTip) : case intersectM of
+                Nothing ->
+                  [ (Time 0.5, scheduleHeaderPoint trunkTip),
+                    (Time 0.5, scheduleBlockPoint trunkTip)
+                  ]
+                Just intersect ->
+                  [ (Time 0.5, scheduleHeaderPoint intersect),
+                    (Time 0.5, scheduleBlockPoint intersect),
+                    (Time 5, scheduleHeaderPoint trunkTip),
+                    (Time 5, scheduleBlockPoint trunkTip)
+                  ]
+            )
             -- The one adversarial peer advertises and serves up to the
             -- intersection early, then waits more than the short wait timeout.
-            [ (Time 0, ScheduleTipPoint branchTip) : case intersectM of
+            [ (Time 0, scheduleTipPoint branchTip) : case intersectM of
                 -- the alternate branch forks from `Origin`
-                Nothing -> [(Time 11, ScheduleTipPoint branchTip)]
+                Nothing -> [(Time 11, scheduleTipPoint branchTip)]
                 -- the alternate branch forks from `intersect`
                 Just intersect ->
-                  [ (Time 0, ScheduleHeaderPoint (NotOrigin intersect)),
-                    (Time 0, ScheduleBlockPoint (NotOrigin intersect)),
-                    (Time 0.5, ScheduleBlockPoint (NotOrigin intersect)),
-                    (Time 16, ScheduleBlockPoint (NotOrigin intersect))
+                  [ (Time 0, scheduleHeaderPoint intersect),
+                    (Time 0, scheduleBlockPoint intersect),
+                    (Time 11, scheduleBlockPoint intersect)
                   ]
             ]

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LoE.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LoE.hs
@@ -41,6 +41,7 @@ tests =
 
 -- | Tests that the selection advances in presence of the LoE when a peer is
 -- killed by something that is not LoE-aware, eg. the timeouts.
+-- NOTE: Same as 'LoP.prop_delayAttack' with timeouts instead of LoP.
 prop_adversaryHitsTimeouts :: Bool -> Property
 prop_adversaryHitsTimeouts timeoutsEnabled =
   noShrinking $
@@ -53,7 +54,8 @@ prop_adversaryHitsTimeouts timeoutsEnabled =
       -- NOTE: Crucially, there must be timeouts for this test, and no LoP.
       ( defaultSchedulerConfig
           { scEnableChainSyncTimeouts = timeoutsEnabled,
-            scEnableLoE = True
+            scEnableLoE = True,
+            scEnableLoP = False
           }
       )
       shrinkPeerSchedules

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LoP.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LoP.hs
@@ -1,0 +1,259 @@
+{-# LANGUAGE BlockArguments      #-}
+{-# LANGUAGE DerivingStrategies  #-}
+{-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE NumericUnderscores  #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Test.Consensus.Genesis.Tests.LoP (tests) where
+
+import           Data.Functor (($>))
+import           Data.Ratio ((%))
+import qualified Ouroboros.Consensus.MiniProtocol.ChainSync.Client as CSClient
+import           Ouroboros.Consensus.Util.IOLike (DiffTime, Time (Time),
+                     fromException)
+import           Ouroboros.Consensus.Util.LeakyBucket
+                     (secondsRationalToDiffTime)
+import           Ouroboros.Network.AnchoredFragment (AnchoredFragment,
+                     HasHeader)
+import qualified Ouroboros.Network.AnchoredFragment as AF
+import           Test.Consensus.BlockTree (BlockTree (..), BlockTreeBranch (..))
+import           Test.Consensus.Genesis.Setup
+import           Test.Consensus.PeerSimulator.Run (SchedulerConfig (..),
+                     defaultSchedulerConfig)
+import           Test.Consensus.PeerSimulator.StateView
+import           Test.Consensus.PointSchedule
+import           Test.Consensus.PointSchedule.Peers (PeerId (..), Peers,
+                     mkPeers, peersOnlyHonest)
+import           Test.Consensus.PointSchedule.Shrinking (shrinkPeerSchedules)
+import           Test.Consensus.PointSchedule.SinglePeer (scheduleBlockPoint,
+                     scheduleHeaderPoint, scheduleTipPoint)
+import           Test.Tasty
+import           Test.Tasty.QuickCheck
+import           Test.Util.Orphans.IOLike ()
+import           Test.Util.TestEnv (adjustQuickCheckTests)
+
+tests :: TestTree
+tests =
+  testGroup
+    "LoP"
+    [ -- \| NOTE: Running the test that must _not_ timeout (@prop_smoke False@) takes
+      -- significantly more time than the one that does. This is because the former
+      -- does all the computation (serving the headers, validating them, serving the
+      -- block, validating them) while the former does nothing, because it timeouts
+      -- before reaching the last tick of the point schedule.
+      adjustQuickCheckTests (`div` 10) $
+        testProperty "wait just enough" (prop_wait False),
+      testProperty "wait too much" (prop_wait True),
+      testProperty "wait behind forecast horizon" prop_waitBehindForecastHorizon,
+      adjustQuickCheckTests (`div` 5) $
+        testProperty "serve just fast enough" (prop_serve False),
+      testProperty "serve too slow" (prop_serve True),
+      adjustQuickCheckTests (`div` 5) $
+        testProperty "delaying attack succeeds without LoP" (prop_delayAttack False),
+      adjustQuickCheckTests (`div` 5) $
+        testProperty "delaying attack fails with LoP" (prop_delayAttack True)
+    ]
+
+prop_wait :: Bool -> Property
+prop_wait mustTimeout =
+  forAllGenesisTest
+    ( do
+        gt@GenesisTest {gtBlockTree} <- genChains (pure 0)
+        let ps = dullSchedule 10 (btTrunk gtBlockTree)
+            gt' = gt {gtLoPBucketParams = LoPBucketParams {lbpCapacity = 10, lbpRate = 1}}
+        pure $ gt' $> ps
+    )
+    -- NOTE: Crucially, there must not be timeouts for this test.
+    (defaultSchedulerConfig {scEnableChainSyncTimeouts = False, scEnableLoP = True})
+    shrinkPeerSchedules
+    ( \_ StateView {svChainSyncExceptions} ->
+        case svChainSyncExceptions of
+          [] -> not mustTimeout
+          [ChainSyncException _pid exn] ->
+            case fromException exn of
+              Just CSClient.EmptyBucket -> mustTimeout
+              _                         -> False
+          _ -> False
+    )
+  where
+    dullSchedule :: (HasHeader blk) => DiffTime -> AnchoredFragment blk -> Peers (PeerSchedule blk)
+    dullSchedule _ (AF.Empty _) = error "requires a non-empty block tree"
+    dullSchedule timeout (_ AF.:> tipBlock) =
+      let offset :: DiffTime = if mustTimeout then 1 else -1
+       in peersOnlyHonest $
+            [ (Time 0, scheduleTipPoint tipBlock),
+              -- This last point does not matter, it is only here to leave the
+              -- connection open (aka. keep the test running) long enough to
+              -- pass the timeout by 'offset'.
+              (Time (timeout + offset), scheduleHeaderPoint tipBlock),
+              (Time (timeout + offset), scheduleBlockPoint tipBlock)
+            ]
+
+prop_waitBehindForecastHorizon :: Property
+prop_waitBehindForecastHorizon =
+  forAllGenesisTest
+    ( do
+        gt@GenesisTest {gtBlockTree} <- genChains (pure 0)
+        let ps = dullSchedule (btTrunk gtBlockTree)
+            gt' = gt {gtLoPBucketParams = LoPBucketParams {lbpCapacity = 10, lbpRate = 1}}
+        pure $ gt' $> ps
+    )
+    -- NOTE: Crucially, there must not be timeouts for this test.
+    (defaultSchedulerConfig {scEnableChainSyncTimeouts = False, scEnableLoP = True})
+    shrinkPeerSchedules
+    ( \_ StateView {svChainSyncExceptions} ->
+        case svChainSyncExceptions of
+          [] -> True
+          _  -> False
+    )
+  where
+    dullSchedule :: (HasHeader blk) => AnchoredFragment blk -> Peers (PeerSchedule blk)
+    dullSchedule (AF.Empty _) = error "requires a non-empty block tree"
+    dullSchedule (_ AF.:> tipBlock) =
+      peersOnlyHonest $
+        [ (Time 0, scheduleTipPoint tipBlock),
+          (Time 0, scheduleHeaderPoint tipBlock),
+          (Time 11, scheduleBlockPoint tipBlock)
+        ]
+
+-- | Simple test where we serve all the chain at regular intervals, but just
+-- slow enough to lose against the LoP bucket.
+--
+-- Let @c@ be the bucket capacity, @r@ be the bucket rate and @t@ be the time
+-- between blocks, then the bucket level right right before getting the token
+-- for the @k@th block will be:
+--
+-- > c - krt + (k-1)
+--
+-- (Note: if @rt ≥ 1@, otherwise it will simply be @c - rt@.) If we are to
+-- survive at least (resp. succumb before) @k > 0@ blocks, then this value will
+-- be positive (resp. negative). This is equivalent to saying that @rt@ must be
+-- lower (resp. greater) than @(c+k-1) / k@.
+--
+-- We will have two versions of this test: one where we serve the @n-1@th block
+-- but succumb before serving the @n@th block, and one where we do manage to
+-- serve the @n@th block, barely.
+prop_serve :: Bool -> Property
+prop_serve mustTimeout =
+  forAllGenesisTest
+    ( do
+        gt@GenesisTest {gtBlockTree} <- genChains (pure 0)
+        let lbpRate = borderlineRate (AF.length (btTrunk gtBlockTree))
+            ps = makeSchedule (btTrunk gtBlockTree)
+            gt' = gt {gtLoPBucketParams = LoPBucketParams {lbpCapacity, lbpRate}}
+        pure $ gt' $> ps
+    )
+    -- NOTE: Crucially, there must not be timeouts for this test.
+    (defaultSchedulerConfig {scEnableChainSyncTimeouts = False, scEnableLoP = True})
+    shrinkPeerSchedules
+    ( \_ StateView {svChainSyncExceptions} ->
+        case svChainSyncExceptions of
+          [] -> not mustTimeout
+          [ChainSyncException _pid exn] ->
+            case fromException exn of
+              Just CSClient.EmptyBucket -> mustTimeout
+              _                         -> False
+          _ -> False
+    )
+  where
+    lbpCapacity :: Integer = 10
+    timeBetweenBlocks :: Rational = 0.100
+
+    -- \| Rate that is almost the limit between surviving and succumbing to the
+    -- LoP bucket, given a number of blocks. One should not exactly use the
+    -- limit rate because it is unspecified what would happen in IOSim and it
+    -- would simply be flakey in IO.
+    borderlineRate :: (Integral n) => n -> Rational
+    borderlineRate numberOfBlocks =
+      (if mustTimeout then (105 % 100) else (95 % 100))
+        * ((fromIntegral lbpCapacity + fromIntegral numberOfBlocks - 1) / (timeBetweenBlocks * fromIntegral numberOfBlocks))
+
+    -- \| Make a schedule serving the given fragment with regularity, one block
+    -- every 'timeBetweenBlocks'. NOTE: We must do something at @Time 0@
+    -- otherwise the others times will be shifted such that the first one is 0.
+    makeSchedule :: (HasHeader blk) => AnchoredFragment blk -> Peers (PeerSchedule blk)
+    makeSchedule (AF.Empty _) = error "fragment must have at least one block"
+    makeSchedule fragment@(_ AF.:> tipBlock) =
+      peersOnlyHonest $
+        (Time 0, scheduleTipPoint tipBlock)
+          : ( flip concatMap (zip [1 ..] (AF.toOldestFirst fragment)) $ \(i, block) ->
+                [ (Time (secondsRationalToDiffTime (i * timeBetweenBlocks)), scheduleHeaderPoint block),
+                  (Time (secondsRationalToDiffTime (i * timeBetweenBlocks)), scheduleBlockPoint block)
+                ]
+            )
+
+-- NOTE: Same as 'LoE.prop_adversaryHitsTimeouts' with LoP instead of timeouts.
+prop_delayAttack :: Bool -> Property
+prop_delayAttack lopEnabled =
+  noShrinking $
+    forAllGenesisTest
+      ( do
+          gt@GenesisTest {gtBlockTree} <- genChains (pure 1)
+          let gt' = gt {gtLoPBucketParams = LoPBucketParams {lbpCapacity = 10, lbpRate = 1}}
+              ps = delaySchedule gtBlockTree
+          pure $ gt' $> ps
+      )
+      -- NOTE: Crucially, there must not be timeouts for this test.
+      ( defaultSchedulerConfig
+          { scEnableChainSyncTimeouts = False,
+            scEnableLoE = True,
+            scEnableLoP = lopEnabled
+          }
+      )
+      shrinkPeerSchedules
+      ( \GenesisTest {gtBlockTree} StateView {svSelectedChain, svChainSyncExceptions} ->
+          let treeTipPoint = AF.headPoint $ btTrunk gtBlockTree
+              selectedTipPoint = AF.castPoint $ AF.headPoint svSelectedChain
+              selectedCorrect = lopEnabled == (treeTipPoint == selectedTipPoint)
+              exceptionsCorrect = case svChainSyncExceptions of
+                [] -> not lopEnabled
+                [ChainSyncException (PeerId _) exn] ->
+                  lopEnabled == (fromException exn == Just CSClient.EmptyBucket)
+                _ -> False
+           in selectedCorrect && exceptionsCorrect
+      )
+  where
+    getOnlyBranch :: BlockTree blk -> BlockTreeBranch blk
+    getOnlyBranch BlockTree {btBranches} = case btBranches of
+      [branch] -> branch
+      _        -> error "tree must have exactly one alternate branch"
+
+    delaySchedule :: (HasHeader blk) => BlockTree blk -> Peers (PeerSchedule blk)
+    delaySchedule tree =
+      let trunkTip = case btTrunk tree of
+            (AF.Empty _)       -> error "tree must have at least one block"
+            (_ AF.:> tipBlock) -> tipBlock
+          branch = getOnlyBranch tree
+          intersectM = case btbPrefix branch of
+            (AF.Empty _)       -> Nothing
+            (_ AF.:> tipBlock) -> Just tipBlock
+          branchTip = case btbFull branch of
+            (AF.Empty _) -> error "alternate branch must have at least one block"
+            (_ AF.:> tipBlock) -> tipBlock
+       in mkPeers
+            -- Eagerly serve the honest tree, but after the adversary has
+            -- advertised its chain.
+            ( (Time 0, scheduleTipPoint trunkTip) : case intersectM of
+                Nothing ->
+                  [ (Time 0.5, scheduleHeaderPoint trunkTip),
+                    (Time 0.5, scheduleBlockPoint trunkTip)
+                  ]
+                Just intersect ->
+                  [ (Time 0.5, scheduleHeaderPoint intersect),
+                    (Time 0.5, scheduleBlockPoint intersect),
+                    (Time 5, scheduleHeaderPoint trunkTip),
+                    (Time 5, scheduleBlockPoint trunkTip)
+                  ]
+            )
+            -- Advertise the alternate branch early, but don't serve it
+            -- past the intersection, and wait for LoP bucket.
+            [ (Time 0, scheduleTipPoint branchTip) : case intersectM of
+                -- the alternate branch forks from `Origin`
+                Nothing -> [(Time 11, scheduleTipPoint branchTip)]
+                -- the alternate branch forks from `intersect`
+                Just intersect ->
+                  [ (Time 0, scheduleHeaderPoint intersect),
+                    (Time 0, scheduleBlockPoint intersect),
+                    (Time 11, scheduleBlockPoint intersect)
+                  ]
+            ]

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/ChainSync.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/ChainSync.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE NumericUnderscores  #-}
+{-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Test.Consensus.PeerSimulator.ChainSync (runChainSyncClient) where
@@ -12,7 +14,8 @@ import qualified Data.Set as Set
 import           Ouroboros.Consensus.Block (Header, Point)
 import           Ouroboros.Consensus.Config (TopLevelConfig (..))
 import           Ouroboros.Consensus.MiniProtocol.ChainSync.Client (ChainDbView,
-                     Consensus, bracketChainSyncClient, chainSyncClient)
+                     ChainSyncLoPBucketConfig, Consensus,
+                     bracketChainSyncClient, chainSyncClient)
 import qualified Ouroboros.Consensus.MiniProtocol.ChainSync.Client as CSClient
 import qualified Ouroboros.Consensus.MiniProtocol.ChainSync.Client.InFutureCheck as InFutureCheck
 import           Ouroboros.Consensus.Util.Condense (Condense (..))
@@ -45,7 +48,6 @@ import           Test.Consensus.PointSchedule.Peers (PeerId)
 import           Test.Util.Orphans.IOLike ()
 import           Test.Util.TestBlock (TestBlock)
 
-
 basicChainSyncClient :: forall m.
   IOLike m =>
   PeerId ->
@@ -54,8 +56,9 @@ basicChainSyncClient :: forall m.
   ChainDbView m TestBlock ->
   StrictTVar m (AnchoredFragment (Header TestBlock)) ->
   (m (), m ()) ->
+  (m (), m (), m ()) ->
   Consensus ChainSyncClientPipelined TestBlock m
-basicChainSyncClient peerId tracer cfg chainDbView varCandidate (startIdling, stopIdling) =
+basicChainSyncClient peerId tracer cfg chainDbView varCandidate (startIdling, stopIdling) (pauseLoPBucket, resumeLoPBucket, grantLoPToken) =
   chainSyncClient
     CSClient.ConfigEnv {
         CSClient.mkPipelineDecision0     = pipelineDecisionLowHighMark 10 20
@@ -71,9 +74,9 @@ basicChainSyncClient peerId tracer cfg chainDbView varCandidate (startIdling, st
       , CSClient.varCandidate
       , CSClient.startIdling
       , CSClient.stopIdling
-      , CSClient.pauseLoPBucket = pure ()
-      , CSClient.resumeLoPBucket = pure ()
-      , CSClient.grantLoPToken = pure ()
+      , CSClient.pauseLoPBucket
+      , CSClient.resumeLoPBucket
+      , CSClient.grantLoPToken
       }
   where
     dummyHeaderInFutureCheck ::
@@ -94,6 +97,7 @@ runChainSyncClient ::
   PeerId ->
   ChainSyncServer (Header TestBlock) (Point TestBlock) (Tip TestBlock) m () ->
   ChainSyncTimeout ->
+  ChainSyncLoPBucketConfig ->
   StateViewTracers m ->
   StrictTVar m (Map PeerId (StrictTVar m (AnchoredFragment (Header TestBlock)))) ->
   m ()
@@ -104,37 +108,37 @@ runChainSyncClient
   peerId
   server
   chainSyncTimeouts
+  lopBucketConfig
   StateViewTracers {svtChainSyncExceptionsTracer}
   varCandidates
   = do
     -- We don't need this shared Set yet. If we need it at some point,
     -- it ought to be passed to `runChainSyncClient`.
     varIdling <- uncheckedNewTVarM $ Set.empty
-    bracketChainSyncClient nullTracer chainDbView varCandidates varIdling peerId ntnVersion CSClient.ChainSyncLoPBucketDisabled $ \ varCandidate idleManagers _lopBucket -> do
+    bracketChainSyncClient nullTracer chainDbView varCandidates varIdling peerId ntnVersion lopBucketConfig $ \ varCandidate idleManagers lopBucket -> do
       res <- try $ runConnectedPeersPipelinedWithLimits
         createConnectedChannels
         nullTracer
         codecChainSyncId
         chainSyncNoSizeLimits
         (timeLimitsChainSync chainSyncTimeouts)
-        (chainSyncClientPeerPipelined (basicChainSyncClient peerId tracer cfg chainDbView varCandidate idleManagers))
+        (chainSyncClientPeerPipelined (basicChainSyncClient peerId tracer cfg chainDbView varCandidate idleManagers lopBucket))
         (chainSyncServerPeer server)
       case res of
+        Right _ -> pure ()
         Left exn -> do
           traceWith svtChainSyncExceptionsTracer $ ChainSyncException peerId exn
           case fromException exn of
-            Just (ExceededSizeLimit _) ->
-              traceUnitWith tracer ("ChainSyncClient " ++ condense peerId) "Terminating because of size limit exceeded."
-            Just (ExceededTimeLimit _) ->
-              traceUnitWith tracer ("ChainSyncClient " ++ condense peerId) "Terminating because of time limit exceeded."
-            Nothing ->
-              pure ()
+            Just (ExceededSizeLimit _) -> trace "Terminating because of size limit exceeded."
+            Just (ExceededTimeLimit _) -> trace "Terminating because of time limit exceeded."
+            Nothing -> pure ()
           case fromException exn of
-            Just ThreadKilled ->
-              traceUnitWith tracer ("ChainSyncClient " ++ condense peerId) "Terminated by GDD governor."
-            _ ->
-              pure ()
-        Right _ -> pure ()
+            Just ThreadKilled -> trace "Terminated by GDD governor."
+            _                 -> pure ()
+          case fromException exn of
+            Just CSClient.EmptyBucket -> trace "Terminating because of empty bucket."
+            _ -> pure ()
   where
     ntnVersion :: NodeToNodeVersion
     ntnVersion = maxBound
+    trace = traceUnitWith tracer $ "ChainSyncClient " ++ condense peerId

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/ChainSync.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/ChainSync.hs
@@ -71,6 +71,9 @@ basicChainSyncClient peerId tracer cfg chainDbView varCandidate (startIdling, st
       , CSClient.varCandidate
       , CSClient.startIdling
       , CSClient.stopIdling
+      , CSClient.pauseLoPBucket = pure ()
+      , CSClient.resumeLoPBucket = pure ()
+      , CSClient.grantLoPToken = pure ()
       }
   where
     dummyHeaderInFutureCheck ::
@@ -107,7 +110,7 @@ runChainSyncClient
     -- We don't need this shared Set yet. If we need it at some point,
     -- it ought to be passed to `runChainSyncClient`.
     varIdling <- uncheckedNewTVarM $ Set.empty
-    bracketChainSyncClient nullTracer chainDbView varCandidates varIdling peerId ntnVersion $ \ varCandidate idleManagers -> do
+    bracketChainSyncClient nullTracer chainDbView varCandidates varIdling peerId ntnVersion CSClient.ChainSyncLoPBucketDisabled $ \ varCandidate idleManagers _lopBucket -> do
       res <- try $ runConnectedPeersPipelinedWithLimits
         createConnectedChannels
         nullTracer

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Run.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Run.hs
@@ -22,7 +22,9 @@ import qualified Data.Map.Strict as Map
 import           Ouroboros.Consensus.Config (TopLevelConfig (..))
 import           Ouroboros.Consensus.Genesis.Governor
                      (reprocessLoEBlocksOnCandidateChange, updateLoEFragStall)
-import           Ouroboros.Consensus.MiniProtocol.ChainSync.Client (ChainDbView)
+import           Ouroboros.Consensus.MiniProtocol.ChainSync.Client (ChainDbView,
+                     ChainSyncLoPBucketConfig (..),
+                     ChainSyncLoPBucketEnabledConfig (..))
 import qualified Ouroboros.Consensus.MiniProtocol.ChainSync.Client as CSClient
 import           Ouroboros.Consensus.Storage.ChainDB.API
 import qualified Ouroboros.Consensus.Storage.ChainDB.API as ChainDB
@@ -53,8 +55,8 @@ import           Test.Consensus.PeerSimulator.StateView
 import           Test.Consensus.PeerSimulator.Trace
 import qualified Test.Consensus.PointSchedule as PointSchedule
 import           Test.Consensus.PointSchedule (GenesisTest (GenesisTest),
-                     GenesisTestFull, NodeState, PeersSchedule,
-                     peersStatesRelative, prettyPeersSchedule)
+                     GenesisTestFull, LoPBucketParams (..), NodeState,
+                     PeersSchedule, peersStatesRelative, prettyPeersSchedule)
 import           Test.Consensus.PointSchedule.Peers (Peer (..), PeerId,
                      getPeerIds)
 import           Test.Util.ChainDB
@@ -88,6 +90,10 @@ data SchedulerConfig =
     -- Just for the purpose of testing that the selection indeed doesn't
     -- advance.
     , scEnableLoE               :: Bool
+
+    -- | Whether to enable to LoP. The parameters of the LoP come from
+    -- 'GenesisTest'. TODO: Same separation for timeouts.
+    , scEnableLoP               :: Bool
   }
 
 -- | Default scheduler config
@@ -98,7 +104,8 @@ defaultSchedulerConfig =
     scDebug = False,
     scTrace = True,
     scTraceState = False,
-    scEnableLoE = False
+    scEnableLoE = False,
+    scEnableLoP = False
   }
 
 -- | Enable debug tracing during a scheduler test.
@@ -123,6 +130,7 @@ startChainSyncConnectionThread ::
   SharedResources m ->
   ChainSyncResources m ->
   ChainSyncTimeout ->
+  ChainSyncLoPBucketConfig ->
   StateViewTracers m ->
   StrictTVar m (Map PeerId (StrictTVar m (AnchoredFragment (Header TestBlock)))) ->
   m ()
@@ -135,12 +143,13 @@ startChainSyncConnectionThread
   SharedResources {srPeerId}
   ChainSyncResources {csrServer}
   chainSyncTimeouts_
+  chainSyncLoPBucketConfig
   tracers
   varCandidates =
     void $
     forkLinkedThread registry ("ChainSyncClient" <> condense srPeerId) $
     bracketSyncWithFetchClient fetchClientRegistry srPeerId $
-    runChainSyncClient tracer cfg chainDbView srPeerId csrServer chainSyncTimeouts_ tracers varCandidates
+    runChainSyncClient tracer cfg chainDbView srPeerId csrServer chainSyncTimeouts_ chainSyncLoPBucketConfig tracers varCandidates
 
 -- | Start the BlockFetch client, using the supplied 'FetchClientRegistry' to
 -- register it for synchronization with the ChainSync client.
@@ -239,7 +248,7 @@ runPointSchedule schedulerConfig genesisTest tracer0 =
     fetchClientRegistry <- newFetchClientRegistry
     let chainDbView = CSClient.defaultChainDbView chainDb
     for_ (psrPeers resources) $ \PeerResources {prShared, prChainSync} -> do
-      startChainSyncConnectionThread registry tracer config chainDbView fetchClientRegistry prShared prChainSync chainSyncTimeouts_ stateViewTracers (psrCandidates resources)
+      startChainSyncConnectionThread registry tracer config chainDbView fetchClientRegistry prShared prChainSync chainSyncTimeouts_ chainSyncLoPBucketConfig stateViewTracers (psrCandidates resources)
       PeerSimulator.BlockFetch.startKeepAliveThread registry fetchClientRegistry (srPeerId prShared)
     for_ (psrPeers resources) $ \PeerResources {prShared, prBlockFetch} ->
       startBlockFetchConnectionThread registry fetchClientRegistry (pure Continue) prShared prBlockFetch
@@ -264,6 +273,7 @@ runPointSchedule schedulerConfig genesisTest tracer0 =
       , gtBlockTree
       , gtSchedule
       , gtChainSyncTimeouts
+      , gtLoPBucketParams = LoPBucketParams { lbpCapacity, lbpRate }
       , gtForecastRange
       } = genesisTest
 
@@ -275,6 +285,11 @@ runPointSchedule schedulerConfig genesisTest tracer0 =
       if scEnableChainSyncTimeouts schedulerConfig
         then gtChainSyncTimeouts
         else chainSyncNoTimeouts
+
+    chainSyncLoPBucketConfig =
+      if scEnableLoP schedulerConfig
+        then ChainSyncLoPBucketEnabled ChainSyncLoPBucketEnabledConfig { csbcCapacity = lbpCapacity, csbcRate = lbpRate }
+        else ChainSyncLoPBucketDisabled
 
 -- | Create a ChainDB and start a BlockRunner that operate on the peers'
 -- candidate fragments.

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Trace.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Trace.hs
@@ -56,7 +56,6 @@ mkCdbTracer tracer =
     trace = traceUnitWith tracer "ChainDB"
 
 mkChainSyncClientTracer ::
-  IOLike m =>
   PeerId ->
   Tracer m String ->
   Tracer m (TraceChainSyncClientEvent TestBlock)
@@ -74,7 +73,15 @@ mkChainSyncClientTracer pid tracer =
       trace $ "Validated header: " ++ terseHeader header
     TraceDownloadedHeader header ->
       trace $ "Downloaded header: " ++ terseHeader header
-    _ -> pure ()
+    TraceGaveLoPToken didGive header bestBlockNo ->
+      trace $
+        (if didGive then "Gave" else "Did not give")
+        ++ " LoP token to " ++ terseHeader header
+        ++ " compared to " ++ show bestBlockNo
+    TraceException exception ->
+      trace $ "Threw an exception: " ++ show exception
+    TraceTermination result ->
+      trace $ "Terminated with result: " ++ show result
   where
     trace = traceUnitWith tracer ("ChainSyncClient " ++ condense pid)
 

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
@@ -25,6 +25,7 @@ module Test.Consensus.PointSchedule (
   , GenesisTest (..)
   , GenesisTestFull
   , GenesisWindow (..)
+  , LoPBucketParams (..)
   , NodeState (..)
   , PeerSchedule
   , PeersSchedule
@@ -304,6 +305,11 @@ newtype GenesisWindow = GenesisWindow { unGenesisWindow :: Word64 }
 newtype ForecastRange = ForecastRange { unForecastRange :: Word64 }
   deriving (Show)
 
+data LoPBucketParams = LoPBucketParams {
+  lbpCapacity :: Integer,
+  lbpRate     :: Rational
+  }
+
 -- | All the data used by point schedule tests.
 data GenesisTest blk schedule = GenesisTest {
   gtSecurityParam     :: SecurityParam,
@@ -312,6 +318,7 @@ data GenesisTest blk schedule = GenesisTest {
   gtDelay             :: Delta,
   gtBlockTree         :: BlockTree blk,
   gtChainSyncTimeouts :: ChainSyncTimeout,
+  gtLoPBucketParams   :: LoPBucketParams,
   gtSlotLength        :: SlotLength,
   gtSchedule          :: schedule
   }
@@ -330,6 +337,9 @@ prettyGenesisTest genesisTest =
   , "    canAwait = " ++ show canAwaitTimeout
   , "    intersect = " ++ show intersectTimeout
   , "    mustReply = " ++ show mustReplyTimeout
+  , "  gtLoPBucketParams: "
+  , "    lbpCapacity = " ++ show lbpCapacity ++ " tokens"
+  , "    lbpRate = " ++ show lbpRate ++ " ≅ " ++ printf "%.2f" (fromRational lbpRate :: Float) ++ " tokens per second"
   , "  gtBlockTree:"
   ] ++ map (("    " ++) . terseFragment) (allFragments gtBlockTree)
     ++ map ("    " ++) (prettyBlockTree gtBlockTree)
@@ -341,6 +351,7 @@ prettyGenesisTest genesisTest =
       , gtDelay = Delta delta
       , gtBlockTree
       , gtChainSyncTimeouts = ChainSyncTimeout{canAwaitTimeout, intersectTimeout, mustReplyTimeout}
+      , gtLoPBucketParams = LoPBucketParams{lbpCapacity, lbpRate}
       , gtSlotLength
       , gtSchedule = _
       } = genesisTest

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/SinglePeer.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/SinglePeer.hs
@@ -235,6 +235,7 @@ peerScheduleFromTipPoints
   -> m [(Time, SchedulePoint blk)]
 peerScheduleFromTipPoints g psp tipPoints trunk0 branches0 = do
     let trunk0v = Vector.fromList $ AF.toOldestFirst trunk0
+        -- NOTE: Is this still correct? Shouldn't it be `withOrigin 0 (+1)`?
         firstTrunkBlockNo = withOrigin 1 (+1) $ AF.anchorBlockNo trunk0
         branches0v = map (Vector.fromList . AF.toOldestFirst) branches0
         anchorBlockIndices =

--- a/ouroboros-consensus/bench/ChainSync-client-bench/Main.hs
+++ b/ouroboros-consensus/bench/ChainSync-client-bench/Main.hs
@@ -137,6 +137,9 @@ oneBenchRun
               , CSClient.varCandidate
               , CSClient.startIdling = pure ()
               , CSClient.stopIdling  = pure ()
+              , CSClient.pauseLoPBucket = pure ()
+              , CSClient.resumeLoPBucket = pure ()
+              , CSClient.grantLoPToken = pure ()
               }
 
     server :: ChainSyncServer H (Point B) (Tip B) IO ()

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -239,6 +239,7 @@ library
     Ouroboros.Consensus.Util.FileLock
     Ouroboros.Consensus.Util.HList
     Ouroboros.Consensus.Util.IOLike
+    Ouroboros.Consensus.Util.LeakyBucket
     Ouroboros.Consensus.Util.MonadSTM.NormalForm
     Ouroboros.Consensus.Util.MonadSTM.RAWLock
     Ouroboros.Consensus.Util.MonadSTM.StrictSVar
@@ -559,18 +560,21 @@ test-suite infra-test
     Test.Ouroboros.Consensus.ChainGenerator.Tests.BitVector
     Test.Ouroboros.Consensus.ChainGenerator.Tests.Counting
     Test.Ouroboros.Consensus.ChainGenerator.Tests.Honest
+    Test.Ouroboros.Consensus.Util.LeakyBucket.Tests
     Test.Util.ChainUpdates.Tests
     Test.Util.Schedule.Tests
     Test.Util.Split.Tests
 
   build-depends:
     , base
+    , io-sim
     , mtl
     , ouroboros-consensus:{ouroboros-consensus, unstable-consensus-testlib}
     , QuickCheck
     , random
     , tasty
     , tasty-quickcheck
+    , time
     , unstable-consensus-testlib
     , vector
 

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Util/LeakyBucket.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Util/LeakyBucket.hs
@@ -1,0 +1,246 @@
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE LambdaCase          #-}
+{-# LANGUAGE MultiWayIf          #-}
+{-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE NumericUnderscores  #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+-- | This module implements a “leaky bucket”. One defines a bucket with a
+-- capacity and a leaking rate; a race (in the sense of Async) starts against
+-- the bucket which leaks at the given rate. The user is provided with a
+-- function to refill the bucket by a certain amount. If the bucket ever goes
+-- empty, both threads are cancelled.
+--
+-- This can be used for instance to enforce a minimal rate of a peer: they race
+-- against the bucket and refill the bucket by a certain amount whenever they do
+-- a “good” action.
+--
+-- NOTE: Even though the imagery is the same, this is different from what is
+-- usually called a “token bucket” or “leaky bucket” in the litterature where it
+-- is mostly used for rate limiting.
+--
+-- REVIEW: Could be used as leaky bucket used for rate limiting algorithms. All
+-- the infrastructure is here (put 'onEmpty' to @pure ()@ and you're good to go)
+-- but it has not been tested with that purpose in mind.
+module Ouroboros.Consensus.Util.LeakyBucket (
+    Config (..)
+  , Handlers (..)
+  , State (..)
+  , diffTimeToSecondsRational
+  , dummyConfig
+  , evalAgainstBucket
+  , execAgainstBucket
+  , runAgainstBucket
+  , secondsRationalToDiffTime
+  ) where
+
+import           Data.Ratio ((%))
+import           Data.Time (DiffTime)
+import           Data.Time.Clock (diffTimeToPicoseconds)
+import           Ouroboros.Consensus.Util.IOLike
+                     (MonadAsync (Async, async, uninterruptibleCancel),
+                     MonadCatch (handle), MonadDelay (threadDelay),
+                     MonadFork (throwTo), MonadMask, MonadMonotonicTime,
+                     MonadSTM, MonadThread (ThreadId, myThreadId),
+                     MonadThrow (finally), SomeException, StrictTVar, Time,
+                     atomically, diffTime, getMonotonicTime, readTVar,
+                     readTVarIO, uncheckedNewTVarM, writeTVar)
+import           Prelude hiding (init)
+
+-- | Configuration of a leaky bucket.
+data Config m = Config
+  { -- | Initial and maximal capacity of the bucket, in number of tokens.
+    capacity       :: Rational,
+    -- | Tokens per second leaking off the bucket.
+    rate           :: Rational,
+    -- | Whether to fill to capacity on overflow or to do nothing.
+    fillOnOverflow :: Bool,
+    -- | A monadic action to trigger when the bucket is empty.
+    onEmpty        :: m ()
+  }
+
+-- | A configuration for a bucket that does nothing.
+dummyConfig :: (Applicative m) => Config m
+dummyConfig =
+  Config
+    { capacity = 0,
+      rate = 0,
+      fillOnOverflow = True,
+      onEmpty = pure ()
+    }
+
+-- | State of a leaky bucket, giving the level and the associated time.
+data State cfg = State
+  { level  :: Rational,
+    time   :: Time,
+    paused :: Bool,
+    config :: cfg
+  }
+  deriving (Eq, Show)
+
+-- | A bucket is simply a TVar of a state.
+type Bucket m = StrictTVar m (State (Config m))
+
+-- | Whether filling the bucket overflew.
+newtype Overflew = Overflew Bool
+
+-- | The handlers to a bucket: contains the API to interact with a running
+-- bucket.
+data Handlers m = Handlers
+  { -- | Refill the bucket by the given amount and returns whether the bucket
+    -- overflew. The bucket may silently get filled to full capacity or not get
+    -- filled depending on 'fillOnOverflow'.
+    fill         :: Rational -> m Overflew,
+    -- | Pause or resume the bucket. Pausing stops the bucket from leaking until
+    -- it is resumed. It is still possible to fill it during that time. @setPaused
+    -- True@ and @setPaused False@ are idempotent.
+    setPaused    :: Bool -> m (),
+    -- | Dynamically update the configuration of the bucket.
+    updateConfig :: (Config m -> Config m) -> m ()
+  }
+
+-- | Create a bucket with the given configuration, then run the action against
+-- that bucket. Returns when the action terminates or the bucket empties. In the
+-- first case, return the value returned by the action. In the second case,
+-- return @Nothing@.
+execAgainstBucket ::
+  (MonadDelay m, MonadAsync m, MonadFork m, MonadMask m) =>
+  Config m ->
+  (Handlers m -> m a) ->
+  m a
+execAgainstBucket config action = snd <$> runAgainstBucket config action
+
+-- | Same as 'execAgainstBucket' but returns the 'State' of the bucket when the
+-- action terminates. Exposed for testing purposes.
+evalAgainstBucket ::
+  (MonadDelay m, MonadAsync m, MonadFork m, MonadMask m) =>
+  Config m ->
+  (Handlers m -> m a) ->
+  m (State (Config m))
+evalAgainstBucket config action = fst <$> runAgainstBucket config action
+
+-- | Same as 'execAgainstBucket' but also returns the 'State' of the bucket when
+-- the action terminates. Exposed for testing purposes.
+runAgainstBucket ::
+  forall m a.
+  (MonadDelay m, MonadAsync m, MonadFork m, MonadMask m) =>
+  Config m ->
+  (Handlers m -> m a) ->
+  m (State (Config m), a)
+runAgainstBucket config action = do
+  bucket <- init config
+  tid <- myThreadId
+  thread <- uncheckedNewTVarM Nothing
+  startThread thread bucket tid
+  finally
+    ( do
+        result <-
+          action $
+            Handlers
+              { fill = (snd <$>) . snapshotFill bucket,
+                setPaused = setPaused bucket,
+                updateConfig = updateConfig thread bucket tid
+              }
+        state <- snapshot bucket
+        pure (state, result)
+    )
+    (stopThread thread)
+  where
+    startThread :: StrictTVar m (Maybe (Async m ())) -> Bucket m -> ThreadId m -> m ()
+    startThread thread bucket tid =
+      readTVarIO thread >>= \case
+        Just _ -> error "LeakyBucket: startThread called when a thread is already running"
+        Nothing -> (atomically . writeTVar thread) =<< leak bucket tid
+
+    stopThread :: StrictTVar m (Maybe (Async m ())) -> m ()
+    stopThread thread =
+      readTVarIO thread >>= \case
+        Just thread' -> uninterruptibleCancel thread'
+        Nothing -> pure ()
+
+    setPaused :: Bucket m -> Bool -> m ()
+    setPaused bucket paused = do
+      newState <- snapshot bucket
+      atomically $ writeTVar bucket newState {paused}
+
+    updateConfig :: StrictTVar m (Maybe (Async m ())) -> Bucket m -> ThreadId m -> (Config m -> Config m) -> m ()
+    updateConfig thread bucket tid = \f -> do
+      -- FIXME: All of that should be in one STM transaction.
+      State {level, time, paused, config = oldConfig} <- snapshot bucket
+      let newConfig@Config {capacity = newCapacity, rate = newRate} = f oldConfig
+          newLevel = min newCapacity level
+      if
+        | newRate <= 0 -> stopThread thread
+        | newRate > rate oldConfig -> stopThread thread >> startThread thread bucket tid
+        | otherwise -> pure ()
+      atomically $ writeTVar bucket State {level = newLevel, time, paused, config = newConfig}
+
+-- | Initialise a bucket given a configuration. The bucket starts full at the
+-- time where one calls 'init'.
+init :: (MonadMonotonicTime m, MonadSTM m) => Config m -> m (Bucket m)
+init config@Config {capacity} = do
+  time <- getMonotonicTime
+  uncheckedNewTVarM $ State {time, level = capacity, paused = False, config}
+
+-- | Monadic action that calls 'threadDelay' until the bucket is empty, then
+-- returns @()@. It receives the 'ThreadId' argument of the action's thread,
+-- which it uses to throw exceptions at it.
+leak :: (MonadDelay m, MonadCatch m, MonadFork m, MonadAsync m) => Bucket m -> ThreadId m -> m (Maybe (Async m ()))
+leak bucket actionThreadId = do
+  State {config = Config {rate}} <- snapshot bucket
+  if rate <= 0
+    then pure Nothing
+    else Just <$> async go
+  where
+    go = do
+      State {level, config = Config {rate, onEmpty}} <- snapshot bucket
+      let timeToWait = secondsRationalToDiffTime (level / rate)
+      -- NOTE: It is possible that @timeToWait == 0@ while @level > 0@ when @level@
+      -- is so tiny that @level / rate@ rounds down to 0 picoseconds. In that case,
+      -- it is safe to assume that it is just zero.
+      if level <= 0 || timeToWait == 0
+        then handle (\(e :: SomeException) -> throwTo actionThreadId e) onEmpty
+        else threadDelay timeToWait >> go
+
+-- | Take a snapshot of the bucket, that is compute its state at the current
+-- time.
+snapshot :: (MonadSTM m, MonadMonotonicTime m) => Bucket m -> m (State (Config m))
+snapshot bucket = fst <$> snapshotFill bucket 0
+
+-- | Same as 'snapshot' but also adds the given quantity to the resulting
+-- level and returns whether this action overflew the bucket.
+--
+-- REVIEW: What to do when 'toAdd' is negative?
+--
+-- REVIEW: Really, this should all be an STM transaction. Now there is the risk
+-- that two snapshot-taking transactions interleave with the time measurement to
+-- get a slightly imprecise state (which is not the worst because everything
+-- should happen very fast). There is also the bigger risk that when we snapshot
+-- and then do something (eg. in the 'setPaused' handler) we interleave with
+-- something else. It cannot easily be an STM transaction, though, because we
+-- need to measure the time, and @io-classes@'s STM does not allow running IO in
+-- an STM.
+snapshotFill :: (MonadSTM m, MonadMonotonicTime m) => Bucket m -> Rational -> m (State (Config m), Overflew)
+snapshotFill bucket toAdd = do
+  newTime <- getMonotonicTime
+  atomically $ do
+    State {level, time, paused, config} <- readTVar bucket
+    let Config {rate, capacity, fillOnOverflow} = config
+        elapsed = diffTime newTime time
+        leaked = if paused then 0 else (diffTimeToSecondsRational elapsed * rate)
+        levelLeaked = max 0 (level - leaked)
+        levelFilled = min capacity (levelLeaked + toAdd)
+        overflew = levelLeaked + toAdd > capacity
+        newLevel = if not overflew || fillOnOverflow then levelFilled else levelLeaked
+        newState = State {time = newTime, level = newLevel, paused, config}
+    writeTVar bucket newState
+    pure (newState, Overflew overflew)
+
+-- | Convert a 'DiffTime' to a 'Rational' number of seconds. This is similar to
+-- 'diffTimeToSeconds' but with picoseconds precision.
+diffTimeToSecondsRational :: DiffTime -> Rational
+diffTimeToSecondsRational = (% 1_000_000_000_000) . diffTimeToPicoseconds
+
+-- | Alias of 'realToFrac' to make code more readable and typing more explicit.
+secondsRationalToDiffTime :: Rational -> DiffTime
+secondsRationalToDiffTime = realToFrac

--- a/ouroboros-consensus/test/infra-test/Main.hs
+++ b/ouroboros-consensus/test/infra-test/Main.hs
@@ -14,6 +14,7 @@ module Main (main) where
 
 import qualified Ouroboros.Consensus.Util.Tests (tests)
 import qualified Test.Ouroboros.Consensus.ChainGenerator.Tests (tests)
+import qualified Test.Ouroboros.Consensus.Util.LeakyBucket.Tests (tests)
 import           Test.Tasty (TestTree, testGroup)
 import qualified Test.Util.ChainUpdates.Tests (tests)
 import qualified Test.Util.Schedule.Tests (tests)
@@ -29,6 +30,7 @@ tests =
   testGroup "test-infra"
   [ Ouroboros.Consensus.Util.Tests.tests
   , Test.Ouroboros.Consensus.ChainGenerator.Tests.tests
+  , Test.Ouroboros.Consensus.Util.LeakyBucket.Tests.tests
   , Test.Util.ChainUpdates.Tests.tests
   , Test.Util.Schedule.Tests.tests
   , Test.Util.Split.Tests.tests

--- a/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/Util/LeakyBucket/Tests.hs
+++ b/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/Util/LeakyBucket/Tests.hs
@@ -1,0 +1,343 @@
+{-# LANGUAGE LambdaCase          #-}
+{-# LANGUAGE MultiWayIf          #-}
+{-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE NumericUnderscores  #-}
+{-# LANGUAGE RankNTypes          #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Test.Ouroboros.Consensus.Util.LeakyBucket.Tests (tests) where
+
+import           Control.Monad (foldM, void)
+import           Control.Monad.IOSim (IOSim, runSimOrThrow)
+import           Data.Either (isLeft, isRight)
+import           Data.Functor ((<&>))
+import           Data.Ratio ((%))
+import           Data.Time.Clock (DiffTime, picosecondsToDiffTime)
+import           Ouroboros.Consensus.Util.IOLike (Exception (displayException),
+                     MonadAsync, MonadCatch (try), MonadDelay, MonadFork,
+                     MonadMask, MonadThrow (throwIO), SomeException,
+                     Time (Time), addTime, fromException, threadDelay)
+import           Ouroboros.Consensus.Util.LeakyBucket
+import           Test.QuickCheck (Arbitrary (arbitrary), Gen, Property,
+                     classify, counterexample, forAll, frequency, ioProperty,
+                     listOf1, scale, suchThat, (===))
+import           Test.Tasty (TestTree, testGroup)
+import           Test.Tasty.QuickCheck (property, testProperty)
+import           Test.Util.TestEnv (adjustQuickCheckTests)
+
+tests :: TestTree
+tests = testGroup "Ouroboros.Consensus.Util.LeakyBucket" [
+  testProperty "play a bit" prop_playABit,
+  testProperty "play too long" prop_playTooLong,
+  testProperty "play too long harmless" prop_playTooLongHarmless,
+  testProperty "wait almost too long" (prop_noRefill (-1)),
+  testProperty "wait just too long" (prop_noRefill 1),
+  testProperty "pause for a time" prop_playWithPause,
+  testProperty "resume too quickly" prop_playWithPauseTooLong,
+  testProperty "propagates exceptions" prop_propagateExceptions,
+  testProperty "propagates exceptions (IO)" prop_propagateExceptionsIO,
+  testProperty "catch exception" prop_catchException,
+  adjustQuickCheckTests (* 10) $ testProperty "random" prop_random
+  ]
+
+--------------------------------------------------------------------------------
+-- Dummy configuration
+--------------------------------------------------------------------------------
+
+newtype Capacity = Capacity { unCapacity :: Rational }
+  deriving Show
+
+instance Arbitrary Capacity where
+  arbitrary = Capacity <$> arbitrary `suchThat` (> 0)
+
+newtype Rate = Rate { unRate :: Rational }
+  deriving Show
+
+instance Arbitrary Rate where
+  arbitrary = Rate <$> arbitrary `suchThat` (> 0)
+
+newtype FillOnOverflow = FillOnOverflow { unFillOnOverflow :: Bool }
+  deriving Show
+
+instance Arbitrary FillOnOverflow where
+  arbitrary = FillOnOverflow <$> arbitrary
+
+-- | Whether to throw on empty bucket.
+newtype ThrowOnEmpty = ThrowOnEmpty { unThrowOnEmpty :: Bool }
+  deriving (Eq, Show)
+
+instance Arbitrary ThrowOnEmpty where
+  arbitrary = ThrowOnEmpty <$> arbitrary
+
+data TestConfig = TestConfig
+  { testCapacity     :: Rational,
+    testRate         :: Rational,
+    testThrowOnEmpty :: Bool
+  }
+  deriving (Eq, Show)
+
+instance Arbitrary TestConfig where
+  arbitrary =
+    TestConfig
+      <$> (unCapacity <$> arbitrary)
+      <*> (unRate <$> arbitrary)
+      <*> (unThrowOnEmpty <$> arbitrary)
+
+data EmptyBucket = EmptyBucket
+  deriving (Eq, Show)
+
+instance Exception EmptyBucket
+
+-- | Make an actual configuration from a test configuration.
+mkConfig :: MonadThrow m => TestConfig -> Config m
+mkConfig TestConfig {testCapacity, testRate, testThrowOnEmpty} =
+  Config
+    { capacity = testCapacity,
+      rate = testRate,
+      fillOnOverflow = True,
+      onEmpty =
+        if testThrowOnEmpty
+          then (throwIO EmptyBucket)
+          else (pure ())
+    }
+
+-- | Make a configuration that fills on overflow and throws 'EmptyBucket' on
+-- empty bucket.
+configThrow :: MonadThrow m => Capacity -> Rate -> Config m
+configThrow (Capacity testCapacity) (Rate testRate) =
+  mkConfig TestConfig{testCapacity, testRate, testThrowOnEmpty = True}
+
+-- | A configuration with capacity and rate 1, that fills on overflow and throws
+-- 'EmptyBucket' on empty bucket.
+config11Throw :: MonadThrow m => Config m
+config11Throw = configThrow (Capacity 1) (Rate 1)
+
+-- | Make a configuration that fills on overflow and does nothing on empty
+-- bucket.
+configPure :: MonadThrow m => Capacity -> Rate -> Config m
+configPure (Capacity testCapacity) (Rate testRate) =
+  mkConfig TestConfig{testCapacity, testRate, testThrowOnEmpty = False}
+
+-- | A configuration with capacity 1 and rate 1, that fills on overflow and does
+-- nothing on empty bucket.
+config11Pure :: MonadThrow m => Config m
+config11Pure = configPure (Capacity 1) (Rate 1)
+
+-- | Strip the configuration from a 'State', so as to make it comparable,
+-- showable, etc.
+stripConfig :: State cfg -> State ()
+stripConfig state = state{config=()}
+
+-- | 'evalAgainstBucket' followed by 'stripConfig'.
+stripEvalAgainstBucket ::
+  (MonadDelay m, MonadAsync m, MonadFork m, MonadMask m) =>
+  Config m ->
+  (Handlers m -> m a) ->
+  m (State ())
+stripEvalAgainstBucket config action = stripConfig <$> evalAgainstBucket config action
+
+-- | Alias for 'runSimOrThrow' by analogy to 'ioProperty'.
+ioSimProperty :: forall a. (forall s. IOSim s a) -> a
+ioSimProperty = runSimOrThrow
+
+-- | QuickCheck helper to check that a code threw the given exception.
+shouldThrow :: (MonadCatch m, Show a, Exception e, Eq e) => m a -> e -> m Property
+shouldThrow a e =
+  try a <&> \case
+    Left exn
+      | fromException exn == Just e -> property True
+      | otherwise -> counterexample ("Expected exception " ++ show e ++ "; got exception " ++ show exn) False
+    Right result -> counterexample ("Expected exception " ++ show e ++ "; got " ++ show result) False
+
+-- | QuickCheck helper to check that a code evaluated to the given value.
+shouldEvaluateTo :: (MonadCatch m, Eq a, Show a) => m a -> a -> m Property
+shouldEvaluateTo a v =
+  try a <&> \case
+    Right result
+      | result == v -> property True
+      | otherwise -> counterexample ("Expected " ++ show v ++ "; got " ++ show result) False
+    Left (exn :: SomeException) -> counterexample ("Expected " ++ show v ++ "; got exception " ++ displayException exn) False
+
+-- | Number of picoseconds in a second (@10^12@).
+picosecondsPerSecond :: Integer
+picosecondsPerSecond = 1_000_000_000_000
+
+--------------------------------------------------------------------------------
+-- Simple properties
+--------------------------------------------------------------------------------
+
+-- | One test case where we wait a bit, then fill, then wait some more. We then
+-- should observe a state with a positive level.
+prop_playABit :: Property
+prop_playABit =
+  ioSimProperty $
+    stripEvalAgainstBucket config11Throw (\handlers -> do
+      threadDelay 0.5
+      void $ fill handlers 67
+      threadDelay 0.9
+    ) `shouldEvaluateTo` State{level = 1 % 10, time = Time 1.4, paused = False, config = ()}
+
+-- | One test case similar to 'prop_playABit' but we wait a bit too long and
+-- should observe the triggering of the 'onEmpty' action.
+prop_playTooLong :: Property
+prop_playTooLong =
+  ioSimProperty $
+    stripEvalAgainstBucket config11Throw (\handlers -> do
+      threadDelay 0.5
+      void $ fill handlers 67
+      threadDelay 1.1
+    ) `shouldThrow` EmptyBucket
+
+-- | One test case similar to 'prop_playTooLong' but 'onEmpty' does nothing and
+-- therefore we should still observe a state at the end.
+prop_playTooLongHarmless :: Property
+prop_playTooLongHarmless =
+  ioSimProperty $
+    stripEvalAgainstBucket config11Pure (\handlers -> do
+      threadDelay 0.5
+      void $ fill handlers 67
+      threadDelay 1.1
+    ) `shouldEvaluateTo` State{level = 0, time = Time 1.6, paused = False, config = ()}
+
+prop_playWithPause :: Property
+prop_playWithPause =
+  ioSimProperty $
+    stripEvalAgainstBucket config11Throw (\handlers -> do
+      threadDelay 0.5
+      setPaused handlers True
+      threadDelay 1.5
+      setPaused handlers False
+      threadDelay 0.4
+    ) `shouldEvaluateTo` State{level = 1 % 10, time = Time 2.4, paused = False, config = ()}
+
+prop_playWithPauseTooLong :: Property
+prop_playWithPauseTooLong =
+  ioSimProperty $
+    stripEvalAgainstBucket config11Throw (\handlers -> do
+      threadDelay 0.5
+      setPaused handlers True
+      threadDelay 1.5
+      setPaused handlers False
+      threadDelay 0.6
+    ) `shouldThrow` EmptyBucket
+
+-- | A bunch of test cases where we wait exactly as much as the bucket runs
+-- except for a given offset. If the offset is negative, we should get a
+-- state. If the offset is positive, we should get an exception. NOTE: Do not
+-- use an offset of @0@. NOTE: Considering the precision, we *need* IOSim for
+-- this test.
+prop_noRefill :: Integer -> Capacity -> Rate -> Property
+prop_noRefill offset capacity@(Capacity c) rate@(Rate r) = do
+  -- NOTE: The @-1@ is to ensure that we do not test the situation where the
+  -- bucket empties at the *exact* same time (curtesy of IOSim) as the action.
+  let ps = floor (c / r * fromInteger picosecondsPerSecond) + offset
+      time = picosecondsToDiffTime ps
+      level = c - (ps % picosecondsPerSecond) * r
+  if
+    | offset < 0 ->
+      ioSimProperty $
+        stripEvalAgainstBucket (configThrow capacity rate) (\_ -> threadDelay time)
+        `shouldEvaluateTo` State{level, time = Time time, paused = False, config = ()}
+    | offset > 0 ->
+      ioSimProperty $
+        stripEvalAgainstBucket (configThrow capacity rate) (\_ -> threadDelay time)
+        `shouldThrow` EmptyBucket
+    | otherwise ->
+      error "prop_noRefill: do not use an offset of 0"
+
+--------------------------------------------------------------------------------
+-- Exception propagation
+--------------------------------------------------------------------------------
+
+-- | A dummy exception that we will use to outrun the bucket.
+data NoPlumberException = NoPlumberException
+  deriving (Eq, Show)
+instance Exception NoPlumberException
+
+-- | One test to check that throwing an exception in the action does propagate
+-- outside of @*AgainstBucket@.
+prop_propagateExceptions :: Property
+prop_propagateExceptions =
+  ioSimProperty $
+    stripEvalAgainstBucket config11Throw (\_ -> throwIO NoPlumberException)
+      `shouldThrow`
+    NoPlumberException
+
+-- | Same as 'prop_propagateExceptions' except it runs in IO.
+prop_propagateExceptionsIO :: Property
+prop_propagateExceptionsIO =
+  ioProperty $
+    stripEvalAgainstBucket config11Throw (\_ -> throwIO NoPlumberException)
+      `shouldThrow`
+    NoPlumberException
+
+-- | One test to show that we can catch the 'EmptyBucket' exception from the
+-- action itself, but that it is not wrapped in 'ExceptionInLinkedThread'.
+prop_catchException :: Property
+prop_catchException =
+  ioSimProperty $
+    execAgainstBucket config11Throw (\_ -> try $ threadDelay 1000)
+      `shouldEvaluateTo`
+    Left EmptyBucket
+
+--------------------------------------------------------------------------------
+-- Against a model
+--------------------------------------------------------------------------------
+
+-- | Abstract “actions” to be run. We can either wait by some time or refill the
+-- bucket by some value.
+data Action = ThreadDelay DiffTime | Fill Rational | SetPaused Bool
+  deriving (Eq, Show)
+
+-- | Random generation of 'Action's. The scales and frequencies are taken such
+-- that we explore as many interesting cases as possible.
+genAction :: Gen Action
+genAction = frequency [
+  (1, ThreadDelay . picosecondsToDiffTime <$> scale (* fromInteger picosecondsPerSecond) (arbitrary `suchThat` (>= 0))),
+  (1, Fill <$> scale (* 1_000_000_000_000_000) (arbitrary `suchThat` (>= 0))),
+  (1, SetPaused <$> arbitrary)
+  ]
+
+-- | How to run the 'Action's in a monad.
+applyActions :: MonadDelay m => Handlers m -> [Action] -> m ()
+applyActions handlers = mapM_ $ \case
+  ThreadDelay t -> threadDelay t
+  Fill t -> void $ fill handlers t
+  SetPaused p -> setPaused handlers p
+
+-- | A model of what we expect the 'Action's to lead to, either an 'EmptyBucket'
+-- exception (if the bucket won the race) or a 'State' (otherwise).
+modelActions :: TestConfig -> [Action] -> Either EmptyBucket (State TestConfig)
+modelActions config =
+  foldM go $ State{level = testCapacity config, time = Time 0, paused = False, config}
+  where
+    go :: State TestConfig -> Action -> Either EmptyBucket (State TestConfig)
+    go state@State{time, level, paused, config=TestConfig{testCapacity, testRate, testThrowOnEmpty}} = \case
+      Fill t ->
+        Right state{level = min testCapacity (level + t)}
+      ThreadDelay t ->
+        let newTime = addTime t time
+            newLevel = if paused then level else max 0 (level - diffTimeToSecondsRational t * testRate)
+         in if newLevel <= 0 && testThrowOnEmpty
+              then Left EmptyBucket
+              else Right state{time = newTime, level = newLevel}
+      SetPaused p ->
+        Right state{paused = p}
+
+-- | A bunch of test cases where we generate a list of 'Action's ,run them via
+-- 'applyActions' and compare the result to that of 'modelActions'.
+prop_random :: TestConfig -> Property
+prop_random testConfig =
+  forAll (listOf1 genAction) $ \actions ->
+    let modelResult = modelActions testConfig actions
+        nbActions = length actions
+     in classify (isLeft modelResult) "bucket finished empty" $
+        classify (isRight modelResult) "bucket finished non-empty" $
+        classify (nbActions <= 10) "<= 10 actions" $
+        classify (10 < nbActions && nbActions <= 20) "11-20 actions" $
+        classify (20 < nbActions && nbActions <= 50) "21-50 actions" $
+        classify (50 < nbActions) "> 50 actions" $
+        runSimOrThrow (
+          try $ stripEvalAgainstBucket (mkConfig testConfig) $
+            flip applyActions actions
+        ) === (stripConfig <$> modelResult)


### PR DESCRIPTION
Notes:

- ~This PR targets `main` because of https://github.com/IntersectMBO/ouroboros-consensus/pull/823 that recently reworked the ChainSync client fully. It would not have made sense to target `genesis/milestone8` to then have a big conflict. This does mean that we will have to be mindful when creating `genesis/milestone7` (yay numbering) in February. Or maybe we should rebase `genesis/milestone8` on a more recent version of `main`?~

- The commits can be read individually.

- ~For now, the bucket is unconditional: it starts when the ChainSync client starts and never ever stops. It would make sense to introduce a mechanism to disable it, which could be useful for tests that do not want to bother with LoP and for when we're caught-up. The `LeakyBucket` module already paves the way to add interactions with the bucket (stop, resume, etc.) by providing a `Handler` type that can for now only refill things.~

- ~We have discussed in sync today where I should hook into, so I'm fairly confident about that. I am not confident at all about my approach to configuration, however.~

- There will be the need for discussions on how the bucket should behave when going from Syncing to CaughtUp back to Syncing. Should we keep the previous level? Should we make it full again? Should we slowly fill it back in?

- There will be the need for discussions on how to choose the capacity and the rate to make it interesting in our Genesis tests.

- The LeakyBucket has for now been written with the idea that it should be leaking and do something when empty. We could modify it every so slightly to also handle the case where the bucket fills up and prevents actions from happening when full. This would allow reuse it later (and, who knows, maybe we want to slowly fill up the bucket when caught up).

- ~The LeakyBucket comes with a fairly extensive test suite, I'd say. There is however no LoP-specific tests of the ChainSync client at this point. I have had to disable it because it was killing peers in the other tests (a good sign imo) and I have tested a previous version based on `genesis/milestone8` and it seemed to behave fine.~

- ~In our Genesis tests, it seems the `EmptyBucket` exception gets wrapped in a `ExceptionInLinkedThread` and I don't know where it comes from but it bugs me. We were rather careful to unwrap such things in the bucket and there is even a test for that so I don't think that it comes from this; probably from something in our peer simulator?~