### PR TITLE
Mempool: trace reason for transaction removal

### DIFF
--- a/ouroboros-consensus/changelog.d/20240126_122429_alexander.esgen_mempool_remove_trace_reason.md
+++ b/ouroboros-consensus/changelog.d/20240126_122429_alexander.esgen_mempool_remove_trace_reason.md
@@ -1,0 +1,4 @@
+### Breaking
+
+- Mempool: add reason for transaction removal to `TraceMempoolRemoveTxs`. This
+  can be used in the node to enrich the trace output.

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Impl/Common.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Impl/Common.hs
@@ -526,10 +526,10 @@ data TraceEventMempool blk
       MempoolSize
       -- ^ The current size of the Mempool.
   | TraceMempoolRemoveTxs
-      [Validated (GenTx blk)]
+      [(Validated (GenTx blk), ApplyTxErr blk)]
       -- ^ Previously valid transactions that are no longer valid because of
-      -- changes in the ledger state. These transactions have been removed
-      -- from the Mempool.
+      -- changes in the ledger state (details are in the provided 'ApplyTxErr').
+      -- These transactions have been removed from the Mempool.
       MempoolSize
       -- ^ The current size of the Mempool.
   | TraceMempoolManuallyRemovedTxs

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Update.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Update.hs
@@ -350,7 +350,7 @@ pureSyncWithLedger istate lstate lcfg capacityOverride =
                         lcfg
                         (ForgeInUnknownSlot lstate)
                         istate
-        removed     = map fst (vrInvalid vr)
+        removed     = vrInvalid vr
         istate'     = internalStateFromVR vr
         mTrace      = if null removed
                       then


### PR DESCRIPTION
Closes #886

Also adapts the corresponding mempool test to check that the attached `ApplyTxErr`s are actually those we expect.