### PR TITLE
ChainGenerators: collate generator postconditions in the README.md

### DIFF
--- a/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
+++ b/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
@@ -234,6 +234,7 @@ test-suite consensus-test
     Test.Consensus.PeerSimulator.Trace
     Test.Consensus.PointSchedule
     Test.Consensus.PointSchedule.Peers
+    Test.Consensus.PointSchedule.Shrinking
     Test.Consensus.PointSchedule.SinglePeer
     Test.Consensus.PointSchedule.SinglePeer.Indices
     Test.Consensus.PointSchedule.Tests

--- a/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
+++ b/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
@@ -225,6 +225,7 @@ test-suite consensus-test
     Test.Consensus.PeerSimulator.ScheduledBlockFetchServer
     Test.Consensus.PeerSimulator.ScheduledChainSyncServer
     Test.Consensus.PeerSimulator.ScheduledServer
+    Test.Consensus.PeerSimulator.StateDiagram
     Test.Consensus.PeerSimulator.StateView
     Test.Consensus.PeerSimulator.Tests
     Test.Consensus.PeerSimulator.Tests.Rollback

--- a/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
+++ b/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
@@ -224,6 +224,7 @@ test-suite consensus-test
     Test.Consensus.PeerSimulator.ScheduledChainSyncServer
     Test.Consensus.PeerSimulator.StateView
     Test.Consensus.PeerSimulator.Tests
+    Test.Consensus.PeerSimulator.Tests.Rollback
     Test.Consensus.PeerSimulator.Tests.Timeouts
     Test.Consensus.PeerSimulator.Trace
     Test.Consensus.PointSchedule

--- a/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
+++ b/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
@@ -210,6 +210,7 @@ test-suite consensus-test
     Test.Consensus.Genesis.Setup.GenChains
     Test.Consensus.Genesis.Tests
     Test.Consensus.Genesis.Tests.LongRangeAttack
+    Test.Consensus.Genesis.Tests.Uniform
     Test.Consensus.HardFork.Combinator
     Test.Consensus.HardFork.Combinator.A
     Test.Consensus.HardFork.Combinator.B

--- a/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
+++ b/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
@@ -217,11 +217,14 @@ test-suite consensus-test
     Test.Consensus.Network.Driver.Limits.Extras
     Test.Consensus.Node
     Test.Consensus.PeerSimulator.BlockFetch
+    Test.Consensus.PeerSimulator.ChainSync
     Test.Consensus.PeerSimulator.Config
     Test.Consensus.PeerSimulator.Handlers
     Test.Consensus.PeerSimulator.Resources
     Test.Consensus.PeerSimulator.Run
+    Test.Consensus.PeerSimulator.ScheduledBlockFetchServer
     Test.Consensus.PeerSimulator.ScheduledChainSyncServer
+    Test.Consensus.PeerSimulator.ScheduledServer
     Test.Consensus.PeerSimulator.StateView
     Test.Consensus.PeerSimulator.Tests
     Test.Consensus.PeerSimulator.Tests.Rollback

--- a/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
+++ b/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
@@ -236,6 +236,7 @@ test-suite consensus-test
     Test.Consensus.PointSchedule.SinglePeer
     Test.Consensus.PointSchedule.SinglePeer.Indices
     Test.Consensus.PointSchedule.Tests
+    Test.Util.TersePrinting
 
   build-depends:
     , base

--- a/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
+++ b/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
@@ -223,6 +223,8 @@ test-suite consensus-test
     Test.Consensus.PeerSimulator.Run
     Test.Consensus.PeerSimulator.ScheduledChainSyncServer
     Test.Consensus.PeerSimulator.StateView
+    Test.Consensus.PeerSimulator.Tests
+    Test.Consensus.PeerSimulator.Tests.Timeouts
     Test.Consensus.PeerSimulator.Trace
     Test.Consensus.PointSchedule
 

--- a/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
+++ b/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
@@ -222,6 +222,7 @@ test-suite consensus-test
     Test.Consensus.PeerSimulator.Resources
     Test.Consensus.PeerSimulator.Run
     Test.Consensus.PeerSimulator.ScheduledChainSyncServer
+    Test.Consensus.PeerSimulator.StateView
     Test.Consensus.PeerSimulator.Trace
     Test.Consensus.PointSchedule
 

--- a/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
+++ b/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
@@ -228,6 +228,9 @@ test-suite consensus-test
     Test.Consensus.PeerSimulator.Tests.Timeouts
     Test.Consensus.PeerSimulator.Trace
     Test.Consensus.PointSchedule
+    Test.Consensus.PointSchedule.SinglePeer
+    Test.Consensus.PointSchedule.SinglePeer.Indices
+    Test.Consensus.PointSchedule.Tests
 
   build-depends:
     , base
@@ -254,6 +257,7 @@ test-suite consensus-test
     , ouroboros-network-protocols
     , QuickCheck
     , quiet
+    , random
     , serialise
     , si-timers
     , sop-extras

--- a/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
+++ b/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
@@ -233,6 +233,7 @@ test-suite consensus-test
     Test.Consensus.PeerSimulator.Tests.Timeouts
     Test.Consensus.PeerSimulator.Trace
     Test.Consensus.PointSchedule
+    Test.Consensus.PointSchedule.Peers
     Test.Consensus.PointSchedule.SinglePeer
     Test.Consensus.PointSchedule.SinglePeer.Indices
     Test.Consensus.PointSchedule.Tests

--- a/ouroboros-consensus-diffusion/test/consensus-test/Main.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Main.hs
@@ -4,6 +4,7 @@ import qualified Test.Consensus.Genesis.Tests (tests)
 import qualified Test.Consensus.HardFork.Combinator (tests)
 import qualified Test.Consensus.Node (tests)
 import qualified Test.Consensus.PeerSimulator.Tests (tests)
+import qualified Test.Consensus.PointSchedule.Tests (tests)
 import           Test.Tasty
 import           Test.Util.TestEnv (defaultMainWithTestEnv,
                      defaultTestEnvConfig)
@@ -22,4 +23,5 @@ tests =
       ]
   , Test.Consensus.Genesis.Tests.tests
   , Test.Consensus.PeerSimulator.Tests.tests
+  , Test.Consensus.PointSchedule.Tests.tests
   ]

--- a/ouroboros-consensus-diffusion/test/consensus-test/Main.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Main.hs
@@ -3,6 +3,7 @@ module Main (main) where
 import qualified Test.Consensus.Genesis.Tests (tests)
 import qualified Test.Consensus.HardFork.Combinator (tests)
 import qualified Test.Consensus.Node (tests)
+import qualified Test.Consensus.PeerSimulator.Tests (tests)
 import           Test.Tasty
 import           Test.Util.TestEnv (defaultMainWithTestEnv,
                      defaultTestEnvConfig)
@@ -20,4 +21,5 @@ tests =
           ]
       ]
   , Test.Consensus.Genesis.Tests.tests
+  , Test.Consensus.PeerSimulator.Tests.tests
   ]

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/BlockTree.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/BlockTree.hs
@@ -16,7 +16,7 @@ module Test.Consensus.BlockTree (
   , findFragment
   , findPath
   , mkTrunk
-  , prettyPrint
+  , prettyBlockTree
   ) where
 
 import           Cardano.Slotting.Slot (SlotNo (unSlotNo))
@@ -156,10 +156,9 @@ findPath source target blockTree = do
 --                      ╰─────3──4─────5
 --
 -- Returns a list of strings intended to be catenated with a newline.
-prettyPrint :: AF.HasHeader blk => BlockTree blk -> [String]
-prettyPrint blockTree = do
-  ["Block tree:"]
-    ++ ["  slots:   " ++ unwords (map (printf "%2d" . unSlotNo) [veryFirstSlot .. veryLastSlot])]
+prettyBlockTree :: AF.HasHeader blk => BlockTree blk -> [String]
+prettyBlockTree blockTree =
+  ["slots:   " ++ unwords (map (printf "%2d" . unSlotNo) [veryFirstSlot .. veryLastSlot])]
     ++ [printTrunk honestFragment]
     ++ (map printBranch adversarialFragments)
 
@@ -176,11 +175,11 @@ prettyPrint blockTree = do
           (honestFragment : adversarialFragments)
 
     printTrunk :: AF.HasHeader blk => AF.AnchoredFragment blk -> String
-    printTrunk = printLine (\_ -> "  trunk:  ─")
+    printTrunk = printLine (\_ -> "trunk:  -")
 
     printBranch :: AF.HasHeader blk => AF.AnchoredFragment blk -> String
     printBranch = printLine $ \firstSlot ->
-      "        " ++ replicate (3 * fromIntegral (unSlotNo (firstSlot - veryFirstSlot))) ' ' ++ " ╰─"
+      "      " ++ replicate (3 * fromIntegral (unSlotNo (firstSlot - veryFirstSlot))) ' ' ++ " `-"
 
     printLine :: AF.HasHeader blk => (SlotNo -> String) -> AF.AnchoredFragment blk -> String
     printLine printHeader fragment =
@@ -198,7 +197,7 @@ prettyPrint blockTree = do
         & Vector.toList . (slotRange Vector.//)
         & map (maybe "  " (printf "%2d"))
         & unwords
-        & map (\c -> if c == ' ' then '─' else c)
+        & map (\c -> if c == ' ' then '-' else c)
       where
         -- Initialize a Vector with the length of the fragment containing only Nothings
         slotRange = Vector.replicate (fromIntegral (unSlotNo lastSlot - unSlotNo firstSlot + 1)) Nothing

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/BlockTree.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/BlockTree.hs
@@ -19,7 +19,6 @@ module Test.Consensus.BlockTree (
   , prettyPrint
   ) where
 
-import           Cardano.Slotting.Block (BlockNo)
 import           Cardano.Slotting.Slot (SlotNo (unSlotNo))
 import           Data.Foldable (asum)
 import           Data.Function ((&))
@@ -27,16 +26,17 @@ import           Data.Functor ((<&>))
 import           Data.Maybe (fromJust, fromMaybe)
 import qualified Data.Vector as Vector
 import           Ouroboros.Consensus.Block.Abstract (blockNo, blockSlot,
-                     unBlockNo)
+                     fromWithOrigin, unBlockNo)
 import qualified Ouroboros.Network.AnchoredFragment as AF
 import           Text.Printf (printf)
 
 -- | Represent a branch of a block tree by a prefix and a suffix. The full
--- fragment (the prefix and suffix catenated) is provided for practicality.
+-- fragment (the prefix and suffix catenated) and the trunk suffix (the rest of
+-- the trunk after the branch forks off) are provided for practicality.
 --
 -- INVARIANT: the head of @btbPrefix@ is the anchor of @btbSuffix@.
 --
--- INVARIANT: @btbFull == fromJust $ AF.join btbPrefix btbSuffix@
+-- INVARIANT: @btbFull == fromJust $ AF.join btbPrefix btbSuffix@.
 data BlockTreeBranch blk = BlockTreeBranch {
     btbPrefix :: AF.AnchoredFragment blk,
     btbSuffix :: AF.AnchoredFragment blk,
@@ -56,6 +56,12 @@ data BlockTreeBranch blk = BlockTreeBranch {
 --
 -- INVARIANT: The branches' suffixes do not contain any block in common with one
 -- another.
+--
+-- INVARIANT: for all @BlockTreeBranch{..}@ in the tree, @btTrunk == fromJust $
+-- AF.join btbPrefix btbTrunkSuffix@.
+--
+-- REVIEW: Find another name so as not to clash with 'BlockTree' from
+-- `unstable-consensus-testlib/Test/Util/TestBlock.hs`.
 data BlockTree blk = BlockTree {
     btTrunk    :: AF.AnchoredFragment blk,
     btBranches :: [BlockTreeBranch blk]
@@ -74,7 +80,7 @@ mkTrunk btTrunk = BlockTree { btTrunk, btBranches = [] }
 -- the trunk.
 --
 -- FIXME: we should enforce that the new branch' suffix does not contain any
--- block in common with an existingbranch.
+-- block in common with an existing branch.
 addBranch :: AF.HasHeader blk => AF.AnchoredFragment blk -> BlockTree blk -> Maybe (BlockTree blk)
 addBranch branch bt = do
   (_, btbPrefix, _, btbSuffix) <- AF.intersect (btTrunk bt) branch
@@ -151,57 +157,56 @@ findPath source target blockTree = do
 -- Returns a list of strings intended to be catenated with a newline.
 prettyPrint :: AF.HasHeader blk => BlockTree blk -> [String]
 prettyPrint blockTree = do
-  let honestFragment = btTrunk blockTree
-  let advFragment = btbSuffix $ head $ btBranches blockTree
-
-  let (oSlotNo, oBlockNo) = slotAndBlockNoFromAnchor $ AF.anchor honestFragment
-  let (hSlotNo, _) = slotAndBlockNoFromAnchor $ AF.headAnchor honestFragment
-
-  let (aoSlotNo, _) = slotAndBlockNoFromAnchor $ AF.anchor advFragment
-  let (ahSlotNo, _) = slotAndBlockNoFromAnchor $ AF.headAnchor advFragment
-
-  let firstSlotNo = min oSlotNo aoSlotNo
-  let lastSlotNo = max hSlotNo ahSlotNo
-
-  -- FIXME: only handles two fragments at this point. not very hard to make it
-  -- handle all of them. Some work needed to make it handle all of them _in a
-  -- clean way_.
-
-  [ "Block tree:"
-    ,
-
-    [firstSlotNo .. lastSlotNo]
-      & map (printf "%2d" . unSlotNo)
-      & unwords
-      & ("  slots: " ++)
-    ,
-
-    honestFragment
-      & AF.toOldestFirst
-      & map (\block -> (fromIntegral (unSlotNo (blockSlot block) - 1), Just (unBlockNo (blockNo block))))
-      & Vector.toList . (Vector.replicate (fromIntegral (unSlotNo hSlotNo - unSlotNo oSlotNo)) Nothing Vector.//)
-      & map (maybe "  " (printf "%2d"))
-      & unwords
-      & map (\c -> if c == ' ' then '─' else c)
-      & ("─" ++)
-      & (printf "%2d" (unBlockNo oBlockNo) ++)
-      & ("  trunk: " ++)
-    ,
-
-    advFragment
-      & AF.toOldestFirst
-      & map (\block -> (fromIntegral (unSlotNo (blockSlot block) - unSlotNo aoSlotNo - 1), Just (unBlockNo (blockNo block))))
-      & Vector.toList . (Vector.replicate (fromIntegral (unSlotNo ahSlotNo - unSlotNo aoSlotNo)) Nothing Vector.//)
-      & map (maybe "  " (printf "%2d"))
-      & unwords
-      & map (\c -> if c == ' ' then '─' else c)
-      & (" ╰─" ++)
-      & (replicate (3 * fromIntegral (unSlotNo (aoSlotNo - oSlotNo))) ' ' ++)
-      & ("         " ++)
-    ]
+  ["Block tree:"]
+    ++ ["  slots:   " ++ unwords (map (printf "%2d" . unSlotNo) [veryFirstSlot .. veryLastSlot])]
+    ++ [printTrunk honestFragment]
+    ++ (map printBranch adversarialFragments)
 
   where
-    slotAndBlockNoFromAnchor :: AF.Anchor b -> (SlotNo, BlockNo)
-    slotAndBlockNoFromAnchor = \case
-      AF.AnchorGenesis -> (0, 0)
-      AF.Anchor slotNo _ blockNo' -> (slotNo, blockNo')
+    honestFragment = btTrunk blockTree
+    adversarialFragments = map btbSuffix (btBranches blockTree)
+
+    veryFirstSlot = firstNo $ honestFragment
+
+    veryLastSlot =
+      foldl max 0 $
+        map
+          lastNo
+          (honestFragment : adversarialFragments)
+
+    printTrunk :: AF.HasHeader blk => AF.AnchoredFragment blk -> String
+    printTrunk = printLine (\_ -> "  trunk:  ─")
+
+    printBranch :: AF.HasHeader blk => AF.AnchoredFragment blk -> String
+    printBranch = printLine $ \firstSlot ->
+      "        " ++ replicate (3 * fromIntegral (unSlotNo (firstSlot - veryFirstSlot))) ' ' ++ " ╰─"
+
+    printLine :: AF.HasHeader blk => (SlotNo -> String) -> AF.AnchoredFragment blk -> String
+    printLine printHeader fragment =
+      let firstSlot = firstNo fragment
+          lastSlot = lastNo fragment
+      in printHeader firstSlot ++ printFragment firstSlot lastSlot fragment
+
+    printFragment :: AF.HasHeader blk => SlotNo -> SlotNo -> AF.AnchoredFragment blk -> String
+    printFragment firstSlot lastSlot fragment =
+      fragment
+        & AF.toOldestFirst
+        -- Turn the fragment into a list of (SlotNo, Just BlockNo)
+        & map (\block -> (fromIntegral (unSlotNo (blockSlot block) - unSlotNo firstSlot), Just (unBlockNo (blockNo block))))
+        -- Update only the Vector elements that have blocks in them
+        & Vector.toList . (slotRange Vector.//)
+        & map (maybe "  " (printf "%2d"))
+        & unwords
+        & map (\c -> if c == ' ' then '─' else c)
+      where
+        -- Initialize a Vector with the length of the fragment containing only Nothings
+        slotRange = Vector.replicate (fromIntegral (unSlotNo lastSlot - unSlotNo firstSlot + 1)) Nothing
+
+    lastNo ::  AF.HasHeader blk => AF.AnchoredFragment blk -> SlotNo
+    lastNo = fromWithOrigin 0 . AF.headSlot
+
+    firstNo :: AF.AnchoredFragment blk -> SlotNo
+    firstNo frag =
+      case AF.anchor frag of
+        AF.AnchorGenesis     -> 0
+        AF.Anchor slotNo _ _ -> slotNo + 1

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/BlockTree.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/BlockTree.hs
@@ -38,9 +38,10 @@ import           Text.Printf (printf)
 --
 -- INVARIANT: @btbFull == fromJust $ AF.join btbPrefix btbSuffix@.
 data BlockTreeBranch blk = BlockTreeBranch {
-    btbPrefix :: AF.AnchoredFragment blk,
-    btbSuffix :: AF.AnchoredFragment blk,
-    btbFull   :: AF.AnchoredFragment blk
+    btbPrefix      :: AF.AnchoredFragment blk,
+    btbSuffix      :: AF.AnchoredFragment blk,
+    btbTrunkSuffix :: AF.AnchoredFragment blk,
+    btbFull        :: AF.AnchoredFragment blk
   }
   deriving (Show)
 
@@ -83,7 +84,7 @@ mkTrunk btTrunk = BlockTree { btTrunk, btBranches = [] }
 -- block in common with an existing branch.
 addBranch :: AF.HasHeader blk => AF.AnchoredFragment blk -> BlockTree blk -> Maybe (BlockTree blk)
 addBranch branch bt = do
-  (_, btbPrefix, _, btbSuffix) <- AF.intersect (btTrunk bt) branch
+  (btbPrefix, _, btbTrunkSuffix, btbSuffix) <- AF.intersect (btTrunk bt) branch
   -- NOTE: We could use the monadic bind for @Maybe@ here but we would rather
   -- catch bugs quicker.
   let btbFull = fromJust $ AF.join btbPrefix btbSuffix

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup.hs
@@ -30,7 +30,7 @@ import           Test.Consensus.PeerSimulator.Trace (traceLinesWith)
 import           Test.Consensus.PointSchedule
 import           Test.QuickCheck
 import           Test.Util.Orphans.IOLike ()
-import           Test.Util.TersePrinting (terseFrag)
+import           Test.Util.TersePrinting (terseFragment)
 import           Test.Util.Tracer (recordingTracerTVar)
 
 -- | Runs the given point schedule and evaluates the given property on the final
@@ -47,7 +47,7 @@ runTest schedulerConfig genesisTest schedule makeProperty = do
     let tracer = if scDebug schedulerConfig then debugTracer else recordingTracer
 
     -- FIXME: should also go in 'prettyGenesisTest' (or 'prettyBlockTree')
-    for_ (allFragments gtBlockTree) \ bt -> traceWith tracer (terseFrag bt)
+    for_ (allFragments gtBlockTree) (traceWith tracer . terseFragment)
 
     traceLinesWith tracer $ [
       "SchedulerConfig:",

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup.hs
@@ -26,6 +26,7 @@ import           Test.Consensus.PeerSimulator.Run
 import           Test.Consensus.PeerSimulator.StateView
 import           Test.Consensus.PeerSimulator.Trace (traceLinesWith)
 import           Test.Consensus.PointSchedule
+import           Test.Consensus.PointSchedule.Peers (Peers)
 import           Test.QuickCheck
 import           Test.Util.Orphans.IOLike ()
 import           Test.Util.TersePrinting (terseFragment)

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup.hs
@@ -91,7 +91,7 @@ forAllGenesisTest ::
   Testable prop =>
   Gen (GenesisTest, PointSchedule) ->
   SchedulerConfig ->
-  (StateView -> prop) ->
+  (GenesisTest -> PointSchedule -> StateView -> prop) ->
   Property
 forAllGenesisTest generator schedulerConfig mkProperty =
   forAllBlind generator $ \(genesisTest, pointSchedule) ->
@@ -100,4 +100,4 @@ forAllGenesisTest generator schedulerConfig mkProperty =
      in classify (allAdversariesSelectable cls) "All adversaries selectable" $
         classify (genesisWindowAfterIntersection cls) "Full genesis window after intersection" $
         counterexample (rgtrTrace result) $
-        mkProperty (rgtrStateView result)
+        mkProperty genesisTest pointSchedule (rgtrStateView result)

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup.hs
@@ -4,7 +4,6 @@
 {-# LANGUAGE LambdaCase                #-}
 {-# LANGUAGE NamedFieldPuns            #-}
 {-# LANGUAGE RankNTypes                #-}
-{-# LANGUAGE RecordWildCards           #-}
 {-# LANGUAGE ScopedTypeVariables       #-}
 
 module Test.Consensus.Genesis.Setup (

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup.hs
@@ -85,27 +85,34 @@ runGenesisTest' schedulerConfig genesisTest schedule makeProperty =
     RunGenesisTestResult{rgtrTrace, rgtrStateView} =
       runGenesisTest schedulerConfig genesisTest schedule
 
-type ForAllGenesisTest schedule prop =
-  Gen (GenesisTest, schedule) ->
-  SchedulerConfig ->
-  (GenesisTest -> schedule -> StateView -> prop) ->
-  Property
-
 -- | All-in-one helper that generates a 'GenesisTest' and a 'PointSchedule',
 -- runs them with 'runGenesisTest', check whether the given property holds on
 -- the resulting 'StateView'.
-forAllGenesisTest :: Testable prop => ForAllGenesisTest PointSchedule prop
+forAllGenesisTest ::
+  Testable prop =>
+  Gen (GenesisTest, PointSchedule) ->
+  SchedulerConfig ->
+  (GenesisTest -> PointSchedule -> StateView -> prop) ->
+  Property
 forAllGenesisTest = mkForAllGenesisTest id
 
 -- | Same as 'forAllGenesisTest' but the schedule is a 'Peers PeerSchedule'.
-forAllGenesisTest' :: Testable prop => ForAllGenesisTest (Peers PeerSchedule) prop
+forAllGenesisTest' ::
+  Testable prop =>
+  Gen (GenesisTest, Peers PeerSchedule) ->
+  SchedulerConfig ->
+  (GenesisTest -> Peers PeerSchedule -> StateView -> prop) ->
+  Property
 forAllGenesisTest' = mkForAllGenesisTest fromSchedulePoints
 
 -- | Common code shared between flavours of 'forAllGenesisTest'.
 mkForAllGenesisTest ::
   Testable prop =>
   (schedule -> PointSchedule) ->
-  ForAllGenesisTest schedule prop
+  Gen (GenesisTest, schedule) ->
+  SchedulerConfig ->
+  (GenesisTest -> schedule -> StateView -> prop) ->
+  Property
 mkForAllGenesisTest mkPointSchedule generator schedulerConfig mkProperty =
   forAllBlind generator $ \(genesisTest, schedule) ->
     let cls = classifiers genesisTest

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup.hs
@@ -19,19 +19,16 @@ import           Control.Monad.Class.MonadTimer.SI (MonadTimer)
 import           Control.Tracer (debugTracer, traceWith)
 import           Data.Either (partitionEithers)
 import           Data.Foldable (for_)
-import           Ouroboros.Consensus.Config (maxRollbacks)
 import           Ouroboros.Consensus.Util.Condense
 import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Network.Protocol.ChainSync.Codec
                      (ChainSyncTimeout (..))
-import qualified Test.Consensus.BlockTree as BT
 import           Test.Consensus.BlockTree (allFragments)
 import           Test.Consensus.Genesis.Setup.GenChains
 import           Test.Consensus.PeerSimulator.Run
 import           Test.Consensus.PeerSimulator.StateView
 import           Test.Consensus.PeerSimulator.Trace (traceLinesWith, terseFrag)
 import           Test.Consensus.PointSchedule
-import           Test.Ouroboros.Consensus.ChainGenerator.Params (ascVal)
 import           Test.QuickCheck
 import           Test.Util.Orphans.IOLike ()
 import           Test.Util.Tracer (recordingTracerTVar)
@@ -48,20 +45,17 @@ runTest ::
 runTest schedulerConfig genesisTest schedule makeProperty = do
     (recordingTracer, getTrace) <- recordingTracerTVar
     let tracer = if scDebug schedulerConfig then debugTracer else recordingTracer
+
+    -- FIXME: should also go in 'prettyGenesisTest' (or 'prettyBlockTree')
     for_ (allFragments gtBlockTree) \ bt -> traceWith tracer (terseFrag bt)
 
-    traceLinesWith tracer [
+    traceLinesWith tracer $ [
       "SchedulerConfig:",
       "  ChainSyncTimeouts:",
       "    canAwait = " ++ show (canAwaitTimeout scChainSyncTimeouts),
       "    intersect = " ++ show (intersectTimeout scChainSyncTimeouts),
-      "    mustReply = " ++ show (mustReplyTimeout scChainSyncTimeouts),
-      "Security param k = " ++ show (maxRollbacks gtSecurityParam),
-      "Honest active slot coefficient asc = " ++ show (ascVal gtHonestAsc),
-      "Genesis window scg = " ++ show (getGenesisWindow gtGenesisWindow)
-      ]
-
-    mapM_ (traceWith tracer) $ BT.prettyPrint gtBlockTree
+      "    mustReply = " ++ show (mustReplyTimeout scChainSyncTimeouts)
+      ] ++ prettyGenesisTest genesisTest
 
     finalStateView <- runPointSchedule schedulerConfig genesisTest schedule tracer
     traceWith tracer (condense finalStateView)
@@ -70,7 +64,7 @@ runTest schedulerConfig genesisTest schedule makeProperty = do
     pure $ counterexample trace $ makeProperty finalStateView
   where
     SchedulerConfig {scChainSyncTimeouts} = schedulerConfig
-    GenesisTest {gtSecurityParam, gtHonestAsc, gtGenesisWindow, gtBlockTree} = genesisTest
+    GenesisTest {gtBlockTree} = genesisTest
 
 -- | Print counterexamples if the test result contains exceptions.
 exceptionCounterexample :: Testable a => (StateView -> [PeerId] -> a) -> StateView -> Property

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup.hs
@@ -26,10 +26,11 @@ import           Test.Consensus.BlockTree (allFragments)
 import           Test.Consensus.Genesis.Setup.GenChains
 import           Test.Consensus.PeerSimulator.Run
 import           Test.Consensus.PeerSimulator.StateView
-import           Test.Consensus.PeerSimulator.Trace (traceLinesWith, terseFrag)
+import           Test.Consensus.PeerSimulator.Trace (traceLinesWith)
 import           Test.Consensus.PointSchedule
 import           Test.QuickCheck
 import           Test.Util.Orphans.IOLike ()
+import           Test.Util.TersePrinting (terseFrag)
 import           Test.Util.Tracer (recordingTracerTVar)
 
 -- | Runs the given point schedule and evaluates the given property on the final

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup/Classifiers.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup/Classifiers.hs
@@ -20,8 +20,10 @@ import           Test.Util.Orphans.IOLike ()
 -- | Interesting categories to classify test inputs
 data Classifiers =
   Classifiers {
-    -- | There are more than k blocks in the alternative chain after the intersection
+    -- | There are more than k blocks in at least one alternative chain after the intersection
     existsSelectableAdversary      :: Bool,
+    -- | There are more than k blocks in all alternative chains after the intersection
+    allAdversariesSelectable       :: Bool,
     -- | There are at least scg slots after the intesection on both the honest
     -- and the alternative chain
     --
@@ -34,7 +36,7 @@ data Classifiers =
 
 classifiers :: GenesisTest -> Classifiers
 classifiers GenesisTest {gtBlockTree, gtSecurityParam = SecurityParam k, gtGenesisWindow = GenesisWindow scg} =
-  Classifiers {existsSelectableAdversary, genesisWindowAfterIntersection}
+  Classifiers {existsSelectableAdversary, allAdversariesSelectable, genesisWindowAfterIntersection}
   where
     genesisWindowAfterIntersection =
       any fragmentHasGenesis branches
@@ -47,6 +49,9 @@ classifiers GenesisTest {gtBlockTree, gtSecurityParam = SecurityParam k, gtGenes
 
     existsSelectableAdversary =
       any isSelectable branches
+
+    allAdversariesSelectable =
+      all isSelectable branches
 
     isSelectable bt = AF.length (btbSuffix bt) > fromIntegral k
 

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup/GenChains.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup/GenChains.hs
@@ -66,7 +66,7 @@ genAlternativeChainSchema (testRecipeH, arHonest) =
     let H.HonestRecipe kcp scg delta _len = testRecipeH
 
     (seedPrefix :: QCGen) <- QC.arbitrary
-    let arPrefix = genPrefixBlockCount seedPrefix arHonest
+    let arPrefix = genPrefixBlockCount kcp seedPrefix arHonest
 
     let testRecipeA = A.AdversarialRecipe {
       A.arPrefix,
@@ -81,6 +81,7 @@ genAlternativeChainSchema (testRecipeH, arHonest) =
         A.NoSuchAdversarialBlock -> pure Nothing
         A.NoSuchCompetitor       -> error $ "impossible! " <> show e
         A.NoSuchIntersection     -> error $ "impossible! " <> show e
+        A.KcpIs1                 -> error $ "impossible! " <> show e
 
       Right (A.SomeCheckedAdversarialRecipe _ testRecipeA'') -> do
         let Count prefixCount = arPrefix

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests.hs
@@ -1,9 +1,11 @@
 module Test.Consensus.Genesis.Tests (tests) where
 
 import qualified Test.Consensus.Genesis.Tests.LongRangeAttack as LongRangeAttack
+import qualified Test.Consensus.Genesis.Tests.Uniform as Uniform
 import           Test.Tasty
 
 tests :: TestTree
 tests = testGroup "Genesis tests"
     [ LongRangeAttack.tests
+    , Uniform.tests
     ]

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LongRangeAttack.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LongRangeAttack.hs
@@ -29,10 +29,10 @@ tests =
 
 prop_longRangeAttack :: Property
 prop_longRangeAttack =
-  forAllGenesisTest
+  forAllGenesisTest'
 
     (do gt@GenesisTest{gtBlockTree} <- genChains (pure 1)
-        ps <- fromSchedulePoints <$> stToGen (longRangeAttack gtBlockTree)
+        ps <- stToGen (longRangeAttack gtBlockTree)
         if allAdversariesSelectable (classifiers gt)
           then pure (gt, ps)
           else discard)

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LongRangeAttack.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LongRangeAttack.hs
@@ -14,6 +14,7 @@ import           Test.Consensus.Genesis.Setup.Classifiers
 import           Test.Consensus.PeerSimulator.Run (noTimeoutsSchedulerConfig)
 import           Test.Consensus.PeerSimulator.StateView
 import           Test.Consensus.PointSchedule
+import           Test.Consensus.PointSchedule.Shrinking (shrinkPeerSchedules)
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
 import           Test.Util.Orphans.IOLike ()
@@ -39,7 +40,7 @@ prop_longRangeAttack =
 
     (noTimeoutsSchedulerConfig defaultPointScheduleConfig)
 
-    (\_ _ _ -> [])
+    shrinkPeerSchedules
 
     -- NOTE: This is the expected behaviour of Praos to be reversed with
     -- Genesis. But we are testing Praos for the moment

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LongRangeAttack.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LongRangeAttack.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE BlockArguments      #-}
 {-# LANGUAGE DerivingStrategies  #-}
+{-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE NamedFieldPuns      #-}
 {-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -8,11 +9,15 @@
 module Test.Consensus.Genesis.Tests.LongRangeAttack (tests) where
 
 import           Control.Monad.IOSim (runSimOrThrow)
+import           Data.List (intercalate)
 import           Ouroboros.Consensus.Block.Abstract (HeaderHash)
+import           Ouroboros.Consensus.Util.Condense (condense)
 import           Ouroboros.Network.AnchoredFragment (headAnchor)
 import qualified Ouroboros.Network.AnchoredFragment as AF
 import           Test.Consensus.Genesis.Setup
 import           Test.Consensus.Genesis.Setup.Classifiers
+import           Test.Consensus.PeerSimulator.Run (noTimeoutsSchedulerConfig)
+import           Test.Consensus.PeerSimulator.StateView
 import           Test.Consensus.PointSchedule
 import qualified Test.QuickCheck as QC
 import           Test.QuickCheck
@@ -23,28 +28,51 @@ import           Test.Util.Orphans.IOLike ()
 import           Test.Util.TestBlock (TestBlock, unTestHash)
 
 tests :: TestTree
-tests = testProperty "long range attack" prop_longRangeAttack
+tests =
+  testGroup "long range attack" [
+    testProperty "one adversary" (prop_longRangeAttack 1 [10])
+    -- TODO we don't have useful classification logic for multiple adversaries yet – if a selectable
+    -- adversary is slow, it might be discarded before it reaches critical length because the faster
+    -- ones have served k blocks off the honest chain if their fork anchor is further down the line.
+    -- ,
+    -- testProperty "three adversaries" (prop_longRangeAttack 1 [2, 5, 10])
+  ]
 
-genChainsAndSchedule :: Word -> ScheduleType -> QC.Gen (GenesisTest, PointSchedule)
-genChainsAndSchedule numAdversaries scheduleType =
+genChainsAndSchedule :: PointScheduleConfig -> Word -> ScheduleType -> QC.Gen (GenesisTest, PointSchedule)
+genChainsAndSchedule scheduleConfig numAdversaries scheduleType =
   unsafeMapSuchThatJust do
     gt <- genChains numAdversaries
-    pure $ ((gt,) <$> genSchedule scheduleType (gtBlockTree gt))
+    pure $ ((gt,) <$> genSchedule scheduleConfig scheduleType (gtBlockTree gt))
 
-prop_longRangeAttack :: QC.Gen QC.Property
-prop_longRangeAttack = do
-  (genesisTest, schedule) <- genChainsAndSchedule 1 FastAdversary
+prop_longRangeAttack :: Int -> [Int] -> QC.Gen QC.Property
+prop_longRangeAttack honestFreq advFreqs = do
+  (genesisTest, schedule) <- genChainsAndSchedule scheduleConfig (fromIntegral (length advFreqs)) (Frequencies freqs)
   let cls = classifiers genesisTest
 
-  pure $ withMaxSuccess 10 $ runSimOrThrow $
-    runTest genesisTest schedule $ \fragment ->
-        classify (genesisWindowAfterIntersection cls) "Full genesis window after intersection"
-        -- This is the expected behavior of Praos to be reversed with Genesis.
-        -- But we are testing Praos for the moment
-        $ existsSelectableAdversary cls ==> not $ isHonestTestFragH fragment
-        -- TODO
-        -- $ not (existsSelectableAdversary cls) ==> immutableTipBeforeFork fragment
+  -- TODO: not existsSelectableAdversary ==> immutableTipBeforeFork svSelectedChain
+
+  pure $ withMaxSuccess 10 $
+    classify (genesisWindowAfterIntersection cls) "Full genesis window after intersection" $
+    allAdversariesSelectable cls
+    ==>
+    runSimOrThrow $
+      runTest
+        (noTimeoutsSchedulerConfig scheduleConfig)
+        genesisTest
+        schedule
+        $ exceptionCounterexample $ \StateView{svSelectedChain} killed ->
+            killCounterexample killed $
+            -- This is the expected behavior of Praos to be reversed with Genesis.
+            -- But we are testing Praos for the moment
+            not (isHonestTestFragH svSelectedChain)
+
   where
+    freqs = mkPeers honestFreq advFreqs
+
+    killCounterexample = \case
+      [] -> property
+      killed -> counterexample ("Some peers were killed: " ++ intercalate ", " (condense <$> killed))
+
     isHonestTestFragH :: TestFragH -> Bool
     isHonestTestFragH frag = case headAnchor frag of
         AF.AnchorGenesis   -> True
@@ -52,3 +80,5 @@ prop_longRangeAttack = do
 
     isHonestTestHeaderHash :: HeaderHash TestBlock -> Bool
     isHonestTestHeaderHash = all (0 ==) . unTestHash
+
+    scheduleConfig = defaultPointScheduleConfig

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LongRangeAttack.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LongRangeAttack.hs
@@ -41,7 +41,7 @@ prop_longRangeAttack =
 
     -- NOTE: This is the expected behaviour of Praos to be reversed with
     -- Genesis. But we are testing Praos for the moment
-    (not . isHonestTestFragH . svSelectedChain)
+    (\_ _ -> not . isHonestTestFragH . svSelectedChain)
 
   where
     isHonestTestFragH :: TestFragH -> Bool

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LongRangeAttack.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LongRangeAttack.hs
@@ -6,7 +6,6 @@
 
 module Test.Consensus.Genesis.Tests.LongRangeAttack (tests) where
 
-import           Control.Monad.IOSim (runSimOrThrow)
 import           Data.List (intercalate)
 import           Ouroboros.Consensus.Block.Abstract (HeaderHash)
 import           Ouroboros.Consensus.Util.Condense (condense)
@@ -49,8 +48,7 @@ prop_longRangeAttack = do
     classify (genesisWindowAfterIntersection cls) "Full genesis window after intersection" $
     allAdversariesSelectable cls
     ==>
-    runSimOrThrow $
-      runTest
+    runGenesisTest
         (noTimeoutsSchedulerConfig scheduleConfig)
         genesisTest
         schedule

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LongRangeAttack.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LongRangeAttack.hs
@@ -2,9 +2,7 @@
 {-# LANGUAGE DerivingStrategies  #-}
 {-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE NamedFieldPuns      #-}
-{-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TupleSections       #-}
 
 module Test.Consensus.Genesis.Tests.LongRangeAttack (tests) where
 

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LongRangeAttack.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LongRangeAttack.hs
@@ -39,6 +39,8 @@ prop_longRangeAttack =
 
     (noTimeoutsSchedulerConfig defaultPointScheduleConfig)
 
+    (\_ _ _ -> [])
+
     -- NOTE: This is the expected behaviour of Praos to be reversed with
     -- Genesis. But we are testing Praos for the moment
     (\_ _ -> not . isHonestTestFragH . svSelectedChain)

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LongRangeAttack.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LongRangeAttack.hs
@@ -28,10 +28,12 @@ import           Test.Tasty
 import           Test.Tasty.QuickCheck
 import           Test.Util.Orphans.IOLike ()
 import           Test.Util.TestBlock (TestBlock, unTestHash)
+import           Test.Util.TestEnv (adjustQuickCheckTests)
 
 tests :: TestTree
 tests =
   testGroup "long range attack" [
+    adjustQuickCheckTests (`div` 10) $
     testProperty "one adversary" (prop_longRangeAttack 1 [10])
     -- TODO we don't have useful classification logic for multiple adversaries yet – if a selectable
     -- adversary is slow, it might be discarded before it reaches critical length because the faster
@@ -57,7 +59,7 @@ prop_longRangeAttack honestFreq advFreqs = do
 
   -- TODO: not existsSelectableAdversary ==> immutableTipBeforeFork svSelectedChain
 
-  pure $ withMaxSuccess 10 $
+  pure $
     classify (genesisWindowAfterIntersection cls) "Full genesis window after intersection" $
     allAdversariesSelectable cls
     ==>

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LongRangeAttack.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LongRangeAttack.hs
@@ -29,11 +29,6 @@ tests =
   testGroup "long range attack" [
     adjustQuickCheckTests (`div` 10) $
     testProperty "one adversary" prop_longRangeAttack
-    -- TODO we don't have useful classification logic for multiple adversaries yet – if a selectable
-    -- adversary is slow, it might be discarded before it reaches critical length because the faster
-    -- ones have served k blocks off the honest chain if their fork anchor is further down the line.
-    -- ,
-    -- testProperty "three adversaries" (prop_longRangeAttack 1 [2, 5, 10])
   ]
 
 prop_longRangeAttack :: QC.Gen QC.Property
@@ -48,7 +43,7 @@ prop_longRangeAttack = do
     classify (genesisWindowAfterIntersection cls) "Full genesis window after intersection" $
     allAdversariesSelectable cls
     ==>
-    runGenesisTest
+    runGenesisTest'
         (noTimeoutsSchedulerConfig scheduleConfig)
         genesisTest
         schedule

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
@@ -121,7 +121,7 @@ prop_serveAdversarialBranches = QC.expectFailure <$> do
   genesisTest <- genChains (QC.choose (1, 4))
   schedulePoints <- genUniformSchedulePoints genesisTest
   pure $
-    runGenesisTest schedulerConfig genesisTest (fromSchedulePoints schedulePoints) $
+    runGenesisTest' schedulerConfig genesisTest (fromSchedulePoints schedulePoints) $
     exceptionCounterexample $
     makeProperty genesisTest schedulePoints
 
@@ -164,7 +164,7 @@ prop_leashingAttackStalling = QC.expectFailure <$> do
   genesisTest <- genChains (QC.choose (1, 4))
   schedulePoints <- genLeashingSchedule genesisTest
   pure $
-    runGenesisTest schedulerConfig genesisTest (fromSchedulePoints schedulePoints) $
+    runGenesisTest' schedulerConfig genesisTest (fromSchedulePoints schedulePoints) $
     exceptionCounterexample $
     makeProperty genesisTest schedulePoints
 
@@ -210,7 +210,7 @@ prop_leashingAttackTimeLimited = QC.expectFailure <$> do
   genesisTest <- genChains (QC.choose (1, 4))
   schedulePoints <- genTimeLimitedSchedule genesisTest
   pure $
-    runGenesisTest schedulerConfig genesisTest (fromSchedulePoints schedulePoints) $
+    runGenesisTest' schedulerConfig genesisTest (fromSchedulePoints schedulePoints) $
     exceptionCounterexample $
     makeProperty genesisTest schedulePoints
 

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
@@ -25,12 +25,12 @@ import           Ouroboros.Network.Block (blockNo, unBlockNo)
 import           Test.Consensus.BlockTree (BlockTree (..))
 import           Test.Consensus.Genesis.Setup
 import           Test.Consensus.Genesis.Setup.Classifiers
-import           Test.Consensus.PeerSimulator.Run (noTimeoutsSchedulerConfig,
-                     scTraceState)
+import           Test.Consensus.PeerSimulator.Run (SchedulerConfig (scTrace),
+                     noTimeoutsSchedulerConfig, scTraceState)
 import           Test.Consensus.PeerSimulator.StateView
 import           Test.Consensus.PointSchedule
 import           Test.Consensus.PointSchedule.SinglePeer
-  (SchedulePoint(ScheduleBlockPoint, ScheduleTipPoint))
+                     (SchedulePoint (ScheduleBlockPoint, ScheduleTipPoint))
 import           Test.Ouroboros.Consensus.ChainGenerator.Params (Delta (Delta))
 import qualified Test.QuickCheck as QC
 import           Test.QuickCheck
@@ -132,7 +132,7 @@ prop_serveAdversarialBranches = QC.expectFailure <$> do
     makeProperty genesisTest schedulePoints
 
   where
-    schedulerConfig = (noTimeoutsSchedulerConfig scheduleConfig) {scTraceState = False}
+    schedulerConfig = (noTimeoutsSchedulerConfig scheduleConfig) {scTraceState = False, scTrace = False}
 
     scheduleConfig = defaultPointScheduleConfig
 
@@ -176,7 +176,8 @@ prop_leashingAttackStalling = QC.expectFailure <$> do
     makeProperty genesisTest schedulePoints
 
   where
-    schedulerConfig = (noTimeoutsSchedulerConfig scheduleConfig) {scEnableGdd = True}
+    schedulerConfig = (noTimeoutsSchedulerConfig scheduleConfig)
+      { scTrace = False }
 
     scheduleConfig = defaultPointScheduleConfig
 
@@ -222,7 +223,8 @@ prop_leashingAttackTimeLimited = QC.expectFailure <$> do
     makeProperty genesisTest schedulePoints
 
   where
-    schedulerConfig = (noTimeoutsSchedulerConfig scheduleConfig) {scEnableGdd = True}
+    schedulerConfig = (noTimeoutsSchedulerConfig scheduleConfig)
+      { scTrace = False }
 
     scheduleConfig = defaultPointScheduleConfig
 
@@ -266,7 +268,7 @@ prop_leashingAttackTimeLimited = QC.expectFailure <$> do
       mapMaybe fromBlockPoint
 
     fromTipPoint (t, ScheduleTipPoint bp) = Just (t, bp)
-    fromTipPoint _ = Nothing
+    fromTipPoint _                        = Nothing
 
 headCallStack :: HasCallStack => [a] -> a
 headCallStack xs = if null xs then error "headCallStack: empty list" else head xs

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
@@ -1,0 +1,125 @@
+{-# LANGUAGE BlockArguments      #-}
+{-# LANGUAGE DerivingStrategies  #-}
+{-# LANGUAGE LambdaCase          #-}
+{-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE RecordWildCards     #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections       #-}
+{-# LANGUAGE TypeFamilies        #-}
+{-# LANGUAGE TypeOperators       #-}
+
+module Test.Consensus.Genesis.Tests.Uniform (tests) where
+
+import           Cardano.Slotting.Slot (SlotNo (SlotNo), WithOrigin (..))
+import           Control.Monad.IOSim (runSimOrThrow)
+import           Data.List (intercalate)
+import           Ouroboros.Consensus.Util.Condense (Condense (condense))
+import qualified Ouroboros.Network.AnchoredFragment as AF
+import           Test.Consensus.BlockTree (BlockTree (..))
+import           Test.Consensus.Genesis.Setup
+import           Test.Consensus.Genesis.Setup.Classifiers
+import           Test.Consensus.PeerSimulator.Run (noTimeoutsSchedulerConfig,
+                     scTraceState)
+import           Test.Consensus.PeerSimulator.StateView
+import           Test.Consensus.PointSchedule
+import           Test.Ouroboros.Consensus.ChainGenerator.Params (Delta (Delta))
+import qualified Test.QuickCheck as QC
+import           Test.QuickCheck
+import           Test.Tasty
+import           Test.Tasty.QuickCheck
+import           Test.Util.Orphans.IOLike ()
+import           Test.Util.QuickCheck (le)
+import           Test.Util.TestBlock (TestBlock, tbSlot)
+import           Test.Util.TestEnv (adjustQuickCheckMaxSize,
+                     adjustQuickCheckTests)
+import           Text.Printf (printf)
+
+tests :: TestTree
+tests =
+  adjustQuickCheckTests (`div` 10) $
+  adjustQuickCheckMaxSize (`div` 10) $
+  testProperty "serve adversarial branches" prop_serveAdversarialBranches
+
+makeProperty ::
+  GenesisTest ->
+  Peers PeerSchedule ->
+  StateView ->
+  [PeerId] ->
+  Property
+makeProperty genesisTest schedule StateView {svSelectedChain} killed =
+  classify genesisWindowAfterIntersection "Full genesis window after intersection" $
+  classify (isOrigin immutableTipHash) "Immutable tip is Origin" $
+  label disconnected $
+  classify (advCount < length (btBranches gtBlockTree)) "Some adversaries performed rollbacks" $
+  counterexample killedPeers $
+  -- We require the honest chain to fit a Genesis window, because otherwise its tip may suggest
+  -- to the governor that the density is too low.
+  longerThanGenesisWindow ==>
+  conjoin [
+    counterexample "The honest peer was disconnected" (not (HonestPeer `elem` killed)),
+    counterexample ("The immutable tip is not honest: " ++ show immutableTip) $
+    property (isHonest immutableTipHash),
+    immutableTipIsRecent
+  ]
+  where
+    advCount = Map.size (others schedule)
+
+    immutableTipIsRecent =
+      counterexample ("Age of the immutable tip: " ++ show immutableTipAge) $
+      immutableTipAge `le` s + fromIntegral d + 1
+
+    SlotNo immutableTipAge = case (honestTipSlot, immutableTipSlot) of
+      (At h, At i)   -> h - i
+      (At h, Origin) -> h
+      _              -> 0
+
+    isOrigin = null
+
+    isHonest = all (0 ==)
+
+    immutableTipHash = simpleHash (AF.anchorToHash immutableTip)
+
+    immutableTip = AF.anchor svSelectedChain
+
+    immutableTipSlot = AF.anchorToSlotNo (AF.anchor svSelectedChain)
+
+    disconnected =
+      printf "disconnected %.1f%% of adversaries" disconnectedPercent
+
+    disconnectedPercent :: Double
+    disconnectedPercent =
+      100 * fromIntegral (length killed) / fromIntegral advCount
+
+    killedPeers = case killed of
+      [] -> "No peers were killed"
+      peers -> "Some peers were killed: " ++ intercalate ", " (condense <$> peers)
+
+    honestTipSlot = At $ tbSlot $ snd $ last $ mapMaybe fromBlockPoint $ value $ honest schedule
+
+    GenesisTest {gtBlockTree, gtGenesisWindow = GenesisWindow s, gtDelay = Delta d} = genesisTest
+
+    Classifiers {genesisWindowAfterIntersection, longerThanGenesisWindow} = classifiers genesisTest
+
+fromBlockPoint :: (DiffTime, SchedulePoint) -> Maybe (DiffTime, TestBlock)
+fromBlockPoint (t, ScheduleBlockPoint bp) = Just (t, bp)
+fromBlockPoint _                          = Nothing
+
+-- | Tests that the immutable tip is not delayed and stays honest with the
+-- adversarial peers serving adversarial branches.
+prop_serveAdversarialBranches :: QC.Gen QC.Property
+prop_serveAdversarialBranches = QC.expectFailure <$> do
+  genesisTest <- genChains (QC.choose (1, 4))
+  schedulePoints <- genUniformSchedulePoints genesisTest
+  pure $
+    runSimOrThrow $
+    runTest schedulerConfig genesisTest (fromSchedulePoints schedulePoints) $
+    exceptionCounterexample $
+    makeProperty genesisTest schedulePoints
+
+  where
+    schedulerConfig = (noTimeoutsSchedulerConfig scheduleConfig) {scTraceState = False}
+
+    scheduleConfig = defaultPointScheduleConfig
+
+genUniformSchedulePoints :: GenesisTest -> QC.Gen (Peers PeerSchedule)
+genUniformSchedulePoints gt = stToGen (uniformPoints (gtBlockTree gt))

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
@@ -54,9 +54,8 @@ makeProperty ::
   GenesisTest ->
   Peers PeerSchedule ->
   StateView ->
-  [PeerId] ->
   Property
-makeProperty genesisTest schedule StateView {svSelectedChain} killed =
+makeProperty genesisTest schedule stateView@StateView{svSelectedChain} =
   classify genesisWindowAfterIntersection "Full genesis window after intersection" $
   classify (isOrigin immutableTipHash) "Immutable tip is Origin" $
   label disconnected $
@@ -96,6 +95,8 @@ makeProperty genesisTest schedule StateView {svSelectedChain} killed =
     disconnected =
       printf "disconnected %.1f%% of adversaries" disconnectedPercent
 
+    killed = chainSyncKilled stateView
+
     disconnectedPercent :: Double
     disconnectedPercent =
       100 * fromIntegral (length killed) / fromIntegral advCount
@@ -122,7 +123,6 @@ prop_serveAdversarialBranches = QC.expectFailure <$> do
   schedulePoints <- genUniformSchedulePoints genesisTest
   pure $
     runGenesisTest' schedulerConfig genesisTest (fromSchedulePoints schedulePoints) $
-    exceptionCounterexample $
     makeProperty genesisTest schedulePoints
 
   where
@@ -165,7 +165,6 @@ prop_leashingAttackStalling = QC.expectFailure <$> do
   schedulePoints <- genLeashingSchedule genesisTest
   pure $
     runGenesisTest' schedulerConfig genesisTest (fromSchedulePoints schedulePoints) $
-    exceptionCounterexample $
     makeProperty genesisTest schedulePoints
 
   where
@@ -211,7 +210,6 @@ prop_leashingAttackTimeLimited = QC.expectFailure <$> do
   schedulePoints <- genTimeLimitedSchedule genesisTest
   pure $
     runGenesisTest' schedulerConfig genesisTest (fromSchedulePoints schedulePoints) $
-    exceptionCounterexample $
     makeProperty genesisTest schedulePoints
 
   where

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
@@ -11,10 +11,17 @@
 module Test.Consensus.Genesis.Tests.Uniform (tests) where
 
 import           Cardano.Slotting.Slot (SlotNo (SlotNo), WithOrigin (..))
+import           Control.Monad (replicateM)
 import           Control.Monad.IOSim (runSimOrThrow)
-import           Data.List (intercalate)
-import           Ouroboros.Consensus.Util.Condense (Condense (condense))
+import           Data.List (group, intercalate, sort)
+import qualified Data.Map.Strict as Map
+import           Data.Maybe (mapMaybe)
+import           Data.Time.Clock (DiffTime)
+import           Data.Word (Word64)
+import           GHC.Stack (HasCallStack)
+import           Ouroboros.Consensus.Util.Condense (condense)
 import qualified Ouroboros.Network.AnchoredFragment as AF
+import           Ouroboros.Network.Block (blockNo, unBlockNo)
 import           Test.Consensus.BlockTree (BlockTree (..))
 import           Test.Consensus.Genesis.Setup
 import           Test.Consensus.Genesis.Setup.Classifiers
@@ -22,6 +29,8 @@ import           Test.Consensus.PeerSimulator.Run (noTimeoutsSchedulerConfig,
                      scTraceState)
 import           Test.Consensus.PeerSimulator.StateView
 import           Test.Consensus.PointSchedule
+import           Test.Consensus.PointSchedule.SinglePeer
+  (SchedulePoint(ScheduleBlockPoint, ScheduleTipPoint))
 import           Test.Ouroboros.Consensus.ChainGenerator.Params (Delta (Delta))
 import qualified Test.QuickCheck as QC
 import           Test.QuickCheck
@@ -36,9 +45,15 @@ import           Text.Printf (printf)
 
 tests :: TestTree
 tests =
+  adjustQuickCheckTests (* 10) $
+  adjustQuickCheckMaxSize (`div` 5) $
+  testGroup "uniform" [
+    -- See Note [Leashing attacks]
+    testProperty "stalling leashing attack" prop_leashingAttackStalling,
+    testProperty "time limited leashing attack" prop_leashingAttackTimeLimited,
   adjustQuickCheckTests (`div` 10) $
-  adjustQuickCheckMaxSize (`div` 10) $
-  testProperty "serve adversarial branches" prop_serveAdversarialBranches
+    testProperty "serve adversarial branches" prop_serveAdversarialBranches
+    ]
 
 makeProperty ::
   GenesisTest ->
@@ -123,3 +138,135 @@ prop_serveAdversarialBranches = QC.expectFailure <$> do
 
 genUniformSchedulePoints :: GenesisTest -> QC.Gen (Peers PeerSchedule)
 genUniformSchedulePoints gt = stToGen (uniformPoints (gtBlockTree gt))
+
+-- Note [Leashing attacks]
+--
+-- A leashing attack would be rehearsed by a point schedule meeting either of
+-- two conditions:
+--
+-- 1) it causes the node under test to stop making progress (i.e. the immutable
+--    tip doesn't get close to the last genesis window of the honest chain), or
+-- 2) it causes the node under test to still make progress but it is too slow
+--    (in some sense of slow)
+--
+-- We produce schedules meeting the first condition by dropping random points
+-- from the schedule of adversarial peers. If peers don't send the headers or
+-- the blocks that they promised with a tip point, the node under test could
+-- wait indefinitely without advancing the immutable tip.
+--
+-- We produce schedules meeting the second condition by stopping the execution
+-- of the schedule after an amount of time that depends on the amount of blocks
+-- to sync up and the timeouts allowed by Limit of Patience.
+-- If the adversarial peers succeed in delaying the immutable tip, interrupting
+-- the test at this point should cause the immutable tip to be too far behind
+-- the last genesis window of the honest chain.
+
+-- | Test that the leashing attacks do not delay the immutable tip
+--
+-- This test is expected to fail because we don't test a genesis implementation
+-- yet.
+prop_leashingAttackStalling :: QC.Gen QC.Property
+prop_leashingAttackStalling = QC.expectFailure <$> do
+  genesisTest <- genChains (QC.choose (1, 4))
+  schedulePoints <- genLeashingSchedule genesisTest
+  pure $
+    runSimOrThrow $
+    runTest schedulerConfig genesisTest (fromSchedulePoints schedulePoints) $
+    exceptionCounterexample $
+    makeProperty genesisTest schedulePoints
+
+  where
+    schedulerConfig = (noTimeoutsSchedulerConfig scheduleConfig) {scEnableGdd = True}
+
+    scheduleConfig = defaultPointScheduleConfig
+
+    -- | Produces schedules that might cause the node under test to stall.
+    --
+    -- This is achieved by dropping random points from the schedule of each peer
+    genLeashingSchedule :: GenesisTest -> QC.Gen (Peers PeerSchedule)
+    genLeashingSchedule genesisTest = do
+      Peers honest advs0 <- genUniformSchedulePoints genesisTest
+      advs <- mapM (mapM dropRandomPoints) advs0
+      pure (Peers honest advs)
+
+    dropRandomPoints :: [(DiffTime, SchedulePoint)] -> QC.Gen [(DiffTime, SchedulePoint)]
+    dropRandomPoints ps = do
+      let lenps = length ps
+      dropCount <- QC.choose (0, max 1 $ div lenps 5)
+      let dedup = map head . group
+      is <- fmap (dedup . sort) $ replicateM dropCount $ QC.choose (0, lenps - 1)
+      pure $ dropElemsAt ps is
+
+    dropElemsAt :: [a] -> [Int] -> [a]
+    dropElemsAt xs [] = xs
+    dropElemsAt xs (i:is) =
+      let (ys, zs) = splitAt i xs
+       in ys ++ dropElemsAt (drop 1 zs) is
+
+-- | Test that the leashing attacks do not delay the immutable tip after. The
+-- immutable tip needs to be advanced enough when the honest peer has offered
+-- all of its ticks.
+--
+-- This test is expected to fail because we don't test a genesis implementation
+-- yet.
+--
+-- See Note [Leashing attacks]
+prop_leashingAttackTimeLimited :: QC.Gen QC.Property
+prop_leashingAttackTimeLimited = QC.expectFailure <$> do
+  genesisTest <- genChains (QC.choose (1, 4))
+  schedulePoints <- genTimeLimitedSchedule genesisTest
+  pure $
+    runSimOrThrow $
+    runTest schedulerConfig genesisTest (fromSchedulePoints schedulePoints) $
+    exceptionCounterexample $
+    makeProperty genesisTest schedulePoints
+
+  where
+    schedulerConfig = (noTimeoutsSchedulerConfig scheduleConfig) {scEnableGdd = True}
+
+    scheduleConfig = defaultPointScheduleConfig
+
+    -- | A schedule which doesn't run past the last event of the honest peer
+    genTimeLimitedSchedule :: GenesisTest -> QC.Gen (Peers PeerSchedule)
+    genTimeLimitedSchedule genesisTest = do
+      Peers honest advs0 <- genUniformSchedulePoints genesisTest
+      let timeLimit = estimateTimeBound (value honest) (map value $ Map.elems advs0)
+          advs = fmap (fmap (takePointsUntil timeLimit)) advs0
+      pure (Peers honest advs)
+
+    takePointsUntil limit = takeWhile ((<= limit) . fst)
+
+    estimateTimeBound :: PeerSchedule -> [PeerSchedule] -> DiffTime
+    estimateTimeBound honest advs =
+      let firstTipPointBlock = headCallStack (mapMaybe fromTipPoint honest)
+          lastBlockPoint = last (mapMaybe fromBlockPoint honest)
+          peerCount = length advs + 1
+          maxBlockNo = maximum $ 0 : blockPointNos honest ++ concatMap blockPointNos advs
+          -- 0.020s is the amount of time LoP grants per interesting header
+          -- 5s is the initial fill of the LoP bucket
+          --
+          -- Since the moment the honest peer offers the first tip, LoP should
+          -- start ticking. Syncing all the blocks might take longer than it
+          -- takes to dispatch all ticks to the honest peer. In this case
+          -- the syncing time is the time bound for the test. If dispatching
+          -- all the ticks takes longer, then the dispatching time becomes
+          -- the time bound.
+          --
+          -- Adversarial peers might cause more ticks to be sent as well. We
+          -- bound it all by considering the highest block number that is ever
+          -- sent.
+      in max
+          (fst lastBlockPoint)
+          (fst firstTipPointBlock +
+              0.020 * fromIntegral maxBlockNo + 5 * fromIntegral peerCount)
+
+    blockPointNos :: [(DiffTime, SchedulePoint)] -> [Word64]
+    blockPointNos =
+      map (unBlockNo . blockNo . snd) .
+      mapMaybe fromBlockPoint
+
+    fromTipPoint (t, ScheduleTipPoint bp) = Just (t, bp)
+    fromTipPoint _ = Nothing
+
+headCallStack :: HasCallStack => [a] -> a
+headCallStack xs = if null xs then error "headCallStack: empty list" else head xs

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
@@ -1,12 +1,8 @@
 {-# LANGUAGE BlockArguments      #-}
 {-# LANGUAGE DerivingStrategies  #-}
-{-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE NamedFieldPuns      #-}
-{-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TupleSections       #-}
 {-# LANGUAGE TypeFamilies        #-}
-{-# LANGUAGE TypeOperators       #-}
 
 module Test.Consensus.Genesis.Tests.Uniform (tests) where
 
@@ -71,7 +67,7 @@ makeProperty genesisTest schedule StateView {svSelectedChain} killed =
   -- to the governor that the density is too low.
   longerThanGenesisWindow ==>
   conjoin [
-    counterexample "The honest peer was disconnected" (not (HonestPeer `elem` killed)),
+    counterexample "The honest peer was disconnected" (HonestPeer `notElem` killed),
     counterexample ("The immutable tip is not honest: " ++ show immutableTip) $
     property (isHonest immutableTipHash),
     immutableTipIsRecent

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
@@ -26,6 +26,7 @@ import           Test.Consensus.PeerSimulator.StateView
 import           Test.Consensus.PointSchedule
 import           Test.Consensus.PointSchedule.Peers (PeerId (..), Peers (..),
                      value)
+import           Test.Consensus.PointSchedule.Shrinking (shrinkPeerSchedules)
 import           Test.Consensus.PointSchedule.SinglePeer
                      (SchedulePoint (ScheduleBlockPoint, ScheduleTipPoint))
 import           Test.Ouroboros.Consensus.ChainGenerator.Params (Delta (Delta))
@@ -130,7 +131,7 @@ prop_serveAdversarialBranches =
     ((noTimeoutsSchedulerConfig defaultPointScheduleConfig)
        {scTraceState = False, scTrace = False})
 
-    (\_ _ _ -> [])
+    shrinkPeerSchedules
 
     theProperty
 
@@ -174,7 +175,7 @@ prop_leashingAttackStalling =
     ((noTimeoutsSchedulerConfig defaultPointScheduleConfig)
       {scTrace = False})
 
-    (\_ _ _ -> [])
+    shrinkPeerSchedules
 
     theProperty
 
@@ -221,7 +222,7 @@ prop_leashingAttackTimeLimited =
     ((noTimeoutsSchedulerConfig defaultPointScheduleConfig)
       {scTrace = False})
 
-    (\_ _ _ -> [])
+    shrinkPeerSchedules
 
     theProperty
 

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
@@ -130,6 +130,8 @@ prop_serveAdversarialBranches =
     ((noTimeoutsSchedulerConfig defaultPointScheduleConfig)
        {scTraceState = False, scTrace = False})
 
+    (\_ _ _ -> [])
+
     theProperty
 
 genUniformSchedulePoints :: GenesisTest -> QC.Gen (Peers PeerSchedule)
@@ -171,6 +173,8 @@ prop_leashingAttackStalling =
 
     ((noTimeoutsSchedulerConfig defaultPointScheduleConfig)
       {scTrace = False})
+
+    (\_ _ _ -> [])
 
     theProperty
 
@@ -216,6 +220,8 @@ prop_leashingAttackTimeLimited =
 
     ((noTimeoutsSchedulerConfig defaultPointScheduleConfig)
       {scTrace = False})
+
+    (\_ _ _ -> [])
 
     theProperty
 

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
@@ -24,6 +24,8 @@ import           Test.Consensus.PeerSimulator.Run (SchedulerConfig (scTrace),
                      noTimeoutsSchedulerConfig, scTraceState)
 import           Test.Consensus.PeerSimulator.StateView
 import           Test.Consensus.PointSchedule
+import           Test.Consensus.PointSchedule.Peers (PeerId (..), Peers (..),
+                     value)
 import           Test.Consensus.PointSchedule.SinglePeer
                      (SchedulePoint (ScheduleBlockPoint, ScheduleTipPoint))
 import           Test.Ouroboros.Consensus.ChainGenerator.Params (Delta (Delta))

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
@@ -8,7 +8,6 @@ module Test.Consensus.Genesis.Tests.Uniform (tests) where
 
 import           Cardano.Slotting.Slot (SlotNo (SlotNo), WithOrigin (..))
 import           Control.Monad (replicateM)
-import           Control.Monad.IOSim (runSimOrThrow)
 import           Data.List (group, intercalate, sort)
 import qualified Data.Map.Strict as Map
 import           Data.Maybe (mapMaybe)
@@ -122,8 +121,7 @@ prop_serveAdversarialBranches = QC.expectFailure <$> do
   genesisTest <- genChains (QC.choose (1, 4))
   schedulePoints <- genUniformSchedulePoints genesisTest
   pure $
-    runSimOrThrow $
-    runTest schedulerConfig genesisTest (fromSchedulePoints schedulePoints) $
+    runGenesisTest schedulerConfig genesisTest (fromSchedulePoints schedulePoints) $
     exceptionCounterexample $
     makeProperty genesisTest schedulePoints
 
@@ -166,8 +164,7 @@ prop_leashingAttackStalling = QC.expectFailure <$> do
   genesisTest <- genChains (QC.choose (1, 4))
   schedulePoints <- genLeashingSchedule genesisTest
   pure $
-    runSimOrThrow $
-    runTest schedulerConfig genesisTest (fromSchedulePoints schedulePoints) $
+    runGenesisTest schedulerConfig genesisTest (fromSchedulePoints schedulePoints) $
     exceptionCounterexample $
     makeProperty genesisTest schedulePoints
 
@@ -213,8 +210,7 @@ prop_leashingAttackTimeLimited = QC.expectFailure <$> do
   genesisTest <- genChains (QC.choose (1, 4))
   schedulePoints <- genTimeLimitedSchedule genesisTest
   pure $
-    runSimOrThrow $
-    runTest schedulerConfig genesisTest (fromSchedulePoints schedulePoints) $
+    runGenesisTest schedulerConfig genesisTest (fromSchedulePoints schedulePoints) $
     exceptionCounterexample $
     makeProperty genesisTest schedulePoints
 

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/ChainSync.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/ChainSync.hs
@@ -37,7 +37,8 @@ import           Test.Consensus.PeerSimulator.StateView
                      StateViewTracers (StateViewTracers, svtChainSyncExceptionsTracer))
 import           Test.Consensus.PeerSimulator.Trace (mkChainSyncClientTracer,
                      traceUnitWith)
-import           Test.Consensus.PointSchedule (PeerId, TestFragH)
+import           Test.Consensus.PointSchedule (TestFragH)
+import           Test.Consensus.PointSchedule.Peers (PeerId)
 import           Test.Util.Orphans.IOLike ()
 import           Test.Util.TestBlock (TestBlock)
 

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/ChainSync.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/ChainSync.hs
@@ -1,0 +1,119 @@
+{-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+module Test.Consensus.PeerSimulator.ChainSync (runChainSyncClient) where
+
+import           Control.Exception (AsyncException (ThreadKilled))
+import           Control.Monad.Class.MonadTimer.SI (MonadTimer)
+import           Control.Tracer (Tracer, nullTracer, traceWith)
+import           Data.Map.Strict (Map)
+import           Data.Proxy (Proxy (..))
+import           Ouroboros.Consensus.Block (Header, Point)
+import           Ouroboros.Consensus.Config (TopLevelConfig (..))
+import           Ouroboros.Consensus.MiniProtocol.ChainSync.Client (ChainDbView,
+                     Consensus, bracketChainSyncClient, chainSyncClient)
+import qualified Ouroboros.Consensus.MiniProtocol.ChainSync.Client.InFutureCheck as InFutureCheck
+import           Ouroboros.Consensus.Util.Condense (Condense (..))
+import           Ouroboros.Consensus.Util.IOLike (Exception (fromException),
+                     IOLike, MonadCatch (try), StrictTVar)
+import           Ouroboros.Network.Block (Tip)
+import           Ouroboros.Network.Channel (createConnectedChannels)
+import           Ouroboros.Network.ControlMessage (ControlMessage (..))
+import           Ouroboros.Network.Driver.Limits
+                     (ProtocolLimitFailure (ExceededSizeLimit, ExceededTimeLimit))
+import           Ouroboros.Network.NodeToNode.Version (NodeToNodeVersion)
+import           Ouroboros.Network.Protocol.ChainSync.ClientPipelined
+                     (ChainSyncClientPipelined, chainSyncClientPeerPipelined)
+import           Ouroboros.Network.Protocol.ChainSync.Codec (ChainSyncTimeout,
+                     codecChainSyncId, timeLimitsChainSync)
+import           Ouroboros.Network.Protocol.ChainSync.PipelineDecision
+                     (pipelineDecisionLowHighMark)
+import           Ouroboros.Network.Protocol.ChainSync.Server (ChainSyncServer,
+                     chainSyncServerPeer)
+import           Test.Consensus.Network.Driver.Limits.Extras
+                     (chainSyncNoSizeLimits,
+                     runConnectedPeersPipelinedWithLimits)
+import           Test.Consensus.PeerSimulator.StateView
+                     (ChainSyncException (ChainSyncException),
+                     StateViewTracers (StateViewTracers, svtChainSyncExceptionsTracer))
+import           Test.Consensus.PeerSimulator.Trace (mkChainSyncClientTracer,
+                     traceUnitWith)
+import           Test.Consensus.PointSchedule (PeerId, TestFragH)
+import           Test.Util.Orphans.IOLike ()
+import           Test.Util.TestBlock (TestBlock)
+
+basicChainSyncClient :: forall m.
+  IOLike m =>
+  Tracer m String ->
+  TopLevelConfig TestBlock ->
+  ChainDbView m TestBlock ->
+  StrictTVar m TestFragH ->
+  Consensus ChainSyncClientPipelined TestBlock m
+basicChainSyncClient tracer cfg chainDbView varCandidate =
+  chainSyncClient
+    (pipelineDecisionLowHighMark 10 20)
+    (mkChainSyncClientTracer tracer)
+    cfg
+    dummyHeaderInFutureCheck
+    chainDbView
+    maxBound
+    (return Continue)
+    nullTracer
+    varCandidate
+  where
+    dummyHeaderInFutureCheck :: InFutureCheck.HeaderInFutureCheck m TestBlock
+    dummyHeaderInFutureCheck = InFutureCheck.HeaderInFutureCheck
+      { InFutureCheck.proxyArrival = Proxy
+      , InFutureCheck.recordHeaderArrival = \_ -> pure ()
+      , InFutureCheck.judgeHeaderArrival = \_ _ _ -> pure ()
+      , InFutureCheck.handleHeaderArrival = \_ -> pure Nothing
+      }
+
+runChainSyncClient ::
+  (IOLike m, MonadTimer m) =>
+  Tracer m String ->
+  TopLevelConfig TestBlock ->
+  ChainDbView m TestBlock ->
+  PeerId ->
+  ChainSyncServer (Header TestBlock) (Point TestBlock) (Tip TestBlock) m () ->
+  ChainSyncTimeout ->
+  StateViewTracers m ->
+  StrictTVar m (Map PeerId (StrictTVar m TestFragH)) ->
+  m ()
+runChainSyncClient
+  tracer
+  cfg
+  chainDbView
+  peerId
+  server
+  chainSyncTimeouts
+  StateViewTracers {svtChainSyncExceptionsTracer}
+  varCandidates
+  =
+    bracketChainSyncClient nullTracer chainDbView varCandidates peerId ntnVersion $ \ varCandidate -> do
+      res <- try $ runConnectedPeersPipelinedWithLimits
+        createConnectedChannels
+        nullTracer
+        codecChainSyncId
+        chainSyncNoSizeLimits
+        (timeLimitsChainSync chainSyncTimeouts)
+        (chainSyncClientPeerPipelined (basicChainSyncClient tracer cfg chainDbView varCandidate))
+        (chainSyncServerPeer server)
+      case res of
+        Left exn -> do
+          traceWith svtChainSyncExceptionsTracer $ ChainSyncException peerId exn
+          case fromException exn of
+            Just (ExceededSizeLimit _) ->
+              traceUnitWith tracer ("ChainSyncClient " ++ condense peerId) "Terminating because of size limit exceeded."
+            Just (ExceededTimeLimit _) ->
+              traceUnitWith tracer ("ChainSyncClient " ++ condense peerId) "Terminating because of time limit exceeded."
+            Nothing ->
+              pure ()
+          case fromException exn of
+            Just ThreadKilled ->
+              traceUnitWith tracer ("ChainSyncClient " ++ condense peerId) "Terminated by GDD governor."
+            _ ->
+              pure ()
+        Right _ -> pure ()
+  where
+    ntnVersion :: NodeToNodeVersion
+    ntnVersion = maxBound

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Handlers.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Handlers.hs
@@ -44,12 +44,10 @@ import           Test.Consensus.PeerSimulator.ScheduledBlockFetchServer
 import           Test.Consensus.PeerSimulator.ScheduledChainSyncServer
                      (FindIntersect (..),
                      RequestNext (AwaitReply, RollBackward, RollForward))
-import           Test.Consensus.PeerSimulator.Trace (terseBlock, terseFrag,
-                     tersePoint)
 import           Test.Consensus.PointSchedule
 import           Test.Util.Orphans.IOLike ()
+import           Test.Util.TersePrinting (terseBlock, terseFrag, tersePoint)
 import           Test.Util.TestBlock (TestBlock, TestHash (TestHash))
-
 
 toPoint :: (HasHeader block, HeaderHash block ~ TestHash) => WithOrigin block -> Point TestBlock
 toPoint = castPoint . withOrigin GenesisPoint blockPoint

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Handlers.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Handlers.hs
@@ -1,41 +1,52 @@
 {-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies        #-}
+{-# LANGUAGE TypeOperators       #-}
 
--- | Business logic of the SyncChain protocol handlers that operates
+-- | Business logic of the ChainSync and BlockFetch protocol handlers that operate
 -- on the 'AdvertisedPoints' of a point schedule.
 --
 -- These are separated from the scheduling related mechanics of the
--- ChainSync server mock that the peer simulator uses, in
--- "Test.Consensus.PeerSimulator.ScheduledChainSyncServer".
+-- server mocks that the peer simulator uses, in
+-- "Test.Consensus.PeerSimulator.ScheduledChainSyncServer" and
+-- "Test.Consensus.PeerSimulator.ScheduledBlockFetchServer".
 module Test.Consensus.PeerSimulator.Handlers (
-    handlerFindIntersection
+    handlerBlockFetch
+  , handlerFindIntersection
   , handlerRequestNext
   ) where
 
+import           Cardano.Slotting.Slot (WithOrigin)
 import           Control.Monad.Trans (lift)
 import           Control.Monad.Writer.Strict (MonadWriter (tell),
                      WriterT (runWriterT))
 import           Data.Coerce (coerce)
-import           Data.Maybe (fromJust)
-import           Ouroboros.Consensus.Block.Abstract (Header, Point (..),
-                     getHeader, withOrigin)
+import           Data.Maybe (fromJust, fromMaybe)
+import           Ouroboros.Consensus.Block (HasHeader, Header, HeaderHash,
+                     Point (GenesisPoint), castPoint, getHeader, withOrigin)
 import           Ouroboros.Consensus.Util.Condense (Condense (..))
 import           Ouroboros.Consensus.Util.IOLike (IOLike, STM, StrictTVar,
                      readTVar, writeTVar)
 import qualified Ouroboros.Network.AnchoredFragment as AF
 import           Ouroboros.Network.Block (blockPoint, getTipPoint)
+import           Ouroboros.Network.BlockFetch.ClientState
+                     (ChainRange (ChainRange))
 import qualified Test.Consensus.BlockTree as BT
 import           Test.Consensus.BlockTree (BlockTree)
 import           Test.Consensus.Network.AnchoredFragment.Extras (intersectWith)
+import           Test.Consensus.PeerSimulator.ScheduledBlockFetchServer
+                     (BlockFetch (..))
 import           Test.Consensus.PeerSimulator.ScheduledChainSyncServer
                      (FindIntersect (..),
                      RequestNext (AwaitReply, RollBackward, RollForward))
-import           Test.Consensus.PeerSimulator.Trace (terseFrag)
-import           Test.Consensus.PointSchedule (AdvertisedPoints (header, tip),
-                     HeaderPoint (HeaderPoint), TipPoint (TipPoint))
+import           Test.Consensus.PeerSimulator.Trace (terseFrag, tersePoint)
+import           Test.Consensus.PointSchedule
 import           Test.Util.Orphans.IOLike ()
-import           Test.Util.TestBlock (TestBlock)
+import           Test.Util.TestBlock (TestBlock, TestHash)
 
+
+toPoint :: (HasHeader block, HeaderHash block ~ TestHash) => WithOrigin block -> Point TestBlock
+toPoint = castPoint . withOrigin GenesisPoint blockPoint
 
 -- | Handle a @MsgFindIntersect@ message.
 --
@@ -45,20 +56,19 @@ handlerFindIntersection ::
   IOLike m =>
   StrictTVar m (Point TestBlock) ->
   BlockTree TestBlock ->
-  AdvertisedPoints ->
   [Point TestBlock] ->
-  STM m (FindIntersect, [String])
-handlerFindIntersection currentIntersection blockTree points clientPoints = do
+  AdvertisedPoints ->
+  STM m (Maybe FindIntersect, [String])
+handlerFindIntersection currentIntersection blockTree clientPoints points = do
   let TipPoint tip' = tip points
       tipPoint = getTipPoint tip'
       fragment = fromJust $ BT.findFragment tipPoint blockTree
   case intersectWith fragment clientPoints of
     Nothing ->
-      pure (IntersectNotFound tip', [])
+      pure (Just (IntersectNotFound tip'), [])
     Just intersection -> do
       writeTVar currentIntersection intersection
-      pure (IntersectFound intersection tip', [])
-  where
+      pure (Just (IntersectFound intersection tip'), [])
 
 -- | Handle a @MsgRequestNext@ message.
 --
@@ -80,26 +90,24 @@ handlerRequestNext currentIntersection blockTree points =
   runWriterT $ do
     intersection <- lift $ readTVar currentIntersection
     trace $ "  last intersection is " ++ condense intersection
-    withOrigin headerIsOrigin (withHeader intersection) (coerce (header points))
+    withHeader intersection (coerce (header points))
   where
-    headerIsOrigin = pure Nothing
-
-    withHeader :: Point TestBlock -> Header TestBlock -> WriterT [String] (STM m) (Maybe RequestNext)
+    withHeader :: Point TestBlock -> WithOrigin (Header TestBlock) -> WriterT [String] (STM m) (Maybe RequestNext)
     withHeader intersection h =
       maybe noPathError (analysePath hp) (BT.findPath intersection hp blockTree)
       where
-        hp = AF.castPoint $ blockPoint h
+        hp = toPoint h
 
     noPathError = error "serveHeader: intersection and headerPoint should always be in the block tree"
 
-    analysePath headerPoint = \case
+    analysePath hp = \case
       -- If the anchor is the intersection (the source of the path-finding) but
       -- the fragment is empty, then the intersection is exactly our header
       -- point and there is nothing to do. If additionally the header point is
       -- also the tip point (because we served our whole chain, or we are
       -- stalling as an adversarial behaviour), then we ask the client to wait;
       -- otherwise we just do nothing.
-      (BT.PathAnchoredAtSource True, AF.Empty _) | getTipPoint tip' == headerPoint -> do
+      (BT.PathAnchoredAtSource True, AF.Empty _) | getTipPoint tip' == hp -> do
         trace "  chain has been fully served"
         pure (Just AwaitReply)
       (BT.PathAnchoredAtSource True, AF.Empty _) -> do
@@ -139,3 +147,57 @@ handlerRequestNext currentIntersection blockTree points =
     TipPoint tip' = tip points
 
     trace = tell . pure
+
+-- | Handle the BlockFetch message (it actually has only one unnamed entry point).
+--
+-- If the requested range ends not after BP, send them.
+-- If BP moved to a fork without serving all blocks corresponding to advertised headers, serve them.
+-- Otherwise, stall.
+handlerBlockFetch ::
+  forall m .
+  IOLike m =>
+  BlockTree TestBlock ->
+  ChainRange (Point TestBlock) ->
+  AdvertisedPoints ->
+  STM m (Maybe BlockFetch, [String])
+handlerBlockFetch blockTree (ChainRange from to) AdvertisedPoints {header = HeaderPoint hp, block = BlockPoint bp} =
+  runWriterT (serveFromBpFragment (AF.sliceRange bpChain from to))
+  where
+    -- Check whether the requested range is contained in the fragment before the block point.
+    -- We may only serve the full range; if the server has only some of the blocks, it must refuse.
+    serveFromBpFragment = \case
+      Just slice -> do
+        trace ("Sending slice " ++ terseFrag slice)
+        pure (Just (StartBatch (AF.toOldestFirst slice)))
+      Nothing    -> do
+        -- If we cannot serve blocks from the BP chain, decide whether to yield control to the scheduler
+        -- or serve blocks anyway.
+        --
+        -- If the @to@ point is not part of the HP chain but BP is, we must have switched to a fork without ensuring
+        -- that BP advances to the last HP advertised on the old chain.
+        -- This should be a precondition violation, but because it would make the schedule generator more complex, we
+        -- simply serve the missing blocks anyway here.
+        --
+        -- Otherwise, we simply have to wait for BP to advance sufficiently, and we block without sending
+        -- a message, to simulate a slow response.
+        case not (AF.withinFragmentBounds to hpChain) && AF.withinFragmentBounds (toPoint bp) hpChain of
+          True ->
+            case AF.sliceRange (fragmentUpTo "requested point" to) from to of
+              Just slice -> do
+                trace "Sending range due to incomplete fork switch"
+                pure (Just (StartBatch (AF.toOldestFirst slice)))
+              Nothing    -> error "BlockFetch: Client requested blocks that aren't in the block tree"
+          False  -> do
+            trace ("Waiting for next tick for range: " ++ tersePoint from ++ " -> " ++ tersePoint to)
+            pure Nothing
+
+    bpChain = fragmentUpTo "block point" (toPoint bp)
+
+    hpChain = fragmentUpTo "header point" (toPoint hp)
+
+    trace = tell . pure
+
+    fragmentUpTo sort b =
+      fromMaybe (fatal sort) (BT.findFragment b blockTree)
+
+    fatal sort = error ("BlockFetch: Could not find " ++ sort ++ " in the block tree")

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Handlers.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Handlers.hs
@@ -28,6 +28,7 @@ import           Test.Consensus.Network.AnchoredFragment.Extras (intersectWith)
 import           Test.Consensus.PeerSimulator.ScheduledChainSyncServer
                      (FindIntersect (..),
                      RequestNext (AwaitReply, RollBackward, RollForward))
+import           Test.Consensus.PeerSimulator.Trace (terseFrag)
 import           Test.Consensus.PointSchedule (AdvertisedPoints (header, tip),
                      HeaderPoint (HeaderPoint), TipPoint (TipPoint))
 import           Test.Util.Orphans.IOLike ()
@@ -97,7 +98,7 @@ handlerRequestNext currentIntersection blockTree points =
       -- we have something to serve.
       (BT.PathAnchoredAtSource True, fragmentAhead@(next AF.:< _)) -> do
         trace "  intersection is before our header point"
-        trace $ "  fragment ahead: " ++ condense fragmentAhead
+        trace $ "  fragment ahead: " ++ terseFrag fragmentAhead
         lift $ writeTVar currentIntersection $ blockPoint next
         pure $ Just (RollForward (getHeader next) (coerce (tip points)))
       -- If the anchor is not the intersection but the fragment is empty, then

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Handlers.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Handlers.hs
@@ -14,19 +14,24 @@ module Test.Consensus.PeerSimulator.Handlers (
     handlerBlockFetch
   , handlerFindIntersection
   , handlerRequestNext
+  , handlerSendBlocks
   ) where
 
-import           Cardano.Slotting.Slot (WithOrigin)
+import           Cardano.Slotting.Slot (WithOrigin (..))
 import           Control.Monad.Trans (lift)
 import           Control.Monad.Writer.Strict (MonadWriter (tell),
                      WriterT (runWriterT))
 import           Data.Coerce (coerce)
+import           Data.List (isSuffixOf)
+import qualified Data.List.NonEmpty as NonEmpty
 import           Data.Maybe (fromJust, fromMaybe)
 import           Ouroboros.Consensus.Block (HasHeader, Header, HeaderHash,
-                     Point (GenesisPoint), castPoint, getHeader, withOrigin)
+                     Point (GenesisPoint), blockHash, castPoint, getHeader,
+                     withOrigin)
 import           Ouroboros.Consensus.Util.Condense (Condense (..))
 import           Ouroboros.Consensus.Util.IOLike (IOLike, STM, StrictTVar,
                      readTVar, writeTVar)
+import           Ouroboros.Network.AnchoredFragment (AnchoredFragment)
 import qualified Ouroboros.Network.AnchoredFragment as AF
 import           Ouroboros.Network.Block (blockPoint, getTipPoint)
 import           Ouroboros.Network.BlockFetch.ClientState
@@ -35,18 +40,40 @@ import qualified Test.Consensus.BlockTree as BT
 import           Test.Consensus.BlockTree (BlockTree)
 import           Test.Consensus.Network.AnchoredFragment.Extras (intersectWith)
 import           Test.Consensus.PeerSimulator.ScheduledBlockFetchServer
-                     (BlockFetch (..))
+                     (BlockFetch (..), SendBlocks (..))
 import           Test.Consensus.PeerSimulator.ScheduledChainSyncServer
                      (FindIntersect (..),
                      RequestNext (AwaitReply, RollBackward, RollForward))
-import           Test.Consensus.PeerSimulator.Trace (terseFrag, tersePoint)
+import           Test.Consensus.PeerSimulator.Trace (terseBlock, terseFrag,
+                     tersePoint)
 import           Test.Consensus.PointSchedule
 import           Test.Util.Orphans.IOLike ()
-import           Test.Util.TestBlock (TestBlock, TestHash)
+import           Test.Util.TestBlock (TestBlock, TestHash (TestHash))
 
 
 toPoint :: (HasHeader block, HeaderHash block ~ TestHash) => WithOrigin block -> Point TestBlock
 toPoint = castPoint . withOrigin GenesisPoint blockPoint
+
+-- | More efficient implementation of a check used in some of the handlers,
+-- determining whether the first argument is on the chain that ends in the
+-- second argument.
+-- We would usually call @withinFragmentBounds@ for this, but since we're
+-- using 'TestBlock', looking at the hash is cheaper.
+isAncestorOf ::
+  HasHeader blk1 =>
+  HasHeader blk2 =>
+  HeaderHash blk1 ~ TestHash =>
+  HeaderHash blk2 ~ TestHash =>
+  WithOrigin blk1 ->
+  WithOrigin blk2 ->
+  Bool
+isAncestorOf (At ancestor) (At descendant) =
+  isSuffixOf (NonEmpty.toList hashA) (NonEmpty.toList hashD)
+  where
+    TestHash hashA = blockHash ancestor
+    TestHash hashD = blockHash descendant
+isAncestorOf (At _) Origin = False
+isAncestorOf Origin _ = True
 
 -- | Handle a @MsgFindIntersect@ message.
 --
@@ -148,6 +175,16 @@ handlerRequestNext currentIntersection blockTree points =
 
     trace = tell . pure
 
+-- REVIEW: We call this a lot, and I assume it creates some significant overhead.
+-- We should figure out a cheaper way to achieve what we're doing with the result.
+-- Since we're in TestBlock, we can at least check whether a block can extend another block,
+-- but then we won't be able to generalize later.
+fragmentUpTo :: BlockTree TestBlock -> String -> Point TestBlock -> AnchoredFragment TestBlock
+fragmentUpTo blockTree desc b =
+  fromMaybe fatal (BT.findFragment b blockTree)
+  where
+    fatal = error ("BlockFetch: Could not find " ++ desc ++ " in the block tree")
+
 -- | Handle the BlockFetch message (it actually has only one unnamed entry point).
 --
 -- If the requested range ends not after BP, send them.
@@ -160,44 +197,144 @@ handlerBlockFetch ::
   ChainRange (Point TestBlock) ->
   AdvertisedPoints ->
   STM m (Maybe BlockFetch, [String])
-handlerBlockFetch blockTree (ChainRange from to) AdvertisedPoints {header = HeaderPoint hp, block = BlockPoint bp} =
-  runWriterT (serveFromBpFragment (AF.sliceRange bpChain from to))
+handlerBlockFetch blockTree (ChainRange from to) AdvertisedPoints {header = HeaderPoint hp} =
+  runWriterT (serveFromBpFragment (AF.sliceRange hpChain from to))
   where
-    -- Check whether the requested range is contained in the fragment before the block point.
-    -- We may only serve the full range; if the server has only some of the blocks, it must refuse.
+    -- Check whether the requested range is contained in the fragment before the header point.
+    -- We may only initiate batch serving if the full range is available; if the server has only some of the blocks, it
+    -- must refuse.
     serveFromBpFragment = \case
       Just slice -> do
-        trace ("Sending slice " ++ terseFrag slice)
+        trace ("Starting batch for slice " ++ terseFrag slice)
         pure (Just (StartBatch (AF.toOldestFirst slice)))
       Nothing    -> do
-        -- If we cannot serve blocks from the BP chain, decide whether to yield control to the scheduler
-        -- or serve blocks anyway.
-        --
-        -- If the @to@ point is not part of the HP chain but BP is, we must have switched to a fork without ensuring
-        -- that BP advances to the last HP advertised on the old chain.
-        -- This should be a precondition violation, but because it would make the schedule generator more complex, we
-        -- simply serve the missing blocks anyway here.
-        --
-        -- Otherwise, we simply have to wait for BP to advance sufficiently, and we block without sending
-        -- a message, to simulate a slow response.
-        case not (AF.withinFragmentBounds to hpChain) && AF.withinFragmentBounds (toPoint bp) hpChain of
-          True ->
-            case AF.sliceRange (fragmentUpTo "requested point" to) from to of
-              Just slice -> do
-                trace "Sending range due to incomplete fork switch"
-                pure (Just (StartBatch (AF.toOldestFirst slice)))
-              Nothing    -> error "BlockFetch: Client requested blocks that aren't in the block tree"
-          False  -> do
-            trace ("Waiting for next tick for range: " ++ tersePoint from ++ " -> " ++ tersePoint to)
-            pure Nothing
+        trace ("Waiting for next tick for range: " ++ tersePoint from ++ " -> " ++ tersePoint to)
+        pure Nothing
 
-    bpChain = fragmentUpTo "block point" (toPoint bp)
-
-    hpChain = fragmentUpTo "header point" (toPoint hp)
+    hpChain = fragmentUpTo blockTree "header point" (toPoint hp)
 
     trace = tell . pure
 
-    fragmentUpTo sort b =
-      fromMaybe (fatal sort) (BT.findFragment b blockTree)
+{-
+If we cannot serve blocks from the BP chain, we need to decide whether to yield control to the scheduler
+or serve blocks anyway.
 
-    fatal sort = error ("BlockFetch: Could not find " ++ sort ++ " in the block tree")
+If the next block to deliver is part of the HP chain, we have to wait for BP to advance
+sufficiently, and we block without sending a message, to simulate a slow response.
+
+If the next block to deliver is not part of the HP chain, we must have switched to a fork without
+ensuring that BP advances to the last HP advertised on the old chain.
+While BP is not on the same chain as HP we wait, because BP might still advance to
+allow the next block to be sent. If BP is in the same chain as HP, we interpret
+that BP has left the old branch, and the requested blocks should be sent at this
+time.
+
+The cases to consider follow:
+
+ 0 1 2 3 4 5 6
+ x-x-x-x-x-x-x
+         ^BP ^HP
+       \-x-x-x
+         ^next
+✅ send the blocks because a rollback happened
+
+ 0 1 2 3 4 5 6
+ x-x-x-x-x-x-x
+   ^BP       ^HP
+       \-x-x-x
+         ^next
+
+❌ BP might still go on the fork where next is, so don't send the blocks yet
+
+ 0 1 2 3 4 5 6
+ x-x-x-x-x-x-x
+   ^BP
+     \-x-x-x-x
+       ^next ^HP
+
+❌ BP could still go on the fork where next is, don't send the blocks yet
+
+ 0 1 2 3 4 5 6
+ x-x-x-x-x-x-x
+     ^BP
+   \-x-x-x-x-x
+     ^next   ^HP
+
+❌ BP could still go on the fork where next is, don't send the blocks yet
+
+ 0 1 2 3 4 5 6
+ x-x-x-x-x-x-x
+     ^BP
+   \-x-x-x-x-x
+     ^next
+   \-x-x-x-x-x
+       ^HP
+
+❌ BP could still go on the fork where next is, don't send the blocks yet
+
+ 0 1 2 3 4 5 6
+ x-x-x-x-x-x-x
+     ^HP
+   \-x-x-x-x-x
+     ^next   ^BP
+
+✅ send the blocks because BP is after next
+
+ 0 1 2 3 4 5 6
+ x-x-x-x-x-x-x
+     ^HP
+   \-x-x-x-x-x
+     ^BP   ^next
+
+❌ BP could still advance past next, don't send the blocks yet
+
+-}
+handlerSendBlocks ::
+  forall m .
+  IOLike m =>
+  [TestBlock] ->
+  AdvertisedPoints ->
+  STM m (Maybe SendBlocks, [String])
+handlerSendBlocks blocks AdvertisedPoints {header = HeaderPoint hp, block = BlockPoint bp} =
+  runWriterT (checkDone blocks)
+  where
+    checkDone = \case
+      [] -> do
+        trace "Batch done"
+        pure (Just BatchDone)
+      (next : future) ->
+        blocksLeft next future
+
+    blocksLeft next future
+      | isAncestorOf (At next) bp
+      || compensateForScheduleRollback next
+      = do
+        trace ("Sending " ++ terseBlock next)
+        pure (Just (SendBlock next future))
+
+      | otherwise
+      = do
+        trace "BP is behind"
+        pure Nothing
+
+    -- Here we encode the conditions for the special situation mentioned above.
+    -- These use aliases for @withinFragmentBounds@ to illustrate what we're testing.
+    -- The names don't precisely match semantically, but it's difficult to understand the
+    -- circumstances otherwise.
+    --
+    -- The involved points are BP, HP, and @next@, which is the block we're deciding whether to
+    -- send or not.
+    --
+    -- Remember that at this point, we already know that we cannot send @next@ regularly, i.e.
+    -- @next@ is not on the chain leading up to BP.
+    -- The conditions in which we send @next@ to compensate for rollbacks are:
+    --
+    -- * @next@ is not on the chain leading up to HP – HP moved to another chain, and
+    --
+    -- * BP is in the same chain as HP and is not an ancestor of @next@ - BP also moved away from the chain of @next@.
+    --
+    -- Precondition: @not (isAncestorOf (At next) bp)@
+    compensateForScheduleRollback next =
+      not (isAncestorOf (At next) hp) && isAncestorOf bp hp && not (isAncestorOf bp (At next))
+
+    trace = tell . pure

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Handlers.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Handlers.hs
@@ -46,7 +46,7 @@ import           Test.Consensus.PeerSimulator.ScheduledChainSyncServer
                      RequestNext (AwaitReply, RollBackward, RollForward))
 import           Test.Consensus.PointSchedule
 import           Test.Util.Orphans.IOLike ()
-import           Test.Util.TersePrinting (terseBlock, terseFrag, tersePoint)
+import           Test.Util.TersePrinting (terseBlock, terseFragment, tersePoint)
 import           Test.Util.TestBlock (TestBlock, TestHash (TestHash))
 
 toPoint :: (HasHeader block, HeaderHash block ~ TestHash) => WithOrigin block -> Point TestBlock
@@ -114,7 +114,7 @@ handlerRequestNext ::
 handlerRequestNext currentIntersection blockTree points =
   runWriterT $ do
     intersection <- lift $ readTVar currentIntersection
-    trace $ "  last intersection is " ++ condense intersection
+    trace $ "  last intersection is " ++ tersePoint intersection
     withHeader intersection (coerce (header points))
   where
     withHeader :: Point TestBlock -> WithOrigin (Header TestBlock) -> WriterT [String] (STM m) (Maybe RequestNext)
@@ -142,7 +142,7 @@ handlerRequestNext currentIntersection blockTree points =
       -- we have something to serve.
       (BT.PathAnchoredAtSource True, fragmentAhead@(next AF.:< _)) -> do
         trace "  intersection is before our header point"
-        trace $ "  fragment ahead: " ++ terseFrag fragmentAhead
+        trace $ "  fragment ahead: " ++ terseFragment fragmentAhead
         lift $ writeTVar currentIntersection $ blockPoint next
         pure $ Just (RollForward (getHeader next) (coerce (tip points)))
       -- If the anchor is not the intersection but the fragment is empty, then
@@ -203,7 +203,7 @@ handlerBlockFetch blockTree (ChainRange from to) AdvertisedPoints {header = Head
     -- must refuse.
     serveFromBpFragment = \case
       Just slice -> do
-        trace ("Starting batch for slice " ++ terseFrag slice)
+        trace ("Starting batch for slice " ++ terseFragment slice)
         pure (Just (StartBatch (AF.toOldestFirst slice)))
       Nothing    -> do
         trace ("Waiting for next tick for range: " ++ tersePoint from ++ " -> " ++ tersePoint to)

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Resources.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Resources.hs
@@ -6,7 +6,8 @@
 -- primitives used by ChainSync and BlockFetch in the handlers that implement
 -- the block tree analysis specific to our peer simulator.
 module Test.Consensus.PeerSimulator.Resources (
-    ChainSyncResources (..)
+    BlockFetchResources (..)
+  , ChainSyncResources (..)
   , PeerResources (..)
   , PeerSimulatorResources (..)
   , SharedResources (..)
@@ -15,8 +16,8 @@ module Test.Consensus.PeerSimulator.Resources (
   , makePeerSimulatorResources
   ) where
 
-import           Control.Concurrent.Class.MonadSTM.Strict (newEmptyTMVarIO,
-                     takeTMVar)
+import           Control.Concurrent.Class.MonadSTM.Strict (atomically, dupTChan,
+                     newBroadcastTChan, readTChan, writeTChan)
 import           Control.Tracer (Tracer)
 import           Data.Foldable (toList)
 import           Data.List.NonEmpty (NonEmpty)
@@ -27,14 +28,16 @@ import           Ouroboros.Consensus.Block (WithOrigin (Origin))
 import           Ouroboros.Consensus.Block.Abstract (Header, Point (..))
 import           Ouroboros.Consensus.Util.Condense (Condense (..))
 import           Ouroboros.Consensus.Util.IOLike (IOLike, MonadSTM (STM),
-                     StrictTMVar, StrictTVar, readTVar, uncheckedNewTVarM,
-                     writeTVar)
+                     StrictTVar, readTVar, uncheckedNewTVarM, writeTVar)
 import qualified Ouroboros.Network.AnchoredFragment as AF
 import           Ouroboros.Network.Block (Tip (..))
+import           Ouroboros.Network.Protocol.BlockFetch.Server (BlockFetchServer)
 import           Ouroboros.Network.Protocol.ChainSync.Server
                      (ChainSyncServer (..))
 import           Test.Consensus.BlockTree (BlockTree)
 import           Test.Consensus.PeerSimulator.Handlers
+import           Test.Consensus.PeerSimulator.ScheduledBlockFetchServer
+                     (runScheduledBlockFetchServer)
 import           Test.Consensus.PeerSimulator.ScheduledChainSyncServer
 import           Test.Consensus.PointSchedule
 import           Test.Util.Orphans.IOLike ()
@@ -63,25 +66,43 @@ data SharedResources m =
 -- "Test.Consensus.PeerSimulator.ScheduledChainSyncServer".
 data ChainSyncResources m =
   ChainSyncResources {
-    -- | A mailbox of node states that is updated by the scheduler in the peer's active tick,
-    -- waking up the chain sync server.
-    csrNextState :: StrictTMVar m NodeState,
-
     -- | The current known intersection with the chain of the client.
     csrCurrentIntersection :: StrictTVar m (Point TestBlock),
 
     -- | The final server passed to typed-protocols.
-    csrServer :: ChainSyncServer (Header TestBlock) (Point TestBlock) (Tip TestBlock) m ()
+    csrServer :: ChainSyncServer (Header TestBlock) (Point TestBlock) (Tip TestBlock) m (),
+
+    -- | This action blocks while this peer is inactive in the point schedule.
+    csrTickStarted :: STM m ()
   }
 
--- | The totality of resources used by a single peer in ChainSync and BlockFetch.
+-- | The data used by the point scheduler to interact with the mocked protocol handler in
+-- "Test.Consensus.PeerSimulator.BlockFetch".
+data BlockFetchResources m =
+  BlockFetchResources {
+    -- | The final server passed to typed-protocols.
+    bfrServer      :: BlockFetchServer TestBlock (Point TestBlock) m (),
+
+    -- | This action blocks while this peer is inactive in the point schedule.
+    bfrTickStarted :: STM m ()
+  }
+
+-- | The totality of resources used by a single peer in ChainSync and BlockFetch and by
+-- the scheduler to interact with it.
 data PeerResources m =
   PeerResources {
     -- | Resources used by ChainSync and BlockFetch.
-    prShared    :: SharedResources m,
+    prShared      :: SharedResources m,
 
     -- | Resources used by ChainSync only.
-    prChainSync :: ChainSyncResources m
+    prChainSync   :: ChainSyncResources m,
+
+    -- | Resources used by BlockFetch only.
+    prBlockFetch  :: BlockFetchResources m,
+
+    -- | An action used by the scheduler to update the peer's advertised points and
+    -- resume processing for the ChainSync and BlockFetch servers.
+    prUpdateState :: NodeState -> STM m ()
   }
 
 -- | Resources for the peer simulator.
@@ -106,41 +127,57 @@ makeChainSyncServerHandlers currentIntersection blockTree =
     csshRequestNext = handlerRequestNext currentIntersection blockTree
   }
 
--- | Transaction that blocks until the next turn of the current peer, when the
--- scheduler puts the new state into the TMVar, and updates the TVar that is
--- read by all of the ChainSync and BlockFetch handlers.
---
--- The ChainSync protocol handler mock is agnostic of our state type,
--- 'NodeState', so we convert it to 'Maybe'.
-waitForNextState ::
-  IOLike m =>
-  StrictTMVar m NodeState ->
-  StrictTVar m (Maybe AdvertisedPoints) ->
-  STM m (Maybe AdvertisedPoints)
-waitForNextState nextState currentState =
-  takeTMVar nextState >>= \ newState -> do
-    let
-      a = case newState of
-        NodeOffline     -> Nothing
-        NodeOnline tick -> Just tick
-    writeTVar currentState a
-    pure a
-
 -- | Create all the resources used exclusively by the ChainSync handlers, and
 -- the ChainSync protocol server that uses the handlers to interface with the
 -- typed-protocols engine.
+--
+-- TODO move server construction to Run?
 makeChainSyncResources ::
   IOLike m =>
+  STM m () ->
   SharedResources m ->
   m (ChainSyncResources m)
-makeChainSyncResources SharedResources {srPeerId, srTracer, srBlockTree, srCurrentState} = do
-  csrNextState <- newEmptyTMVarIO
+makeChainSyncResources csrTickStarted SharedResources {srPeerId, srTracer, srBlockTree, srCurrentState} = do
   csrCurrentIntersection <- uncheckedNewTVarM $ AF.Point Origin
   let
-    wait = waitForNextState csrNextState srCurrentState
     handlers = makeChainSyncServerHandlers csrCurrentIntersection srBlockTree
-    csrServer = runScheduledChainSyncServer (condense srPeerId) wait (readTVar srCurrentState) srTracer handlers
-  pure ChainSyncResources {csrServer, csrNextState, csrCurrentIntersection}
+    csrServer = runScheduledChainSyncServer (condense srPeerId) csrTickStarted (readTVar srCurrentState) srTracer handlers
+  pure ChainSyncResources {csrTickStarted, csrServer, csrCurrentIntersection}
+
+-- | Create the concurrency transactions for communicating the begin of a peer's
+-- tick and its new state to the ChainSync and BlockFetch servers.
+--
+-- We use a 'TChan' with two consumers and return only an action that takes a
+-- 'NodeState', which should be called by the scheduler in each of this peer's
+-- ticks.
+--
+-- The action writes the new state (converted to 'Maybe') to the shared TVar,
+-- and publishes an item to the channel _only if_ the state is 'NodeOnline'.
+--
+-- If the peer's servers block on the channel whenever they have exhausted the
+-- possible actions for a tick, the scheduler will be resumed.
+-- When the scheduler then calls the update action in this peer's next tick,
+-- both consumers will be unblocked and able to fetch the new state from the
+-- TVar.
+updateState ::
+  IOLike m =>
+  StrictTVar m (Maybe AdvertisedPoints) ->
+  m (NodeState -> STM m (), STM m (), STM m ())
+updateState srCurrentState =
+  atomically $ do
+    publisher <- newBroadcastTChan
+    consumer1 <- dupTChan publisher
+    consumer2 <- dupTChan publisher
+    let
+      newState s = do
+        writeTVar srCurrentState =<< case s of
+          NodeOffline     -> pure Nothing
+          NodeOnline tick -> do
+            -- REVIEW: Is it ok to only unblock the peer when it is online?
+            -- So far we've handled Nothing in the ChainSync server by skipping the tick.
+            writeTChan publisher ()
+            pure (Just tick)
+    pure (newState, readTChan consumer1, readTChan consumer2)
 
 -- | Create all concurrency resources and the ChainSync protocol server used
 -- for a single peer.
@@ -149,6 +186,8 @@ makeChainSyncResources SharedResources {srPeerId, srTracer, srBlockTree, srCurre
 -- type 'AdvertisedPoints' that is updated by a separate scheduler, waking up
 -- the protocol handlers to process messages until the conditions of the new
 -- state are satisfied.
+--
+-- TODO pass BFR and CSR to runScheduled... rather than passing the individual resources in and storing the result
 makePeerResources ::
   IOLike m =>
   Tracer m String ->
@@ -157,9 +196,11 @@ makePeerResources ::
   m (PeerResources m)
 makePeerResources srTracer srBlockTree srPeerId = do
   srCurrentState <- uncheckedNewTVarM Nothing
+  (prUpdateState, csrTickStarted, bfrTickStarted) <- updateState srCurrentState
   let prShared = SharedResources {srTracer, srBlockTree, srPeerId, srCurrentState}
-  prChainSync <- makeChainSyncResources prShared
-  pure PeerResources {prChainSync, prShared}
+      prBlockFetch = BlockFetchResources {bfrTickStarted, bfrServer = runScheduledBlockFetchServer (condense srPeerId) bfrTickStarted (readTVar srCurrentState) srTracer (handlerBlockFetch srBlockTree)}
+  prChainSync <- makeChainSyncResources csrTickStarted prShared
+  pure PeerResources {prShared, prChainSync, prBlockFetch, prUpdateState}
 
 -- | Create resources for all given peers operating on the given block tree.
 makePeerSimulatorResources ::

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Resources.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Resources.hs
@@ -41,6 +41,7 @@ import           Test.Consensus.PeerSimulator.ScheduledBlockFetchServer
                      runScheduledBlockFetchServer)
 import           Test.Consensus.PeerSimulator.ScheduledChainSyncServer
 import           Test.Consensus.PointSchedule
+import           Test.Consensus.PointSchedule.Peers (PeerId)
 import           Test.Util.Orphans.IOLike ()
 import           Test.Util.TestBlock (TestBlock)
 

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Run.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Run.hs
@@ -52,9 +52,10 @@ import           Test.Consensus.PeerSimulator.StateView
 import           Test.Consensus.PeerSimulator.Trace
 import qualified Test.Consensus.PointSchedule as PointSchedule
 import           Test.Consensus.PointSchedule (GenesisTest (GenesisTest),
-                     Peer (Peer), PeerId, PointSchedule (PointSchedule),
-                     PointScheduleConfig, TestFragH, Tick (Tick),
-                     pointSchedulePeers, prettyPointSchedule)
+                     PointSchedule (PointSchedule), PointScheduleConfig,
+                     TestFragH, Tick (Tick), pointSchedulePeers,
+                     prettyPointSchedule)
+import           Test.Consensus.PointSchedule.Peers (Peer (..), PeerId)
 import           Test.Ouroboros.Consensus.ChainGenerator.Params (Asc)
 import           Test.Util.ChainDB
 import           Test.Util.Orphans.IOLike ()

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Run.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Run.hs
@@ -12,60 +12,44 @@ module Test.Consensus.PeerSimulator.Run (
   , runPointSchedule
   ) where
 
-import           Cardano.Slotting.Slot (WithOrigin (At, Origin))
 import           Cardano.Slotting.Time (SlotLength, slotLengthFromSec)
-import           Control.Exception (AsyncException (ThreadKilled))
 import           Control.Monad.Class.MonadTime (MonadTime)
 import           Control.Monad.Class.MonadTimer.SI (MonadTimer)
-import           Control.Tracer (Tracer, nullTracer, traceWith)
+import           Control.Tracer (Tracer, traceWith)
 import           Data.Foldable (for_)
 import           Data.Functor (void)
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import           Data.Proxy (Proxy (..))
 import           Ouroboros.Consensus.Config (TopLevelConfig (..))
 import           Ouroboros.Consensus.MiniProtocol.ChainSync.Client (ChainDbView,
-                     Consensus, bracketChainSyncClient, chainSyncClient,
                      defaultChainDbView)
-import qualified Ouroboros.Consensus.MiniProtocol.ChainSync.Client.InFutureCheck as InFutureCheck
 import           Ouroboros.Consensus.Storage.ChainDB.API
 import qualified Ouroboros.Consensus.Storage.ChainDB.API as ChainDB
 import           Ouroboros.Consensus.Storage.ChainDB.Impl
                      (ChainDbArgs (cdbTracer))
 import qualified Ouroboros.Consensus.Storage.ChainDB.Impl as ChainDB.Impl
 import           Ouroboros.Consensus.Util.Condense (Condense (..))
-import           Ouroboros.Consensus.Util.IOLike (Exception (fromException),
-                     IOLike, MonadCatch (try), MonadDelay (threadDelay),
-                     MonadSTM (atomically, retry), StrictTVar, readTVar,
-                     tryPutTMVar)
+import           Ouroboros.Consensus.Util.IOLike (IOLike,
+                     MonadDelay (threadDelay), MonadSTM (atomically),
+                     StrictTVar, readTVar)
 import           Ouroboros.Consensus.Util.ResourceRegistry
-import           Ouroboros.Network.Block (blockPoint)
 import           Ouroboros.Network.BlockFetch (FetchClientRegistry,
                      bracketSyncWithFetchClient, newFetchClientRegistry)
-import           Ouroboros.Network.Channel (createConnectedChannels)
 import           Ouroboros.Network.ControlMessage (ControlMessage (..),
                      ControlMessageSTM)
-import           Ouroboros.Network.Driver.Limits
-import           Ouroboros.Network.NodeToNode.Version (NodeToNodeVersion)
-import           Ouroboros.Network.Protocol.ChainSync.ClientPipelined
-                     (ChainSyncClientPipelined, chainSyncClientPeerPipelined)
 import           Ouroboros.Network.Protocol.ChainSync.Codec
-import           Ouroboros.Network.Protocol.ChainSync.PipelineDecision
-                     (pipelineDecisionLowHighMark)
-import           Ouroboros.Network.Protocol.ChainSync.Server
-                     (chainSyncServerPeer)
-import qualified Test.Consensus.BlockTree as BT
 import           Test.Consensus.Genesis.Setup.GenChains (GenesisTest)
 import           Test.Consensus.Network.Driver.Limits.Extras
 import qualified Test.Consensus.PeerSimulator.BlockFetch as PeerSimulator.BlockFetch
+import           Test.Consensus.PeerSimulator.BlockFetch (runBlockFetchClient,
+                     startBlockFetchLogic)
+import           Test.Consensus.PeerSimulator.ChainSync (runChainSyncClient)
 import           Test.Consensus.PeerSimulator.Config
 import           Test.Consensus.PeerSimulator.Resources
 import           Test.Consensus.PeerSimulator.StateView
 import           Test.Consensus.PeerSimulator.Trace
 import qualified Test.Consensus.PointSchedule as PointSchedule
-import           Test.Consensus.PointSchedule
-                     (AdvertisedPoints (AdvertisedPoints),
-                     BlockPoint (BlockPoint), GenesisTest (GenesisTest),
+import           Test.Consensus.PointSchedule (GenesisTest (GenesisTest),
                      Peer (Peer), PeerId, PointSchedule (PointSchedule),
                      PointScheduleConfig, TestFragH, Tick (Tick),
                      pointSchedulePeers)
@@ -126,33 +110,6 @@ noTimeoutsSchedulerConfig scSchedule =
 debugScheduler :: SchedulerConfig -> SchedulerConfig
 debugScheduler conf = conf { scDebug = True }
 
-basicChainSyncClient :: forall m.
-  IOLike m =>
-  Tracer m String ->
-  TopLevelConfig TestBlock ->
-  ChainDbView m TestBlock ->
-  StrictTVar m TestFragH ->
-  Consensus ChainSyncClientPipelined TestBlock m
-basicChainSyncClient tracer cfg chainDbView varCandidate =
-  chainSyncClient
-    (pipelineDecisionLowHighMark 10 20)
-    (mkChainSyncClientTracer tracer)
-    cfg
-    dummyHeaderInFutureCheck
-    chainDbView
-    maxBound
-    (return Continue)
-    nullTracer
-    varCandidate
-  where
-    dummyHeaderInFutureCheck :: InFutureCheck.HeaderInFutureCheck m TestBlock
-    dummyHeaderInFutureCheck = InFutureCheck.HeaderInFutureCheck
-      { InFutureCheck.proxyArrival = Proxy
-      , InFutureCheck.recordHeaderArrival = \_ -> pure ()
-      , InFutureCheck.judgeHeaderArrival = \_ _ _ -> pure ()
-      , InFutureCheck.handleHeaderArrival = \_ -> pure Nothing
-      }
-
 -- | Run a ChainSync protocol for one peer, consisting of a server and client.
 --
 -- The connection uses timeouts based on the ASC.
@@ -181,41 +138,14 @@ startChainSyncConnectionThread
   chainDbView
   fetchClientRegistry
   SharedResources {srPeerId}
-  ChainSyncResources {csrServer}
+  ChainSyncResources{csrServer}
   SchedulerConfig {scChainSyncTimeouts}
-  StateViewTracers {svtChainSyncExceptionsTracer}
-  varCandidates
-  =
-  void $ forkLinkedThread registry ("ChainSyncClient" <> condense srPeerId) $
-    bracketSyncWithFetchClient fetchClientRegistry srPeerId $ do
-      bracketChainSyncClient nullTracer chainDbView varCandidates srPeerId ntnVersion $ \ varCandidate -> do
-        res <- try $ runConnectedPeersPipelinedWithLimits
-          createConnectedChannels
-          nullTracer
-          codecChainSyncId
-          chainSyncNoSizeLimits
-          (timeLimitsChainSync scChainSyncTimeouts)
-          (chainSyncClientPeerPipelined (basicChainSyncClient tracer cfg chainDbView varCandidate))
-          (chainSyncServerPeer csrServer)
-        case res of
-          Left exn -> do
-            traceWith svtChainSyncExceptionsTracer $ ChainSyncException srPeerId exn
-            case fromException exn of
-              Just (ExceededSizeLimit _) ->
-                traceUnitWith tracer ("ChainSyncClient " ++ condense srPeerId) "Terminating because of size limit exceeded."
-              Just (ExceededTimeLimit _) ->
-                traceUnitWith tracer ("ChainSyncClient " ++ condense srPeerId) "Terminating because of time limit exceeded."
-              Nothing ->
-                pure ()
-            case fromException exn of
-              Just ThreadKilled ->
-                traceUnitWith tracer ("ChainSyncClient " ++ condense srPeerId) "Terminated by GDD governor."
-              _ ->
-                pure ()
-          Right _ -> pure ()
-  where
-    ntnVersion :: NodeToNodeVersion
-    ntnVersion = maxBound
+  tracers
+  varCandidates =
+    void $
+    forkLinkedThread registry ("ChainSyncClient" <> condense srPeerId) $
+    bracketSyncWithFetchClient fetchClientRegistry srPeerId $
+    runChainSyncClient tracer cfg chainDbView srPeerId csrServer scChainSyncTimeouts tracers varCandidates
 
 -- | Start the BlockFetch client, using the supplied 'FetchClientRegistry' to
 -- register it for synchronization with the ChainSync client.
@@ -225,21 +155,17 @@ startBlockFetchConnectionThread ::
   FetchClientRegistry PeerId (Header TestBlock) TestBlock m ->
   ControlMessageSTM m ->
   SharedResources m ->
+  BlockFetchResources m ->
   m ()
-startBlockFetchConnectionThread registry fetchClientRegistry controlMsgSTM SharedResources {srPeerId, srBlockTree, srCurrentState} =
-  void $ forkLinkedThread registry ("BlockFetchClient" <> condense srPeerId) $
-    PeerSimulator.BlockFetch.runBlockFetchClient srPeerId fetchClientRegistry controlMsgSTM getCurrentChain
-  where
-    getCurrentChain = atomically $ do
-      nodeState <- readTVar srCurrentState
-      case nodeState of
-        Nothing -> retry
-        Just AdvertisedPoints {block = BlockPoint (At b)} -> do
-          case BT.findFragment (blockPoint b) srBlockTree of
-            Just f  -> pure f
-            Nothing -> error "block tip is not in the block tree"
-        Just AdvertisedPoints {block = BlockPoint Origin} ->
-          retry
+startBlockFetchConnectionThread
+  registry
+  fetchClientRegistry
+  controlMsgSTM
+  SharedResources {srPeerId}
+  BlockFetchResources {bfrServer} =
+    void $
+    forkLinkedThread registry ("BlockFetchClient" <> condense srPeerId) $
+    runBlockFetchClient srPeerId fetchClientRegistry controlMsgSTM bfrServer
 
 -- | The 'Tick' contains a state update for a specific peer.
 -- If the peer has not terminated by protocol rules, this will update its TMVar
@@ -253,15 +179,11 @@ dispatchTick ::
   m ()
 dispatchTick tracer peers Tick {active = Peer pid state, duration} =
   case peers Map.!? pid of
-    Just PeerResources {prChainSync = ChainSyncResources {csrNextState}} -> do
-      -- REVIEW: It would be worth sanity-checking that our understanding of
-      -- `threadDelay` is correct; and maybe getting explicit information from
-      -- both ChainSync & BlockFetch servers that they are done.
-      threadDelay duration
+    Just PeerResources {prUpdateState} -> do
       trace $ "Writing state " ++ condense state
-      atomically (tryPutTMVar csrNextState state) >>= \case
-        True -> trace $ "Waiting for full resolution of " ++ condense pid ++ "'s tick..."
-        False -> trace $ "Client for " ++ condense pid ++ " has ceased operation."
+      atomically (prUpdateState state)
+      trace $ "Waiting for full resolution of " ++ condense pid ++ "'s tick..."
+      threadDelay duration
       trace $ condense pid ++ "'s tick is now done."
     Nothing -> error "“The impossible happened,” as GHC would say."
   where
@@ -318,13 +240,13 @@ runPointSchedule schedulerConfig GenesisTest {gtSecurityParam = k, gtBlockTree} 
     for_ (psrPeers resources) $ \PeerResources {prShared, prChainSync} -> do
       startChainSyncConnectionThread registry tracer config chainDbView fetchClientRegistry prShared prChainSync schedulerConfig stateViewTracers (psrCandidates resources)
       PeerSimulator.BlockFetch.startKeepAliveThread registry fetchClientRegistry (srPeerId prShared)
-    for_ (psrPeers resources) $ \PeerResources {prShared} ->
-      startBlockFetchConnectionThread registry fetchClientRegistry (pure Continue) prShared
+    for_ (psrPeers resources) $ \PeerResources {prShared, prBlockFetch} ->
+      startBlockFetchConnectionThread registry fetchClientRegistry (pure Continue) prShared prBlockFetch
     -- The block fetch logic needs to be started after the block fetch clients
     -- otherwise, an internal assertion fails because getCandidates yields more
     -- peer fragments than registered clients.
     let getCandidates = traverse readTVar =<< readTVar (psrCandidates resources)
-    PeerSimulator.BlockFetch.startBlockFetchLogic registry chainDb fetchClientRegistry getCandidates
+    startBlockFetchLogic registry chainDb fetchClientRegistry getCandidates
     runScheduler tracer pointSchedule (psrPeers resources)
     snapshotStateView stateViewTracers chainDb
   where

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Run.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Run.hs
@@ -12,6 +12,7 @@ module Test.Consensus.PeerSimulator.Run (
   , runPointSchedule
   ) where
 
+import           Cardano.Slotting.Slot (WithOrigin (At, Origin))
 import           Cardano.Slotting.Time (SlotLength, slotLengthFromSec)
 import           Control.Exception (AsyncException (ThreadKilled))
 import           Control.Monad.Class.MonadTime (MonadTime)
@@ -21,20 +22,12 @@ import           Data.Foldable (for_)
 import           Data.Functor (void)
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-<<<<<<< HEAD
 import           Data.Proxy (Proxy (..))
-import           Data.Traversable (for)
-=======
->>>>>>> 38f2da1be (Various improvements to the peer simulator)
 import           Ouroboros.Consensus.Config (TopLevelConfig (..))
 import           Ouroboros.Consensus.MiniProtocol.ChainSync.Client (ChainDbView,
-<<<<<<< HEAD
-                     Consensus, chainSyncClient, defaultChainDbView)
-import qualified Ouroboros.Consensus.MiniProtocol.ChainSync.Client.InFutureCheck as InFutureCheck
-=======
                      Consensus, bracketChainSyncClient, chainSyncClient,
                      defaultChainDbView)
->>>>>>> 38f2da1be (Various improvements to the peer simulator)
+import qualified Ouroboros.Consensus.MiniProtocol.ChainSync.Client.InFutureCheck as InFutureCheck
 import           Ouroboros.Consensus.Storage.ChainDB.API
 import qualified Ouroboros.Consensus.Storage.ChainDB.API as ChainDB
 import           Ouroboros.Consensus.Storage.ChainDB.Impl
@@ -70,10 +63,12 @@ import           Test.Consensus.PeerSimulator.Resources
 import           Test.Consensus.PeerSimulator.StateView
 import           Test.Consensus.PeerSimulator.Trace
 import qualified Test.Consensus.PointSchedule as PointSchedule
-import           Test.Consensus.PointSchedule (GenesisTest (GenesisTest),
+import           Test.Consensus.PointSchedule
+                     (AdvertisedPoints (AdvertisedPoints),
+                     BlockPoint (BlockPoint), GenesisTest (GenesisTest),
                      Peer (Peer), PeerId, PointSchedule (PointSchedule),
                      PointScheduleConfig, TestFragH, Tick (Tick),
-                     pointSchedulePeers, pscTickDuration)
+                     pointSchedulePeers)
 import           Test.Ouroboros.Consensus.ChainGenerator.Params (Asc)
 import           Test.Util.ChainDB
 import           Test.Util.Orphans.IOLike ()
@@ -239,11 +234,12 @@ startBlockFetchConnectionThread registry fetchClientRegistry controlMsgSTM Share
       nodeState <- readTVar srCurrentState
       case nodeState of
         Nothing -> retry
-        Just aps -> do
-          let PointSchedule.BlockPoint b = PointSchedule.block aps
+        Just AdvertisedPoints {block = BlockPoint (At b)} -> do
           case BT.findFragment (blockPoint b) srBlockTree of
             Just f  -> pure f
             Nothing -> error "block tip is not in the block tree"
+        Just AdvertisedPoints {block = BlockPoint Origin} ->
+          retry
 
 -- | The 'Tick' contains a state update for a specific peer.
 -- If the peer has not terminated by protocol rules, this will update its TMVar
@@ -251,22 +247,21 @@ startBlockFetchConnectionThread registry fetchClientRegistry controlMsgSTM Share
 -- for new instructions.
 dispatchTick ::
   IOLike m =>
-  SchedulerConfig ->
   Tracer m String ->
   Map PeerId (PeerResources m) ->
   Tick ->
   m ()
-dispatchTick config tracer peers Tick {active = Peer pid state} =
+dispatchTick tracer peers Tick {active = Peer pid state, duration} =
   case peers Map.!? pid of
     Just PeerResources {prChainSync = ChainSyncResources {csrNextState}} -> do
+      -- REVIEW: It would be worth sanity-checking that our understanding of
+      -- `threadDelay` is correct; and maybe getting explicit information from
+      -- both ChainSync & BlockFetch servers that they are done.
+      threadDelay duration
       trace $ "Writing state " ++ condense state
       atomically (tryPutTMVar csrNextState state) >>= \case
         True -> trace $ "Waiting for full resolution of " ++ condense pid ++ "'s tick..."
         False -> trace $ "Client for " ++ condense pid ++ " has ceased operation."
-      -- REVIEW: It would be worth sanity-checking that our understanding of
-      -- `threadDelay` is correct; and maybe getting explicit information from
-      -- both ChainSync & BlockFetch servers that they are done.
-      threadDelay (pscTickDuration (scSchedule config))
       trace $ condense pid ++ "'s tick is now done."
     Nothing -> error "“The impossible happened,” as GHC would say."
   where
@@ -279,16 +274,15 @@ dispatchTick config tracer peers Tick {active = Peer pid state} =
 -- client.
 runScheduler ::
   IOLike m =>
-  SchedulerConfig ->
   Tracer m String ->
   PointSchedule ->
   Map PeerId (PeerResources m) ->
   m ()
-runScheduler config tracer PointSchedule {ticks=ps} peers = do
+runScheduler tracer PointSchedule {ticks=ps} peers = do
   traceWith tracer "Schedule is:"
   for_ ps  $ \tick -> traceWith tracer $ "  " ++ condense tick
   traceStartOfTime
-  for_ ps (dispatchTick config tracer peers)
+  for_ ps (dispatchTick tracer peers)
   traceEndOfTime
   where
     traceStartOfTime =
@@ -331,7 +325,7 @@ runPointSchedule schedulerConfig GenesisTest {gtSecurityParam = k, gtBlockTree} 
     -- peer fragments than registered clients.
     let getCandidates = traverse readTVar =<< readTVar (psrCandidates resources)
     PeerSimulator.BlockFetch.startBlockFetchLogic registry chainDb fetchClientRegistry getCandidates
-    runScheduler schedulerConfig tracer pointSchedule (psrPeers resources)
+    runScheduler tracer pointSchedule (psrPeers resources)
     snapshotStateView stateViewTracers chainDb
   where
     config = defaultCfg k

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Run.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Run.hs
@@ -5,28 +5,36 @@
 {-# LANGUAGE TypeFamilies        #-}
 
 module Test.Consensus.PeerSimulator.Run (
-    ChainSyncException (..)
-  , SchedulerConfig (..)
+    SchedulerConfig (..)
+  , debugScheduler
+  , defaultSchedulerConfig
+  , noTimeoutsSchedulerConfig
   , runPointSchedule
   ) where
 
-import           Control.Monad.Class.MonadAsync
-                     (AsyncCancelled (AsyncCancelled))
+import           Cardano.Slotting.Time (SlotLength, slotLengthFromSec)
+import           Control.Exception (AsyncException (ThreadKilled))
 import           Control.Monad.Class.MonadTime (MonadTime)
 import           Control.Monad.Class.MonadTimer.SI (MonadTimer)
 import           Control.Tracer (Tracer, nullTracer, traceWith)
 import           Data.Foldable (for_)
 import           Data.Functor (void)
-import           Data.List.NonEmpty (NonEmpty, nonEmpty)
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
+<<<<<<< HEAD
 import           Data.Proxy (Proxy (..))
 import           Data.Traversable (for)
+=======
+>>>>>>> 38f2da1be (Various improvements to the peer simulator)
 import           Ouroboros.Consensus.Config (TopLevelConfig (..))
-import qualified Ouroboros.Consensus.HardFork.History.EraParams as HardFork
 import           Ouroboros.Consensus.MiniProtocol.ChainSync.Client (ChainDbView,
+<<<<<<< HEAD
                      Consensus, chainSyncClient, defaultChainDbView)
 import qualified Ouroboros.Consensus.MiniProtocol.ChainSync.Client.InFutureCheck as InFutureCheck
+=======
+                     Consensus, bracketChainSyncClient, chainSyncClient,
+                     defaultChainDbView)
+>>>>>>> 38f2da1be (Various improvements to the peer simulator)
 import           Ouroboros.Consensus.Storage.ChainDB.API
 import qualified Ouroboros.Consensus.Storage.ChainDB.API as ChainDB
 import           Ouroboros.Consensus.Storage.ChainDB.Impl
@@ -35,9 +43,8 @@ import qualified Ouroboros.Consensus.Storage.ChainDB.Impl as ChainDB.Impl
 import           Ouroboros.Consensus.Util.Condense (Condense (..))
 import           Ouroboros.Consensus.Util.IOLike (Exception (fromException),
                      IOLike, MonadCatch (try), MonadDelay (threadDelay),
-                     MonadSTM (atomically, retry), MonadThrow (throwIO),
-                     SomeException, StrictTVar, readTVar, readTVarIO,
-                     tryPutTMVar, uncheckedNewTVarM, writeTVar)
+                     MonadSTM (atomically, retry), StrictTVar, readTVar,
+                     tryPutTMVar)
 import           Ouroboros.Consensus.Util.ResourceRegistry
 import           Ouroboros.Network.Block (blockPoint)
 import           Ouroboros.Network.BlockFetch (FetchClientRegistry,
@@ -46,6 +53,7 @@ import           Ouroboros.Network.Channel (createConnectedChannels)
 import           Ouroboros.Network.ControlMessage (ControlMessage (..),
                      ControlMessageSTM)
 import           Ouroboros.Network.Driver.Limits
+import           Ouroboros.Network.NodeToNode.Version (NodeToNodeVersion)
 import           Ouroboros.Network.Protocol.ChainSync.ClientPipelined
                      (ChainSyncClientPipelined, chainSyncClientPeerPipelined)
 import           Ouroboros.Network.Protocol.ChainSync.Codec
@@ -59,11 +67,13 @@ import           Test.Consensus.Network.Driver.Limits.Extras
 import qualified Test.Consensus.PeerSimulator.BlockFetch as PeerSimulator.BlockFetch
 import           Test.Consensus.PeerSimulator.Config
 import           Test.Consensus.PeerSimulator.Resources
+import           Test.Consensus.PeerSimulator.StateView
 import           Test.Consensus.PeerSimulator.Trace
 import qualified Test.Consensus.PointSchedule as PointSchedule
 import           Test.Consensus.PointSchedule (GenesisTest (GenesisTest),
                      Peer (Peer), PeerId, PointSchedule (PointSchedule),
-                     TestFragH, Tick (Tick), pointSchedulePeers)
+                     PointScheduleConfig, TestFragH, Tick (Tick),
+                     pointSchedulePeers, pscTickDuration)
 import           Test.Ouroboros.Consensus.ChainGenerator.Params (Asc)
 import           Test.Util.ChainDB
 import           Test.Util.Orphans.IOLike ()
@@ -72,14 +82,54 @@ import           Test.Util.TestBlock (Header (..), TestBlock, testInitExtLedger)
 -- | Behavior config for the scheduler.
 data SchedulerConfig =
   SchedulerConfig {
-    -- | Whether to use timouts for the ChainSync protocol.
-    -- These apply when the client sends a MsgRequestNext and the server doesn't reply.
-    -- Because the point schedule cannot yet handle the case where a slow peer has a
-    -- header point that's behind the latest header that another peer has sent, we need
-    -- to be able to disable them.
-    enableTimeouts :: Bool
+    -- | Timeouts for the ChainSync protocol. These apply when the client sends
+    -- a 'MsgRequestNext' or a 'MsgFindIntersect' and the server doesn't reply.
+    -- Because the point schedule cannot yet handle the case where a slow peer
+    -- has a header point that's behind the latest header that another peer has
+    -- sent, we need to be able to control or disable them.
+    scChainSyncTimeouts :: ChainSyncTimeout
+
+    -- | The duration of a single slot, used by the peer simulator to wait
+    -- between ticks.
+    , scSlotLength      :: SlotLength
+
+    -- | Config shared with point schedule generators.
+    , scSchedule        :: PointScheduleConfig
+
+    -- | If 'True', 'Test.Consensus.Genesis.Setup.runTest' will enable full
+    -- tracing during the test.
+    --
+    -- Use 'debugScheduler' to toggle it conveniently.
+    , scDebug           :: Bool
   }
-  deriving (Show)
+
+-- | Determine timeouts based on the 'Asc' and a slot length of 20 seconds.
+defaultSchedulerConfig :: PointScheduleConfig -> Asc -> SchedulerConfig
+defaultSchedulerConfig scSchedule asc =
+  SchedulerConfig {
+    scChainSyncTimeouts = chainSyncTimeouts scSlotLength asc,
+    scSlotLength,
+    scSchedule,
+    scDebug = False
+  }
+  where
+    scSlotLength = slotLengthFromSec 20
+
+-- | Config with no timeouts and a slot length of 20 seconds.
+noTimeoutsSchedulerConfig :: PointScheduleConfig -> SchedulerConfig
+noTimeoutsSchedulerConfig scSchedule =
+  SchedulerConfig {
+    scChainSyncTimeouts = chainSyncNoTimeouts,
+    scSlotLength,
+    scSchedule,
+    scDebug = False
+  }
+  where
+    scSlotLength = slotLengthFromSec 20
+
+-- | Enable debug tracing during a scheduler test.
+debugScheduler :: SchedulerConfig -> SchedulerConfig
+debugScheduler conf = conf { scDebug = True }
 
 basicChainSyncClient :: forall m.
   IOLike m =>
@@ -108,14 +158,6 @@ basicChainSyncClient tracer cfg chainDbView varCandidate =
       , InFutureCheck.handleHeaderArrival = \_ -> pure Nothing
       }
 
--- | A record to associate an exception thrown by the ChainSync
--- thread with the peer that it was running for.
-data ChainSyncException = ChainSyncException
-       { csePeerId    :: PeerId
-       , cseException :: SomeException
-       }
-    deriving Show
-
 -- | Run a ChainSync protocol for one peer, consisting of a server and client.
 --
 -- The connection uses timeouts based on the ASC.
@@ -129,46 +171,56 @@ startChainSyncConnectionThread ::
   ResourceRegistry m ->
   Tracer m String ->
   TopLevelConfig TestBlock ->
-  Asc ->
   ChainDbView m TestBlock ->
   FetchClientRegistry PeerId (Header TestBlock) TestBlock m ->
   SharedResources m ->
   ChainSyncResources m ->
   SchedulerConfig ->
-  m (StrictTVar m (Maybe ChainSyncException))
-startChainSyncConnectionThread registry tracer cfg activeSlotCoefficient chainDbView fetchClientRegistry SharedResources {srPeerId, srCandidateFragment} ChainSyncResources {csrServer} SchedulerConfig {enableTimeouts} = do
-  let
-    slotLength = HardFork.eraSlotLength . topLevelConfigLedger $ cfg
-    timeouts | enableTimeouts = chainSyncTimeouts slotLength activeSlotCoefficient
-             | otherwise = chainSyncNoTimeouts
-  traceWith tracer $ "timeouts:"
-  traceWith tracer $ "  canAwait = " ++ show (canAwaitTimeout timeouts)
-  traceWith tracer $ "  intersect = " ++ show (intersectTimeout timeouts)
-  traceWith tracer $ "  mustReply = " ++ show (mustReplyTimeout timeouts)
-  chainSyncException <- uncheckedNewTVarM Nothing
-  _ <- forkLinkedThread registry ("ChainSyncClient" <> condense srPeerId) $
+  StateViewTracers m ->
+  StrictTVar m (Map PeerId (StrictTVar m TestFragH)) ->
+  m ()
+startChainSyncConnectionThread
+  registry
+  tracer
+  cfg
+  chainDbView
+  fetchClientRegistry
+  SharedResources {srPeerId}
+  ChainSyncResources {csrServer}
+  SchedulerConfig {scChainSyncTimeouts}
+  StateViewTracers {svtChainSyncExceptionsTracer}
+  varCandidates
+  =
+  void $ forkLinkedThread registry ("ChainSyncClient" <> condense srPeerId) $
     bracketSyncWithFetchClient fetchClientRegistry srPeerId $ do
-      res <- try $ runConnectedPeersPipelinedWithLimits
-        createConnectedChannels
-        nullTracer
-        codecChainSyncId
-        chainSyncNoSizeLimits
-        (timeLimitsChainSync timeouts)
-        (chainSyncClientPeerPipelined (basicChainSyncClient tracer cfg chainDbView srCandidateFragment))
-        (chainSyncServerPeer csrServer)
-      case res of
-        Left exn -> do
-          atomically $ writeTVar chainSyncException $ Just $ ChainSyncException srPeerId exn
-          case fromException exn of
-            Just (ExceededSizeLimit _) ->
-              traceUnitWith tracer ("ChainSyncClient " ++ condense srPeerId) "Terminating because of size limit exceeded."
-            Just (ExceededTimeLimit _) ->
-              traceUnitWith tracer ("ChainSyncClient " ++ condense srPeerId) "Terminating because of time limit exceeded."
-            Nothing ->
-              pure ()
-          throwIO exn
-        Right res' -> pure res'
-  pure chainSyncException
+      bracketChainSyncClient nullTracer chainDbView varCandidates srPeerId ntnVersion $ \ varCandidate -> do
+        res <- try $ runConnectedPeersPipelinedWithLimits
+          createConnectedChannels
+          nullTracer
+          codecChainSyncId
+          chainSyncNoSizeLimits
+          (timeLimitsChainSync scChainSyncTimeouts)
+          (chainSyncClientPeerPipelined (basicChainSyncClient tracer cfg chainDbView varCandidate))
+          (chainSyncServerPeer csrServer)
+        case res of
+          Left exn -> do
+            traceWith svtChainSyncExceptionsTracer $ ChainSyncException srPeerId exn
+            case fromException exn of
+              Just (ExceededSizeLimit _) ->
+                traceUnitWith tracer ("ChainSyncClient " ++ condense srPeerId) "Terminating because of size limit exceeded."
+              Just (ExceededTimeLimit _) ->
+                traceUnitWith tracer ("ChainSyncClient " ++ condense srPeerId) "Terminating because of time limit exceeded."
+              Nothing ->
+                pure ()
+            case fromException exn of
+              Just ThreadKilled ->
+                traceUnitWith tracer ("ChainSyncClient " ++ condense srPeerId) "Terminated by GDD governor."
+              _ ->
+                pure ()
+          Right _ -> pure ()
+  where
+    ntnVersion :: NodeToNodeVersion
+    ntnVersion = maxBound
 
 -- | Start the BlockFetch client, using the supplied 'FetchClientRegistry' to
 -- register it for synchronization with the ChainSync client.
@@ -199,18 +251,22 @@ startBlockFetchConnectionThread registry fetchClientRegistry controlMsgSTM Share
 -- for new instructions.
 dispatchTick ::
   IOLike m =>
+  SchedulerConfig ->
   Tracer m String ->
   Map PeerId (PeerResources m) ->
   Tick ->
   m ()
-dispatchTick tracer peers Tick {active = Peer pid state} =
+dispatchTick config tracer peers Tick {active = Peer pid state} =
   case peers Map.!? pid of
     Just PeerResources {prChainSync = ChainSyncResources {csrNextState}} -> do
       trace $ "Writing state " ++ condense state
       atomically (tryPutTMVar csrNextState state) >>= \case
         True -> trace $ "Waiting for full resolution of " ++ condense pid ++ "'s tick..."
         False -> trace $ "Client for " ++ condense pid ++ " has ceased operation."
-      threadDelay 0.100
+      -- REVIEW: It would be worth sanity-checking that our understanding of
+      -- `threadDelay` is correct; and maybe getting explicit information from
+      -- both ChainSync & BlockFetch servers that they are done.
+      threadDelay (pscTickDuration (scSchedule config))
       trace $ condense pid ++ "'s tick is now done."
     Nothing -> error "“The impossible happened,” as GHC would say."
   where
@@ -223,19 +279,30 @@ dispatchTick tracer peers Tick {active = Peer pid state} =
 -- client.
 runScheduler ::
   IOLike m =>
+  SchedulerConfig ->
   Tracer m String ->
   PointSchedule ->
   Map PeerId (PeerResources m) ->
   m ()
-runScheduler tracer (PointSchedule ps) peers = do
+runScheduler config tracer PointSchedule {ticks=ps} peers = do
   traceWith tracer "Schedule is:"
   for_ ps  $ \tick -> traceWith tracer $ "  " ++ condense tick
-  traceWith tracer "--------------------------------------------------------------------------------"
-  traceWith tracer "Running point schedule ..."
-  traceWith tracer "--------------------------------------------------------------------------------"
-  for_ ps (dispatchTick tracer peers)
-  traceWith tracer "--------------------------------------------------------------------------------"
-  traceWith tracer "Finished running point schedule"
+  traceStartOfTime
+  for_ ps (dispatchTick config tracer peers)
+  traceEndOfTime
+  where
+    traceStartOfTime =
+      traceLinesWith tracer [
+        hline,
+        "Running point schedule ...",
+        hline
+        ]
+    traceEndOfTime =
+      traceLinesWith tracer [
+        hline,
+        "Finished running point schedule"
+        ]
+    hline = "--------------------------------------------------------------------------------"
 
 -- | Construct STM resources, set up ChainSync and BlockFetch threads, and
 -- send all ticks in a 'PointSchedule' to all given peers in turn.
@@ -246,53 +313,38 @@ runPointSchedule ::
   GenesisTest ->
   PointSchedule ->
   Tracer m String ->
-  m (Either (NonEmpty ChainSyncException) TestFragH)
-runPointSchedule schedulerConfig GenesisTest {gtSecurityParam = k, gtHonestAsc = asc, gtBlockTree} pointSchedule tracer =
+  m StateView
+runPointSchedule schedulerConfig GenesisTest {gtSecurityParam = k, gtBlockTree} pointSchedule tracer =
   withRegistry $ \registry -> do
-    resources <- makePeersResources tracer gtBlockTree (pointSchedulePeers pointSchedule)
-    let candidates = srCandidateFragment . prShared <$> resources
-    traceWith tracer $ "Security param k = " ++ show k
-    chainDb <- mkChainDb tracer candidates config registry
+    stateViewTracers <- defaultStateViewTracers
+    resources <- makePeerSimulatorResources tracer gtBlockTree (pointSchedulePeers pointSchedule)
+    chainDb <- mkChainDb tracer config registry
     fetchClientRegistry <- newFetchClientRegistry
     let chainDbView = defaultChainDbView chainDb
-    chainSyncRess <- for resources $ \PeerResources {prShared, prChainSync} -> do
-      chainSyncRes <- startChainSyncConnectionThread registry tracer config asc chainDbView fetchClientRegistry prShared prChainSync schedulerConfig
+    for_ (psrPeers resources) $ \PeerResources {prShared, prChainSync} -> do
+      startChainSyncConnectionThread registry tracer config chainDbView fetchClientRegistry prShared prChainSync schedulerConfig stateViewTracers (psrCandidates resources)
       PeerSimulator.BlockFetch.startKeepAliveThread registry fetchClientRegistry (srPeerId prShared)
-      pure chainSyncRes
-    for_ resources $ \PeerResources {prShared} ->
+    for_ (psrPeers resources) $ \PeerResources {prShared} ->
       startBlockFetchConnectionThread registry fetchClientRegistry (pure Continue) prShared
     -- The block fetch logic needs to be started after the block fetch clients
     -- otherwise, an internal assertion fails because getCandidates yields more
     -- peer fragments than registered clients.
-    let getCandidates = traverse readTVar candidates
+    let getCandidates = traverse readTVar =<< readTVar (psrCandidates resources)
     PeerSimulator.BlockFetch.startBlockFetchLogic registry chainDb fetchClientRegistry getCandidates
-    runScheduler tracer pointSchedule resources
-    chainSyncExceptions <- collectExceptions (Map.elems chainSyncRess)
-    b <- atomically $ ChainDB.getCurrentChain chainDb
-    pure $ maybe (Right b) Left chainSyncExceptions
+    runScheduler schedulerConfig tracer pointSchedule (psrPeers resources)
+    snapshotStateView stateViewTracers chainDb
   where
     config = defaultCfg k
-
-    collectExceptions :: [StrictTVar m (Maybe ChainSyncException)] -> m (Maybe (NonEmpty ChainSyncException))
-    collectExceptions vars = do
-      res <- mapM readTVarIO vars
-      pure $ nonEmpty [ e | Just e <- res, not (isAsyncCancelled e) ]
-
-    isAsyncCancelled :: ChainSyncException -> Bool
-    isAsyncCancelled e = case fromException $ cseException e of
-      Just AsyncCancelled -> True
-      _                   -> False
 
 -- | Create a ChainDB and start a BlockRunner that operate on the peers'
 -- candidate fragments.
 mkChainDb ::
   IOLike m =>
   Tracer m String ->
-  Map PeerId (StrictTVar m TestFragH) ->
   TopLevelConfig TestBlock ->
   ResourceRegistry m ->
   m (ChainDB m TestBlock)
-mkChainDb tracer _candidateVars nodeCfg registry = do
+mkChainDb tracer nodeCfg registry = do
     chainDbArgs <- do
       mcdbNodeDBs <- emptyNodeDBs
       pure $ (

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/ScheduledBlockFetchServer.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/ScheduledBlockFetchServer.hs
@@ -11,7 +11,6 @@ module Test.Consensus.PeerSimulator.ScheduledBlockFetchServer (
   ) where
 
 import           Control.Tracer
-import           Data.List (intercalate)
 import           Ouroboros.Consensus.Block (Point)
 import           Ouroboros.Consensus.Util.Condense (Condense)
 import           Ouroboros.Consensus.Util.IOLike (IOLike, MonadSTM (STM))
@@ -20,6 +19,7 @@ import           Ouroboros.Network.Protocol.BlockFetch.Server
 import           Test.Consensus.PeerSimulator.ScheduledServer
                      (ScheduledServer (..), awaitOnlineState, runHandler)
 import           Test.Consensus.PeerSimulator.Trace
+import           Test.Util.TersePrinting (terseBlock)
 import           Test.Util.TestBlock (TestBlock)
 
 data SendBlocks =
@@ -63,7 +63,7 @@ scheduledBlockFetchServer ScheduledBlockFetchServer {sbfsServer, sbfsHandlers} =
     blockFetch range =
       runHandler sbfsServer "BlockFetch" (bfshBlockFetch range) $ \case
         StartBatch blocks -> do
-          trace $ "  sending blocks: " ++ intercalate " " (terseBlock <$> blocks)
+          trace $ "  sending blocks: " ++ unwords (terseBlock <$> blocks)
           trace "done handling BlockFetch"
           pure $ SendMsgStartBatch (sendBlocks blocks)
         NoBlocks -> do

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/ScheduledBlockFetchServer.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/ScheduledBlockFetchServer.hs
@@ -1,0 +1,96 @@
+{-# LANGUAGE LambdaCase          #-}
+{-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Test.Consensus.PeerSimulator.ScheduledBlockFetchServer (
+    BlockFetch (..)
+  , ScheduledBlockFetchServer (..)
+  , runScheduledBlockFetchServer
+  ) where
+
+import           Control.Tracer
+import           Data.List (intercalate)
+import           Ouroboros.Consensus.Block (Point)
+import           Ouroboros.Consensus.Util.Condense (Condense)
+import           Ouroboros.Consensus.Util.IOLike (IOLike, MonadSTM (STM))
+import           Ouroboros.Network.BlockFetch.ClientState (ChainRange)
+import           Ouroboros.Network.Protocol.BlockFetch.Server
+import           Test.Consensus.PeerSimulator.ScheduledServer
+                     (ScheduledServer (..), awaitOnlineState, runHandler)
+import           Test.Consensus.PeerSimulator.Trace
+import           Test.Util.TestBlock (TestBlock)
+
+data SendBlocks =
+  Block TestBlock
+  |
+  BatchDone
+  deriving (Eq, Show)
+
+data BlockFetch =
+  StartBatch [TestBlock]
+  |
+  NoBlocks
+  deriving (Eq, Show)
+
+-- | Resources used by a BlockFetch server mock.
+data ScheduledBlockFetchServer m a =
+  ScheduledBlockFetchServer {
+    sbfsServer :: ScheduledServer m a,
+    sbfsHandler       :: ChainRange (Point TestBlock) -> a -> STM m (Maybe BlockFetch, [String])
+  }
+
+scheduledBlockFetchServer ::
+  forall m a .
+  Condense a =>
+  IOLike m =>
+  ScheduledBlockFetchServer m a ->
+  BlockFetchServer TestBlock (Point TestBlock) m ()
+scheduledBlockFetchServer ScheduledBlockFetchServer {sbfsServer, sbfsHandler} =
+  server
+  where
+    server = BlockFetchServer blockFetch ()
+
+    blockFetch range =
+      runHandler sbfsServer "BlockFetch" (sbfsHandler range) $ \case
+        StartBatch blocks -> do
+          trace $ "  sending blocks: " ++ intercalate " " (terseBlock <$> blocks)
+          trace "done handling BlockFetch"
+          pure $ SendMsgStartBatch (sendBlocks blocks)
+        NoBlocks -> do
+          trace "  no blocks available"
+          trace "done handling BlockFetch"
+          pure (SendMsgNoBlocks (server <$ awaitOnlineState sbfsServer))
+
+    sendBlocks :: [TestBlock] -> m (BlockFetchSendBlocks TestBlock (Point TestBlock) m ())
+    sendBlocks = \case
+      []         -> do
+        trace "Batch done"
+        pure (SendMsgBatchDone (pure server))
+      blk : blks -> do
+        trace ("Sending " ++ terseBlock blk)
+        pure (SendMsgBlock blk (sendBlocks blks))
+
+    trace = traceWith (ssTracer sbfsServer)
+
+-- | Construct a BlockFetch server for the peer simulator.
+--
+-- See 'scheduledBlockFetchServer'.
+runScheduledBlockFetchServer ::
+  Condense a =>
+  IOLike m =>
+  String ->
+  STM m () ->
+  STM m (Maybe a) ->
+  Tracer m String ->
+  (ChainRange (Point TestBlock) -> a -> STM m (Maybe BlockFetch, [String])) ->
+  BlockFetchServer TestBlock (Point TestBlock) m ()
+runScheduledBlockFetchServer ssPeerId ssTickStarted ssCurrentState tracer sbfsHandler =
+  scheduledBlockFetchServer ScheduledBlockFetchServer {
+    sbfsServer = ScheduledServer {
+      ssPeerId,
+      ssTickStarted,
+      ssCurrentState,
+      ssTracer = Tracer (traceUnitWith tracer ("ScheduledBlockFetchServer " ++ ssPeerId))
+    },
+    sbfsHandler
+  }

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/ScheduledChainSyncServer.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/ScheduledChainSyncServer.hs
@@ -25,7 +25,7 @@ import           Ouroboros.Network.Protocol.ChainSync.Server
 import           Test.Consensus.PeerSimulator.ScheduledServer
                      (ScheduledServer (..), awaitOnlineState, runHandler)
 import           Test.Consensus.PeerSimulator.Trace (traceUnitWith)
-import           Test.Util.TersePrinting (terseHeader)
+import           Test.Util.TersePrinting (terseHeader, terseTip)
 import           Test.Util.TestBlock (Header (..), TestBlock)
 
 -- | Pure representation of the messages produced by the handler for the @StNext@
@@ -96,7 +96,7 @@ scheduledChainSyncServer ScheduledChainSyncServer {scssHandlers, scssServer} =
       runHandler scssServer "MsgRequestNext" csshRequestNext $ \case
         RollForward header tip -> do
           trace $ "  gotta serve " ++ terseHeader header
-          trace $ "  tip is      " ++ condense tip
+          trace $ "  tip is      " ++ terseTip tip
           trace "done handling MsgRequestNext"
           pure $ Left $ SendMsgRollForward header tip go
         RollBackward point tip -> do

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/ScheduledChainSyncServer.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/ScheduledChainSyncServer.hs
@@ -24,7 +24,8 @@ import           Ouroboros.Network.Protocol.ChainSync.Server
                      ServerStNext (SendMsgRollBackward, SendMsgRollForward))
 import           Test.Consensus.PeerSimulator.ScheduledServer
                      (ScheduledServer (..), awaitOnlineState, runHandler)
-import           Test.Consensus.PeerSimulator.Trace (terseHeader, traceUnitWith)
+import           Test.Consensus.PeerSimulator.Trace (traceUnitWith)
+import           Test.Util.TersePrinting (terseHeader)
 import           Test.Util.TestBlock (Header (..), TestBlock)
 
 -- | Pure representation of the messages produced by the handler for the @StNext@

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/ScheduledChainSyncServer.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/ScheduledChainSyncServer.hs
@@ -24,7 +24,7 @@ import           Ouroboros.Network.Protocol.ChainSync.Server
                      ServerStIdle (ServerStIdle, recvMsgDoneClient, recvMsgFindIntersect, recvMsgRequestNext),
                      ServerStIntersect (SendMsgIntersectFound, SendMsgIntersectNotFound),
                      ServerStNext (SendMsgRollBackward, SendMsgRollForward))
-import           Test.Consensus.PeerSimulator.Trace (traceUnitWith)
+import           Test.Consensus.PeerSimulator.Trace (terseHeader, traceUnitWith)
 import           Test.Util.TestBlock (Header (..), TestBlock)
 
 -- | Pure representation of the messages produced by the handler for the @StNext@
@@ -144,7 +144,7 @@ scheduledChainSyncServer server@ScheduledChainSyncServer {scssHandlers, scssTrac
       trace $ "  state is " ++ condense currentState
       runHandlerWithTrace requestNextTracer (csshRequestNext currentState) >>= \case
         Just (RollForward header tip) -> do
-          trace $ "  gotta serve " ++ condense header
+          trace $ "  gotta serve " ++ terseHeader header
           trace $ "  tip is      " ++ condense tip
           trace "done handling MsgRequestNext"
           pure $ Left $ SendMsgRollForward header tip go

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/ScheduledServer.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/ScheduledServer.hs
@@ -1,0 +1,98 @@
+{-# LANGUAGE LambdaCase     #-}
+{-# LANGUAGE NamedFieldPuns #-}
+
+module Test.Consensus.PeerSimulator.ScheduledServer (
+    ScheduledServer (..)
+  , awaitOnlineState
+  , ensureCurrentState
+  , runHandler
+  , runHandlerWithTrace
+  ) where
+import           Control.Tracer (Tracer (Tracer), traceWith)
+import           Data.Foldable (traverse_)
+import           Ouroboros.Consensus.Util.Condense (Condense (condense))
+import           Ouroboros.Consensus.Util.IOLike (IOLike,
+                     MonadSTM (STM, atomically))
+
+data ScheduledServer m a =
+  ScheduledServer {
+    ssPeerId       :: String,
+    ssCurrentState :: STM m (Maybe a),
+    ssTickStarted  :: STM m (),
+    ssTracer       :: Tracer m String
+  }
+
+nextTickState :: IOLike m => ScheduledServer m a -> m (Maybe a)
+nextTickState ScheduledServer {ssCurrentState, ssTickStarted} =
+  atomically (ssTickStarted >> ssCurrentState)
+
+retryOffline :: IOLike m => ScheduledServer m a -> Maybe a -> m a
+retryOffline server = maybe (awaitOnlineState server) pure
+
+-- | Block until the peer simulator has updated the concurrency primitive that
+-- indicates that it's this peer's server's turn in the point schedule.
+-- If the new state is 'Nothing', the point schedule has declared this peer as
+-- offline for the current tick, so it will not resume operation and wait for
+-- the next update.
+awaitOnlineState :: IOLike m => ScheduledServer m a -> m a
+awaitOnlineState server =
+  retryOffline server =<< nextTickState server
+
+-- | Fetch the current state from the STM action, and if it is 'Nothing',
+-- wait for the next tick to be triggered in 'awaitOnlineState'.
+--
+-- Since processing of a tick always ends when the handler finishes
+-- after serving the last point, this function is only relevant for the
+-- initial state update.
+ensureCurrentState :: IOLike m => ScheduledServer m a -> m a
+ensureCurrentState server =
+  retryOffline server =<< atomically (ssCurrentState server)
+
+-- | Handler functions are STM actions for the usual race condition reasons,
+-- which means that they cannot emit trace messages.
+--
+-- For that reason, we allow them to return their messages alongside the
+-- protocol result and emit them here.
+runHandlerWithTrace ::
+  IOLike m =>
+  Tracer m String ->
+  STM m (a, [String]) ->
+  m a
+runHandlerWithTrace tracer handler = do
+  (result, handlerMessages) <- atomically handler
+  traverse_ (traceWith tracer) handlerMessages
+  pure result
+
+-- | Run a peer server's message handler by fetching state from the scheduler's STM interface.
+--
+-- The handler is an STM action that returns a protocol result and log messages.
+--
+-- If the result is 'Nothing', the server's activity for the current tick is complete
+-- and we listen for the scheduler's signal to start the next tick, which we continue without
+-- updating the protocol handler (in @restart@).
+--
+-- Otherwise, the result is passed to @dispatchMessage@, which produces a native protocol handler
+-- message with the server's continuation in it.
+runHandler ::
+  IOLike m =>
+  Condense a =>
+  ScheduledServer m a ->
+  String ->
+  (a -> STM m (Maybe msg, [String])) ->
+  (msg -> m h) ->
+  m h
+runHandler server@ScheduledServer{ssTracer} handlerName handler dispatchMessage =
+  run
+  where
+    run = do
+      currentState <- ensureCurrentState server
+      trace ("handling " ++ handlerName)
+      trace ("  state is " ++ condense currentState)
+      maybe restart dispatchMessage =<< runHandlerWithTrace handlerTracer (handler currentState)
+
+    restart = do
+      trace "  cannot serve at this point; waiting for node state and starting again"
+      awaitOnlineState server *> run
+
+    trace = traceWith ssTracer
+    handlerTracer = Tracer $ \ msg -> traceWith ssTracer (handlerName ++ " | " ++ msg)

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/StateDiagram.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/StateDiagram.hs
@@ -54,8 +54,9 @@ import           Ouroboros.Network.Block (HeaderHash, Tip (Tip))
 import           Test.Consensus.BlockTree (BlockTree (btBranches, btTrunk),
                      BlockTreeBranch (btbSuffix), prettyBlockTree)
 import qualified Test.Consensus.PointSchedule as PS
-import           Test.Consensus.PointSchedule (AdvertisedPoints, PeerId (..),
-                     TestFrag, TestFragH, genesisAdvertisedPoints)
+import           Test.Consensus.PointSchedule (AdvertisedPoints, TestFrag,
+                     TestFragH, genesisAdvertisedPoints)
+import           Test.Consensus.PointSchedule.Peers (PeerId (..))
 import           Test.Util.TestBlock (TestBlock, TestHash (TestHash))
 
 enableDebug :: Bool

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/StateDiagram.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/StateDiagram.hs
@@ -1,0 +1,863 @@
+{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase                 #-}
+{-# LANGUAGE NamedFieldPuns             #-}
+{-# LANGUAGE OverloadedStrings          #-}
+{-# LANGUAGE TypeFamilies               #-}
+
+-- | A pretty-printer and tracer that shows the current peer simulator state in
+-- a block tree, highlighting the candidate fragments, selection, and forks in
+-- different colors, omitting uninteresting segments.
+module Test.Consensus.PeerSimulator.StateDiagram (
+    PeerSimState (..)
+  , RenderConfig (..)
+  , defaultRenderConfig
+  , peerSimStateDiagram
+  , peerSimStateDiagramSTMTracer
+  , peerSimStateDiagramSTMTracerDebug
+  , peerSimStateDiagramTracer
+  , peerSimStateDiagramWith
+  ) where
+
+import           Cardano.Slotting.Block (BlockNo (BlockNo))
+import           Cardano.Slotting.Slot (SlotNo (SlotNo), WithOrigin (..),
+                     fromWithOrigin, withOrigin)
+import           Control.Monad (guard)
+import           Control.Monad.State.Strict (State, gets, modify', runState,
+                     state)
+import           Control.Tracer (Tracer (Tracer), debugTracer, traceWith)
+import           Data.Bifunctor (first)
+import           Data.Foldable (foldl', foldr')
+import           Data.List (intersperse, mapAccumL, sort, transpose)
+import           Data.List.NonEmpty (NonEmpty ((:|)), nonEmpty, (<|))
+import qualified Data.List.NonEmpty as NonEmpty
+import           Data.Map (Map)
+import           Data.Map.Strict ((!?))
+import qualified Data.Map.Strict as Map
+import           Data.Maybe (mapMaybe)
+import           Data.String (IsString (fromString))
+import           Data.Vector (Vector)
+import qualified Data.Vector as Vector
+import qualified Data.Vector.Mutable as MV
+import           Data.Word (Word64)
+import qualified Debug.Trace as Debug
+import           GHC.Exts (IsList (..))
+import           Ouroboros.Consensus.Block (blockNo, blockSlot, getHeader)
+import           Ouroboros.Consensus.Util (eitherToMaybe)
+import           Ouroboros.Consensus.Util.Condense (Condense (..))
+import           Ouroboros.Consensus.Util.IOLike (IOLike, MonadSTM (STM),
+                     atomically, modifyTVar, readTVar, uncheckedNewTVarM)
+import           Ouroboros.Network.AnchoredFragment (anchor, anchorToSlotNo)
+import qualified Ouroboros.Network.AnchoredFragment as AF
+import           Test.Consensus.BlockTree (BlockTree (btBranches, btTrunk),
+                     BlockTreeBranch (btbSuffix), prettyBlockTree)
+import           Test.Consensus.PointSchedule (PeerId (..), TestFrag, TestFragH)
+import           Test.Util.TestBlock (TestBlock)
+
+enableDebug :: Bool
+enableDebug = False
+
+debugRender :: String -> a -> a
+debugRender
+  | enableDebug
+  = Debug.trace
+  | otherwise
+  = const id
+
+----------------------------------------------------------------------------------------------------
+-- Colors
+----------------------------------------------------------------------------------------------------
+
+data SGR =
+  Color Word64
+  |
+  BgColor Word64
+  |
+  Bold
+  |
+  Reset
+  |
+  Keep
+
+renderSgr :: [SGR] -> String
+renderSgr =
+  foldMap $ \case
+    Color n -> sgr ("38;5;" ++ show n)
+    BgColor n -> sgr ("48;5;" ++ show n)
+    Bold -> sgr "1"
+    Reset -> sgr "0"
+    Keep -> ""
+  where
+    sgr x = "\ESC[" ++ x ++ "m"
+
+data Col =
+  ColAspect (NonEmpty Aspect) Col
+  |
+  Col [SGR] Col
+  |
+  ColString String
+  |
+  ColCat [Col]
+
+instance IsString Col where
+  fromString = ColString
+
+instance IsList Col where
+  type Item Col = Col
+  fromList = ColCat
+  toList = \case
+    ColCat cols -> cols
+    c -> [c]
+
+instance Semigroup Col where
+  l <> r = ColCat [l, r]
+
+instance Monoid Col where
+  mempty = ""
+
+colLength :: Col -> Int
+colLength = \case
+  ColAspect _ c -> colLength c
+  Col _ c -> colLength c
+  ColString s -> length s
+  ColCat cs -> sum (colLength <$> cs)
+
+data Colors =
+  Colors {
+    candidates :: [Word64],
+    selection  :: Maybe Word64,
+    slotNumber :: Word64,
+    cache      :: Map PeerId Word64,
+    stack      :: [[SGR]]
+  }
+
+candidateColor :: PeerId -> Colors -> (Maybe Word64, Colors)
+candidateColor pid s@Colors {candidates, cache}
+  | Just c <- cached
+  = (Just c, s)
+
+  | h : t <- filter unused candidates
+  = (Just h, s {candidates = t, cache = Map.insert pid h cache})
+
+  | otherwise
+  = (Nothing, s)
+  where
+    cached = cache !? pid
+    unused c = not (elem c cache)
+
+getColor :: Bool -> Aspect -> State Colors (Maybe [SGR])
+getColor bg = \case
+  Selection -> do
+    c <- gets selection
+    pure (Just (Bold : maybe [] (pure . mkColor) c))
+  Candidate pid ->
+    fmap (pure . mkColor) <$> state (candidateColor pid)
+  Fork -> pure Nothing
+  SlotNumber -> do
+    c <- gets slotNumber
+    pure (Just [mkColor c])
+  where
+    mkColor | bg = BgColor
+            | otherwise = Color
+
+getColors :: NonEmpty Aspect -> State Colors [SGR]
+getColors aspects = do
+  (main, rest) <- findColor False (NonEmpty.toList aspects)
+  (bg, _) <- findColor True rest
+  pure (main ++ bg)
+  where
+    findColor bg (h : t) =
+      getColor bg h >>= \case
+        Just c -> pure (c, t)
+        Nothing -> findColor bg t
+    findColor _ [] = pure ([], [])
+
+renderCol :: Col -> State Colors String
+renderCol col =
+  spin col
+  where
+    spin = \case
+      ColAspect aspects sub -> do
+        sgr <- getColors aspects
+        withSgr sgr sub
+      Col sgr sub ->
+        withSgr sgr sub
+      ColString s -> pure s
+      ColCat cols -> concat <$> traverse spin cols
+
+    withSgr sgr sub = do
+      pre <- push sgr
+      s <- spin sub
+      pop
+      pure (renderSgr sgr ++ s ++ renderSgr pre)
+
+    push sgr =
+      state $ \case
+        s@Colors {stack = []} -> ([Reset], s {stack = [sgr, [Reset]]})
+        s@Colors {stack = h : t} -> ([Reset], s {stack = sgr : h : t})
+
+    pop = modify' $ \ s@Colors {stack} -> s {stack = drop 1 stack}
+
+runCol :: [Word64] -> Maybe Word64 -> Word64 -> Map PeerId Word64 -> State Colors a -> (a, Colors)
+runCol cand selection slotNumber cache s =
+  runState s Colors {candidates = cand, selection, slotNumber, cache, stack = []}
+
+----------------------------------------------------------------------------------------------------
+-- Slots
+----------------------------------------------------------------------------------------------------
+
+slotInt :: SlotNo -> Int
+slotInt (SlotNo s) = fromIntegral s
+
+blockInt :: BlockNo -> Int
+blockInt (BlockNo s) = fromIntegral s
+
+data Range =
+  Range {
+    from :: Int,
+    to   :: Int
+  }
+  deriving (Show, Eq, Ord)
+
+instance Condense Range where
+  condense (Range from to) = "[" ++ condense from ++ "," ++ condense to ++ "]"
+
+data Aspect =
+  Fork
+  |
+  Selection
+  |
+  Candidate PeerId
+  |
+  SlotNumber
+  deriving (Eq, Show, Ord)
+
+instance Condense Aspect where
+  condense = \case
+    Selection -> "s"
+    Candidate _ -> "c"
+    Fork -> "f"
+    SlotNumber -> "n"
+
+data AspectEdge =
+  EdgeLeft
+  |
+  EdgeRight
+  |
+  NoEdge
+  deriving (Show)
+
+data SlotAspect =
+  SlotAspect {
+    slotAspect :: Aspect,
+    edge       :: AspectEdge
+  }
+  deriving (Show)
+
+data SlotCapacity =
+  SlotOutside
+  |
+  SlotBlock Int
+  |
+  SlotEmpty
+  deriving (Show)
+
+instance Condense SlotCapacity where
+  condense = \case
+    SlotOutside -> ""
+    SlotBlock n -> "-" ++ condense n
+    SlotEmpty -> ""
+
+data Slot =
+  Slot {
+    num      :: WithOrigin Int,
+    capacity :: SlotCapacity,
+    aspects  :: [SlotAspect]
+  }
+  deriving (Show)
+
+instance Condense Slot where
+  condense Slot {num, capacity} =
+    sn ++ condense capacity
+    where
+      sn = case num of
+        Origin -> "G"
+        At n   -> show n
+
+----------------------------------------------------------------------------------------------------
+-- Slots vectors
+----------------------------------------------------------------------------------------------------
+
+data BranchSlots =
+  BranchSlots {
+    frag  :: TestFragH,
+    slots :: Vector Slot,
+    cands :: [PeerId]
+  }
+  deriving (Show)
+
+addAspect :: Aspect -> Range -> Bool -> Vector Slot -> Vector Slot
+addAspect slotAspect (Range l u) overFork slots =
+  debugRender (show (l, u, slotAspect)) $
+  debugRender (condense (Vector.toList (ins <$> sub))) $
+  Vector.update slots (ins <$> sub)
+  where
+    ins (i, slot) =
+      (i, slot {aspects = newAspect : aspects slot})
+      where
+        newAspect = SlotAspect {slotAspect, edge = mkEdge i}
+
+    mkEdge i | i == l && not overFork = EdgeLeft
+             | i == u = EdgeRight
+             | otherwise = NoEdge
+
+    sub = Vector.slice l count (Vector.indexed slots)
+
+    count | u == l = 1
+          | otherwise = u - l + 1
+
+initSlots :: Int -> Range -> TestFrag -> Vector Slot
+initSlots lastSlot (Range l u) blocks =
+  Vector.fromList (snd (mapAccumL step (AF.toOldestFirst blocks) [-1 .. lastSlot]))
+  where
+    step bs cur
+      | cur == -1
+      = (bs, Slot {num = Origin, capacity = SlotOutside, aspects = []})
+
+      | b : rest <- bs
+      , s <- slotInt (blockSlot b)
+      , s == cur
+      = (rest, mkSlot cur (SlotBlock (blockInt (blockNo b))))
+
+      | cur >= l - 1 && cur <= u
+      = (bs, mkSlot cur SlotEmpty)
+
+      | otherwise
+      = (bs, mkSlot cur SlotOutside)
+
+    mkSlot num capacity =
+      Slot {num = At num, capacity, aspects = []}
+
+initBranch :: Int -> Range -> TestFrag -> BranchSlots
+initBranch lastSlot fragRange fragment =
+  BranchSlots {
+    frag = AF.mapAnchoredFragment getHeader fragment,
+    slots = initSlots lastSlot fragRange fragment,
+    cands = []
+  }
+
+data TreeSlots =
+  TreeSlots {
+    lastSlot :: Int,
+    branches :: [BranchSlots]
+  }
+  deriving (Show)
+
+initTree :: BlockTree TestBlock -> TreeSlots
+initTree blockTree =
+  TreeSlots {lastSlot, branches = trunk : branches}
+  where
+    trunk = initFR trunkRange
+
+    branches = initFR <$> branchRanges
+
+    initFR = uncurry (initBranch lastSlot)
+
+    lastSlot = foldr' (max . (to . fst)) 0 (trunkRange : branchRanges)
+
+    trunkRange = withRange (btTrunk blockTree)
+
+    branchRanges = withRange . btbSuffix <$> btBranches blockTree
+
+    withRange f = (mkRange f, f)
+
+    mkRange f =
+      Range l u
+      where
+        l = withOrigin 0 slotInt (AF.lastSlot f)
+        u = withOrigin 0 slotInt (AF.headSlot f)
+
+commonRange :: TestFragH -> TestFragH -> Maybe (Range, Bool)
+commonRange branch segment = do
+  (preB, preS, _, _) <- AF.intersect branch segment
+  lower <- findLower (AF.toNewestFirst preB) (AF.toNewestFirst preS)
+  upper <- eitherToMaybe (AF.head preB)
+  let
+    aB = anchor preB
+    aS = anchor preS
+    asB = anchorToSlotNo aB
+    asS = anchorToSlotNo aS
+    l = blockSlot lower
+    u = blockSlot upper
+    overFork = asS < asB && aB == anchor branch
+  guard (u >= l)
+  pure (Range (slotInt l + (if overFork then 0 else 1)) (slotInt u + 1), overFork)
+  where
+    findLower preB preS =
+      foldl' step Nothing (zip preB preS)
+    step prev (b1, b2) | b1 == b2 = Just b1
+                       | otherwise = prev
+
+addFragRange :: Aspect -> TestFragH -> TreeSlots -> TreeSlots
+addFragRange aspect selection TreeSlots {lastSlot, branches} =
+  TreeSlots {lastSlot, branches = forBranch <$> branches}
+  where
+    forBranch branch@BranchSlots {frag, slots, cands} =
+      case commonRange frag selection of
+        Just (range, overFork) -> branch {slots = addAspect aspect range overFork slots, cands = addCandidate cands}
+        _          -> branch
+
+    addCandidate old | Candidate peerId <- aspect = peerId : old
+                     | otherwise = old
+
+addCandidateRange :: TreeSlots -> (PeerId, TestFragH) -> TreeSlots
+addCandidateRange ranges (pid, candidate) =
+  addFragRange (Candidate pid) candidate ranges
+
+updateSlot :: Int -> (Slot -> Slot) -> Vector Slot -> Vector Slot
+updateSlot i f =
+  Vector.modify (\ mv -> MV.modify mv f i)
+
+addForks :: TreeSlots -> TreeSlots
+addForks ranges@TreeSlots {branches} =
+  ranges {branches = addFork <$> branches}
+  where
+    addFork fr@BranchSlots {frag, slots} =
+      fr {slots = updateSlot s update slots}
+      where
+        update slot =
+          slot {
+            capacity = SlotEmpty,
+            aspects = SlotAspect {slotAspect = Fork, edge = NoEdge} : aspects slot
+          }
+        s = slotInt (withOrigin 0 (+ 1) (anchorToSlotNo (anchor frag)))
+
+----------------------------------------------------------------------------------------------------
+-- Cells
+----------------------------------------------------------------------------------------------------
+
+data CellSort =
+  CellHere (NonEmpty Aspect)
+  |
+  CellOther
+  deriving (Show)
+
+instance Condense CellSort where
+  condense = \case
+    CellHere a -> "h" ++ condense (toList a)
+    CellOther -> "o"
+
+data FragCell =
+  FragCell {
+    fcLabel       :: Maybe String,
+    fcSort        :: CellSort,
+    fcLineAspects :: [Aspect]
+  }
+  deriving (Show)
+
+instance Condense FragCell where
+  condense (FragCell l s a) =
+    lb ++ " " ++ condense s ++ condense a
+    where
+      lb = case l of
+        Just x  -> x
+        Nothing -> "-"
+
+data Cell =
+  Cell FragCell
+  |
+  CellEmpty
+  |
+  CellSlotNo (WithOrigin Int)
+  |
+  CellLabels [PeerId]
+  deriving (Show)
+
+instance Condense Cell where
+  condense = \case
+    Cell c -> condense c
+    CellEmpty -> "E"
+    CellSlotNo n -> "S" ++ show n
+    CellLabels _ -> "L"
+
+mainAspects :: [SlotAspect] -> Maybe (NonEmpty Aspect)
+mainAspects =
+  nonEmpty . sort . fmap slotAspect
+
+lineAspects :: [SlotAspect] -> [Aspect]
+lineAspects =
+  sort . mapMaybe check
+  where
+    check SlotAspect {edge, slotAspect}
+      | EdgeLeft <- edge
+      = Nothing
+      | otherwise
+      = Just slotAspect
+
+prependList :: [a] -> NonEmpty a -> NonEmpty a
+prependList = \case
+  [] -> id
+  h : t -> ((h :| t) <>)
+
+branchCells :: BranchSlots -> NonEmpty Cell
+branchCells BranchSlots {cands, slots} =
+  prependList (fragCell <$> Vector.toList slots) (pure labels)
+  where
+    fragCell Slot {capacity, aspects}
+      | SlotOutside <- capacity
+      = CellEmpty
+
+      | otherwise
+      , cellSort <- maybe CellOther CellHere (mainAspects aspects)
+      = Cell (FragCell (content capacity) cellSort (lineAspects aspects))
+
+    content = \case
+      SlotBlock num -> Just (show num)
+      _ -> Nothing
+
+    labels = CellLabels cands
+
+slotNoCells :: Int -> NonEmpty Cell
+slotNoCells lastSlot =
+  CellSlotNo Origin :| (CellSlotNo . At <$> [0 .. lastSlot]) ++ [CellEmpty]
+
+treeCells :: TreeSlots -> NonEmpty (NonEmpty Cell)
+treeCells TreeSlots {lastSlot, branches} =
+  slotNoCells lastSlot :| (branchCells <$> branches)
+
+----------------------------------------------------------------------------------------------------
+-- Render cells
+----------------------------------------------------------------------------------------------------
+
+newtype SlotWidth =
+  SlotWidth Int
+  deriving (Eq, Show, Ord, Num)
+
+data RenderSlot =
+  SlotEllipsis Int
+  |
+  RenderSlot Int SlotWidth (NonEmpty Cell)
+  deriving (Show)
+
+data RenderCell =
+  CellEllipsis
+  |
+  RenderCell SlotWidth Cell
+  deriving (Show)
+
+instance Condense RenderCell where
+  condense = \case
+    CellEllipsis -> " .. "
+    RenderCell _ cell -> condense cell
+
+renderPeerId :: PeerId -> String
+renderPeerId = \case
+  HonestPeer -> "honest"
+  PeerId p -> p
+
+slotWidth :: NonEmpty Cell -> SlotWidth
+slotWidth =
+  maximum . fmap cellWidth
+  where
+    cellWidth = \case
+      Cell FragCell {fcLabel = Just label} -> SlotWidth (length label)
+      CellLabels peerIds -> SlotWidth (sum (labelWidth <$> peerIds))
+      _ -> 1
+
+    labelWidth pid = 2 + length (renderPeerId pid)
+
+contiguous :: [(Int, Bool, a)] -> [[(Int, a)]]
+contiguous ((i0, _, a0) : rest) =
+  result (foldl' step (pure (i0, a0), []) rest)
+  where
+    result (cur, res) = reverse (reverse (toList cur) : res)
+
+    step (cur@((prev, _) :| _), res) (i, force, a)
+      | i == prev + 1 || force
+      = ((i, a) <| cur, res)
+      | otherwise
+      = (pure (i, a), reverse (toList cur) : res)
+contiguous [] = []
+
+cellSlots :: Int -> [(Int, Bool, NonEmpty Cell)] -> [RenderSlot]
+cellSlots branches =
+  concat . intersperse [SlotEllipsis branches] . fmap (fmap (uncurry withMaxSize)) . contiguous
+  where
+    withMaxSize slot cells = RenderSlot slot (slotWidth cells) cells
+
+pruneCells :: NonEmpty (NonEmpty Cell) -> [RenderSlot]
+pruneCells branches =
+  -- debugRender (unlines (condense <$> branches)) $
+  cellSlots (length branches) (mapMaybe cellSlot (zip slotRange (NonEmpty.toList (NonEmpty.transpose branches))))
+  where
+    cellSlot :: (WithOrigin Int, NonEmpty Cell) -> Maybe (Int, Bool, NonEmpty Cell)
+    cellSlot (num, frags)
+      | let noEll = any forceNoEllipsis frags
+      , noEll || any essential frags
+      = keep num noEll frags
+      | otherwise
+      = Nothing
+
+    keep num noEll frags = Just (fromWithOrigin (-1) num, noEll, frags)
+
+    essential = \case
+      Cell FragCell {fcSort = CellHere _} -> True
+      _ -> False
+
+    forceNoEllipsis = \case
+      CellLabels _ -> True
+      _ -> False
+
+    slotRange = Origin : (At <$> [0 ..])
+
+----------------------------------------------------------------------------------------------------
+-- Render
+----------------------------------------------------------------------------------------------------
+
+data RenderConfig =
+  RenderConfig {
+    lineWidth       :: Int,
+    ellipsis        :: String,
+    slotDistance    :: Int,
+    boringChar      :: Char,
+    candidateChar   :: Char,
+    selectionChar   :: Char,
+    forkChar        :: Char,
+    candidateColors :: [Word64],
+    cachedPeers     :: Map PeerId Word64,
+    selectionColor  :: Maybe Word64,
+    slotNumberColor :: Word64
+  }
+
+padCell :: RenderConfig -> Char -> SlotWidth -> String -> String
+padCell RenderConfig {slotDistance} padChar (SlotWidth w) s
+  | pad <= 0 = s
+  |otherwise = replicate pad padChar ++ s
+  where
+    pad = w - length s + slotDistance
+
+lineChar :: RenderConfig -> [Aspect] -> Char
+lineChar config aspects
+  | elem Selection aspects
+  = selectionChar config
+
+  | any isCandidate aspects
+  = candidateChar config
+
+  | otherwise
+  = boringChar config
+  where
+    isCandidate = \case
+      Candidate _ -> True
+      _ -> False
+
+colorAspects :: [Aspect] -> [Aspect]
+colorAspects =
+  filter $ \case
+    Fork -> False
+    Selection -> False
+    _ -> True
+
+renderLine :: RenderConfig -> SlotWidth -> [Aspect] -> Int -> Col
+renderLine config@RenderConfig {slotDistance, forkChar} (SlotWidth width) aspects labelWidth =
+  case colorAspects aspects of
+    [] -> ColString lineString
+    colors -> ColCat [ColAspect (pure color) (ColString [c]) | (c, color) <- zip lineString (cycle colors)]
+  where
+    lineString | elem Fork aspects = replicate (lineWidth - 1) ' ' ++ [forkChar]
+               | otherwise = replicate lineWidth lc
+    lineWidth = max 0 (width - labelWidth + slotDistance)
+    lc = lineChar config aspects
+
+labelColor :: CellSort -> Maybe (NonEmpty Aspect)
+labelColor = \case
+  CellOther -> Nothing
+  CellHere aspects ->
+    nonEmpty (colorAspects (toList aspects))
+
+renderSpecifiedLabel :: String -> CellSort -> Col
+renderSpecifiedLabel label srt =
+  case labelColor srt of
+    Nothing -> text
+    Just as -> ColAspect as text
+  where
+    text = ColString label
+
+renderLabel :: Maybe String -> CellSort -> Col
+renderLabel label srt
+  | Just specified <- label
+  = renderSpecifiedLabel specified srt
+  | otherwise
+  = ""
+
+renderFragCell :: RenderConfig -> SlotWidth -> FragCell -> Col
+renderFragCell config width FragCell {fcLabel, fcSort, fcLineAspects} =
+  renderLine config width fcLineAspects (colLength label) <> label
+  where
+    label = renderLabel fcLabel fcSort
+
+renderSlotNo :: RenderConfig -> SlotWidth -> WithOrigin Int -> Col
+renderSlotNo config width num =
+  ColAspect (pure SlotNumber) (ColString (padCell config ' ' width label))
+  where
+    label = case num of
+      Origin -> "G"
+      At s   -> show s
+
+renderLabels :: [PeerId] -> Col
+renderLabels peers =
+  ColCat [ColAspect (pure (Candidate p)) (ColString ("  " ++ renderPeerId p)) | p <- peers]
+
+renderCell :: RenderConfig -> RenderCell -> Col
+renderCell config@RenderConfig {ellipsis} = \case
+  RenderCell width (Cell cell) -> renderFragCell config width cell
+  RenderCell width (CellEmpty) -> ColString (padCell config ' ' width "")
+  RenderCell width (CellSlotNo n) -> renderSlotNo config width n
+  RenderCell _ (CellLabels peers) -> renderLabels peers
+  CellEllipsis -> ColString ellipsis
+
+renderBranch :: RenderConfig -> [RenderCell] -> Col
+renderBranch config cells =
+  debugRender (condense cells) $
+  foldMap (renderCell config) cells
+
+-- | Use w + 2 because we want the effective width, which includes the line segment.
+renderSlotWidth :: Int -> RenderSlot -> Int
+renderSlotWidth ellipsisWidth = \case
+  SlotEllipsis _ -> ellipsisWidth
+  RenderSlot _ (SlotWidth w) _ -> w + 2
+
+breakLines :: RenderConfig -> [RenderSlot] -> [[RenderSlot]]
+breakLines RenderConfig {lineWidth, ellipsis} =
+  result . foldl' step (0, [], [])
+  where
+    result (_, cur, res) = reverse (reverse cur : res)
+    step (w, cur, res) slot
+      | new <= lineWidth = (new, slot : cur, res)
+      | otherwise = (curW, [slot], reverse cur : res)
+      where
+        new = w + curW
+        curW = renderSlotWidth (length ellipsis) slot
+
+renderCells :: [RenderSlot] -> [[RenderCell]]
+renderCells =
+  transpose . fmap toCells
+  where
+    toCells = \case
+      RenderSlot _ width cells -> RenderCell width <$> toList cells
+      SlotEllipsis n -> replicate n CellEllipsis
+
+renderSlotSequence :: RenderConfig -> [RenderSlot] -> [Col]
+renderSlotSequence config =
+  fmap (renderBranch config) . renderCells
+
+renderSlots :: RenderConfig -> [RenderSlot] -> [[Col]]
+renderSlots config slots =
+  renderSlotSequence config <$> breakLines config slots
+
+renderColBlocks :: RenderConfig -> [[Col]] -> ([String], Colors)
+renderColBlocks RenderConfig {candidateColors, selectionColor, slotNumberColor, cachedPeers} cols =
+  first (fmap unlines) (runCol candidateColors selectionColor slotNumberColor cachedPeers (traverse (traverse renderCol) cols))
+
+------------------------------------------------------------------------------------------------------
+---- API
+------------------------------------------------------------------------------------------------------
+
+-- | All inputs for the state diagram printer.
+data PeerSimState =
+  PeerSimState {
+    pssBlockTree  :: BlockTree TestBlock,
+    pssSelection  :: TestFragH,
+    pssCandidates :: Map PeerId TestFragH
+  }
+
+-- TODO add an aspect for the last block of each branch?
+
+-- | Pretty-print the current peer simulator state in a block tree, highlighting
+-- the candidate fragments, selection, and forks in different colors, omitting
+-- uninteresting segments.
+peerSimStateDiagramWith :: RenderConfig -> PeerSimState -> (String, Map PeerId Word64)
+peerSimStateDiagramWith config PeerSimState {pssBlockTree, pssSelection, pssCandidates} =
+  debugRender (unlines (prettyBlockTree pssBlockTree)) $
+  (unlines blocks, cache)
+  where
+    (blocks, Colors {cache}) = renderColBlocks config (renderSlots config frags)
+
+    frags =
+      pruneCells $
+      treeCells $
+      addForks $
+      flip (foldl' addCandidateRange) (Map.toList pssCandidates) $
+      addFragRange Selection pssSelection $
+      initTree pssBlockTree
+
+defaultRenderConfig :: RenderConfig
+defaultRenderConfig =
+  RenderConfig {
+    lineWidth = 80,
+    ellipsis = " .. ",
+    slotDistance = 2,
+    boringChar = '·',
+    candidateChar = '-',
+    selectionChar = '*',
+    forkChar = '`',
+    candidateColors = [164, 113, 142, 81, 33],
+    cachedPeers = mempty,
+    selectionColor = Just 123,
+    slotNumberColor = 166
+  }
+
+peerSimStateDiagram :: PeerSimState -> String
+peerSimStateDiagram =
+  fst . peerSimStateDiagramWith defaultRenderConfig
+
+-- | Construct a tracer that prints the current peer simulator state in
+-- a block tree, highlighting the candidate fragments, selection, and forks in
+-- different colors, omitting uninteresting segments.
+peerSimStateDiagramTracer ::
+  Tracer m String ->
+  Tracer m PeerSimState
+peerSimStateDiagramTracer tracer =
+  Tracer (traceWith tracer . peerSimStateDiagram)
+
+-- | Construct a stateful tracer that prints the current peer simulator state in
+-- a block tree, highlighting the candidate fragments, selection, and forks in
+-- different colors, omitting uninteresting segments.
+--
+-- Since the tracer gets its input from concurrent state, it takes only a dummy
+-- @()@ value as its argument.
+peerSimStateDiagramSTMTracer ::
+  IOLike m =>
+  Tracer m String ->
+  BlockTree TestBlock ->
+  STM m TestFragH ->
+  STM m (Map PeerId TestFragH) ->
+  m (Tracer m ())
+peerSimStateDiagramSTMTracer stringTracer pssBlockTree selectionVar candidatesVar = do
+  peerCache <- uncheckedNewTVarM mempty
+  pure $ Tracer $ const $ do
+    (s, cachedPeers) <- atomically $ do
+      pssSelection <- selectionVar
+      pssCandidates <- candidatesVar
+      cachedPeers <- readTVar peerCache
+      pure (PeerSimState {pssBlockTree, pssSelection, pssCandidates}, cachedPeers)
+    let (blocks, newPeers) = peerSimStateDiagramWith (defaultRenderConfig {cachedPeers}) s
+    atomically (modifyTVar peerCache (newPeers <>))
+    traceWith stringTracer blocks
+
+-- | Construct a stateful tracer that prints the current peer simulator state in
+-- a block tree, highlighting the candidate fragments, selection, and forks in
+-- different colors, omitting uninteresting segments.
+--
+-- Since the tracer gets its input from concurrent state, it takes only a dummy
+-- @()@ value as its argument.
+--
+-- This variant uses the global debug tracer.
+peerSimStateDiagramSTMTracerDebug ::
+  IOLike m =>
+  BlockTree TestBlock ->
+  STM m TestFragH ->
+  STM m (Map PeerId TestFragH) ->
+  m (Tracer m ())
+peerSimStateDiagramSTMTracerDebug =
+  peerSimStateDiagramSTMTracer debugTracer

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/StateView.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/StateView.hs
@@ -1,0 +1,73 @@
+{-# LANGUAGE NamedFieldPuns #-}
+
+module Test.Consensus.PeerSimulator.StateView (
+    ChainSyncException (..)
+  , StateView (..)
+  , StateViewTracers (..)
+  , defaultStateViewTracers
+  , snapshotStateView
+  ) where
+
+import           Control.Tracer (Tracer)
+import           Ouroboros.Consensus.Storage.ChainDB (ChainDB)
+import qualified Ouroboros.Consensus.Storage.ChainDB as ChainDB
+import           Ouroboros.Consensus.Util.Condense (Condense (condense))
+import           Ouroboros.Consensus.Util.IOLike (IOLike, SomeException,
+                     atomically)
+import           Test.Consensus.PeerSimulator.Trace (terseFragH)
+import           Test.Consensus.PointSchedule (PeerId, TestFragH)
+import           Test.Util.TestBlock (TestBlock)
+import           Test.Util.Tracer (recordingTracerTVar)
+
+-- | A record to associate an exception thrown by the ChainSync
+-- thread with the peer that it was running for.
+data ChainSyncException = ChainSyncException
+       { csePeerId    :: PeerId
+       , cseException :: SomeException
+       }
+    deriving Show
+
+-- | A state view is a partial view of the state of the whole peer simulator.
+-- This includes information about the part of the code that is being tested
+-- (for instance the fragment that is selected by the ChainDB) but also
+-- information about the mocked peers (for instance the exceptions raised in the
+-- mocked ChainSync server threads).
+data StateView = StateView {
+    svSelectedChain       :: TestFragH,
+    svChainSyncExceptions :: [ChainSyncException]
+  }
+  deriving Show
+
+instance Condense StateView where
+  condense StateView {svSelectedChain, svChainSyncExceptions} =
+    "SelectedChain: " ++ terseFragH svSelectedChain ++ "\nChainSyncExceptions: " ++ show svChainSyncExceptions
+
+-- | State view tracers are a lightweight mechanism to record information that
+-- can later be used to produce a state view. This mechanism relies on
+-- contra-tracers which we already use in a pervasives way.
+data StateViewTracers m = StateViewTracers {
+    svtChainSyncExceptionsTracer :: Tracer m ChainSyncException
+  , svtGetChainSyncExceptions    :: m [ChainSyncException]
+  }
+
+-- | Make default state view tracers. The tracers are all freshly initialised
+-- and contain no information.
+defaultStateViewTracers ::
+  IOLike m =>
+  m (StateViewTracers m)
+defaultStateViewTracers = do
+  (svtChainSyncExceptionsTracer, svtGetChainSyncExceptions) <- recordingTracerTVar
+  pure StateViewTracers {svtChainSyncExceptionsTracer, svtGetChainSyncExceptions}
+
+-- | Use the state view tracers as well as some extra information to produce a
+-- state view. This mostly consists in reading and storing the current state of
+-- the tracers.
+snapshotStateView ::
+  IOLike m =>
+  StateViewTracers m ->
+  ChainDB m TestBlock ->
+  m StateView
+snapshotStateView StateViewTracers{svtGetChainSyncExceptions} chainDb = do
+  svChainSyncExceptions <- svtGetChainSyncExceptions
+  svSelectedChain <- atomically $ ChainDB.getCurrentChain chainDb
+  pure StateView {svSelectedChain, svChainSyncExceptions}

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/StateView.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/StateView.hs
@@ -15,7 +15,7 @@ import           Ouroboros.Consensus.Util.Condense (Condense (condense))
 import           Ouroboros.Consensus.Util.IOLike (IOLike, SomeException,
                      atomically)
 import           Test.Consensus.PointSchedule (PeerId, TestFragH)
-import           Test.Util.TersePrinting (terseFragH)
+import           Test.Util.TersePrinting (terseHFragment)
 import           Test.Util.TestBlock (TestBlock)
 import           Test.Util.Tracer (recordingTracerTVar)
 
@@ -44,7 +44,7 @@ data StateView = StateView {
 
 instance Condense StateView where
   condense StateView {svSelectedChain, svChainSyncExceptions} =
-    "SelectedChain: " ++ terseFragH svSelectedChain ++ "\n"
+    "SelectedChain: " ++ terseHFragment svSelectedChain ++ "\n"
     ++ "ChainSyncExceptions:\n" ++ unlines (("  - " ++) . condense <$> svChainSyncExceptions)
 
 -- | State view tracers are a lightweight mechanism to record information that

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/StateView.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/StateView.hs
@@ -14,8 +14,8 @@ import qualified Ouroboros.Consensus.Storage.ChainDB as ChainDB
 import           Ouroboros.Consensus.Util.Condense (Condense (condense))
 import           Ouroboros.Consensus.Util.IOLike (IOLike, SomeException,
                      atomically)
-import           Test.Consensus.PeerSimulator.Trace (terseFragH)
 import           Test.Consensus.PointSchedule (PeerId, TestFragH)
+import           Test.Util.TersePrinting (terseFragH)
 import           Test.Util.TestBlock (TestBlock)
 import           Test.Util.Tracer (recordingTracerTVar)
 

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/StateView.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/StateView.hs
@@ -27,6 +27,10 @@ data ChainSyncException = ChainSyncException
        }
     deriving Show
 
+instance Condense ChainSyncException where
+  condense ChainSyncException{csePeerId, cseException} =
+    condense csePeerId ++ ": " ++ show cseException
+
 -- | A state view is a partial view of the state of the whole peer simulator.
 -- This includes information about the part of the code that is being tested
 -- (for instance the fragment that is selected by the ChainDB) but also
@@ -40,7 +44,8 @@ data StateView = StateView {
 
 instance Condense StateView where
   condense StateView {svSelectedChain, svChainSyncExceptions} =
-    "SelectedChain: " ++ terseFragH svSelectedChain ++ "\nChainSyncExceptions: " ++ show svChainSyncExceptions
+    "SelectedChain: " ++ terseFragH svSelectedChain ++ "\n"
+    ++ "ChainSyncExceptions:\n" ++ unlines (("  - " ++) . condense <$> svChainSyncExceptions)
 
 -- | State view tracers are a lightweight mechanism to record information that
 -- can later be used to produce a state view. This mechanism relies on

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/StateView.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/StateView.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE LambdaCase     #-}
 {-# LANGUAGE NamedFieldPuns #-}
 
 module Test.Consensus.PeerSimulator.StateView (
@@ -19,7 +18,8 @@ import qualified Ouroboros.Consensus.Storage.ChainDB as ChainDB
 import           Ouroboros.Consensus.Util.Condense (Condense (condense))
 import           Ouroboros.Consensus.Util.IOLike (IOLike, SomeException,
                      atomically)
-import           Test.Consensus.PointSchedule (PeerId, TestFragH)
+import           Test.Consensus.PointSchedule (TestFragH)
+import           Test.Consensus.PointSchedule.Peers (PeerId)
 import           Test.Util.TersePrinting (terseHFragment)
 import           Test.Util.TestBlock (TestBlock)
 import           Test.Util.Tracer (recordingTracerTVar)

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests.hs
@@ -1,0 +1,9 @@
+module Test.Consensus.PeerSimulator.Tests (tests) where
+
+import qualified Test.Consensus.PeerSimulator.Tests.Timeouts as Timeouts
+import           Test.Tasty
+
+tests :: TestTree
+tests = testGroup "PeerSimulator" [
+    Timeouts.tests
+  ]

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests.hs
@@ -1,9 +1,11 @@
 module Test.Consensus.PeerSimulator.Tests (tests) where
 
+import qualified Test.Consensus.PeerSimulator.Tests.Rollback as Rollback
 import qualified Test.Consensus.PeerSimulator.Tests.Timeouts as Timeouts
 import           Test.Tasty
 
 tests :: TestTree
 tests = testGroup "PeerSimulator" [
+    Rollback.tests,
     Timeouts.tests
   ]

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
@@ -21,10 +21,18 @@ import           Test.Tasty
 import           Test.Tasty.QuickCheck
 import           Test.Util.Orphans.IOLike ()
 import           Test.Util.TestBlock (TestBlock, unTestHash)
+import           Test.Util.TestEnv (adjustQuickCheckTests)
 
 tests :: TestTree
 tests = testGroup "rollback" [
-  testProperty "can rollback" (prop_rollback True),
+  -- NOTE: The property @prop_rollback True@ discards a lot of inputs, making
+  -- it quite flakey. We increase the maximum number of discarded tests per
+  -- successful ones so as to make this test more reliable.
+  adjustQuickCheckTests (`div` 10) $
+  localOption (QuickCheckMaxRatio 100) $
+  testProperty "can rollback" (prop_rollback True)
+  ,
+  adjustQuickCheckTests (`div` 10) $
   testProperty "cannot rollback" (prop_rollback False)
   ]
 

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
@@ -1,0 +1,90 @@
+{-# LANGUAGE BlockArguments      #-}
+{-# LANGUAGE DerivingStrategies  #-}
+{-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Test.Consensus.PeerSimulator.Tests.Rollback (tests) where
+
+import           Control.Monad.IOSim (runSimOrThrow)
+import           Data.Maybe (fromJust)
+import           Ouroboros.Consensus.Block (ChainHash (..))
+import           Ouroboros.Consensus.Config.SecurityParam
+import qualified Ouroboros.Network.AnchoredFragment as AF
+import           Test.Consensus.BlockTree (BlockTree (..), BlockTreeBranch (..))
+import           Test.Consensus.Genesis.Setup
+import           Test.Consensus.PeerSimulator.Run (noTimeoutsSchedulerConfig)
+import           Test.Consensus.PeerSimulator.StateView
+import           Test.Consensus.PointSchedule
+import qualified Test.QuickCheck as QC
+import           Test.QuickCheck
+import           Test.Tasty
+import           Test.Tasty.QuickCheck
+import           Test.Util.Orphans.IOLike ()
+import           Test.Util.TestBlock (TestBlock, unTestHash)
+
+tests :: TestTree
+tests = testGroup "rollback" [
+  testProperty "can rollback" (prop_rollback True),
+  testProperty "cannot rollback" (prop_rollback False)
+  ]
+
+-- | @prop_rollback True@ tests that the selection of the node under test
+-- changes branches when sent a rollback to a block no older than 'k' blocks
+-- before the current selection.
+--
+-- @prop_rollback False@ tests that the selection of the node under test *does
+-- not* change branches when sent a rollback to a block strictly older than 'k'
+-- blocks before the current selection.
+prop_rollback :: Bool -> QC.Gen QC.Property
+prop_rollback wantRollback = do
+  genesisTest <- genChains 1
+
+  let schedule = rollbackSchedule (gtBlockTree genesisTest)
+
+  -- | We consider the test case interesting if we want a rollback and we can
+  -- actually get one, or if we want no rollback and we cannot actually get one.
+  pure $
+    wantRollback == canRollbackFromTrunkTip (gtSecurityParam genesisTest) (gtBlockTree genesisTest)
+    ==>
+      runSimOrThrow $ runTest schedulerConfig genesisTest schedule $ \StateView{svSelectedChain} ->
+        let headOnAlternativeChain = case AF.headHash svSelectedChain of
+              GenesisHash    -> False
+              BlockHash hash -> any (0 /=) $ unTestHash hash
+        in
+        -- The test passes if we want a rollback and we actually end up on the
+        -- alternative chain or if we want no rollback and end up on the trunk.
+        wantRollback == headOnAlternativeChain
+
+  where
+    schedulerConfig = noTimeoutsSchedulerConfig defaultPointScheduleConfig
+
+    -- A schedule that advertises all the points of the trunk, then switches to
+    -- the first alternative chain of the given block tree.
+    --
+    -- PRECONDITION: Block tree with at least one alternative chain.
+    rollbackSchedule :: BlockTree TestBlock -> PointSchedule
+    rollbackSchedule blockTree =
+      let trunk = btTrunk blockTree
+          branch = btbSuffix $ head $ btBranches blockTree
+          states = banalStates trunk ++ banalStates branch
+          peers = peersOnlyHonest states
+          pointSchedule = balanced peers
+       in fromJust pointSchedule
+
+    -- | Whether it is possible to roll back from the trunk after having served
+    -- it fully, that is whether there is an alternative chain that forks of the
+    -- trunk no more than 'k' blocks from the tip and that is longer than the
+    -- trunk.
+    --
+    -- PRECONDITION: Block tree with exactly one alternative chain, otherwise
+    -- this property does not make sense. With no alternative chain, this will
+    -- even crash.
+    --
+    -- REVIEW: Why does 'existsSelectableAdversary' get to be a classifier and
+    -- not this? (or a generalised version of this)
+    canRollbackFromTrunkTip :: SecurityParam -> BlockTree TestBlock -> Bool
+    canRollbackFromTrunkTip (SecurityParam k) blockTree =
+      let BlockTreeBranch{btbSuffix, btbTrunkSuffix} = head $ btBranches blockTree
+          lengthSuffix = AF.length btbSuffix
+          lengthTrunkSuffix = AF.length btbTrunkSuffix
+       in lengthTrunkSuffix <= fromIntegral k && lengthSuffix > lengthTrunkSuffix

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
@@ -68,7 +68,7 @@ prop_rollback wantRollback = do
           branch = btbSuffix $ head $ btBranches blockTree
           states = banalStates trunk ++ banalStates branch
           peers = peersOnlyHonest states
-          pointSchedule = balanced peers
+          pointSchedule = balanced defaultPointScheduleConfig peers
        in fromJust pointSchedule
 
     -- | Whether it is possible to roll back from the trunk after having served

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
@@ -5,7 +5,6 @@
 
 module Test.Consensus.PeerSimulator.Tests.Rollback (tests) where
 
-import           Control.Monad.IOSim (runSimOrThrow)
 import           Ouroboros.Consensus.Block (ChainHash (..))
 import           Ouroboros.Consensus.Config.SecurityParam
 import qualified Ouroboros.Network.AnchoredFragment as AF
@@ -46,7 +45,7 @@ prop_rollback = do
   pure $
     alternativeChainIsLongEnough (gtSecurityParam genesisTest) (gtBlockTree genesisTest)
     ==>
-      runSimOrThrow $ runTest schedulerConfig genesisTest schedule $ \StateView{svSelectedChain} ->
+      runGenesisTest schedulerConfig genesisTest schedule $ \StateView{svSelectedChain} ->
         let headOnAlternativeChain = case AF.headHash svSelectedChain of
               GenesisHash    -> False
               BlockHash hash -> any (0 /=) $ unTestHash hash
@@ -72,7 +71,7 @@ prop_cannotRollback = do
   pure $
     alternativeChainIsLongEnough (gtSecurityParam genesisTest) (gtBlockTree genesisTest)
     ==>
-      runSimOrThrow $ runTest schedulerConfig genesisTest schedule $ \StateView{svSelectedChain} ->
+      runGenesisTest schedulerConfig genesisTest schedule $ \StateView{svSelectedChain} ->
         let headOnAlternativeChain = case AF.headHash svSelectedChain of
               GenesisHash    -> False
               BlockHash hash -> any (0 /=) $ unTestHash hash

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
@@ -45,6 +45,8 @@ prop_rollback = do
 
     (noTimeoutsSchedulerConfig defaultPointScheduleConfig)
 
+    (\_ _ _ -> [])
+
     (\_ _ -> not . hashOnTrunk . AF.headHash . svSelectedChain)
 
 -- @prop_cannotRollback@ tests that the selection of the node under test *does
@@ -60,6 +62,8 @@ prop_cannotRollback =
           else discard)
 
     (noTimeoutsSchedulerConfig defaultPointScheduleConfig)
+
+    (\_ _ _ -> [])
 
     (\_ _ -> hashOnTrunk . AF.headHash . svSelectedChain)
 

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
@@ -6,7 +6,6 @@
 module Test.Consensus.PeerSimulator.Tests.Rollback (tests) where
 
 import           Control.Monad.IOSim (runSimOrThrow)
-import           Data.Maybe (fromJust)
 import           Ouroboros.Consensus.Block (ChainHash (..))
 import           Ouroboros.Consensus.Config.SecurityParam
 import qualified Ouroboros.Network.AnchoredFragment as AF
@@ -45,7 +44,7 @@ tests = testGroup "rollback" [
 -- blocks before the current selection.
 prop_rollback :: Bool -> QC.Gen QC.Property
 prop_rollback wantRollback = do
-  genesisTest <- genChains 1
+  genesisTest <- genChains (pure 1)
 
   let schedule = rollbackSchedule (gtBlockTree genesisTest)
 
@@ -77,7 +76,7 @@ prop_rollback wantRollback = do
           states = banalStates trunk ++ banalStates branch
           peers = peersOnlyHonest states
           pointSchedule = balanced defaultPointScheduleConfig peers
-       in fromJust pointSchedule
+       in pointSchedule
 
     -- | Whether it is possible to roll back from the trunk after having served
     -- it fully, that is whether there is an alternative chain that forks of the

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
@@ -13,6 +13,7 @@ import           Test.Consensus.Genesis.Setup
 import           Test.Consensus.PeerSimulator.Run (noTimeoutsSchedulerConfig)
 import           Test.Consensus.PeerSimulator.StateView
 import           Test.Consensus.PointSchedule
+import           Test.Consensus.PointSchedule.Peers (peersOnlyHonest)
 import           Test.QuickCheck
 import           Test.Tasty
 import           Test.Tasty.QuickCheck

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
@@ -71,8 +71,6 @@ prop_cannotRollback = do
   -- the implementation doesn't
   pure $
     alternativeChainIsLongEnough (gtSecurityParam genesisTest) (gtBlockTree genesisTest)
-      &&
-    honestChainIsLongEnough (gtSecurityParam genesisTest) (gtBlockTree genesisTest)
     ==>
       runSimOrThrow $ runTest schedulerConfig genesisTest schedule $ \StateView{svSelectedChain} ->
         let headOnAlternativeChain = case AF.headHash svSelectedChain of
@@ -102,18 +100,6 @@ rollbackSchedule n blockTree =
       peers = peersOnlyHonest states
       pointSchedule = balanced defaultPointScheduleConfig peers
    in pointSchedule
-
--- | Whether the honest chain has more than 'k' blocks after the
--- intersection with the alternative chain.
---
--- PRECONDITION: Block tree with exactly one alternative chain, otherwise
--- this property does not make sense. With no alternative chain, this will
--- even crash.
-honestChainIsLongEnough :: SecurityParam -> BlockTree TestBlock -> Bool
-honestChainIsLongEnough (SecurityParam k) blockTree =
-  let BlockTreeBranch{btbTrunkSuffix} = head $ btBranches blockTree
-      lengthTrunkSuffix = AF.length btbTrunkSuffix
-   in lengthTrunkSuffix > fromIntegral k
 
 -- | Whether the alternative chain has more than 'k' blocks after the
 -- intersection with the honest chain.

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
@@ -24,74 +24,105 @@ import           Test.Util.TestEnv (adjustQuickCheckTests)
 
 tests :: TestTree
 tests = testGroup "rollback" [
-  -- NOTE: The property @prop_rollback True@ discards a lot of inputs, making
-  -- it quite flakey. We increase the maximum number of discarded tests per
-  -- successful ones so as to make this test more reliable.
   adjustQuickCheckTests (`div` 10) $
   localOption (QuickCheckMaxRatio 100) $
-  testProperty "can rollback" (prop_rollback True)
+  testProperty "can rollback" prop_rollback
   ,
   adjustQuickCheckTests (`div` 10) $
-  testProperty "cannot rollback" (prop_rollback False)
+  testProperty "cannot rollback" prop_cannotRollback
   ]
 
--- | @prop_rollback True@ tests that the selection of the node under test
+-- | @prop_rollback@ tests that the selection of the node under test
 -- changes branches when sent a rollback to a block no older than 'k' blocks
 -- before the current selection.
---
--- @prop_rollback False@ tests that the selection of the node under test *does
--- not* change branches when sent a rollback to a block strictly older than 'k'
--- blocks before the current selection.
-prop_rollback :: Bool -> QC.Gen QC.Property
-prop_rollback wantRollback = do
+prop_rollback :: QC.Gen QC.Property
+prop_rollback = do
   genesisTest <- genChains (pure 1)
 
-  let schedule = rollbackSchedule (gtBlockTree genesisTest)
+  let SecurityParam k = gtSecurityParam genesisTest
+      schedule = rollbackSchedule (fromIntegral k) (gtBlockTree genesisTest)
 
-  -- | We consider the test case interesting if we want a rollback and we can
-  -- actually get one, or if we want no rollback and we cannot actually get one.
+  -- We consider the test case interesting if we can rollback
   pure $
-    wantRollback == canRollbackFromTrunkTip (gtSecurityParam genesisTest) (gtBlockTree genesisTest)
+    alternativeChainIsLongEnough (gtSecurityParam genesisTest) (gtBlockTree genesisTest)
     ==>
       runSimOrThrow $ runTest schedulerConfig genesisTest schedule $ \StateView{svSelectedChain} ->
         let headOnAlternativeChain = case AF.headHash svSelectedChain of
               GenesisHash    -> False
               BlockHash hash -> any (0 /=) $ unTestHash hash
         in
-        -- The test passes if we want a rollback and we actually end up on the
-        -- alternative chain or if we want no rollback and end up on the trunk.
-        wantRollback == headOnAlternativeChain
+        -- The test passes if we end up on the alternative chain
+        headOnAlternativeChain
 
   where
     schedulerConfig = noTimeoutsSchedulerConfig defaultPointScheduleConfig
 
-    -- A schedule that advertises all the points of the trunk, then switches to
-    -- the first alternative chain of the given block tree.
-    --
-    -- PRECONDITION: Block tree with at least one alternative chain.
-    rollbackSchedule :: BlockTree TestBlock -> PointSchedule
-    rollbackSchedule blockTree =
-      let trunk = btTrunk blockTree
-          branch = btbSuffix $ head $ btBranches blockTree
-          states = banalStates trunk ++ banalStates branch
-          peers = peersOnlyHonest states
-          pointSchedule = balanced defaultPointScheduleConfig peers
-       in pointSchedule
+-- @prop_cannotRollback@ tests that the selection of the node under test *does
+-- not* change branches when sent a rollback to a block strictly older than 'k'
+-- blocks before the current selection.
+prop_cannotRollback :: QC.Gen QC.Property
+prop_cannotRollback = do
+  genesisTest <- genChains (pure 1)
 
-    -- | Whether it is possible to roll back from the trunk after having served
-    -- it fully, that is whether there is an alternative chain that forks of the
-    -- trunk no more than 'k' blocks from the tip and that is longer than the
-    -- trunk.
-    --
-    -- PRECONDITION: Block tree with exactly one alternative chain, otherwise
-    -- this property does not make sense. With no alternative chain, this will
-    -- even crash.
-    --
-    -- REVIEW: Why does 'existsSelectableAdversary' get to be a classifier and
-    -- not this? (or a generalised version of this)
-    canRollbackFromTrunkTip :: SecurityParam -> BlockTree TestBlock -> Bool
-    canRollbackFromTrunkTip (SecurityParam k) blockTree =
-      let BlockTreeBranch{btbSuffix, btbTrunkSuffix} = head $ btBranches blockTree
-          lengthSuffix = AF.length btbSuffix
-          lengthTrunkSuffix = AF.length btbTrunkSuffix
-       in lengthTrunkSuffix <= fromIntegral k && lengthSuffix > lengthTrunkSuffix
+  let SecurityParam k = gtSecurityParam genesisTest
+      schedule = rollbackSchedule (fromIntegral (k + 1)) (gtBlockTree genesisTest)
+
+  -- We consider the test case interesting if it allows to rollback even if
+  -- the implementation doesn't
+  pure $
+    alternativeChainIsLongEnough (gtSecurityParam genesisTest) (gtBlockTree genesisTest)
+      &&
+    honestChainIsLongEnough (gtSecurityParam genesisTest) (gtBlockTree genesisTest)
+    ==>
+      runSimOrThrow $ runTest schedulerConfig genesisTest schedule $ \StateView{svSelectedChain} ->
+        let headOnAlternativeChain = case AF.headHash svSelectedChain of
+              GenesisHash    -> False
+              BlockHash hash -> any (0 /=) $ unTestHash hash
+        in
+        -- The test passes if we end up on the trunk.
+        not headOnAlternativeChain
+
+  where
+    schedulerConfig = noTimeoutsSchedulerConfig defaultPointScheduleConfig
+
+-- | A schedule that advertises all the points of the trunk up until the nth
+-- block after the intersection, then switches to the first alternative
+-- chain of the given block tree.
+--
+-- PRECONDITION: Block tree with at least one alternative chain.
+rollbackSchedule :: Int -> BlockTree TestBlock -> PointSchedule
+rollbackSchedule n blockTree =
+  let branch = head $ btBranches blockTree
+      trunkSuffix = AF.takeOldest n (btbTrunkSuffix branch)
+      states = concat
+        [ banalStates (btbPrefix branch)
+        , banalStates trunkSuffix
+        , banalStates (btbSuffix branch)
+        ]
+      peers = peersOnlyHonest states
+      pointSchedule = balanced defaultPointScheduleConfig peers
+   in pointSchedule
+
+-- | Whether the honest chain has more than 'k' blocks after the
+-- intersection with the alternative chain.
+--
+-- PRECONDITION: Block tree with exactly one alternative chain, otherwise
+-- this property does not make sense. With no alternative chain, this will
+-- even crash.
+honestChainIsLongEnough :: SecurityParam -> BlockTree TestBlock -> Bool
+honestChainIsLongEnough (SecurityParam k) blockTree =
+  let BlockTreeBranch{btbTrunkSuffix} = head $ btBranches blockTree
+      lengthTrunkSuffix = AF.length btbTrunkSuffix
+   in lengthTrunkSuffix > fromIntegral k
+
+-- | Whether the alternative chain has more than 'k' blocks after the
+-- intersection with the honest chain.
+--
+-- PRECONDITION: Block tree with exactly one alternative chain, otherwise
+-- this property does not make sense. With no alternative chain, this will
+-- even crash.
+alternativeChainIsLongEnough :: SecurityParam -> BlockTree TestBlock -> Bool
+alternativeChainIsLongEnough (SecurityParam k) blockTree =
+  let BlockTreeBranch{btbSuffix} = head $ btBranches blockTree
+      lengthSuffix = AF.length btbSuffix
+   in lengthSuffix > fromIntegral k

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
@@ -45,7 +45,7 @@ prop_rollback = do
   pure $
     alternativeChainIsLongEnough (gtSecurityParam genesisTest) (gtBlockTree genesisTest)
     ==>
-      runGenesisTest schedulerConfig genesisTest schedule $ \StateView{svSelectedChain} ->
+      runGenesisTest' schedulerConfig genesisTest schedule $ \StateView{svSelectedChain} ->
         let headOnAlternativeChain = case AF.headHash svSelectedChain of
               GenesisHash    -> False
               BlockHash hash -> any (0 /=) $ unTestHash hash
@@ -71,7 +71,7 @@ prop_cannotRollback = do
   pure $
     alternativeChainIsLongEnough (gtSecurityParam genesisTest) (gtBlockTree genesisTest)
     ==>
-      runGenesisTest schedulerConfig genesisTest schedule $ \StateView{svSelectedChain} ->
+      runGenesisTest' schedulerConfig genesisTest schedule $ \StateView{svSelectedChain} ->
         let headOnAlternativeChain = case AF.headHash svSelectedChain of
               GenesisHash    -> False
               BlockHash hash -> any (0 /=) $ unTestHash hash

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
@@ -44,7 +44,7 @@ prop_rollback = do
 
     (noTimeoutsSchedulerConfig defaultPointScheduleConfig)
 
-    (not . hashOnTrunk . AF.headHash . svSelectedChain)
+    (\_ _ -> not . hashOnTrunk . AF.headHash . svSelectedChain)
 
 -- @prop_cannotRollback@ tests that the selection of the node under test *does
 -- not* change branches when sent a rollback to a block strictly older than 'k'
@@ -60,7 +60,7 @@ prop_cannotRollback =
 
     (noTimeoutsSchedulerConfig defaultPointScheduleConfig)
 
-    (hashOnTrunk . AF.headHash . svSelectedChain)
+    (\_ _ -> hashOnTrunk . AF.headHash . svSelectedChain)
 
 -- | A schedule that advertises all the points of the trunk up until the nth
 -- block after the intersection, then switches to the first alternative

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
@@ -33,7 +33,7 @@ tests = adjustQuickCheckTests (`div` 10) $ testProperty "timeouts" prop_timeouts
 
 prop_timeouts :: QC.Gen QC.Property
 prop_timeouts = do
-  genesisTest <- genChains 0
+  genesisTest <- genChains (pure 0)
 
   -- Use higher tick duration to avoid the test taking really long
   let scSchedule = PointScheduleConfig {pscTickDuration = 1}
@@ -69,7 +69,7 @@ prop_timeouts = do
           headerPoint = HeaderPoint $ At (getHeader tipBlock)
           blockPoint = BlockPoint (At tipBlock)
           state = Peer HonestPeer $ NodeOnline $ AdvertisedPoints tipPoint headerPoint blockPoint
-          tick = Tick { active = state, duration = pscTickDuration scheduleConfig }
+          tick = Tick { active = state, duration = pscTickDuration scheduleConfig, number = 0 }
           maximumNumberOfTicks = round $ timeout / pscTickDuration scheduleConfig
       in
       PointSchedule (tick :| replicate maximumNumberOfTicks tick) (HonestPeer :| [])

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
@@ -13,6 +13,7 @@ import qualified Ouroboros.Network.AnchoredFragment as AF
 import           Ouroboros.Network.Block (tipFromHeader)
 import           Ouroboros.Network.Driver.Limits
                      (ProtocolLimitFailure (ExceededTimeLimit))
+import           Ouroboros.Network.Point (WithOrigin (At))
 import           Ouroboros.Network.Protocol.ChainSync.Codec (mustReplyTimeout)
 import           Test.Consensus.BlockTree (btTrunk)
 import           Test.Consensus.Genesis.Setup
@@ -64,8 +65,8 @@ prop_timeouts = do
     dullSchedule _ _ (AF.Empty _) = error "requires a non-empty block tree"
     dullSchedule scheduleConfig timeout (_ AF.:> tipBlock) =
       let tipPoint = TipPoint $ tipFromHeader tipBlock
-          headerPoint = HeaderPoint $ getHeader tipBlock
-          blockPoint = BlockPoint tipBlock
+          headerPoint = HeaderPoint $ At (getHeader tipBlock)
+          blockPoint = BlockPoint (At tipBlock)
           state = Peer HonestPeer $ NodeOnline $ AdvertisedPoints tipPoint headerPoint blockPoint
           tick = Tick { active = state, duration = pscTickDuration scheduleConfig }
           maximumNumberOfTicks = round $ timeout / pscTickDuration scheduleConfig

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
@@ -17,6 +17,7 @@ import           Test.Consensus.PeerSimulator.Run (SchedulerConfig (..),
                      defaultSchedulerConfig)
 import           Test.Consensus.PeerSimulator.StateView
 import           Test.Consensus.PointSchedule
+import           Test.Consensus.PointSchedule.Peers (Peer (..), PeerId (..))
 import           Test.QuickCheck
 import           Test.Tasty
 import           Test.Tasty.QuickCheck

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
@@ -67,7 +67,7 @@ prop_timeouts = do
           headerPoint = HeaderPoint $ getHeader tipBlock
           blockPoint = BlockPoint tipBlock
           state = Peer HonestPeer $ NodeOnline $ AdvertisedPoints tipPoint headerPoint blockPoint
-          tick = Tick { active = state }
+          tick = Tick { active = state, duration = pscTickDuration scheduleConfig }
           maximumNumberOfTicks = round $ timeout / pscTickDuration scheduleConfig
       in
       PointSchedule (tick :| replicate maximumNumberOfTicks tick) (HonestPeer :| [])

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
@@ -43,7 +43,7 @@ prop_timeouts = do
           (btTrunk $ gtBlockTree genesisTest)
 
   pure $
-    runGenesisTest schedulerConfig genesisTest schedule $ \stateView ->
+    runGenesisTest' schedulerConfig genesisTest schedule $ \stateView ->
       case svChainSyncExceptions stateView of
         [] ->
           counterexample ("result: " ++ condense (svSelectedChain stateView)) False

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
@@ -1,0 +1,73 @@
+{-# LANGUAGE LambdaCase     #-}
+{-# LANGUAGE NamedFieldPuns #-}
+
+module Test.Consensus.PeerSimulator.Tests.Timeouts (tests) where
+
+import           Control.Monad.IOSim (runSimOrThrow)
+import           Data.List.NonEmpty (NonEmpty ((:|)))
+import           Data.Maybe (fromJust)
+import           Ouroboros.Consensus.Block (getHeader)
+import           Ouroboros.Consensus.Util.Condense
+import           Ouroboros.Consensus.Util.IOLike (DiffTime, fromException)
+import qualified Ouroboros.Network.AnchoredFragment as AF
+import           Ouroboros.Network.Block (tipFromHeader)
+import           Ouroboros.Network.Driver.Limits
+                     (ProtocolLimitFailure (ExceededTimeLimit))
+import           Ouroboros.Network.Protocol.ChainSync.Codec (mustReplyTimeout)
+import           Test.Consensus.BlockTree (btTrunk)
+import           Test.Consensus.Genesis.Setup
+import           Test.Consensus.PeerSimulator.Run (SchedulerConfig (..),
+                     defaultSchedulerConfig)
+import           Test.Consensus.PeerSimulator.StateView
+import           Test.Consensus.PointSchedule
+import qualified Test.QuickCheck as QC
+import           Test.QuickCheck
+import           Test.Tasty
+import           Test.Tasty.QuickCheck
+import           Test.Util.Orphans.IOLike ()
+
+tests :: TestTree
+tests = testProperty "timeouts" prop_timeouts
+
+prop_timeouts :: QC.Gen QC.Property
+prop_timeouts = do
+  genesisTest <- genChains 0
+
+  -- Use higher tick duration to avoid the test taking really long
+  let scSchedule = PointScheduleConfig {pscTickDuration = 1}
+
+      schedulerConfig = defaultSchedulerConfig scSchedule (gtHonestAsc genesisTest)
+
+      schedule =
+        dullSchedule
+          scSchedule
+          (fromJust $ mustReplyTimeout (scChainSyncTimeouts schedulerConfig))
+          (btTrunk $ gtBlockTree genesisTest)
+
+  pure $ withMaxSuccess 10 $ runSimOrThrow $
+    runTest schedulerConfig genesisTest schedule $ \stateView ->
+      case svChainSyncExceptions stateView of
+        [] ->
+          counterexample ("result: " ++ condense (svSelectedChain stateView)) False
+        [exn] ->
+          case fromException $ cseException exn of
+            Just (ExceededTimeLimit _) -> property True
+            _ -> counterexample ("exception: " ++ show exn) False
+        exns ->
+          counterexample ("exceptions: " ++ show exns) False
+
+  where
+
+    -- A schedule that advertises all the points of the chain from the start but
+    -- contains just one too many ticks, therefore reaching the timeouts.
+    dullSchedule :: PointScheduleConfig -> DiffTime -> TestFrag -> PointSchedule
+    dullSchedule _ _ (AF.Empty _) = error "requires a non-empty block tree"
+    dullSchedule scheduleConfig timeout (_ AF.:> tipBlock) =
+      let tipPoint = TipPoint $ tipFromHeader tipBlock
+          headerPoint = HeaderPoint $ getHeader tipBlock
+          blockPoint = BlockPoint tipBlock
+          state = Peer HonestPeer $ NodeOnline $ AdvertisedPoints tipPoint headerPoint blockPoint
+          tick = Tick { active = state }
+          maximumNumberOfTicks = round $ timeout / pscTickDuration scheduleConfig
+      in
+      PointSchedule (tick :| replicate maximumNumberOfTicks tick) (HonestPeer :| [])

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
@@ -26,9 +26,10 @@ import           Test.QuickCheck
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
 import           Test.Util.Orphans.IOLike ()
+import           Test.Util.TestEnv (adjustQuickCheckTests)
 
 tests :: TestTree
-tests = testProperty "timeouts" prop_timeouts
+tests = adjustQuickCheckTests (`div` 10) $ testProperty "timeouts" prop_timeouts
 
 prop_timeouts :: QC.Gen QC.Property
 prop_timeouts = do
@@ -45,7 +46,7 @@ prop_timeouts = do
           (fromJust $ mustReplyTimeout (scChainSyncTimeouts schedulerConfig))
           (btTrunk $ gtBlockTree genesisTest)
 
-  pure $ withMaxSuccess 10 $ runSimOrThrow $
+  pure $ runSimOrThrow $
     runTest schedulerConfig genesisTest schedule $ \stateView ->
       case svChainSyncExceptions stateView of
         [] ->

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
@@ -1,6 +1,3 @@
-{-# LANGUAGE LambdaCase     #-}
-{-# LANGUAGE NamedFieldPuns #-}
-
 module Test.Consensus.PeerSimulator.Tests.Timeouts (tests) where
 
 import           Control.Monad.IOSim (runSimOrThrow)
@@ -36,13 +33,13 @@ prop_timeouts = do
   genesisTest <- genChains (pure 0)
 
   -- Use higher tick duration to avoid the test taking really long
-  let scSchedule = PointScheduleConfig {pscTickDuration = 1}
+  let scSchedule' = PointScheduleConfig {pscTickDuration = 1}
 
-      schedulerConfig = defaultSchedulerConfig scSchedule (gtHonestAsc genesisTest)
+      schedulerConfig = defaultSchedulerConfig scSchedule' (gtHonestAsc genesisTest)
 
       schedule =
         dullSchedule
-          scSchedule
+          scSchedule'
           (fromJust $ mustReplyTimeout (scChainSyncTimeouts schedulerConfig))
           (btTrunk $ gtBlockTree genesisTest)
 

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
@@ -1,6 +1,5 @@
 module Test.Consensus.PeerSimulator.Tests.Timeouts (tests) where
 
-import           Control.Monad.IOSim (runSimOrThrow)
 import           Data.List.NonEmpty (NonEmpty ((:|)))
 import           Data.Maybe (fromJust)
 import           Ouroboros.Consensus.Block (getHeader)
@@ -43,8 +42,8 @@ prop_timeouts = do
           (fromJust $ mustReplyTimeout (scChainSyncTimeouts schedulerConfig))
           (btTrunk $ gtBlockTree genesisTest)
 
-  pure $ runSimOrThrow $
-    runTest schedulerConfig genesisTest schedule $ \stateView ->
+  pure $
+    runGenesisTest schedulerConfig genesisTest schedule $ \stateView ->
       case svChainSyncExceptions stateView of
         [] ->
           counterexample ("result: " ++ condense (svSelectedChain stateView)) False

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
@@ -17,7 +17,6 @@ import           Test.Consensus.PeerSimulator.Run (SchedulerConfig (..),
                      defaultSchedulerConfig)
 import           Test.Consensus.PeerSimulator.StateView
 import           Test.Consensus.PointSchedule
-import qualified Test.QuickCheck as QC
 import           Test.QuickCheck
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
@@ -27,7 +26,7 @@ import           Test.Util.TestEnv (adjustQuickCheckTests)
 tests :: TestTree
 tests = adjustQuickCheckTests (`div` 10) $ testProperty "timeouts" prop_timeouts
 
-prop_timeouts :: QC.Gen QC.Property
+prop_timeouts :: Gen Property
 prop_timeouts = do
   genesisTest <- genChains (pure 0)
 
@@ -42,6 +41,9 @@ prop_timeouts = do
           (fromJust $ mustReplyTimeout (scChainSyncTimeouts schedulerConfig))
           (btTrunk $ gtBlockTree genesisTest)
 
+  -- NOTE: Because the scheduler configuration depends on the generated
+  -- 'GenesisTest' itself, we cannot rely on helpers such as
+  -- 'forAllGenesisTest'.
   pure $
     runGenesisTest' schedulerConfig genesisTest schedule $ \stateView ->
       case svChainSyncExceptions stateView of

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Trace.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Trace.hs
@@ -7,6 +7,7 @@
 module Test.Consensus.PeerSimulator.Trace (
     mkCdbTracer
   , mkChainSyncClientTracer
+  , prettyTime
   , terseBlock
   , terseFrag
   , terseFragH
@@ -75,20 +76,20 @@ mkChainSyncClientTracer tracer =
   where
     trace = traceUnitWith tracer "ChainSyncClient"
 
+prettyTime :: MonadMonotonicTime m => m String
+prettyTime = do
+  Time time <- getMonotonicTime
+  let ps = diffTimeToPicoseconds time
+      milliseconds = (ps `div` 1_000_000_000) `mod` 1_000
+      seconds = (ps `div` 1_000_000_000_000) `rem` 60
+      minutes = (ps `div` 1_000_000_000_000) `quot` 60
+  pure $ printf "%02d:%02d.%03d" minutes seconds milliseconds
+
 -- | Trace using the given tracer, printing the current time (typically the time
 -- of the simulation) and the unit name.
-traceUnitWith :: MonadMonotonicTime m => Tracer m String -> String -> String -> m ()
-traceUnitWith tracer unit msg = do
-  time <- getMonotonicTime
-  traceWith tracer $ printf "%s %s | %s" (showTime time) unit msg
-  where
-    showTime :: Time -> String
-    showTime (Time time) =
-      let ps = diffTimeToPicoseconds time
-          milliseconds = (ps `div` 1_000_000_000) `mod` 1_000
-          seconds = (ps `div` 1_000_000_000_000) `rem` 60
-          minutes = (ps `div` 1_000_000_000_000) `quot` 60
-       in printf "%02d:%02d.%03d" minutes seconds milliseconds
+traceUnitWith :: Tracer m String -> String -> String -> m ()
+traceUnitWith tracer unit msg =
+  traceWith tracer $ printf "%s | %s" unit msg
 
 traceLinesWith ::
   Tracer m String ->

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Trace.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Trace.hs
@@ -19,9 +19,10 @@ import           Ouroboros.Consensus.MiniProtocol.ChainSync.Client
 import qualified Ouroboros.Consensus.Storage.ChainDB.Impl as ChainDB.Impl
 import           Ouroboros.Consensus.Storage.ChainDB.Impl.Types
                      (SelectionChangedInfo (..), TraceAddBlockEvent (..))
-import           Ouroboros.Consensus.Util.Condense (Condense (..))
 import           Ouroboros.Consensus.Util.IOLike (IOLike, MonadMonotonicTime,
                      Time (Time), getMonotonicTime)
+import           Test.Util.TersePrinting (terseHFragment, tersePoint,
+                     terseRealPoint)
 import           Test.Util.TestBlock (TestBlock)
 import           Text.Printf (printf)
 
@@ -35,11 +36,11 @@ mkCdbTracer tracer =
       case event of
         AddedToCurrentChain _ SelectionChangedInfo {newTipPoint} _ _ -> do
           trace "Added to current chain"
-          trace $ "New tip: " ++ condense newTipPoint
+          trace $ "New tip: " ++ terseRealPoint newTipPoint
         SwitchedToAFork _ SelectionChangedInfo {newTipPoint} _ newFragment -> do
           trace "Switched to a fork"
-          trace $ "New tip: " ++ condense newTipPoint
-          trace $ "New fragment: " ++ condense newFragment
+          trace $ "New tip: " ++ terseRealPoint newTipPoint
+          trace $ "New fragment: " ++ terseHFragment newFragment
         _ -> pure ()
     _ -> pure ()
   where
@@ -52,9 +53,9 @@ mkChainSyncClientTracer ::
 mkChainSyncClientTracer tracer =
   Tracer $ \case
     TraceRolledBack point ->
-      trace $ "Rolled back to: " ++ condense point
+      trace $ "Rolled back to: " ++ tersePoint point
     TraceFoundIntersection point _ourTip _theirTip ->
-      trace $ "Found intersection at: " ++ condense point
+      trace $ "Found intersection at: " ++ tersePoint point
     _ -> pure ()
   where
     trace = traceUnitWith tracer "ChainSyncClient"

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Trace.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Trace.hs
@@ -36,9 +36,9 @@ import           Ouroboros.Consensus.Util.Condense (Condense (..))
 import           Ouroboros.Consensus.Util.IOLike (IOLike, MonadMonotonicTime,
                      Time (Time), getMonotonicTime)
 import           Ouroboros.Network.AnchoredFragment
-                     (Anchor (Anchor, AnchorGenesis), AnchoredSeq (Empty),
-                     anchor, mapAnchoredFragment, toOldestFirst)
-import           Test.Consensus.PointSchedule (TestFrag, TestFragH)
+                     (Anchor (Anchor, AnchorGenesis), AnchoredFragment,
+                     AnchoredSeq (Empty), anchor, mapAnchoredFragment,
+                     toOldestFirst)
 import           Test.Util.TestBlock (Header (TestHeader), TestBlock,
                      TestHash (TestHash), unTestHash)
 import           Text.Printf (printf)
@@ -122,7 +122,7 @@ tersePoint = \case
   BlockPoint slot hash -> terseSlotBlockFork slot (BlockNo (fromIntegral (length (unTestHash hash)))) hash
   GenesisPoint -> "G"
 
-terseFragH :: TestFragH -> String
+terseFragH :: AnchoredFragment (Header TestBlock) -> String
 terseFragH frag =
   renderAnchor ++ renderBlocks
   where
@@ -136,6 +136,6 @@ terseFragH frag =
       | all (== 0) (unTestHash hash) = ""
       | otherwise = condense hash
 
-terseFrag :: TestFrag -> String
+terseFrag :: AnchoredFragment TestBlock -> String
 terseFrag =
   terseFragH . mapAnchoredFragment getHeader

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Trace.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Trace.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE NamedFieldPuns     #-}
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE TypeFamilies       #-}
-{-# LANGUAGE TypeOperators      #-}
 
 -- | Helpers for tracing used by the peer simulator.
 module Test.Consensus.PeerSimulator.Trace (
@@ -20,7 +19,6 @@ module Test.Consensus.PeerSimulator.Trace (
 import           Cardano.Slotting.Block (BlockNo (BlockNo))
 import           Cardano.Slotting.Slot (SlotNo (SlotNo))
 import           Control.Tracer (Tracer (Tracer), traceWith)
-import           Data.Foldable (traverse_)
 import           Data.List (intercalate)
 import           Data.List.NonEmpty (NonEmpty ((:|)))
 import           Data.Time.Clock (diffTimeToPicoseconds)
@@ -93,11 +91,10 @@ traceUnitWith tracer unit msg = do
        in printf "%02d:%02d.%03d" minutes seconds milliseconds
 
 traceLinesWith ::
-  Applicative m =>
   Tracer m String ->
   [String] ->
   m ()
-traceLinesWith = traverse_ . traceWith
+traceLinesWith tracer = traceWith tracer . unlines
 
 terseSlotBlock :: SlotNo -> BlockNo -> String
 terseSlotBlock (SlotNo slot) (BlockNo block) =

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Trace.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Trace.hs
@@ -128,7 +128,7 @@ terseFragH frag =
   where
     renderBlocks = case frag of
       Empty _ -> ""
-      _       -> " ⚓ " ++ intercalate " " (terseHeader <$> toOldestFirst frag)
+      _       -> " | " ++ intercalate " " (terseHeader <$> toOldestFirst frag)
     renderAnchor = case anchor frag of
       AnchorGenesis -> "G"
       Anchor slot hash block -> terseSlotBlock slot block ++ renderAnchorHash hash

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Trace.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Trace.hs
@@ -64,10 +64,10 @@ prettyTime :: MonadMonotonicTime m => m String
 prettyTime = do
   Time time <- getMonotonicTime
   let ps = diffTimeToPicoseconds time
-      milliseconds = (ps `div` 1_000_000_000) `mod` 1_000
-      seconds = (ps `div` 1_000_000_000_000) `rem` 60
-      minutes = (ps `div` 1_000_000_000_000) `quot` 60
-  pure $ printf "%02d:%02d.%03d" minutes seconds milliseconds
+      milliseconds = ps `quot` 1_000_000_000
+      seconds = milliseconds `quot` 1_000
+      minutes = seconds `quot` 60
+  pure $ printf "%02d:%02d.%03d" minutes (seconds `rem` 60) (milliseconds `rem` 1_000)
 
 -- | Trace using the given tracer, printing the current time (typically the time
 -- of the simulation) and the unit name.

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
@@ -47,7 +47,6 @@ module Test.Consensus.PointSchedule (
   , defaultPointScheduleConfig
   , fromSchedulePoints
   , genesisAdvertisedPoints
-  , lastHonestBlockPoint
   , longRangeAttack
   , mkPeers
   , peersOnlyHonest
@@ -542,17 +541,3 @@ stToGen ::
 stToGen gen = do
   seed :: QCGen <- arbitrary
   pure (runSTGen_ seed gen)
-
--- | Return the last block point served by the honest peer. Fails if the honest
--- peer never sends a block, that is if they have no ticks or they only have
--- 'NodeOffline' ticks.
-lastHonestBlockPoint :: PointSchedule -> WithOrigin TestBlock
-lastHonestBlockPoint = go Nothing . toList . ticks
-  where
-    go :: Maybe (WithOrigin TestBlock) -> [Tick] -> WithOrigin TestBlock
-    go Nothing [] = error "lastHonestBlockPoint"
-    go (Just bp) [] = bp
-    go _ (Tick{active=Peer HonestPeer (NodeOnline points)} : ticks) =
-      let AdvertisedPoints{block = BlockPoint bp} = points
-       in go (Just bp) ticks
-    go bp (_ : ticks) = go bp ticks

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
@@ -46,6 +46,7 @@ module Test.Consensus.PointSchedule (
   , genesisAdvertisedPoints
   , headerPointBlock
   , longRangeAttack
+  , peerSchedulesBlocks
   , pointScheduleBlocks
   , pointSchedulePeers
   , prettyGenesisTest
@@ -82,7 +83,7 @@ import           Test.Consensus.PointSchedule.Peers (Peer (..), PeerId (..),
 import           Test.Consensus.PointSchedule.SinglePeer
                      (IsTrunk (IsBranch, IsTrunk), PeerScheduleParams (..),
                      SchedulePoint (..), defaultPeerScheduleParams, mergeOn,
-                     peerScheduleFromTipPoints)
+                     peerScheduleFromTipPoints, schedulePointToBlock)
 import           Test.Consensus.PointSchedule.SinglePeer.Indices
                      (uniformRMDiffTime)
 import           Test.Ouroboros.Consensus.ChainGenerator.Params (Asc,
@@ -327,6 +328,14 @@ fromSchedulePoints peers = do
     durations = snd (mapAccumL (\ prev start -> (start, start - prev)) 0 (drop 1 starts)) ++ [0.1]
 
     (starts, states) = unzip $ foldr (mergeOn fst) [] (peerStates <$> toList (peersList peers))
+
+-- | List of all blocks appearing in the schedule.
+peerScheduleBlocks :: PeerSchedule -> [TestBlock]
+peerScheduleBlocks = map (schedulePointToBlock . snd)
+
+-- | List of all blocks appearing in the schedules.
+peerSchedulesBlocks :: Peers PeerSchedule -> [TestBlock]
+peerSchedulesBlocks = concatMap (peerScheduleBlocks . value) . toList . peersList
 
 ----------------------------------------------------------------------------------------------------
 -- Schedule generators

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
@@ -32,6 +32,7 @@ module Test.Consensus.PointSchedule (
   , NodeState (..)
   , Peer (..)
   , PeerId (..)
+  , Peers (..)
   , PointSchedule (..)
   , PointScheduleConfig (..)
   , ScheduleType (..)

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
@@ -49,6 +49,8 @@ module Test.Consensus.PointSchedule (
   , onlyHonestWithMintingPointSchedule
   , peersOnlyHonest
   , pointSchedulePeers
+  , prettyGenesisTest
+  , prettyPointSchedule
   ) where
 
 import           Data.Foldable (toList)
@@ -73,7 +75,8 @@ import           Ouroboros.Network.Block (SlotNo, Tip (Tip, TipGenesis),
                      blockNo, blockSlot, getTipSlotNo, tipFromHeader)
 import           Ouroboros.Network.Point (WithOrigin (At))
 import           System.Random.Stateful (StatefulGen)
-import           Test.Consensus.BlockTree (BlockTree (..), BlockTreeBranch (..))
+import           Test.Consensus.BlockTree (BlockTree (..), BlockTreeBranch (..),
+                     prettyBlockTree)
 import           Test.Consensus.PointSchedule.SinglePeer
                      (IsTrunk (IsBranch, IsTrunk), PeerScheduleParams (..),
                      SchedulePoint (..), defaultPeerScheduleParams, mergeOn,
@@ -262,6 +265,10 @@ data PointSchedule =
 
 instance Condense PointSchedule where
   condense (PointSchedule ticks _) = unlines (condense <$> toList ticks)
+
+prettyPointSchedule :: PointSchedule -> [String]
+prettyPointSchedule PointSchedule{ticks} =
+  "PointSchedule:" : (("  " ++) <$> (condense <$> toList ticks))
 
 -- | Parameters that are significant for components outside of generators, like the peer
 -- simulator.
@@ -615,6 +622,15 @@ data GenesisTest = GenesisTest {
   gtGenesisWindow :: GenesisWindow,
   gtBlockTree     :: BlockTree TestBlock
   }
+
+prettyGenesisTest :: GenesisTest -> [String]
+prettyGenesisTest GenesisTest{gtHonestAsc, gtSecurityParam, gtGenesisWindow, gtBlockTree} =
+  [ "GenesisTest:"
+  , "  gtHonestAsc: " ++ show gtHonestAsc
+  , "  gtSecurityParam: " ++ show gtSecurityParam
+  , "  gtGenesisWindow: " ++ show gtGenesisWindow
+  , "  gtBlockTree:"
+  ] ++ (("    " ++) <$> prettyBlockTree gtBlockTree)
 
 -- | Create a point schedule from the given block tree.
 --

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
@@ -77,8 +77,7 @@ import           Ouroboros.Consensus.Util.Condense (Condense (condense))
 import           Ouroboros.Network.AnchoredFragment (AnchoredFragment,
                      AnchoredSeq (Empty, (:>)))
 import qualified Ouroboros.Network.AnchoredFragment as AF
-import           Ouroboros.Network.Block (Tip (Tip, TipGenesis), blockNo,
-                     blockSlot, tipFromHeader)
+import           Ouroboros.Network.Block (Tip (TipGenesis), tipFromHeader)
 import           Ouroboros.Network.Point (WithOrigin (At))
 import qualified System.Random.Stateful as Random
 import           System.Random.Stateful (STGenM, StatefulGen, runSTGen_)
@@ -94,7 +93,9 @@ import           Test.Ouroboros.Consensus.ChainGenerator.Params (Asc,
                      Delta (Delta), ascVal)
 import           Test.QuickCheck (Gen, arbitrary)
 import           Test.QuickCheck.Random (QCGen)
-import           Test.Util.TestBlock (Header (TestHeader), TestBlock)
+import           Test.Util.TersePrinting (terseBlock, terseHeader, terseTip,
+                     terseWithOrigin)
+import           Test.Util.TestBlock (Header, TestBlock)
 import           Text.Printf (printf)
 
 ----------------------------------------------------------------------------------------------------
@@ -112,9 +113,7 @@ newtype TipPoint =
   deriving (Eq, Show)
 
 instance Condense TipPoint where
-  condense (TipPoint TipGenesis) = "G"
-  condense (TipPoint (Tip slot _ bno)) =
-      "B:" <> condense bno <> ",S:" <> condense slot
+  condense (TipPoint tip) = terseTip tip
 
 -- | The latest header that should be sent to the client by the ChainSync server
 -- in a tick.
@@ -123,11 +122,7 @@ newtype HeaderPoint =
   deriving (Eq, Show)
 
 instance Condense HeaderPoint where
-  condense = \case
-    HeaderPoint (At (TestHeader b)) ->
-      "B:" <> condense (blockNo b) <> ",S:" <> condense (blockSlot b)
-    HeaderPoint Origin ->
-      "G"
+  condense (HeaderPoint header) = terseWithOrigin terseHeader header
 
 -- | The latest block that should be sent to the client by the BlockFetch server
 -- in a tick.
@@ -136,11 +131,7 @@ newtype BlockPoint =
   deriving (Eq, Show)
 
 instance Condense BlockPoint where
-  condense = \case
-    BlockPoint (At b) ->
-      "B:" <> condense (blockNo b) <> ",S:" <> condense (blockSlot b)
-    BlockPoint Origin ->
-      "G"
+  condense (BlockPoint block) = terseWithOrigin terseBlock block
 
 -- | The set of parameters that define the state that a peer should reach when it receives control
 -- by the scheduler in a single tick.

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
@@ -47,6 +47,7 @@ module Test.Consensus.PointSchedule (
   , defaultPointScheduleConfig
   , fromSchedulePoints
   , genesisAdvertisedPoints
+  , lastHonestBlockPoint
   , longRangeAttack
   , mkPeers
   , peersOnlyHonest
@@ -541,3 +542,17 @@ stToGen ::
 stToGen gen = do
   seed :: QCGen <- arbitrary
   pure (runSTGen_ seed gen)
+
+-- | Return the last block point served by the honest peer. Fails if the honest
+-- peer never sends a block, that is if they have no ticks or they only have
+-- 'NodeOffline' ticks.
+lastHonestBlockPoint :: PointSchedule -> WithOrigin TestBlock
+lastHonestBlockPoint = go Nothing . toList . ticks
+  where
+    go :: Maybe (WithOrigin TestBlock) -> [Tick] -> WithOrigin TestBlock
+    go Nothing [] = error "lastHonestBlockPoint"
+    go (Just bp) [] = bp
+    go _ (Tick{active=Peer HonestPeer (NodeOnline points)} : ticks) =
+      let AdvertisedPoints{block = BlockPoint bp} = points
+       in go (Just bp) ticks
+    go bp (_ : ticks) = go bp ticks

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveGeneric         #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE LambdaCase            #-}
@@ -32,10 +31,7 @@ module Test.Consensus.PointSchedule (
   , GenesisWindow (..)
   , HeaderPoint (..)
   , NodeState (..)
-  , Peer (..)
-  , PeerId (..)
   , PeerSchedule
-  , Peers (..)
   , PointSchedule (..)
   , PointScheduleConfig (..)
   , TestFrag
@@ -48,8 +44,6 @@ module Test.Consensus.PointSchedule (
   , fromSchedulePoints
   , genesisAdvertisedPoints
   , longRangeAttack
-  , mkPeers
-  , peersOnlyHonest
   , pointSchedulePeers
   , prettyGenesisTest
   , prettyPointSchedule
@@ -59,17 +53,13 @@ module Test.Consensus.PointSchedule (
 
 import           Control.Monad.ST (ST)
 import           Data.Foldable (toList)
-import           Data.Hashable (Hashable)
 import           Data.List (mapAccumL, partition, scanl', transpose)
-import           Data.List.NonEmpty (NonEmpty ((:|)))
+import           Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NonEmpty
-import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           Data.Maybe (fromMaybe, listToMaybe)
-import           Data.String (IsString (fromString))
 import           Data.Time (DiffTime)
 import           Data.Word (Word64)
-import           GHC.Generics (Generic)
 import           Ouroboros.Consensus.Block.Abstract (WithOrigin (..), getHeader)
 import           Ouroboros.Consensus.Protocol.Abstract (SecurityParam,
                      maxRollbacks)
@@ -83,6 +73,8 @@ import qualified System.Random.Stateful as Random
 import           System.Random.Stateful (STGenM, StatefulGen, runSTGen_)
 import           Test.Consensus.BlockTree (BlockTree (..), BlockTreeBranch (..),
                      prettyBlockTree)
+import           Test.Consensus.PointSchedule.Peers (Peer (..), PeerId (..),
+                     Peers (..), getPeerIds, mkPeers, peersList)
 import           Test.Consensus.PointSchedule.SinglePeer
                      (IsTrunk (IsBranch, IsTrunk), PeerScheduleParams (..),
                      SchedulePoint (..), defaultPeerScheduleParams, mergeOn,
@@ -180,62 +172,6 @@ instance Condense NodeState where
     NodeOnline points -> condense points
     NodeOffline -> "*chrrrk* <signal lost>"
 
--- | Identifier used to index maps and specify which peer is active during a tick.
-data PeerId =
-  HonestPeer
-  |
-  PeerId String
-  deriving (Eq, Generic, Show, Ord)
-
-instance IsString PeerId where
-  fromString "honest" = HonestPeer
-  fromString i        = PeerId i
-
-instance Condense PeerId where
-  condense = \case
-    HonestPeer -> "honest"
-    PeerId name -> name
-
-instance Hashable PeerId
-
--- | General-purpose functor associated with a peer.
-data Peer a =
-  Peer {
-    name  :: PeerId,
-    value :: a
-  }
-  deriving (Eq, Show)
-
-instance Functor Peer where
-  fmap f Peer {name, value} = Peer {name, value = f value}
-
-instance Foldable Peer where
-  foldr step z (Peer _ a) = step a z
-
-instance Traversable Peer where
-  sequenceA (Peer name fa) =
-    Peer name <$> fa
-
-instance Condense a => Condense (Peer a) where
-  condense Peer {name, value} = condense name ++ ": " ++ condense value
-
--- | General-purpose functor for a set of peers.
---
--- REVIEW: There is a duplicate entry for the honest peer, here. We should
--- probably either have only the 'Map' or have the keys of the map be 'String'?
---
--- Alternatively, we could just have 'newtype PeerId = PeerId String' with an
--- alias for 'HonestPeer = PeerId "honest"'?
-data Peers a =
-  Peers {
-    honest :: Peer a,
-    others :: Map PeerId (Peer a)
-  }
-  deriving (Eq, Show)
-
-instance Functor Peers where
-  fmap f Peers {honest, others} = Peers {honest = f <$> honest, others = fmap f <$> others}
-
 -- | A tick is an entry in a 'PointSchedule', containing the peer that is
 -- going to change state.
 data Tick =
@@ -260,14 +196,6 @@ tickDefault PointScheduleConfig {pscTickDuration} number active =
 tickDefaults :: PointScheduleConfig -> [Peer NodeState] -> [Tick]
 tickDefaults psc states =
   uncurry (tickDefault psc) <$> zip [0 ..] states
-
--- | A set of peers with only one honest peer carrying the given value.
-peersOnlyHonest :: a -> Peers a
-peersOnlyHonest value =
-  Peers {
-    honest = Peer {name = HonestPeer, value},
-    others = Map.empty
-    }
 
 -- | A point schedule is a series of states for a set of peers.
 --
@@ -307,32 +235,12 @@ defaultPointScheduleConfig =
 -- Accessors
 ----------------------------------------------------------------------------------------------------
 
--- | Extract all 'PeerId's.
-getPeerIds :: Peers a -> NonEmpty PeerId
-getPeerIds peers = HonestPeer :| Map.keys (others peers)
-
 -- | Get the names of the peers involved in this point schedule.
 -- This is the main motivation for requiring the point schedule to be
 -- nonempty, so we don't have to carry around another value for the
 -- 'PeerId's.
 pointSchedulePeers :: PointSchedule -> NonEmpty PeerId
 pointSchedulePeers = peerIds
-
--- | Convert 'Peers' to a list of 'Peer'.
-peersList :: Peers a -> NonEmpty (Peer a)
-peersList Peers {honest, others} =
-  honest :| Map.elems others
-
--- | Construct 'Peers' from values, adding adversary names based on the default schema.
--- A single adversary gets the ID @adversary@, multiple get enumerated as @adversary N@.
-mkPeers :: a -> [a] -> Peers a
-mkPeers h as =
-  Peers (Peer HonestPeer h) (Map.fromList (mkPeer <$> advs as))
-  where
-    mkPeer (pid, a) = (pid, Peer pid a)
-    advs [a] = [("adversary", a)]
-    advs _   = zip enumAdvs as
-    enumAdvs = (\ n -> PeerId ("adversary " ++ show n)) <$> [1 :: Int ..]
 
 ----------------------------------------------------------------------------------------------------
 -- Conversion to 'PointSchedule'

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
@@ -4,6 +4,8 @@
 {-# LANGUAGE LambdaCase            #-}
 {-# LANGUAGE NamedFieldPuns        #-}
 {-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE RankNTypes            #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
 
 -- | Data types and generators that convert a 'BlockTree' to a 'PointSchedule'.
 --
@@ -32,10 +34,10 @@ module Test.Consensus.PointSchedule (
   , NodeState (..)
   , Peer (..)
   , PeerId (..)
+  , PeerSchedule
   , Peers (..)
   , PointSchedule (..)
   , PointScheduleConfig (..)
-  , ScheduleType (..)
   , TestFrag
   , TestFragH
   , Tick (..)
@@ -44,19 +46,23 @@ module Test.Consensus.PointSchedule (
   , banalStates
   , defaultPointScheduleConfig
   , fromSchedulePoints
-  , genSchedule
+  , genesisAdvertisedPoints
+  , longRangeAttack
   , mkPeers
-  , onlyHonestWithMintingPointSchedule
   , peersOnlyHonest
   , pointSchedulePeers
   , prettyGenesisTest
   , prettyPointSchedule
+  , stToGen
+  , uniformPoints
   ) where
 
+import           Control.Monad.ST (ST)
 import           Data.Foldable (toList)
 import           Data.Hashable (Hashable)
-import           Data.List (mapAccumL, scanl', sortOn, transpose)
-import           Data.List.NonEmpty (NonEmpty ((:|)), nonEmpty)
+import           Data.List (mapAccumL, partition, scanl', transpose)
+import           Data.List.NonEmpty (NonEmpty ((:|)))
+import qualified Data.List.NonEmpty as NonEmpty
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           Data.Maybe (fromMaybe, listToMaybe)
@@ -64,25 +70,32 @@ import           Data.String (IsString (fromString))
 import           Data.Time (DiffTime)
 import           Data.Word (Word64)
 import           GHC.Generics (Generic)
-import           Ouroboros.Consensus.Block.Abstract (HasHeader,
-                     WithOrigin (Origin), getHeader)
-import           Ouroboros.Consensus.Protocol.Abstract (SecurityParam)
+import           Ouroboros.Consensus.Block.Abstract (WithOrigin (..), getHeader)
+import           Ouroboros.Consensus.Protocol.Abstract (SecurityParam,
+                     maxRollbacks)
 import           Ouroboros.Consensus.Util.Condense (Condense (condense))
 import           Ouroboros.Network.AnchoredFragment (AnchoredFragment,
-                     AnchoredSeq (Empty, (:>)), anchorFromBlock)
+                     AnchoredSeq (Empty, (:>)))
 import qualified Ouroboros.Network.AnchoredFragment as AF
-import           Ouroboros.Network.Block (SlotNo, Tip (Tip, TipGenesis),
-                     blockNo, blockSlot, getTipSlotNo, tipFromHeader)
+import           Ouroboros.Network.Block (Tip (Tip, TipGenesis), blockNo,
+                     blockSlot, tipFromHeader)
 import           Ouroboros.Network.Point (WithOrigin (At))
-import           System.Random.Stateful (StatefulGen)
+import qualified System.Random.Stateful as Random
+import           System.Random.Stateful (STGenM, StatefulGen, runSTGen_)
 import           Test.Consensus.BlockTree (BlockTree (..), BlockTreeBranch (..),
                      prettyBlockTree)
 import           Test.Consensus.PointSchedule.SinglePeer
                      (IsTrunk (IsBranch, IsTrunk), PeerScheduleParams (..),
                      SchedulePoint (..), defaultPeerScheduleParams, mergeOn,
                      peerScheduleFromTipPoints)
-import           Test.Ouroboros.Consensus.ChainGenerator.Params (Asc)
+import           Test.Consensus.PointSchedule.SinglePeer.Indices
+                     (uniformRMDiffTime)
+import           Test.Ouroboros.Consensus.ChainGenerator.Params (Asc,
+                     Delta (Delta), ascVal)
+import           Test.QuickCheck (Gen, arbitrary)
+import           Test.QuickCheck.Random (QCGen)
 import           Test.Util.TestBlock (Header (TestHeader), TestBlock)
+import           Text.Printf (printf)
 
 ----------------------------------------------------------------------------------------------------
 -- Data types
@@ -148,6 +161,14 @@ instance Condense AdvertisedPoints where
     "TP " ++ condense tip ++
     " | HP " ++ condense header ++
     " | BP " ++ condense block
+
+genesisAdvertisedPoints :: AdvertisedPoints
+genesisAdvertisedPoints =
+  AdvertisedPoints {
+    tip = TipPoint TipGenesis,
+    header = HeaderPoint Origin,
+    block = BlockPoint Origin
+  }
 
 -- | The state of a peer in a single tick.
 --
@@ -230,16 +251,24 @@ data Tick =
   Tick {
     active   :: Peer NodeState,
     -- | The duration of this tick, for the scheduler to pass to @threadDelay@.
-    duration :: DiffTime
+    duration :: DiffTime,
+    number   :: Word
   }
   deriving (Eq, Show)
 
 instance Condense Tick where
-  condense Tick {active, duration} = condense active ++ " | " ++ show duration
+  condense Tick {active, duration, number} =
+    show number ++ ": " ++ condense active ++ " | " ++ showDT duration
+    where
+      showDT t = printf "%.6f" (realToFrac t :: Double)
 
-tickDefault :: PointScheduleConfig -> Peer NodeState -> Tick
-tickDefault PointScheduleConfig {pscTickDuration} active =
-  Tick {active, duration = pscTickDuration}
+tickDefault :: PointScheduleConfig -> Word -> Peer NodeState -> Tick
+tickDefault PointScheduleConfig {pscTickDuration} number active =
+  Tick {active, duration = pscTickDuration, number}
+
+tickDefaults :: PointScheduleConfig -> [Peer NodeState] -> [Tick]
+tickDefaults psc states =
+  uncurry (tickDefault psc) <$> zip [0 ..] states
 
 -- | A set of peers with only one honest peer carrying the given value.
 peersOnlyHonest :: a -> Peers a
@@ -291,24 +320,6 @@ defaultPointScheduleConfig =
 getPeerIds :: Peers a -> NonEmpty PeerId
 getPeerIds peers = HonestPeer :| Map.keys (others peers)
 
--- | Extract the trunk and all the branches from the 'BlockTree' and store them in
--- an honest 'Peer' and several adversarial ones, respectively.
-blockTreePeers :: BlockTree TestBlock -> Peers TestFrag
-blockTreePeers BlockTree {btTrunk, btBranches} =
-  Peers {
-    honest = Peer HonestPeer btTrunk,
-    others = Map.fromList (branches btBranches)
-  }
-  where
-    branches = \case
-      [b] -> [peer "adversary" b]
-      bs -> uncurry branch <$> zip [1 :: Int ..] bs
-
-    branch num =
-      peer (PeerId ("adversary " <> show num))
-
-    peer pid BlockTreeBranch {btbFull} = (pid, Peer pid btbFull)
-
 -- | Get the names of the peers involved in this point schedule.
 -- This is the main motivation for requiring the point schedule to be
 -- nonempty, so we don't have to carry around another value for the
@@ -336,9 +347,10 @@ mkPeers h as =
 -- Conversion to 'PointSchedule'
 ----------------------------------------------------------------------------------------------------
 
--- | Ensure that a 'PointSchedule' isn't empty.
-pointSchedule :: [Tick] -> NonEmpty PeerId -> Maybe PointSchedule
-pointSchedule ticks nePeerIds = (`PointSchedule` nePeerIds) <$> nonEmpty ticks
+-- | Create a point schedule from a list of ticks
+pointSchedule :: [Tick] -> NonEmpty PeerId -> PointSchedule
+pointSchedule [] _nePeerIds = error "pointSchedule: no ticks"
+pointSchedule ticks nePeerIds = PointSchedule (NonEmpty.fromList ticks) nePeerIds
 
 -- | Convert a @SinglePeer@ schedule to a 'NodeState' schedule.
 --
@@ -350,9 +362,13 @@ pointSchedule ticks nePeerIds = (`PointSchedule` nePeerIds) <$> nonEmpty ticks
 -- This is a preliminary measure to make the long range attack test work, since that relies on the
 -- honest node sending headers later than the adversary, which is not possible if the adversary's
 -- first tip point is delayed by 20 or more seconds due to being in a later slot.
-peerStates :: PeerId -> [(DiffTime, SchedulePoint)] -> [(DiffTime, Peer NodeState)]
-peerStates peerId pts =
-  zip (0 : (shiftTime <$> times)) (Peer peerId . NodeOnline <$> scanl' modPoint zero points)
+--
+-- Finally, drops the first state, since all points being 'Origin' (in particular the tip) has no
+-- useful effects in the simulator, but it could set the tip in the GDD governor to 'Origin', which
+-- causes slow nodes to be disconnected right away.
+peerStates :: Peer PeerSchedule -> [(DiffTime, Peer NodeState)]
+peerStates Peer {name, value = schedulePoints} =
+  drop 1 (zip (0 : (shiftTime <$> times)) (Peer name . NodeOnline <$> scanl' modPoint genesisAdvertisedPoints points))
   where
     shiftTime t = t - firstTipOffset
 
@@ -361,44 +377,25 @@ peerStates peerId pts =
       ScheduleHeaderPoint h -> z {header = HeaderPoint (At (getHeader h))}
       ScheduleBlockPoint b -> z {block = BlockPoint (At b)}
 
-    zero = AdvertisedPoints {
-      tip = TipPoint TipGenesis,
-      header = HeaderPoint Origin,
-      block = BlockPoint Origin
-    }
-
     firstTipOffset = fromMaybe 0 (listToMaybe times)
 
-    (times, points) = unzip pts
+    (times, points) = unzip schedulePoints
+
+type PeerSchedule = [(DiffTime, SchedulePoint)]
 
 -- | Convert a set of @SinglePeer@ schedules to a 'PointSchedule'.
 --
 -- Call 'peerStates' for each peer, then merge all of them sorted by tick start times, then convert
 -- start times to relative tick durations.
-fromSchedulePoints :: Map PeerId [(DiffTime, SchedulePoint)] -> Maybe PointSchedule
+fromSchedulePoints :: Peers PeerSchedule -> PointSchedule
 fromSchedulePoints peers = do
-  peerIds <- nonEmpty (Map.keys peers)
-  pointSchedule (zipWith Tick states durations) peerIds
+  pointSchedule (zipWith3 Tick states durations [0 ..]) peerIds
   where
-    durations = drop 1 (snd (mapAccumL (\ prev start -> (start, start - prev)) 0 (drop 1 starts))) ++ [0]
+    peerIds = getPeerIds peers
 
-    (starts, states) = unzip $ foldr (mergeOn fst) [] [peerStates p sch | (p, sch) <- Map.toList peers]
+    durations = snd (mapAccumL (\ prev start -> (start, start - prev)) 0 (drop 1 starts)) ++ [0.1]
 
-----------------------------------------------------------------------------------------------------
--- Folding functions
-----------------------------------------------------------------------------------------------------
-
--- | Combine two 'Peers' by creating tuples of the two honest 'Peer's and of each pair
--- of 'others' with the same 'PeerId', dropping any 'Peer' that is present in only one
--- of the 'Map's.
-zipPeers :: Peers a -> Peers b -> Peers (a, b)
-zipPeers a b =
-  Peers {
-    honest = Peer HonestPeer (value (honest a), value (honest b)),
-    others = Map.intersectionWith zp (others a) (others b)
-  }
-  where
-    zp p1 p2 = Peer (name p1) (value p1, value p2)
+    (starts, states) = unzip $ foldr (mergeOn fst) [] (peerStates <$> toList (peersList peers))
 
 ----------------------------------------------------------------------------------------------------
 -- Schedule generators
@@ -428,156 +425,13 @@ banalStates frag@(_ :> tipBlock) =
 balanced ::
   PointScheduleConfig ->
   Peers [NodeState] ->
-  Maybe PointSchedule
+  PointSchedule
 balanced config states =
-  pointSchedule (map (tickDefault config) activeSeq) (getPeerIds states)
+  pointSchedule (tickDefaults config activeSeq) (getPeerIds states)
   where
     -- Sequence containing the first state of all the nodes in order, then the
     -- second in order, etc.
     activeSeq = concat $ transpose $ sequenceA (honest states) : (sequenceA <$> Map.elems (others states))
-
--- | Generate a point schedule that serves a single header in each tick for each
--- peer in turn. See 'blockTreePeers' for peers generation.
-banalPointSchedule ::
-  PointScheduleConfig ->
-  BlockTree TestBlock ->
-  Maybe PointSchedule
-banalPointSchedule config blockTree =
-  balanced config (banalStates <$> blockTreePeers blockTree)
-
--- | Generate a point schedule for the scenario in which adversaries send blocks much faster
--- than the honest node.
---
--- This is intended to test the Limit on Eagerness, which prevents the selection from advancing
--- far enough into a fork that the immutable tip moves into the fork as well (i.e. more than k
--- blocks).
---
--- The LoE is only resolved when all peers with forks at that block have been disconnected from,
--- in particular due to a decision based on the Genesis density criterion.
---
--- This is implemented by initializing each peer's schedule with 'banalStates' (which advances by
--- one block per tick) and assigning interval lengths to each peer tick based on the frequency
--- config in the first argument, then sorting the resulting absolute times.
-frequencyPointSchedule ::
-  -- | A set of relative frequencies.
-  -- If peer A has a value of @2@ and peer B has @6@, peer B will get three turns in the schedule
-  -- for each turn of A.
-  --
-  -- Given @Peers { honest = 1, others = [("A", 2), ("B", 10)] }@, we get a schedule like
-  --
-  -- @BBBBABBBBBHAB BBBBABBBBBHAB...@
-  --
-  -- with the intermediate interval representation:
-  --
-  -- B(1/10) B(2/10) B(3/10) B(4/10) A(1/2) B(5/10) B(6/10) B(7/10) B(8/10) B(9/10) H(1/1) (2/2) B(10/10)
-  --
-  -- With the order of equal values determined by the @PeerId@s.
-  PointScheduleConfig ->
-  Peers Int ->
-  BlockTree TestBlock ->
-  Maybe PointSchedule
-frequencyPointSchedule config freqs blockTree =
-  pointSchedule (map (tickDefault config . fmap snd) (sortOn (fst . value) catted)) (getPeerIds freqs)
-  where
-    catted = sequenceA =<< toList (peersList intvals)
-
-    intvals = uncurry mkIntvals <$> zipPeers freqs states
-
-    mkIntvals freq ss = zip (peerIntervals (length ss) freq) ss
-
-    states = banalStates <$> frags
-
-    frags = blockTreePeers blockTree
-
-    peerIntervals :: Int -> Int -> [Double]
-    peerIntervals count freq =
-      (* intvalLen) <$> [1 .. fromIntegral count]
-      where
-        intvalLen = 1 / fromIntegral freq
-
--- | Generate a point schedule that consist of a single tick in which the honest peer advertises
--- its entire chain immediately.
-onlyHonestPointSchedule ::
-  PointScheduleConfig ->
-  BlockTree TestBlock ->
-  Maybe PointSchedule
-onlyHonestPointSchedule _ BlockTree {btTrunk = Empty _} = Nothing
-onlyHonestPointSchedule config BlockTree {btTrunk = _ :> tipBlock} =
-  Just $ PointSchedule (pure tick) (HonestPeer :| [])
-  where
-    tick = tickDefault config honestPeerState
-    honestPeerState = Peer HonestPeer (NodeOnline points)
-    points = AdvertisedPoints tipPoint headerPoint blockPoint
-    tipPoint = TipPoint (tipFromHeader tipBlock)
-    headerPoint = HeaderPoint $ At (getHeader tipBlock)
-    blockPoint = BlockPoint (At tipBlock)
-
--- | Generate a point schedule that consist of a single tick in which the honest peer advertises
--- its entire chain as it becomes available.
---
--- No idea what the point of this is.
-onlyHonestWithMintingPointSchedule ::
-  PointScheduleConfig ->
-  SlotNo ->
-  Int ->
-  TestFrag ->
-  Maybe PointSchedule
-onlyHonestWithMintingPointSchedule config initialSlotNo _ticksPerSlot fullFragment@(_ :> finalBlock) =
-  pointSchedule (map tickAtSlotNo [initialSlotNo .. finalSlotNo]) (HonestPeer :| [])
-  where
-    -- If we hold a block, we are guaranteed that the slot number cannot be
-    -- origin?
-    finalSlotNo = case getTipSlotNo $ tipFromHeader finalBlock of
-      At s -> s
-      _    -> error "unexpected alternative"
-
-    advertisedPointsAtSlotNo :: SlotNo -> AdvertisedPoints
-    advertisedPointsAtSlotNo slotNo =
-      case fst $ splitFragmentAtSlotNo slotNo fullFragment of
-        Empty _ -> error "onlyHonestWithMintingPointSchedule: there should be a block at that slot"
-        (_ :> tipBlock) ->
-          let tipPoint = TipPoint $ tipFromHeader tipBlock
-              headerPoint = HeaderPoint $ At (getHeader tipBlock)
-              blockPoint = BlockPoint (At tipBlock)
-           in AdvertisedPoints tipPoint headerPoint blockPoint
-
-    tickAtSlotNo :: SlotNo -> Tick
-    tickAtSlotNo slotNo =
-      let honestPeerState =
-            Peer HonestPeer $
-              NodeOnline $
-              advertisedPointsAtSlotNo slotNo
-       in
-          tickDefault config honestPeerState
-onlyHonestWithMintingPointSchedule _ _initialSlotNo _ticksPerSlot _fullFragment =
-    error "unexpected alternative"
-
--- onlyHonestWithMintingPointSchedule' :: SlotNo -> Int -> TestFrag -> PointSchedule
--- onlyHonestWithMintingPointSchedule' initialSlotNo ticksPerSlot fullFragment =
---   let (availFragment, futureFragment) = splitFragmentAtSlotNo (At initialSlotNo) fullFragment
---       blockSlotNos = map blockSlotNo toOldestFirst futureFragment
-
--- | Given a slot number and an anchored fragment 'a', splits the fragment into
--- two 'b' and 'c' such that:
---
--- - 'b' is anchored in the same place as 'a' and contains all the blocks of 'a'
---   that have a slot number smaller than (or equal to) the given one.
---
--- - 'c' is anchored at the last block of 'b' and contains all the blocks of 'a'
---   that have a slot number strictly greater than the given one.
-splitFragmentAtSlotNo ::
-  HasHeader b =>
-  SlotNo ->
-  AnchoredFragment b ->
-  (AnchoredFragment b, AnchoredFragment b)
-splitFragmentAtSlotNo slotNo (fragment :> block) =
-  if blockSlot block <= slotNo then
-    (fragment :> block, Empty $ anchorFromBlock block)
-  else
-    let (firstPart, secondPart) = splitFragmentAtSlotNo slotNo fragment in
-      (firstPart, secondPart :> block)
-splitFragmentAtSlotNo _ (Empty anchor) =
-  (Empty anchor, Empty anchor)
 
 -- | Produce a schedule similar to @Frequencies (Peers 1 [10])@, using the new @SinglePeer@
 -- generator.
@@ -585,34 +439,89 @@ splitFragmentAtSlotNo _ (Empty anchor) =
 -- We hardcode the two schedules to use the latest block as the initial tip point.
 -- The honest peer gets a substantially larger (and disconnected) delay interval to ensure
 -- that k+1 blocks are sent fast enough to trigger selection of a fork.
-newLongRangeAttack ::
+longRangeAttack ::
   StatefulGen g m =>
-  g ->
   BlockTree TestBlock ->
-  m (Maybe PointSchedule)
-newLongRangeAttack g BlockTree {btTrunk, btBranches = [branch]} = do
+  g ->
+  m (Peers PeerSchedule)
+longRangeAttack BlockTree {btTrunk, btBranches = [branch]} g = do
   honest <- peerScheduleFromTipPoints g honParams [(IsTrunk, [AF.length btTrunk - 1])] btTrunk []
   adv <- peerScheduleFromTipPoints g advParams [(IsBranch, [AF.length (btbFull branch) - 1])] btTrunk [btbFull branch]
-  pure (fromSchedulePoints (Map.fromList [(HonestPeer, honest), ("adversary 1", adv)]))
+  pure (mkPeers honest [adv])
   where
     honParams = defaultPeerScheduleParams {pspHeaderDelayInterval = (0.3, 0.4)}
     advParams = defaultPeerScheduleParams {pspTipDelayInterval = (0, 0.1)}
 
-newLongRangeAttack _ _ =
-  pure Nothing
+longRangeAttack _ _ =
+  error "longRangeAttack can only deal with single adversary"
 
--- | Encodes the different scheduling styles for use with quickcheck generators.
-data ScheduleType =
-  Frequencies (Peers Int)
-  |
-  Banal
-  |
-  OnlyHonest
-  |
-  NewLRA
-  deriving (Eq, Show)
+-- | Generate a schedule in which the trunk and branches are served by one peer each, using
+-- a single tip point, without specifically assigned delay intervals like in
+-- 'newLongRangeAttack'.
+--
+-- Include rollbacks in a percentage of adversaries, in which case that peer uses two branchs.
+--
+uniformPoints ::
+  StatefulGen g m =>
+  BlockTree TestBlock ->
+  g ->
+  m (Peers PeerSchedule)
+uniformPoints BlockTree {btTrunk, btBranches} g = do
+  honestTip0 <- firstTip btTrunk
+  honest <- mkSchedule [(IsTrunk, [honestTip0 .. AF.length btTrunk - 1])] []
+  advs <- takeBranches btBranches
+  pure (mkPeers honest advs)
+  where
+    takeBranches = \case
+        [] -> pure []
+        [b] -> pure <$> withoutRollback b
+        b1 : b2 : branches -> do
+          a <- Random.uniformDouble01M g
+          if a < rollbackProb
+          then do
+            this <- withRollback b1 b2
+            rest <- takeBranches branches
+            pure (this : rest)
+          else do
+            this <- withoutRollback b1
+            rest <- takeBranches (b2 : branches)
+            pure (this : rest)
 
-newtype GenesisWindow = GenesisWindow { getGenesisWindow :: Word64 }
+    withoutRollback branch = do
+      tips <- mkTips branch
+      mkSchedule tips [btbSuffix branch]
+
+    withRollback b1 b2 = do
+      firstTips <- mkTips b1
+      let secondTips = [AF.length (btbSuffix b2) - 1]
+      mkSchedule (firstTips ++ [(IsBranch, secondTips)]) [btbSuffix b1, btbSuffix b2]
+
+    mkSchedule tips branches = do
+      params <- mkParams
+      peerScheduleFromTipPoints g params tips btTrunk branches
+
+    mkTips branch = do
+      tip0 <- firstTip (btbFull branch)
+      let (pre, post) = partition (< firstSuffixBlock) [tip0 .. lastBlock]
+      pure ((if null pre then [] else [(IsTrunk, pre)]) ++ [(IsBranch, (shift <$> post))])
+      where
+        shift i = i - firstSuffixBlock
+        firstSuffixBlock = lastBlock - AF.length (btbSuffix branch) + 1
+        lastBlock = AF.length full - 1
+        full = btbFull branch
+
+    firstTip frag = pure (AF.length frag - 1)
+
+    mkParams = do
+      tipL <- uniformRMDiffTime (0, 0.5) g
+      tipU <- uniformRMDiffTime (1, 2) g
+      headerL <- uniformRMDiffTime (0.018, 0.03) g
+      headerU <- uniformRMDiffTime (0.021, 0.04) g
+      pure defaultPeerScheduleParams {pspTipDelayInterval = (tipL, tipU), pspHeaderDelayInterval = (headerL, headerU)}
+
+    rollbackProb = 0.2
+
+newtype GenesisWindow = GenesisWindow { unGenesisWindow :: Word64 }
   deriving (Show)
 
 -- | All the data used by point schedule tests.
@@ -620,30 +529,24 @@ data GenesisTest = GenesisTest {
   gtHonestAsc     :: Asc,
   gtSecurityParam :: SecurityParam,
   gtGenesisWindow :: GenesisWindow,
+  gtDelay         :: Delta,
   gtBlockTree     :: BlockTree TestBlock
   }
 
 prettyGenesisTest :: GenesisTest -> [String]
-prettyGenesisTest GenesisTest{gtHonestAsc, gtSecurityParam, gtGenesisWindow, gtBlockTree} =
+prettyGenesisTest GenesisTest{gtHonestAsc, gtSecurityParam, gtGenesisWindow, gtDelay = Delta delta, gtBlockTree} =
   [ "GenesisTest:"
-  , "  gtHonestAsc: " ++ show gtHonestAsc
-  , "  gtSecurityParam: " ++ show gtSecurityParam
-  , "  gtGenesisWindow: " ++ show gtGenesisWindow
+  , "  gtHonestAsc: " ++ show (ascVal gtHonestAsc)
+  , "  gtSecurityParam: " ++ show (maxRollbacks gtSecurityParam)
+  , "  gtGenesisWindow: " ++ show (unGenesisWindow gtGenesisWindow)
+  , "  gtDelay: " ++ show delta
   , "  gtBlockTree:"
   ] ++ (("    " ++) <$> prettyBlockTree gtBlockTree)
 
--- | Create a point schedule from the given block tree.
---
--- The first argument determines the scheduling style.
-genSchedule ::
-  StatefulGen g m =>
-  g ->
-  PointScheduleConfig ->
-  ScheduleType ->
-  BlockTree TestBlock ->
-  m (Maybe PointSchedule)
-genSchedule g config = \case
-  Frequencies fs -> pure . frequencyPointSchedule config fs
-  Banal -> pure . banalPointSchedule config
-  OnlyHonest -> pure . onlyHonestPointSchedule config
-  NewLRA -> newLongRangeAttack g
+-- | Wrap a 'ST' generator in 'Gen'.
+stToGen ::
+  (forall s . STGenM QCGen s -> ST s a) ->
+  Gen a
+stToGen gen = do
+  seed :: QCGen <- arbitrary
+  pure (runSTGen_ seed gen)

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
@@ -345,7 +345,7 @@ pointSchedule ticks nePeerIds = (`PointSchedule` nePeerIds) <$> nonEmpty ticks
 -- first tip point is delayed by 20 or more seconds due to being in a later slot.
 peerStates :: PeerId -> [(DiffTime, SchedulePoint)] -> [(DiffTime, Peer NodeState)]
 peerStates peerId pts =
-  zip (shiftTime <$> times) (Peer peerId . NodeOnline <$> scanl' modPoint zero points)
+  zip (0 : (shiftTime <$> times)) (Peer peerId . NodeOnline <$> scanl' modPoint zero points)
   where
     shiftTime t = t - firstTipOffset
 

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Peers.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Peers.hs
@@ -14,6 +14,8 @@ module Test.Consensus.PointSchedule.Peers (
     Peer (..)
   , PeerId (..)
   , Peers (..)
+  , fromMap
+  , fromMap'
   , getPeerIds
   , mkPeers
   , mkPeers'
@@ -22,6 +24,8 @@ module Test.Consensus.PointSchedule.Peers (
   , peersFromPeerList
   , peersList
   , peersOnlyHonest
+  , toMap
+  , toMap'
   ) where
 
 import           Data.Hashable (Hashable)
@@ -149,3 +153,20 @@ peersFromPeerIdList = flip $ \val -> peersFromPeerList . fmap (flip Peer val)
 -- | Like 'peersFromPeerIdList' with @()@.
 peersFromPeerIdList' :: NonEmpty PeerId -> Peers ()
 peersFromPeerIdList' = flip peersFromPeerIdList ()
+
+toMap :: Peers a -> Map PeerId (Peer a)
+toMap Peers{honest, others} = Map.insert HonestPeer honest others
+
+-- | Same as 'toMap' but the map contains unwrapped values.
+toMap' :: Peers a -> Map PeerId a
+toMap' = fmap (\(Peer _ v) -> v) . toMap
+
+fromMap :: Map PeerId (Peer a) -> Peers a
+fromMap peers = Peers{
+    honest = peers Map.! HonestPeer,
+    others = Map.delete HonestPeer peers
+  }
+
+-- | Same as 'fromMap' but the map contains unwrapped values.
+fromMap' :: Map PeerId a -> Peers a
+fromMap' = fromMap . Map.mapWithKey Peer

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Peers.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Peers.hs
@@ -1,0 +1,113 @@
+{-# LANGUAGE DeriveGeneric         #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE LambdaCase            #-}
+{-# LANGUAGE NamedFieldPuns        #-}
+{-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE RankNTypes            #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
+
+-- | This module contains the definition of point schedule _peers_ as well as
+-- all kind of utilities to manipulate them.
+
+module Test.Consensus.PointSchedule.Peers (
+    Peer (..)
+  , PeerId (..)
+  , Peers (..)
+  , getPeerIds
+  , mkPeers
+  , peersList
+  , peersOnlyHonest
+  ) where
+
+import           Data.Hashable (Hashable)
+import           Data.List.NonEmpty (NonEmpty ((:|)))
+import           Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import           Data.String (IsString (fromString))
+import           GHC.Generics (Generic)
+import           Ouroboros.Consensus.Util.Condense (Condense (condense))
+
+-- | Identifier used to index maps and specify which peer is active during a tick.
+data PeerId =
+  HonestPeer
+  |
+  PeerId String
+  deriving (Eq, Generic, Show, Ord)
+
+instance IsString PeerId where
+  fromString "honest" = HonestPeer
+  fromString i        = PeerId i
+
+instance Condense PeerId where
+  condense = \case
+    HonestPeer -> "honest"
+    PeerId name -> name
+
+instance Hashable PeerId
+
+-- | General-purpose functor associated with a peer.
+data Peer a =
+  Peer {
+    name  :: PeerId,
+    value :: a
+  }
+  deriving (Eq, Show)
+
+instance Functor Peer where
+  fmap f Peer {name, value} = Peer {name, value = f value}
+
+instance Foldable Peer where
+  foldr step z (Peer _ a) = step a z
+
+instance Traversable Peer where
+  sequenceA (Peer name fa) =
+    Peer name <$> fa
+
+instance Condense a => Condense (Peer a) where
+  condense Peer {name, value} = condense name ++ ": " ++ condense value
+
+-- | General-purpose functor for a set of peers.
+--
+-- REVIEW: There is a duplicate entry for the honest peer, here. We should
+-- probably either have only the 'Map' or have the keys of the map be 'String'?
+--
+-- Alternatively, we could just have 'newtype PeerId = PeerId String' with an
+-- alias for 'HonestPeer = PeerId "honest"'?
+data Peers a =
+  Peers {
+    honest :: Peer a,
+    others :: Map PeerId (Peer a)
+  }
+  deriving (Eq, Show)
+
+instance Functor Peers where
+  fmap f Peers {honest, others} = Peers {honest = f <$> honest, others = fmap f <$> others}
+
+-- | A set of peers with only one honest peer carrying the given value.
+peersOnlyHonest :: a -> Peers a
+peersOnlyHonest value =
+  Peers {
+    honest = Peer {name = HonestPeer, value},
+    others = Map.empty
+    }
+
+-- | Extract all 'PeerId's.
+getPeerIds :: Peers a -> NonEmpty PeerId
+getPeerIds peers = HonestPeer :| Map.keys (others peers)
+
+-- | Convert 'Peers' to a list of 'Peer'.
+peersList :: Peers a -> NonEmpty (Peer a)
+peersList Peers {honest, others} =
+  honest :| Map.elems others
+
+-- | Construct 'Peers' from values, adding adversary names based on the default schema.
+-- A single adversary gets the ID @adversary@, multiple get enumerated as @adversary N@.
+mkPeers :: a -> [a] -> Peers a
+mkPeers h as =
+  Peers (Peer HonestPeer h) (Map.fromList (mkPeer <$> advs as))
+  where
+    mkPeer (pid, a) = (pid, Peer pid a)
+    advs [a] = [("adversary", a)]
+    advs _   = zip enumAdvs as
+    enumAdvs = (\ n -> PeerId ("adversary " ++ show n)) <$> [1 :: Int ..]

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Shrinking.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Shrinking.hs
@@ -1,0 +1,13 @@
+module Test.Consensus.PointSchedule.Shrinking (shrinkPeerSchedules) where
+
+import           Test.Consensus.PeerSimulator.StateView (StateView)
+import           Test.Consensus.PointSchedule (GenesisTest, PeerSchedule)
+import           Test.Consensus.PointSchedule.Peers (Peers (..))
+
+-- | Shrink a 'Peers PeerSchedule'.
+shrinkPeerSchedules ::
+  GenesisTest ->
+  Peers PeerSchedule ->
+  StateView ->
+  [(GenesisTest, Peers PeerSchedule)]
+shrinkPeerSchedules _genesisTest _schedule _stateView = []

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Shrinking.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Shrinking.hs
@@ -21,17 +21,23 @@ import           Test.QuickCheck (shrinkList)
 import           Test.Util.TestBlock (TestBlock, TestHash (unTestHash))
 
 -- | Shrink a 'Peers PeerSchedule'. This does not affect the honest peer; it
--- does, however, attempt to remove other peers. The block tree is trimmed to
--- keep only parts that are necessary for the shrunk schedule.
+-- does, however, attempt to remove other peers or ticks of other peers. The
+-- block tree is trimmed to keep only parts that are necessary for the shrunk
+-- schedule.
 shrinkPeerSchedules ::
   GenesisTest ->
   Peers PeerSchedule ->
   StateView ->
   [(GenesisTest, Peers PeerSchedule)]
 shrinkPeerSchedules genesisTest schedule _stateView =
-  shrinkOtherPeers (const []) schedule <&> \shrunkSchedule ->
+  shrinkOtherPeers shrinkPeerSchedule schedule <&> \shrunkSchedule ->
     let trimmedBlockTree = trimBlockTree (gtBlockTree genesisTest) (fromSchedulePoints shrunkSchedule)
      in (genesisTest{gtBlockTree = trimmedBlockTree}, shrunkSchedule)
+
+-- | Shrink a 'PeerSchedule' by removing ticks from it. The other ticks are kept
+-- unchanged.
+shrinkPeerSchedule :: PeerSchedule -> [PeerSchedule]
+shrinkPeerSchedule = shrinkList (const [])
 
 -- | Shrink the 'others' field of a 'Peers' structure by attempting to remove
 -- peers or by shrinking their values using the given shrinking function.

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Shrinking.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Shrinking.hs
@@ -54,9 +54,9 @@ trimBlockTree' = keepOnlyAncestorsOf . peerSchedulesBlocks
 -- that contains ancestors of the given blocks.
 keepOnlyAncestorsOf :: [TestBlock] -> BlockTree TestBlock -> BlockTree TestBlock
 keepOnlyAncestorsOf blocks bt =
-    let leafs = blocksWithoutDescendents blocks
-        trunk = keepOnlyAncestorsOf' leafs (btTrunk bt)
-        branches = mapMaybe (fragmentToMaybe . keepOnlyAncestorsOf' leafs . btbSuffix) (btBranches bt)
+    let leaves = blocksWithoutDescendents blocks
+        trunk = keepOnlyAncestorsOf' leaves (btTrunk bt)
+        branches = mapMaybe (fragmentToMaybe . keepOnlyAncestorsOf' leaves . btbSuffix) (btBranches bt)
      in foldr addBranch' (mkTrunk trunk) branches
   where
     fragmentToMaybe (Empty _) = Nothing
@@ -65,7 +65,7 @@ keepOnlyAncestorsOf blocks bt =
     -- | Given some blocks and a fragment, keep only the prefix of the fragment
     -- that contains ancestors of the given blocks.
     keepOnlyAncestorsOf' :: [TestBlock] -> AnchoredFragment TestBlock -> AnchoredFragment TestBlock
-    keepOnlyAncestorsOf' leafs = takeWhileOldest (\block -> (block `isAncestorOf`) `any` leafs)
+    keepOnlyAncestorsOf' leaves = takeWhileOldest (\block -> (block `isAncestorOf`) `any` leaves)
 
     -- | Return a subset of the given blocks containing only the ones that do
     -- not have any other descendents in the set.
@@ -78,8 +78,8 @@ keepOnlyAncestorsOf blocks bt =
         -- | Blocks that do not have any descendents earlier in the list.
         blocksWithoutPreviousDescendents =
           foldl
-            (\leafs block ->
-               if (block `isAncestorOf`) `any` leafs
-                 then leafs
-                 else block : leafs)
+            (\leaves block ->
+               if (block `isAncestorOf`) `any` leaves
+                 then leaves
+                 else block : leaves)
             []

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Shrinking.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Shrinking.hs
@@ -1,13 +1,24 @@
 {-# LANGUAGE NamedFieldPuns #-}
-{-# LANGUAGE TupleSections  #-}
 
 module Test.Consensus.PointSchedule.Shrinking (shrinkPeerSchedules) where
 
+import           Data.Functor ((<&>))
+import           Data.List (isSuffixOf, sortOn)
+import qualified Data.List.NonEmpty as NonEmpty
 import qualified Data.Map.Strict as Map
+import           Data.Maybe (mapMaybe)
+import           Ouroboros.Network.AnchoredFragment (AnchoredFragment,
+                     AnchoredSeq (Empty, (:>)))
+import           Ouroboros.Network.Block (blockHash, blockSlot)
+import           Test.Consensus.BlockTree (BlockTree (..), BlockTreeBranch (..),
+                     addBranch', mkTrunk)
 import           Test.Consensus.PeerSimulator.StateView (StateView)
-import           Test.Consensus.PointSchedule (GenesisTest, PeerSchedule)
+import           Test.Consensus.PointSchedule (GenesisTest (gtBlockTree),
+                     PeerSchedule, PointSchedule, fromSchedulePoints,
+                     pointScheduleBlocks)
 import           Test.Consensus.PointSchedule.Peers (Peers (..))
 import           Test.QuickCheck (shrinkList)
+import           Test.Util.TestBlock (TestBlock, TestHash (unTestHash))
 
 -- | Shrink a 'Peers PeerSchedule'. This does not affect the honest peer; it
 -- does, however, attempt to remove other peers. The block tree is trimmed to
@@ -18,7 +29,9 @@ shrinkPeerSchedules ::
   StateView ->
   [(GenesisTest, Peers PeerSchedule)]
 shrinkPeerSchedules genesisTest schedule _stateView =
-  map (genesisTest,) $ shrinkOtherPeers (const []) schedule
+  shrinkOtherPeers (const []) schedule <&> \shrunkSchedule ->
+    let trimmedBlockTree = trimBlockTree (gtBlockTree genesisTest) (fromSchedulePoints shrunkSchedule)
+     in (genesisTest{gtBlockTree = trimmedBlockTree}, shrunkSchedule)
 
 -- | Shrink the 'others' field of a 'Peers' structure by attempting to remove
 -- peers or by shrinking their values using the given shrinking function.
@@ -26,3 +39,52 @@ shrinkOtherPeers :: (a -> [a]) -> Peers a -> [Peers a]
 shrinkOtherPeers shrink Peers{honest, others} =
   map (Peers honest . Map.fromList) $
     shrinkList (traverse (traverse shrink)) $ Map.toList others
+
+-- | Remove blocks from the given block tree that are not necessary for the
+-- given point schedule. If entire branches are unused, they are removed. If the
+-- trunk is unused, then it remains as an empty anchored fragment.
+trimBlockTree :: BlockTree TestBlock -> PointSchedule -> BlockTree TestBlock
+trimBlockTree bt ps =
+    let youngest = selectYoungest (pointScheduleBlocks ps)
+        trunk = trimFragment youngest (btTrunk bt)
+        branches = mapMaybe (fragmentToMaybe . trimFragment youngest . btbSuffix) (btBranches bt)
+     in foldr addBranch' (mkTrunk trunk) branches
+  where
+    fragmentToMaybe (Empty _) = Nothing
+    fragmentToMaybe fragment  = Just fragment
+
+    -- | Given a list of blocks and a fragment, cut the fragment such that it
+    -- contains only blocks that are ancestors of blocks in the list.
+    trimFragment :: [TestBlock] -> AnchoredFragment TestBlock -> AnchoredFragment TestBlock
+    trimFragment _ fragment@(Empty _) = fragment
+    trimFragment youngest (fragment :> block)
+      | any (block `isOlderThan`) youngest = fragment :> block
+      | otherwise = trimFragment youngest fragment
+
+    -- | Return a subset of the given block containing youngest elements. It is
+    -- not guaranteed that this set is minimal. It is however guaranteed that
+    -- any block in the input list is an ancestor of a block in the output list.
+    selectYoungest :: [TestBlock] -> [TestBlock]
+    selectYoungest =
+        -- NOTE: We process blocks from the biggest slot to the smallest; this
+        -- should make us select only the tip of each chain.
+        go [] . reverse . sortOn blockSlot
+      where
+        go youngest [] = youngest
+        go youngest (block : blocks)
+          | any (`isYoungerThan` block) youngest = go youngest blocks
+          | otherwise = go (block : youngest) blocks
+
+    -- | Partial comparison of blocks. A block is older than another block if it
+    -- is its ancestor. For test blocks, this can be seen in the hash.
+    isOlderThan :: TestBlock -> TestBlock -> Bool
+    isOlderThan b1 b2 =
+      -- NOTE: 'unTestHash' returns the list of hash components _in reverse
+      -- order_ so we need to test that one hash is the _suffix_ of the other.
+      NonEmpty.toList (unTestHash (blockHash b1))
+        `isSuffixOf`
+      NonEmpty.toList (unTestHash (blockHash b2))
+
+    -- | Partial comparison of blocks. @isYoungerThan = flip isOlderThan@.
+    isYoungerThan :: TestBlock -> TestBlock -> Bool
+    isYoungerThan = flip isOlderThan

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Shrinking.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Shrinking.hs
@@ -1,13 +1,28 @@
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE TupleSections  #-}
+
 module Test.Consensus.PointSchedule.Shrinking (shrinkPeerSchedules) where
 
+import qualified Data.Map.Strict as Map
 import           Test.Consensus.PeerSimulator.StateView (StateView)
 import           Test.Consensus.PointSchedule (GenesisTest, PeerSchedule)
 import           Test.Consensus.PointSchedule.Peers (Peers (..))
+import           Test.QuickCheck (shrinkList)
 
--- | Shrink a 'Peers PeerSchedule'.
+-- | Shrink a 'Peers PeerSchedule'. This does not affect the honest peer; it
+-- does, however, attempt to remove other peers. The block tree is trimmed to
+-- keep only parts that are necessary for the shrunk schedule.
 shrinkPeerSchedules ::
   GenesisTest ->
   Peers PeerSchedule ->
   StateView ->
   [(GenesisTest, Peers PeerSchedule)]
-shrinkPeerSchedules _genesisTest _schedule _stateView = []
+shrinkPeerSchedules genesisTest schedule _stateView =
+  map (genesisTest,) $ shrinkOtherPeers (const []) schedule
+
+-- | Shrink the 'others' field of a 'Peers' structure by attempting to remove
+-- peers or by shrinking their values using the given shrinking function.
+shrinkOtherPeers :: (a -> [a]) -> Peers a -> [Peers a]
+shrinkOtherPeers shrink Peers{honest, others} =
+  map (Peers honest . Map.fromList) $
+    shrinkList (traverse (traverse shrink)) $ Map.toList others

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Shrinking.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Shrinking.hs
@@ -3,13 +3,12 @@
 module Test.Consensus.PointSchedule.Shrinking (shrinkPeerSchedules) where
 
 import           Data.Functor ((<&>))
-import           Data.List (isSuffixOf, sortOn)
-import qualified Data.List.NonEmpty as NonEmpty
+import           Data.List (sortOn)
 import qualified Data.Map.Strict as Map
 import           Data.Maybe (mapMaybe)
 import           Ouroboros.Network.AnchoredFragment (AnchoredFragment,
                      AnchoredSeq (Empty), takeWhileOldest)
-import           Ouroboros.Network.Block (blockHash, blockSlot)
+import           Ouroboros.Network.Block (blockSlot)
 import           Test.Consensus.BlockTree (BlockTree (..), BlockTreeBranch (..),
                      addBranch', mkTrunk)
 import           Test.Consensus.PeerSimulator.StateView (StateView)
@@ -17,7 +16,7 @@ import           Test.Consensus.PointSchedule (GenesisTest (gtBlockTree),
                      PeerSchedule, peerSchedulesBlocks)
 import           Test.Consensus.PointSchedule.Peers (Peers (..))
 import           Test.QuickCheck (shrinkList)
-import           Test.Util.TestBlock (TestBlock, TestHash (unTestHash))
+import           Test.Util.TestBlock (TestBlock, isAncestorOf)
 
 -- | Shrink a 'Peers PeerSchedule'. This does not affect the honest peer; it
 -- does, however, attempt to remove other peers or ticks of other peers. The
@@ -84,13 +83,3 @@ keepOnlyAncestorsOf blocks bt =
                  then leafs
                  else block : leafs)
             []
-
-    -- | Partial comparison of blocks. A block is older than another block if it
-    -- is its ancestor. For test blocks, this can be seen in the hash.
-    isAncestorOf :: TestBlock -> TestBlock -> Bool
-    isAncestorOf b1 b2 =
-      -- NOTE: 'unTestHash' returns the list of hash components _in reverse
-      -- order_ so we need to test that one hash is the _suffix_ of the other.
-      NonEmpty.toList (unTestHash (blockHash b1))
-        `isSuffixOf`
-      NonEmpty.toList (unTestHash (blockHash b2))

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Shrinking.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Shrinking.hs
@@ -64,7 +64,7 @@ trimBlockTree bt ps =
     trimFragment :: [TestBlock] -> AnchoredFragment TestBlock -> AnchoredFragment TestBlock
     trimFragment _ fragment@(Empty _) = fragment
     trimFragment youngest (fragment :> block)
-      | any (block `isOlderThan`) youngest = fragment :> block
+      | any (block `isAncestorOf`) youngest = fragment :> block
       | otherwise = trimFragment youngest fragment
 
     -- | Return a subset of the given block containing youngest elements. It is
@@ -78,19 +78,19 @@ trimBlockTree bt ps =
       where
         go youngest [] = youngest
         go youngest (block : blocks)
-          | any (`isYoungerThan` block) youngest = go youngest blocks
+          | any (`isDescendentOf` block) youngest = go youngest blocks
           | otherwise = go (block : youngest) blocks
 
     -- | Partial comparison of blocks. A block is older than another block if it
     -- is its ancestor. For test blocks, this can be seen in the hash.
-    isOlderThan :: TestBlock -> TestBlock -> Bool
-    isOlderThan b1 b2 =
+    isAncestorOf :: TestBlock -> TestBlock -> Bool
+    isAncestorOf b1 b2 =
       -- NOTE: 'unTestHash' returns the list of hash components _in reverse
       -- order_ so we need to test that one hash is the _suffix_ of the other.
       NonEmpty.toList (unTestHash (blockHash b1))
         `isSuffixOf`
       NonEmpty.toList (unTestHash (blockHash b2))
 
-    -- | Partial comparison of blocks. @isYoungerThan = flip isOlderThan@.
-    isYoungerThan :: TestBlock -> TestBlock -> Bool
-    isYoungerThan = flip isOlderThan
+    -- | Partial comparison of blocks. @isDescendentOf = flip isAncestorOf@.
+    isDescendentOf :: TestBlock -> TestBlock -> Bool
+    isDescendentOf = flip isAncestorOf

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/SinglePeer.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/SinglePeer.hs
@@ -1,0 +1,324 @@
+-- | This module contains functions for generating random point schedules.
+--
+-- A point schedule is a set of tables, having one table per simulated peer.
+-- Each row of a table correspond to a point in time, also called a tick.
+--
+-- Each tick has a timestamp and a state to set for the corresponding peer at
+-- that time. The state of each peer is described by three blocks points
+-- related to the peer's hypothetical chain selection:
+--
+-- * Tip Point: the tip of the hypothetical chain selection. This tip is
+--       advertised to the node under test in ChainSync client exchanges.
+-- * Header Point: the most recent header that the peer should send to the
+--       node under test. Any newer headers should wait until the Header
+--       Point is updated to newer headers.
+-- * Block Point: the most recent block that the peer should send to the
+--       node under test. Any newer blocks should wait until the Block Point
+--       is updated to newer headers.
+--
+-- Given a chain selection like this:
+--
+-- > Genesis -> A -> B -> C -> D
+--
+-- The point schedule of a peer might look like this:
+--
+-- > +--------+----------------+----------------+----------------+
+-- > | Tick   | Tip Point      | Header Point   | Block Point    |
+-- > +--------+----------------+----------------+----------------+
+-- > |   0.0s | Genesis        | Genesis        | Genesis        |
+-- > +--------+----------------+----------------+----------------+
+-- > |   1.2s | D              | Genesis        | Genesis        |
+-- > +--------+----------------+----------------+----------------+
+-- > |   1.3s | D              | C              | Genesis        |
+-- > +--------+----------------+----------------+----------------+
+-- > |   1.6s | D              | C              | B              |
+-- > +--------+----------------+----------------+----------------+
+-- > |   2.0s | D              | C              | C              |
+-- > +--------+----------------+----------------+----------------+
+-- > |   2.2s | D              | D              | D              |
+-- > +--------+----------------+----------------+----------------+
+--
+-- Some rules apply to how the point schedule progresses, although
+-- exceptions might be tested occasionally. In general,
+--
+-- * The Tip Point is set first
+-- * Header points are not allowed to point to newer blocks than the tip point
+-- * Block points are not allowed to point to newer blocks than the header point
+--
+-- The following is an example with rollbacks:
+--
+-- > Genesis -> A -> B -> C -> D
+-- >                   \-> C' -> D' -> E
+--
+-- > +--------+----------------+----------------+----------------+
+-- > | Tick   | Tip Point      | Header Point   | Block Point    |
+-- > +--------+----------------+----------------+----------------+
+-- > |   0.0s | Genesis        | Genesis        | Genesis        |
+-- > +--------+----------------+----------------+----------------+
+-- > |   1.2s | D              | Genesis        | Genesis        |
+-- > +--------+----------------+----------------+----------------+
+-- > |   1.3s | D              | C              | Genesis        |
+-- > +--------+----------------+----------------+----------------+
+-- > |   1.6s | D              | C              | B              |
+-- > +--------+----------------+----------------+----------------+
+-- > |   2.0s | D              | C              | C              |
+-- > +--------+----------------+----------------+----------------+
+-- > |   2.1s | D              | D              | C              |
+-- > +--------+----------------+----------------+----------------+
+-- > |   2.3s | D              | D              | D              |
+-- > +--------+----------------+----------------+----------------+
+-- > |   2.4s | E              | D              | D              |
+-- > +--------+----------------+----------------+----------------+
+-- > |   2.6s | E              | D'             | D              |
+-- > +--------+----------------+----------------+----------------+
+-- > |   2.7s | E              | D'             | C'             |
+-- > +--------+----------------+----------------+----------------+
+-- > |   2.9s | E              | D'             | D'             |
+-- > +--------+----------------+----------------+----------------+
+-- > |   3.0s | E              | E              | D'             |
+-- > +--------+----------------+----------------+----------------+
+-- > |   3.1s | E              | E              | E              |
+-- > +--------+----------------+----------------+----------------+
+--
+module Test.Consensus.PointSchedule.SinglePeer (
+    IsTrunk (..)
+  , PeerScheduleParams (..)
+  , SchedulePoint (..)
+  , defaultPeerScheduleParams
+  , peerScheduleFromTipPoints
+  , schedulePointToBlock
+  , singleJumpPeerSchedule
+    -- * Exposed for testing
+  , zipMany
+  ) where
+
+import           Cardano.Slotting.Slot (WithOrigin (At, Origin), withOrigin)
+import           Control.Arrow (second)
+import           Data.List (mapAccumL)
+import           Data.Time.Clock (DiffTime)
+import           Data.Vector (Vector)
+import qualified Data.Vector as Vector
+import qualified Ouroboros.Network.AnchoredFragment as AF
+import           Ouroboros.Network.Block (BlockNo (unBlockNo), SlotNo)
+import qualified System.Random.Stateful as R (StatefulGen)
+import           Test.Consensus.PointSchedule.SinglePeer.Indices
+                     (HeaderPointSchedule (hpsBranch, hpsTrunk),
+                     headerPointSchedule, singleJumpTipPoints, tipPointSchedule)
+import           Test.Util.TestBlock (TestBlock, tbSlot)
+
+
+-- | A point in the schedule of a single peer.
+data SchedulePoint
+  = ScheduleTipPoint TestBlock
+  | ScheduleHeaderPoint TestBlock
+  | ScheduleBlockPoint TestBlock
+  deriving (Eq, Show)
+
+schedulePointToBlock :: SchedulePoint -> TestBlock
+schedulePointToBlock (ScheduleTipPoint b)    = b
+schedulePointToBlock (ScheduleHeaderPoint b) = b
+schedulePointToBlock (ScheduleBlockPoint b)  = b
+
+-- | Parameters for generating a schedule for a single peer.
+--
+-- In the most general form, the caller provides a list of tip points and the
+-- schedule is generated by following the given tip points. All headers points
+-- and block points are sent eventually, but the points are delayed according
+-- to these parameters.
+data PeerScheduleParams = PeerScheduleParams
+  { pspSlotLength          :: DiffTime
+    -- | Each of these pairs specifies a range of delays for a point. The
+    -- actual delay is chosen uniformly at random from the range.
+    --
+    -- For tip points, the delay is relative to the slot of the tip point.
+  , pspTipDelayInterval    :: (DiffTime, DiffTime)
+    -- | For header points, the delay is relative to the previous header point
+    -- or the tip point that advertises the existence of the header (whichever
+    -- happened most recently).
+  , pspHeaderDelayInterval :: (DiffTime, DiffTime)
+    -- | For block points, the delay is relative to the previous block point or
+    -- the header point that advertises the existence of the block (whichever
+    -- happened most recently).
+  , pspBlockDelayInterval  :: (DiffTime, DiffTime)
+  }
+  deriving (Show)
+
+defaultPeerScheduleParams :: PeerScheduleParams
+defaultPeerScheduleParams = PeerScheduleParams
+  { pspSlotLength = 20
+  , pspTipDelayInterval = (0, 1)
+  , pspHeaderDelayInterval = (0.018, 0.021)
+  , pspBlockDelayInterval = (0.050, 0.055)
+  }
+
+-- | Generate a schedule for a single peer that jumps once to the middle of a
+-- sequence of blocks.
+--
+--  See 'peerScheduleFromTipPoints' for generation of schedules with rollbacks
+singleJumpPeerSchedule
+  :: R.StatefulGen g m
+  => g
+  -> PeerScheduleParams
+  -> AF.AnchoredFragment TestBlock
+  -> m [(DiffTime, SchedulePoint)]
+singleJumpPeerSchedule g psp chain = do
+    let chainv = Vector.fromList $ AF.toOldestFirst chain
+    (tps, hps, bps) <- singleJumpRawPeerSchedule g psp tbSlot chainv
+    let tipPoints = map (second ScheduleTipPoint) tps
+        headerPoints = map (second ScheduleHeaderPoint) hps
+        blockPoints = map (second ScheduleBlockPoint) bps
+    -- merge the schedules
+    pure $
+      mergeOn fst tipPoints $
+      mergeOn fst headerPoints blockPoints
+
+singleJumpRawPeerSchedule
+  :: R.StatefulGen g m
+  => g
+  -> PeerScheduleParams
+  -> (b -> SlotNo)
+  -> Vector b
+  -> m ([(DiffTime, b)], [(DiffTime, b)], [(DiffTime, b)])
+singleJumpRawPeerSchedule g psp slotOfB chainv = do
+    -- generate the tip points
+    ixs <- singleJumpTipPoints g 0 (Vector.length chainv - 1)
+    let tipPointBlks = map (chainv Vector.!) ixs
+        tipPointSlots = map slotOfB tipPointBlks
+    -- generate the tip point schedule
+    ts <- tipPointSchedule g (pspSlotLength psp) (pspTipDelayInterval psp) tipPointSlots
+    -- generate the header point schedule
+    hpss <- headerPointSchedule g (pspHeaderDelayInterval psp) [(Nothing, zip ts ixs)]
+    let hps = concatMap hpsTrunk hpss
+    -- generate the block point schedule
+    bpss <- headerPointSchedule g (pspBlockDelayInterval psp) [(Nothing, hps)]
+    -- collect the blocks for each schedule
+    let bps = concatMap hpsTrunk bpss
+        tipPointTips = zip ts tipPointBlks
+        hpsHeaders = map (second (chainv Vector.!)) hps
+        bpsBlks = map (second (chainv Vector.!)) bps
+    pure (tipPointTips, hpsHeaders, bpsBlks)
+
+data IsTrunk = IsTrunk | IsBranch
+  deriving (Eq, Show)
+
+-- | @peerScheduleFromTipPoints g params tps trunk branches@ generates a schedule for
+-- a single peer that follows the given tip points.
+--
+-- @tps@ contains the tip points for each fragment.
+--
+-- @trunk@ is the fragment for the honest chain
+--
+-- @branches@ contains the fragments for the alternative chains in ascending
+-- order of their intersections with the honest chain.
+--
+peerScheduleFromTipPoints
+  :: R.StatefulGen g m
+  => g
+  -> PeerScheduleParams
+  -> [(IsTrunk, [Int])]
+  -> AF.AnchoredFragment TestBlock
+  -> [AF.AnchoredFragment TestBlock]
+  -> m [(DiffTime, SchedulePoint)]
+peerScheduleFromTipPoints g psp tipPoints trunk0 branches0 = do
+    let trunk0v = Vector.fromList $ AF.toOldestFirst trunk0
+        firstTrunkBlockNo = withOrigin 1 (+1) $ AF.anchorBlockNo trunk0
+        branches0v = map (Vector.fromList . AF.toOldestFirst) branches0
+        anchorBlockIndices =
+          [ fromIntegral $ unBlockNo $ fragmentAnchorBlockNo b - firstTrunkBlockNo
+          | b <- branches0
+          ]
+        isTrunks = map fst tipPoints
+        intersections = intersperseTrunkFragments anchorBlockIndices isTrunks
+    (tps, hps, bps) <- rawPeerScheduleFromTipPoints g psp tbSlot tipPoints trunk0v branches0v intersections
+    let tipPoints' = map (second ScheduleTipPoint) tps
+        headerPoints = map (second ScheduleHeaderPoint) hps
+        blockPoints = map (second ScheduleBlockPoint) bps
+    -- merge the schedules
+    pure $
+      mergeOn fst tipPoints' $
+      mergeOn fst headerPoints blockPoints
+  where
+    fragmentAnchorBlockNo :: AF.AnchoredFragment TestBlock -> BlockNo
+    fragmentAnchorBlockNo f = case AF.anchorBlockNo f of
+      At s   -> s
+      Origin -> 0
+
+    intersperseTrunkFragments :: [Int] -> [IsTrunk] -> [Maybe Int]
+    intersperseTrunkFragments [] [] = []
+    intersperseTrunkFragments iis (IsTrunk:isTrunks) = Nothing : intersperseTrunkFragments iis isTrunks
+    intersperseTrunkFragments (i:is) (IsBranch:isTrunks) = Just i : intersperseTrunkFragments is isTrunks
+    intersperseTrunkFragments _ [] = error "intersperseTrunkFragments: not enough isTrunk flags"
+    intersperseTrunkFragments [] _ = error "intersperseTrunkFragments: not enough intersections"
+
+rawPeerScheduleFromTipPoints
+  :: R.StatefulGen g m
+  => g
+  -> PeerScheduleParams
+  -> (b -> SlotNo)
+  -> [(IsTrunk, [Int])]
+  -> Vector b
+  -> [Vector b]
+  -> [Maybe Int]
+  -> m ([(DiffTime, b)], [(DiffTime, b)], [(DiffTime, b)])
+rawPeerScheduleFromTipPoints g psp slotOfB tipPoints trunk0v branches0v intersections = do
+    let (isTrunks, tpIxs) = unzip tipPoints
+        pairedVectors = pairVectorsWithChunks trunk0v branches0v isTrunks
+        tipPointBlks = concat $ zipWith indicesToBlocks pairedVectors tpIxs
+        tipPointSlots = map slotOfB tipPointBlks
+    -- generate the tip point schedule
+    ts <- tipPointSchedule g (pspSlotLength psp) (pspTipDelayInterval psp) tipPointSlots
+    -- generate the header point schedule
+    let tpSchedules = zipMany ts tpIxs
+    hpss <- headerPointSchedule g (pspHeaderDelayInterval psp) $ zip intersections tpSchedules
+    -- generate the block point schedule
+    let (hpsPerBranch, vs) = unzip $ filter (not . null . snd .fst) $ concat
+          [ [((Nothing, hpsTrunk hps), trunk0v), ((mi, hpsBranch hps), v)]
+          | (mi, hps, v) <- zip3 intersections hpss pairedVectors
+          ]
+    bpss <- headerPointSchedule g (pspBlockDelayInterval psp) hpsPerBranch
+    let tipPointTips = zip ts tipPointBlks
+        hpsHeaders = concat $ zipWith (scheduleIndicesToBlocks trunk0v) pairedVectors hpss
+        bpsBlks = concat $ zipWith (scheduleIndicesToBlocks trunk0v) vs bpss
+    pure (tipPointTips, hpsHeaders, bpsBlks)
+
+  where
+    pairVectorsWithChunks
+      :: Vector b
+      -> [Vector b]
+      -> [IsTrunk]
+      -> [Vector b]
+    pairVectorsWithChunks trunk branches =
+       snd . mapAccumL pairVectors branches
+      where
+        pairVectors brs IsTrunk       = (brs, trunk)
+        pairVectors (br:brs) IsBranch = (brs, br)
+        pairVectors [] IsBranch       = error "not enough branches"
+
+    -- | Replaces block indices with the actual blocks
+    scheduleIndicesToBlocks :: Vector b -> Vector b -> HeaderPointSchedule -> [(DiffTime, b)]
+    scheduleIndicesToBlocks trunk v hps =
+        map (second (trunk Vector.!)) (hpsTrunk hps)
+          ++ map (second (v Vector.!)) (hpsBranch hps)
+
+    indicesToBlocks :: Vector b -> [Int] -> [b]
+    indicesToBlocks v ixs = map (v Vector.!) ixs
+
+
+-- | Merge two sorted lists.
+--
+-- PRECONDITION: The lists are sorted.
+--
+mergeOn :: Ord b => (a -> b) -> [a] -> [a] -> [a]
+mergeOn _f [] ys = ys
+mergeOn _f xs [] = xs
+mergeOn f xxs@(x:xs) yys@(y:ys) =
+    if f x <= f y
+      then x : mergeOn f xs yys
+      else y : mergeOn f xxs ys
+
+zipMany :: [a] -> [[b]] -> [[(a, b)]]
+zipMany xs0 = snd . mapAccumL (go []) xs0
+  where
+    go acc xs []         = (xs, reverse acc)
+    go _acc [] _ys       = error "zipMany: lengths don't match"
+    go acc (x:xs) (y:ys) = go ((x, y) : acc) xs ys

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/SinglePeer.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/SinglePeer.hs
@@ -202,15 +202,18 @@ singleJumpRawPeerSchedule g psp slotOfB chainv = do
 data IsTrunk = IsTrunk | IsBranch
   deriving (Eq, Show)
 
--- | @peerScheduleFromTipPoints g params tps trunk branches@ generates a schedule for
--- a single peer that follows the given tip points.
+-- | @peerScheduleFromTipPoints g params tps trunk branches@ generates a
+-- schedule for a single peer that follows the given tip points.
 --
--- @tps@ contains the tip points for each fragment.
+-- @tps@ contains the tip points for each fragment. The indices correspond to
+-- the fragments in branches and go from @0@ to @length branch - 1@.
 --
 -- @trunk@ is the fragment for the honest chain
 --
 -- @branches@ contains the fragments for the alternative chains in ascending
--- order of their intersections with the honest chain.
+-- order of their intersections with the honest chain. Each fragment is anchored
+-- at the intersection, and therefore their first block must be the first block
+-- after the intersection.
 --
 peerScheduleFromTipPoints
   :: R.StatefulGen g m

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/SinglePeer.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/SinglePeer.hs
@@ -89,6 +89,7 @@ module Test.Consensus.PointSchedule.SinglePeer (
   , schedulePointToBlock
   , singleJumpPeerSchedule
     -- * Exposed for testing
+  , mergeOn
   , zipMany
   ) where
 

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/SinglePeer/Indices.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/SinglePeer/Indices.hs
@@ -18,6 +18,7 @@ module Test.Consensus.PointSchedule.SinglePeer.Indices (
   , rollbacksTipPoints
   , singleJumpTipPoints
   , tipPointSchedule
+  , uniformRMDiffTime
   ) where
 
 import           Control.Monad (forM, replicateM)

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/SinglePeer/Indices.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/SinglePeer/Indices.hs
@@ -1,0 +1,316 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+-- | Schedule generators for a single peer
+--
+-- These functions generate schedules for the tip points, the header points and
+-- the block points of a single peer. All of them are expressed in terms of
+-- block indices rather than actual block points.
+--
+-- The tip points are to be generated first with either of 'singleJumpTipPoints'
+-- or 'rollbacksTipPoints'. Then the tip points can be assigned times at which
+-- to announce them with 'tipPointSchedule'. Then, the header points can be
+-- generated with 'headerPointSchedule'. Finally, the block points can be
+-- generated with 'headerPointSchedule' as well. See the implementation of
+-- 'Test.Consensus.PointSchedule.Random.singleJumpPeerSchedule' for an example.
+--
+module Test.Consensus.PointSchedule.SinglePeer.Indices (
+    HeaderPointSchedule (..)
+  , headerPointSchedule
+  , rollbacksTipPoints
+  , singleJumpTipPoints
+  , tipPointSchedule
+  ) where
+
+import           Control.Monad (forM, replicateM)
+import           Data.List (sort)
+import           Data.Time.Clock (DiffTime, diffTimeToPicoseconds,
+                     picosecondsToDiffTime)
+import           GHC.Stack (HasCallStack)
+import           Ouroboros.Network.Block (SlotNo (SlotNo))
+import qualified System.Random.Stateful as R
+
+
+-- | @singleJumpTipPoints g m n@ generates a list of tip points for a single peer
+-- serving a single branch between block indices @m@ and @n@. The schedule is a
+-- list of block indices for the tip point of the peer state.
+--
+-- The first tip jumps to a block in the middle of the index range, and
+-- then updates the tip one block at a time.
+--
+-- > singleJumpTipPoints
+-- >   :: g
+-- >   -> {m:Int | m >= 0}
+-- >   -> {n:Int | n >= 0}
+-- >   -> m {v:[Int]
+-- >        | isSorted v &&
+-- >          all (m<=) v &&
+-- >          all (<=n) v &&
+-- >          not (hasDuplicates v)
+-- >        }
+--
+singleJumpTipPoints :: R.StatefulGen g m => g -> Int -> Int -> m [Int]
+singleJumpTipPoints _g m n
+    | n < m = pure []
+singleJumpTipPoints g m n = do
+    jump <- R.uniformRM (m, n) g
+    pure [jump..n]
+
+-- | @rollbacksTipPoints k bs g@ generates a schedule for a single peer
+-- serving from multiple alternative branches. The schedule is a list of block
+-- indices for the tip point of the peer state. Here the block indices are
+-- separated per branch in the result. Each index is relative to the branch it
+-- belongs to.
+--
+-- @k@ is the security parameter.
+--
+-- @bs@ are the length in blocks of the alternative branches of the block tree.
+-- The lengths need to be provided in the order in which the branches intersect
+-- with the trunk.
+--
+-- > rollbacksTipPoints
+-- >   :: g
+-- >   -> {k:Int | k > 0}
+-- >   -> {bs:[Int] | all (0<=) bs}
+-- >   -> m {v:[Int]
+-- >        | isSorted v &&
+-- >          all (all (0<=)) v &&
+-- >          all (all (<k)) v &&
+-- >          all isSorted v &&
+-- >          all (not . hasDuplicates) v &&
+-- >          and [all (<bn) bbs | (bn, bbs) <- zip bs v] &&
+-- >          length v == length bs bracketChainSyncClient
+-- >        }
+--
+rollbacksTipPoints
+  :: R.StatefulGen g m => g -> Int -> [Int] -> m [[Int]]
+rollbacksTipPoints g k = mapM walkBranch
+  where
+    walkBranch bn = singleJumpTipPoints g 0 (min (k-1) (bn - 1))
+
+
+-- | @tipPointSchedule g slotLengh msgDelayInterval slots@ attaches times to a
+-- sequence of tip points. These times are the times at which the tip points
+-- should be offered to the node under test. Times are expressed as an offset
+-- from the time of slot 0.
+--
+-- @slotLength@ is the length of a slot in seconds.
+--
+-- @msgDelayInterval@ is the interval from which to sample the delay of
+-- each tip point after the slot in which it was minted.
+--
+-- @slots@ are the slot numbers of the blocks in the tip point schedule.
+-- Because the slots might belong to different branches, they might be
+-- duplicated or not monotonically increasing. e.g.
+--
+-- If 0s and 1s signal the tip points that we want to announce
+--
+-- > slot number: 0123456
+-- > trunk  :     011001
+-- > alternative:   01101
+--
+-- The slots of the tip points to serve could be @[1, 2, 5, 3, 4, 6]@
+-- Then the generated times could be close to
+--
+-- > [1*20, 2*20, 5*20, t3, t4, 6*20]
+--
+-- where @t3@ and @t4@ are chosen randomly in the interval between the
+-- branch tips, that is between 5*20 and 6*20.
+--
+-- > tipPointSchedule
+-- >   :: g
+-- >   -> {slotLength:DiffTime | slotLength >= 0}
+-- >   -> {msgDelayInterval:(DiffTime, DiffTime)
+-- >      | fst msgDelayInterval <= snd msgDelayInterval
+-- >      }
+-- >   -> {slots:[SlotNo] | all (0<=) slots}
+-- >   -> m {v:[DiffTime] | isSorted v && length v == length slots}
+--
+tipPointSchedule
+  :: forall g m. R.StatefulGen g m => g -> DiffTime -> (DiffTime, DiffTime) -> [SlotNo] -> m [DiffTime]
+tipPointSchedule _g slotLength (a, b) _slots
+    | slotLength <= b = error "tipPointSchedule: slotLength <= maximum delay"
+    | b < a = error "tipPointSchedule: empty delay interval"
+tipPointSchedule g slotLength msgDelayInterval slots = do
+    let -- pairs of times corresponding to the start and end of each interval
+        -- between tip points
+        slotTimes = map toDiffTime slots
+        timePairs = zip slotTimes $ tail slotTimes ++ [last slotTimes + 1]
+    go timePairs
+  where
+    go :: [(DiffTime, DiffTime)] -> m [DiffTime]
+    go [] = pure []
+    go xs = do
+      -- While the slots are increasing, assign a time to each point
+      -- by choosing a random time in the delay interval after the
+      -- slot start
+      let (pointSeq, newBranch) = span (\(a, b) -> a < b) xs
+      times <- forM pointSeq $ \(s, _) -> do
+                 delay <- uniformRMDiffTime msgDelayInterval g
+                 pure $ s + delay
+      (times', xss) <- case newBranch of
+        [] -> pure ([], [])
+        ((seqLast, _) : branches) -> do
+          delay <- uniformRMDiffTime msgDelayInterval g
+          let lastTime = seqLast + delay
+          (times', xss) <- handleDelayedTipPoints lastTime branches
+          pure (lastTime : times', xss)
+      -- When the slots are not increasing, we must be doing a rollback.
+      -- We might have tip points in past slots.
+      times'' <- go xss
+      pure $ times ++ times' ++ times''
+
+    -- | The start of each slot in the schedule
+    toDiffTime :: SlotNo -> DiffTime
+    toDiffTime (SlotNo s) = fromIntegral s * slotLength
+
+    -- | Assign times to tip points in past slots. A past slots is
+    -- any earlier slot than the first parameter.
+    --
+    -- Yields the assigned times and the remaining tip points which
+    -- aren't in the past.
+    handleDelayedTipPoints :: DiffTime -> [(DiffTime, DiffTime)] -> m ([DiffTime], [(DiffTime, DiffTime)])
+    handleDelayedTipPoints lastTime xss = do
+      let (pointSeq, newBranch) = span (\(a, _) -> a + fst msgDelayInterval <= lastTime) xss
+          nseq = length pointSeq
+          -- The first point in xss that is not in the past
+          firstLater = case newBranch of
+            -- If there is no later point, pick an arbitrary later time interval
+            -- to sample from
+            []           -> lastTime + toDiffTime (toEnum nseq)
+            ((a, _) : _) -> a + fst msgDelayInterval
+      times <- replicateM nseq (uniformRMDiffTime (lastTime, firstLater) g)
+      pure (sort times, newBranch)
+
+uniformRMDiffTime :: R.StatefulGen g m => (DiffTime, DiffTime) -> g -> m DiffTime
+uniformRMDiffTime (a, b) g =
+    picosecondsToDiffTime <$>
+      R.uniformRM (diffTimeToPicoseconds a, diffTimeToPicoseconds b) g
+
+data HeaderPointSchedule = HeaderPointSchedule {
+    hpsTrunk  :: [(DiffTime, Int)] -- ^ header points up to the intersection
+  , hpsBranch :: [(DiffTime, Int)] -- ^ header points after the intersection
+                                   -- indices are relative to the branch
+  }
+  deriving (Show)
+
+-- | @headerPointSchedule g msgDelayInterval tpSchedule@ generates a
+-- schedule of header points for a single peer.
+--
+-- @msgDelayInterval@ is the interval from which to sample the delay of
+-- each header after offering the previous header.
+--
+-- @tpSchedule@ is the tip point schedule for the peer.
+-- Tip points are grouped by the branch they point to. Each group has
+-- the index of the intersection block with the trunk. Then each group
+-- has a list of tip point block indices relative to the branch. Groups
+-- corresponding to tip points in trunk use 'Nothing' as the intersection.
+--
+-- For each group of tip points, the schedule generates a HeaderPointSchedule,
+-- which provides the time at which each header should be offered.
+--
+-- If scheduled, header points are guaranteed to be scheduled after the tip
+-- point that enables them. They might not be generated if they cannot be
+-- delivered before a tip point of a different branch is announced.  The
+-- header points on a same chain are never announced out of order.
+--
+-- > headerPointSchedule
+-- >   :: g
+-- >   -> {msgDelayInterval:(DiffTime, DiffTime)
+-- >      | fst msgDelayInterval <= snd msgDelayInterval
+-- >      }
+-- >   -> {tpSchedule:[(Maybe Int, [(DiffTime, Int)]]
+-- >      | isSorted (catMaybes (map fst tpSchedule)) &&
+-- >        all (\(_, xs) -> isSorted xs) tpSchedule &&
+-- >        all (\(_, xs) -> all (0<=) (map snd xs)) tpSchedule &&
+-- >        all (\(_, xs) -> not (hasDuplicates (map snd xs))) tpSchedule &&
+-- >        all (\(_, xs) -> not (null xs)) tpSchedule &&
+-- >        all (\(_, xs) -> all (0<=) (map snd xs)) tpSchedule
+-- >      }
+-- >   -> m {v:[HeaderPointSchedule]
+-- >        | length v == length tpSchedule &&
+-- >          isSorted [ map fst (hpsTrunk hps) ++ map fst (hpsBranch hps) | hps <- v ] &&
+-- >          isSorted [ map snd (hpsTrunk hps) | hps <- v ] &&
+-- >          all (\hps -> isSorted (map snd $ hpsBranch hps)) v &&
+-- >          all (\hps -> all (0<=) (map snd (hpsTrunk hps))) v &&
+-- >          all (\hps -> all (0<=) (map snd (hpsBranch hps))) v &&
+-- >          all (\hps -> not (hasDuplicates (map snd (hpsTrunk hps)))) v &&
+-- >          all (\hps -> not (hasDuplicates (map snd (hpsBranch hps)))) v
+-- >        }
+headerPointSchedule
+  :: forall g m. (HasCallStack, R.StatefulGen g m)
+  => g
+  -> (DiffTime, DiffTime)
+  -> [(Maybe Int, [(DiffTime, Int)])]
+  -> m [HeaderPointSchedule]
+headerPointSchedule g msgDelayInterval xs =
+   let -- Pair each  branch with the maximum time at which its header points
+       -- should be offered
+       xs' = zip xs $ map (Just . fst . headCallStack . snd) (tail xs) ++ [Nothing]
+    in snd <$> mapAccumM genHPBranchSchedule (0, 0) xs'
+
+  where
+    -- | @genHPBranchSchedule (tNext, trunkNextHp) ((mi, tps), mtMax)@ generates
+    -- a schedule for a single branch.
+    --
+    -- @tNext@ is the time at which the next header point should be offered.
+    --
+    -- @trunkNextHp@ is the index of the next header point that was offered
+    -- from the trunk.
+    --
+    -- @mi@ is the index of the intersection block with the trunk. Nothing
+    -- means this group has tip points from the trunk.
+    --
+    -- @tps@ is the list of tip point indices relative to the branch.
+    --
+    -- @mtMax@ is the maximum time at which the last header point can be
+    -- offered. 'Nothing' stands for infinity.
+    --
+    -- Returns the time at which the last header point was offered, the next
+    -- header point to offer and the schedule for the branch.
+    genHPBranchSchedule
+      :: (DiffTime, Int)
+      -> ((Maybe Int, [(DiffTime, Int)]), Maybe DiffTime)
+      -> m ((DiffTime, Int), HeaderPointSchedule)
+    genHPBranchSchedule (tNext, trunkNextHp) ((_mi, []), _mtMax) =
+      pure ((tNext, trunkNextHp), HeaderPointSchedule [] [])
+    genHPBranchSchedule (tNext, trunkNextHp) ((Nothing, tps), mtMax) = do
+      (p, tsTrunk) <- mapAccumM (generatePerTipPointTimes mtMax) (tNext, trunkNextHp) tps
+      pure (p, HeaderPointSchedule (concat tsTrunk) [])
+    genHPBranchSchedule (tNext, trunkNextHp) ((Just iLast, tps@((firstTipTime, _):_)), mtMax) = do
+      ((tNext', trunkNextHp'), tsTrunk) <- generatePerTipPointTimes mtMax (tNext, trunkNextHp) (firstTipTime, iLast)
+      ((tNext'', _), tsBranch) <- mapAccumM (generatePerTipPointTimes mtMax) (tNext', 0) tps
+      pure ((tNext'', trunkNextHp'), HeaderPointSchedule tsTrunk (concat tsBranch))
+
+    -- | @generatePerTipPointTimes mtMax (tNext, nextHp) (tTip, tp)@ schedules the header
+    -- points from @nextHp@ to @tp@ in ascending order starting from the maximum
+    -- of @tNext@ and @tTip + t@ where t is sampled from @msgDelayInterval@.
+    --
+    -- Less header points are scheduled if they would be scheduled after @mtMax@.
+    --
+    -- The delay of each tipPoint is sampled from @msgDelayInterval@.
+    --
+    generatePerTipPointTimes
+      :: Maybe DiffTime
+      -> (DiffTime, Int)
+      -> (DiffTime, Int)
+      -> m ((DiffTime, Int), [(DiffTime, Int)])
+    generatePerTipPointTimes mtMax (tNext0, nextHp0) (tTip, tp) = do
+       t <- uniformRMDiffTime msgDelayInterval g
+       go (max tNext0 (tTip + t)) nextHp0 []
+      where
+        go :: DiffTime -> Int -> [(DiffTime, Int)] -> m ((DiffTime, Int), [(DiffTime, Int)])
+        go tNext nextHp acc = do
+          if maybe False (tNext >) mtMax || nextHp > tp then
+            pure ((tNext, nextHp), reverse acc)
+          else do
+            t <- (+tNext) <$> uniformRMDiffTime msgDelayInterval g
+            go t (nextHp+1) ((tNext, nextHp) : acc)
+
+mapAccumM :: Monad m => (s -> x -> m (s, y)) -> s -> [x] -> m (s, [y])
+mapAccumM _ acc [] = pure (acc, [])
+mapAccumM f acc (x:xs) = do
+    (acc', y) <- f acc x
+    (acc'', ys) <- mapAccumM f acc' xs
+    pure (acc'', y:ys)
+
+headCallStack :: HasCallStack => [a] -> a
+headCallStack xs = if null xs then error "headCallStack: empty list" else head xs

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Tests.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Tests.hs
@@ -1,0 +1,382 @@
+{-# LANGUAGE LambdaCase       #-}
+{-# LANGUAGE NamedFieldPuns   #-}
+{-# LANGUAGE TypeApplications #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Test.Consensus.PointSchedule.Tests (tests) where
+
+import           Cardano.Slotting.Slot (SlotNo (..), WithOrigin (..),
+                     withOrigin)
+import           Control.Monad (forM, replicateM)
+import           Data.Bifunctor (second)
+import           Data.List (foldl', group, isSuffixOf, partition, sort)
+import qualified Data.List.NonEmpty as NonEmpty
+import           Data.Maybe (isNothing)
+import           Data.Time.Clock (DiffTime, diffTimeToPicoseconds,
+                     picosecondsToDiffTime)
+import           GHC.Stack (HasCallStack)
+import qualified Ouroboros.Network.AnchoredFragment as AF
+import           Ouroboros.Network.Block (blockHash)
+import           System.Random.Stateful (runSTGen_)
+import           Test.Consensus.PointSchedule.SinglePeer
+import           Test.Consensus.PointSchedule.SinglePeer.Indices
+import qualified Test.QuickCheck as QC hiding (elements)
+import           Test.QuickCheck
+import           Test.QuickCheck.Random
+import           Test.Tasty
+import           Test.Tasty.QuickCheck
+import qualified Test.Util.QuickCheck as QC
+import           Test.Util.TestBlock (TestBlock, TestHash (unTestHash),
+                     firstBlock, modifyFork, successorBlock, tbSlot)
+import           Test.Util.TestEnv
+
+
+tests :: TestTree
+tests =
+    adjustQuickCheckTests (* 100) $
+    adjustOption (\(QuickCheckMaxSize n) -> QuickCheckMaxSize (n `div` 10)) $
+    testGroup "PointSchedule"
+      [ testProperty "zipMany" prop_zipMany
+      , testProperty "singleJumpTipPoints" prop_singleJumpTipPoints
+      , testProperty "tipPointSchedule" prop_tipPointSchedule
+      , testProperty "headerPointSchedule" prop_headerPointSchedule
+      , testProperty "peerScheduleFromTipPoints" prop_peerScheduleFromTipPoints
+      ]
+
+prop_zipMany :: [[Int]] -> QC.Property
+prop_zipMany xss =
+    let xs :: [Int]
+        xs = concatMap (map (+1)) xss
+        ys :: [[(Int, Int)]]
+        ys = zipMany xs xss
+     in
+          length xss QC.=== length ys
+        QC..&&.
+          map (map snd) ys QC.=== xss
+        QC..&&.
+          concatMap (map fst) ys QC.=== xs
+
+
+data SingleJumpTipPointsInput = SingleJumpTipPointsInput
+  { sjtpMin :: Int
+  , sjtpMax :: Int
+  } deriving (Show)
+
+instance QC.Arbitrary SingleJumpTipPointsInput where
+  arbitrary = do
+    QC.NonNegative a <- QC.arbitrary
+    QC.NonNegative b <- QC.arbitrary
+    pure $ SingleJumpTipPointsInput (min a b) (max a b)
+
+prop_singleJumpTipPoints :: QCGen -> SingleJumpTipPointsInput -> QC.Property
+prop_singleJumpTipPoints seed (SingleJumpTipPointsInput m n) =
+    runSTGen_ seed $ \g -> do
+      xs <- singleJumpTipPoints g m n
+      pure $ isSorted QC.le xs
+        QC..&&.
+         (QC.counterexample ("length xs = " ++ show (length xs)) $
+           length xs `QC.le` n - m + 1
+         )
+        QC..&&.
+         (QC.counterexample ("head xs = " ++ show (headCallStack xs)) $
+             headCallStack xs `QC.le` n
+           QC..&&.
+             m `QC.le` headCallStack xs
+         )
+
+data TipPointScheduleInput = TipPointScheduleInput
+  { tpsSlotLength  :: DiffTime
+  , tpsMsgInterval :: (DiffTime, DiffTime)
+  , tpsSlots       :: [SlotNo]
+  } deriving (Show)
+
+instance QC.Arbitrary TipPointScheduleInput where
+  arbitrary = do
+    slotLength <- chooseDiffTime (1, 20)
+    msgInterval <- genTimeInterval (slotLength - 0.1)
+    slots0 <- dedupSorted . map (SlotNo . QC.getNonNegative) <$> QC.orderedList
+    slots1 <- dedupSorted . map (SlotNo . QC.getNonNegative) <$> QC.orderedList
+    pure $ TipPointScheduleInput slotLength msgInterval (slots0 ++ slots1)
+
+prop_tipPointSchedule :: QCGen -> TipPointScheduleInput -> QC.Property
+prop_tipPointSchedule seed (TipPointScheduleInput slotLength msgInterval slots) =
+    runSTGen_ seed $ \g -> do
+      ts <- tipPointSchedule g slotLength msgInterval slots
+      pure $
+          (QC.counterexample ("length slots = " ++ show (length slots)) $
+           QC.counterexample ("length ts = " ++ show (length ts)) $
+             length slots QC.=== length ts
+          )
+        QC..&&.
+          isSorted QC.le ts
+
+data HeaderPointScheduleInput = HeaderPointScheduleInput
+  { hpsMsgInterval :: (DiffTime, DiffTime)
+  , hpsTipPoints   :: [(Maybe Int, [(DiffTime, Int)])]
+  } deriving (Show)
+
+instance QC.Arbitrary HeaderPointScheduleInput where
+  arbitrary = do
+    msgInterval <- genTimeInterval 10
+    branchTips <- genTipPoints
+    let branchCount = length branchTips
+        tpCount = sum $ map length branchTips
+    ts <- scanl1 (+) . sort <$> replicateM tpCount (chooseDiffTime (7, 12))
+    let tpts = zipMany ts branchTips
+    intersectionBlocks <- genIntersections branchCount
+    maybes <- QC.infiniteList @(Maybe Int)
+    let intersections = zipWith (>>) maybes $ map Just intersectionBlocks
+    pure $ HeaderPointScheduleInput msgInterval (zip intersections tpts)
+
+prop_headerPointSchedule :: QCGen -> HeaderPointScheduleInput -> QC.Property
+prop_headerPointSchedule g (HeaderPointScheduleInput msgDelayInterval xs) =
+    runSTGen_ g $ \g' -> do
+      hpss <- headerPointSchedule g' msgDelayInterval xs
+      pure $
+          (QC.counterexample ("length xs = " ++ show (length xs)) $
+           QC.counterexample ("length hpss = " ++ show (length hpss)) $
+            length xs QC.=== length hpss
+          )
+        QC..&&.
+          (QC.counterexample ("header points are sorted in each branch") $
+            foldr (QC..&&.) (QC.property True)
+              [ QC.counterexample ("branch = " ++ show hps) $
+                isSorted QC.lt (map snd trunk) QC..&&. isSorted QC.lt (map snd branch)
+              | hps@(HeaderPointSchedule trunk branch) <- hpss
+              ]
+          )
+         QC..&&.
+          (QC.counterexample ("times are sorted accross branches") $
+           QC.counterexample ("branches = " ++ show hpss) $
+            isSorted QC.le $ concat
+              [ map fst trunk ++ map fst branch
+              | HeaderPointSchedule trunk branch <- hpss
+              ]
+          )
+        QC..&&.
+          (QC.counterexample ("trunk header points are sorted accross branches") $
+           QC.counterexample ("branches = " ++ show hpss) $
+            isSorted QC.lt $ concat
+              [ map snd trunk | HeaderPointSchedule trunk _ <- hpss ]
+          )
+        QC..&&.
+          (QC.counterexample "branch header points follow tip points" $
+           QC.counterexample ("branches = " ++ show hpss) $
+             foldr (QC..&&.) (QC.property True) $
+               zipWith (\hps x ->
+                 case x of
+                   (Just _, b) -> headerPointsFollowTipPoints leMaybe (hpsBranch hps) b
+                   _ -> QC.property True
+                ) hpss xs
+          )
+  where
+    leMaybe :: Ord a => a -> a -> Maybe Ordering
+    leMaybe a b = Just $ compare a b
+
+data PeerScheduleFromTipPointsInput = PeerScheduleFromTipPointsInput
+       PeerScheduleParams
+       [(IsTrunk, [Int])]
+       (AF.AnchoredFragment TestBlock)
+       [AF.AnchoredFragment TestBlock]
+
+instance Show PeerScheduleFromTipPointsInput where
+  show (PeerScheduleFromTipPointsInput psp tps trunk branches) =
+    unlines
+      [ "PeerScheduleFromTipPointsInput"
+      , "  params = "  ++ show psp
+      , "  tipPoints = " ++ show tps
+      , "  trunk = " ++ show (AF.toOldestFirst trunk)
+      , "  branches = " ++ show [ (AF.anchorBlockNo b, AF.toOldestFirst b) | b <- branches ]
+      ]
+
+instance QC.Arbitrary PeerScheduleFromTipPointsInput where
+  arbitrary = do
+    slotLength <- chooseDiffTime (1, 20)
+    tipDelayInterval <- genTimeInterval (slotLength - 0.1)
+    headerDelayInterval <- genTimeInterval (min 2 (slotLength - 0.1))
+    blockDelayInterval <- genTimeInterval (min 2 (slotLength - 0.1))
+    tipPoints <- genTipPoints
+    isTrunks <- QC.infiniteList
+    intersections <- genIntersections (length tipPoints)
+    let tstps = zip isTrunks tipPoints
+        tsi = zip isTrunks intersections
+        -- The maximum block number in the tip points and the intersections.
+        maxBlock =
+          maximum $ concat [ b | (IsTrunk, b) <- tstps ] ++
+                           [ i | (IsBranch, i) <- tsi ]
+    trunkSlots <- map SlotNo <$> genSortedVectorWithoutDuplicates (maxBlock + 1)
+    let branchesTipPoints = [ b | (IsBranch, b) <- tstps ]
+    branchesSlots <- forM branchesTipPoints $ \b -> do
+      let maxBranchBlock = maximum b
+      map SlotNo <$> genSortedVectorWithoutDuplicates (maxBranchBlock + 1)
+    let trunk = mkFragment Origin trunkSlots 0
+        branchIntersections = [ i | (IsBranch, i) <- tsi ]
+        branches =
+          [ genAdversarialFragment trunk fNo i branchSlots
+          | (fNo, branchSlots, i)  <- zip3 [1..] branchesSlots branchIntersections
+          ]
+        psp = PeerScheduleParams
+          { pspSlotLength = slotLength
+          , pspTipDelayInterval = tipDelayInterval
+          , pspHeaderDelayInterval = headerDelayInterval
+          , pspBlockDelayInterval = blockDelayInterval
+          }
+
+    pure $ PeerScheduleFromTipPointsInput psp tstps trunk branches
+
+instance QC.Arbitrary IsTrunk where
+  arbitrary = QC.elements [IsTrunk, IsBranch]
+
+prop_peerScheduleFromTipPoints :: QCGen -> PeerScheduleFromTipPointsInput -> QC.Property
+prop_peerScheduleFromTipPoints seed (PeerScheduleFromTipPointsInput psp tps trunk branches) =
+    runSTGen_ seed $ \g -> do
+      ss <- peerScheduleFromTipPoints g psp tps trunk branches
+      let (tps', (hps, _bps)) =
+            partition (isHeaderPoint . snd) <$> partition (isTipPoint . snd) ss
+      pure $
+          (QC.counterexample ("hps = " ++ show (map (second showPoint) hps)) $
+           QC.counterexample ("tps' = " ++ show (map (second showPoint) tps')) $
+             headerPointsFollowTipPoints isAncestorBlock
+               (map (second schedulePointToBlock) hps)
+               (map (second schedulePointToBlock) tps')
+          )
+        QC..&&.
+          (QC.counterexample ("schedule = " ++ show (map (second showPoint) ss)) $
+            isSorted QC.le (map fst ss))
+        QC..&&.
+          (QC.counterexample ("schedule = " ++ show (map (second showPoint) ss)) $
+           QC.counterexample ("header points don't decrease or repeat") $
+            noReturnToAncestors (filter isHeaderPoint $ map snd ss)
+          )
+        QC..&&.
+          (QC.counterexample ("schedule = " ++ show (map (second showPoint) ss)) $
+           QC.counterexample ("block points don't decrease or repeat") $
+            noReturnToAncestors (filter isBlockPoint $ map snd ss)
+          )
+  where
+    showPoint :: SchedulePoint -> String
+    showPoint (ScheduleTipPoint b)    = "TP " ++ show (blockHash b)
+    showPoint (ScheduleHeaderPoint b) = "HP " ++ show (blockHash b)
+    showPoint (ScheduleBlockPoint b)  = "BP " ++ show (blockHash b)
+
+    isTipPoint :: SchedulePoint -> Bool
+    isTipPoint (ScheduleTipPoint _) = True
+    isTipPoint _                    = False
+
+    isHeaderPoint :: SchedulePoint -> Bool
+    isHeaderPoint (ScheduleHeaderPoint _) = True
+    isHeaderPoint _                       = False
+
+    isBlockPoint :: SchedulePoint -> Bool
+    isBlockPoint (ScheduleBlockPoint _) = True
+    isBlockPoint _                      = False
+
+isAncestorBlock :: TestBlock -> TestBlock -> Maybe Ordering
+isAncestorBlock b0 b1 =
+    if isSuffixOf
+         (NonEmpty.toList (unTestHash (blockHash b0)))
+         (NonEmpty.toList (unTestHash (blockHash b1)))
+    then if blockHash b0 == blockHash b1
+      then Just EQ
+      else Just LT
+    else Nothing
+
+noReturnToAncestors :: [SchedulePoint] -> QC.Property
+noReturnToAncestors = go []
+  where
+    go _ [] = QC.property True
+    go ancestors (p : ss) =
+      let b = schedulePointToBlock p
+       in   foldr (QC..&&.) (QC.property True)
+              (map (isNotAncestorOf b) ancestors)
+          QC..&&.
+            go (b : ancestors) ss
+
+    isNotAncestorOf :: TestBlock -> TestBlock -> QC.Property
+    isNotAncestorOf b0 b1 =
+      QC.counterexample ("return to ancestor: " ++ show (blockHash b0) ++ " -> " ++ show (blockHash b1)) $
+        QC.property $ isNothing $ isAncestorBlock b0 b1
+
+genTimeInterval :: DiffTime -> QC.Gen (DiffTime, DiffTime)
+genTimeInterval trange = do
+    a <- chooseDiffTime (1, trange)
+    b <- chooseDiffTime (1, trange)
+    pure (min a b, max a b)
+
+genTipPoints :: QC.Gen [[Int]]
+genTipPoints = do
+    branchCount <- QC.choose (1, 5)
+    xss <- QC.vector branchCount
+    pure $ map (dedupSorted . sort . map QC.getNonNegative . QC.getNonEmpty) xss
+
+-- | @genIntersections n@ generates a list of @n@ intersections as block numbers.
+genIntersections :: Int -> QC.Gen [Int]
+genIntersections n =
+    -- Intersection with the genesis block is represented by @Just (-1)@.
+    map (\x -> x - 1) . sort . map QC.getNonNegative <$> QC.vector n
+
+isSorted :: Show a => (a -> a -> QC.Property) -> [a] -> QC.Property
+isSorted cmp xs =
+    QC.counterexample ("isSorted " ++ show xs) $
+    foldr (QC..&&.) (QC.property True)
+      [ cmp a b | (a, b) <- zip xs (drop 1 xs) ]
+
+chooseDiffTime :: (DiffTime, DiffTime) -> QC.Gen DiffTime
+chooseDiffTime (a, b) = do
+    let aInt = diffTimeToPicoseconds a
+        bInt = diffTimeToPicoseconds b
+    picosecondsToDiffTime <$> QC.chooseInteger (aInt, bInt)
+
+dedupSorted :: Eq a => [a] -> [a]
+dedupSorted = map headCallStack . group
+
+headCallStack :: HasCallStack => [a] -> a
+headCallStack xs = if null xs then error "headCallStack: empty list" else head xs
+
+headerPointsFollowTipPoints :: Show a => (a -> a -> Maybe Ordering) -> [(DiffTime, a)] -> [(DiffTime, a)] -> QC.Property
+headerPointsFollowTipPoints _ [] [] = QC.property True
+headerPointsFollowTipPoints isAncestor ((t0, i0) : ss) ((t1, i1) : ps) =
+      QC.counterexample "schedule times follow tip points" (QC.ge t0 t1)
+    QC..&&.
+      (case isAncestor i0 i1 of
+         Just LT -> headerPointsFollowTipPoints isAncestor ss ((t1, i1) : ps)
+         Just EQ -> headerPointsFollowTipPoints isAncestor ss ps
+         _       -> headerPointsFollowTipPoints isAncestor ((t0, i0) : ss) ps
+      )
+headerPointsFollowTipPoints _ [] _ps =
+--      There can be unscheduled header points if they would be produced so
+--      late that they would come after the tip point has moved to another branch.
+--
+--      QC.counterexample ("schedule times are sufficient for: " ++ show ps) $
+--        QC.property False
+      QC.property True
+headerPointsFollowTipPoints _ ss [] =
+      QC.counterexample ("schedule times finish after last tip point: " ++ show ss) $
+        QC.property False
+
+-- | @genAdversarialFragment goodBlocks forkNo prefixCount slotsA@ generates
+-- a fragment for a chain that forks off the given chain.
+genAdversarialFragment :: AF.AnchoredFragment TestBlock -> Int -> Int -> [SlotNo] -> AF.AnchoredFragment TestBlock
+genAdversarialFragment goodBlocks forkNo prefixCount slotsA
+      = mkFragment intersectionBlock slotsA forkNo
+  where
+    -- blocks in the common prefix in reversed order
+    intersectionBlock = case AF.head $ AF.takeOldest (prefixCount + 1) goodBlocks of
+        Left _  -> Origin
+        Right b -> At b
+
+-- | @mkFragment pre active forkNo@ generates a list of blocks at the given slots.
+mkFragment :: WithOrigin TestBlock -> [SlotNo] -> Int -> AF.AnchoredFragment TestBlock
+mkFragment pre active forkNo = AF.fromNewestFirst anchor $ foldl' issue [] active
+  where
+    anchor = withOrigin AF.AnchorGenesis AF.anchorFromBlock pre
+    issue (h : t) s = (successorBlock h) {tbSlot = s} : h : t
+    issue [] s | Origin <- pre = [(firstBlock (fromIntegral forkNo)) {tbSlot = s}]
+               | At h <- pre = [(modifyFork (const (fromIntegral forkNo)) (successorBlock h)) {tbSlot = s}]
+
+-- | @genVectorWithoutDuplicates n@ generates a vector of length @n@
+-- without duplicates.
+genSortedVectorWithoutDuplicates :: (QC.Arbitrary a, Num a, Ord a) => Int -> QC.Gen [a]
+genSortedVectorWithoutDuplicates n = do
+    x0 <- QC.arbitrary
+    scanl (+) x0 . map ((+1) . QC.getNonNegative) <$> QC.vector (n - 1)

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Util/TersePrinting.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Util/TersePrinting.hs
@@ -1,0 +1,68 @@
+{-# LANGUAGE LambdaCase   #-}
+{-# LANGUAGE TypeFamilies #-}
+
+-- | Helpers for printing various objects in a terse way. Terse printing is
+-- similar to that provided by the 'Condense' typeclass except it can be
+-- sometimes even more compact and it is very specific to tests.
+module Test.Util.TersePrinting (
+    terseBlock
+  , terseFrag
+  , terseFragH
+  , terseHeader
+  , tersePoint
+  ) where
+
+import           Cardano.Slotting.Block (BlockNo (BlockNo))
+import           Cardano.Slotting.Slot (SlotNo (SlotNo))
+import           Data.List.NonEmpty (NonEmpty ((:|)))
+import           Ouroboros.Consensus.Block (Header,
+                     Point (BlockPoint, GenesisPoint), blockHash, blockNo,
+                     blockSlot, getHeader)
+import           Ouroboros.Consensus.Util.Condense (Condense (..))
+import           Ouroboros.Network.AnchoredFragment
+                     (Anchor (Anchor, AnchorGenesis), AnchoredFragment,
+                     AnchoredSeq (Empty), anchor, mapAnchoredFragment,
+                     toOldestFirst)
+import           Test.Util.TestBlock (Header (TestHeader), TestBlock,
+                     TestHash (TestHash), unTestHash)
+
+terseSlotBlock :: SlotNo -> BlockNo -> String
+terseSlotBlock (SlotNo slot) (BlockNo block) =
+  show block ++ "-" ++ show slot
+
+terseSlotBlockFork :: SlotNo -> BlockNo -> TestHash -> String
+terseSlotBlockFork sno bno (TestHash hash) =
+  terseSlotBlock sno bno ++ forkNoSuffix hash
+  where
+    forkNoSuffix (forkNo :| _) | forkNo == 0 = ""
+                               | otherwise = "[" ++ show forkNo ++ "]"
+
+terseBlock :: TestBlock -> String
+terseBlock block =
+  terseSlotBlockFork (blockSlot block) (blockNo block) (blockHash block)
+
+terseHeader :: Header TestBlock -> String
+terseHeader (TestHeader block) = terseBlock block
+
+tersePoint :: Point TestBlock -> String
+tersePoint = \case
+  BlockPoint slot hash -> terseSlotBlockFork slot (BlockNo (fromIntegral (length (unTestHash hash)))) hash
+  GenesisPoint -> "G"
+
+terseFragH :: AnchoredFragment (Header TestBlock) -> String
+terseFragH frag =
+  renderAnchor ++ renderBlocks
+  where
+    renderBlocks = case frag of
+      Empty _ -> ""
+      _       -> " | " ++ unwords (terseHeader <$> toOldestFirst frag)
+    renderAnchor = case anchor frag of
+      AnchorGenesis -> "G"
+      Anchor slot hash block -> terseSlotBlock slot block ++ renderAnchorHash hash
+    renderAnchorHash hash
+      | all (== 0) (unTestHash hash) = ""
+      | otherwise = condense hash
+
+terseFrag :: AnchoredFragment TestBlock -> String
+terseFrag =
+  terseFragH . mapAnchoredFragment getHeader

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Consensus/ChainGenerator/Adversarial.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Consensus/ChainGenerator/Adversarial.hs
@@ -14,7 +14,7 @@ module Test.Ouroboros.Consensus.ChainGenerator.Adversarial (
     -- * Generating
     AdversarialRecipe (AdversarialRecipe, arHonest, arParams, arPrefix)
   , CheckedAdversarialRecipe (UnsafeCheckedAdversarialRecipe, carHonest, carParams, carWin)
-  , NoSuchAdversarialChainSchema (NoSuchAdversarialBlock, NoSuchCompetitor, NoSuchIntersection)
+  , NoSuchAdversarialChainSchema (NoSuchAdversarialBlock, NoSuchCompetitor, NoSuchIntersection, KcpIs1)
   , SomeCheckedAdversarialRecipe (SomeCheckedAdversarialRecipe)
   , checkAdversarialRecipe
   , uniformAdversarialChain
@@ -355,6 +355,12 @@ data NoSuchAdversarialChainSchema =
   |
     -- | @not (0 <= 'arPrefix' <= C)@ where @C@ is the number of active slots in 'arHonest'
     NoSuchIntersection
+  |
+    -- | @k=1@
+    --
+    -- This may technically be viable, but our current specification for
+    -- 'uniformAdversarialChain' requires @k>1@.
+    KcpIs1
   deriving (Eq, Show)
 
 -----
@@ -374,6 +380,8 @@ checkAdversarialRecipe ::
          (SomeCheckedAdversarialRecipe base hon)
 checkAdversarialRecipe recipe = do
     when (0 == k) $ Exn.throwError NoSuchAdversarialBlock
+
+    when (1 == k) $ Exn.throwError KcpIs1
 
     -- validate 'arPrefix'
     firstAdvSlot <- case compare arPrefix 0 of
@@ -631,15 +639,18 @@ withinYS (Delta d) !mbYS !(RI.Race (C.SomeWindow Proxy win)) = case mbYS of
 --
 -- The count will be strictly smaller than the number of active slots in the given 'ChainSchema'.
 --
--- REVIEW: why do we not allow forking off the block number 1?
-genPrefixBlockCount :: R.RandomGen g => g -> ChainSchema base hon -> C.Var hon 'ActiveSlotE
-genPrefixBlockCount g schedH =
-    if C.toVar numChoices < 2 then C.Count 0 {- can always pick genesis -} else do
+-- The result is guaranteed to leave more than k active slots after the
+-- intersection.
+genPrefixBlockCount :: R.RandomGen g => Kcp -> g -> ChainSchema base hon -> C.Var hon 'ActiveSlotE
+genPrefixBlockCount (Kcp k) g schedH
+    | C.getCount numChoices <= 0 = error "there should be at least k+1 blocks in the honest schema"
+    | otherwise =
+        -- uniformIndex is going to pick a number between 0 and numChoices-1
         C.toVar $ R.runSTGen_ g $ C.uniformIndex numChoices
   where
     ChainSchema _slots v = schedH
 
-    numChoices = pc C.- 1   -- can't pick the last active slot
+    numChoices = actives C.- k
 
-    -- 'H.uniformTheHonestChain' ensures 0 < pc
-    pc = BV.countActivesInV S.notInverted v
+    -- 'H.uniformTheHonestChain' ensures k < active
+    actives = BV.countActivesInV S.notInverted v

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Consensus/ChainGenerator/Counting.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Consensus/ChainGenerator/Counting.hs
@@ -39,6 +39,7 @@ module Test.Ouroboros.Consensus.ChainGenerator.Counting (
   , joinWin
   , toWindow
   , toWindowVar
+  , truncateWin
   , windowLast
   , windowSize
   , windowStart
@@ -224,6 +225,9 @@ windowStart win = fromWindow win (Count 0)
 
 windowLast :: Contains elem outer inner -> Index outer elem
 windowLast win = fromWindow win $ lastIndex $ windowSize win
+
+truncateWin :: Contains elem outer inner -> Size inner elem -> Contains elem outer inner
+truncateWin (UnsafeContains start len) x = UnsafeContains start (min len x)
 
 -- | 'Contains' is a 'Data.Semigroupoid.Semigroupoid'
 joinWin :: Contains elem outer mid -> Contains elem mid inner -> Contains elem outer inner

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Consensus/ChainGenerator/Honest.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Consensus/ChainGenerator/Honest.hs
@@ -104,10 +104,12 @@ data NoSuchHonestChainSchema =
 
 genHonestRecipe :: QC.Gen HonestRecipe
 genHonestRecipe = sized1 $ \sz -> do
-  (kcp, Scg s, delta) <- genKSD
-  -- s <= l, most of the time
-  l <- QC.frequency [(9, (+ s) <$> QC.choose (0, 5 * sz)), (1, QC.choose (1, s))]
-  pure $ HonestRecipe kcp (Scg s) delta (Len l)
+    (Kcp k, Scg s, Delta d) <- genKSD
+    -- 2s slots has at least 2k blocks. But that is ensuring k-1 more blocks
+    -- than we actually need. Thus it's safe to remove the k-1 last slots.
+    -- Therefore we set for a length of at least 2s - (k - 1).
+    l <- (+ (2*s - (k - 1))) <$> QC.choose (0, 5 * sz)
+    pure $ HonestRecipe (Kcp k) (Scg s) (Delta d) (Len l)
 
 -- | Checks whether the given 'HonestRecipe' determines a valid input to
 -- 'uniformTheHonestChain'

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Consensus/ChainGenerator/Params.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Consensus/ChainGenerator/Params.hs
@@ -98,7 +98,9 @@ genAsc = ascFromBits <$> QC.choose (1 :: Word8, maxBound - 1)
 
 genKSD :: QC.Gen (Kcp, Scg, Delta)
 genKSD = sized1 $ \sz -> do
-    d <- QC.choose (0, div sz 4)
+    -- k > 1 so we can ensure an alternative schema loses the density comparison
+    -- without having to deactivate the first active slot
     k <- (+ 2) <$> QC.choose (0, 2 * sz)
     s <- (+ k) <$> QC.choose (0, 3 * sz)   -- ensures @k / s <= 1@
+    d <- QC.choose (0, max 0 $ min (div sz 4) (s-1)) -- ensures @d < s@
     pure (Kcp k, Scg s, Delta d)

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Consensus/ChainGenerator/Params.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Consensus/ChainGenerator/Params.hs
@@ -99,6 +99,6 @@ genAsc = ascFromBits <$> QC.choose (1 :: Word8, maxBound - 1)
 genKSD :: QC.Gen (Kcp, Scg, Delta)
 genKSD = sized1 $ \sz -> do
     d <- QC.choose (0, div sz 4)
-    k <- QC.choose (1, 2 * sz)
+    k <- (+ 2) <$> QC.choose (0, 2 * sz)
     s <- (+ k) <$> QC.choose (0, 3 * sz)   -- ensures @k / s <= 1@
     pure (Kcp k, Scg s, Delta d)

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Consensus/ChainGenerator/README.md
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Consensus/ChainGenerator/README.md
@@ -12,3 +12,35 @@ However, it is generally assumed that tests will use the generated schemas witho
 
 The generators themselves have some tests in the ouroboros-consensus:test:infra-test suite, but they merely test that the generators are behaving as expected.
 (If the "mutation" subset of tests in that suite seem flaky, try increasing the number of seeds attempted per QuickCheck counterexample candidate.)
+
+-----
+
+`uniformTheHonestChain` ensures the following postconditions.
+
+- The schema contains exactly `Len` slots.
+  Each slot after the last in the schema is considered a _future slot_.
+
+- There is at least one honest active slot in the schema.
+
+- For each of the `Len` slots, the window of `Scg` slots that begins with that slot contains at least `Kcp` active slots, assuming each future slot is honest active.
+
+`uniformAdversarialChain` ensures the following postconditions.
+Let sai abbreviate "slot after the intersection".
+Let asai abbreviate "active sai".
+
+- These postconditions are all subject to the assumption that future slots are honest active and alternative inactive.
+
+- The alternative schema begins with the slot after its intersection with the honest schema and ends in the same slot as the honest schema.
+
+- The intersection is chosen such that there is at least one honest asai and at least one alternative asai.
+
+- Ouroboros Praos requires that the `Kcp+1`st alternative asai either doesn't exist or else is at least `Del+1` slots after the `Kcp+1`st honest asai.
+
+    - Moreover, for all `i>0`, the `i+Kcp+1`st alternative asai either is more than `Scg` slots after the first alternative asai, doesn't exist, or else is at least `Del+1` slots after the `i+Kcp+1`st honest asai.
+      Informally: the adversary is always free to have chosen a later intersection, and this property ensures doing so would not have benefited them.
+      However, the property also assumes (extremely pessimistically) that the adversary can arbitrarily accelerate their election rate one stability window after their first block.
+
+- Ouroboros Genesis requires that the first `Scg` sais contain strictly more honest active than alternative active.
+
+    - Moreover, that inequality must hold for every prefix of that window that includes the `Kcp+1`st honest asai.
+      This rules out a corner case in which the Genesis rule would disagree with the Praos rule, which the Genesis authors argued has a similar probability as a Praos Common Prefix violation.

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/QuickCheck.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/QuickCheck.hs
@@ -92,12 +92,11 @@ forAllGenRunShrinkCheck ::
 forAllGenRunShrinkCheck gen run shrink_ check =
   forAllBlind gen $ \input ->
     shrinking
-      (run' <.> uncurry shrink_)
+      (map run' . uncurry shrink_)
       (run' input)
       (uncurry check)
   where
     run' inp = (inp, run inp)
-    (<.>) f g x = f <$> g x
 
 {-------------------------------------------------------------------------------
   Comparison functions

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/QuickCheck.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/QuickCheck.hs
@@ -27,6 +27,7 @@ module Test.Util.QuickCheck (
   , shrinkNP
     -- * Convenience
   , collects
+  , forAllGenRunShrinkCheck
   ) where
 
 import           Control.Monad.Except
@@ -71,6 +72,32 @@ checkShrinker p =
 -- | Check invariant
 checkInvariant :: (a -> Except String ()) -> (a -> Property)
 checkInvariant f = expectRight () . runExcept . f
+
+-- | Explicit quantification using the “gen-run-shrink-check” pattern.
+--
+-- Instead of the usual two stages where one generates an input and then checks
+-- the property for that input, we rely on three stages: one generates an input,
+-- then transforms it into an output, and then checks the output.
+--
+-- When adding a shrinker to the mix, we can allow it to inspect the output
+-- value as well, which increases its expressivity. This makes sense if the
+-- “run” phase is particularly expensive.
+forAllGenRunShrinkCheck ::
+  Testable prop =>
+  Gen input ->
+  (input -> output) ->
+  (input -> output -> [input]) ->
+  (input -> output -> prop) ->
+  Property
+forAllGenRunShrinkCheck gen run shrink_ check =
+  forAllBlind gen $ \input ->
+    shrinking
+      (run' <.> uncurry shrink_)
+      (run' input)
+      (uncurry check)
+  where
+    run' inp = (inp, run inp)
+    (<.>) f g x = f <$> g x
 
 {-------------------------------------------------------------------------------
   Comparison functions

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/TestBlock.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/TestBlock.hs
@@ -72,6 +72,8 @@ module Test.Util.TestBlock (
   , Permutation (..)
   , isAncestorOf
   , isDescendentOf
+  , isStrictAncestorOf
+  , isStrictDescendentOf
   , permute
   , unsafeTestBlockWithPayload
   ) where
@@ -266,6 +268,11 @@ isAncestorOf b1 b2 =
     `isSuffixOf`
   NE.toList (unTestHash (blockHash b2))
 
+-- | Variant of 'isAncestorOf' that returns @False@ when the two blocks are
+-- equal.
+isStrictAncestorOf :: TestBlock -> TestBlock -> Bool
+isStrictAncestorOf b1 b2 = b1 `isAncestorOf` b2 && b1 /= b2
+
 -- | A block @b1@ is the descendent of another block @b2@ if there exists a
 -- chain of blocks from @b2@ to @b1@. For test blocks in particular, this can be
 -- seen in the hash: the hash of @b2@ should be a prefix of the hash of @b1@.
@@ -276,6 +283,11 @@ isAncestorOf b1 b2 =
 -- not (b1 `isAncestorOf` b2) || b1 == b2@.
 isDescendentOf :: TestBlock -> TestBlock -> Bool
 isDescendentOf = flip isAncestorOf
+
+-- | Variant of 'isDescendentOf' that returns @False@ when the two blocks are
+-- equal.
+isStrictDescendentOf :: TestBlock -> TestBlock -> Bool
+isStrictDescendentOf b1 b2 = b1 `isDescendentOf` b2 && b1 /= b2
 
 instance ShowProxy TestBlock where
 

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/TestBlock.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/TestBlock.hs
@@ -71,6 +71,7 @@ module Test.Util.TestBlock (
     -- * Support for tests
   , Permutation (..)
   , permute
+  , unsafeTestBlockWithPayload
   ) where
 
 import           Cardano.Crypto.DSIGN
@@ -217,6 +218,12 @@ data TestBlockWith ptype = TestBlockWith {
     }
   deriving stock    (Show, Eq, Ord, Generic)
   deriving anyclass (Serialise, NoThunks, ToExpr)
+
+-- | Create a block directly with the given parameters. This allows creating
+-- inconsistent blocks; prefer 'firstBlockWithPayload' or 'successorBlockWithPayload'.
+unsafeTestBlockWithPayload :: TestHash -> SlotNo -> Validity -> ptype -> TestBlockWith ptype
+unsafeTestBlockWithPayload tbHash tbSlot tbValid tbPayload =
+  TestBlockWith{tbHash, tbSlot, tbValid, tbPayload}
 
 -- | Create the first block in the given fork, @[fork]@, with the given payload.
 -- The 'SlotNo' will be 1.

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/TestEnv.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/TestEnv.hs
@@ -3,6 +3,7 @@
 -- | A @tasty@ command-line option for enabling nightly tests
 module Test.Util.TestEnv (
     TestEnv (..)
+  , adjustQuickCheckMaxSize
   , adjustQuickCheckTests
   , askTestEnv
   , defaultMainWithTestEnv
@@ -85,3 +86,16 @@ adjustQuickCheckTests :: (Int -> Int) -> TestTree -> TestTree
 adjustQuickCheckTests f =
   adjustOption $ \(QuickCheckTests n) ->
     QuickCheckTests $ if n == 0 then 0 else max 1 (f n)
+
+-- | Locally adjust the maximum size parameter of QuickCheck tests for the given
+-- test subtree, similar to 'adjustQuickCheckTests'.
+--
+-- The size parameter is varied across test runs from 0 to @maxSize - 1@
+-- cyclically, influencing the result of generators that make use of it, like
+-- those that call 'Test.QuickCheck.sized'.
+--
+-- The default is 100.
+adjustQuickCheckMaxSize :: (Int -> Int) -> TestTree -> TestTree
+adjustQuickCheckMaxSize f =
+  adjustOption $ \(QuickCheckMaxSize n) ->
+    QuickCheckMaxSize $ if n == 0 then 0 else max 1 (f n)

--- a/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/ChainGenerator/Tests/Adversarial.hs
+++ b/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/ChainGenerator/Tests/Adversarial.hs
@@ -31,16 +31,19 @@ import qualified Test.Ouroboros.Consensus.ChainGenerator.Slot as S
 import           Test.Ouroboros.Consensus.ChainGenerator.Slot (E (SlotE))
 import qualified Test.Ouroboros.Consensus.ChainGenerator.Some as Some
 import qualified Test.Ouroboros.Consensus.ChainGenerator.Tests.Honest as H
-import qualified Test.QuickCheck as QC
+import qualified Test.QuickCheck as QC hiding (elements)
 import           Test.QuickCheck.Extras (unsafeMapSuchThatJust)
 import           Test.QuickCheck.Random (QCGen)
 import qualified Test.Tasty as TT
 import qualified Test.Tasty.QuickCheck as TT
+import qualified Test.Util.QuickCheck as QC
 
 -----
 
 tests :: [TT.TestTree]
 tests = [
+    TT.testProperty "k+1 blocks after the intersection" prop_kPlus1BlocksAfterIntersection
+  ,
     TT.testProperty "Adversarial chains lose density and race comparisons" prop_adversarialChain
   ,
     TT.localOption (TT.QuickCheckMaxSize 14) $ TT.testProperty "Adversarial chains win if checked with relaxed parameters" prop_adversarialChainMutation
@@ -106,9 +109,9 @@ instance QC.Arbitrary SomeTestAdversarial where
 
         testSeedPrefix <- QC.arbitrary @QCGen
 
-        let arPrefix = genPrefixBlockCount testSeedPrefix arHonest
+        let arPrefix = genPrefixBlockCount kcp testSeedPrefix arHonest
 
-        let H.HonestRecipe kcp scg delta _len = testRecipeH
+            H.HonestRecipe kcp scg delta _len = testRecipeH
 
             testRecipeA = A.AdversarialRecipe {
                 A.arPrefix
@@ -125,6 +128,7 @@ instance QC.Arbitrary SomeTestAdversarial where
                 A.NoSuchAdversarialBlock -> pure Nothing
                 A.NoSuchCompetitor       -> error $ "impossible! " <> show e
                 A.NoSuchIntersection     -> error $ "impossible! " <> show e
+                A.KcpIs1                 -> error $ "impossible! " <> show e
 
             Right testRecipeA' -> do
                 pure $ Just $ SomeTestAdversarial Proxy Proxy $ TestAdversarial {
@@ -142,6 +146,45 @@ instance QC.Arbitrary SomeTestAdversarial where
                   ,
                     testSeedH
                   }
+
+-- | The honest schema has k+1 blocks after the intersection.
+prop_kPlus1BlocksAfterIntersection :: SomeTestAdversarial -> QCGen -> QC.Property
+prop_kPlus1BlocksAfterIntersection someTestAdversarial testSeedA = runIdentity $ do
+    SomeTestAdversarial Proxy Proxy TestAdversarial {
+        testAscA
+      ,
+        testRecipeA
+      ,
+        testRecipeA'
+      } <- pure someTestAdversarial
+    A.SomeCheckedAdversarialRecipe Proxy recipeA' <- pure testRecipeA'
+
+    let A.AdversarialRecipe { A.arHonest = schedH } = testRecipeA
+        schedA = A.uniformAdversarialChain (Just testAscA) recipeA' testSeedA
+        H.ChainSchema winA _vA = schedA
+        H.ChainSchema _winH vH = schedH
+        A.AdversarialRecipe { A.arParams = (Kcp k, scg, _delta) } = testRecipeA
+
+    C.SomeWindow Proxy stabWin <- do
+        pure $ calculateStability scg schedA
+
+    pure $
+      QC.counterexample (unlines $
+                            H.prettyChainSchema schedH "H"
+                            ++ H.prettyChainSchema schedA "A"
+                          )
+      $ QC.counterexample ("arPrefix = " <> show (A.arPrefix testRecipeA))
+      $ QC.counterexample ("stabWin  = " <> show stabWin)
+      $ QC.counterexample ("stabWin' = " <> show (C.joinWin winA stabWin))
+      $ QC.counterexample ("The honest chain should have k+1 blocks after the intersection")
+          (BV.countActivesInV S.notInverted vH
+            `QC.ge` C.toSize (C.Count (k + 1) + A.arPrefix testRecipeA)
+          )
+-- TODO: uncomment this after ensuring the same for the alternative schema
+--        QC..&&.
+--        QC.counterexample ("The alternative chain should have k+1 blocks after the intersection")
+--          (BV.countActivesInV S.notInverted vA `QC.ge` C.Count (k + 1))
+
 
 -- | No seed exists such that each 'A.checkAdversarialChain' rejects the result of 'A.uniformAdversarialChain'
 prop_adversarialChain :: SomeTestAdversarial -> QCGen -> QC.Property
@@ -308,7 +351,7 @@ instance QC.Arbitrary SomeTestAdversarialMutation where
 
             testSeedPrefix <- QC.arbitrary @QCGen
 
-            let arPrefix = genPrefixBlockCount testSeedPrefix arHonest
+            let arPrefix = genPrefixBlockCount kcp testSeedPrefix arHonest
 
             let recipeA = A.AdversarialRecipe {
                     A.arPrefix
@@ -323,6 +366,7 @@ instance QC.Arbitrary SomeTestAdversarialMutation where
                     A.NoSuchAdversarialBlock -> Nothing
                     A.NoSuchCompetitor       -> error $ "impossible! " <> show e
                     A.NoSuchIntersection     -> error $ "impossible! " <> show e
+                    A.KcpIs1                 -> error $ "impossible! " <> show e
 
                 Right recipeA' -> case Exn.runExcept $ A.checkAdversarialRecipe $ mutateAdversarial recipeA mut of
                     Left{} -> Nothing

--- a/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/ChainGenerator/Tests/Adversarial.hs
+++ b/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/ChainGenerator/Tests/Adversarial.hs
@@ -25,15 +25,14 @@ import qualified Test.Ouroboros.Consensus.ChainGenerator.BitVector as BV
 import qualified Test.Ouroboros.Consensus.ChainGenerator.Counting as C
 import qualified Test.Ouroboros.Consensus.ChainGenerator.Honest as H
 import           Test.Ouroboros.Consensus.ChainGenerator.Params (Asc,
-                     Delta (Delta), Kcp (Kcp), Len (Len), Scg (Scg), genAsc,
-                     genKSD)
+                     Delta (Delta), Kcp (Kcp), Len (Len), Scg (Scg), genAsc)
 import qualified Test.Ouroboros.Consensus.ChainGenerator.RaceIterator as RI
 import qualified Test.Ouroboros.Consensus.ChainGenerator.Slot as S
 import           Test.Ouroboros.Consensus.ChainGenerator.Slot (E (SlotE))
 import qualified Test.Ouroboros.Consensus.ChainGenerator.Some as Some
 import qualified Test.Ouroboros.Consensus.ChainGenerator.Tests.Honest as H
 import qualified Test.QuickCheck as QC
-import           Test.QuickCheck.Extras (sized1, unsafeMapSuchThatJust)
+import           Test.QuickCheck.Extras (unsafeMapSuchThatJust)
 import           Test.QuickCheck.Random (QCGen)
 import qualified Test.Tasty as TT
 import qualified Test.Tasty.QuickCheck as TT
@@ -42,9 +41,9 @@ import qualified Test.Tasty.QuickCheck as TT
 
 tests :: [TT.TestTree]
 tests = [
-    TT.testProperty "prop_adversarialChain" prop_adversarialChain
+    TT.testProperty "Adversarial chains lose density and race comparisons" prop_adversarialChain
   ,
-    TT.localOption (TT.QuickCheckMaxSize 14) $ TT.testProperty "prop_adversarialChainMutation" prop_adversarialChainMutation
+    TT.localOption (TT.QuickCheckMaxSize 14) $ TT.testProperty "Adversarial chains win if checked with relaxed parameters" prop_adversarialChainMutation
   ]
 
 -----
@@ -295,14 +294,7 @@ instance QC.Arbitrary SomeTestAdversarialMutation where
     arbitrary = do
         mut <- QC.elements [minBound .. maxBound :: AdversarialMutation]
         unsafeMapSuchThatJust $ do
-            (kcp, scg, delta, len) <- sized1 $ \sz -> do
-                (kcp, Scg s, delta) <- genKSD
-
-                l <- (+ s) <$> QC.choose (0, 5 * sz)
-
-                pure (kcp, Scg s, delta, Len l)
-
-            let recipeH = H.HonestRecipe kcp scg delta len
+            recipeH@(H.HonestRecipe kcp scg delta len) <- H.genHonestRecipe
 
             someTestRecipeH' <- case Exn.runExcept $ H.checkHonestRecipe recipeH of
                 Left e  -> error $ "impossible! " <> show (recipeH, e)


### PR DESCRIPTION
While reviewing PR #888, I found it useful to collate the `ChainGenerators` postconditions as of PR #848.