### PR TITLE
Remove the type `PointSchedule`

### DIFF
--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup.hs
@@ -8,7 +8,6 @@
 module Test.Consensus.Genesis.Setup (
     module Test.Consensus.Genesis.Setup.GenChains
   , forAllGenesisTest
-  , forAllGenesisTest'
   , runGenesisTest
   , runGenesisTest'
   ) where
@@ -43,7 +42,7 @@ data RunGenesisTestResult = RunGenesisTestResult {
 -- property on the final 'StateView'.
 runGenesisTest ::
   SchedulerConfig ->
-  GenesisTest PointSchedule ->
+  GenesisTest (Peers PeerSchedule) ->
   RunGenesisTestResult
 runGenesisTest schedulerConfig genesisTest =
   runSimOrThrow $ do
@@ -76,7 +75,7 @@ runGenesisTest schedulerConfig genesisTest =
 runGenesisTest' ::
   Testable prop =>
   SchedulerConfig ->
-  GenesisTest PointSchedule ->
+  GenesisTest (Peers PeerSchedule) ->
   (StateView -> prop) ->
   Property
 runGenesisTest' schedulerConfig genesisTest makeProperty =
@@ -85,38 +84,17 @@ runGenesisTest' schedulerConfig genesisTest makeProperty =
     RunGenesisTestResult{rgtrTrace, rgtrStateView} =
       runGenesisTest schedulerConfig genesisTest
 
--- | All-in-one helper that generates a 'GenesisTest' and a 'PointSchedule',
--- runs them with 'runGenesisTest', check whether the given property holds on
--- the resulting 'StateView'.
+-- | All-in-one helper that generates a 'GenesisTest' and a 'Peers
+-- PeerSchedule', runs them with 'runGenesisTest', check whether the given
+-- property holds on the resulting 'StateView'.
 forAllGenesisTest ::
-  Testable prop =>
-  Gen (GenesisTest PointSchedule) ->
-  SchedulerConfig ->
-  (GenesisTest PointSchedule -> StateView -> [GenesisTest PointSchedule]) ->
-  (GenesisTest PointSchedule -> StateView -> prop) ->
-  Property
-forAllGenesisTest = mkForAllGenesisTest id
-
--- | Same as 'forAllGenesisTest' but the schedule is a 'Peers PeerSchedule'.
-forAllGenesisTest' ::
   Testable prop =>
   Gen (GenesisTest (Peers PeerSchedule)) ->
   SchedulerConfig ->
   (GenesisTest (Peers PeerSchedule) -> StateView -> [GenesisTest (Peers PeerSchedule)]) ->
   (GenesisTest (Peers PeerSchedule) -> StateView -> prop) ->
   Property
-forAllGenesisTest' = mkForAllGenesisTest fromSchedulePoints
-
--- | Common code shared between flavours of 'forAllGenesisTest'.
-mkForAllGenesisTest ::
-  Testable prop =>
-  (schedule -> PointSchedule) ->
-  Gen (GenesisTest schedule) ->
-  SchedulerConfig ->
-  (GenesisTest schedule -> StateView -> [GenesisTest schedule]) ->
-  (GenesisTest schedule -> StateView -> prop) ->
-  Property
-mkForAllGenesisTest mkPointSchedule generator schedulerConfig shrinker mkProperty =
+forAllGenesisTest generator schedulerConfig shrinker mkProperty =
   forAllGenRunShrinkCheck generator runner shrinker' $ \genesisTest result ->
     let cls = classifiers genesisTest
      in classify (allAdversariesSelectable cls) "All adversaries selectable" $
@@ -124,5 +102,5 @@ mkForAllGenesisTest mkPointSchedule generator schedulerConfig shrinker mkPropert
         counterexample (rgtrTrace result) $
         mkProperty genesisTest (rgtrStateView result)
   where
-    runner = runGenesisTest schedulerConfig . fmap mkPointSchedule
+    runner = runGenesisTest schedulerConfig
     shrinker' gt = shrinker gt . rgtrStateView

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LongRangeAttack.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LongRangeAttack.hs
@@ -31,7 +31,7 @@ tests =
 
 prop_longRangeAttack :: Property
 prop_longRangeAttack =
-  forAllGenesisTest'
+  forAllGenesisTest
 
     (do gt@GenesisTest{gtBlockTree} <- genChains (pure 1)
         ps <- stToGen (longRangeAttack gtBlockTree)

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LongRangeAttack.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LongRangeAttack.hs
@@ -39,7 +39,7 @@ prop_longRangeAttack =
           then pure $ gt $> ps
           else discard)
 
-    (noTimeoutsSchedulerConfig defaultPointScheduleConfig)
+    noTimeoutsSchedulerConfig
 
     shrinkPeerSchedules
 

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
@@ -8,10 +8,10 @@ module Test.Consensus.Genesis.Tests.Uniform (tests) where
 
 import           Cardano.Slotting.Slot (SlotNo (SlotNo), WithOrigin (..))
 import           Control.Monad (replicateM)
+import           Control.Monad.Class.MonadTime.SI (Time, addTime)
 import           Data.List (group, intercalate, sort)
 import qualified Data.Map.Strict as Map
 import           Data.Maybe (mapMaybe)
-import           Data.Time.Clock (DiffTime)
 import           Data.Word (Word64)
 import           GHC.Stack (HasCallStack)
 import           Ouroboros.Consensus.Util.Condense (condense)
@@ -120,7 +120,7 @@ theProperty genesisTest stateView@StateView{svSelectedChain} =
 
     Classifiers {genesisWindowAfterIntersection, longerThanGenesisWindow} = classifiers genesisTest
 
-fromBlockPoint :: (DiffTime, SchedulePoint) -> Maybe (DiffTime, TestBlock)
+fromBlockPoint :: (Time, SchedulePoint) -> Maybe (Time, TestBlock)
 fromBlockPoint (t, ScheduleBlockPoint bp) = Just (t, bp)
 fromBlockPoint _                          = Nothing
 
@@ -191,7 +191,7 @@ prop_leashingAttackStalling =
       advs <- mapM (mapM dropRandomPoints) advs0
       pure $ Peers honest advs
 
-    dropRandomPoints :: [(DiffTime, SchedulePoint)] -> QC.Gen [(DiffTime, SchedulePoint)]
+    dropRandomPoints :: [(Time, SchedulePoint)] -> QC.Gen [(Time, SchedulePoint)]
     dropRandomPoints ps = do
       let lenps = length ps
       dropCount <- QC.choose (0, max 1 $ div lenps 5)
@@ -237,7 +237,7 @@ prop_leashingAttackTimeLimited =
 
     takePointsUntil limit = takeWhile ((<= limit) . fst)
 
-    estimateTimeBound :: PeerSchedule -> [PeerSchedule] -> DiffTime
+    estimateTimeBound :: PeerSchedule -> [PeerSchedule] -> Time
     estimateTimeBound honest advs =
       let firstTipPointBlock = headCallStack (mapMaybe fromTipPoint honest)
           lastBlockPoint = last (mapMaybe fromBlockPoint honest)
@@ -258,10 +258,9 @@ prop_leashingAttackTimeLimited =
           -- sent.
       in max
           (fst lastBlockPoint)
-          (fst firstTipPointBlock +
-              0.020 * fromIntegral maxBlockNo + 5 * fromIntegral peerCount)
+          (addTime (0.020 * fromIntegral maxBlockNo + 5 * fromIntegral peerCount) (fst firstTipPointBlock))
 
-    blockPointNos :: [(DiffTime, SchedulePoint)] -> [Word64]
+    blockPointNos :: [(Time, SchedulePoint)] -> [Word64]
     blockPointNos =
       map (unBlockNo . blockNo . snd) .
       mapMaybe fromBlockPoint

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
@@ -128,7 +128,7 @@ fromBlockPoint _                          = Nothing
 -- adversarial peers serving adversarial branches.
 prop_serveAdversarialBranches :: Property
 prop_serveAdversarialBranches =
-  expectFailure $ forAllGenesisTest'
+  expectFailure $ forAllGenesisTest
 
     (genChains (QC.choose (1, 4)) `enrichedWith` genUniformSchedulePoints)
 
@@ -170,7 +170,7 @@ genUniformSchedulePoints gt = stToGen (uniformPoints (gtBlockTree gt))
 -- yet.
 prop_leashingAttackStalling :: Property
 prop_leashingAttackStalling =
-  expectFailure $ forAllGenesisTest'
+  expectFailure $ forAllGenesisTest
 
     (genChains (QC.choose (1, 4)) `enrichedWith` genLeashingSchedule)
 
@@ -215,7 +215,7 @@ prop_leashingAttackStalling =
 -- See Note [Leashing attacks]
 prop_leashingAttackTimeLimited :: Property
 prop_leashingAttackTimeLimited =
-  expectFailure $ forAllGenesisTest'
+  expectFailure $ forAllGenesisTest
 
     (genChains (QC.choose (1, 4)) `enrichedWith` genTimeLimitedSchedule)
 
@@ -278,7 +278,7 @@ headCallStack xs = if null xs then error "headCallStack: empty list" else head x
 -- This is pretty slow since it relies on timeouts to terminate the test.
 prop_loeStalling :: Property
 prop_loeStalling =
-  forAllGenesisTest'
+  forAllGenesisTest
 
     (genChains (QC.choose (1, 4)) `enrichedWith` genUniformSchedulePoints)
 

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
@@ -132,7 +132,7 @@ prop_serveAdversarialBranches =
 
     (genChains (QC.choose (1, 4)) `enrichedWith` genUniformSchedulePoints)
 
-    ((noTimeoutsSchedulerConfig defaultPointScheduleConfig)
+    (noTimeoutsSchedulerConfig
        {scTraceState = False, scTrace = False})
 
     shrinkPeerSchedules
@@ -174,7 +174,7 @@ prop_leashingAttackStalling =
 
     (genChains (QC.choose (1, 4)) `enrichedWith` genLeashingSchedule)
 
-    ((noTimeoutsSchedulerConfig defaultPointScheduleConfig)
+    (noTimeoutsSchedulerConfig
       {scTrace = False})
 
     shrinkPeerSchedules
@@ -219,7 +219,7 @@ prop_leashingAttackTimeLimited =
 
     (genChains (QC.choose (1, 4)) `enrichedWith` genTimeLimitedSchedule)
 
-    ((noTimeoutsSchedulerConfig defaultPointScheduleConfig)
+    (noTimeoutsSchedulerConfig
       {scTrace = False})
 
     shrinkPeerSchedules
@@ -282,7 +282,7 @@ prop_loeStalling =
 
     (genChains (QC.choose (1, 4)) `enrichedWith` genUniformSchedulePoints)
 
-    ((noTimeoutsSchedulerConfig defaultPointScheduleConfig) {
+    (noTimeoutsSchedulerConfig {
       scTrace = False,
       scEnableLoE = True,
       scChainSyncTimeouts = chainSyncNoTimeouts {canAwaitTimeout = shortWait}

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Run.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Run.hs
@@ -54,8 +54,8 @@ import           Test.Consensus.PeerSimulator.StateView
 import           Test.Consensus.PeerSimulator.Trace
 import qualified Test.Consensus.PointSchedule as PointSchedule
 import           Test.Consensus.PointSchedule (GenesisTest (GenesisTest),
-                     NodeState, PeerSchedule, PointScheduleConfig, TestFragH,
-                     peersStatesRelative, prettyPeersSchedule)
+                     NodeState, PeerSchedule, TestFragH, peersStatesRelative,
+                     prettyPeersSchedule)
 import           Test.Consensus.PointSchedule.Peers (Peer (..), PeerId, Peers,
                      getPeerIds)
 import           Test.Ouroboros.Consensus.ChainGenerator.Params (Asc)
@@ -76,9 +76,6 @@ data SchedulerConfig =
     -- | The duration of a single slot, used by the peer simulator to wait
     -- between ticks.
     , scSlotLength      :: SlotLength
-
-    -- | Config shared with point schedule generators.
-    , scSchedule        :: PointScheduleConfig
 
     -- | If 'True', 'Test.Consensus.Genesis.Setup.runTest' will print traces
     -- to stderr.
@@ -103,12 +100,11 @@ data SchedulerConfig =
   }
 
 -- | Determine timeouts based on the 'Asc' and a slot length of 20 seconds.
-defaultSchedulerConfig :: PointScheduleConfig -> Asc -> SchedulerConfig
-defaultSchedulerConfig scSchedule asc =
+defaultSchedulerConfig :: Asc -> SchedulerConfig
+defaultSchedulerConfig asc =
   SchedulerConfig {
     scChainSyncTimeouts = chainSyncTimeouts scSlotLength asc,
     scSlotLength,
-    scSchedule,
     scDebug = False,
     scTrace = True,
     scTraceState = False,
@@ -118,12 +114,11 @@ defaultSchedulerConfig scSchedule asc =
     scSlotLength = slotLengthFromSec 20
 
 -- | Config with no timeouts and a slot length of 20 seconds.
-noTimeoutsSchedulerConfig :: PointScheduleConfig -> SchedulerConfig
-noTimeoutsSchedulerConfig scSchedule =
+noTimeoutsSchedulerConfig :: SchedulerConfig
+noTimeoutsSchedulerConfig =
   SchedulerConfig {
     scChainSyncTimeouts = chainSyncNoTimeouts,
     scSlotLength,
-    scSchedule,
     scDebug = False,
     scTrace = True,
     scTraceState = False,

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
@@ -46,7 +46,7 @@ prop_rollback = do
     (do gt@GenesisTest{gtSecurityParam, gtBlockTree} <- genChains (pure 1)
         pure gt {gtSchedule =  rollbackSchedule (fromIntegral (maxRollbacks gtSecurityParam)) gtBlockTree})
 
-    (noTimeoutsSchedulerConfig defaultPointScheduleConfig)
+    noTimeoutsSchedulerConfig
 
     (\_ _ -> [])
 
@@ -62,7 +62,7 @@ prop_cannotRollback =
     (do gt@GenesisTest{gtSecurityParam, gtBlockTree} <- genChains (pure 1)
         pure gt {gtSchedule = rollbackSchedule (fromIntegral (maxRollbacks gtSecurityParam + 1)) gtBlockTree})
 
-    (noTimeoutsSchedulerConfig defaultPointScheduleConfig)
+    noTimeoutsSchedulerConfig
 
     (\_ _ -> [])
 

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
@@ -2,18 +2,24 @@
 {-# LANGUAGE DerivingStrategies  #-}
 {-# LANGUAGE NamedFieldPuns      #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections       #-}
 
 module Test.Consensus.PeerSimulator.Tests.Rollback (tests) where
 
+import           Control.Monad.Class.MonadTime.SI (Time (Time))
 import           Ouroboros.Consensus.Block (ChainHash (..), Header)
 import           Ouroboros.Consensus.Config.SecurityParam
+import           Ouroboros.Network.AnchoredFragment (AnchoredFragment,
+                     toOldestFirst)
 import qualified Ouroboros.Network.AnchoredFragment as AF
 import           Test.Consensus.BlockTree (BlockTree (..), BlockTreeBranch (..))
 import           Test.Consensus.Genesis.Setup
 import           Test.Consensus.PeerSimulator.Run (noTimeoutsSchedulerConfig)
 import           Test.Consensus.PeerSimulator.StateView
 import           Test.Consensus.PointSchedule
-import           Test.Consensus.PointSchedule.Peers (peersOnlyHonest)
+import           Test.Consensus.PointSchedule.Peers (Peers, peersOnlyHonest)
+import           Test.Consensus.PointSchedule.SinglePeer (SchedulePoint (..))
+import           Test.QuickCheck
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
 import           Test.Util.Orphans.IOLike ()
@@ -67,18 +73,21 @@ prop_cannotRollback =
 -- chain of the given block tree.
 --
 -- PRECONDITION: Block tree with at least one alternative chain.
-rollbackSchedule :: Int -> BlockTree TestBlock -> PointSchedule
+rollbackSchedule :: Int -> BlockTree TestBlock -> Peers PeerSchedule
 rollbackSchedule n blockTree =
-  let branch = head $ btBranches blockTree
-      trunkSuffix = AF.takeOldest n (btbTrunkSuffix branch)
-      states = concat
-        [ banalStates (btbPrefix branch)
-        , banalStates trunkSuffix
-        , banalStates (btbSuffix branch)
-        ]
-      peers = peersOnlyHonest states
-      pointSchedule = balanced defaultPointScheduleConfig peers
-   in pointSchedule
+    let branch = head $ btBranches blockTree
+        trunkSuffix = AF.takeOldest n (btbTrunkSuffix branch)
+        schedulePoints = concat
+          [ banalSchedulePoints (btbPrefix branch)
+          , banalSchedulePoints trunkSuffix
+          , banalSchedulePoints (btbSuffix branch)
+          ]
+    in peersOnlyHonest $ zip (map (Time . (/30)) [0..]) schedulePoints
+  where
+    banalSchedulePoints :: AnchoredFragment TestBlock -> [SchedulePoint]
+    banalSchedulePoints = concatMap banalSchedulePoints' . toOldestFirst
+    banalSchedulePoints' :: TestBlock -> [SchedulePoint]
+    banalSchedulePoints' block = [ScheduleTipPoint block, ScheduleHeaderPoint block, ScheduleBlockPoint block]
 
 -- | Given a hash, checks whether it is on the trunk of the block tree, that is
 -- if it only contains zeroes.

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
@@ -1,16 +1,13 @@
 module Test.Consensus.PeerSimulator.Tests.Timeouts (tests) where
 
 import           Data.Functor (($>))
-import           Data.List.NonEmpty (NonEmpty ((:|)))
 import           Data.Maybe (fromJust)
-import           Ouroboros.Consensus.Block (getHeader)
 import           Ouroboros.Consensus.Util.Condense
-import           Ouroboros.Consensus.Util.IOLike (DiffTime, fromException)
+import           Ouroboros.Consensus.Util.IOLike (DiffTime, Time (Time),
+                     fromException)
 import qualified Ouroboros.Network.AnchoredFragment as AF
-import           Ouroboros.Network.Block (tipFromHeader)
 import           Ouroboros.Network.Driver.Limits
                      (ProtocolLimitFailure (ExceededTimeLimit))
-import           Ouroboros.Network.Point (WithOrigin (At))
 import           Ouroboros.Network.Protocol.ChainSync.Codec (mustReplyTimeout)
 import           Test.Consensus.BlockTree (btTrunk)
 import           Test.Consensus.Genesis.Setup
@@ -18,7 +15,8 @@ import           Test.Consensus.PeerSimulator.Run (SchedulerConfig (..),
                      defaultSchedulerConfig)
 import           Test.Consensus.PeerSimulator.StateView
 import           Test.Consensus.PointSchedule
-import           Test.Consensus.PointSchedule.Peers (Peer (..), PeerId (..))
+import           Test.Consensus.PointSchedule.Peers (Peers, peersOnlyHonest)
+import           Test.Consensus.PointSchedule.SinglePeer (SchedulePoint (..))
 import           Test.QuickCheck
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
@@ -33,19 +31,16 @@ prop_timeouts = do
   genesisTest <- genChains (pure 0)
 
   -- Use higher tick duration to avoid the test taking really long
-  let scSchedule' = PointScheduleConfig {pscTickDuration = 1}
-
-      schedulerConfig = defaultSchedulerConfig scSchedule' (gtHonestAsc genesisTest)
+  let schedulerConfig = defaultSchedulerConfig defaultPointScheduleConfig (gtHonestAsc genesisTest)
 
       schedule =
         dullSchedule
-          scSchedule'
           (fromJust $ mustReplyTimeout (scChainSyncTimeouts schedulerConfig))
           (btTrunk $ gtBlockTree genesisTest)
 
       genesisTest' = genesisTest $> schedule
 
-  -- NOTE: Because the scheduler configuration depends on the generated
+  -- FIXME: Because the scheduler configuration depends on the generated
   -- 'GenesisTest' itself, we cannot rely on helpers such as
   -- 'forAllGenesisTest'.
   pure $
@@ -61,17 +56,14 @@ prop_timeouts = do
           counterexample ("exceptions: " ++ show exns) False
 
   where
-
     -- A schedule that advertises all the points of the chain from the start but
     -- contains just one too many ticks, therefore reaching the timeouts.
-    dullSchedule :: PointScheduleConfig -> DiffTime -> TestFrag -> PointSchedule
-    dullSchedule _ _ (AF.Empty _) = error "requires a non-empty block tree"
-    dullSchedule scheduleConfig timeout (_ AF.:> tipBlock) =
-      let tipPoint = TipPoint $ tipFromHeader tipBlock
-          headerPoint = HeaderPoint $ At (getHeader tipBlock)
-          blockPoint = BlockPoint (At tipBlock)
-          state = Peer HonestPeer $ NodeOnline $ AdvertisedPoints tipPoint headerPoint blockPoint
-          tick = Tick { active = state, duration = pscTickDuration scheduleConfig, number = 0 }
-          maximumNumberOfTicks = round $ timeout / pscTickDuration scheduleConfig
-      in
-      PointSchedule (tick :| replicate maximumNumberOfTicks tick) (HonestPeer :| [])
+    dullSchedule :: DiffTime -> TestFrag -> Peers PeerSchedule
+    dullSchedule _ (AF.Empty _) = error "requires a non-empty block tree"
+    dullSchedule timeout (_ AF.:> tipBlock) =
+      let tickDuration = 1 -- 1s
+          maximumNumberOfTicks = round $ timeout / tickDuration
+       in peersOnlyHonest $
+            (Time 0, ScheduleTipPoint tipBlock)
+              : (Time 0, ScheduleHeaderPoint tipBlock)
+              : zip (map (Time . (* tickDuration)) [0..]) (replicate maximumNumberOfTicks (ScheduleBlockPoint tipBlock))

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
@@ -1,8 +1,9 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+
 module Test.Consensus.PeerSimulator.Tests.Timeouts (tests) where
 
 import           Data.Functor (($>))
 import           Data.Maybe (fromJust)
-import           Data.Time (secondsToDiffTime)
 import           Ouroboros.Consensus.Util.Condense
 import           Ouroboros.Consensus.Util.IOLike (DiffTime, Time (Time),
                      fromException)
@@ -25,10 +26,13 @@ import           Test.Util.Orphans.IOLike ()
 import           Test.Util.TestEnv (adjustQuickCheckTests)
 
 tests :: TestTree
-tests = adjustQuickCheckTests (`div` 10) $ testProperty "timeouts" prop_timeouts
+tests = testGroup "timeouts" [
+  adjustQuickCheckTests (`div` 10) $ testProperty "does time out" (prop_timeouts True),
+  adjustQuickCheckTests (`div` 10) $ testProperty "does not time out" (prop_timeouts False)
+  ]
 
-prop_timeouts :: Gen Property
-prop_timeouts = do
+prop_timeouts :: Bool -> Gen Property
+prop_timeouts mustTimeout = do
   genesisTest <- genChains (pure 0)
 
   -- Use higher tick duration to avoid the test taking really long
@@ -48,25 +52,21 @@ prop_timeouts = do
     runGenesisTest' schedulerConfig genesisTest' $ \stateView ->
       case svChainSyncExceptions stateView of
         [] ->
-          counterexample ("result: " ++ condense (svSelectedChain stateView)) False
+          counterexample ("result: " ++ condense (svSelectedChain stateView)) (not mustTimeout)
         [exn] ->
           case fromException $ cseException exn of
-            Just (ExceededTimeLimit _) -> property True
+            Just (ExceededTimeLimit _) -> property mustTimeout
             _ -> counterexample ("exception: " ++ show exn) False
         exns ->
           counterexample ("exceptions: " ++ show exns) False
 
   where
-    -- A schedule that advertises all the points of the chain from the start but
-    -- contains just one too many ticks, therefore reaching the timeouts.
     dullSchedule :: DiffTime -> TestFrag -> Peers PeerSchedule
     dullSchedule _ (AF.Empty _) = error "requires a non-empty block tree"
     dullSchedule timeout (_ AF.:> tipBlock) =
-      let tickDuration = secondsToDiffTime 1 -- 1s
-          maximumNumberOfTicks = round $ timeout / tickDuration
-       in peersOnlyHonest $
-            (Time 0, ScheduleTipPoint tipBlock)
-              : (Time 0, ScheduleHeaderPoint tipBlock)
-              : zip
-                  (map (Time . (* tickDuration) . secondsToDiffTime) [0..])
-                  (replicate (1 + maximumNumberOfTicks) (ScheduleBlockPoint tipBlock))
+      let offset :: DiffTime = if mustTimeout then 1 else -1
+       in peersOnlyHonest $ [
+            (Time 0, ScheduleTipPoint tipBlock),
+            (Time 0, ScheduleHeaderPoint tipBlock),
+            (Time (timeout + offset), ScheduleBlockPoint tipBlock)
+            ]

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
@@ -31,7 +31,7 @@ prop_timeouts = do
   genesisTest <- genChains (pure 0)
 
   -- Use higher tick duration to avoid the test taking really long
-  let schedulerConfig = defaultSchedulerConfig defaultPointScheduleConfig (gtHonestAsc genesisTest)
+  let schedulerConfig = defaultSchedulerConfig (gtHonestAsc genesisTest)
 
       schedule =
         dullSchedule

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
@@ -2,6 +2,7 @@ module Test.Consensus.PeerSimulator.Tests.Timeouts (tests) where
 
 import           Data.Functor (($>))
 import           Data.Maybe (fromJust)
+import           Data.Time (secondsToDiffTime)
 import           Ouroboros.Consensus.Util.Condense
 import           Ouroboros.Consensus.Util.IOLike (DiffTime, Time (Time),
                      fromException)
@@ -61,9 +62,11 @@ prop_timeouts = do
     dullSchedule :: DiffTime -> TestFrag -> Peers PeerSchedule
     dullSchedule _ (AF.Empty _) = error "requires a non-empty block tree"
     dullSchedule timeout (_ AF.:> tipBlock) =
-      let tickDuration = 1 -- 1s
+      let tickDuration = secondsToDiffTime 1 -- 1s
           maximumNumberOfTicks = round $ timeout / tickDuration
        in peersOnlyHonest $
             (Time 0, ScheduleTipPoint tipBlock)
               : (Time 0, ScheduleHeaderPoint tipBlock)
-              : zip (map (Time . (* tickDuration)) [0..]) (replicate maximumNumberOfTicks (ScheduleBlockPoint tipBlock))
+              : zip
+                  (map (Time . (* tickDuration) . secondsToDiffTime) [0..])
+                  (replicate (1 + maximumNumberOfTicks) (ScheduleBlockPoint tipBlock))

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
@@ -77,8 +77,8 @@ import qualified System.Random.Stateful as Random
 import           System.Random.Stateful (STGenM, StatefulGen, runSTGen_)
 import           Test.Consensus.BlockTree (BlockTree (..), BlockTreeBranch (..),
                      prettyBlockTree)
-import           Test.Consensus.PointSchedule.Peers (Peer (..),
-                     Peers (..), mkPeers, peersList)
+import           Test.Consensus.PointSchedule.Peers (Peer (..), Peers (..),
+                     mkPeers, peersList)
 import           Test.Consensus.PointSchedule.SinglePeer
                      (IsTrunk (IsBranch, IsTrunk), PeerScheduleParams (..),
                      SchedulePoint (..), defaultPeerScheduleParams, mergeOn,

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
@@ -35,10 +35,8 @@ module Test.Consensus.PointSchedule (
   , TestFrag
   , TestFragH
   , TipPoint (..)
-  , blockPointBlock
   , enrichedWith
   , genesisAdvertisedPoints
-  , headerPointBlock
   , longRangeAttack
   , peerSchedulesBlocks
   , peerStates
@@ -47,7 +45,6 @@ module Test.Consensus.PointSchedule (
   , prettyGenesisTest
   , prettyPeersSchedule
   , stToGen
-  , tipPointBlock
   , uniformPoints
   ) where
 
@@ -86,8 +83,7 @@ import           Test.QuickCheck (Gen, arbitrary)
 import           Test.QuickCheck.Random (QCGen)
 import           Test.Util.TersePrinting (terseBlock, terseHeader, terseTip,
                      terseWithOrigin)
-import           Test.Util.TestBlock (Header, TestBlock, Validity (Valid),
-                     testHeader, unsafeTestBlockWithPayload)
+import           Test.Util.TestBlock (Header, TestBlock)
 
 ----------------------------------------------------------------------------------------------------
 -- Data types
@@ -106,12 +102,6 @@ newtype TipPoint =
 instance Condense TipPoint where
   condense (TipPoint tip) = terseTip tip
 
--- | Convert a 'TipPoint' to a 'TestBlock'.
-tipPointBlock :: TipPoint -> Maybe TestBlock
-tipPointBlock (TipPoint TipGenesis) = Nothing
-tipPointBlock (TipPoint (Tip slot hash _)) =
-  Just $ unsafeTestBlockWithPayload hash slot Valid ()
-
 -- | The latest header that should be sent to the client by the ChainSync server
 -- in a tick.
 newtype HeaderPoint =
@@ -121,11 +111,6 @@ newtype HeaderPoint =
 instance Condense HeaderPoint where
   condense (HeaderPoint header) = terseWithOrigin terseHeader header
 
--- | Convert a 'HeaderPoint' to a 'TestBlock'.
-headerPointBlock :: HeaderPoint -> Maybe TestBlock
-headerPointBlock (HeaderPoint Origin)      = Nothing
-headerPointBlock (HeaderPoint (At header)) = Just $ testHeader header
-
 -- | The latest block that should be sent to the client by the BlockFetch server
 -- in a tick.
 newtype BlockPoint =
@@ -134,11 +119,6 @@ newtype BlockPoint =
 
 instance Condense BlockPoint where
   condense (BlockPoint block) = terseWithOrigin terseBlock block
-
--- | Convert a 'BlockPoint' to a 'Point'.
-blockPointBlock :: BlockPoint -> Maybe TestBlock
-blockPointBlock (BlockPoint Origin)     = Nothing
-blockPointBlock (BlockPoint (At block)) = Just block
 
 -- | The set of parameters that define the state that a peer should reach when it receives control
 -- by the scheduler in a single tick.

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
@@ -35,7 +35,6 @@ module Test.Consensus.PointSchedule (
   , TestFrag
   , TestFragH
   , TipPoint (..)
-  , banalStates
   , blockPointBlock
   , enrichedWith
   , genesisAdvertisedPoints
@@ -65,8 +64,7 @@ import           Ouroboros.Consensus.Block.Abstract (WithOrigin (..), getHeader)
 import           Ouroboros.Consensus.Protocol.Abstract (SecurityParam,
                      maxRollbacks)
 import           Ouroboros.Consensus.Util.Condense (Condense (condense))
-import           Ouroboros.Network.AnchoredFragment (AnchoredFragment,
-                     AnchoredSeq (Empty, (:>)))
+import           Ouroboros.Network.AnchoredFragment (AnchoredFragment)
 import qualified Ouroboros.Network.AnchoredFragment as AF
 import           Ouroboros.Network.Block (Tip (..), tipFromHeader)
 import           Ouroboros.Network.Point (WithOrigin (At))
@@ -256,20 +254,6 @@ peerSchedulesBlocks = concatMap (peerScheduleBlocks . value) . toList . peersLis
 ----------------------------------------------------------------------------------------------------
 -- Schedule generators
 ----------------------------------------------------------------------------------------------------
-
--- | Create a peer schedule by serving one header in each tick.
-banalStates :: TestFrag -> [NodeState]
-banalStates (Empty _) = []
-banalStates frag@(_ :> tipBlock) =
-  spin [] frag
-  where
-    spin z (Empty _) = z
-    spin z (pre :> block) =
-      let header = HeaderPoint $ At (getHeader block)
-       in spin
-            (NodeOnline AdvertisedPoints {tip, header, block = BlockPoint (At block)} : z)
-            pre
-    tip = TipPoint $ tipFromHeader tipBlock
 
 -- | Produce a schedule similar to @Frequencies (Peers 1 [10])@, using the new @SinglePeer@
 -- generator.

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
@@ -50,7 +50,6 @@ import           Data.Foldable (toList)
 import           Data.Functor (($>))
 import           Data.List (mapAccumL, partition, scanl')
 import           Data.Time (DiffTime)
-import           Data.Traversable (for)
 import           Data.Word (Word64)
 import           Ouroboros.Consensus.Block.Abstract (WithOrigin (..), getHeader)
 import           Ouroboros.Consensus.Protocol.Abstract (SecurityParam,
@@ -164,8 +163,9 @@ instance Condense NodeState where
 
 prettyPeersSchedule :: Peers PeerSchedule -> [String]
 prettyPeersSchedule peers =
-  for (zip [(0 :: Integer)..] (peersStates peers)) $ \(number, (time, peerState)) ->
-  show number ++ ": " ++ condense peerState ++ " @" ++ show time
+  map
+    (\(number, (time, peerState)) -> show number ++ ": " ++ condense peerState ++ " @" ++ show time)
+    (zip [(0 :: Int)..] (peersStates peers))
 
 ----------------------------------------------------------------------------------------------------
 -- Conversion to 'PointSchedule'

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
@@ -32,14 +32,11 @@ module Test.Consensus.PointSchedule (
   , HeaderPoint (..)
   , NodeState (..)
   , PeerSchedule
-  , PointScheduleConfig (..)
   , TestFrag
   , TestFragH
-  , Tick (..)
   , TipPoint (..)
   , banalStates
   , blockPointBlock
-  , defaultPointScheduleConfig
   , enrichedWith
   , genesisAdvertisedPoints
   , headerPointBlock
@@ -93,7 +90,6 @@ import           Test.Util.TersePrinting (terseBlock, terseHeader, terseTip,
                      terseWithOrigin)
 import           Test.Util.TestBlock (Header, TestBlock, Validity (Valid),
                      testHeader, unsafeTestBlockWithPayload)
-import           Text.Printf (printf)
 
 ----------------------------------------------------------------------------------------------------
 -- Data types
@@ -193,40 +189,10 @@ instance Condense NodeState where
     NodeOnline points -> condense points
     NodeOffline -> "*chrrrk* <signal lost>"
 
--- | A tick is an entry in a 'PointSchedule', containing the peer that is
--- going to change state.
-data Tick =
-  Tick {
-    active   :: Peer NodeState,
-    -- | The duration of this tick, for the scheduler to pass to @threadDelay@.
-    duration :: DiffTime,
-    number   :: Word
-  }
-  deriving (Eq, Show)
-
-instance Condense Tick where
-  condense Tick {active, duration, number} =
-    show number ++ ": " ++ condense active ++ " | " ++ showDT duration
-    where
-      showDT t = printf "%.6f" (realToFrac t :: Double)
-
 prettyPeersSchedule :: Peers PeerSchedule -> [String]
 prettyPeersSchedule peers =
   for (zip [(0 :: Integer)..] (peersStates peers)) $ \(number, (time, peerState)) ->
   show number ++ ": " ++ condense peerState ++ " @" ++ show time
-
--- | Parameters that are significant for components outside of generators, like the peer
--- simulator.
-data PointScheduleConfig =
-  PointScheduleConfig {
-    -- | Duration of a tick, for timeouts in the scheduler.
-    pscTickDuration :: DiffTime
-  }
-  deriving (Eq, Show)
-
-defaultPointScheduleConfig :: PointScheduleConfig
-defaultPointScheduleConfig =
-  PointScheduleConfig {pscTickDuration = 0.1}
 
 ----------------------------------------------------------------------------------------------------
 -- Conversion to 'PointSchedule'

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
@@ -6,13 +6,10 @@
 {-# LANGUAGE RankNTypes            #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
 
--- | Data types and generators that convert a 'BlockTree' to a 'PointSchedule'.
---
--- Point schedules can have arbitrary configurations that model different behaviors
--- we want to use for tests.
+-- | Data types and generators for point schedules.
 --
 -- Each generator takes a set of 'AnchoredFragment's corresponding to the tested peers'
--- chains, and converts them to a 'PointSchedule' consisting of a sequence of states
+-- chains, and converts them to a point schedule consisting of a sequence of states
 -- ('AdvertisedPoints'), each of which is associated with a single peer.
 --
 -- When a schedule is executed in a test, each tick is processed in order.
@@ -22,8 +19,6 @@
 -- The state in the current tick determines the actions that the peer is allowed to perform,
 -- and once it fulfills the state's criteria, it yields control back to the scheduler,
 -- who then activates the next tick's peer.
---
--- /Note/: At the moment this implementation is experimental.
 module Test.Consensus.PointSchedule (
     AdvertisedPoints (..)
   , BlockPoint (..)

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
@@ -54,6 +54,7 @@ module Test.Consensus.PointSchedule (
   , pointScheduleBlocks
   , pointSchedulePeers
   , prettyGenesisTest
+  , prettyPeersSchedule
   , prettyPointSchedule
   , stToGen
   , tipPointBlock
@@ -71,6 +72,7 @@ import qualified Data.List.NonEmpty as NonEmpty
 import qualified Data.Map.Strict as Map
 import           Data.Maybe (catMaybes)
 import           Data.Time (DiffTime)
+import           Data.Traversable (for)
 import           Data.Word (Word64)
 import           Ouroboros.Consensus.Block.Abstract (WithOrigin (..), getHeader)
 import           Ouroboros.Consensus.Protocol.Abstract (SecurityParam,
@@ -246,6 +248,11 @@ instance Condense PointSchedule where
 prettyPointSchedule :: PointSchedule -> [String]
 prettyPointSchedule PointSchedule{ticks} =
   "PointSchedule:" : (("  " ++) <$> (condense <$> toList ticks))
+
+prettyPeersSchedule :: Peers PeerSchedule -> [String]
+prettyPeersSchedule peers =
+  for (zip [(0 :: Integer)..] (peersStates peers)) $ \(number, (time, peerState)) ->
+  show number ++ ": " ++ condense peerState ++ " @" ++ show time
 
 -- | Parameters that are significant for components outside of generators, like the peer
 -- simulator.

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/SinglePeer.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/SinglePeer.hs
@@ -95,6 +95,7 @@ module Test.Consensus.PointSchedule.SinglePeer (
 
 import           Cardano.Slotting.Slot (WithOrigin (At, Origin), withOrigin)
 import           Control.Arrow (second)
+import           Control.Monad.Class.MonadTime.SI (Time)
 import           Data.List (mapAccumL)
 import           Data.Time.Clock (DiffTime)
 import           Data.Vector (Vector)
@@ -161,7 +162,7 @@ singleJumpPeerSchedule
   => g
   -> PeerScheduleParams
   -> AF.AnchoredFragment TestBlock
-  -> m [(DiffTime, SchedulePoint)]
+  -> m [(Time, SchedulePoint)]
 singleJumpPeerSchedule g psp chain = do
     let chainv = Vector.fromList $ AF.toOldestFirst chain
     (tps, hps, bps) <- singleJumpRawPeerSchedule g psp tbSlot chainv
@@ -179,7 +180,7 @@ singleJumpRawPeerSchedule
   -> PeerScheduleParams
   -> (b -> SlotNo)
   -> Vector b
-  -> m ([(DiffTime, b)], [(DiffTime, b)], [(DiffTime, b)])
+  -> m ([(Time, b)], [(Time, b)], [(Time, b)])
 singleJumpRawPeerSchedule g psp slotOfB chainv = do
     -- generate the tip points
     ixs <- singleJumpTipPoints g 0 (Vector.length chainv - 1)
@@ -222,7 +223,7 @@ peerScheduleFromTipPoints
   -> [(IsTrunk, [Int])]
   -> AF.AnchoredFragment TestBlock
   -> [AF.AnchoredFragment TestBlock]
-  -> m [(DiffTime, SchedulePoint)]
+  -> m [(Time, SchedulePoint)]
 peerScheduleFromTipPoints g psp tipPoints trunk0 branches0 = do
     let trunk0v = Vector.fromList $ AF.toOldestFirst trunk0
         firstTrunkBlockNo = withOrigin 1 (+1) $ AF.anchorBlockNo trunk0
@@ -263,7 +264,7 @@ rawPeerScheduleFromTipPoints
   -> Vector b
   -> [Vector b]
   -> [Maybe Int]
-  -> m ([(DiffTime, b)], [(DiffTime, b)], [(DiffTime, b)])
+  -> m ([(Time, b)], [(Time, b)], [(Time, b)])
 rawPeerScheduleFromTipPoints g psp slotOfB tipPoints trunk0v branches0v intersections = do
     let (isTrunks, tpIxs) = unzip tipPoints
         pairedVectors = pairVectorsWithChunks trunk0v branches0v isTrunks
@@ -299,7 +300,7 @@ rawPeerScheduleFromTipPoints g psp slotOfB tipPoints trunk0v branches0v intersec
         pairVectors [] IsBranch       = error "not enough branches"
 
     -- | Replaces block indices with the actual blocks
-    scheduleIndicesToBlocks :: Vector b -> Vector b -> HeaderPointSchedule -> [(DiffTime, b)]
+    scheduleIndicesToBlocks :: Vector b -> Vector b -> HeaderPointSchedule -> [(Time, b)]
     scheduleIndicesToBlocks trunk v hps =
         map (second (trunk Vector.!)) (hpsTrunk hps)
           ++ map (second (v Vector.!)) (hpsBranch hps)

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/SinglePeer/Indices.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/SinglePeer/Indices.hs
@@ -181,7 +181,7 @@ tipPointSchedule g slotLength msgDelayInterval slots = do
           firstLater = case newBranch of
             -- If there is no later point, pick an arbitrary later time interval
             -- to sample from
-            []           -> addTime (let Time lt = lastTime in lt) (slotTime (toEnum nseq)) -- REVIEW: why are we summing two absolute times?
+            []           -> addTime (slotsDiffTime (toEnum nseq)) lastTime
             ((a, _) : _) -> addTime (fst msgDelayInterval) a
       times <- replicateM nseq (uniformRMTime (lastTime, firstLater) g)
       pure (sort times, newBranch)

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/SinglePeer/Indices.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/SinglePeer/Indices.hs
@@ -313,7 +313,7 @@ headerPointSchedule g msgDelayInterval xs =
           if maybe False (tNext >) mtMax || nextHp > tp then
             pure ((tNext, nextHp), reverse acc)
           else do
-            t <- (flip addTime tNext) <$> uniformRMDiffTime msgDelayInterval g
+            t <- (`addTime` tNext) <$> uniformRMDiffTime msgDelayInterval g
             go t (nextHp+1) ((tNext, nextHp) : acc)
 
 mapAccumM :: Monad m => (s -> x -> m (s, y)) -> s -> [x] -> m (s, [y])

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Tests.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Tests.hs
@@ -10,6 +10,7 @@ import           Cardano.Slotting.Slot (SlotNo (..), WithOrigin (..),
 import           Control.Monad (forM, replicateM)
 import           Control.Monad.Class.MonadTime.SI (Time (Time))
 import           Data.Bifunctor (second)
+import           Data.Coerce (coerce)
 import           Data.List (foldl', group, isSuffixOf, partition, sort)
 import qualified Data.List.NonEmpty as NonEmpty
 import           Data.Maybe (isNothing)
@@ -120,7 +121,7 @@ instance QC.Arbitrary HeaderPointScheduleInput where
     branchTips <- genTipPoints
     let branchCount = length branchTips
         tpCount = sum $ map length branchTips
-    ts <- map Time <$> scanl1 (+) . sort <$> replicateM tpCount (chooseDiffTime (7, 12))
+    ts <- coerce <$> scanl1 (+) . sort <$> replicateM tpCount (chooseDiffTime (7, 12))
     let tpts = zipMany ts branchTips
     intersectionBlocks <- genIntersections branchCount
     maybes <- QC.infiniteList @(Maybe Int)


### PR DESCRIPTION
Builds on https://github.com/IntersectMBO/ouroboros-consensus/pull/880 that included the schedules in `GenesisTest` instead of carrying pairs `(GenesisTest, schedule)` everywhere.

This PR removes the `PointSchedule` type. It came from the observation that this type was nowadays only used as an intermediary between the `SchedulePoint`-based schedules and the peer simulator, but that it was actually only used in few places. I think it is nicer to reduce the number of notions of schedules that we have in our code -- it would make it easier to onboard on and maintain. I would however want to check first with you @tek @facundominguez whether you can think of reasons not to get rid of this type; in particular if there are pieces of work that are not on `genesis/milestone8` and that crucially use it.

This PR contains an additional commit, ac3aad8d9d5f77a2d1ba7a5ea5cf60cf18055805, that uses the type `Time` to make more explicit where we use `DiffTime` as an actual time duration and where we use it as an absolute time (in an arbitrary clock, but nonetheless). I personally think it drastically improves the reading of the functions in `SinglePeer` (and, actually, this commit started with me just wondering whether `DiffTime`s were meant as relative or absolute in some place in this PR) but we can also drop it.

I had other clean up in mind and most importantly to drop the `NodeState` type and some other related things, but I will not pursue them in this PR and I would rather have your opinion on this part of the work first.