### PR TITLE
Bump to GHC 9.6.4, update tools

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
        fail-fast: false
        matrix:
-         ghc: ["8.10.7", "9.6.3"]
+         ghc: ["8.10.7", "9.6.4"]
          cabal: ["3.10.1.0"]
          os: [ubuntu-latest]
     env:
@@ -172,7 +172,7 @@ jobs:
       if: |
         github.event_name == 'push'
         && github.ref == 'refs/heads/main'
-        && matrix.ghc=='9.6.3'
+        && matrix.ghc=='9.6.4'
       run: |
         cabal build --dry-run --enable-tests all
         ./scripts/docs/haddocks.sh
@@ -182,7 +182,7 @@ jobs:
       if: |
         github.event_name == 'push'
         && github.ref == 'refs/heads/main'
-        && matrix.ghc=='9.6.3'
+        && matrix.ghc=='9.6.4'
       uses: actions/upload-artifact@v4
       with:
         name: haddocks

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -168,7 +168,7 @@ and improvements are always welcome.
 
 ## Formatting the code
 
-We use `stylish-haskell` 0.14.5.0 for Haskell code formatting.
+We use `stylish-haskell` 0.14.6.0 for Haskell code formatting.
 
 Either enable editor integration or call the script used by CI itself:
 

--- a/flake.lock
+++ b/flake.lock
@@ -225,11 +225,11 @@
     "hackageNix": {
       "flake": false,
       "locked": {
-        "lastModified": 1705450998,
-        "narHash": "sha256-3MfI/48FOfwSvWzJW89lF/cU9HJIw8swmQZzrHO/44M=",
+        "lastModified": 1705883077,
+        "narHash": "sha256-KfQfG7ZKH5mvjdLulDKvvY75V0ZdtR04GPKcg2pEL9s=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "de3d2b30f3f149f338e533b111b38b6d03090931",
+        "rev": "bd2d081c571174c2e81c7e2bba1346ae4757de75",
         "type": "github"
       },
       "original": {
@@ -257,6 +257,8 @@
         "hls-2.2": "hls-2.2",
         "hls-2.3": "hls-2.3",
         "hls-2.4": "hls-2.4",
+        "hls-2.5": "hls-2.5",
+        "hls-2.6": "hls-2.6",
         "hpc-coveralls": "hpc-coveralls",
         "hydra": "hydra",
         "iserv-proxy": "iserv-proxy",
@@ -276,11 +278,11 @@
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1704156612,
-        "narHash": "sha256-JOAIVXNh5UNryoJHEQ0TGWWkyBq5f/F5ITFjOzXLXW0=",
+        "lastModified": 1705908259,
+        "narHash": "sha256-tph8oo/6fl7BqkwnZxO79FGoIpi9UAOo2OuQErsuWM4=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "651cfbaf9effe950fbd9a52cb39fcbab2aa0dbbe",
+        "rev": "eb39cf1442d9e90516ce74aebe2324e47c7d8f01",
         "type": "github"
       },
       "original": {
@@ -370,6 +372,40 @@
       "original": {
         "owner": "haskell",
         "ref": "2.4.0.1",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.5": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1701080174,
+        "narHash": "sha256-fyiR9TaHGJIIR0UmcCb73Xv9TJq3ht2ioxQ2mT7kVdc=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "27f8c3d3892e38edaef5bea3870161815c4d014c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.5.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.6": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1705325287,
+        "narHash": "sha256-+P87oLdlPyMw8Mgoul7HMWdEvWP/fNlo8jyNtwME8E8=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "6e0b342fa0327e628610f2711f8c3e4eaaa08b1e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.6.0.0",
         "repo": "haskell-language-server",
         "type": "github"
       }
@@ -718,11 +754,11 @@
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1704154190,
-        "narHash": "sha256-qbB89x4v4Qf2XgfmN4iKmmKNULFaMyU6gbIyPj4RcgI=",
+        "lastModified": 1705882461,
+        "narHash": "sha256-qUNNA0Z35o6wz+kIs+UdoJWxDbHBhvWyv9BqfsiwPWc=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "a0e554abda5ba94926d5bf522958f22d212260ec",
+        "rev": "37ad7b37b3f8e78757f661417304fcfebcbdb92e",
         "type": "github"
       },
       "original": {

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -14,7 +14,7 @@ let
   };
   hsPkgs = haskell-nix.cabalProject {
     src = ./..;
-    compiler-nix-name = "ghc963";
+    compiler-nix-name = "ghc964";
     flake.variants = {
       ghc810 = { compiler-nix-name = lib.mkForce "ghc8107"; };
     };
@@ -34,9 +34,6 @@ let
               extraSrcFiles = [ "golden/${n}/**/*" ];
             }) [ "byron" "shelley" "cardano" ]);
       }
-      ({ lib, pkgs, ... }: lib.mkIf pkgs.stdenv.hostPlatform.isWindows {
-        reinstallableLibGhc = false;
-      })
     ];
     flake.variants = {
       noAsserts = {

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -22,7 +22,7 @@ hsPkgs.shellFor {
   # This is the place for tools that are required to be built with the same GHC
   # version as used in hsPkgs.
   tools = lib.mapAttrs (_: t: t // { index-state = pkgs.tool-index-state; }) {
-    haskell-language-server = { version = "2.5.0.0"; };
+    haskell-language-server = { version = "2.6.0.0"; };
   };
 
   shellHook = ''

--- a/nix/tools.nix
+++ b/nix/tools.nix
@@ -2,7 +2,7 @@ inputs: final: prev:
 
 let
   inherit (final) lib;
-  tool-index-state = "2024-01-01T00:00:00Z";
+  tool-index-state = "2024-01-22T00:00:00Z";
   tool = name: version: other:
     final.haskell-nix.tool final.hsPkgs.args.compiler-nix-name name ({
       version = version;
@@ -19,8 +19,8 @@ in
     src = final.fetchFromGitHub {
       owner = "haskell";
       repo = "cabal";
-      rev = "27f4ee71d949837ba31e170d205fbe6c1ecf847d";
-      hash = "sha256-Ia0CgKuqtYynSIR1TQd2/enB+IpzCYrB7CbbVBb3Rus=";
+      rev = "adc283a0f06c7d24aeed67e69aca3d71c04010b3";
+      hash = "sha256-3K9WVR/tINK3PyGlXpypSpp1pguHTnolDruHNE+VvE4=";
     };
     index-state = tool-index-state;
     inherit (final.hsPkgs.args) compiler-nix-name;
@@ -48,9 +48,9 @@ in
     '';
   };
 
-  stylish-haskell = tool "stylish-haskell" "0.14.5.0" { };
+  stylish-haskell = tool "stylish-haskell" "0.14.6.0" { };
 
-  cabal-fmt = tool "cabal-fmt" "0.1.9" { };
+  cabal-fmt = tool "cabal-fmt" "0.1.10" { };
 
   haskellBuildUtils = prev.haskellBuildUtils.override {
     inherit (final.hsPkgs.args) compiler-nix-name;


### PR DESCRIPTION
 - Update to GHC 9.6.4
   
   This release includes [this GHC commit](https://gitlab.haskell.org/ghc/ghc/-/commit/1ae57288cabdd818180f38c9f55d8da8ac4c1d0c), potentially fixing #164.
 - Update [HLS 2.6](https://github.com/haskell/haskell-language-server/releases/tag/2.6.0.0), which in particular includes the following improvement:

   > Improvements to multiple home unit support with GHC 9.4. Using cabal 3.11+ will
load proper multiple home unit sessions by default, fixing a lot of issues with
loading and reloading projects that have more than one component.
   
   Also bump cabal HEAD as motivated by this.
 - Remove now-redundant haskell.nix workaround for mingwW64.
 - Bump stylish-haskell to 0.14.6.0 and cabal-fmt to 0.1.10.
