### PR TITLE
Only limit initial chain selection length when LoE is active

### DIFF
--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl.hs
@@ -156,6 +156,7 @@ openDBInternal args launchBgTasks = runWithTempRegistry $ do
                           varInvalid
                           varFutureBlocks
                           (Args.cdbCheckInFuture args)
+                          (Args.cdbLoELimit args)
       traceWith initChainSelTracer InitalChainSelected
 
       let chain  = VF.validatedFragment chainAndLedger


### PR DESCRIPTION
As discussed in the [deliverable PR](https://github.com/IntersectMBO/ouroboros-consensus/pull/925#discussion_r1467733808)