### PR TITLE
LoE and shrinking of schedules

### DIFF
--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBSynthesizer/Run.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBSynthesizer/Run.hs
@@ -30,10 +30,9 @@ import qualified Ouroboros.Consensus.Node.InitStorage as Node
 import           Ouroboros.Consensus.Node.ProtocolInfo (ProtocolInfo (..))
 import           Ouroboros.Consensus.Shelley.Node (ShelleyGenesis (..),
                      validateGenesis)
-import qualified Ouroboros.Consensus.Storage.ChainDB as ChainDB (defaultArgs,
-                     getTipPoint)
-import qualified Ouroboros.Consensus.Storage.ChainDB.Impl as ChainDB (cdbTracer,
-                     withDB)
+import qualified Ouroboros.Consensus.Storage.ChainDB as ChainDB
+                     (ChainDbArgs (..), defaultArgs, getTipPoint)
+import qualified Ouroboros.Consensus.Storage.ChainDB.Impl as ChainDB (withDB)
 import           Ouroboros.Consensus.Util.IOLike (atomically)
 import           Ouroboros.Consensus.Util.ResourceRegistry
 import           Ouroboros.Network.Block

--- a/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
+++ b/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
@@ -248,6 +248,7 @@ test-suite consensus-test
     Test.Consensus.PointSchedule.SinglePeer
     Test.Consensus.PointSchedule.SinglePeer.Indices
     Test.Consensus.PointSchedule.Tests
+    Test.Util.TersePrinting
 
   build-depends:
     , base

--- a/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
+++ b/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
@@ -245,6 +245,8 @@ test-suite consensus-test
     Test.Consensus.PeerSimulator.Tests.Timeouts
     Test.Consensus.PeerSimulator.Trace
     Test.Consensus.PointSchedule
+    Test.Consensus.PointSchedule.Peers
+    Test.Consensus.PointSchedule.Shrinking
     Test.Consensus.PointSchedule.SinglePeer
     Test.Consensus.PointSchedule.SinglePeer.Indices
     Test.Consensus.PointSchedule.Tests

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Node.hs
@@ -96,6 +96,7 @@ import           Ouroboros.Consensus.Node.Tracers
 import           Ouroboros.Consensus.NodeKernel
 import           Ouroboros.Consensus.Storage.ChainDB (ChainDB, ChainDbArgs)
 import qualified Ouroboros.Consensus.Storage.ChainDB as ChainDB
+import           Ouroboros.Consensus.Storage.ChainDB.API (LoE (LoEDisabled))
 import           Ouroboros.Consensus.Storage.ImmutableDB (ChunkInfo,
                      ValidationPolicy (..))
 import           Ouroboros.Consensus.Storage.LedgerDB.DiskPolicy
@@ -679,7 +680,7 @@ mkChainDbArgs
     , ChainDB.cdbCheckIntegrity = nodeCheckIntegrity (configStorage cfg)
     , ChainDB.cdbGenesis        = return initLedger
     , ChainDB.cdbCheckInFuture  = inFuture
-
+    , ChainDB.cdbLoE            = LoEDisabled
     , ChainDB.cdbRegistry       = registry
     }
 

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup.hs
@@ -26,10 +26,11 @@ import           Test.Consensus.BlockTree (allFragments)
 import           Test.Consensus.Genesis.Setup.GenChains
 import           Test.Consensus.PeerSimulator.Run
 import           Test.Consensus.PeerSimulator.StateView
-import           Test.Consensus.PeerSimulator.Trace (traceLinesWith, terseFrag)
+import           Test.Consensus.PeerSimulator.Trace (traceLinesWith)
 import           Test.Consensus.PointSchedule
 import           Test.QuickCheck
 import           Test.Util.Orphans.IOLike ()
+import           Test.Util.TersePrinting (terseFragment)
 import           Test.Util.Tracer (recordingTracerTVar)
 
 -- | Runs the given point schedule and evaluates the given property on the final
@@ -46,7 +47,7 @@ runTest schedulerConfig genesisTest schedule makeProperty = do
     let tracer = if scDebug schedulerConfig then debugTracer else recordingTracer
 
     -- TODO: should also go in 'prettyGenesisTest' (or 'prettyBlockTree')
-    for_ (allFragments gtBlockTree) \ bt -> traceWith tracer (terseFrag bt)
+    for_ (allFragments gtBlockTree) (traceWith tracer . terseFragment)
 
     traceLinesWith tracer $ [
       "SchedulerConfig:",

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup.hs
@@ -4,7 +4,6 @@
 {-# LANGUAGE LambdaCase                #-}
 {-# LANGUAGE NamedFieldPuns            #-}
 {-# LANGUAGE RankNTypes                #-}
-{-# LANGUAGE RecordWildCards           #-}
 {-# LANGUAGE ScopedTypeVariables       #-}
 
 module Test.Consensus.Genesis.Setup (

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LongRangeAttack.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LongRangeAttack.hs
@@ -1,24 +1,19 @@
 {-# LANGUAGE BlockArguments      #-}
 {-# LANGUAGE DerivingStrategies  #-}
-{-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE NamedFieldPuns      #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Test.Consensus.Genesis.Tests.LongRangeAttack (tests) where
 
-import           Control.Monad.IOSim (runSimOrThrow)
-import           Data.List (intercalate)
 import           Ouroboros.Consensus.Block.Abstract (HeaderHash)
-import           Ouroboros.Consensus.Util.Condense (condense)
 import           Ouroboros.Network.AnchoredFragment (headAnchor)
 import qualified Ouroboros.Network.AnchoredFragment as AF
 import           Test.Consensus.Genesis.Setup
 import           Test.Consensus.Genesis.Setup.Classifiers
+                     (allAdversariesSelectable, classifiers)
 import           Test.Consensus.PeerSimulator.Run (noTimeoutsSchedulerConfig)
 import           Test.Consensus.PeerSimulator.StateView
 import           Test.Consensus.PointSchedule
-import qualified Test.QuickCheck as QC
-import           Test.QuickCheck
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
 import           Test.Util.Orphans.IOLike ()
@@ -30,44 +25,28 @@ tests =
   testGroup "long range attack" [
     adjustQuickCheckTests (`div` 10) $
     testProperty "one adversary" prop_longRangeAttack
-    -- TODO we don't have useful classification logic for multiple adversaries yet – if a selectable
-    -- adversary is slow, it might be discarded before it reaches critical length because the faster
-    -- ones have served k blocks off the honest chain if their fork anchor is further down the line.
-    -- ,
-    -- testProperty "three adversaries" (prop_longRangeAttack 1 [2, 5, 10])
   ]
 
-prop_longRangeAttack :: QC.Gen QC.Property
-prop_longRangeAttack = do
-  -- | Create a block tree with @1@ alternative chain.
-  genesisTest <- genChains (pure 1)
+prop_longRangeAttack :: Property
+prop_longRangeAttack =
+  forAllGenesisTest
 
-  -- | Create a 'longRangeAttack' schedule based on the generated chains.
-  schedule <- fromSchedulePoints <$> stToGen (longRangeAttack (gtBlockTree genesisTest))
-  let cls = classifiers genesisTest
+    (do
+        -- Create a block tree with @1@ alternative chain.
+        gt@GenesisTest{gtBlockTree} <- genChains (pure 1)
+        -- Create a 'longRangeAttack' schedule based on the generated chains.
+        ps <- fromSchedulePoints <$> stToGen (longRangeAttack gtBlockTree)
+        if allAdversariesSelectable (classifiers gt)
+          then pure (gt, ps)
+          else discard)
 
-  -- TODO: not existsSelectableAdversary ==> immutableTipBeforeFork svSelectedChain
+    (noTimeoutsSchedulerConfig defaultPointScheduleConfig)
 
-  pure $
-    classify (genesisWindowAfterIntersection cls) "Full genesis window after intersection" $
-    allAdversariesSelectable cls
-    ==>
-    runSimOrThrow $
-      runTest
-        (noTimeoutsSchedulerConfig scheduleConfig)
-        genesisTest
-        schedule
-        $ exceptionCounterexample $ \StateView{svSelectedChain} killed ->
-            killCounterexample killed $
-            -- This is the expected behavior of Praos to be reversed with Genesis.
-            -- But we are testing Praos for the moment
-            not (isHonestTestFragH svSelectedChain)
+    -- NOTE: This is the expected behaviour of Praos to be reversed with
+    -- Genesis. But we are testing Praos for the moment
+    (\_ _ -> not . isHonestTestFragH . svSelectedChain)
 
   where
-    killCounterexample = \case
-      [] -> property
-      killed -> counterexample ("Some peers were killed: " ++ intercalate ", " (condense <$> killed))
-
     isHonestTestFragH :: TestFragH -> Bool
     isHonestTestFragH frag = case headAnchor frag of
         AF.AnchorGenesis   -> True
@@ -75,5 +54,3 @@ prop_longRangeAttack = do
 
     isHonestTestHeaderHash :: HeaderHash TestBlock -> Bool
     isHonestTestHeaderHash = all (0 ==) . unTestHash
-
-    scheduleConfig = defaultPointScheduleConfig

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LongRangeAttack.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LongRangeAttack.hs
@@ -2,9 +2,7 @@
 {-# LANGUAGE DerivingStrategies  #-}
 {-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE NamedFieldPuns      #-}
-{-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TupleSections       #-}
 
 module Test.Consensus.Genesis.Tests.LongRangeAttack (tests) where
 

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LongRangeAttack.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LongRangeAttack.hs
@@ -14,6 +14,7 @@ import           Test.Consensus.Genesis.Setup.Classifiers
 import           Test.Consensus.PeerSimulator.Run (noTimeoutsSchedulerConfig)
 import           Test.Consensus.PeerSimulator.StateView
 import           Test.Consensus.PointSchedule
+import           Test.Consensus.PointSchedule.Shrinking (shrinkPeerSchedules)
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
 import           Test.Util.Orphans.IOLike ()
@@ -29,18 +30,20 @@ tests =
 
 prop_longRangeAttack :: Property
 prop_longRangeAttack =
-  forAllGenesisTest
+  forAllGenesisTest'
 
     (do
         -- Create a block tree with @1@ alternative chain.
         gt@GenesisTest{gtBlockTree} <- genChains (pure 1)
         -- Create a 'longRangeAttack' schedule based on the generated chains.
-        ps <- fromSchedulePoints <$> stToGen (longRangeAttack gtBlockTree)
+        ps <- stToGen (longRangeAttack gtBlockTree)
         if allAdversariesSelectable (classifiers gt)
           then pure (gt, ps)
           else discard)
 
     (noTimeoutsSchedulerConfig defaultPointScheduleConfig)
+
+    shrinkPeerSchedules
 
     -- NOTE: This is the expected behaviour of Praos to be reversed with
     -- Genesis. But we are testing Praos for the moment

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
@@ -31,6 +31,9 @@ import           Test.Consensus.PeerSimulator.Run (SchedulerConfig (scTrace),
                      noTimeoutsSchedulerConfig, scTraceState)
 import           Test.Consensus.PeerSimulator.StateView
 import           Test.Consensus.PointSchedule
+import           Test.Consensus.PointSchedule.Peers (PeerId (..), Peers (..),
+                     value)
+import           Test.Consensus.PointSchedule.Shrinking (shrinkPeerSchedules)
 import           Test.Consensus.PointSchedule.SinglePeer
                      (SchedulePoint (ScheduleBlockPoint, ScheduleTipPoint))
 import           Test.Ouroboros.Consensus.ChainGenerator.Params (Delta (Delta))
@@ -135,6 +138,8 @@ prop_serveAdversarialBranches =
     ((noTimeoutsSchedulerConfig defaultPointScheduleConfig)
        {scTraceState = False, scTrace = False})
 
+    shrinkPeerSchedules
+
     theProperty
 
 genUniformSchedulePoints :: GenesisTest -> QC.Gen (Peers PeerSchedule)
@@ -176,6 +181,8 @@ prop_leashingAttackStalling =
 
     ((noTimeoutsSchedulerConfig defaultPointScheduleConfig)
       {scTrace = False})
+
+    shrinkPeerSchedules
 
     theProperty
 
@@ -221,6 +228,8 @@ prop_leashingAttackTimeLimited =
 
     ((noTimeoutsSchedulerConfig defaultPointScheduleConfig)
       {scTrace = False})
+
+    shrinkPeerSchedules
 
     theProperty
 

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
@@ -1,12 +1,8 @@
 {-# LANGUAGE BlockArguments      #-}
 {-# LANGUAGE DerivingStrategies  #-}
-{-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE NamedFieldPuns      #-}
-{-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TupleSections       #-}
 {-# LANGUAGE TypeFamilies        #-}
-{-# LANGUAGE TypeOperators       #-}
 
 -- | Peer simulator tests based on randomly generated schedules. They share the
 -- same property stating that the immutable tip should be on the trunk of the
@@ -77,7 +73,7 @@ makeProperty genesisTest schedule StateView {svSelectedChain} killed =
   -- to the governor that the density is too low.
   longerThanGenesisWindow ==>
   conjoin [
-    counterexample "The honest peer was disconnected" (not (HonestPeer `elem` killed)),
+    counterexample "The honest peer was disconnected" (HonestPeer `notElem` killed),
     counterexample ("The immutable tip is not honest: " ++ show immutableTip) $
     property (isHonest immutableTipHash),
     immutableTipIsRecent

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
@@ -24,11 +24,16 @@ import           GHC.Stack (HasCallStack)
 import           Ouroboros.Consensus.Util.Condense (condense)
 import qualified Ouroboros.Network.AnchoredFragment as AF
 import           Ouroboros.Network.Block (blockNo, unBlockNo)
-import           Test.Consensus.BlockTree (BlockTree (..))
+import           Ouroboros.Network.Protocol.ChainSync.Codec
+                     (ChainSyncTimeout (..))
+import           Ouroboros.Network.Protocol.Limits (shortWait)
+import           Test.Consensus.BlockTree (BlockTree (..), btbSuffix)
 import           Test.Consensus.Genesis.Setup
 import           Test.Consensus.Genesis.Setup.Classifiers
-import           Test.Consensus.PeerSimulator.Run (SchedulerConfig (scTrace),
-                     noTimeoutsSchedulerConfig, scTraceState)
+import           Test.Consensus.Network.Driver.Limits.Extras
+                     (chainSyncNoTimeouts)
+import           Test.Consensus.PeerSimulator.Run (SchedulerConfig (..),
+                     noTimeoutsSchedulerConfig)
 import           Test.Consensus.PeerSimulator.StateView
 import           Test.Consensus.PointSchedule
 import           Test.Consensus.PointSchedule.Peers (PeerId (..), Peers (..),
@@ -56,8 +61,10 @@ tests =
     -- See Note [Leashing attacks]
     testProperty "stalling leashing attack" prop_leashingAttackStalling,
     testProperty "time limited leashing attack" prop_leashingAttackTimeLimited,
-  adjustQuickCheckTests (`div` 10) $
-    testProperty "serve adversarial branches" prop_serveAdversarialBranches
+    adjustQuickCheckTests (`div` 10) $
+    testProperty "serve adversarial branches" prop_serveAdversarialBranches,
+    adjustQuickCheckTests (`div` 100) $
+    testProperty "the LoE stalls the chain, but the immutable tip is honest" prop_loeStalling
     ]
 
 theProperty ::
@@ -280,3 +287,45 @@ headCallStack :: HasCallStack => [a] -> a
 headCallStack = \case
   x:_ -> x
   _   -> error "headCallStack: empty list"
+
+-- | Test that enabling the LoE using the updater that sets the LoE fragment to
+-- the shared prefix (as used by the GDDG) causes the selection to remain at
+-- the first fork intersection (keeping the immutable tip honest).
+--
+-- This is pretty slow since it relies on timeouts to terminate the test.
+prop_loeStalling :: Property
+prop_loeStalling =
+  forAllGenesisTest'
+
+    (do gt <- genChains (QC.choose (1, 4))
+        ps <- genUniformSchedulePoints gt
+        pure (gt, ps))
+
+    ((noTimeoutsSchedulerConfig defaultPointScheduleConfig) {
+      scTrace = False,
+      scEnableLoE = True,
+      scChainSyncTimeouts = chainSyncNoTimeouts {canAwaitTimeout = shortWait}
+    })
+
+    (\_ _ _ -> [])
+
+    prop
+  where
+    prop GenesisTest {gtBlockTree = BlockTree {btTrunk, btBranches}} _ StateView{svSelectedChain} =
+      classify (any (== selectionTip) allTips) "The selection is at a branch tip" $
+      classify (any anchorIsImmutableTip suffixes) "The immutable tip is at a fork intersection" $
+      property (isHonest immutableTipHash)
+      where
+        anchorIsImmutableTip branch = simpleHash (AF.anchorToHash (AF.anchor branch)) == immutableTipHash
+
+        isHonest = all (0 ==)
+
+        immutableTipHash = simpleHash (AF.anchorToHash immutableTip)
+
+        immutableTip = AF.anchor svSelectedChain
+
+        selectionTip = simpleHash (AF.headHash svSelectedChain)
+
+        allTips = simpleHash . AF.headHash <$> (btTrunk : suffixes)
+
+        suffixes = btbSuffix <$> btBranches

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/ChainSync.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/ChainSync.hs
@@ -40,7 +40,8 @@ import           Test.Consensus.PeerSimulator.StateView
                      StateViewTracers (StateViewTracers, svtChainSyncExceptionsTracer))
 import           Test.Consensus.PeerSimulator.Trace (mkChainSyncClientTracer,
                      traceUnitWith)
-import           Test.Consensus.PointSchedule (PeerId, TestFragH)
+import           Test.Consensus.PointSchedule (TestFragH)
+import           Test.Consensus.PointSchedule.Peers (PeerId)
 import           Test.Util.Orphans.IOLike ()
 import           Test.Util.TestBlock (TestBlock)
 

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Handlers.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Handlers.hs
@@ -44,12 +44,10 @@ import           Test.Consensus.PeerSimulator.ScheduledBlockFetchServer
 import           Test.Consensus.PeerSimulator.ScheduledChainSyncServer
                      (FindIntersect (..),
                      RequestNext (AwaitReply, RollBackward, RollForward))
-import           Test.Consensus.PeerSimulator.Trace (terseBlock, terseFrag,
-                     tersePoint)
 import           Test.Consensus.PointSchedule
 import           Test.Util.Orphans.IOLike ()
+import           Test.Util.TersePrinting (terseBlock, terseFragment, tersePoint)
 import           Test.Util.TestBlock (TestBlock, TestHash (TestHash))
-
 
 toPoint :: (HasHeader block, HeaderHash block ~ TestHash) => WithOrigin block -> Point TestBlock
 toPoint = castPoint . withOrigin GenesisPoint blockPoint
@@ -116,7 +114,7 @@ handlerRequestNext ::
 handlerRequestNext currentIntersection blockTree points =
   runWriterT $ do
     intersection <- lift $ readTVar currentIntersection
-    trace $ "  last intersection is " ++ condense intersection
+    trace $ "  last intersection is " ++ tersePoint intersection
     withHeader intersection (coerce (header points))
   where
     withHeader :: Point TestBlock -> WithOrigin (Header TestBlock) -> WriterT [String] (STM m) (Maybe RequestNext)
@@ -144,7 +142,7 @@ handlerRequestNext currentIntersection blockTree points =
       -- we have something to serve.
       (BT.PathAnchoredAtSource True, fragmentAhead@(next AF.:< _)) -> do
         trace "  intersection is before our header point"
-        trace $ "  fragment ahead: " ++ terseFrag fragmentAhead
+        trace $ "  fragment ahead: " ++ terseFragment fragmentAhead
         lift $ writeTVar currentIntersection $ blockPoint next
         pure $ Just (RollForward (getHeader next) (coerce (tip points)))
       -- If the anchor is not the intersection but the fragment is empty, then
@@ -211,7 +209,7 @@ handlerBlockFetch blockTree (ChainRange from to) AdvertisedPoints {header = Head
     -- must refuse.
     serveFromBpFragment = \case
       Just slice -> do
-        trace ("Starting batch for slice " ++ terseFrag slice)
+        trace ("Starting batch for slice " ++ terseFragment slice)
         pure (Just (StartBatch (AF.toOldestFirst slice)))
       Nothing    -> do
         trace ("Waiting for next tick for range: " ++ tersePoint from ++ " -> " ++ tersePoint to)

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Resources.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Resources.hs
@@ -41,6 +41,7 @@ import           Test.Consensus.PeerSimulator.ScheduledBlockFetchServer
                      runScheduledBlockFetchServer)
 import           Test.Consensus.PeerSimulator.ScheduledChainSyncServer
 import           Test.Consensus.PointSchedule
+import           Test.Consensus.PointSchedule.Peers (PeerId)
 import           Test.Util.Orphans.IOLike ()
 import           Test.Util.TestBlock (TestBlock)
 

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Run.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Run.hs
@@ -52,9 +52,10 @@ import           Test.Consensus.PeerSimulator.StateView
 import           Test.Consensus.PeerSimulator.Trace
 import qualified Test.Consensus.PointSchedule as PointSchedule
 import           Test.Consensus.PointSchedule (GenesisTest (GenesisTest),
-                     Peer (Peer), PeerId, PointSchedule (PointSchedule),
-                     PointScheduleConfig, TestFragH, Tick (Tick),
-                     pointSchedulePeers, prettyPointSchedule)
+                     PointSchedule (PointSchedule), PointScheduleConfig,
+                     TestFragH, Tick (Tick), pointSchedulePeers,
+                     prettyPointSchedule)
+import           Test.Consensus.PointSchedule.Peers (Peer (..), PeerId)
 import           Test.Ouroboros.Consensus.ChainGenerator.Params (Asc)
 import           Test.Util.ChainDB
 import           Test.Util.Orphans.IOLike ()

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Run.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Run.hs
@@ -21,12 +21,13 @@ import           Data.Functor (void)
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           Ouroboros.Consensus.Config (TopLevelConfig (..))
+import           Ouroboros.Consensus.Genesis.Governor (updateLoEFragStall)
 import           Ouroboros.Consensus.MiniProtocol.ChainSync.Client (ChainDbView)
 import qualified Ouroboros.Consensus.MiniProtocol.ChainSync.Client as CSClient
 import           Ouroboros.Consensus.Storage.ChainDB.API
 import qualified Ouroboros.Consensus.Storage.ChainDB.API as ChainDB
 import           Ouroboros.Consensus.Storage.ChainDB.Impl
-                     (ChainDbArgs (cdbTracer))
+                     (ChainDbArgs (cdbTracer), cdbLoE)
 import qualified Ouroboros.Consensus.Storage.ChainDB.Impl as ChainDB.Impl
 import           Ouroboros.Consensus.Util.Condense (Condense (..))
 import           Ouroboros.Consensus.Util.IOLike (IOLike,
@@ -87,9 +88,17 @@ data SchedulerConfig =
     -- | Whether to trace when running the scheduler.
     , scTrace           :: Bool
 
-    -- Whether to trace only the current state of the candidates and selection,
+    -- | Whether to trace only the current state of the candidates and selection,
     -- which provides a less verbose view of the test progress.
     , scTraceState      :: Bool
+
+    -- | The LoE is degenerate at the moment, so when this is enabled, we use
+    -- the stalling version of the fragment updater, which sets it to the shared
+    -- prefix of all candidates, in anticipation of the GDDG killing peers,
+    -- which never happens.
+    -- Just for the purpose of testing that the selection indeed doesn't
+    -- advance.
+    , scEnableLoE       :: Bool
   }
 
 -- | Determine timeouts based on the 'Asc' and a slot length of 20 seconds.
@@ -101,7 +110,8 @@ defaultSchedulerConfig scSchedule asc =
     scSchedule,
     scDebug = False,
     scTrace = True,
-    scTraceState = False
+    scTraceState = False,
+    scEnableLoE = False
   }
   where
     scSlotLength = slotLengthFromSec 20
@@ -115,7 +125,8 @@ noTimeoutsSchedulerConfig scSchedule =
     scSchedule,
     scDebug = False,
     scTrace = True,
-    scTraceState = False
+    scTraceState = False,
+    scEnableLoE = False
   }
   where
     scSlotLength = slotLengthFromSec 20
@@ -253,7 +264,9 @@ runPointSchedule schedulerConfig GenesisTest {gtSecurityParam = k, gtBlockTree} 
   withRegistry $ \registry -> do
     stateViewTracers <- defaultStateViewTracers
     resources <- makePeerSimulatorResources tracer gtBlockTree (pointSchedulePeers pointSchedule)
-    chainDb <- mkChainDb tracer config registry
+    let getCandidates = traverse readTVar =<< readTVar (psrCandidates resources)
+        updateLoEFrag = updateLoEFragStall k getCandidates
+    chainDb <- mkChainDb schedulerConfig tracer config registry updateLoEFrag
     fetchClientRegistry <- newFetchClientRegistry
     let chainDbView = CSClient.defaultChainDbView chainDb
     for_ (psrPeers resources) $ \PeerResources {prShared, prChainSync} -> do
@@ -264,8 +277,7 @@ runPointSchedule schedulerConfig GenesisTest {gtSecurityParam = k, gtBlockTree} 
     -- The block fetch logic needs to be started after the block fetch clients
     -- otherwise, an internal assertion fails because getCandidates yields more
     -- peer fragments than registered clients.
-    let getCandidates = traverse readTVar =<< readTVar (psrCandidates resources)
-        getCurrentChain = ChainDB.getCurrentChain chainDb
+    let getCurrentChain = ChainDB.getCurrentChain chainDb
         getPoints = traverse readTVar (srCurrentState . prShared <$> (psrPeers resources))
         mkStateTracer
           | scTraceState schedulerConfig
@@ -285,11 +297,13 @@ runPointSchedule schedulerConfig GenesisTest {gtSecurityParam = k, gtBlockTree} 
 -- candidate fragments.
 mkChainDb ::
   IOLike m =>
+  SchedulerConfig ->
   Tracer m String ->
   TopLevelConfig TestBlock ->
   ResourceRegistry m ->
+  UpdateLoEFrag m TestBlock ->
   m (ChainDB m TestBlock)
-mkChainDb tracer nodeCfg registry = do
+mkChainDb schedulerConfig tracer nodeCfg registry updateLoEFrag = do
     chainDbArgs <- do
       mcdbNodeDBs <- emptyNodeDBs
       pure $ (
@@ -301,7 +315,8 @@ mkChainDb tracer nodeCfg registry = do
           , mcdbNodeDBs
           }
         ) {
-            cdbTracer = mkCdbTracer tracer
+            cdbTracer = mkCdbTracer tracer,
+            cdbLoE
         }
     (_, (chainDB, ChainDB.Impl.Internal{intAddBlockRunner})) <-
       allocate
@@ -310,3 +325,7 @@ mkChainDb tracer nodeCfg registry = do
         (ChainDB.closeDB . fst)
     _ <- forkLinkedThread registry "AddBlockRunner" intAddBlockRunner
     pure chainDB
+  where
+    cdbLoE
+      | scEnableLoE schedulerConfig = LoEEnabled updateLoEFrag
+      | otherwise = LoEDisabled

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/ScheduledBlockFetchServer.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/ScheduledBlockFetchServer.hs
@@ -11,7 +11,6 @@ module Test.Consensus.PeerSimulator.ScheduledBlockFetchServer (
   ) where
 
 import           Control.Tracer
-import           Data.List (intercalate)
 import           Ouroboros.Consensus.Block (Point)
 import           Ouroboros.Consensus.Util.Condense (Condense)
 import           Ouroboros.Consensus.Util.IOLike (IOLike, MonadSTM (STM))
@@ -20,6 +19,7 @@ import           Ouroboros.Network.Protocol.BlockFetch.Server
 import           Test.Consensus.PeerSimulator.ScheduledServer
                      (ScheduledServer (..), awaitOnlineState, runHandler)
 import           Test.Consensus.PeerSimulator.Trace
+import           Test.Util.TersePrinting (terseBlock)
 import           Test.Util.TestBlock (TestBlock)
 
 -- | Return values for the 'handlerSendBlocks'.
@@ -72,7 +72,7 @@ scheduledBlockFetchServer ScheduledBlockFetchServer {sbfsServer, sbfsHandlers} =
     blockFetch range =
       runHandler sbfsServer "BlockFetch" (bfshBlockFetch range) $ \case
         StartBatch blocks -> do
-          trace $ "  sending blocks: " ++ intercalate " " (terseBlock <$> blocks)
+          trace $ "  sending blocks: " ++ unwords (terseBlock <$> blocks)
           trace "done handling BlockFetch"
           pure $ SendMsgStartBatch (sendBlocks blocks)
         NoBlocks -> do

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/ScheduledChainSyncServer.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/ScheduledChainSyncServer.hs
@@ -24,7 +24,8 @@ import           Ouroboros.Network.Protocol.ChainSync.Server
                      ServerStNext (SendMsgRollBackward, SendMsgRollForward))
 import           Test.Consensus.PeerSimulator.ScheduledServer
                      (ScheduledServer (..), awaitOnlineState, runHandler)
-import           Test.Consensus.PeerSimulator.Trace (terseHeader, traceUnitWith)
+import           Test.Consensus.PeerSimulator.Trace (traceUnitWith)
+import           Test.Util.TersePrinting (terseHeader, terseTip)
 import           Test.Util.TestBlock (Header (..), TestBlock)
 
 -- | Pure representation of the messages produced by the handler for the @StNext@
@@ -95,7 +96,7 @@ scheduledChainSyncServer ScheduledChainSyncServer {scssHandlers, scssServer} =
       runHandler scssServer "MsgRequestNext" csshRequestNext $ \case
         RollForward header tip -> do
           trace $ "  gotta serve " ++ terseHeader header
-          trace $ "  tip is      " ++ condense tip
+          trace $ "  tip is      " ++ terseTip tip
           trace "done handling MsgRequestNext"
           pure $ Left $ SendMsgRollForward header tip go
         RollBackward point tip -> do

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/StateDiagram.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/StateDiagram.hs
@@ -54,8 +54,9 @@ import           Ouroboros.Network.Block (HeaderHash, Tip (Tip))
 import           Test.Consensus.BlockTree (BlockTree (btBranches, btTrunk),
                      BlockTreeBranch (btbSuffix), prettyBlockTree)
 import qualified Test.Consensus.PointSchedule as PS
-import           Test.Consensus.PointSchedule (AdvertisedPoints, PeerId (..),
-                     TestFrag, TestFragH, genesisAdvertisedPoints)
+import           Test.Consensus.PointSchedule (AdvertisedPoints, TestFrag,
+                     TestFragH, genesisAdvertisedPoints)
+import           Test.Consensus.PointSchedule.Peers (PeerId (..))
 import           Test.Util.TestBlock (TestBlock, TestHash (TestHash))
 
 enableDebug :: Bool

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/StateView.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/StateView.hs
@@ -14,8 +14,8 @@ import qualified Ouroboros.Consensus.Storage.ChainDB as ChainDB
 import           Ouroboros.Consensus.Util.Condense (Condense (condense))
 import           Ouroboros.Consensus.Util.IOLike (IOLike, SomeException,
                      atomically)
-import           Test.Consensus.PeerSimulator.Trace (terseFragH)
 import           Test.Consensus.PointSchedule (PeerId, TestFragH)
+import           Test.Util.TersePrinting (terseHFragment)
 import           Test.Util.TestBlock (TestBlock)
 import           Test.Util.Tracer (recordingTracerTVar)
 
@@ -26,6 +26,10 @@ data ChainSyncException = ChainSyncException
        , cseException :: SomeException
        }
     deriving Show
+
+instance Condense ChainSyncException where
+  condense ChainSyncException{csePeerId, cseException} =
+    condense csePeerId ++ ": " ++ show cseException
 
 -- | A state view is a partial view of the state of the whole peer simulator.
 -- This includes information about the part of the code that is being tested
@@ -40,7 +44,8 @@ data StateView = StateView {
 
 instance Condense StateView where
   condense StateView {svSelectedChain, svChainSyncExceptions} =
-    "SelectedChain: " ++ terseFragH svSelectedChain ++ "\nChainSyncExceptions: " ++ show svChainSyncExceptions
+    "SelectedChain: " ++ terseHFragment svSelectedChain ++ "\n"
+    ++ "ChainSyncExceptions:\n" ++ unlines (("  - " ++) . condense <$> svChainSyncExceptions)
 
 -- | State view tracers are a lightweight mechanism to record information that
 -- can later be used to produce a state view. This mechanism relies on

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/StateView.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/StateView.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE LambdaCase     #-}
 {-# LANGUAGE NamedFieldPuns #-}
 
 module Test.Consensus.PeerSimulator.StateView (
@@ -19,7 +18,8 @@ import qualified Ouroboros.Consensus.Storage.ChainDB as ChainDB
 import           Ouroboros.Consensus.Util.Condense (Condense (condense))
 import           Ouroboros.Consensus.Util.IOLike (IOLike, SomeException,
                      atomically)
-import           Test.Consensus.PointSchedule (PeerId, TestFragH)
+import           Test.Consensus.PointSchedule (TestFragH)
+import           Test.Consensus.PointSchedule.Peers (PeerId)
 import           Test.Util.TersePrinting (terseHFragment)
 import           Test.Util.TestBlock (TestBlock)
 import           Test.Util.Tracer (recordingTracerTVar)

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
@@ -13,6 +13,7 @@ import           Test.Consensus.Genesis.Setup
 import           Test.Consensus.PeerSimulator.Run (noTimeoutsSchedulerConfig)
 import           Test.Consensus.PeerSimulator.StateView
 import           Test.Consensus.PointSchedule
+import           Test.Consensus.PointSchedule.Peers (peersOnlyHonest)
 import           Test.QuickCheck
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
@@ -47,6 +48,8 @@ prop_rollback = do
 
     (noTimeoutsSchedulerConfig defaultPointScheduleConfig)
 
+    (\_ _ _ -> [])
+
     (\_ _ -> not . hashOnTrunk . AF.headHash . svSelectedChain)
 
 -- @prop_cannotRollback@ tests that the selection of the node under test *does
@@ -62,6 +65,8 @@ prop_cannotRollback =
           else discard)
 
     (noTimeoutsSchedulerConfig defaultPointScheduleConfig)
+
+    (\_ _ _ -> [])
 
     (\_ _ -> hashOnTrunk . AF.headHash . svSelectedChain)
 

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
@@ -5,8 +5,7 @@
 
 module Test.Consensus.PeerSimulator.Tests.Rollback (tests) where
 
-import           Control.Monad.IOSim (runSimOrThrow)
-import           Ouroboros.Consensus.Block (ChainHash (..))
+import           Ouroboros.Consensus.Block (ChainHash (..), Header)
 import           Ouroboros.Consensus.Config.SecurityParam
 import qualified Ouroboros.Network.AnchoredFragment as AF
 import           Test.Consensus.BlockTree (BlockTree (..), BlockTreeBranch (..))
@@ -14,7 +13,6 @@ import           Test.Consensus.Genesis.Setup
 import           Test.Consensus.PeerSimulator.Run (noTimeoutsSchedulerConfig)
 import           Test.Consensus.PeerSimulator.StateView
 import           Test.Consensus.PointSchedule
-import qualified Test.QuickCheck as QC
 import           Test.QuickCheck
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
@@ -35,55 +33,37 @@ tests = testGroup "rollback" [
 -- | @prop_rollback@ tests that the selection of the node under test
 -- changes branches when sent a rollback to a block no older than 'k' blocks
 -- before the current selection.
-prop_rollback :: QC.Gen QC.Property
+prop_rollback :: Property
 prop_rollback = do
-  -- Create a block tree with @1@ alternative chain, such that we can rollback
-  -- from the trunk to that chain.
-  genesisTest <- genChains (pure 1)
+  forAllGenesisTest
 
-  let SecurityParam k = gtSecurityParam genesisTest
-      schedule = rollbackSchedule (fromIntegral k) (gtBlockTree genesisTest)
+    (do
+        -- Create a block tree with @1@ alternative chain, such that we can rollback
+        -- from the trunk to that chain.
+        gt@GenesisTest{gtSecurityParam, gtBlockTree} <- genChains (pure 1)
+        if alternativeChainIsLongEnough gtSecurityParam gtBlockTree
+          then pure (gt, rollbackSchedule (fromIntegral (maxRollbacks gtSecurityParam)) gtBlockTree)
+          else discard)
 
-  -- We consider the test case interesting if we can rollback
-  pure $
-    alternativeChainIsLongEnough (gtSecurityParam genesisTest) (gtBlockTree genesisTest)
-    ==>
-      runSimOrThrow $ runTest schedulerConfig genesisTest schedule $ \StateView{svSelectedChain} ->
-        let headOnAlternativeChain = case AF.headHash svSelectedChain of
-              GenesisHash    -> False
-              BlockHash hash -> any (0 /=) $ unTestHash hash
-        in
-        -- The test passes if we end up on the alternative chain
-        headOnAlternativeChain
+    (noTimeoutsSchedulerConfig defaultPointScheduleConfig)
 
-  where
-    schedulerConfig = noTimeoutsSchedulerConfig defaultPointScheduleConfig
+    (\_ _ -> not . hashOnTrunk . AF.headHash . svSelectedChain)
 
 -- @prop_cannotRollback@ tests that the selection of the node under test *does
 -- not* change branches when sent a rollback to a block strictly older than 'k'
 -- blocks before the current selection.
-prop_cannotRollback :: QC.Gen QC.Property
-prop_cannotRollback = do
-  genesisTest <- genChains (pure 1)
+prop_cannotRollback :: Property
+prop_cannotRollback =
+  forAllGenesisTest
 
-  let SecurityParam k = gtSecurityParam genesisTest
-      schedule = rollbackSchedule (fromIntegral (k + 1)) (gtBlockTree genesisTest)
+    (do gt@GenesisTest{gtSecurityParam, gtBlockTree} <- genChains (pure 1)
+        if alternativeChainIsLongEnough gtSecurityParam gtBlockTree
+          then pure (gt, rollbackSchedule (fromIntegral (maxRollbacks gtSecurityParam + 1)) gtBlockTree)
+          else discard)
 
-  -- We consider the test case interesting if it allows to rollback even if
-  -- the implementation doesn't
-  pure $
-    alternativeChainIsLongEnough (gtSecurityParam genesisTest) (gtBlockTree genesisTest)
-    ==>
-      runSimOrThrow $ runTest schedulerConfig genesisTest schedule $ \StateView{svSelectedChain} ->
-        let headOnAlternativeChain = case AF.headHash svSelectedChain of
-              GenesisHash    -> False
-              BlockHash hash -> any (0 /=) $ unTestHash hash
-        in
-        -- The test passes if we end up on the trunk.
-        not headOnAlternativeChain
+    (noTimeoutsSchedulerConfig defaultPointScheduleConfig)
 
-  where
-    schedulerConfig = noTimeoutsSchedulerConfig defaultPointScheduleConfig
+    (\_ _ -> hashOnTrunk . AF.headHash . svSelectedChain)
 
 -- | A schedule that advertises all the points of the trunk up until the nth
 -- block after the intersection, then switches to the first alternative
@@ -118,3 +98,9 @@ alternativeChainIsLongEnough (SecurityParam k) blockTree =
         _   -> error "The block tree must have exactly one alternative branch"
       lengthSuffix = AF.length btbSuffix
    in lengthSuffix > fromIntegral k
+
+-- | Given a hash, checks whether it is on the trunk of the block tree, that is
+-- if it only contains zeroes.
+hashOnTrunk :: ChainHash (Header TestBlock) -> Bool
+hashOnTrunk GenesisHash      = True
+hashOnTrunk (BlockHash hash) = all (== 0) $ unTestHash hash

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
@@ -17,6 +17,7 @@ import           Test.Consensus.PeerSimulator.Run (SchedulerConfig (..),
                      defaultSchedulerConfig)
 import           Test.Consensus.PeerSimulator.StateView
 import           Test.Consensus.PointSchedule
+import           Test.Consensus.PointSchedule.Peers (Peer (..), PeerId (..))
 import           Test.QuickCheck
 import           Test.Tasty
 import           Test.Tasty.QuickCheck

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
@@ -1,6 +1,5 @@
 module Test.Consensus.PeerSimulator.Tests.Timeouts (tests) where
 
-import           Control.Monad.IOSim (runSimOrThrow)
 import           Data.List.NonEmpty (NonEmpty ((:|)))
 import           Data.Maybe (fromJust)
 import           Ouroboros.Consensus.Block (getHeader)
@@ -18,7 +17,6 @@ import           Test.Consensus.PeerSimulator.Run (SchedulerConfig (..),
                      defaultSchedulerConfig)
 import           Test.Consensus.PeerSimulator.StateView
 import           Test.Consensus.PointSchedule
-import qualified Test.QuickCheck as QC
 import           Test.QuickCheck
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
@@ -28,7 +26,7 @@ import           Test.Util.TestEnv (adjustQuickCheckTests)
 tests :: TestTree
 tests = adjustQuickCheckTests (`div` 10) $ testProperty "timeouts" prop_timeouts
 
-prop_timeouts :: QC.Gen QC.Property
+prop_timeouts :: Gen Property
 prop_timeouts = do
   genesisTest <- genChains (pure 0)
 
@@ -43,8 +41,11 @@ prop_timeouts = do
           (fromJust $ mustReplyTimeout (scChainSyncTimeouts schedulerConfig))
           (btTrunk $ gtBlockTree genesisTest)
 
-  pure $ runSimOrThrow $
-    runTest schedulerConfig genesisTest schedule $ \stateView ->
+  -- NOTE: Because the scheduler configuration depends on the generated
+  -- 'GenesisTest' itself, we cannot rely on helpers such as
+  -- 'forAllGenesisTest'.
+  pure $
+    runGenesisTest' schedulerConfig genesisTest schedule $ \stateView ->
       case svChainSyncExceptions stateView of
         [] ->
           counterexample ("result: " ++ condense (svSelectedChain stateView)) False

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
@@ -1,6 +1,3 @@
-{-# LANGUAGE LambdaCase     #-}
-{-# LANGUAGE NamedFieldPuns #-}
-
 module Test.Consensus.PeerSimulator.Tests.Timeouts (tests) where
 
 import           Control.Monad.IOSim (runSimOrThrow)
@@ -36,13 +33,13 @@ prop_timeouts = do
   genesisTest <- genChains (pure 0)
 
   -- Use higher tick duration to avoid the test taking really long
-  let scSchedule = PointScheduleConfig {pscTickDuration = 1}
+  let scSchedule' = PointScheduleConfig {pscTickDuration = 1}
 
-      schedulerConfig = defaultSchedulerConfig scSchedule (gtHonestAsc genesisTest)
+      schedulerConfig = defaultSchedulerConfig scSchedule' (gtHonestAsc genesisTest)
 
       schedule =
         dullSchedule
-          scSchedule
+          scSchedule'
           (fromJust $ mustReplyTimeout (scChainSyncTimeouts schedulerConfig))
           (btTrunk $ gtBlockTree genesisTest)
 

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Trace.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Trace.hs
@@ -2,45 +2,28 @@
 {-# LANGUAGE NamedFieldPuns     #-}
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE TypeFamilies       #-}
-{-# LANGUAGE TypeOperators      #-}
 
 -- | Helpers for tracing used by the peer simulator.
 module Test.Consensus.PeerSimulator.Trace (
     mkCdbTracer
   , mkChainSyncClientTracer
-  , terseBlock
-  , terseFrag
-  , terseFragH
-  , terseHeader
-  , tersePoint
+  , prettyTime
   , traceLinesWith
   , traceUnitWith
   ) where
 
-import           Cardano.Slotting.Block (BlockNo (BlockNo))
-import           Cardano.Slotting.Slot (SlotNo (SlotNo))
 import           Control.Tracer (Tracer (Tracer), traceWith)
-import           Data.Foldable (traverse_)
-import           Data.List (intercalate)
-import           Data.List.NonEmpty (NonEmpty ((:|)))
 import           Data.Time.Clock (diffTimeToPicoseconds)
-import           Ouroboros.Consensus.Block (Header,
-                     Point (BlockPoint, GenesisPoint), blockHash, blockNo,
-                     blockSlot, getHeader)
 import           Ouroboros.Consensus.MiniProtocol.ChainSync.Client
                      (TraceChainSyncClientEvent (..))
 import qualified Ouroboros.Consensus.Storage.ChainDB.Impl as ChainDB.Impl
 import           Ouroboros.Consensus.Storage.ChainDB.Impl.Types
                      (SelectionChangedInfo (..), TraceAddBlockEvent (..))
-import           Ouroboros.Consensus.Util.Condense (Condense (..))
 import           Ouroboros.Consensus.Util.IOLike (IOLike, MonadMonotonicTime,
                      Time (Time), getMonotonicTime)
-import           Ouroboros.Network.AnchoredFragment
-                     (Anchor (Anchor, AnchorGenesis), AnchoredFragment,
-                     AnchoredSeq (Empty), anchor, mapAnchoredFragment,
-                     toOldestFirst)
-import           Test.Util.TestBlock (Header (TestHeader), TestBlock,
-                     TestHash (TestHash), unTestHash)
+import           Test.Util.TersePrinting (terseHFragment, tersePoint,
+                     terseRealPoint)
+import           Test.Util.TestBlock (TestBlock)
 import           Text.Printf (printf)
 
 mkCdbTracer ::
@@ -53,11 +36,11 @@ mkCdbTracer tracer =
       case event of
         AddedToCurrentChain _ SelectionChangedInfo {newTipPoint} _ _ -> do
           trace "Added to current chain"
-          trace $ "New tip: " ++ condense newTipPoint
+          trace $ "New tip: " ++ terseRealPoint newTipPoint
         SwitchedToAFork _ SelectionChangedInfo {newTipPoint} _ newFragment -> do
           trace "Switched to a fork"
-          trace $ "New tip: " ++ condense newTipPoint
-          trace $ "New fragment: " ++ condense newFragment
+          trace $ "New tip: " ++ terseRealPoint newTipPoint
+          trace $ "New fragment: " ++ terseHFragment newFragment
         _ -> pure ()
     _ -> pure ()
   where
@@ -70,72 +53,30 @@ mkChainSyncClientTracer ::
 mkChainSyncClientTracer tracer =
   Tracer $ \case
     TraceRolledBack point ->
-      trace $ "Rolled back to: " ++ condense point
+      trace $ "Rolled back to: " ++ tersePoint point
     TraceFoundIntersection point _ourTip _theirTip ->
-      trace $ "Found intersection at: " ++ condense point
+      trace $ "Found intersection at: " ++ tersePoint point
     _ -> pure ()
   where
     trace = traceUnitWith tracer "ChainSyncClient"
 
+prettyTime :: MonadMonotonicTime m => m String
+prettyTime = do
+  Time time <- getMonotonicTime
+  let ps = diffTimeToPicoseconds time
+      milliseconds = ps `quot` 1_000_000_000
+      seconds = milliseconds `quot` 1_000
+      minutes = seconds `quot` 60
+  pure $ printf "%02d:%02d.%03d" minutes (seconds `rem` 60) (milliseconds `rem` 1_000)
+
 -- | Trace using the given tracer, printing the current time (typically the time
 -- of the simulation) and the unit name.
-traceUnitWith :: MonadMonotonicTime m => Tracer m String -> String -> String -> m ()
-traceUnitWith tracer unit msg = do
-  time <- getMonotonicTime
-  traceWith tracer $ printf "%s %s | %s" (showTime time) unit msg
-  where
-    showTime :: Time -> String
-    showTime (Time time) =
-      let ps = diffTimeToPicoseconds time
-          milliseconds = (ps `div` 1_000_000_000) `mod` 1_000
-          seconds = (ps `div` 1_000_000_000_000) `rem` 60
-          minutes = (ps `div` 1_000_000_000_000) `quot` 60
-       in printf "%02d:%02d.%03d" minutes seconds milliseconds
+traceUnitWith :: Tracer m String -> String -> String -> m ()
+traceUnitWith tracer unit msg =
+  traceWith tracer $ printf "%s | %s" unit msg
 
 traceLinesWith ::
-  Applicative m =>
   Tracer m String ->
   [String] ->
   m ()
-traceLinesWith = traverse_ . traceWith
-
-terseSlotBlock :: SlotNo -> BlockNo -> String
-terseSlotBlock (SlotNo slot) (BlockNo block) =
-  show slot ++ "-" ++ show block
-
-terseSlotBlockFork :: SlotNo -> BlockNo -> TestHash -> String
-terseSlotBlockFork sno bno (TestHash hash) =
-  terseSlotBlock sno bno ++ forkNoSuffix hash
-  where
-    forkNoSuffix (forkNo :| _) | forkNo == 0 = ""
-                               | otherwise = "[" ++ show forkNo ++ "]"
-
-terseBlock :: TestBlock -> String
-terseBlock block =
-  terseSlotBlockFork (blockSlot block) (blockNo block) (blockHash block)
-
-terseHeader :: Header TestBlock -> String
-terseHeader (TestHeader block) = terseBlock block
-
-tersePoint :: Point TestBlock -> String
-tersePoint = \case
-  BlockPoint slot hash -> terseSlotBlockFork slot (BlockNo (fromIntegral (length (unTestHash hash)))) hash
-  GenesisPoint -> "G"
-
-terseFragH :: AnchoredFragment (Header TestBlock) -> String
-terseFragH frag =
-  renderAnchor ++ renderBlocks
-  where
-    renderBlocks = case frag of
-      Empty _ -> ""
-      _       -> " | " ++ intercalate " " (terseHeader <$> toOldestFirst frag)
-    renderAnchor = case anchor frag of
-      AnchorGenesis -> "G"
-      Anchor slot hash block -> terseSlotBlock slot block ++ renderAnchorHash hash
-    renderAnchorHash hash
-      | all (== 0) (unTestHash hash) = ""
-      | otherwise = condense hash
-
-terseFrag :: AnchoredFragment TestBlock -> String
-terseFrag =
-  terseFragH . mapAnchoredFragment getHeader
+traceLinesWith tracer = traceWith tracer . unlines

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Trace.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Trace.hs
@@ -19,6 +19,7 @@ import           Ouroboros.Consensus.MiniProtocol.ChainSync.Client
 import qualified Ouroboros.Consensus.Storage.ChainDB.Impl as ChainDB.Impl
 import           Ouroboros.Consensus.Storage.ChainDB.Impl.Types
                      (SelectionChangedInfo (..), TraceAddBlockEvent (..))
+import           Ouroboros.Consensus.Util.Condense (Condense (..))
 import           Ouroboros.Consensus.Util.IOLike (IOLike, MonadMonotonicTime,
                      Time (Time), getMonotonicTime)
 import           Test.Util.TersePrinting (terseHFragment, tersePoint,
@@ -41,6 +42,9 @@ mkCdbTracer tracer =
           trace "Switched to a fork"
           trace $ "New tip: " ++ terseRealPoint newTipPoint
           trace $ "New fragment: " ++ terseHFragment newFragment
+        StoreButDontChange block -> do
+          trace "Did not add block due to LoE"
+          trace $ "Block: " ++ condense block
         _ -> pure ()
     _ -> pure ()
   where

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveGeneric         #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE LambdaCase            #-}
@@ -32,10 +31,7 @@ module Test.Consensus.PointSchedule (
   , GenesisWindow (..)
   , HeaderPoint (..)
   , NodeState (..)
-  , Peer (..)
-  , PeerId (..)
   , PeerSchedule
-  , Peers (..)
   , PointSchedule (..)
   , PointScheduleConfig (..)
   , TestFrag
@@ -44,32 +40,31 @@ module Test.Consensus.PointSchedule (
   , TipPoint (..)
   , balanced
   , banalStates
+  , blockPointBlock
   , defaultPointScheduleConfig
   , fromSchedulePoints
   , genesisAdvertisedPoints
+  , headerPointBlock
   , longRangeAttack
-  , mkPeers
-  , peersOnlyHonest
+  , peerSchedulesBlocks
+  , pointScheduleBlocks
   , pointSchedulePeers
   , prettyGenesisTest
   , prettyPointSchedule
   , stToGen
+  , tipPointBlock
   , uniformPoints
   ) where
 
 import           Control.Monad.ST (ST)
 import           Data.Foldable (toList)
-import           Data.Hashable (Hashable)
 import           Data.List (mapAccumL, partition, scanl', transpose)
-import           Data.List.NonEmpty (NonEmpty ((:|)))
+import           Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NonEmpty
-import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import           Data.Maybe (fromMaybe, listToMaybe)
-import           Data.String (IsString (fromString))
+import           Data.Maybe (catMaybes, fromMaybe, listToMaybe)
 import           Data.Time (DiffTime)
 import           Data.Word (Word64)
-import           GHC.Generics (Generic)
 import           Ouroboros.Consensus.Block.Abstract (WithOrigin (..), getHeader)
 import           Ouroboros.Consensus.Protocol.Abstract (SecurityParam,
                      maxRollbacks)
@@ -77,16 +72,18 @@ import           Ouroboros.Consensus.Util.Condense (Condense (condense))
 import           Ouroboros.Network.AnchoredFragment (AnchoredFragment,
                      AnchoredSeq (Empty, (:>)))
 import qualified Ouroboros.Network.AnchoredFragment as AF
-import           Ouroboros.Network.Block (Tip (TipGenesis), tipFromHeader)
+import           Ouroboros.Network.Block (Tip (..), tipFromHeader)
 import           Ouroboros.Network.Point (WithOrigin (At))
 import qualified System.Random.Stateful as Random
 import           System.Random.Stateful (STGenM, StatefulGen, runSTGen_)
 import           Test.Consensus.BlockTree (BlockTree (..), BlockTreeBranch (..),
                      prettyBlockTree)
+import           Test.Consensus.PointSchedule.Peers (Peer (..), PeerId (..),
+                     Peers (..), getPeerIds, mkPeers, peersList)
 import           Test.Consensus.PointSchedule.SinglePeer
                      (IsTrunk (IsBranch, IsTrunk), PeerScheduleParams (..),
                      SchedulePoint (..), defaultPeerScheduleParams, mergeOn,
-                     peerScheduleFromTipPoints)
+                     peerScheduleFromTipPoints, schedulePointToBlock)
 import           Test.Consensus.PointSchedule.SinglePeer.Indices
                      (uniformRMDiffTime)
 import           Test.Ouroboros.Consensus.ChainGenerator.Params (Asc,
@@ -95,7 +92,8 @@ import           Test.QuickCheck (Gen, arbitrary)
 import           Test.QuickCheck.Random (QCGen)
 import           Test.Util.TersePrinting (terseBlock, terseHeader, terseTip,
                      terseWithOrigin)
-import           Test.Util.TestBlock (Header, TestBlock)
+import           Test.Util.TestBlock (Header, TestBlock, Validity (Valid),
+                     testHeader, unsafeTestBlockWithPayload)
 import           Text.Printf (printf)
 
 ----------------------------------------------------------------------------------------------------
@@ -115,6 +113,12 @@ newtype TipPoint =
 instance Condense TipPoint where
   condense (TipPoint tip) = terseTip tip
 
+-- | Convert a 'TipPoint' to a 'TestBlock'.
+tipPointBlock :: TipPoint -> Maybe TestBlock
+tipPointBlock (TipPoint TipGenesis) = Nothing
+tipPointBlock (TipPoint (Tip slot hash _)) =
+  Just $ unsafeTestBlockWithPayload hash slot Valid ()
+
 -- | The latest header that should be sent to the client by the ChainSync server
 -- in a tick.
 newtype HeaderPoint =
@@ -124,6 +128,11 @@ newtype HeaderPoint =
 instance Condense HeaderPoint where
   condense (HeaderPoint header) = terseWithOrigin terseHeader header
 
+-- | Convert a 'HeaderPoint' to a 'TestBlock'.
+headerPointBlock :: HeaderPoint -> Maybe TestBlock
+headerPointBlock (HeaderPoint Origin)      = Nothing
+headerPointBlock (HeaderPoint (At header)) = Just $ testHeader header
+
 -- | The latest block that should be sent to the client by the BlockFetch server
 -- in a tick.
 newtype BlockPoint =
@@ -132,6 +141,11 @@ newtype BlockPoint =
 
 instance Condense BlockPoint where
   condense (BlockPoint block) = terseWithOrigin terseBlock block
+
+-- | Convert a 'BlockPoint' to a 'Point'.
+blockPointBlock :: BlockPoint -> Maybe TestBlock
+blockPointBlock (BlockPoint Origin)     = Nothing
+blockPointBlock (BlockPoint (At block)) = Just block
 
 -- | The set of parameters that define the state that a peer should reach when it receives control
 -- by the scheduler in a single tick.
@@ -180,62 +194,6 @@ instance Condense NodeState where
     NodeOnline points -> condense points
     NodeOffline -> "*chrrrk* <signal lost>"
 
--- | Identifier used to index maps and specify which peer is active during a tick.
-data PeerId =
-  HonestPeer
-  |
-  PeerId String
-  deriving (Eq, Generic, Show, Ord)
-
-instance IsString PeerId where
-  fromString "honest" = HonestPeer
-  fromString i        = PeerId i
-
-instance Condense PeerId where
-  condense = \case
-    HonestPeer -> "honest"
-    PeerId name -> name
-
-instance Hashable PeerId
-
--- | General-purpose functor associated with a peer.
-data Peer a =
-  Peer {
-    name  :: PeerId,
-    value :: a
-  }
-  deriving (Eq, Show)
-
-instance Functor Peer where
-  fmap f Peer {name, value} = Peer {name, value = f value}
-
-instance Foldable Peer where
-  foldr step z (Peer _ a) = step a z
-
-instance Traversable Peer where
-  sequenceA (Peer name fa) =
-    Peer name <$> fa
-
-instance Condense a => Condense (Peer a) where
-  condense Peer {name, value} = condense name ++ ": " ++ condense value
-
--- | General-purpose functor for a set of peers.
---
--- REVIEW: There is a duplicate entry for the honest peer, here. We should
--- probably either have only the 'Map' or have the keys of the map be 'String'?
---
--- Alternatively, we could just have 'newtype PeerId = PeerId String' with an
--- alias for 'HonestPeer = PeerId "honest"'?
-data Peers a =
-  Peers {
-    honest :: Peer a,
-    others :: Map PeerId (Peer a)
-  }
-  deriving (Eq, Show)
-
-instance Functor Peers where
-  fmap f Peers {honest, others} = Peers {honest = f <$> honest, others = fmap f <$> others}
-
 -- | A tick is an entry in a 'PointSchedule', containing the peer that is
 -- going to change state.
 data Tick =
@@ -260,14 +218,6 @@ tickDefault PointScheduleConfig {pscTickDuration} number active =
 tickDefaults :: PointScheduleConfig -> [Peer NodeState] -> [Tick]
 tickDefaults psc states =
   uncurry (tickDefault psc) <$> zip [0 ..] states
-
--- | A set of peers with only one honest peer carrying the given value.
-peersOnlyHonest :: a -> Peers a
-peersOnlyHonest value =
-  Peers {
-    honest = Peer {name = HonestPeer, value},
-    others = Map.empty
-    }
 
 -- | A point schedule is a series of states for a set of peers.
 --
@@ -307,10 +257,6 @@ defaultPointScheduleConfig =
 -- Accessors
 ----------------------------------------------------------------------------------------------------
 
--- | Extract all 'PeerId's.
-getPeerIds :: Peers a -> NonEmpty PeerId
-getPeerIds peers = HonestPeer :| Map.keys (others peers)
-
 -- | Get the names of the peers involved in this point schedule.
 -- This is the main motivation for requiring the point schedule to be
 -- nonempty, so we don't have to carry around another value for the
@@ -318,21 +264,16 @@ getPeerIds peers = HonestPeer :| Map.keys (others peers)
 pointSchedulePeers :: PointSchedule -> NonEmpty PeerId
 pointSchedulePeers = peerIds
 
--- | Convert 'Peers' to a list of 'Peer'.
-peersList :: Peers a -> NonEmpty (Peer a)
-peersList Peers {honest, others} =
-  honest :| Map.elems others
-
--- | Construct 'Peers' from values, adding adversary names based on the default schema.
--- A single adversary gets the ID @adversary@, multiple get enumerated as @adversary N@.
-mkPeers :: a -> [a] -> Peers a
-mkPeers h as =
-  Peers (Peer HonestPeer h) (Map.fromList (mkPeer <$> advs as))
-  where
-    mkPeer (pid, a) = (pid, Peer pid a)
-    advs [a] = [("adversary", a)]
-    advs _   = zip enumAdvs as
-    enumAdvs = (\ n -> PeerId ("adversary " ++ show n)) <$> [1 :: Int ..]
+-- | List of all blocks appearing in the schedule as tip point, header point or
+-- block point.
+pointScheduleBlocks :: PointSchedule -> [TestBlock]
+pointScheduleBlocks PointSchedule{ticks} =
+  catMaybes $ concatMap
+    (\Tick{active=Peer{value}} -> case value of
+         NodeOffline -> []
+         NodeOnline (AdvertisedPoints{tip, header, block}) ->
+           [tipPointBlock tip, headerPointBlock header, blockPointBlock block])
+    ticks
 
 ----------------------------------------------------------------------------------------------------
 -- Conversion to 'PointSchedule'
@@ -387,6 +328,14 @@ fromSchedulePoints peers = do
     durations = snd (mapAccumL (\ prev start -> (start, start - prev)) 0 (drop 1 starts)) ++ [0.1]
 
     (starts, states) = unzip $ foldr (mergeOn fst) [] (peerStates <$> toList (peersList peers))
+
+-- | List of all blocks appearing in the schedule.
+peerScheduleBlocks :: PeerSchedule -> [TestBlock]
+peerScheduleBlocks = map (schedulePointToBlock . snd)
+
+-- | List of all blocks appearing in the schedules.
+peerSchedulesBlocks :: Peers PeerSchedule -> [TestBlock]
+peerSchedulesBlocks = concatMap (peerScheduleBlocks . value) . toList . peersList
 
 ----------------------------------------------------------------------------------------------------
 -- Schedule generators

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
@@ -77,8 +77,7 @@ import           Ouroboros.Consensus.Util.Condense (Condense (condense))
 import           Ouroboros.Network.AnchoredFragment (AnchoredFragment,
                      AnchoredSeq (Empty, (:>)))
 import qualified Ouroboros.Network.AnchoredFragment as AF
-import           Ouroboros.Network.Block (Tip (Tip, TipGenesis), blockNo,
-                     blockSlot, tipFromHeader)
+import           Ouroboros.Network.Block (Tip (TipGenesis), tipFromHeader)
 import           Ouroboros.Network.Point (WithOrigin (At))
 import qualified System.Random.Stateful as Random
 import           System.Random.Stateful (STGenM, StatefulGen, runSTGen_)
@@ -94,7 +93,9 @@ import           Test.Ouroboros.Consensus.ChainGenerator.Params (Asc,
                      Delta (Delta), ascVal)
 import           Test.QuickCheck (Gen, arbitrary)
 import           Test.QuickCheck.Random (QCGen)
-import           Test.Util.TestBlock (Header (TestHeader), TestBlock)
+import           Test.Util.TersePrinting (terseBlock, terseHeader, terseTip,
+                     terseWithOrigin)
+import           Test.Util.TestBlock (Header, TestBlock)
 import           Text.Printf (printf)
 
 ----------------------------------------------------------------------------------------------------
@@ -112,9 +113,7 @@ newtype TipPoint =
   deriving (Eq, Show)
 
 instance Condense TipPoint where
-  condense (TipPoint TipGenesis) = "G"
-  condense (TipPoint (Tip slot _ bno)) =
-      "B:" <> condense bno <> ",S:" <> condense slot
+  condense (TipPoint tip) = terseTip tip
 
 -- | The latest header that should be sent to the client by the ChainSync server
 -- in a tick.
@@ -123,11 +122,7 @@ newtype HeaderPoint =
   deriving (Eq, Show)
 
 instance Condense HeaderPoint where
-  condense = \case
-    HeaderPoint (At (TestHeader b)) ->
-      "B:" <> condense (blockNo b) <> ",S:" <> condense (blockSlot b)
-    HeaderPoint Origin ->
-      "G"
+  condense (HeaderPoint header) = terseWithOrigin terseHeader header
 
 -- | The latest block that should be sent to the client by the BlockFetch server
 -- in a tick.
@@ -136,11 +131,7 @@ newtype BlockPoint =
   deriving (Eq, Show)
 
 instance Condense BlockPoint where
-  condense = \case
-    BlockPoint (At b) ->
-      "B:" <> condense (blockNo b) <> ",S:" <> condense (blockSlot b)
-    BlockPoint Origin ->
-      "G"
+  condense (BlockPoint block) = terseWithOrigin terseBlock block
 
 -- | The set of parameters that define the state that a peer should reach when it receives control
 -- by the scheduler in a single tick.

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Peers.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Peers.hs
@@ -1,0 +1,172 @@
+{-# LANGUAGE DeriveGeneric         #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE LambdaCase            #-}
+{-# LANGUAGE NamedFieldPuns        #-}
+{-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE RankNTypes            #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
+
+-- | This module contains the definition of point schedule _peers_ as well as
+-- all kind of utilities to manipulate them.
+
+module Test.Consensus.PointSchedule.Peers (
+    Peer (..)
+  , PeerId (..)
+  , Peers (..)
+  , fromMap
+  , fromMap'
+  , getPeerIds
+  , mkPeers
+  , mkPeers'
+  , peersFromPeerIdList
+  , peersFromPeerIdList'
+  , peersFromPeerList
+  , peersList
+  , peersOnlyHonest
+  , toMap
+  , toMap'
+  ) where
+
+import           Data.Hashable (Hashable)
+import           Data.List.NonEmpty (NonEmpty ((:|)))
+import qualified Data.List.NonEmpty as NonEmpty
+import           Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import           Data.String (IsString (fromString))
+import           GHC.Generics (Generic)
+import           Ouroboros.Consensus.Util.Condense (Condense (condense))
+
+-- | Identifier used to index maps and specify which peer is active during a tick.
+data PeerId =
+  HonestPeer
+  |
+  PeerId String
+  deriving (Eq, Generic, Show, Ord)
+
+instance IsString PeerId where
+  fromString "honest" = HonestPeer
+  fromString i        = PeerId i
+
+instance Condense PeerId where
+  condense = \case
+    HonestPeer -> "honest"
+    PeerId name -> name
+
+instance Hashable PeerId
+
+-- | General-purpose functor associated with a peer.
+data Peer a =
+  Peer {
+    name  :: PeerId,
+    value :: a
+  }
+  deriving (Eq, Show)
+
+instance Functor Peer where
+  fmap f Peer {name, value} = Peer {name, value = f value}
+
+instance Foldable Peer where
+  foldr step z (Peer _ a) = step a z
+
+instance Traversable Peer where
+  sequenceA (Peer name fa) =
+    Peer name <$> fa
+
+instance Condense a => Condense (Peer a) where
+  condense Peer {name, value} = condense name ++ ": " ++ condense value
+
+-- | General-purpose functor for a set of peers.
+--
+-- REVIEW: There is a duplicate entry for the honest peer, here. We should
+-- probably either have only the 'Map' or have the keys of the map be 'String'?
+--
+-- Alternatively, we could just have 'newtype PeerId = PeerId String' with an
+-- alias for 'HonestPeer = PeerId "honest"'?
+data Peers a =
+  Peers {
+    honest :: Peer a,
+    others :: Map PeerId (Peer a)
+  }
+  deriving (Eq, Show)
+
+instance Functor Peers where
+  fmap f Peers {honest, others} = Peers {honest = f <$> honest, others = fmap f <$> others}
+
+-- | A set of peers with only one honest peer carrying the given value.
+peersOnlyHonest :: a -> Peers a
+peersOnlyHonest value =
+  Peers {
+    honest = Peer {name = HonestPeer, value},
+    others = Map.empty
+    }
+
+-- | Extract all 'PeerId's.
+getPeerIds :: Peers a -> NonEmpty PeerId
+getPeerIds peers = HonestPeer :| Map.keys (others peers)
+
+-- | Convert 'Peers' to a list of 'Peer'.
+peersList :: Peers a -> NonEmpty (Peer a)
+peersList Peers {honest, others} =
+  honest :| Map.elems others
+
+-- | Construct 'Peers' from values, adding adversary names based on the default schema.
+-- A single adversary gets the ID @adversary@, multiple get enumerated as @adversary N@.
+mkPeers :: a -> [a] -> Peers a
+mkPeers h as =
+  Peers (Peer HonestPeer h) (Map.fromList (mkPeer <$> advs as))
+  where
+    mkPeer (pid, a) = (pid, Peer pid a)
+    advs [a] = [("adversary", a)]
+    advs _   = zip enumAdvs as
+    enumAdvs = (\ n -> PeerId ("adversary " ++ show n)) <$> [1 :: Int ..]
+
+-- | Make a 'Peers' structure from the honest value and the other peers. Fail if
+-- one of the other peers is the 'HonestPeer'.
+mkPeers' :: a -> [Peer a] -> Peers a
+mkPeers' value prs =
+    Peers (Peer HonestPeer value) (Map.fromList $ dupAdvPeerId <$> prs)
+  where
+    -- | Duplicate an adversarial peer id; fail if honest.
+    dupAdvPeerId :: Peer a -> (PeerId, Peer a)
+    dupAdvPeerId (Peer HonestPeer _) = error "cannot be the honest peer"
+    dupAdvPeerId peer@(Peer pid _)   = (pid, peer)
+
+-- | Make a 'Peers' structure from a non-empty list of peers. Fail if the honest
+-- peer is not exactly once in the list.
+peersFromPeerList :: NonEmpty (Peer a) -> Peers a
+peersFromPeerList =
+    uncurry mkPeers' . extractHonestPeer . NonEmpty.toList
+  where
+    -- | Return the value associated with the honest peer and the list of peers
+    -- excluding the honest one.
+    extractHonestPeer :: [Peer a] -> (a, [Peer a])
+    extractHonestPeer [] = error "could not find honest peer"
+    extractHonestPeer (Peer HonestPeer value : peers) = (value, peers)
+    extractHonestPeer (peer : peers) = (peer :) <$> extractHonestPeer peers
+
+-- | Make a 'Peers' structure from a non-empty list of peer ids and a default
+-- value. Fails if the honest peer is not exactly once in the list.
+peersFromPeerIdList :: NonEmpty PeerId -> a -> Peers a
+peersFromPeerIdList = flip $ \val -> peersFromPeerList . fmap (flip Peer val)
+
+-- | Like 'peersFromPeerIdList' with @()@.
+peersFromPeerIdList' :: NonEmpty PeerId -> Peers ()
+peersFromPeerIdList' = flip peersFromPeerIdList ()
+
+toMap :: Peers a -> Map PeerId (Peer a)
+toMap Peers{honest, others} = Map.insert HonestPeer honest others
+
+-- | Same as 'toMap' but the map contains unwrapped values.
+toMap' :: Peers a -> Map PeerId a
+toMap' = fmap (\(Peer _ v) -> v) . toMap
+
+fromMap :: Map PeerId (Peer a) -> Peers a
+fromMap peers = Peers{
+    honest = peers Map.! HonestPeer,
+    others = Map.delete HonestPeer peers
+  }
+
+-- | Same as 'fromMap' but the map contains unwrapped values.
+fromMap' :: Map PeerId a -> Peers a
+fromMap' = fromMap . Map.mapWithKey Peer

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Shrinking.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Shrinking.hs
@@ -1,0 +1,75 @@
+{-# LANGUAGE NamedFieldPuns #-}
+
+module Test.Consensus.PointSchedule.Shrinking (shrinkPeerSchedules) where
+
+import           Data.Containers.ListUtils (nubOrd)
+import           Data.Functor ((<&>))
+import qualified Data.Map.Strict as Map
+import           Data.Maybe (mapMaybe)
+import           Ouroboros.Network.AnchoredFragment (AnchoredFragment,
+                     AnchoredSeq (Empty), takeWhileOldest)
+import           Test.Consensus.BlockTree (BlockTree (..), BlockTreeBranch (..),
+                     addBranch', mkTrunk)
+import           Test.Consensus.PeerSimulator.StateView (StateView)
+import           Test.Consensus.PointSchedule (GenesisTest (gtBlockTree),
+                     PeerSchedule, peerSchedulesBlocks)
+import           Test.Consensus.PointSchedule.Peers (Peers (..))
+import           Test.QuickCheck (shrinkList)
+import           Test.Util.TestBlock (TestBlock, isAncestorOf,
+                     isStrictAncestorOf)
+
+-- | Shrink a 'Peers PeerSchedule'. This does not affect the honest peer; it
+-- does, however, attempt to remove other peers or ticks of other peers. The
+-- block tree is trimmed to keep only parts that are necessary for the shrunk
+-- schedule.
+shrinkPeerSchedules ::
+  GenesisTest ->
+  Peers PeerSchedule ->
+  StateView ->
+  [(GenesisTest, Peers PeerSchedule)]
+shrinkPeerSchedules genesisTest schedule _stateView =
+  shrinkOtherPeers shrinkPeerSchedule schedule <&> \shrunkSchedule ->
+    let trimmedBlockTree = trimBlockTree' shrunkSchedule (gtBlockTree genesisTest)
+     in (genesisTest{gtBlockTree = trimmedBlockTree}, shrunkSchedule)
+
+-- | Shrink a 'PeerSchedule' by removing ticks from it. The other ticks are kept
+-- unchanged.
+shrinkPeerSchedule :: PeerSchedule -> [PeerSchedule]
+shrinkPeerSchedule = shrinkList (const [])
+
+-- | Shrink the 'others' field of a 'Peers' structure by attempting to remove
+-- peers or by shrinking their values using the given shrinking function.
+shrinkOtherPeers :: (a -> [a]) -> Peers a -> [Peers a]
+shrinkOtherPeers shrink Peers{honest, others} =
+  map (Peers honest . Map.fromList) $
+    shrinkList (traverse (traverse shrink)) $ Map.toList others
+
+-- | Remove blocks from the given block tree that are not necessary for the
+-- given peer schedules. If entire branches are unused, they are removed. If the
+-- trunk is unused, then it remains as an empty anchored fragment.
+trimBlockTree' :: Peers PeerSchedule -> BlockTree TestBlock -> BlockTree TestBlock
+trimBlockTree' = keepOnlyAncestorsOf . peerSchedulesBlocks
+
+-- | Given some blocks and a block tree, keep only the prefix of the block tree
+-- that contains ancestors of the given blocks.
+keepOnlyAncestorsOf :: [TestBlock] -> BlockTree TestBlock -> BlockTree TestBlock
+keepOnlyAncestorsOf blocks bt =
+    let leaves = blocksWithoutDescendents blocks
+        trunk = keepOnlyAncestorsOf' leaves (btTrunk bt)
+        branches = mapMaybe (fragmentToMaybe . keepOnlyAncestorsOf' leaves . btbSuffix) (btBranches bt)
+     in foldr addBranch' (mkTrunk trunk) branches
+  where
+    fragmentToMaybe (Empty _) = Nothing
+    fragmentToMaybe fragment  = Just fragment
+
+    -- | Given some blocks and a fragment, keep only the prefix of the fragment
+    -- that contains ancestors of the given blocks.
+    keepOnlyAncestorsOf' :: [TestBlock] -> AnchoredFragment TestBlock -> AnchoredFragment TestBlock
+    keepOnlyAncestorsOf' leaves = takeWhileOldest (\block -> (block `isAncestorOf`) `any` leaves)
+
+    -- | Return a subset of the given blocks containing only the ones that do
+    -- not have any other descendents in the set.
+    blocksWithoutDescendents :: [TestBlock] -> [TestBlock]
+    blocksWithoutDescendents bs =
+      let bs' = nubOrd bs
+       in [ b | b <- bs', not ((b `isStrictAncestorOf`) `any` bs') ]

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Util/TersePrinting.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Util/TersePrinting.hs
@@ -1,0 +1,117 @@
+{-# LANGUAGE TypeFamilies #-}
+
+-- | Helpers for printing various objects in a terse way. Terse printing is
+-- similar to that provided by the 'Condense' typeclass except it can be
+-- sometimes even more compact and it is very specific to tests.
+module Test.Util.TersePrinting (
+    terseBlock
+  , terseFragment
+  , terseHFragment
+  , terseHeader
+  , tersePoint
+  , terseRealPoint
+  , terseTip
+  , terseWithOrigin
+  ) where
+
+import           Cardano.Slotting.Block (BlockNo (BlockNo))
+import           Data.List (intercalate)
+import           Data.List.NonEmpty (NonEmpty ((:|)), toList)
+import qualified Data.List.NonEmpty as NE
+import           Ouroboros.Consensus.Block (Header,
+                     Point (BlockPoint, GenesisPoint), RealPoint,
+                     SlotNo (SlotNo), blockHash, blockNo, blockSlot,
+                     realPointToPoint)
+import           Ouroboros.Network.AnchoredFragment (Anchor, AnchoredFragment,
+                     anchor, anchorToPoint, mapAnchoredFragment, toOldestFirst)
+import           Ouroboros.Network.Block (Tip (..))
+import           Ouroboros.Network.Point (WithOrigin (..))
+import           Test.Util.TestBlock (Header (TestHeader), TestBlock,
+                     TestHash (TestHash), unTestHash)
+
+-- | Run-length encoding of a list. This groups consecutive duplicate elements,
+-- counting them. Only the first element of the equality is kept. For instance:
+--
+-- > runLengthEncoding [0, 0, 1, 0, 2, 2, 2] = [(2, 0), (1, 1), (1, 0), (3, 2)]
+runLengthEncoding :: Eq a => [a] -> [(Int, a)]
+runLengthEncoding xs = [(length ys, NE.head ys) | ys <- NE.group xs]
+
+-- | Print the given 'BlockNo', 'SlotNo' and 'TestHash' in a terse way:
+-- @block-slot[hash]@. @hash@ only shows if there is a non-zero element in it.
+-- When it shows, it shows in a compact form. For instance, the hash
+-- @[0,0,1,0,0,0]@ shows as @[2x0,1,3x0]@. This function is meant as a helper
+-- for other functions.
+terseBlockSlotHash :: BlockNo -> SlotNo -> TestHash -> String
+terseBlockSlotHash (BlockNo bno) (SlotNo sno) (TestHash hash) =
+    show bno ++ "-" ++ show sno ++ renderHash
+  where
+    renderHash = case runLengthEncoding (reverse (toList hash)) of
+      [(_, 0)]    -> ""
+      hashGrouped -> "[" ++ intercalate "," (map renderGroup hashGrouped) ++ "]"
+    renderGroup (1, e) = show e
+    renderGroup (n, e) = show n ++ "x" ++ show e
+
+-- | Same as 'terseBlockSlotHash' except only the last element of the hash
+-- shows, if it is non-zero. This makes sense when showing a fragment.
+terseBlockSlotHash' :: BlockNo -> SlotNo -> TestHash -> String
+terseBlockSlotHash' (BlockNo bno) (SlotNo sno) (TestHash hash) =
+    show bno ++ "-" ++ show sno ++ renderHashSuffix hash
+  where
+    renderHashSuffix (forkNo :| _)
+      | forkNo == 0 = ""
+      | otherwise = "[" ++ show forkNo ++ "]"
+
+-- | Print a 'TestBlock' as @block-slot[hash]@. @hash@ only shows if there is a
+-- non-zero element in it. When it shows, it shows in a compact form. For
+-- instance, the hash @[0,0,1,0,0,0]@ shows as @[2x0,1,3x0]@.
+terseBlock :: TestBlock -> String
+terseBlock block = terseBlockSlotHash (blockNo block) (blockSlot block) (blockHash block)
+
+-- | Same as 'terseBlock' except only the last element of the hash shows, if it
+-- is non-zero. This makes sense when showing a fragment.
+terseBlock' :: TestBlock -> String
+terseBlock' block = terseBlockSlotHash' (blockNo block) (blockSlot block) (blockHash block)
+
+-- | Same as 'terseBlock' for headers.
+terseHeader :: Header TestBlock -> String
+terseHeader (TestHeader block) = terseBlock block
+
+-- | Same as 'terseBlock' for points. Genesis shows as @G@.
+tersePoint :: Point TestBlock -> String
+tersePoint GenesisPoint = "G"
+tersePoint (BlockPoint slot hash) =
+  terseBlockSlotHash (BlockNo (fromIntegral (length (unTestHash hash)))) slot hash
+
+terseRealPoint :: RealPoint TestBlock -> String
+terseRealPoint = tersePoint . realPointToPoint
+
+-- | Same as 'tersePoint' for anchors.
+terseAnchor :: Anchor TestBlock -> String
+terseAnchor = tersePoint . anchorToPoint
+
+-- | Same as 'tersePoint' for tips.
+terseTip :: Tip TestBlock -> String
+terseTip TipGenesis         = "G"
+terseTip (Tip sno hash bno) = terseBlockSlotHash bno sno hash
+
+-- | Given a printer for elements of type @a@, prints a @WithOrigin a@ in a
+-- terse way. Origin shows as @G@.
+terseWithOrigin :: (a -> String) -> WithOrigin a -> String
+terseWithOrigin _ Origin      = "G"
+terseWithOrigin terseA (At a) = terseA a
+
+-- | Print a fragment of 'TestBlock' in a terse way. This shows as @anchor |
+-- block ...@ where @anchor@ is printed with 'terseAnchor' and @block@s are
+-- printed with @terseBlock'@; in particular, only the last element of the hash
+-- shows and only when it is non-zero.
+terseFragment :: AnchoredFragment TestBlock -> String
+terseFragment fragment =
+    terseAnchor (anchor fragment) ++ renderBlocks
+  where
+    renderBlocks = case toOldestFirst fragment of
+      []     -> ""
+      blocks -> " | " ++ unwords (map terseBlock' blocks)
+
+-- | Same as 'terseFragment' for fragments of headers.
+terseHFragment :: AnchoredFragment (Header TestBlock) -> String
+terseHFragment = terseFragment . mapAnchoredFragment (\(TestHeader block) -> block)

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -79,6 +79,7 @@ library
     Ouroboros.Consensus.Fragment.InFuture
     Ouroboros.Consensus.Fragment.Validated
     Ouroboros.Consensus.Fragment.ValidatedDiff
+    Ouroboros.Consensus.Genesis.Governor
     Ouroboros.Consensus.HardFork.Abstract
     Ouroboros.Consensus.HardFork.Combinator
     Ouroboros.Consensus.HardFork.Combinator.Abstract

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Fragment/Diff.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Fragment/Diff.hs
@@ -89,8 +89,8 @@ extend = ChainDiff 0
 -- PRECONDITION: the candidate fragment must intersect with the current chain
 -- fragment.
 diff ::
-     (HasHeader b, HasCallStack)
-  => AnchoredFragment b  -- ^ Current chain
+     (HasHeader b, HasHeader b', HeaderHash b ~ HeaderHash b', HasCallStack)
+  => AnchoredFragment b' -- ^ Current chain
   -> AnchoredFragment b  -- ^ Candidate chain
   -> ChainDiff b
 diff curChain candChain =

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Genesis/Governor.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Genesis/Governor.hs
@@ -1,0 +1,94 @@
+{-# LANGUAGE FlexibleContexts     #-}
+{-# LANGUAGE GADTs                #-}
+{-# LANGUAGE LambdaCase           #-}
+{-# LANGUAGE MultiWayIf           #-}
+{-# LANGUAGE NamedFieldPuns       #-}
+{-# LANGUAGE PatternSynonyms      #-}
+{-# LANGUAGE RecordWildCards      #-}
+{-# LANGUAGE ScopedTypeVariables  #-}
+{-# LANGUAGE TypeOperators        #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Ouroboros.Consensus.Genesis.Governor (
+    updateLoEFragStall
+  , updateLoEFragUnconditional
+  ) where
+
+import           Control.Monad.Except ()
+import           Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import           Ouroboros.Consensus.Block.Abstract (GetHeader, Header)
+import           Ouroboros.Consensus.Config.SecurityParam
+                     (SecurityParam (SecurityParam))
+import           Ouroboros.Consensus.Storage.ChainDB.API
+                     (UpdateLoEFrag (UpdateLoEFrag))
+import           Ouroboros.Consensus.Util.AnchoredFragment (stripCommonPrefix)
+import           Ouroboros.Consensus.Util.MonadSTM.NormalForm
+                     (MonadSTM (STM, atomically))
+import           Ouroboros.Network.AnchoredFragment (AnchoredFragment)
+import qualified Ouroboros.Network.AnchoredFragment as AF
+
+-- | A dummy version of the LoE that sets the LoE fragment to the current
+-- selection.
+updateLoEFragUnconditional ::
+  MonadSTM m =>
+  UpdateLoEFrag m blk
+updateLoEFragUnconditional =
+  UpdateLoEFrag $ \ curChain _ setLoEFrag -> atomically (setLoEFrag curChain)
+
+-- | Compute the fragment between the immutable tip, as given by the anchor
+-- of @curChain@, and the earliest intersection of the @candidates@.
+-- This excludes the selection from the set of intersected fragments since we
+-- need to be able to select k+1 blocks on a new chain when a fork's peer is
+-- killed on which we had selected k blocks, where the selection would
+-- otherwise keep the LoE fragment at the killed peer's intersection.
+sharedCandidatePrefix ::
+  GetHeader blk =>
+  SecurityParam ->
+  AnchoredFragment (Header blk) ->
+  Map peer (AnchoredFragment (Header blk)) ->
+  AnchoredFragment (Header blk)
+sharedCandidatePrefix (SecurityParam k) curChain candidates =
+  trunc
+  where
+    trunc | excess > 0 = snd (AF.splitAt excess shared)
+          | otherwise = shared
+
+    excess = AF.length shared - fromIntegral k
+
+    shared = fst (stripCommonPrefix (AF.anchor curChain) immutableTipSuffixes)
+
+    immutableTip = AF.anchorPoint curChain
+
+    splitAfterImmutableTip frag =
+      snd <$> AF.splitAfterPoint frag immutableTip
+
+    immutableTipSuffixes =
+      -- If a ChainSync client's candidate forks off before the
+      -- immutable tip, then this transaction is currently winning an
+      -- innocuous race versus the thread that will fatally raise
+      -- 'InvalidIntersection' within that ChainSync client, so it's
+      -- sound to pre-emptively discard their candidate from this
+      -- 'Map' via 'mapMaybe'.
+      Map.mapMaybe splitAfterImmutableTip candidates
+
+-- | This version of the LoE implements part of the intended Genesis approach.
+-- The fragment is set to the prefix of all candidates, ranging from the
+-- immutable tip to the earliest intersection of all peers.
+--
+-- Using this will cause ChainSel to stall indefinitely, or until a peer
+-- disconnects for unrelated reasons.
+-- In the future, the Genesis Density Disconnect Governor variant will extend
+-- this with an analysis that will always result in disconnections from peers
+-- to ensure the selection can advance.
+updateLoEFragStall ::
+  MonadSTM m =>
+  GetHeader blk =>
+  SecurityParam ->
+  STM m (Map peer (AnchoredFragment (Header blk))) ->
+  UpdateLoEFrag m blk
+updateLoEFragStall k getCandidates =
+  UpdateLoEFrag $ \ curChain _ setLoEFrag ->
+    atomically $ do
+      candidates <- getCandidates
+      setLoEFrag (sharedCandidatePrefix k curChain candidates)

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ChainSync/Client.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ChainSync/Client.hs
@@ -91,6 +91,7 @@ import           Ouroboros.Consensus.Storage.ChainDB (ChainDB,
                      InvalidBlockReason)
 import qualified Ouroboros.Consensus.Storage.ChainDB as ChainDB
 import           Ouroboros.Consensus.Util
+import           Ouroboros.Consensus.Util.AnchoredFragment (cross)
 import           Ouroboros.Consensus.Util.Assert (assertWithMsg)
 import           Ouroboros.Consensus.Util.EarlyExit (WithEarlyExit, exitEarly)
 import qualified Ouroboros.Consensus.Util.EarlyExit as EarlyExit
@@ -1471,24 +1472,6 @@ ourTipFromChain ::
   => AnchoredFragment (Header blk)
   -> Our (Tip blk)
 ourTipFromChain = Our . AF.anchorToTip . AF.headAnchor
-
--- | If the two fragments `c1` and `c2` intersect, return the intersection
--- point and join the prefix of `c1` before the intersection with the suffix of
--- `c2` after the intersection. The resulting fragment has the same anchor as
--- `c1` and the same head as `c2`.
-cross ::
-     HasHeader blk
-  => AnchoredFragment blk
-  -> AnchoredFragment blk
-  -> Maybe (Point blk, AnchoredFragment blk)
-cross c1 c2 = do
-    (p1, _p2, _s1, s2) <- AF.intersect c1 c2
-    -- Note that the head of `p1` and `_p2` is the intersection point, and
-    -- `_s1` and `s2` are anchored in the intersection point.
-    let crossed = case AF.join p1 s2 of
-            Just c  -> c
-            Nothing -> error "invariant violation of AF.intersect"
-    pure (AF.anchorPoint s2, crossed)
 
 -- | A type-legos auxillary function used in 'readLedgerState'.
 castM :: Monad m => m (WithEarlyExit m x) -> WithEarlyExit m x

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/API.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/API.hs
@@ -63,6 +63,10 @@ module Ouroboros.Consensus.Storage.ChainDB.API (
   , IsEBB (..)
     -- * Exceptions
   , ChainDbError (..)
+    -- * Genesis
+  , LoE (..)
+  , UpdateLoEFrag (..)
+  , processLoE
   ) where
 
 import           Control.Monad (void)
@@ -330,6 +334,9 @@ data ChainDB m blk = ChainDB {
       -- which rechecks the blocks in all candidate chains whenever a new
       -- invalid block is detected. These blocks are likely to be valid.
     , getIsInvalidBlock :: STM m (WithFingerprint (HeaderHash blk -> Maybe (InvalidBlockReason blk)))
+
+    , setLoEFrag :: AnchoredFragment (Header blk) -> STM m ()
+      -- ^ Update the LoE fragment, which is anchored in a recent immutable tip.
 
       -- | Close the ChainDB
       --
@@ -858,3 +865,54 @@ instance (Typeable blk, StandardHash blk) => Exception (ChainDbError blk) where
       "The block/header follower was used after it was closed"
     InvalidIteratorRange {} ->
       "An invalid range of blocks was requested"
+
+-- | The Limit on Eagerness is a mechanism for keeping ChainSel from advancing
+-- the current selection in the case of competing chains.
+-- It requires a resolution mechanism to prevent indefinite stalling, which
+-- will be implemented by the Genesis Density Disconnection principle soon,
+-- a condition applied via 'UpdateLoEFrag' that disconnects from peers with forks
+-- it considers inferior.
+--
+-- This type indicates whether the feature is enabled, and contains an update
+-- callback if it is.
+data LoE m blk =
+  -- | The LoE is disabled, so ChainSel will not keep the selection from
+  -- advancing.
+  LoEDisabled
+  |
+  -- | The LoE is enabled, using the security parameter @k@ as the limit.
+  -- When the selection's tip is @k@ blocks after the earliest intersection of
+  -- of all candidate fragments, ChainSel will not add new blocks to the
+  -- selection.
+  LoEEnabled (UpdateLoEFrag m blk)
+  deriving stock (Generic)
+  deriving anyclass (NoThunks)
+
+-- | This callback is a hook into ChainSync that is called right before deciding
+-- whether a block can be added to the current selection.
+--
+-- Its purpose is to update the fragment whose tip provides the reference point
+-- for the Limit on Eagerness, described in the docs of 'LoELimit'.
+--
+-- The callback is applied to the current chain, the current ledger state and
+-- an STM action that writes the new LoE fragment to the state.
+data UpdateLoEFrag m blk = UpdateLoEFrag {
+    updateLoEFrag ::
+         AnchoredFragment (Header blk)
+      -> ExtLedgerState blk
+      -> (AnchoredFragment (Header blk) -> STM m ())
+      -> m ()
+  }
+  deriving stock (Generic)
+  deriving anyclass (NoThunks)
+
+processLoE ::
+     Applicative m
+  => AnchoredFragment (Header blk)
+  -> ExtLedgerState blk
+  -> (AnchoredFragment (Header blk) -> STM m ())
+  -> LoE m blk
+  -> m ()
+processLoE curChain ledger setLoEFrag = \case
+  LoEDisabled -> pure ()
+  LoEEnabled hook -> updateLoEFrag hook curChain ledger setLoEFrag

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl.hs
@@ -156,6 +156,7 @@ openDBInternal args launchBgTasks = runWithTempRegistry $ do
                           varInvalid
                           varFutureBlocks
                           (Args.cdbCheckInFuture args)
+                          (Args.cdbLoE args)
       traceWith initChainSelTracer InitalChainSelected
 
       let chain  = VF.validatedFragment chainAndLedger
@@ -174,6 +175,7 @@ openDBInternal args launchBgTasks = runWithTempRegistry $ do
       copyFuse           <- newFuse "copy to immutable db"
       chainSelFuse       <- newFuse "chain selection"
       blocksToAdd        <- newBlocksToAdd (Args.cdbBlocksToAddSize args)
+      varLoEFrag         <- newTVarIO (AF.Empty AF.AnchorGenesis)
 
       let env = CDB { cdbImmutableDB     = immutableDB
                     , cdbVolatileDB      = volatileDB
@@ -200,6 +202,8 @@ openDBInternal args launchBgTasks = runWithTempRegistry $ do
                     , cdbCheckInFuture   = Args.cdbCheckInFuture args
                     , cdbBlocksToAdd     = blocksToAdd
                     , cdbFutureBlocks    = varFutureBlocks
+                    , cdbLoEFrag         = varLoEFrag
+                    , cdbLoE             = Args.cdbLoE args
                     }
       h <- fmap CDBHandle $ newTVarIO $ ChainDbOpen env
       let chainDB = API.ChainDB
@@ -216,6 +220,7 @@ openDBInternal args launchBgTasks = runWithTempRegistry $ do
             , stream                = Iterator.stream  h
             , newFollower           = Follower.newFollower h
             , getIsInvalidBlock     = getEnvSTM  h Query.getIsInvalidBlock
+            , setLoEFrag            = writeTVar varLoEFrag
             , closeDB               = closeDB h
             , isOpen                = isOpen  h
             }

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Args.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Args.hs
@@ -19,6 +19,7 @@ import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.Fragment.InFuture (CheckInFuture)
 import           Ouroboros.Consensus.Ledger.Extended
+import           Ouroboros.Consensus.Storage.ChainDB.API (LoE (LoEDisabled))
 import           Ouroboros.Consensus.Storage.ChainDB.Impl.LgrDB (LedgerDB')
 import qualified Ouroboros.Consensus.Storage.ChainDB.Impl.LgrDB as LgrDB
 import           Ouroboros.Consensus.Storage.ChainDB.Impl.Types
@@ -75,6 +76,10 @@ data ChainDbArgs f m blk = ChainDbArgs {
       -- is the maximum number of blocks that could be kept in memory at the
       -- same time when the background thread processing the blocks can't keep
       -- up.
+
+      -- Limit on Eagerness
+    , cdbLoE                    :: LoE m blk
+      -- ^ The callback for advancing the LoE fragment, if enabled.
     }
 
 -- | Arguments specific to the ChainDB, not to the ImmutableDB, VolatileDB, or
@@ -95,6 +100,7 @@ data ChainDbSpecificArgs f m blk = ChainDbSpecificArgs {
     , cdbsRegistry        :: HKD f (ResourceRegistry m)
     , cdbsTracer          :: Tracer m (TraceEvent blk)
     , cdbsHasFSGsmDB      :: SomeHasFS m
+    , cdbsLoE             :: LoE m blk
     }
 
 -- | Default arguments
@@ -131,6 +137,7 @@ defaultSpecificArgs mkFS = ChainDbSpecificArgs {
     , cdbsRegistry        = NoDefault
     , cdbsTracer          = nullTracer
     , cdbsHasFSGsmDB      = mkFS $ RelativeMountPoint "gsm"
+    , cdbsLoE             = LoEDisabled
     }
 
 -- | Default arguments
@@ -200,6 +207,7 @@ fromChainDbArgs ChainDbArgs{..} = (
         , cdbsCheckInFuture   = cdbCheckInFuture
         , cdbsBlocksToAddSize = cdbBlocksToAddSize
         , cdbsHasFSGsmDB      = cdbHasFSGsmDB
+        , cdbsLoE             = cdbLoE
         }
     )
 
@@ -241,6 +249,7 @@ toChainDbArgs ImmutableDB.ImmutableDbArgs {..}
     , cdbGcDelay                = cdbsGcDelay
     , cdbGcInterval             = cdbsGcInterval
     , cdbBlocksToAddSize        = cdbsBlocksToAddSize
+    , cdbLoE                    = cdbsLoE
     }
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/ChainSel.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/ChainSel.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE NamedFieldPuns       #-}
 {-# LANGUAGE RecordWildCards      #-}
 {-# LANGUAGE ScopedTypeVariables  #-}
+{-# LANGUAGE TypeOperators        #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 -- | Operations involving chain selection: the initial chain selection and
@@ -36,6 +37,7 @@ import           Data.Maybe.Strict (StrictMaybe (..), isSNothing,
                      strictMaybeToMaybe)
 import           Data.Set (Set)
 import qualified Data.Set as Set
+import           Data.Word (Word64)
 import           GHC.Stack (HasCallStack)
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config
@@ -56,7 +58,7 @@ import           Ouroboros.Consensus.Ledger.Inspect
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
 import           Ouroboros.Consensus.Storage.ChainDB.API (AddBlockPromise (..),
                      AddBlockResult (..), BlockComponent (..), ChainType (..),
-                     InvalidBlockReason (..))
+                     InvalidBlockReason (..), LoE (..), processLoE)
 import           Ouroboros.Consensus.Storage.ChainDB.API.Types.InvalidBlockPunishment
                      (InvalidBlockPunishment)
 import qualified Ouroboros.Consensus.Storage.ChainDB.API.Types.InvalidBlockPunishment as InvalidBlockPunishment
@@ -102,9 +104,10 @@ initialChainSelection ::
   -> StrictTVar m (WithFingerprint (InvalidBlocks blk))
   -> StrictTVar m (FutureBlocks m blk)
   -> CheckInFuture m blk
+  -> LoE m blk
   -> m (ChainAndLedger blk)
 initialChainSelection immutableDB volatileDB lgrDB tracer cfg varInvalid
-                      varFutureBlocks futureCheck = do
+                      varFutureBlocks futureCheck loELimit = do
     -- We follow the steps from section "## Initialization" in ChainDB.md
 
     (i :: Anchor blk, succsOf, ledger) <- atomically $ do
@@ -130,6 +133,8 @@ initialChainSelection immutableDB volatileDB lgrDB tracer cfg varInvalid
   where
     bcfg :: BlockConfig blk
     bcfg = configBlock cfg
+
+    SecurityParam k = configSecurityParam cfg
 
     -- | Turn the 'ValidatedChainDiff' into a 'ChainAndLedger'.
     --
@@ -157,8 +162,18 @@ initialChainSelection immutableDB volatileDB lgrDB tracer cfg varInvalid
     constructChains i succsOf = flip evalStateT Map.empty $
         mapM constructChain suffixesAfterI
       where
+        -- We now prevent selecting more than k blocks in maximalCandidates
+        -- when the LoE is enabled to avoid circumventing the LoE on startup.
+        -- Shutting down a syncing node and then restarting it should not cause
+        -- it to select the longest chain the VolDB, since that chain might be
+        -- adversarial (ie the LoE did not allow the node to select it when it
+        -- arrived).
         suffixesAfterI :: [NonEmpty (HeaderHash blk)]
-        suffixesAfterI = Paths.maximalCandidates succsOf (AF.anchorToPoint i)
+        suffixesAfterI = Paths.maximalCandidates succsOf limit (AF.anchorToPoint i)
+          where
+            limit = case loELimit of
+              LoEEnabled _ -> k
+              LoEDisabled  -> maxBound
 
         constructChain ::
              NonEmpty (HeaderHash blk)
@@ -450,14 +465,32 @@ chainSelectionForBlock ::
   -> InvalidBlockPunishment m
   -> Electric m (Point blk)
 chainSelectionForBlock cdb@CDB{..} blockCache hdr punish = electric $ do
-    (invalid, succsOf, lookupBlockInfo, curChain, tipPoint, ledgerDB)
-      <- atomically $ (,,,,,)
-          <$> (forgetFingerprint <$> readTVar cdbInvalid)
-          <*> VolatileDB.filterByPredecessor  cdbVolatileDB
-          <*> VolatileDB.getBlockInfo         cdbVolatileDB
-          <*> Query.getCurrentChain           cdb
-          <*> Query.getTipPoint               cdb
-          <*> LgrDB.getCurrent                cdbLgrDB
+    (invalid, succsOf', lookupBlockInfo, lookupBlockInfo', curChain, tipPoint, ledgerDB, loeFrag)
+      <- atomically $ do
+          (invalid, succsOf, lookupBlockInfo, curChain, tipPoint, ledgerDB, loeFrag) <-
+                (,,,,,,)
+            <$> (forgetFingerprint <$> readTVar cdbInvalid)
+            <*> VolatileDB.filterByPredecessor  cdbVolatileDB
+            <*> VolatileDB.getBlockInfo         cdbVolatileDB
+            <*> Query.getCurrentChain           cdb
+            <*> Query.getTipPoint               cdb
+            <*> LgrDB.getCurrent                cdbLgrDB
+            <*> readTVar                        cdbLoEFrag
+
+          -- Let these two functions ignore invalid blocks
+          let lookupBlockInfo' = ignoreInvalid    cdb invalid lookupBlockInfo
+              succsOf'         = ignoreInvalidSuc cdb invalid succsOf
+
+              loeFrag' = case cross curChain loeFrag of
+                Just (_, frag) -> frag
+                -- We don't crash if the LoE fragment doesn't intersect with the selection
+                -- because we update the selection _after_ updating the LoE fragment, which
+                -- means it could move to another fork or beyond the end of the LF, depending
+                -- on the implementation of @updateLoEFrag@.
+                Nothing        -> AF.Empty (AF.anchor curChain)
+
+          pure (invalid, succsOf', lookupBlockInfo, lookupBlockInfo', curChain, tipPoint, ledgerDB, loeFrag')
+
     let curChainAndLedger :: ChainAndLedger blk
         curChainAndLedger =
           -- The current chain we're working with here is not longer than @k@
@@ -469,12 +502,10 @@ chainSelectionForBlock cdb@CDB{..} blockCache hdr punish = electric $ do
         immBlockNo :: WithOrigin BlockNo
         immBlockNo = AF.anchorBlockNo curChain
 
-        -- Let these two functions ignore invalid blocks
-        lookupBlockInfo' = ignoreInvalid    cdb invalid lookupBlockInfo
-        succsOf'         = ignoreInvalidSuc cdb invalid succsOf
-
     -- The preconditions
     assert (isJust $ lookupBlockInfo (headerHash hdr)) $ return ()
+
+    processLoE curChain (LgrDB.ledgerDbCurrent ledgerDB) (writeTVar cdbLoEFrag) cdbLoE
 
     if
       -- The chain might have grown since we added the block such that the
@@ -496,15 +527,23 @@ chainSelectionForBlock cdb@CDB{..} blockCache hdr punish = electric $ do
         return tipPoint
 
       -- The block @b@ fits onto the end of our current chain
-      | pointHash tipPoint == headerPrevHash hdr -> do
+      | pointHash tipPoint == headerPrevHash hdr
+        -- TODO could be optimized if necessary/easy enough
+      , let newBlockFrag = curChain AF.:> hdr
+      , Just maxExtra <- computeLoEMaxExtra loELimit loeFrag newBlockFrag -> do
         -- ### Add to current chain
         traceWith addBlockTracer (TryAddToCurrentChain p)
-        addToCurrentChain succsOf' curChainAndLedger
+        addToCurrentChain succsOf' curChainAndLedger maxExtra
 
-      | Just diff <- Paths.isReachable lookupBlockInfo' curChain p -> do
+      | Just diff <- Paths.isReachable lookupBlockInfo' curChain p
+        -- TODO could be optimized if necessary/easy enough
+      , let curChain' =
+              AF.mapAnchoredFragment (castHeaderFields . getHeaderFields) curChain
+      , Just newBlockFrag <- Diff.apply curChain' diff
+      , Just maxExtra <- computeLoEMaxExtra loELimit loeFrag newBlockFrag -> do
         -- ### Switch to a fork
         traceWith addBlockTracer (TrySwitchToAFork p diff)
-        switchToAFork succsOf' lookupBlockInfo' curChainAndLedger diff
+        switchToAFork succsOf' lookupBlockInfo' curChainAndLedger maxExtra diff
 
       | otherwise -> do
         -- ### Store but don't change the current chain
@@ -516,6 +555,10 @@ chainSelectionForBlock cdb@CDB{..} blockCache hdr punish = electric $ do
     -- will first copy the blocks/headers to trim (from the end of the
     -- fragment) from the VolatileDB to the ImmutableDB.
   where
+    loELimit = case cdbLoE of
+      LoEEnabled _ -> k
+      LoEDisabled  -> maxBound
+
     SecurityParam k = configSecurityParam cdbTopLevelConfig
 
     p :: RealPoint blk
@@ -555,9 +598,12 @@ chainSelectionForBlock cdb@CDB{..} blockCache hdr punish = electric $ do
       => (ChainHash blk -> Set (HeaderHash blk))
       -> ChainAndLedger blk
          -- ^ The current chain and ledger
+      -> Word64
+         -- ^ How many extra blocks to select after @b@ at most.
       -> m (Point blk)
-    addToCurrentChain succsOf curChainAndLedger = do
-        let suffixesAfterB = Paths.maximalCandidates succsOf (realPointToPoint p)
+    addToCurrentChain succsOf curChainAndLedger maxExtra = do
+        -- Extensions of @B@ that do not exceed the LoE
+        let suffixesAfterB = Paths.maximalCandidates succsOf maxExtra (realPointToPoint p)
 
         -- Fragments that are anchored at @curHead@, i.e. suffixes of the
         -- current chain.
@@ -622,10 +668,12 @@ chainSelectionForBlock cdb@CDB{..} blockCache hdr punish = electric $ do
       -> LookupBlockInfo blk
       -> ChainAndLedger blk
          -- ^ The current chain (anchored at @i@) and ledger
+      -> Word64
+         -- ^ How many extra blocks to select after @b@ at most.
       -> ChainDiff (HeaderFields blk)
          -- ^ Header fields for @(x,b]@
       -> m (Point blk)
-    switchToAFork succsOf lookupBlockInfo curChainAndLedger diff = do
+    switchToAFork succsOf lookupBlockInfo curChainAndLedger maxExtra diff = do
         -- We use a cache to avoid reading the headers from disk multiple
         -- times in case they're part of multiple forks that go through @b@.
         let initCache = Map.singleton (headerHash hdr) hdr
@@ -649,8 +697,8 @@ chainSelectionForBlock cdb@CDB{..} blockCache hdr punish = electric $ do
             -- chain. We don't want to needlessly read the headers from disk
             -- for those candidates.
           . NE.filter (not . Diff.rollbackExceedsSuffix)
-            -- 1. Extend the diff with candidates fitting on @B@
-          . Paths.extendWithSuccessors succsOf lookupBlockInfo
+            -- 1. Extend the diff with candidates fitting on @B@ and not exceeding the LoE
+          . Paths.extendWithSuccessors succsOf lookupBlockInfo maxExtra
           $ diff
 
         case NE.nonEmpty chainDiffs of
@@ -669,6 +717,27 @@ chainSelectionForBlock cdb@CDB{..} blockCache hdr punish = electric $ do
         chainSelEnv = mkChainSelEnv curChainAndLedger
         curChain    = VF.validatedFragment curChainAndLedger
         curTip      = castPoint $ AF.headPoint curChain
+
+    -- | How many extra blocks to select at most after the block @b@ that is
+    -- currently being processed, according to the LoE. If not even @b@ is
+    -- allowed to be selected, return 'Nothing'.
+    computeLoEMaxExtra ::
+         (HasHeader x, HeaderHash x ~ HeaderHash blk)
+      => Word64
+         -- ^ How many blocks can be selected beyond the LoE.
+      -> AnchoredFragment (Header blk)
+         -- ^ The fragment with the LoE as its tip, with the same anchor as
+         -- @curChain@.
+      -> AnchoredFragment x
+         -- ^ The fragment with the new block @b@ as its tip, with the same
+         -- anchor as @curChain@.
+      -> Maybe Word64
+    computeLoEMaxExtra loeLimit loeFrag newBlockFrag
+      | budgetAlreadyUsed > loeLimit = Nothing
+      | otherwise                    = Just $ loeLimit - budgetAlreadyUsed
+      where
+        -- How many blocks did we already select beyond the LoE, including @b@.
+        budgetAlreadyUsed = Diff.getRollback $ Diff.diff newBlockFrag loeFrag
 
     mkSelectionChangedInfo ::
          AnchoredFragment (Header blk) -- ^ old chain

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Types.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Types.hs
@@ -81,7 +81,8 @@ import           Ouroboros.Consensus.Ledger.SupportsProtocol
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Storage.ChainDB.API (AddBlockPromise (..),
                      AddBlockResult (..), ChainDbError (..), ChainType,
-                     InvalidBlockReason, StreamFrom, StreamTo, UnknownRange)
+                     InvalidBlockReason, LoE, StreamFrom, StreamTo,
+                     UnknownRange)
 import           Ouroboros.Consensus.Storage.ChainDB.API.Types.InvalidBlockPunishment
                      (InvalidBlockPunishment)
 import           Ouroboros.Consensus.Storage.ChainDB.Impl.LgrDB (LedgerDB',
@@ -267,6 +268,14 @@ data ChainDbEnv m blk = CDB
     -- The number of blocks from the future is bounded by the number of
     -- upstream peers multiplied by the max clock skew divided by the slot
     -- length.
+  , cdbLoEFrag         :: !(StrictTVar m (AnchoredFragment (Header blk)))
+    -- ^ Fragment whose tip indicates the Limit on Eagerness, i.e. we are not
+    -- allowed to select a chain from which we could not switch back to a chain
+    -- containing it. The fragment is usually anchored at a recent immutable
+    -- tip; if it does not, it will conservatively be treated as the empty
+    -- fragment anchored in the current immutable tip.
+  , cdbLoE             :: LoE m blk
+    -- ^ See 'Args.cdbLoELimit'.
   } deriving (Generic)
 
 -- | We include @blk@ in 'showTypeOf' because it helps resolving type families

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Consensus/ChainGenerator/Counting.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Consensus/ChainGenerator/Counting.hs
@@ -39,6 +39,7 @@ module Test.Ouroboros.Consensus.ChainGenerator.Counting (
   , joinWin
   , toWindow
   , toWindowVar
+  , truncateWin
   , windowLast
   , windowSize
   , windowStart
@@ -224,6 +225,9 @@ windowStart win = fromWindow win (Count 0)
 
 windowLast :: Contains elem outer inner -> Index outer elem
 windowLast win = fromWindow win $ lastIndex $ windowSize win
+
+truncateWin :: Contains elem outer inner -> Size inner elem -> Contains elem outer inner
+truncateWin (UnsafeContains start len) x = UnsafeContains start (min len x)
 
 -- | 'Contains' is a 'Data.Semigroupoid.Semigroupoid'
 joinWin :: Contains elem outer mid -> Contains elem mid inner -> Contains elem outer inner

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/ChainDB.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/ChainDB.hs
@@ -109,6 +109,7 @@ fromMinimalChainDbArgs MinimalChainDbArgs {..} = ChainDbArgs {
   , cdbGcDelay                = 1
   , cdbGcInterval             = 1
   , cdbBlocksToAddSize        = 1
+  , cdbLoE                    = LoEDisabled
   }
   where
     mcdbNodeDBs' = unsafeToUncheckedStrictTVar <$> mcdbNodeDBs


### PR DESCRIPTION
This PR implements Limit of Eagerness and shrinking of schedules for genesis tests.

Please, note that this PR targets the branch of #840, our previous milestone.

### Shrinking

Each test currently has one honest peer, and one or more adversarial peers, which are adversarial because they might serve other chains than the honest one, or they might send headers or blocks with delay.

Shrinking, then, is implemented by dropping adversarial peers or messages sent by adversarial peers. It does not attempt yet to modify the schedule of the honest peer. The shrinker is best approached from the function `shrinkPeerSchedules` in `ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Shrinking.hs` in b95f45e. c8a4605 includes some preparatory refactorings.

### LoE

Limit of Eagerness is a mechanism that prevents the syncing node from selecting a chain more than k blocks long when its peers disagree on what the best chain is. In combination with a component in the works that disconnects peers with suboptimal chains (GDD governor), LoE helps the syncing node to follow the best chain.

The commit implementing LoE is 03af403.

### Other work

Additionally, further improvements to pretty printing of traces can be found in 3ac5193, and a fix to the schema generator can be found in 6d901d7.

More details on the schema generator problems can be found in the documentation of `ensureLowerDensityInWindows`, but the essence of it is that adversarial chains could be generated that didn't lose the density comparisons with the honest chain. These chains aren't interesting then, because in practice we always expect the honest chain to win the density comparisons.