### PR TITLE
Add GHC 9.8.1 to Nix CI

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -57,13 +57,15 @@
             (import ./nix/pdfs.nix)
           ];
         };
-        hydraJobs = import ./nix/ci.nix pkgs;
+        hydraJobs = import ./nix/ci.nix { inherit inputs pkgs; };
       in
       {
         devShells = rec {
           default = ghc96;
           ghc96 = hydraJobs.native.haskell96.devShell;
           ghc96-profiled = hydraJobs.native.haskell96.devShellProfiled;
+          ghc98 = hydraJobs.native.haskell98.devShell;
+          ghc98-profiled = hydraJobs.native.haskell98.devShellProfiled;
 
           website = pkgs.mkShell {
             packages = [ pkgs.nodejs pkgs.yarn ];

--- a/nix/ci.nix
+++ b/nix/ci.nix
@@ -1,4 +1,4 @@
-pkgs:
+{ inputs, pkgs }:
 
 let
   inherit (pkgs) lib haskell-nix;
@@ -30,9 +30,9 @@ let
         haskellLib.collectChecks' projectHsPkgs;
     } // lib.optionalAttrs noCross {
       devShell =
-        import ./shell.nix { inherit pkgs hsPkgs; };
+        import ./shell.nix { inherit inputs pkgs hsPkgs; };
       devShellProfiled =
-        import ./shell.nix { inherit pkgs; hsPkgs = hsPkgs.projectVariants.profiled; };
+        import ./shell.nix { inherit inputs pkgs; hsPkgs = hsPkgs.projectVariants.profiled; };
     };
 
   jobs = lib.filterAttrsRecursive (n: v: n != "recurseForDerivations") ({
@@ -46,6 +46,9 @@ let
       haskell810 = builtins.removeAttrs
         (mkHaskellJobsFor pkgs.hsPkgs.projectVariants.ghc810)
         [ "checks" "devShell" "devShellProfiled" ];
+
+      # also already test GHC 9.8, but only on Linux to reduce CI load
+      haskell98 = mkHaskellJobsFor pkgs.hsPkgs.projectVariants.ghc98;
     };
   } // lib.optionalAttrs (buildSystem == "x86_64-linux") {
     windows = {

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -17,6 +17,7 @@ let
     compiler-nix-name = "ghc964";
     flake.variants = {
       ghc810 = { compiler-nix-name = lib.mkForce "ghc8107"; };
+      ghc98 = { compiler-nix-name = lib.mkForce "ghc981"; };
     };
     inputMap = {
       "https://chap.intersectmbo.org/" = inputs.CHaP;

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -1,4 +1,4 @@
-{ pkgs, hsPkgs }:
+{ inputs, pkgs, hsPkgs }:
 
 let
   inherit (pkgs) lib;
@@ -21,8 +21,11 @@ hsPkgs.shellFor {
 
   # This is the place for tools that are required to be built with the same GHC
   # version as used in hsPkgs.
-  tools = lib.mapAttrs (_: t: t // { index-state = pkgs.tool-index-state; }) {
-    haskell-language-server = { version = "2.6.0.0"; };
+  tools = {
+    haskell-language-server = {
+      src = inputs.haskellNix.inputs."hls-2.6";
+      configureArgs = "--disable-benchmarks --disable-tests";
+    };
   };
 
   shellHook = ''


### PR DESCRIPTION
 - Add GHC 9.8.1 to the Nix Hydra CI as a follow-up to #814 
 - Build HLS from GitHub instead from Hackage. HLS only builds for GHC 9.8 with a few `allow-newer` ATM, so it is convenient to reuse the upstream `cabal.project` of HLS for this (which is not distributed on Hackage). It also sets an `index-state`, so we don't need to set our `tool-index-state` for it.