### PR TITLE
Properly relocate `::` in the codebase

### DIFF
--- a/ouroboros-consensus-cardano/src/byron/Ouroboros/Consensus/Byron/Ledger/Forge.hs
+++ b/ouroboros-consensus-cardano/src/byron/Ouroboros/Consensus/Byron/Ledger/Forge.hs
@@ -46,8 +46,8 @@ import           Ouroboros.Consensus.Ledger.SupportsMempool
 import qualified Ouroboros.Consensus.Mempool as Mempool
 import           Ouroboros.Consensus.Protocol.PBFT
 
-forgeByronBlock
-  :: HasCallStack
+forgeByronBlock ::
+     HasCallStack
   => TopLevelConfig ByronBlock
   -> Mempool.TxOverrides ByronBlock   -- ^ How to override max tx capacity
                                       --   defined by ledger
@@ -59,8 +59,8 @@ forgeByronBlock
   -> ByronBlock
 forgeByronBlock cfg = forgeRegularBlock (configBlock cfg)
 
-forgeEBB
-  :: BlockConfig ByronBlock
+forgeEBB ::
+     BlockConfig ByronBlock
   -> SlotNo                          -- ^ Current slot
   -> BlockNo                         -- ^ Current block number
   -> ChainHash ByronBlock            -- ^ Previous hash
@@ -123,8 +123,8 @@ initBlockPayloads = BlockPayloads
   , bpUpProposal = Nothing
   }
 
-forgeRegularBlock
-  :: HasCallStack
+forgeRegularBlock ::
+     HasCallStack
   => BlockConfig ByronBlock
   -> Mempool.TxOverrides ByronBlock    -- ^ How to override max tx capacity
                                        --   defined by ledger

--- a/ouroboros-consensus-cardano/src/byron/Ouroboros/Consensus/Byron/Ledger/PBFT.hs
+++ b/ouroboros-consensus-cardano/src/byron/Ouroboros/Consensus/Byron/Ledger/PBFT.hs
@@ -77,11 +77,11 @@ toPBftLedgerView = PBftLedgerView . Delegation.unMap
 fromPBftLedgerView :: PBftLedgerView PBftByronCrypto -> Delegation.Map
 fromPBftLedgerView = Delegation.Map . pbftDelegates
 
-encodeByronChainDepState
-  :: ChainDepState (BlockProtocol ByronBlock)
+encodeByronChainDepState ::
+     ChainDepState (BlockProtocol ByronBlock)
   -> Encoding
 encodeByronChainDepState = S.encodePBftState
 
-decodeByronChainDepState
-  :: Decoder s (ChainDepState (BlockProtocol ByronBlock))
+decodeByronChainDepState ::
+     Decoder s (ChainDepState (BlockProtocol ByronBlock))
 decodeByronChainDepState = S.decodePBftState

--- a/ouroboros-consensus-cardano/src/byron/Ouroboros/Consensus/Byron/Ledger/Serialisation.hs
+++ b/ouroboros-consensus-cardano/src/byron/Ouroboros/Consensus/Byron/Ledger/Serialisation.hs
@@ -229,8 +229,8 @@ encodeByronRegularHeader :: RawHeader -> CBOR.Encoding
 encodeByronRegularHeader = toByronCBOR . CBOR.encodePreEncoded . CC.headerAnnotation
 
 -- | Inverse of 'encodeByronRegularHeader'
-decodeByronRegularHeader
-  :: CC.EpochSlots
+decodeByronRegularHeader ::
+     CC.EpochSlots
   -> Decoder s (Lazy.ByteString -> RawHeader)
 decodeByronRegularHeader epochSlots =
     toPlainDecoder byronProtVer $

--- a/ouroboros-consensus-cardano/src/byron/Ouroboros/Consensus/Byron/Node.hs
+++ b/ouroboros-consensus-cardano/src/byron/Ouroboros/Consensus/Byron/Node.hs
@@ -124,8 +124,8 @@ type instance ForgeStateInfo ByronBlock = ()
 
 type instance ForgeStateUpdateError ByronBlock = Void
 
-byronBlockForging
-  :: Monad m
+byronBlockForging ::
+     Monad m
   => Mempool.TxOverrides ByronBlock
   -> ByronLeaderCredentials
   -> BlockForging m ByronBlock

--- a/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/Node.hs
+++ b/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/Node.hs
@@ -1139,8 +1139,8 @@ protocolInfoCardano paramsCardano
             praos  maxTxCapacityOverridesConway  :*
             Nil
 
-protocolClientInfoCardano
-  :: forall c.
+protocolClientInfoCardano ::
+     forall c.
      -- Byron
      EpochSlots
   -> ProtocolClientInfo (CardanoBlock c)

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Ledger.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Ledger.hs
@@ -149,8 +149,8 @@ shelleyEraParamsNeverHardForks genesis = HardFork.EraParams {
     , eraSafeZone   = HardFork.UnsafeIndefiniteSafeZone
     }
 
-mkShelleyLedgerConfig
-  :: SL.ShelleyGenesis (EraCrypto era)
+mkShelleyLedgerConfig ::
+     SL.ShelleyGenesis (EraCrypto era)
   -> Core.TranslationContext era
   -> EpochInfo (Except HardFork.PastHorizonException)
   -> MaxMajorProtVer

--- a/ouroboros-consensus-cardano/src/unstable-byron-testlib/Ouroboros/Consensus/ByronDual/Ledger.hs
+++ b/ouroboros-consensus-cardano/src/unstable-byron-testlib/Ouroboros/Consensus/ByronDual/Ledger.hs
@@ -198,8 +198,8 @@ bridgeTransactionIds = Spec.Test.transactionIds
   Block forging
 -------------------------------------------------------------------------------}
 
-forgeDualByronBlock
-  :: HasCallStack
+forgeDualByronBlock ::
+     HasCallStack
   => TopLevelConfig DualByronBlock
   -> BlockNo                              -- ^ Current block number
   -> SlotNo                               -- ^ Current slot number

--- a/ouroboros-consensus-cardano/src/unstable-byron-testlib/Ouroboros/Consensus/ByronDual/Node.hs
+++ b/ouroboros-consensus-cardano/src/unstable-byron-testlib/Ouroboros/Consensus/ByronDual/Node.hs
@@ -54,8 +54,8 @@ import qualified Test.Cardano.Chain.UTxO.Model as Spec.Test
   BlockForging
 -------------------------------------------------------------------------------}
 
-dualByronBlockForging
-  :: Monad m
+dualByronBlockForging ::
+     Monad m
   => ByronLeaderCredentials
   -> BlockForging m DualByronBlock
 dualByronBlockForging creds = BlockForging {

--- a/ouroboros-consensus-cardano/src/unstable-byron-testlib/Test/ThreadNet/Infra/Byron/ProtocolInfo.hs
+++ b/ouroboros-consensus-cardano/src/unstable-byron-testlib/Test/ThreadNet/Infra/Byron/ProtocolInfo.hs
@@ -69,8 +69,8 @@ mkProtocolByron params coreNodeId genesisConfig genesisSecrets =
           , byronMaxTxCapacityOverrides = Mempool.mkOverrides Mempool.noOverridesMeasure
           }
 
-mkLeaderCredentials
-  :: HasCallStack
+mkLeaderCredentials ::
+     HasCallStack
   => Genesis.Config
   -> Genesis.GeneratedSecrets
   -> CoreNodeId

--- a/ouroboros-consensus-cardano/src/unstable-byron-testlib/Test/ThreadNet/Infra/Byron/TrackUpdates.hs
+++ b/ouroboros-consensus-cardano/src/unstable-byron-testlib/Test/ThreadNet/Infra/Byron/TrackUpdates.hs
@@ -81,8 +81,8 @@ data SoftwareVersionUpdateLabel = SoftwareVersionUpdateLabel
 -- | Classify the a @QuickCheck@ test's input and output with respect to
 -- whether the protocol\/software version should have been\/was updated
 --
-mkUpdateLabels
-  :: PBftParams
+mkUpdateLabels ::
+     PBftParams
   -> NumSlots
   -> Genesis.Config
   -> NodeJoinPlan
@@ -360,8 +360,8 @@ data ProposalState =
 --    mitigating circumstances, such as the test not even being scheduled to
 --    reach the second epoch.
 --
-mkProtocolByronAndHardForkTxs
-  :: forall m. (Monad m, HasCallStack)
+mkProtocolByronAndHardForkTxs ::
+     forall m. (Monad m, HasCallStack)
   => PBftParams
   -> CoreNodeId
   -> Genesis.Config
@@ -419,8 +419,8 @@ mkProtocolByronAndHardForkTxs
 --
 -- Without loss of generality, the proposal is signed by @'CoreNodeId' 0@.
 --
-mkHardForkProposal
-  :: HasCallStack
+mkHardForkProposal ::
+     HasCallStack
   => PBftParams
   -> Genesis.Config
   -> Genesis.GeneratedSecrets
@@ -472,8 +472,8 @@ mkHardForkProposal params genesisConfig genesisSecrets propPV =
 -- tricky to get right, and this function lets use reuse the existing CBOR
 -- instances.
 --
-loopbackAnnotations
-  :: ( DecCBOR (f ByteSpan)
+loopbackAnnotations ::
+     ( DecCBOR (f ByteSpan)
      , EncCBOR (f ())
      , Functor f
      )

--- a/ouroboros-consensus-cardano/src/unstable-cardano-testlib/Test/Consensus/Cardano/Generators.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-testlib/Test/Consensus/Cardano/Generators.hs
@@ -147,8 +147,8 @@ instance Arbitrary (BlockNodeToNodeVersion blk)
     , (9, EraNodeToNodeEnabled <$> arbitrary)
     ]
 
-arbitraryNodeToNode
-  :: ( Arbitrary (WithVersion ByronNodeToNodeVersion byron)
+arbitraryNodeToNode ::
+     ( Arbitrary (WithVersion ByronNodeToNodeVersion byron)
      , Arbitrary (WithVersion ShelleyNodeToNodeVersion shelley)
      , Arbitrary (WithVersion ShelleyNodeToNodeVersion allegra)
      , Arbitrary (WithVersion ShelleyNodeToNodeVersion mary)
@@ -375,8 +375,8 @@ instance Arbitrary (BlockNodeToClientVersion blk)
     , (9, EraNodeToClientEnabled <$> arbitrary)
     ]
 
-arbitraryNodeToClient
-  :: ( Arbitrary (WithVersion ByronNodeToClientVersion   byron)
+arbitraryNodeToClient ::
+     ( Arbitrary (WithVersion ByronNodeToClientVersion   byron)
      , Arbitrary (WithVersion ShelleyNodeToClientVersion shelley)
      , Arbitrary (WithVersion ShelleyNodeToClientVersion allegra)
      , Arbitrary (WithVersion ShelleyNodeToClientVersion mary)

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Api/SerialiseTextEnvelope.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Api/SerialiseTextEnvelope.hs
@@ -215,8 +215,8 @@ readTextEnvelopeFromFile path =
       . hoistEither $ Aeson.eitherDecodeStrict' bs
 
 
-readTextEnvelopeOfTypeFromFile
-  :: TextEnvelopeType
+readTextEnvelopeOfTypeFromFile ::
+     TextEnvelopeType
   -> FilePath
   -> IO (Either (FileError TextEnvelopeError) TextEnvelope)
 readTextEnvelopeOfTypeFromFile expectedType path =

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Node/Protocol.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Node/Protocol.hs
@@ -20,8 +20,8 @@ import           Control.Monad.Trans.Except.Extra (firstExceptT)
 -- Conversions from configuration into specific protocols and their params
 --
 
-mkConsensusProtocol
-  :: NodeProtocolConfiguration
+mkConsensusProtocol ::
+     NodeProtocolConfiguration
   -> Maybe ProtocolFilepaths
   -> ExceptT ProtocolInstantiationError IO SomeConsensusProtocol
 mkConsensusProtocol ncProtocolConfig mProtocolFiles =

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Node/Protocol/Byron.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Node/Protocol/Byron.hs
@@ -48,8 +48,8 @@ import           Prelude hiding (show, (.))
 -- This also serves a purpose as a sanity check that we have all the necessary
 -- type class instances available.
 --
-mkSomeConsensusProtocolByron
-  :: NodeByronProtocolConfiguration
+mkSomeConsensusProtocolByron ::
+     NodeByronProtocolConfiguration
   -> Maybe ProtocolFilepaths
   -> ExceptT ByronProtocolInstantiationError IO SomeConsensusProtocol
 mkSomeConsensusProtocolByron NodeByronProtocolConfiguration {

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Node/Protocol/Cardano.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Node/Protocol/Cardano.hs
@@ -53,8 +53,8 @@ import qualified Ouroboros.Consensus.Mempool as Mempool
 -- This also serves a purpose as a sanity check that we have all the necessary
 -- type class instances available.
 --
-mkSomeConsensusProtocolCardano
-  :: NodeByronProtocolConfiguration
+mkSomeConsensusProtocolCardano ::
+     NodeByronProtocolConfiguration
   -> NodeShelleyProtocolConfiguration
   -> NodeAlonzoProtocolConfiguration
   -> NodeConwayProtocolConfiguration

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Node/Protocol/Shelley.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Node/Protocol/Shelley.hs
@@ -63,8 +63,8 @@ import           Prelude (String, id)
 --
 -- This also serves a purpose as a sanity check that we have all the necessary
 -- type class instances available.
-mkSomeConsensusProtocolShelley
-  :: NodeShelleyProtocolConfiguration
+mkSomeConsensusProtocolShelley ::
+     NodeShelleyProtocolConfiguration
   -> Maybe ProtocolFilepaths
   -> ExceptT ShelleyProtocolInstantiationError IO SomeConsensusProtocol
 mkSomeConsensusProtocolShelley NodeShelleyProtocolConfiguration {
@@ -129,8 +129,8 @@ validateGenesis genesis =
     firstExceptT GenesisValidationErrors . hoistEither $
       Shelley.validateGenesis genesis
 
-readLeaderCredentials
-  :: Maybe ProtocolFilepaths
+readLeaderCredentials ::
+     Maybe ProtocolFilepaths
   -> ExceptT PraosLeaderCredentialsError IO [ShelleyLeaderCredentials StandardCrypto]
 readLeaderCredentials Nothing = return []
 readLeaderCredentials (Just pfp) =
@@ -171,8 +171,8 @@ readLeaderCredentialsSingleton ProtocolFilepaths {shelleyVRFFile = Nothing} =
 readLeaderCredentialsSingleton ProtocolFilepaths {shelleyKESFile = Nothing} =
      left KESKeyNotSpecified
 
-opCertKesKeyCheck
-  :: FilePath
+opCertKesKeyCheck ::
+     FilePath
   -- ^ KES key
   -> FilePath
   -- ^ Operational certificate
@@ -197,8 +197,8 @@ data ShelleyCredentials
     , scKes  :: (TextEnvelope, FilePath)
     }
 
-readLeaderCredentialsBulk
-  :: ProtocolFilepaths
+readLeaderCredentialsBulk ::
+     ProtocolFilepaths
   -> ExceptT PraosLeaderCredentialsError IO [ShelleyLeaderCredentials StandardCrypto]
 readLeaderCredentialsBulk ProtocolFilepaths { shelleyBulkCredsFile = mfp } =
   mapM parseShelleyCredentials =<< readBulkFile mfp

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBSynthesizer/Forging.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBSynthesizer/Forging.hs
@@ -54,8 +54,8 @@ initialForgeState = ForgeState 0 0 0 0
 -- DUPLICATE: runForge mirrors forging loop from ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
 -- For an extensive commentary of the forging loop, see there.
 
-runForge
-  :: forall blk.
+runForge ::
+     forall blk.
     ( LedgerSupportsProtocol blk )
     => EpochSize
     -> SlotNo
@@ -192,8 +192,8 @@ blockContextFromPrevHeader hdr =
 
 -- | Determine the 'BlockContext' for a block about to be forged from the
 -- current slot, ChainDB chain fragment, and ChainDB tip block number
-mkCurrentBlockContext
-  :: forall blk.
+mkCurrentBlockContext ::
+     forall blk.
      ( GetHeader blk
      , BasicEnvelopeValidation blk )
   => SlotNo

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBSynthesizer/Run.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBSynthesizer/Run.hs
@@ -44,8 +44,8 @@ import           System.Directory
 import           System.FilePath (takeDirectory, (</>))
 
 
-initialize
-    :: NodeFilePaths
+initialize ::
+       NodeFilePaths
     -> NodeCredentials
     -> DBSynthesizerOptions
     -> IO (Either String (DBSynthesizerConfig, SomeConsensusProtocol))

--- a/ouroboros-consensus-cardano/src/unstable-shelley-testlib/Test/Consensus/Shelley/Examples.hs
+++ b/ouroboros-consensus-cardano/src/unstable-shelley-testlib/Test/Consensus/Shelley/Examples.hs
@@ -71,8 +71,8 @@ import           Test.Util.Serialisation.SomeResult (SomeResult (..))
 codecConfig :: CodecConfig StandardShelleyBlock
 codecConfig = ShelleyCodecConfig
 
-fromShelleyLedgerExamples
-  :: ShelleyCompatible (TPraos (EraCrypto era)) era
+fromShelleyLedgerExamples ::
+     ShelleyCompatible (TPraos (EraCrypto era)) era
   => ShelleyLedgerExamples era
   -> Examples (ShelleyBlock (TPraos (EraCrypto era)) era)
 fromShelleyLedgerExamples ShelleyLedgerExamples {

--- a/ouroboros-consensus-cardano/src/unstable-shelley-testlib/Test/ThreadNet/Infra/Shelley.hs
+++ b/ouroboros-consensus-cardano/src/unstable-shelley-testlib/Test/ThreadNet/Infra/Shelley.hs
@@ -239,8 +239,8 @@ data KesConfig = KesConfig
 
 -- | A 'KesConfig' that will not require more evolutions than this test's crypto
 -- allows.
-mkKesConfig
-  :: forall proxy c. Crypto c
+mkKesConfig ::
+     forall proxy c. Crypto c
   => proxy c -> NumSlots -> KesConfig
 mkKesConfig _ (NumSlots t) = KesConfig
     { maxEvolutions
@@ -275,8 +275,8 @@ mkEpochSize (SecurityParam k) f =
 -- | Note: a KES algorithm supports a particular max number of KES evolutions,
 -- but we can configure a potentially lower maximum for the ledger, that's why
 -- we take it as an argument.
-mkGenesisConfig
-  :: forall c. PraosCrypto c
+mkGenesisConfig ::
+     forall c. PraosCrypto c
   => ProtVer   -- ^ Initial protocol version
   -> SecurityParam
   -> Rational  -- ^ Initial active slot coefficient

--- a/ouroboros-consensus-cardano/src/unstable-shelley-testlib/Test/ThreadNet/TxGen/Shelley.hs
+++ b/ouroboros-consensus-cardano/src/unstable-shelley-testlib/Test/ThreadNet/TxGen/Shelley.hs
@@ -84,8 +84,8 @@ instance HashAlgorithm h => TxGen (ShelleyBlock (TPraos (MockCrypto h)) (MockShe
               Left  _   -> go (tx:acc) (n - 1) st
               Right st' -> go (tx:acc) (n - 1) st'
 
-genTx
-  :: forall h. HashAlgorithm h
+genTx ::
+     forall h. HashAlgorithm h
   => TopLevelConfig (ShelleyBlock (TPraos (MockCrypto h)) (MockShelley h))
   -> SlotNo
   -> TickedLedgerState (ShelleyBlock (TPraos (MockCrypto h)) (MockShelley h))

--- a/ouroboros-consensus-cardano/test/byron-test/Test/ThreadNet/Byron.hs
+++ b/ouroboros-consensus-cardano/test/byron-test/Test/ThreadNet/Byron.hs
@@ -793,8 +793,8 @@ prop_deterministicPlan params numSlots numCoreNodes =
   where
     njp = trivialNodeJoinPlan numCoreNodes
 
-expectedCannotForge
-  :: SecurityParam
+expectedCannotForge ::
+     SecurityParam
   -> NumCoreNodes
   -> NodeRestarts
   -> SlotNo
@@ -839,8 +839,8 @@ expectedCannotForge _ _ _ _ _ _ = False
 --
 -- See @genNodeRekeys@ for the logic that ensures at least one of those slots'
 -- leaders will be able to lead.
-latestPossibleDlgMaturation
-  :: SecurityParam -> NumCoreNodes -> SlotNo -> SlotNo
+latestPossibleDlgMaturation ::
+     SecurityParam -> NumCoreNodes -> SlotNo -> SlotNo
 latestPossibleDlgMaturation
   (SecurityParam k) (NumCoreNodes n) (SlotNo rekeySlot) =
     SlotNo $ rekeySlot + n + 2 * k
@@ -1216,8 +1216,8 @@ genByronNodeJoinPlan params numSlots@(NumSlots t)
 -- since otherwise its inability to lead may spoil the invariants established
 -- by 'genByronNodeJoinPlan'.
 --
-genNodeRekeys
-  :: PBftParams
+genNodeRekeys ::
+     PBftParams
   -> NodeJoinPlan
   -> NodeTopology
   -> NumSlots
@@ -1278,8 +1278,8 @@ genNodeRekeys params nodeJoinPlan nodeTopology numSlots@(NumSlots t)
 -- | Overwrite the 'ProtocolInfo''s operational key, if any, and provide a
 -- transaction for its new delegation certificate
 --
-mkRekeyUpd
-  :: Monad m
+mkRekeyUpd ::
+     Monad m
   => Genesis.Config
   -> Genesis.GeneratedSecrets
   -> CoreNodeId
@@ -1309,8 +1309,8 @@ mkRekeyUpd genesisConfig genesisSecrets cid pInfo blockForging eno newSK = do
 
 -- | The secret key for a node index
 --
-genesisSecretFor
-  :: Genesis.Config
+genesisSecretFor ::
+     Genesis.Config
   -> Genesis.GeneratedSecrets
   -> CoreNodeId
   -> Crypto.SignKeyDSIGN Crypto.ByronDSIGN
@@ -1333,8 +1333,8 @@ genesisSecretFor genesisConfig genesisSecrets cid =
 -- | Create new 'ByronLeaderCredentials' by generating a new delegation
 -- certificate for the given new operational key.
 --
-updSignKey
-  :: Crypto.SignKeyDSIGN Crypto.ByronDSIGN
+updSignKey ::
+     Crypto.SignKeyDSIGN Crypto.ByronDSIGN
   -> BlockConfig ByronBlock
   -> CoreNodeId
   -> EpochNumber

--- a/ouroboros-consensus-cardano/test/cardano-test/Test/Consensus/Cardano/Serialisation.hs
+++ b/ouroboros-consensus-cardano/test/cardano-test/Test/Consensus/Cardano/Serialisation.hs
@@ -49,8 +49,8 @@ testCodecCfg =
     ShelleyCodecConfig
     ShelleyCodecConfig
 
-dictNestedHdr
-  :: forall a.
+dictNestedHdr ::
+     forall a.
      NestedCtxt_ (CardanoBlock MockCryptoCompatByron) Header a
   -> Dict (Eq a, Show a)
 dictNestedHdr = \case

--- a/ouroboros-consensus-cardano/test/cardano-test/Test/ThreadNet/Cardano.hs
+++ b/ouroboros-consensus-cardano/test/cardano-test/Test/ThreadNet/Cardano.hs
@@ -427,8 +427,8 @@ prop_simple_cardano_convergence TestSetup
         counterexample "CP violation in final chains!" $
         property $ maxRollbacks setupK >= finalIntersectionDepth
 
-mkProtocolCardanoAndHardForkTxs
-  :: forall c m. (IOLike m, CardanoHardForkConstraints c)
+mkProtocolCardanoAndHardForkTxs ::
+     forall c m. (IOLike m, CardanoHardForkConstraints c)
      -- Byron
   => PBftParams
   -> CoreNodeId

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToClient.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToClient.hs
@@ -104,8 +104,8 @@ data Handlers m peer blk = Handlers {
         :: LocalTxMonitorServer (GenTxId blk) (GenTx blk) SlotNo m ()
     }
 
-mkHandlers
-  :: forall m blk addrNTN addrNTC.
+mkHandlers ::
+     forall m blk addrNTN addrNTC.
      ( IOLike m
      , LedgerSupportsMempool blk
      , LedgerSupportsProtocol blk
@@ -378,8 +378,8 @@ data Apps m peer bCS bTX bSQ bTM a = Apps {
     }
 
 -- | Construct the 'NetworkApplication' for the node-to-client protocols
-mkApps
-  :: forall m addrNTN addrNTC blk e bCS bTX bSQ bTM.
+mkApps ::
+     forall m addrNTN addrNTC blk e bCS bTX bSQ bTM.
      ( IOLike m
      , Exception e
      , ShowProxy blk
@@ -456,8 +456,8 @@ mkApps kernel Tracers {..} Codecs {..} Handlers {..} =
 
 -- | A projection from 'NetworkApplication' to a server-side
 -- 'OuroborosApplication' for the node-to-client protocols.
-responder
-  :: N.NodeToClientVersion
+responder ::
+     N.NodeToClientVersion
   -> Apps m (ConnectionId peer) b b b b a
   -> OuroborosApplicationWithMinimalCtx 'ResponderMode peer b m Void a
 responder version Apps {..} =

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToNode.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToNode.hs
@@ -195,8 +195,8 @@ data Handlers m addr blk = Handlers {
         -> PeerSharingServer addr m
     }
 
-mkHandlers
-  :: forall m blk addrNTN addrNTC.
+mkHandlers ::
+     forall m blk addrNTN addrNTC.
      ( IOLike m
      , MonadTime m
      , MonadTimer m
@@ -523,8 +523,8 @@ byteLimits = ByteLimits {
          . BSL.length
 
 -- | Construct the 'NetworkApplication' for the node-to-node protocols
-mkApps
-  :: forall m addrNTN addrNTC blk e bCS bBF bTX bKA bPS.
+mkApps ::
+     forall m addrNTN addrNTC blk e bCS bBF bTX bKA bPS.
      ( IOLike m
      , MonadTimer m
      , Ord addrNTN
@@ -784,8 +784,8 @@ mkApps kernel Tracers {..} mkCodecs ByteLimits {..} genChainSyncTimeout ReportPe
 -- Implementation note: network currently doesn't enable protocols conditional
 -- on the protocol version, but it eventually may; this is why @_version@ is
 -- currently unused.
-initiator
-  :: MiniProtocolParameters
+initiator ::
+     MiniProtocolParameters
   -> NodeToNodeVersion
   -> PSTypes.PeerSharing
   -> Apps m addr b b b b b a c
@@ -819,8 +819,8 @@ initiator miniProtocolParameters version ownPeerSharing Apps {..} =
 -- Implementation note: network currently doesn't enable protocols conditional
 -- on the protocol version, but it eventually may; this is why @_version@ is
 -- currently unused.
-initiatorAndResponder
-  :: MiniProtocolParameters
+initiatorAndResponder ::
+     MiniProtocolParameters
   -> NodeToNodeVersion
   -> PSTypes.PeerSharing
   -> Apps m addr b b b b b a c

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Node.hs
@@ -586,8 +586,8 @@ stdWithCheckedDB pb databasePath networkMagic body = do
     mountPoint = MountPoint databasePath
     hasFS      = ioHasFS mountPoint
 
-openChainDB
-  :: forall m blk. (RunNode blk, IOLike m)
+openChainDB ::
+     forall m blk. (RunNode blk, IOLike m)
   => ResourceRegistry m
   -> CheckInFuture m blk
   -> TopLevelConfig blk
@@ -606,8 +606,8 @@ openChainDB registry inFuture cfg initLedger defArgs customiseArgs =
              (nodeImmutableDbChunkInfo (configStorage cfg))
              defArgs
 
-mkChainDbArgs
-  :: forall m blk. (RunNode blk, IOLike m)
+mkChainDbArgs ::
+     forall m blk. (RunNode blk, IOLike m)
   => ResourceRegistry m
   -> CheckInFuture m blk
   -> TopLevelConfig blk
@@ -633,8 +633,8 @@ mkChainDbArgs
     , ChainDB.cdbRegistry       = registry
     }
 
-mkNodeKernelArgs
-  :: forall m addrNTN addrNTC blk. (RunNode blk, IOLike m)
+mkNodeKernelArgs ::
+     forall m addrNTN addrNTC blk. (RunNode blk, IOLike m)
   => ResourceRegistry m
   -> Int
   -> StdGen
@@ -682,8 +682,8 @@ mkNodeKernelArgs
 -- through 'llrnCustomiseNodeKernelArgs', but there are some limits to some
 -- values. This function makes sure we don't exceed those limits and that the
 -- values are consistent.
-nodeKernelArgsEnforceInvariants
-  :: NodeKernelArgs m addrNTN (ConnectionId addrNTC) blk
+nodeKernelArgsEnforceInvariants ::
+     NodeKernelArgs m addrNTN (ConnectionId addrNTC) blk
   -> NodeKernelArgs m addrNTN (ConnectionId addrNTC) blk
 nodeKernelArgsEnforceInvariants nodeKernelArgs = nodeKernelArgs
     { miniProtocolParameters = miniProtocolParameters

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Node/DbMarker.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Node/DbMarker.hs
@@ -61,8 +61,8 @@ import           Text.Read (readMaybe)
 --   contents could not be parsed, we also throw a 'DbMarkerError'.
 --
 -- Note that an 'FsError' can also be thrown.
-checkDbMarker
-  :: forall m h. MonadThrow m
+checkDbMarker ::
+     forall m h. MonadThrow m
   => HasFS m h
   -> MountPoint
      -- ^ Database directory. Should be the mount point of the @HasFS@. Used

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Node/Recovery.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Node/Recovery.hs
@@ -29,8 +29,8 @@ newtype LastShutDownWasClean = LastShutDownWasClean Bool
   deriving (Eq, Show)
 
 -- | Return 'True' when 'cleanShutdownMarkerFile' exists.
-hasCleanShutdownMarker
-  :: HasFS m h
+hasCleanShutdownMarker ::
+     HasFS m h
   -> m Bool
 hasCleanShutdownMarker hasFS =
     doesFileExist hasFS cleanShutdownMarkerFile
@@ -38,8 +38,8 @@ hasCleanShutdownMarker hasFS =
 -- | Create the 'cleanShutdownMarkerFile'.
 --
 -- Idempotent.
-createCleanShutdownMarker
-  :: IOLike m
+createCleanShutdownMarker ::
+     IOLike m
   => HasFS m h
   -> m ()
 createCleanShutdownMarker hasFS = do
@@ -51,8 +51,8 @@ createCleanShutdownMarker hasFS = do
 -- | Remove 'cleanShutdownMarkerFile'.
 --
 -- Will throw an 'FsResourceDoesNotExist' error when it does not exist.
-removeCleanShutdownMarker
-  :: HasFS m h
+removeCleanShutdownMarker ::
+     HasFS m h
   -> m ()
 removeCleanShutdownMarker hasFS =
     removeFile hasFS cleanShutdownMarkerFile
@@ -85,8 +85,8 @@ exceptionRequiresRecovery pb e = case toExitReason pb e of
 --   a shutdown handler that writes the marker except for certain exceptions
 --   (see 'exceptionRequiresRecovery') that indicate corruption, for which we
 --   want the next startup to do revalidation.
-runWithCheckedDB
-  :: forall a m h blk. (IOLike m, StandardHash blk, Typeable blk)
+runWithCheckedDB ::
+     forall a m h blk. (IOLike m, StandardHash blk, Typeable blk)
   => Proxy blk
   -> HasFS m h
   -> (LastShutDownWasClean -> (ChainDB m blk -> m a -> m a) -> m a)
@@ -134,8 +134,8 @@ runWithCheckedDB pb hasFS body = do
   Auxiliary
 -------------------------------------------------------------------------------}
 
-onExceptionIf
-  :: (IOLike m, Exception e)
+onExceptionIf ::
+     (IOLike m, Exception e)
   => (e -> Bool)  -- ^ Predicate to selection exceptions
   -> m ()         -- ^ Exception handler
   -> m a

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
@@ -142,8 +142,8 @@ data NodeKernelArgs m addrNTN addrNTC blk = NodeKernelArgs {
     , keepAliveRng            :: StdGen
     }
 
-initNodeKernel
-    :: forall m addrNTN addrNTC blk.
+initNodeKernel ::
+       forall m addrNTN addrNTC blk.
        ( IOLike m
        , RunNode blk
        , Ord addrNTN
@@ -219,8 +219,8 @@ data InternalState m addrNTN addrNTC blk = IS {
     , peerSharingRegistry :: PeerSharingRegistry addrNTN m
     }
 
-initInternalState
-    :: forall m addrNTN addrNTC blk.
+initInternalState ::
+       forall m addrNTN addrNTC blk.
        ( IOLike m
        , Ord addrNTN
        , Typeable addrNTN
@@ -262,8 +262,8 @@ initInternalState NodeKernelArgs { tracers, chainDB, registry, cfg
 
     return IS {..}
 
-forkBlockForging
-    :: forall m addrNTN addrNTC blk.
+forkBlockForging ::
+       forall m addrNTN addrNTC blk.
        (IOLike m, RunNode blk)
     => InternalState m addrNTN addrNTC blk
     -> BlockForging m blk
@@ -505,8 +505,8 @@ blockContextFromPrevHeader hdr =
 -- was also elected leader and managed to produce a block before us), the tip's
 -- predecessor. If the chain is empty, then it will refer to the chain's anchor
 -- point, which may be genesis.
-mkCurrentBlockContext
-  :: forall blk. RunNode blk
+mkCurrentBlockContext ::
+     forall blk. RunNode blk
   => SlotNo
      -- ^ the current slot, i.e. the slot of the block about to be forged
   -> AnchoredFragment (Header blk)
@@ -569,8 +569,8 @@ mkCurrentBlockContext currentSlot c = case c of
   TxSubmission integration
 -------------------------------------------------------------------------------}
 
-getMempoolReader
-  :: forall m blk.
+getMempoolReader ::
+     forall m blk.
      ( LedgerSupportsMempool blk
      , IOLike m
      , HasTxId (GenTx blk)
@@ -596,8 +596,8 @@ getMempoolReader mempool = MempoolReader.TxSubmissionMempoolReader
         , mempoolHasTx      = snapshotHasTx
         }
 
-getMempoolWriter
-  :: ( LedgerSupportsMempool blk
+getMempoolWriter ::
+     ( LedgerSupportsMempool blk
      , IOLike m
      , HasTxId (GenTx blk)
      )

--- a/ouroboros-consensus-diffusion/src/unstable-diffusion-testlib/Test/ThreadNet/Network.hs
+++ b/ouroboros-consensus-diffusion/src/unstable-diffusion-testlib/Test/ThreadNet/Network.hs
@@ -174,8 +174,8 @@ data TestNodeInitialization m blk = TestNodeInitialization
   , tniBlockForging :: m [BlockForging m blk]
   }
 
-plainTestNodeInitialization
-  :: ProtocolInfo blk
+plainTestNodeInitialization ::
+     ProtocolInfo blk
   -> m [BlockForging m blk]
   -> TestNodeInitialization m blk
 plainTestNodeInitialization pInfo blockForging = TestNodeInitialization
@@ -1129,8 +1129,8 @@ data RestartCause
 
 -- | Fork two directed edges, one in each direction between the two vertices
 --
-forkBothEdges
-  :: (IOLike m, RunNode blk, HasCallStack)
+forkBothEdges ::
+     (IOLike m, RunNode blk, HasCallStack)
   => ResourceRegistry m
   -> OracularClock m
   -> Tracer m (SlotNo, MiniProtocolState)
@@ -1361,8 +1361,8 @@ directedEdgeInner registry clock (version, blockVersion) (cfg, calcMessageDelay)
 -- Sending adds the message to a queue. The delaying argument should use
 -- 'threadDelay' in order to delay the transfer of the given message from the
 -- queue to the recipient.
-createConnectedChannelsWithDelay
-  :: IOLike m
+createConnectedChannelsWithDelay ::
+     IOLike m
   => ResourceRegistry m
   -> (CoreNodeId, CoreNodeId, String)
      -- ^ (client, server, protocol)

--- a/ouroboros-consensus-diffusion/src/unstable-diffusion-testlib/Test/ThreadNet/Ref/PBFT.hs
+++ b/ouroboros-consensus-diffusion/src/unstable-diffusion-testlib/Test/ThreadNet/Ref/PBFT.hs
@@ -281,8 +281,8 @@ resultConstrName = \case
 --
 -- See 'Result'.
 --
-simulate
-  :: HasCallStack => PBftParams -> NodeJoinPlan -> NumSlots -> Result
+simulate ::
+     HasCallStack => PBftParams -> NodeJoinPlan -> NumSlots -> Result
 simulate params nodeJoinPlan numSlots =
     case simulateShort params nodeJoinPlan numSlots of
       Left (Det st@State{outs}) -> Outcomes $ toList outs <> go st
@@ -339,8 +339,8 @@ data DetOrNondet
     --
     -- See 'Result'.
 
-simulateShort
-  :: HasCallStack
+simulateShort ::
+     HasCallStack
   => PBftParams -> NodeJoinPlan -> NumSlots -> Either DetOrNondet ShortState
 simulateShort params nodeJoinPlan (NumSlots t)
   -- no one has time to forge
@@ -379,8 +379,8 @@ emptyShortState (NodeJoinPlan m) = ShortState
   , ssNextSlot = 0
   }
 
-stepShort
-  :: HasCallStack
+stepShort ::
+     HasCallStack
   => PBftParams -> ShortState -> Either DetOrNondet ShortState
 stepShort params st
   | Just don <- mbDon = Left don

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/BlockFetch.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/BlockFetch.hs
@@ -50,8 +50,8 @@ import           Test.Util.TestBlock (BlockConfig (TestBlockConfig), TestBlock)
 import           Test.Util.Time (dawnOfTime)
 
 
-startBlockFetchLogic
-  :: forall m peer.
+startBlockFetchLogic ::
+     forall m peer.
      (Hashable peer, Ord peer, IOLike m)
   => ResourceRegistry m
   -> ChainDB m TestBlock
@@ -91,8 +91,8 @@ startBlockFetchLogic registry chainDb fetchClientRegistry getCandidates = do
         fetchClientRegistry
         blockFetchCfg
 
-startKeepAliveThread
-  :: forall m peer.
+startKeepAliveThread ::
+     forall m peer.
      (Ord peer, IOLike m)
   => ResourceRegistry m
   -> FetchClientRegistry peer (Header TestBlock) TestBlock m
@@ -103,8 +103,8 @@ startKeepAliveThread registry fetchClientRegistry peerId =
       bracketKeepAliveClient fetchClientRegistry peerId $ \_ ->
         atomically retry
 
-runBlockFetchClient
-  :: (Ord peer, IOLike m, MonadTime m)
+runBlockFetchClient ::
+     (Ord peer, IOLike m, MonadTime m)
   => peer
   -> FetchClientRegistry peer (Header TestBlock) TestBlock m
   -> ControlMessageSTM m

--- a/ouroboros-consensus-protocol/src/ouroboros-consensus-protocol/Ouroboros/Consensus/Protocol/Ledger/Util.hs
+++ b/ouroboros-consensus-protocol/src/ouroboros-consensus-protocol/Ouroboros/Consensus/Protocol/Ledger/Util.hs
@@ -17,8 +17,8 @@ import           Ouroboros.Consensus.HardFork.History.Util (addEpochs,
 -- some other slot.
 --
 -- PRECONDITION: the two slots must be in the same era.
-isNewEpoch
-  :: EpochInfo Identity
+isNewEpoch ::
+     EpochInfo Identity
   -> WithOrigin SlotNo
      -- ^ Slot we are comparing a new epoch against
   -> SlotNo

--- a/ouroboros-consensus-protocol/src/ouroboros-consensus-protocol/Ouroboros/Consensus/Protocol/TPraos.hs
+++ b/ouroboros-consensus-protocol/src/ouroboros-consensus-protocol/Ouroboros/Consensus/Protocol/TPraos.hs
@@ -193,8 +193,8 @@ data TPraosParams = TPraosParams {
     }
   deriving (Generic, NoThunks)
 
-mkTPraosParams
-  :: MaxMajorProtVer
+mkTPraosParams ::
+     MaxMajorProtVer
   -> SL.Nonce  -- ^ Initial nonce
   -> SL.ShelleyGenesis era
   -> TPraosParams

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Fragment/Diff.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Fragment/Diff.hs
@@ -88,8 +88,8 @@ extend = ChainDiff 0
 --
 -- PRECONDITION: the candidate fragment must intersect with the current chain
 -- fragment.
-diff
-  :: (HasHeader b, HasCallStack)
+diff ::
+     (HasHeader b, HasCallStack)
   => AnchoredFragment b  -- ^ Current chain
   -> AnchoredFragment b  -- ^ Candidate chain
   -> ChainDiff b
@@ -116,8 +116,8 @@ diff curChain candChain =
 --
 -- The returned fragment will have the same anchor point as the given
 -- fragment.
-apply
-  :: HasHeader b
+apply ::
+     HasHeader b
   => AnchoredFragment b
   -> ChainDiff b
   -> Maybe (AnchoredFragment b)
@@ -142,8 +142,8 @@ append (ChainDiff nbRollback suffix) b = (ChainDiff nbRollback (suffix :> b))
 --
 -- If the length of the truncated suffix is shorter than the rollback,
 -- 'Nothing' is returned.
-truncate
-  :: (HasHeader b, HasCallStack)
+truncate ::
+     (HasHeader b, HasCallStack)
   => Point b
   -> ChainDiff b
   -> ChainDiff b
@@ -157,16 +157,16 @@ truncate pt (ChainDiff nbRollback suffix)
 -- starting from the left, i.e., the \"oldest\" blocks.
 --
 -- If the new suffix is shorter than the diff's rollback, return 'Nothing'.
-takeWhileOldest
-  :: HasHeader b
+takeWhileOldest ::
+     HasHeader b
   => (b -> Bool)
   -> ChainDiff b
   -> ChainDiff b
 takeWhileOldest accept (ChainDiff nbRollback suffix) =
     ChainDiff nbRollback (AF.takeWhileOldest accept suffix)
 
-mapM
-  :: forall a b m.
+mapM ::
+     forall a b m.
      ( HasHeader b
      , HeaderHash a ~ HeaderHash b
      , Monad m

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Fragment/ValidatedDiff.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Fragment/ValidatedDiff.hs
@@ -68,8 +68,8 @@ new chainDiff ledger =
           "tip of ChainDiff doesn't match ledger: " <>
           show chainDiffTip <> " /= " <> show ledgerTip
 
-toValidatedFragment
-  :: (GetTip l, HasHeader b, HeaderHash l ~ HeaderHash b, HasCallStack)
+toValidatedFragment ::
+     (GetTip l, HasHeader b, HeaderHash l ~ HeaderHash b, HasCallStack)
   => ValidatedChainDiff b l
   -> ValidatedFragment b l
 toValidatedFragment (UnsafeValidatedChainDiff cs l) =

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/AcrossEras.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/AcrossEras.hs
@@ -229,8 +229,8 @@ oneEraBlockHeader =
     . hcmap proxySingle (getHeader . unI)
     . getOneEraBlock
 
-getSameValue
-  :: forall xs a. (IsNonEmpty xs, Eq a, SListI xs, HasCallStack)
+getSameValue ::
+     forall xs a. (IsNonEmpty xs, Eq a, SListI xs, HasCallStack)
   => NP (K a) xs
   -> a
 getSameValue values =

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Ledger/CommonProtocolParams.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Ledger/CommonProtocolParams.hs
@@ -14,8 +14,8 @@ instance CanHardFork xs => CommonProtocolParams (HardForkBlock xs) where
   maxHeaderSize = askCurrentLedger maxHeaderSize
   maxTxSize     = askCurrentLedger maxTxSize
 
-askCurrentLedger
-  :: CanHardFork xs
+askCurrentLedger ::
+     CanHardFork xs
   => (forall blk. CommonProtocolParams blk => LedgerState blk -> a)
   -> LedgerState (HardForkBlock xs) -> a
 askCurrentLedger f =

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Node.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Node.hs
@@ -36,8 +36,8 @@ instance CanHardFork xs => ConfigSupportsNode (HardForkBlock xs) where
   Auxiliary
 -------------------------------------------------------------------------------}
 
-getSameConfigValue
-  :: forall xs a. (CanHardFork xs, Eq a, HasCallStack)
+getSameConfigValue ::
+     forall xs a. (CanHardFork xs, Eq a, HasCallStack)
   => (forall blk. ConfigSupportsNode blk => BlockConfig blk -> a)
   -> BlockConfig (HardForkBlock xs)
   -> a

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Extended.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Extended.hs
@@ -213,8 +213,8 @@ decodeExtLedgerState decodeLedgerState
   Casts
 -------------------------------------------------------------------------------}
 
-castExtLedgerState
-  :: ( Coercible (LedgerState blk)
+castExtLedgerState ::
+     ( Coercible (LedgerState blk)
                  (LedgerState blk')
      , Coercible (ChainDepState (BlockProtocol blk))
                  (ChainDepState (BlockProtocol blk'))

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/API.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/API.hs
@@ -248,8 +248,8 @@ isMempoolTxRejected _                   = False
 -- concurrent threads using 'addTx'.
 --
 -- See 'addTx' for further details.
-addTxs
-  :: forall m blk. MonadSTM m
+addTxs ::
+     forall m blk. MonadSTM m
   => Mempool m blk
   -> [GenTx blk]
   -> m [MempoolAddTxResult blk]
@@ -262,8 +262,8 @@ addTxs mempool = mapM (addTx mempool AddTxForRemotePeer)
 -- concurrent threads using 'addTx'.
 --
 -- See 'addTx' for further details.
-addLocalTxs
-  :: forall m blk. MonadSTM m
+addLocalTxs ::
+     forall m blk. MonadSTM m
   => Mempool m blk
   -> [GenTx blk]
   -> m [MempoolAddTxResult blk]

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Capacity.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Capacity.hs
@@ -69,8 +69,8 @@ mkCapacityBytesOverride = MempoolCapacityBytesOverride . MempoolCapacityBytes
 
 -- | If no override is provided, calculate the default mempool capacity as 2x
 -- the current ledger's maximum transaction capacity of a block.
-computeMempoolCapacity
-  :: LedgerSupportsMempool blk
+computeMempoolCapacity ::
+     LedgerSupportsMempool blk
   => TickedLedgerState blk
   -> MempoolCapacityBytesOverride
   -> MempoolCapacityBytes

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Impl/Common.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Impl/Common.hs
@@ -135,8 +135,8 @@ deriving instance ( NoThunks (Validated (GenTx blk))
 isMempoolSize :: InternalState blk -> MempoolSize
 isMempoolSize = TxSeq.toMempoolSize . isTxs
 
-initInternalState
-  :: LedgerSupportsMempool blk
+initInternalState ::
+     LedgerSupportsMempool blk
   => MempoolCapacityBytesOverride
   -> TicketNo  -- ^ Used for 'isLastTicketNo'
   -> SlotNo
@@ -220,8 +220,8 @@ initMempoolEnv ledgerInterface cfg capacityOverride tracer txSize = do
 -------------------------------------------------------------------------------}
 
 -- | Tick the 'LedgerState' using the given 'BlockSlot'.
-tickLedgerState
-  :: forall blk. (UpdateLedger blk, ValidateEnvelope blk)
+tickLedgerState ::
+     forall blk. (UpdateLedger blk, ValidateEnvelope blk)
   => LedgerConfig     blk
   -> ForgeLedgerState blk
   -> (SlotNo, TickedLedgerState blk)
@@ -408,8 +408,8 @@ validationResultFromIS is = ValidationResult {
       } = is
 
 -- | Create a Mempool Snapshot from a given Internal State of the mempool.
-snapshotFromIS
-  :: HasTxId (GenTx blk)
+snapshotFromIS ::
+     HasTxId (GenTx blk)
   => InternalState blk
   -> MempoolSnapshot blk
 snapshotFromIS is = MempoolSnapshot {
@@ -460,8 +460,8 @@ snapshotFromIS is = MempoolSnapshot {
 --
 -- When these don't match, the transaction in the internal state will be
 -- revalidated ('revalidateTxsFor').
-validateStateFor
-  :: (LedgerSupportsMempool blk, HasTxId (GenTx blk), ValidateEnvelope blk)
+validateStateFor ::
+     (LedgerSupportsMempool blk, HasTxId (GenTx blk), ValidateEnvelope blk)
   => MempoolCapacityBytesOverride
   -> LedgerConfig     blk
   -> ForgeLedgerState blk
@@ -486,8 +486,8 @@ validateStateFor capacityOverride cfg blockLedgerState is
 -- | Revalidate the given transactions (@['TxTicket' ('GenTx' blk)]@), which
 -- are /all/ the transactions in the Mempool against the given ticked ledger
 -- state, which corresponds to the chain's ledger state.
-revalidateTxsFor
-  :: (LedgerSupportsMempool blk, HasTxId (GenTx blk))
+revalidateTxsFor ::
+     (LedgerSupportsMempool blk, HasTxId (GenTx blk))
   => MempoolCapacityBytesOverride
   -> LedgerConfig blk
   -> SlotNo

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Init.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Init.hs
@@ -29,8 +29,8 @@ import           Ouroboros.Consensus.Util.STM (Watcher (..), forkLinkedWatcher)
 
 -- | Create a @Mempool m blk@ in @m@ to manipulate the mempool. It will also
 -- fork a thread that syncs the mempool and the ledger when the ledger changes.
-openMempool
-  :: ( IOLike m
+openMempool ::
+     ( IOLike m
      , LedgerSupportsMempool blk
      , HasTxId (GenTx blk)
      , ValidateEnvelope blk
@@ -82,8 +82,8 @@ forkSyncStateOnTipPointChange registry menv =
 -- that synchronises with the ledger state whenever the later changes.
 --
 -- Intended for testing purposes.
-openMempoolWithoutSyncThread
-  :: ( IOLike m
+openMempoolWithoutSyncThread ::
+     ( IOLike m
      , LedgerSupportsMempool blk
      , HasTxId (GenTx blk)
      , ValidateEnvelope blk
@@ -97,8 +97,8 @@ openMempoolWithoutSyncThread
 openMempoolWithoutSyncThread ledger cfg capacityOverride tracer txSize =
     mkMempool <$> initMempoolEnv ledger cfg capacityOverride tracer txSize
 
-mkMempool
-  :: ( IOLike m
+mkMempool ::
+     ( IOLike m
      , LedgerSupportsMempool blk
      , HasTxId (GenTx blk)
      , ValidateEnvelope blk

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Query.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Query.hs
@@ -12,8 +12,8 @@ import           Ouroboros.Consensus.Mempool.Impl.Common
 
 -- | Get a snapshot of the mempool state that is valid with respect to
 -- the given ledger state
-pureGetSnapshotFor
-  :: ( LedgerSupportsMempool blk
+pureGetSnapshotFor ::
+     ( LedgerSupportsMempool blk
      , HasTxId (GenTx blk)
      , ValidateEnvelope blk
      )

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Update.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Update.hs
@@ -167,8 +167,8 @@ implTryAddTx istate cfg txSize wti tx = do
 -- It returns 'NoSpaceLeft' only when the current mempool size is bigger or
 -- equal than then mempool capacity. Otherwise it will validate the transaction
 -- and add it to the mempool if there is at least one byte free on the mempool.
-pureTryAddTx
-  :: ( LedgerSupportsMempool blk
+pureTryAddTx ::
+     ( LedgerSupportsMempool blk
      , HasTxId (GenTx blk)
      )
   => LedgerCfg (LedgerState blk)
@@ -253,8 +253,8 @@ implRemoveTxs menv txs = do
 
 -- | Craft a 'RemoveTxs' that manually removes the given transactions from the
 -- mempool, returning inside it an updated InternalState.
-pureRemoveTxs
-  :: ( LedgerSupportsMempool blk
+pureRemoveTxs ::
+     ( LedgerSupportsMempool blk
      , HasTxId (GenTx blk)
      , ValidateEnvelope blk
      )
@@ -337,8 +337,8 @@ implSyncWithLedger menv = do
 -- be stored for committing this synchronization with the Ledger.
 --
 -- See the documentation of 'runSyncWithLedger' for more context.
-pureSyncWithLedger
-  :: (LedgerSupportsMempool blk, HasTxId (GenTx blk), ValidateEnvelope blk)
+pureSyncWithLedger ::
+     (LedgerSupportsMempool blk, HasTxId (GenTx blk), ValidateEnvelope blk)
   => InternalState blk
   -> LedgerState blk
   -> LedgerConfig blk

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/BlockFetch/Server.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/BlockFetch/Server.hs
@@ -64,8 +64,8 @@ instance Exception BlockFetchServerException
 -- | Block fetch server based on
 -- 'Ouroboros.Network.BlockFetch.Examples.mockBlockFetchServer1', but using
 -- the 'ChainDB'.
-blockFetchServer
-    :: forall m blk.
+blockFetchServer ::
+       forall m blk.
        ( IOLike m
        , StandardHash blk
        , Typeable     blk

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ChainSync/Server.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ChainSync/Server.hs
@@ -33,16 +33,16 @@ import           Ouroboros.Network.Block (ChainUpdate (..), Serialised,
 import           Ouroboros.Network.Protocol.ChainSync.Server
 
 
-chainSyncHeaderServerFollower
-    :: ChainDB m blk
+chainSyncHeaderServerFollower ::
+       ChainDB m blk
     -> ChainDB.ChainType
     -> ResourceRegistry m
     -> m (Follower m blk (WithPoint blk (SerialisedHeader blk)))
 chainSyncHeaderServerFollower chainDB chainType registry =
   ChainDB.newFollower chainDB registry chainType getSerialisedHeaderWithPoint
 
-chainSyncBlockServerFollower
-    :: ChainDB m blk
+chainSyncBlockServerFollower ::
+       ChainDB m blk
     -> ResourceRegistry m
     -> m (Follower m blk (WithPoint blk (Serialised blk)))
 chainSyncBlockServerFollower chainDB registry =
@@ -53,8 +53,8 @@ chainSyncBlockServerFollower chainDB registry =
 -- The node-to-node protocol uses the chain sync mini-protocol with chain
 -- headers (and fetches blocks separately with the block fetch mini-protocol).
 --
-chainSyncHeadersServer
-    :: forall m blk.
+chainSyncHeadersServer ::
+       forall m blk.
        ( IOLike m
        , HasHeader (Header blk)
        )
@@ -70,8 +70,8 @@ chainSyncHeadersServer tracer chainDB flr =
 -- The local node-to-client protocol uses the chain sync mini-protocol with
 -- chains of full blocks (rather than a header \/ body split).
 --
-chainSyncBlocksServer
-    :: forall m blk. (IOLike m, HasHeader (Header blk))
+chainSyncBlocksServer ::
+       forall m blk. (IOLike m, HasHeader (Header blk))
     => Tracer m (TraceChainSyncServerEvent blk)
     -> ChainDB m blk
     -> Follower m blk (WithPoint blk (Serialised blk))

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/LocalTxSubmission/Server.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/LocalTxSubmission/Server.hs
@@ -19,8 +19,8 @@ import           Ouroboros.Network.Protocol.LocalTxSubmission.Type
 
 -- | Local transaction submission server, for adding txs to the 'Mempool'
 --
-localTxSubmissionServer
-  :: MonadSTM m
+localTxSubmissionServer ::
+     MonadSTM m
   => Tracer m (TraceLocalTxSubmissionServerEvent blk)
   -> Mempool m blk
   -> LocalTxSubmissionServer (GenTx blk) (ApplyTxErr blk) m ()

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Node/NetworkProtocolVersion.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Node/NetworkProtocolVersion.hs
@@ -55,8 +55,8 @@ class HasNetworkProtocolVersion blk => SupportedNetworkProtocolVersion blk where
 --
 -- Chooses the greatest in 'supportedNodeToNodeVersions' and
 -- 'supportedNodeToClientVersions'.
-latestReleasedNodeVersionDefault
-  :: SupportedNetworkProtocolVersion blk
+latestReleasedNodeVersionDefault ::
+     SupportedNetworkProtocolVersion blk
   => Proxy blk
   -> (Maybe NodeToNodeVersion, Maybe NodeToClientVersion)
 latestReleasedNodeVersionDefault prx =

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/API.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/API.hs
@@ -482,8 +482,8 @@ instance StandardHash blk => StandardHash (WithPoint blk b)
 getPoint :: BlockComponent blk (Point blk)
 getPoint = BlockPoint <$> GetSlot <*> GetHash
 
-getSerialisedBlockWithPoint
-  :: BlockComponent blk (WithPoint blk (Serialised blk))
+getSerialisedBlockWithPoint ::
+     BlockComponent blk (WithPoint blk (Serialised blk))
 getSerialisedBlockWithPoint =
     WithPoint <$> (Serialised <$> GetRawBlock) <*> getPoint
 
@@ -550,8 +550,8 @@ emptyIterator = Iterator {
 
 -- | Variant of 'traverse' instantiated to @'Iterator' m blk@ that executes
 -- the monadic function when calling 'iteratorNext'.
-traverseIterator
-  :: Monad m
+traverseIterator ::
+     Monad m
   => (b -> m b')
   -> Iterator m blk b
   -> Iterator m blk b'
@@ -763,8 +763,8 @@ data Follower m blk a = Follower {
 -- | Variant of 'traverse' instantiated to @'Follower' m blk@ that executes the
 -- monadic function when calling 'followerInstruction' and
 -- 'followerInstructionBlocking'.
-traverseFollower
-  :: Monad m
+traverseFollower ::
+     Monad m
   => (b -> m b')
   -> Follower m blk b
   -> Follower m blk b'

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl.hs
@@ -76,8 +76,8 @@ import qualified Ouroboros.Network.AnchoredFragment as AF
   Initialization
 -------------------------------------------------------------------------------}
 
-withDB
-  :: forall m blk a.
+withDB ::
+     forall m blk a.
      ( IOLike m
      , LedgerSupportsProtocol blk
      , InspectLedger blk
@@ -90,8 +90,8 @@ withDB
   -> m a
 withDB args = bracket (fst <$> openDBInternal args True) API.closeDB
 
-openDB
-  :: forall m blk.
+openDB ::
+     forall m blk.
      ( IOLike m
      , LedgerSupportsProtocol blk
      , InspectLedger blk
@@ -103,8 +103,8 @@ openDB
   -> m (ChainDB m blk)
 openDB args = fst <$> openDBInternal args True
 
-openDBInternal
-  :: forall m blk.
+openDBInternal ::
+     forall m blk.
      ( IOLike m
      , LedgerSupportsProtocol blk
      , InspectLedger blk
@@ -261,8 +261,8 @@ isOpen (CDBHandle varState) = readTVar varState <&> \case
     ChainDbClosed    -> False
     ChainDbOpen _env -> True
 
-closeDB
-  :: forall m blk.
+closeDB ::
+     forall m blk.
      ( IOLike m
      , HasHeader (Header blk)
      , HasCallStack

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Background.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Background.hs
@@ -80,8 +80,8 @@ import qualified Ouroboros.Network.AnchoredFragment as AF
   Launch background tasks
 -------------------------------------------------------------------------------}
 
-launchBgTasks
-  :: forall m blk.
+launchBgTasks ::
+     forall m blk.
      ( IOLike m
      , LedgerSupportsProtocol blk
      , InspectLedger blk
@@ -231,8 +231,8 @@ copyToImmutableDB CDB{..} = withCopyLock $ do
 -- GC can happen, when we restart the node and schedule the /next/ GC, it will
 -- /imply/ any previously scheduled GC, since GC is driven by slot number
 -- ("garbage collect anything older than @x@").
-copyAndSnapshotRunner
-  :: forall m blk.
+copyAndSnapshotRunner ::
+     forall m blk.
      ( IOLike m
      , ConsensusProtocol (BlockProtocol blk)
      , HasHeader blk
@@ -426,8 +426,8 @@ data GcParams = GcParams {
 newGcSchedule :: IOLike m => m (GcSchedule m)
 newGcSchedule = GcSchedule <$> newTVarIO Seq.empty
 
-scheduleGC
-  :: forall m blk. IOLike m
+scheduleGC ::
+     forall m blk. IOLike m
   => Tracer m (TraceGCEvent blk)
   -> SlotNo    -- ^ The slot to use for garbage collection
   -> GcParams
@@ -445,8 +445,8 @@ scheduleGC tracer slotNo gcParams (GcSchedule varQueue) = do
         -> queue  :|> ScheduledGc timeScheduledForGC slotNo
     traceWith tracer $ ScheduledGC slotNo timeScheduledForGC
 
-computeTimeForGC
-  :: GcParams
+computeTimeForGC ::
+     GcParams
   -> Time  -- ^ Now
   -> Time  -- ^ The time at which to perform the GC
 computeTimeForGC GcParams { gcDelay, gcInterval } (Time now) =
@@ -475,8 +475,8 @@ roundUpToInterval interval x
   where
     (d, m) = x `divMod` fromIntegral interval
 
-gcScheduleRunner
-  :: forall m. IOLike m
+gcScheduleRunner ::
+     forall m. IOLike m
   => GcSchedule m
   -> (SlotNo -> m ())  -- ^ GC function
   -> m Void
@@ -520,8 +520,8 @@ dumpGcSchedule (GcSchedule varQueue) = toList <$> readTVar varQueue
 
 -- | Read blocks from 'cdbBlocksToAdd' and add them synchronously to the
 -- ChainDB.
-addBlockRunner
-  :: ( IOLike m
+addBlockRunner ::
+     ( IOLike m
      , LedgerSupportsProtocol blk
      , InspectLedger blk
      , HasHardForkHistory blk

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/ChainSel.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/ChainSel.hs
@@ -95,8 +95,8 @@ import qualified Ouroboros.Network.AnchoredSeq as AS
 -- Returns the chosen validated chain and corresponding ledger.
 --
 -- See "## Initialization" in ChainDB.md.
-initialChainSelection
-  :: forall m blk. (IOLike m, LedgerSupportsProtocol blk)
+initialChainSelection ::
+     forall m blk. (IOLike m, LedgerSupportsProtocol blk)
   => ImmutableDB m blk
   -> VolatileDB m blk
   -> LgrDB m blk
@@ -238,8 +238,8 @@ initialChainSelection immutableDB volatileDB lgrDB tracer cfg varInvalid
 -- in-memory state, it can't get out of sync with the file system state. On
 -- the next startup, a correct in-memory state will be reconstructed from the
 -- file system state.
-addBlockAsync
-  :: forall m blk. (IOLike m, HasHeader blk)
+addBlockAsync ::
+     forall m blk. (IOLike m, HasHeader blk)
   => ChainDbEnv m blk
   -> InvalidBlockPunishment m
   -> blk
@@ -255,8 +255,8 @@ addBlockAsync CDB { cdbTracer, cdbBlocksToAdd } =
 --
 -- When the slot of the block is > the current slot, a chain selection will be
 -- scheduled in the slot of the block.
-addBlockSync
-  :: forall m blk.
+addBlockSync ::
+     forall m blk.
      ( IOLike m
      , LedgerSupportsProtocol blk
      , InspectLedger blk
@@ -358,8 +358,8 @@ addBlockSync cdb@CDB {..} BlockToAdd { blockToAdd = b, .. } = do
 -- (because of corruption). The \"immutable\" block is then also the tip of
 -- the chain. If we then try to add the EBB after it, it will have the same
 -- block number, so we must allow it.
-olderThanK
-  :: HasHeader (Header blk)
+olderThanK ::
+     HasHeader (Header blk)
   => Header blk
      -- ^ Header of the block to add
   -> IsEBB
@@ -383,8 +383,8 @@ data ChainSwitchType = AddingBlocks | SwitchingToAFork
   deriving (Show, Eq)
 
 -- | Return the new tip.
-chainSelectionForFutureBlocks
-  :: ( IOLike m
+chainSelectionForFutureBlocks ::
+     ( IOLike m
      , LedgerSupportsProtocol blk
      , InspectLedger blk
      , HasHardForkHistory blk
@@ -439,8 +439,8 @@ chainSelectionForFutureBlocks cdb@CDB{..} blockCache = do
 -- * when we switch to a distant fork
 --
 -- This cost is currently deemed acceptable.
-chainSelectionForBlock
-  :: forall m blk.
+chainSelectionForBlock ::
+     forall m blk.
      ( IOLike m
      , LedgerSupportsProtocol blk
      , InspectLedger blk
@@ -824,8 +824,8 @@ chainSelectionForBlock cdb@CDB{..} blockCache hdr punish = do
 -- the corresponding header from the VolatileDB and store it in the cache.
 --
 -- PRECONDITION: the header (block) must exist in the VolatileDB.
-getKnownHeaderThroughCache
-  :: (MonadThrow m, HasHeader blk)
+getKnownHeaderThroughCache ::
+     (MonadThrow m, HasHeader blk)
   => VolatileDB m blk
   -> HeaderHash blk
   -> StateT (Map (HeaderHash blk) (Header blk)) m (Header blk)
@@ -882,8 +882,8 @@ data ChainSelEnv m blk = ChainSelEnv
 --
 -- PRECONDITION: the candidate chain diffs must fit on the (given) current
 -- chain.
-chainSelection
-  :: forall m blk.
+chainSelection ::
+     forall m blk.
      ( IOLike m
      , LedgerSupportsProtocol blk
      , HasCallStack
@@ -1061,8 +1061,8 @@ data ValidationResult blk =
 -- If a block in the fragment is invalid, then the fragment in the returned
 -- 'ValidatedChainDiff' is a prefix of the given candidate chain diff (upto
 -- the last valid block).
-ledgerValidateCandidate
-  :: forall m blk.
+ledgerValidateCandidate ::
+     forall m blk.
      ( IOLike m
      , LedgerSupportsProtocol blk
      , HasCallStack
@@ -1149,8 +1149,8 @@ ledgerValidateCandidate chainSelEnv chainDiff@(ChainDiff rollback suffix) =
 -- 'InFutureExceedsClockSkew' as the reason.
 --
 -- When truncation happened, 'Left' is returned, otherwise 'Right'.
-futureCheckCandidate
-  :: forall m blk. (IOLike m, LedgerSupportsProtocol blk)
+futureCheckCandidate ::
+     forall m blk. (IOLike m, LedgerSupportsProtocol blk)
   => ChainSelEnv m blk
   -> ValidatedChainDiff (Header blk) (LedgerDB' blk)
   -> m (Either (ChainDiff (Header blk))
@@ -1223,8 +1223,8 @@ futureCheckCandidate chainSelEnv validatedChainDiff =
 
 -- | Validate a candidate chain using 'ledgerValidateCandidate' and
 -- 'futureCheck'.
-validateCandidate
-  :: ( IOLike m
+validateCandidate ::
+     ( IOLike m
      , LedgerSupportsProtocol blk
      , HasCallStack
      )
@@ -1294,8 +1294,8 @@ isPipelineable bcfg tentativeState ChainDiff {..}
 -------------------------------------------------------------------------------}
 
 -- | Wrap a @getter@ function so that it returns 'Nothing' for invalid blocks.
-ignoreInvalid
-  :: HasHeader blk
+ignoreInvalid ::
+     HasHeader blk
   => proxy blk
   -> InvalidBlocks blk
   -> (HeaderHash blk -> Maybe a)
@@ -1306,8 +1306,8 @@ ignoreInvalid _ invalid getter hash
 
 -- | Wrap a @successors@ function so that invalid blocks are not returned as
 -- successors.
-ignoreInvalidSuc
-  :: HasHeader blk
+ignoreInvalidSuc ::
+     HasHeader blk
   => proxy blk
   -> InvalidBlocks blk
   -> (ChainHash blk -> Set (HeaderHash blk))

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Iterator.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Iterator.hs
@@ -176,8 +176,8 @@ import           Ouroboros.Consensus.Util.ResourceRegistry (ResourceRegistry)
 -- the VolatileDB, we try to see whether it can be streamed from the ImmutableDB
 -- instead. Opening such an iterator costs 2 (cached) reads from disk upfront.
 -- This can happen multiple times.
-stream
-  :: forall m blk b.
+stream ::
+     forall m blk b.
      ( IOLike m
      , HasHeader blk
      , HasCallStack

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/LgrDB.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/LgrDB.hs
@@ -216,8 +216,8 @@ openDB args@LgrDbArgs { lgrHasFS = lgrHasFS@(SomeHasFS hasFS), .. } replayTracer
       , replayed
       )
 
-initFromDisk
-  :: forall blk m.
+initFromDisk ::
+     forall blk m.
      ( IOLike m
      , LedgerSupportsProtocol blk
      , LgrDbSerialiseConstraints blk

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Paths.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Paths.hs
@@ -290,8 +290,8 @@ data ReversePath blk =
 
 -- | Lazily compute the 'ReversePath' that starts (i.e., ends) with the given
 -- 'HeaderHash'.
-computeReversePath
-  :: forall blk.
+computeReversePath ::
+     forall blk.
      LookupBlockInfo blk
   -> HeaderHash blk
      -- ^ End hash
@@ -369,8 +369,8 @@ computeReversePath lookupBlockInfo endHash =
 --
 -- When the suffix of the 'ChainDiff' is non-empty, @P@ will be the last point
 -- in the suffix.
-isReachable
-  :: forall blk. (HasHeader blk, GetHeader blk)
+isReachable ::
+     forall blk. (HasHeader blk, GetHeader blk)
   => LookupBlockInfo blk
   -> AnchoredFragment (Header blk) -- ^ Chain fragment to connect the point to
   -> RealPoint blk

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Query.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Query.hs
@@ -60,8 +60,8 @@ import           Ouroboros.Network.Block (MaxSlotNo, maxSlotNoFromWithOrigin)
 -- In the latter case, we don't take blocks already in the ImmutableDB into
 -- account, as we know they /must/ have been \"immutable\" at some point, and,
 -- therefore, /must/ still be \"immutable\".
-getCurrentChain
-  :: forall m blk.
+getCurrentChain ::
+     forall m blk.
      ( IOLike m
      , HasHeader (Header blk)
      , ConsensusProtocol (BlockProtocol blk)
@@ -78,8 +78,8 @@ getLedgerDB ::
   => ChainDbEnv m blk -> STM m (LgrDB.LedgerDB' blk)
 getLedgerDB CDB{..} = LgrDB.getCurrent cdbLgrDB
 
-getTipBlock
-  :: forall m blk.
+getTipBlock ::
+     forall m blk.
      ( IOLike m
      , HasHeader blk
      , HasHeader (Header blk)
@@ -92,8 +92,8 @@ getTipBlock cdb@CDB{..} = do
       Origin      -> return Nothing
       NotOrigin p -> Just <$> getAnyKnownBlock cdbImmutableDB cdbVolatileDB p
 
-getTipHeader
-  :: forall m blk.
+getTipHeader ::
+     forall m blk.
      ( IOLike m
      , HasHeader blk
      , HasHeader (Header blk)
@@ -116,8 +116,8 @@ getTipHeader CDB{..} = do
             -- been appended to the ImmutableDB since we obtained 'anchorOrHdr'.
             Just <$> ImmutableDB.getKnownBlockComponent cdbImmutableDB GetHeader p
 
-getTipPoint
-  :: forall m blk. (IOLike m, HasHeader (Header blk))
+getTipPoint ::
+     forall m blk. (IOLike m, HasHeader (Header blk))
   => ChainDbEnv m blk -> STM m (Point blk)
 getTipPoint CDB{..} =
     (castPoint . AF.headPoint) <$> readTVar cdbChain

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Types.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Types.hs
@@ -459,8 +459,8 @@ newBlocksToAdd queueSize = BlocksToAdd <$>
     atomically (newTBQueue (fromIntegral queueSize))
 
 -- | Add a block to the 'BlocksToAdd' queue. Can block when the queue is full.
-addBlockToAdd
-  :: (IOLike m, HasHeader blk)
+addBlockToAdd ::
+     (IOLike m, HasHeader blk)
   => Tracer m (TraceAddBlockEvent blk)
   -> BlocksToAdd m blk
   -> InvalidBlockPunishment m

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ImmutableDB/API.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ImmutableDB/API.hs
@@ -197,8 +197,8 @@ data Iterator m blk b = Iterator {
 
 -- | Variant of 'traverse' instantiated to @'Iterator' m blk m@ that executes
 -- the monadic function when calling 'iteratorNext'.
-traverseIterator
-  :: Monad m
+traverseIterator ::
+     Monad m
   => (b -> m b')
   -> Iterator m blk b
   -> Iterator m blk b'

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ImmutableDB/Impl/Index.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ImmutableDB/Impl/Index.hs
@@ -119,8 +119,8 @@ data Index m blk h = Index
   deriving NoThunks via OnlyCheckWhnfNamed "Index" (Index m blk h)
 
 -- | See 'Primary.readOffset'.
-readOffset
-  :: Functor m
+readOffset ::
+     Functor m
   => Index m blk h
   -> ChunkNo
   -> RelativeSlot
@@ -129,8 +129,8 @@ readOffset index chunk slot = runIdentity <$>
     readOffsets index chunk (Identity slot)
 
 -- | See 'Secondary.readEntry'.
-readEntry
-  :: Functor m
+readEntry ::
+     Functor m
   => Index m blk h
   -> ChunkNo
   -> IsEBB
@@ -143,8 +143,8 @@ readEntry index chunk isEBB slotOffset = runIdentity <$>
   File-backed index
 ------------------------------------------------------------------------------}
 
-fileBackedIndex
-  :: forall m blk h.
+fileBackedIndex ::
+     forall m blk h.
      (ConvertRawHash blk, MonadCatch m, StandardHash blk, Typeable blk)
   => HasFS m h
   -> ChunkInfo
@@ -175,8 +175,8 @@ fileBackedIndex hasFS chunkInfo = Index
 --
 -- Spawns a background thread to expire past chunks from the cache that
 -- haven't been used for a while.
-cachedIndex
-  :: forall m blk h.
+cachedIndex ::
+     forall m blk h.
      (IOLike m, ConvertRawHash blk, StandardHash blk, Typeable blk)
   => HasFS m h
   -> ResourceRegistry m

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ImmutableDB/Impl/Index/Cache.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ImmutableDB/Impl/Index/Cache.hs
@@ -192,8 +192,8 @@ data Cached blk = Cached
   }
   deriving (Generic, NoThunks)
 
-checkInvariants
-  :: Word32  -- ^ Maximum number of past chunks to cache
+checkInvariants ::
+     Word32  -- ^ Maximum number of past chunks to cache
   -> Cached blk
   -> Maybe String
 checkInvariants pastChunksToCache Cached {..} = either Just (const Nothing) $ do
@@ -222,8 +222,8 @@ checkInvariants pastChunksToCache Cached {..} = either Just (const Nothing) $ do
 -- NOTE: does not trim the cache.
 --
 -- PRECONDITION: the given 'ChunkNo' is < the 'currentChunk'.
-addPastChunkInfo
-  :: ChunkNo
+addPastChunkInfo ::
+     ChunkNo
   -> LastUsed
   -> PastChunkInfo blk
   -> Cached blk
@@ -260,8 +260,8 @@ addPastChunkInfo chunk lastUsed pastChunkInfo cached =
 -- function directly after adding a past chunk to 'Cached'.
 --
 -- If a past chunk was evicted, its chunk number is returned.
-evictIfNecessary
-  :: Word32  -- ^ Maximum number of past chunks to cache
+evictIfNecessary ::
+     Word32  -- ^ Maximum number of past chunks to cache
   -> Cached blk
   -> (Cached blk, Maybe ChunkNo)
 evictIfNecessary maxNbPastChunks cached
@@ -286,8 +286,8 @@ evictIfNecessary maxNbPastChunks cached
 -- @-fstrictness@ optimisation (enabled by default for -O1).
 {-# INLINE evictIfNecessary #-}
 
-lookupPastChunkInfo
-  :: ChunkNo
+lookupPastChunkInfo ::
+     ChunkNo
   -> LastUsed
   -> Cached blk
   -> Maybe (PastChunkInfo blk, Cached blk)
@@ -305,8 +305,8 @@ lookupPastChunkInfo chunk lastUsed cached@Cached { pastChunksInfo } =
       Nothing                -> (Nothing, Nothing)
       Just (_lastUsed, info) -> (Just info, Just (lastUsed, info))
 
-openChunk
-  :: ChunkNo
+openChunk ::
+     ChunkNo
   -> LastUsed
   -> CurrentChunkInfo blk
   -> Cached blk
@@ -338,8 +338,8 @@ openChunk chunk lastUsed newCurrentChunkInfo cached
       { currentChunk, currentChunkInfo, pastChunksInfo, nbPastChunks
       } = cached
 
-emptyCached
-  :: ChunkNo -- ^ The current chunk
+emptyCached ::
+     ChunkNo -- ^ The current chunk
   -> CurrentChunkInfo blk
   -> Cached blk
 emptyCached currentChunk currentChunkInfo = Cached
@@ -365,8 +365,8 @@ data CacheEnv m blk h = CacheEnv
 -- unused past chunks ('expireUnusedChunks').
 --
 -- PRECONDITION: 'pastChunksToCache' (in 'CacheConfig') > 0
-newEnv
-  :: ( HasCallStack
+newEnv ::
+     ( HasCallStack
      , ConvertRawHash blk
      , IOLike m
      , StandardHash blk
@@ -408,8 +408,8 @@ newEnv hasFS registry tracer cacheConfig chunkInfo chunk = do
 --
 -- Will expire past chunks that haven't been used for 'expireUnusedAfter' from
 -- the cache.
-expireUnusedChunks
-  :: (HasCallStack, IOLike m)
+expireUnusedChunks ::
+     (HasCallStack, IOLike m)
   => CacheEnv m blk h
   -> m Void
 expireUnusedChunks CacheEnv { cacheVar, cacheConfig, tracer } =
@@ -465,8 +465,8 @@ expireUnusedChunks CacheEnv { cacheVar, cacheConfig, tracer } =
   Reading indices
 ------------------------------------------------------------------------------}
 
-readPrimaryIndex
-  :: (HasCallStack, IOLike m, Typeable blk, StandardHash blk)
+readPrimaryIndex ::
+     (HasCallStack, IOLike m, Typeable blk, StandardHash blk)
   => Proxy blk
   -> HasFS m h
   -> ChunkInfo
@@ -486,8 +486,8 @@ readPrimaryIndex pb hasFS chunkInfo chunk = do
     firstRelativeSlot :: RelativeSlot
     firstRelativeSlot = firstBlockOrEBB chunkInfo chunk
 
-readSecondaryIndex
-  :: ( HasCallStack
+readSecondaryIndex ::
+     ( HasCallStack
      , ConvertRawHash blk
      , IOLike m
      , StandardHash blk
@@ -508,8 +508,8 @@ readSecondaryIndex hasFS@HasFS { hGetSize } chunk firstIsEBB = do
     -- Don't stop until the end
     stopCondition = const False
 
-loadCurrentChunkInfo
-  :: forall m h blk.
+loadCurrentChunkInfo ::
+     forall m h blk.
      ( HasCallStack
      , ConvertRawHash blk
      , IOLike m
@@ -540,8 +540,8 @@ loadCurrentChunkInfo hasFS chunkInfo chunk = do
   where
     primaryIndexFile = fsPathPrimaryIndexFile chunk
 
-loadPastChunkInfo
-  :: forall blk m h.
+loadPastChunkInfo ::
+     forall blk m h.
      ( HasCallStack
      , ConvertRawHash blk
      , IOLike m
@@ -560,8 +560,8 @@ loadPastChunkInfo hasFS chunkInfo chunk = do
       , pastChunkEntries = Vector.fromList $ forceElemsToWHNF entries
       }
 
-getChunkInfo
-  :: forall m blk h.
+getChunkInfo ::
+     forall m blk h.
      ( HasCallStack
      , ConvertRawHash blk
      , IOLike m
@@ -632,8 +632,8 @@ close CacheEnv { bgThreadVar } =
 --
 -- PRECONDITION: the background thread expiring unused past chunks must have
 -- been terminated.
-restart
-  :: (ConvertRawHash blk, IOLike m, StandardHash blk, Typeable blk)
+restart ::
+     (ConvertRawHash blk, IOLike m, StandardHash blk, Typeable blk)
   => CacheEnv m blk h
   -> ChunkNo  -- ^ The new current chunk
   -> m ()
@@ -654,8 +654,8 @@ restart cacheEnv chunk = do
   On the primary index
 ------------------------------------------------------------------------------}
 
-readOffsets
-  :: ( HasCallStack
+readOffsets ::
+     ( HasCallStack
      , ConvertRawHash blk
      , IOLike m
      , StandardHash blk
@@ -697,8 +697,8 @@ readOffsets cacheEnv chunk relSlots =
       | otherwise
       = Nothing
 
-readFirstFilledSlot
-  :: ( HasCallStack
+readFirstFilledSlot ::
+     ( HasCallStack
      , ConvertRawHash blk
      , IOLike m
      , StandardHash blk
@@ -724,8 +724,8 @@ readFirstFilledSlot cacheEnv chunk =
 
 -- | This is called when a new chunk is started, which means we need to update
 -- 'Cached' to reflect this.
-openPrimaryIndex
-  :: ( HasCallStack
+openPrimaryIndex ::
+     ( HasCallStack
      , ConvertRawHash blk
      , IOLike m
      , StandardHash blk
@@ -756,8 +756,8 @@ openPrimaryIndex cacheEnv chunk allowExisting = do
     HasFS { hClose } = hasFS
     CacheConfig { pastChunksToCache } = cacheConfig
 
-appendOffsets
-  :: (HasCallStack, Foldable f, IOLike m)
+appendOffsets ::
+     (HasCallStack, Foldable f, IOLike m)
   => CacheEnv m blk h
   -> Handle h
   -> f SecondaryOffset
@@ -779,8 +779,8 @@ appendOffsets CacheEnv { hasFS, cacheVar } pHnd offsets = do
   On the secondary index
 ------------------------------------------------------------------------------}
 
-readEntries
-  :: forall m blk h t.
+readEntries ::
+     forall m blk h t.
      ( HasCallStack
      , ConvertRawHash blk
      , IOLike m
@@ -820,8 +820,8 @@ readEntries cacheEnv chunk toRead =
       ("no entry missing for " <> show secondaryOffset)
       prettyCallStack
 
-readAllEntries
-  :: forall m blk h.
+readAllEntries ::
+     forall m blk h.
      ( HasCallStack
      , ConvertRawHash blk
      , IOLike m
@@ -849,8 +849,8 @@ readAllEntries cacheEnv secondaryOffset chunk stopCondition
     toDrop = fromIntegral $
       secondaryOffset `div` Secondary.entrySize (Proxy @blk)
 
-appendEntry
-  :: forall m blk h. (HasCallStack, ConvertRawHash blk, IOLike m)
+appendEntry ::
+     forall m blk h. (HasCallStack, ConvertRawHash blk, IOLike m)
   => CacheEnv m blk h
   -> ChunkNo
   -> Handle h

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ImmutableDB/Impl/Index/Primary.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ImmutableDB/Impl/Index/Primary.hs
@@ -164,8 +164,8 @@ slots (MkPrimaryIndex _ offsets) = fromIntegral $ V.length offsets - 1
 
 -- | Read the 'SecondaryOffset' corresponding to the given relative slot in
 -- the primary index. Return 'Nothing' when the slot is empty.
-readOffset
-  :: forall blk m h.
+readOffset ::
+     forall blk m h.
      (HasCallStack, MonadThrow m, StandardHash blk, Typeable blk)
   => Proxy blk
   -> HasFS m h
@@ -179,8 +179,8 @@ readOffset pb hasFS chunk slot = runIdentity <$>
 --
 -- NOTE: only use this for a few offsets, as we will seek (@pread@) for each
 -- offset. Use 'load' if you want to read the whole primary index.
-readOffsets
-  :: forall blk m h t.
+readOffsets ::
+     forall blk m h t.
      ( HasCallStack
      , MonadThrow m
      , Traversable t
@@ -226,8 +226,8 @@ readOffsets pb hasFS@HasFS { hGetSize } chunk toRead =
 -- number and offset 0.
 --
 -- May throw 'InvalidPrimaryIndexException'.
-readFirstFilledSlot
-  :: forall blk m h.
+readFirstFilledSlot ::
+     forall blk m h.
      (HasCallStack, MonadThrow m, StandardHash blk, Typeable blk)
   => Proxy blk
   -> HasFS m h
@@ -289,8 +289,8 @@ readFirstFilledSlot pb hasFS@HasFS { hSeek, hGetSome } chunkInfo chunk =
                  runGet pb primaryIndexFile getSecondaryOffset acc'
 
 -- | Load a primary index file in memory.
-load
-  :: forall blk m h.
+load ::
+     forall blk m h.
      (HasCallStack, MonadThrow m, StandardHash blk, Typeable blk)
   => Proxy blk
   -> HasFS m h
@@ -325,8 +325,8 @@ load pb hasFS chunk =
 --
 -- > primaryIndex === primaryIndex'
 --
-write
-  :: (HasCallStack, MonadThrow m)
+write ::
+     (HasCallStack, MonadThrow m)
   => HasFS m h
   -> ChunkNo
   -> PrimaryIndex
@@ -359,8 +359,8 @@ truncateToSlot chunkInfo relSlot primary@(MkPrimaryIndex _ offsets) =
 
 -- | On-disk variant of 'truncateToSlot'. The truncation is done without
 -- reading the primary index from disk.
-truncateToSlotFS
-  :: (HasCallStack, MonadThrow m)
+truncateToSlotFS ::
+     (HasCallStack, MonadThrow m)
   => HasFS m h
   -> ChunkNo
   -> RelativeSlot
@@ -380,8 +380,8 @@ truncateToSlotFS hasFS@HasFS { hTruncate, hGetSize } chunk relSlot =
 --
 -- POSTCONDITION: the last slot of the primary index file will be filled,
 -- unless the index itself is empty.
-unfinalise
-  :: (HasCallStack, MonadThrow m, StandardHash blk, Typeable blk)
+unfinalise ::
+     (HasCallStack, MonadThrow m, StandardHash blk, Typeable blk)
   => Proxy blk
   -> HasFS m h
   -> ChunkInfo
@@ -398,8 +398,8 @@ unfinalise pb hasFS chunkInfo chunk = do
 --
 -- The file is opened with the given 'AllowExisting' value. When given
 -- 'MustBeNew', the version number is written to the file.
-open
-  :: (HasCallStack, MonadCatch m)
+open ::
+     (HasCallStack, MonadCatch m)
   => HasFS m h
   -> ChunkNo
   -> AllowExisting
@@ -422,8 +422,8 @@ open hasFS@HasFS { hOpen, hClose } chunk allowExisting = do
 
 -- | Append the given 'SecondaryOffset' to the end of the file (passed as a
 -- handle).
-appendOffsets
-  :: (Monad m, Foldable f, HasCallStack)
+appendOffsets ::
+     (Monad m, Foldable f, HasCallStack)
   => HasFS m h
   -> Handle h
   -> f SecondaryOffset
@@ -600,8 +600,8 @@ lastFilledSlot chunkInfo (MkPrimaryIndex chunk offsets) =
 --
 -- We use @x, y, z@ in the examples above, but in practice these will be
 -- multiples of the (fixed) size of an entry in secondary index.
-backfill
-  :: RelativeSlot     -- ^ The slot to write to (>= next expected slot)
+backfill ::
+     RelativeSlot     -- ^ The slot to write to (>= next expected slot)
   -> RelativeSlot     -- ^ The next expected slot to write to
   -> SecondaryOffset  -- ^ The last 'SecondaryOffset' written to
   -> [SecondaryOffset]
@@ -615,8 +615,8 @@ backfill slot nextExpected offset =
 -- to the chunk size.
 --
 -- See 'backfill' for more details.
-backfillChunk
-  :: ChunkInfo
+backfillChunk ::
+     ChunkInfo
   -> ChunkNo
   -> NextRelativeSlot
   -> SecondaryOffset

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ImmutableDB/Impl/Index/Secondary.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ImmutableDB/Impl/Index/Secondary.hs
@@ -152,8 +152,8 @@ data BlockSize
 
 -- | Read the entry at the given 'SecondaryOffset'. Interpret it as an EBB
 -- depending on the given 'IsEBB'.
-readEntry
-  :: forall m blk h.
+readEntry ::
+     forall m blk h.
      ( HasCallStack
      , ConvertRawHash blk
      , MonadThrow m
@@ -173,8 +173,8 @@ readEntry hasFS chunk isEBB slotOffset = runIdentity <$>
 -- NOTE: only use this for a few entries, as we will seek (@pread@) for each
 -- entry. Use 'readAllEntries' if you want to read all entries in the
 -- secondary index file.
-readEntries
-  :: forall m blk h t.
+readEntries ::
+     forall m blk h t.
      ( HasCallStack
      , ConvertRawHash blk
      , MonadThrow m
@@ -220,8 +220,8 @@ readEntries hasFS chunk toRead =
 -- 'SecondaryOffset' until the stop condition is true or until the end of the
 -- file is reached. The entry for which the stop condition is true will be the
 -- last in the returned list of entries.
-readAllEntries
-  :: forall m blk h.
+readAllEntries ::
+     forall m blk h.
      ( HasCallStack
      , ConvertRawHash blk
      , MonadThrow m
@@ -291,8 +291,8 @@ readAllEntries hasFS secondaryOffset chunk stopAfter chunkFileSize = \isEBB ->
     consMaybe :: Maybe a -> [a] -> [a]
     consMaybe = maybe id (:)
 
-appendEntry
-  :: forall m blk h. (HasCallStack, ConvertRawHash blk, MonadThrow m)
+appendEntry ::
+     forall m blk h. (HasCallStack, ConvertRawHash blk, MonadThrow m)
   => HasFS m h
   -> Handle h
   -> Entry blk
@@ -305,8 +305,8 @@ appendEntry hasFS sHnd entry = do
 
 -- | Remove all entries after the entry at the given 'SecondaryOffset'. That
 -- entry will now be the last entry in the secondary index file.
-truncateToEntry
-  :: forall m blk h. (HasCallStack, ConvertRawHash blk, MonadThrow m)
+truncateToEntry ::
+     forall m blk h. (HasCallStack, ConvertRawHash blk, MonadThrow m)
   => Proxy blk
   -> HasFS m h
   -> ChunkNo
@@ -320,8 +320,8 @@ truncateToEntry pb hasFS chunk secondaryOffset =
     HasFS { hTruncate } = hasFS
     offset              = fromIntegral (secondaryOffset + entrySize pb)
 
-writeAllEntries
-  :: forall m blk h. (HasCallStack, ConvertRawHash blk, MonadThrow m)
+writeAllEntries ::
+     forall m blk h. (HasCallStack, ConvertRawHash blk, MonadThrow m)
   => HasFS m h
   -> ChunkNo
   -> [Entry blk]

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ImmutableDB/Impl/Parser.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ImmutableDB/Impl/Parser.hs
@@ -202,8 +202,8 @@ parseChunkFile ccfg hasFS isNotCorrupt fsPath expectedChecksums k =
 
 -- | Thread some state through a 'Stream'. An early return is possible by
 -- returning 'Left'.
-mapAccumS
-  :: Monad m
+mapAccumS ::
+     Monad m
   => s  -- ^ Initial state
   -> (s -> a -> Either r (b, s))
   -> Stream (Of a) m r
@@ -220,8 +220,8 @@ mapAccumS st0 updateAcc = go st0
 -- first element in the stream to construct the initial state. For all
 -- elements in the stream after the first one, the second function argument is
 -- used.
-mapAccumS0
-  :: forall m a b r s. Monad m
+mapAccumS0 ::
+     forall m a b r s. Monad m
   => (a -> Either r (b, s))
   -> (s -> a -> Either r (b, s))
   -> Stream (Of a) m r

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ImmutableDB/Impl/Util.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ImmutableDB/Impl/Util.hs
@@ -131,8 +131,8 @@ tryImmutableDB pb = try . wrapFsError pb
 
 -- | Wrapper around 'Get.runGetOrFail' that throws an 'InvalidFileError' when
 -- it failed or when there was unconsumed input.
-runGet
-  :: forall blk a m.
+runGet ::
+     forall blk a m.
      (HasCallStack, MonadThrow m, StandardHash blk, Typeable blk)
   => Proxy blk
   -> FsPath
@@ -151,8 +151,8 @@ runGet _ file get bl = case Get.runGetOrFail get bl of
            InvalidFileError @blk file msg prettyCallStack
 
 -- | Same as 'runGet', but allows unconsumed input and returns it.
-runGetWithUnconsumed
-  :: forall blk a m.
+runGetWithUnconsumed ::
+     forall blk a m.
      (HasCallStack, MonadThrow m, StandardHash blk, Typeable blk)
   => Proxy blk
   -> FsPath

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/Init.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/Init.hs
@@ -233,8 +233,8 @@ initStartingWith tracer cfg streamAPI initDb = do
 --
 -- Between the tip of the immutable DB and the point of the starting block,
 -- the node could (if it so desired) easily compute a "percentage complete".
-decorateReplayTracerWithGoal
-  :: Point blk -- ^ Tip of the ImmutableDB
+decorateReplayTracerWithGoal ::
+     Point blk -- ^ Tip of the ImmutableDB
   -> Tracer m (TraceReplayEvent blk)
   -> Tracer m (ReplayGoal blk -> TraceReplayEvent blk)
 decorateReplayTracerWithGoal immTip = contramap ($ (ReplayGoal immTip))
@@ -242,8 +242,8 @@ decorateReplayTracerWithGoal immTip = contramap ($ (ReplayGoal immTip))
 -- | Add the block at which a replay started.
 --
 -- This allows to compute a "percentage complete" when tracing the events.
-decorateReplayTracerWithStart
-  :: Point blk -- ^ Starting point of the replay
+decorateReplayTracerWithStart ::
+     Point blk -- ^ Starting point of the replay
   -> Tracer m (ReplayGoal blk -> TraceReplayEvent blk)
   -> Tracer m (ReplayStart blk -> ReplayGoal blk -> TraceReplayEvent blk)
 decorateReplayTracerWithStart start = contramap ($ (ReplayStart start))

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Util.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Util.hs
@@ -257,8 +257,8 @@ safeMaximumOn f = safeMaximumBy (compare `on` f)
 
 -- | Calls 'hashFromBytes' and throws an error if the input is of the wrong
 -- length.
-hashFromBytesE
-  :: forall h a. (HashAlgorithm h, HasCallStack)
+hashFromBytesE ::
+     forall h a. (HashAlgorithm h, HasCallStack)
   => Strict.ByteString
   -> Hash h a
 hashFromBytesE bs = fromMaybe (error msg) $ hashFromBytes bs
@@ -269,8 +269,8 @@ hashFromBytesE bs = fromMaybe (error msg) $ hashFromBytes bs
 
 -- | Calls 'hashFromBytesShort' and throws an error if the input is of the
 -- wrong length.
-hashFromBytesShortE
-  :: forall h a. (HashAlgorithm h, HasCallStack)
+hashFromBytesShortE ::
+     forall h a. (HashAlgorithm h, HasCallStack)
   => ShortByteString
   -> Hash h a
 hashFromBytesShortE bs = fromMaybe (error msg) $ hashFromBytesShort bs

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Util/AnchoredFragment.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Util/AnchoredFragment.hs
@@ -43,15 +43,15 @@ import qualified Ouroboros.Network.AnchoredFragment as AF
 -- the head of a fragment very often anyway, only when catching up. As soon as
 -- a new block/header is added to the fragment, the right decision will be
 -- made again ('GT' or 'LT').
-compareHeadBlockNo
-  :: HasHeader b
+compareHeadBlockNo ::
+     HasHeader b
   => AnchoredFragment b
   -> AnchoredFragment b
   -> Ordering
 compareHeadBlockNo = compare `on` AF.headBlockNo
 
-forksAtMostKBlocks
-  :: HasHeader b
+forksAtMostKBlocks ::
+     HasHeader b
   => Word64              -- ^ How many blocks can it fork?
   -> AnchoredFragment b  -- ^ Our chain.
   -> AnchoredFragment b  -- ^ Their chain

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Util/CBOR.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Util/CBOR.hs
@@ -224,8 +224,8 @@ readIncremental = \(SomeHasFS hasFS) decoder fp -> withLiftST $ \liftST -> do
 -- NOTE: f we introduce user-facing streaming API also, the fact that we are
 -- using @streaming@ here should not dictate that we should stick with it
 -- later; rather, we should revisit this code at that point.
-withStreamIncrementalOffsets
-  :: forall m h a r. (IOLike m, HasCallStack)
+withStreamIncrementalOffsets ::
+     forall m h a r. (IOLike m, HasCallStack)
   => HasFS m h
   -> (forall s . CBOR.D.Decoder s (LBS.ByteString -> a))
   -> FsPath

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Util/MonadSTM/RAWLock.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Util/MonadSTM/RAWLock.hs
@@ -166,8 +166,8 @@ withReadAccess rawLock =
 --
 -- Will block when there is another appender, a writer, or when a writer is
 -- waiting to take the lock.
-withAppendAccess
-  :: forall m st a. IOLike m => RAWLock m st -> (st -> m (st, a)) -> m a
+withAppendAccess ::
+     forall m st a. IOLike m => RAWLock m st -> (st -> m (st, a)) -> m a
 withAppendAccess rawLock k = snd . fst <$>
     generalBracket
       (atomically $ unsafeAcquireAppendAccess rawLock)
@@ -181,8 +181,8 @@ withAppendAccess rawLock k = snd . fst <$>
 --
 -- Will block when there is another writer or while there are readers and/or
 -- an appender.
-withWriteAccess
-  :: forall m st a. IOLike m => RAWLock m st -> (st -> m (st, a)) -> m a
+withWriteAccess ::
+     forall m st a. IOLike m => RAWLock m st -> (st -> m (st, a)) -> m a
 withWriteAccess rawLock k = snd . fst <$>
     generalBracket
       (unsafeAcquireWriteAccess rawLock)
@@ -193,8 +193,8 @@ withWriteAccess rawLock k = snd . fst <$>
       k
 
 -- | Internal helper
-stateToPutBack
-  :: st  -- ^ Acquired state
+stateToPutBack ::
+     st  -- ^ Acquired state
   -> ExitCase (st, a)
      -- ^ Result of 'generalBracket', containing the modified state in case of
      -- success
@@ -223,8 +223,8 @@ read (RAWLock var) = readTVar var >>= \case
 --
 -- Unless the lock has already been poisoned, in which case the original
 -- exception with which the lock was poisoned will be thrown.
-poison
-  :: (IOLike m, Exception e, HasCallStack)
+poison ::
+     (IOLike m, Exception e, HasCallStack)
   => RAWLock m st -> (CallStack -> e) -> m (Maybe st)
 poison (RAWLock var) mkEx = atomically $ do
     rawSt <- readTVar var
@@ -289,8 +289,8 @@ unsafeAcquireAppendAccess (RAWLock var) = do
 -- Composable with other 'STM' transactions.
 --
 -- NOTE: __must__ be preceded by a call to 'unsafeAcquireAppendAccess'.
-unsafeReleaseAppendAccess
-  :: IOLike m
+unsafeReleaseAppendAccess ::
+     IOLike m
   => RAWLock m st
   -> st  -- ^ State to store in the lock
   -> STM m ()
@@ -327,8 +327,8 @@ unsafeAcquireWriteAccess rawLock@(RAWLock var) = join $ atomically $ do
 -- Does /not/ compose with other 'STM' transactions.
 --
 -- NOTE: __must__ be preceded by a call to 'unsafeAcquireWriteAccess'.
-unsafeReleaseWriteAccess
-  :: IOLike m
+unsafeReleaseWriteAccess ::
+     IOLike m
   => RAWLock m st
   -> st  -- ^ State to store in the lock
   -> m ()
@@ -379,8 +379,8 @@ emptyRAWState = ReadAppend (Readers 0) NoAppender
   Pure internals: transitions between the 'RAWState's
 -------------------------------------------------------------------------------}
 
-acquireReadAccessPure
-  :: RAWState st -> Except SomeException (Maybe (RAWState st, st))
+acquireReadAccessPure ::
+     RAWState st -> Except SomeException (Maybe (RAWState st, st))
 acquireReadAccessPure = \case
     ReadAppend readers appender st
       -> return $ Just (ReadAppend (succ readers) appender st, st)
@@ -391,8 +391,8 @@ acquireReadAccessPure = \case
     Poisoned (AllowThunk ex)
       -> throwError ex
 
-releaseReadAccessPure
-  :: RAWState st -> Except SomeException (RAWState st)
+releaseReadAccessPure ::
+     RAWState st -> Except SomeException (RAWState st)
 releaseReadAccessPure = \case
     ReadAppend readers appender st
       | 0 <- readers
@@ -409,8 +409,8 @@ releaseReadAccessPure = \case
     Poisoned (AllowThunk ex)
       -> throwError ex
 
-acquireAppendAccessPure
-  :: RAWState st -> Except SomeException (Maybe (RAWState st, st))
+acquireAppendAccessPure ::
+     RAWState st -> Except SomeException (Maybe (RAWState st, st))
 acquireAppendAccessPure = \case
     ReadAppend readers appender st
       | NoAppender <- appender
@@ -424,8 +424,8 @@ acquireAppendAccessPure = \case
     Poisoned (AllowThunk ex)
       -> throwError ex
 
-releaseAppendAccessPure
-  :: st -> RAWState st -> Except SomeException (RAWState st)
+releaseAppendAccessPure ::
+     st -> RAWState st -> Except SomeException (RAWState st)
 releaseAppendAccessPure st' = \case
     ReadAppend readers appender _st
       | NoAppender <- appender
@@ -442,8 +442,8 @@ releaseAppendAccessPure st' = \case
     Poisoned (AllowThunk ex)
       -> throwError ex
 
-acquireWriteAccessPure
-  :: RAWState st -> Except SomeException (Maybe (RAWState st, Maybe st))
+acquireWriteAccessPure ::
+     RAWState st -> Except SomeException (Maybe (RAWState st, Maybe st))
 acquireWriteAccessPure = \case
     -- When there are no readers or appender in the 'ReadAppend' we can
     -- directly go to the 'Writing' state, if not, we'll go to the
@@ -465,8 +465,8 @@ acquireWriteAccessPure = \case
     Poisoned (AllowThunk ex)
       -> throwError ex
 
-releaseWriteAccessPure
-  :: st -> RAWState st -> Except SomeException (RAWState st)
+releaseWriteAccessPure ::
+     st -> RAWState st -> Except SomeException (RAWState st)
 releaseWriteAccessPure st' = \case
     ReadAppend _readers _appender _st
       -> error "releasing a writer in ReadAppend"
@@ -477,8 +477,8 @@ releaseWriteAccessPure st' = \case
     Poisoned (AllowThunk ex)
       -> throwError ex
 
-poisonPure
-  :: SomeException -> RAWState st -> Except SomeException (RAWState st, Maybe st)
+poisonPure ::
+     SomeException -> RAWState st -> Except SomeException (RAWState st, Maybe st)
 poisonPure ex = \case
     ReadAppend _readers _appender st
       -> return (Poisoned (AllowThunk ex), Just st)

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Util/ResourceRegistry.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Util/ResourceRegistry.hs
@@ -734,8 +734,8 @@ bracketWithPrivateRegistry newA closeA body =
 -- NOTE: we explicitly don't let 'runWithTempRegistry' return the final state,
 -- because the state /must/ have been stored somewhere safely, transferring
 -- the resources, before the temporary registry is closed.
-runWithTempRegistry
-  :: (IOLike m, HasCallStack)
+runWithTempRegistry ::
+     (IOLike m, HasCallStack)
   => WithTempRegistry st m (a, st)
   -> m a
 runWithTempRegistry m = withRegistry $ \rr -> do
@@ -786,8 +786,8 @@ runWithTempRegistry m = withRegistry $ \rr -> do
 -- async exception is received at that time, then the inner resources will be
 -- closed and then the composite resource will be closed. This means there's a
 -- risk of /double freeing/, which can be harmless if anticipated.
-runInnerWithTempRegistry
-  :: forall innerSt st m res a. IOLike m
+runInnerWithTempRegistry ::
+     forall innerSt st m res a. IOLike m
   => WithTempRegistry innerSt m (a, innerSt, res)
      -- ^ The embedded computation; see ASSUMPTION above
   -> (res -> m Bool)
@@ -878,8 +878,8 @@ instance MonadState s m => MonadState s (WithTempRegistry st m) where
 --
 -- NOTE: does not check that it's called by the same thread that allocated the
 -- resources, as it's an internal function only used in 'runWithTempRegistry'.
-untrackTransferredTo
-  :: IOLike m
+untrackTransferredTo ::
+     IOLike m
   => ResourceRegistry m
   -> TransferredTo st
   -> st
@@ -891,8 +891,8 @@ untrackTransferredTo rr transferredTo st =
 
 -- | Allocate a resource in a temporary registry until it has been transferred
 -- to the final state @st@. See 'runWithTempRegistry' for more details.
-allocateTemp
-  :: (IOLike m, HasCallStack)
+allocateTemp ::
+     (IOLike m, HasCallStack)
   => m a
      -- ^ Allocate the resource
   -> (a -> m Bool)
@@ -917,8 +917,8 @@ allocateTemp alloc free isTransferred = WithTempRegistry $ do
 -- | Higher level API on top of 'runWithTempRegistry': modify the given @st@,
 -- allocating resources in the process that will be transferred to the
 -- returned @st@.
-modifyWithTempRegistry
-  :: forall m st a. IOLike m
+modifyWithTempRegistry ::
+     forall m st a. IOLike m
   => m st                                 -- ^ Get the state
   -> (st -> ExitCase st -> m ())          -- ^ Store the new state
   -> StateT st (WithTempRegistry st m) a  -- ^ Modify the state

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Util/Versioned.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Util/Versioned.hs
@@ -72,8 +72,8 @@ data VersionDecoder a where
                -> VersionDecoder to
 
 -- | Return a 'Decoder' for the given 'VersionDecoder'.
-getVersionDecoder
-  :: VersionNumber
+getVersionDecoder ::
+     VersionNumber
   -> VersionDecoder a
   -> forall s. Decoder s a
 getVersionDecoder vn = \case
@@ -87,8 +87,8 @@ getVersionDecoder vn = \case
 
 -- | Given a 'VersionNumber' and the encoding of an @a@, encode the
 -- corresponding @'Versioned' a@. Use 'decodeVersion' to decode it.
-encodeVersion
-  :: VersionNumber
+encodeVersion ::
+     VersionNumber
   -> Encoding
   -> Encoding
 encodeVersion vn encodedA = mconcat
@@ -104,8 +104,8 @@ encodeVersion vn encodedA = mconcat
 -- looked up in the given list. The first match is used (using the semantics
 -- of 'lookup'). When no match is found, a decoder that fails with
 -- 'UnknownVersion' is returned.
-decodeVersion
-  :: [(VersionNumber, VersionDecoder a)]
+decodeVersion ::
+     [(VersionNumber, VersionDecoder a)]
   -> forall s. Decoder s a
 decodeVersion versionDecoders =
     versioned <$> decodeVersioned versionDecoders
@@ -125,8 +125,8 @@ decodeVersion versionDecoders =
 -- Note that this will not work if the previous encoding can start with list
 -- length 2, as the new versioned decoder will be called in those cases, not the
 -- hook.
-decodeVersionWithHook
-  :: forall a.
+decodeVersionWithHook ::
+     forall a.
      (forall s. Maybe Int -> Decoder s a)
   -> [(VersionNumber, VersionDecoder a)]
   -> forall s. Decoder s a
@@ -156,14 +156,14 @@ decodeVersionWithHook hook versionDecoders = do
           Nothing   -> fail $ show $ UnknownVersion vn
           Just vDec -> getVersionDecoder vn vDec
 
-encodeVersioned
-  :: (          a -> Encoding)
+encodeVersioned ::
+     (          a -> Encoding)
   -> (Versioned a -> Encoding)
 encodeVersioned enc (Versioned vn a) =
     encodeVersion vn (enc a)
 
-decodeVersioned
-  :: [(VersionNumber, VersionDecoder a)]
+decodeVersioned ::
+     [(VersionNumber, VersionDecoder a)]
   -> forall s. Decoder s (Versioned a)
 decodeVersioned versionDecoders = do
     enforceSize "Versioned" 2

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/ChainUpdates.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/ChainUpdates.hs
@@ -83,8 +83,8 @@ data UpdateBehavior =
     TentativeChainBehavior
   deriving stock (Show, Eq, Enum, Bounded)
 
-genChainUpdates
-  :: UpdateBehavior
+genChainUpdates ::
+     UpdateBehavior
   -> SecurityParam
   -> Int  -- ^ The number of updates to generate
   -> Gen [ChainUpdate]

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/Corruption.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/Corruption.hs
@@ -41,8 +41,8 @@ applyCorruption (Corruption n) bs
 -- bytestring succeeds, pass the deserialised value to the integrity checking
 -- function. If that function returns 'False', the corruption was detected, if
 -- it returns 'True', the corruption was not detected and the test fails.
-detectCorruption
-  :: Show a
+detectCorruption ::
+     Show a
   => (a -> Encoding)
   -> (forall s. Decoder s (Lazy.ByteString -> a))
   -> (a -> Bool)

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/FileLock.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/FileLock.hs
@@ -19,8 +19,8 @@ import           Test.Util.Orphans.IOLike ()
 -- Supports an optional delay in release to simulate lazy, non-synchronous
 -- unlocking as done by Linux (near instantaneous but not instant) and
 -- Windows.
-mockFileLock
-  :: Maybe DiffTime  -- ^ Optional release delay
+mockFileLock ::
+     Maybe DiffTime  -- ^ Optional release delay
   -> IOSim s (FileLock (IOSim s))
 mockFileLock releaseDelay = do
     locks <- newMockFileLocks releaseDelay

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/Serialisation/Roundtrip.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/Serialisation/Roundtrip.hs
@@ -707,14 +707,14 @@ prop_estimateBlockSize ccfg (WithVersion version (Coherent blk))
   Serialised helpers
 -------------------------------------------------------------------------------}
 
-encodeThroughSerialised
-  :: (a -> Encoding)
+encodeThroughSerialised ::
+     (a -> Encoding)
   -> (Serialised a -> Encoding)
   -> (a -> Encoding)
 encodeThroughSerialised enc encSerialised = encSerialised . mkSerialised enc
 
-decodeThroughSerialised
-  :: (forall s. Decoder s (Lazy.ByteString -> a))
+decodeThroughSerialised ::
+     (forall s. Decoder s (Lazy.ByteString -> a))
   -> (forall s. Decoder s (Serialised a))
   -> (forall s. Decoder s a)
 decodeThroughSerialised dec decSerialised = do

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/Split.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/Split.hs
@@ -17,8 +17,8 @@ import           Data.Word (Word64)
 -- | The returned @b@ is the first in the list.
 --
 -- INVARIANT The output data is a segmentation of the given list.
-spanLeft
-  :: forall x a b.
+spanLeft ::
+     forall x a b.
      (x -> Either a b) -> [x] -> ([a], Maybe (b, [x]))
 spanLeft prj xs = (reverse acc, mbBxs)
   where
@@ -47,8 +47,8 @@ data Prj a b = Prj !a !b
 -- list.
 --
 -- INVARIANT The output data is a segmentation of the given list.
-splitAtJust
-  :: forall x b.
+splitAtJust ::
+     forall x b.
      (x -> Maybe b) -> Word64 -> [x] -> (Maybe ([x], b), [x])
 splitAtJust prj = \n xs ->
   if 0 == n then (Nothing, xs)

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/Mempool.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/Mempool.hs
@@ -441,15 +441,15 @@ txIsValid :: LedgerState TestBlock -> TestTx -> Bool
 txIsValid ledgerState tx =
     isRight $ runExcept $ applyTxToLedger ledgerState tx
 
-txsAreValid
-  :: LedgerState TestBlock
+txsAreValid ::
+     LedgerState TestBlock
   -> [TestTx]
   -> Either TestTxError (LedgerState TestBlock)
 txsAreValid ledgerState txs =
     runExcept $ repeatedlyM (flip applyTxToLedger) txs ledgerState
 
-validateTxs
-  :: LedgerState TestBlock
+validateTxs ::
+     LedgerState TestBlock
   -> [TestTx]
   -> ([(TestTx, Bool)], LedgerState TestBlock)
 validateTxs = go []
@@ -692,8 +692,8 @@ data TestMempool m = TestMempool
 -- module "Ouroboros.Consensus.Mock.Ledger.Block". This is why the generators do
 -- not care about the mempool capacity when generating transactions for a
 -- mempool with the 'NoMempoolCapacityBytesOverride' option set.
-withTestMempool
-  :: forall prop. Testable prop
+withTestMempool ::
+     forall prop. Testable prop
   => TestSetup
   -> (forall m. IOLike m => TestMempool m -> m prop)
   -> Property
@@ -1112,8 +1112,8 @@ currentTicketAssignment Mempool { syncWithLedger } = do
 instance Arbitrary Actions where
   arbitrary = sized $ genActions (choose (1, 3))
 
-genActions
-  :: Gen Int  -- ^ Generate the number of transactions to add
+genActions ::
+     Gen Int  -- ^ Generate the number of transactions to add
   -> Int      -- ^ How many actions
   -> Gen Actions
 genActions genNbToAdd = go testInitLedger mempty mempty

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/MiniProtocol/ChainSync/Client.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/MiniProtocol/ChainSync/Client.hs
@@ -307,8 +307,8 @@ data ChainSyncOutcome = ChainSyncOutcome {
 --
 -- Note that updates that are scheduled before the time at which we start
 -- syncing help generate different chains to start syncing from.
-runChainSync
-    :: forall m. (IOLike m, MonadTime m)
+runChainSync ::
+       forall m. (IOLike m, MonadTime m)
     => ClockSkew
     -> SecurityParam
     -> ClientUpdates
@@ -865,8 +865,8 @@ removeLateClientUpdates (ServerUpdates (Schedule sus))
   Generating a schedule of updates
 -------------------------------------------------------------------------------}
 
-genUpdateSchedule
-  :: UpdateBehavior
+genUpdateSchedule ::
+     UpdateBehavior
   -> SecurityParam
   -> Gen (Schedule ChainUpdate)
 genUpdateSchedule updateBehavior securityParam =

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/MiniProtocol/LocalStateQuery/Server.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/MiniProtocol/LocalStateQuery/Server.hs
@@ -116,8 +116,8 @@ prop_localStateQueryServer k bt p (Positive (Small n)) = checkOutcome k chain ac
 -- implementation details.
 --
 -- Additionally, this function labels the test results.
-checkOutcome
-  :: SecurityParam
+checkOutcome ::
+     SecurityParam
   -> Chain TestBlock
   -> [(Maybe (Point TestBlock), Either AcquireFailure (Point TestBlock))]
   -> Property
@@ -154,8 +154,8 @@ checkOutcome k chain = conjoin . map (uncurry checkResult)
       Right _result -> tabulate "Acquired" ["Success"] True
       Left  failure -> counterexample ("acuire tip point resulted in " ++ show failure) False
 
-mkClient
-  :: Monad m
+mkClient ::
+     Monad m
   => [Maybe (Point TestBlock)]
   -> LocalStateQueryClient
        TestBlock
@@ -165,8 +165,8 @@ mkClient
        [(Maybe (Point TestBlock), Either AcquireFailure (Point TestBlock))]
 mkClient points = localStateQueryClient [(pt, BlockQuery QueryLedgerTip) | pt <- points]
 
-mkServer
-  :: IOLike m
+mkServer ::
+     IOLike m
   => SecurityParam
   -> Chain TestBlock
   -> m (LocalStateQueryServer TestBlock (Point TestBlock) (Query TestBlock) m ())
@@ -184,8 +184,8 @@ mkServer k chain = do
       Chain.drop (fromIntegral (maxRollbacks k)) chain
 
 -- | Initialise a 'LgrDB' with the given chain.
-initLgrDB
-  :: forall m. IOLike m
+initLgrDB ::
+     forall m. IOLike m
   => SecurityParam
   -> Chain TestBlock
   -> m (LgrDB m TestBlock)

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/Util/MonadSTM/RAWLock.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/Util/MonadSTM/RAWLock.hs
@@ -134,8 +134,8 @@ prop_RAWLock_correctness (TestSetup rawDelays) =
 
 -- | Like 'monadicSim' (which is like 'monadicIO' for the IO simulator), but
 -- allows inspecting the trace for labelling purposes.
-monadicSimWithTrace
-  :: Testable a
+monadicSimWithTrace ::
+     Testable a
   => (forall x. SimTrace x -> Property -> Property)
   -> (forall s. PropertyM (IOSim s) a)
   -> Property

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/Util/Versioned.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/Util/Versioned.hs
@@ -71,8 +71,8 @@ version1 = Version1 1 100
 version2 :: Version2
 version2 = Version2 1 100 101
 
-decodeLatestVersion
-  :: [(VersionNumber, VersionDecoder Version2)]
+decodeLatestVersion ::
+     [(VersionNumber, VersionDecoder Version2)]
 decodeLatestVersion =
     [ (0, Incompatible "missing field 1")
     , (1, Migrate (Decode decode) $ \(Version1 a b) ->

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/GcSchedule.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/GcSchedule.hs
@@ -212,8 +212,8 @@ overlap :: GcState -> Int
 overlap = length . unGcBlocks . gcBlocks
 
 -- | Number of blocks that could be GC'ed but haven't been
-unnecessaryOverlap
-  :: Time  -- ^ The current time
+unnecessaryOverlap ::
+     Time  -- ^ The current time
   -> GcState
   -> Int
 unnecessaryOverlap now =
@@ -242,8 +242,8 @@ runGc now gcState = GcState {
     toGarbageCollection :: ScheduledGc -> (SlotNo, Time)
     toGarbageCollection (ScheduledGc time slot) = (slot, time)
 
-step
-  :: GcParams
+step ::
+     GcParams
   -> Block
   -> GcState
   -> GcState

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/Iterator.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/Iterator.hs
@@ -331,8 +331,8 @@ type IterRes = Either (UnknownRange TestBlock)
 -- | Open an iterator with the given bounds on the given 'TestSetup'. Return a
 -- trace of the 'TraceIteratorEvent's produced and the result of the iterator
 -- itself.
-runIterator
-  :: TestSetup
+runIterator ::
+     TestSetup
   -> StreamFrom TestBlock
   -> StreamTo   TestBlock
   -> ([TraceIteratorEvent TestBlock], IterRes)
@@ -361,8 +361,8 @@ runIterator setup from to = runSimOrThrow $ withRegistry $ \r -> do
   Setting up a mock IteratorEnv
 -------------------------------------------------------------------------------}
 
-initIteratorEnv
-  :: forall m. IOLike m
+initIteratorEnv ::
+     forall m. IOLike m
   => TestSetup
   -> Tracer m (TraceIteratorEvent TestBlock)
   -> m (IteratorEnv m TestBlock)

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/Model.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/Model.hs
@@ -242,8 +242,8 @@ maxActualRollback k m =
 -- the background thread copying blocks from the VolatileDB to the ImmutableDB
 -- might not have caught up yet. This means we cannot use the tip of the
 -- ImmutableDB to know the most recent \"immutable\" block.
-immutableChain
-  :: SecurityParam
+immutableChain ::
+     SecurityParam
   -> Model blk
   -> Chain blk
 immutableChain (SecurityParam k) m =
@@ -265,8 +265,8 @@ immutableChain (SecurityParam k) m =
 -- 1. The last @k@ blocks of the current chain.
 -- 2. The suffix of the current chain not part of the 'immutableDbChain', i.e.,
 --    the \"ImmutableDB\".
-volatileChain
-    :: (HasHeader a, HasHeader blk)
+volatileChain ::
+       (HasHeader a, HasHeader blk)
     => SecurityParam
     -> (blk -> a)  -- ^ Provided since 'AnchoredFragment' is not a functor
     -> Model blk
@@ -346,8 +346,8 @@ getLedgerDB cfg m@Model{..} =
   Construction
 -------------------------------------------------------------------------------}
 
-empty
-  :: ExtLedgerState blk
+empty ::
+     ExtLedgerState blk
   -> Word64   -- ^ Max clock skew in number of blocks
   -> Model blk
 empty initLedger maxClockSkew = Model {
@@ -366,8 +366,8 @@ empty initLedger maxClockSkew = Model {
 
 -- | Advance the 'currentSlot' of the model to the given 'SlotNo' if the
 -- current slot of the model < the given 'SlotNo'.
-advanceCurSlot
-  :: SlotNo  -- ^ The new current slot
+advanceCurSlot ::
+     SlotNo  -- ^ The new current slot
   -> Model blk -> Model blk
 advanceCurSlot curSlot m = m { currentSlot = curSlot `max` currentSlot m }
 
@@ -457,8 +457,8 @@ addBlocks :: LedgerSupportsProtocol blk
 addBlocks cfg = repeatedly (addBlock cfg)
 
 -- | Wrapper around 'addBlock' that returns an 'AddBlockPromise'.
-addBlockPromise
-  :: forall m blk. (LedgerSupportsProtocol blk, MonadSTM m)
+addBlockPromise ::
+     forall m blk. (LedgerSupportsProtocol blk, MonadSTM m)
   => TopLevelConfig blk
   -> blk
   -> Model blk
@@ -477,8 +477,8 @@ addBlockPromise cfg blk m = (result, m')
   Iterators
 -------------------------------------------------------------------------------}
 
-stream
-  :: GetPrevHash blk
+stream ::
+     GetPrevHash blk
   => SecurityParam
   -> StreamFrom  blk
   -> StreamTo    blk
@@ -518,8 +518,8 @@ iteratorNext itrId blockComponent m =
   where
     updateIter bs = m { iterators = Map.insert itrId bs (iterators m) }
 
-getBlockComponent
-  :: forall blk b. ModelSupportsBlock blk
+getBlockComponent ::
+     forall blk b. ModelSupportsBlock blk
   => blk -> BlockComponent blk b -> b
 getBlockComponent blk = \case
     GetVerifiedBlock -> blk  -- We don't verify it
@@ -924,8 +924,8 @@ garbageCollectablePoint secParam m pt
 -- | Return 'True' when the next block the given iterator would produced is
 -- eligible for garbage collection, i.e. the real implementation might have
 -- garbage collected it.
-garbageCollectableIteratorNext
-  :: forall blk. ModelSupportsBlock blk
+garbageCollectableIteratorNext ::
+     forall blk. ModelSupportsBlock blk
   => SecurityParam -> Model blk -> IteratorId -> Bool
 garbageCollectableIteratorNext secParam m itId =
     case fst (iteratorNext itId GetBlock m) of
@@ -981,8 +981,8 @@ closeDB m@Model{..} = m {
 reopen :: Model blk -> Model blk
 reopen m = m { isOpen = True }
 
-wipeVolatileDB
-  :: forall blk. LedgerSupportsProtocol blk
+wipeVolatileDB ::
+     forall blk. LedgerSupportsProtocol blk
   => TopLevelConfig blk
   -> Model blk
   -> (Point blk, Model blk)

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
@@ -365,8 +365,8 @@ data ChainDBEnv m blk = ChainDBEnv {
     -- ^ Needed to reopen a ChainDB, i.e., open a new one.
   }
 
-open
-  :: (IOLike m, TestConstraints blk)
+open ::
+     (IOLike m, TestConstraints blk)
   => ChainDbArgs Identity m blk -> m (ChainDBState m blk)
 open args = do
     (chainDB, internal) <- openDBInternal args False
@@ -375,8 +375,8 @@ open args = do
     return ChainDBState { chainDB, internal, addBlockAsync }
 
 -- PRECONDITION: the ChainDB is closed
-reopen
-  :: (IOLike m, TestConstraints blk)
+reopen ::
+     (IOLike m, TestConstraints blk)
   => ChainDBEnv m blk -> m ()
 reopen ChainDBEnv { varDB, args } = do
     chainDBState <- open args
@@ -879,8 +879,8 @@ lockstep model@Model {..} cmd (At resp) = Event
 type BlockGen blk m = Model blk m Symbolic -> Gen blk
 
 -- | Generate a 'Cmd'
-generator
-  :: forall blk m. TestConstraints blk
+generator ::
+     forall blk m. TestConstraints blk
   => BlockGen     blk m
   -> Model        blk m Symbolic
   -> Gen (At Cmd  blk m Symbolic)

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/Unit.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/Unit.hs
@@ -93,8 +93,8 @@ followerInstructionOnEmptyChain = do
 --            \
 --             \--- b3 -- b4
 --
-followerSwitchesToNewChain
-  :: (Block m ~ TestBlock, SupportsUnitTest m, MonadError TestFailure m) => m ()
+followerSwitchesToNewChain ::
+     (Block m ~ TestBlock, SupportsUnitTest m, MonadError TestFailure m) => m ()
 followerSwitchesToNewChain =
   let fork i = TestBody i True
   in do
@@ -311,8 +311,8 @@ newtype ModelM blk a = ModelM
                       MonadState (Model blk), MonadError TestFailure)
 
 
-runModel
-  :: Model blk
+runModel ::
+     Model blk
   -> TopLevelConfig blk
   -> ModelM blk b
   -> Either TestFailure b
@@ -382,8 +382,8 @@ newtype SystemM blk m a = SystemM
                       MonadReader (ChainDBEnv m blk), MonadError TestFailure)
 
 
-runSystem
-  :: (forall a. (ChainDBEnv m blk -> m [TraceEvent blk] -> m a) -> m a)
+runSystem ::
+     (forall a. (ChainDBEnv m blk -> m [TraceEvent blk] -> m a) -> m a)
   -> SystemM blk m b
   -> m (Either TestFailure b)
 runSystem withChainDbEnv expr
@@ -392,8 +392,8 @@ runSystem withChainDbEnv expr
 
 
 -- | Provide a standard ChainDbEnv for testing.
-withTestChainDbEnv
-  :: (IOLike m, TestConstraints blk)
+withTestChainDbEnv ::
+     (IOLike m, TestConstraints blk)
   => TopLevelConfig blk
   -> ImmutableDB.ChunkInfo
   -> ExtLedgerState blk

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/TestBlock.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/TestBlock.hs
@@ -334,8 +334,8 @@ newtype ChainLength = ChainLength Int
   Creating blocks
 -------------------------------------------------------------------------------}
 
-mkBlock
-  :: HasCallStack
+mkBlock ::
+     HasCallStack
   => (SlotNo -> Bool)
   -- ^ Is this slot allowed contain an EBB?
   --


### PR DESCRIPTION
Main benefit is quickly searching for definitions.

Also point 2.a of https://github.com/IntersectMBO/ouroboros-consensus/blob/main/docs/website/contents/for-developers/StyleGuide.md

Crafted via:
```bash
for f in $(rg -U "^[[:alnum:]]+\n^\s+::" -l); do
  perl -i~ -0777 -pe 's/^([[:alnum:]]+)\n( +)::/\1 ::\n\2  /gm' $f
done

# just for windows
find . -name "*.hs" -not -type d -exec file "{}" ";" | grep CRLF | cut -d':' -f1 | xargs sed -i 's_\r__g'
```