### PR TITLE
Make Conway query constructors ill-typed in pre-Conway eras

### DIFF
--- a/ouroboros-consensus-cardano/changelog.d/20240124_143703_nick.frisby_conway_only_queries.md
+++ b/ouroboros-consensus-cardano/changelog.d/20240124_143703_nick.frisby_conway_only_queries.md
@@ -1,0 +1,20 @@
+<!--
+### Patch
+
+- A bullet item for the Patch category.
+
+-->
+<!--
+### Non-Breaking
+
+- A bullet item for the Non-Breaking category.
+
+-->
+
+### Breaking
+
+- The type system now prohibits Conway-specific queries for Shelley-based eras
+  before Conway, by adding the `ConwayEraGov era` constraint to those query
+  constructors.
+- The new `getConwayEraGovDict` enables the decoder to find the necessary
+  dictionaries and issue a specific error message if there isn't one.


### PR DESCRIPTION
Closes Issue #864.

The new queries for Conway governance now require an instance of the ledger's `ConwayGovEra` class, so uses of them in eras before Conway will cause type errors.

Ideally the per-Conway eras would have an `Unsatisfiable` instance of `ConwayGovEra`, but that's only available as of GHC 9.8.1 [release notes](https://downloads.haskell.org/ghc/latest/docs/users_guide/9.8.1-notes.html).

If I understand correctly, it's no longer necessary for `GetConstitution` to return a `Maybe`, for example.