### PR TITLE
simplify the LSQ server test

### DIFF
--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/MiniProtocol/LocalStateQuery/Server.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/MiniProtocol/LocalStateQuery/Server.hs
@@ -78,25 +78,29 @@ tests = testGroup "LocalStateQueryServer"
 --   chain, a state and send the 'QueryLedgerTip'. Collect these results.
 -- * Check that when acquiring failed, it rightfully failed. Otherwise, check
 --   whether the returned tip matches the block.
-prop_localStateQueryServer
-  :: SecurityParam
+prop_localStateQueryServer ::
+     SecurityParam
   -> BlockTree
   -> Permutation
-  -> Positive (Small Int)
   -> Property
-prop_localStateQueryServer k bt p (Positive (Small n)) = checkOutcome k chain actualOutcome
+prop_localStateQueryServer k bt p = checkOutcome k chain actualOutcome
   where
     chain :: Chain TestBlock
     chain = treePreferredChain bt
 
-    points :: [Target (Point TestBlock)]
-    points = permute p $
-         replicate n VolatileTip
-      ++ (SpecificPoint . blockPoint <$> treeToBlocks bt)
+    -- A random sequence of targets: one for each block in the tree and also a
+    -- random number of immtip/voltip queries
+    --
+    -- The fact that the queries are ordered /shouldn't/ ultimately matter,
+    -- since the server has selected the same chain the entire time.
+    targets :: [Target (Point TestBlock)]
+    targets = permute p $
+        VolatileTip
+      : ImmutableTip
+      : (SpecificPoint . blockPoint <$> treeToBlocks bt)
 
-    actualOutcome :: [(Target (Point TestBlock), Either AcquireFailure (Point TestBlock))]
     actualOutcome = runSimOrThrow $ do
-      let client = mkClient points
+      let client = mkClient targets
       server <- mkServer k chain
       (\(a, _, _) -> a) <$>
         connect
@@ -128,8 +132,8 @@ checkOutcome k chain = conjoin . map (uncurry checkResult)
     immutableSlot = Chain.headSlot $
       Chain.drop (fromIntegral (maxRollbacks k)) chain
 
-    checkResult
-      :: Target (Point TestBlock)
+    checkResult ::
+         Target (Point TestBlock)
       -> Either AcquireFailure (Point TestBlock)
       -> Property
     checkResult (SpecificPoint pt) = \case
@@ -144,7 +148,7 @@ checkOutcome k chain = conjoin . map (uncurry checkResult)
         | otherwise
         -> tabulate "Acquired" ["AcquireFailurePointNotOnChain"] $ property True
       Left AcquireFailurePointTooOld
-        | pointSlot pt >= immutableSlot
+        | pointSlot pt >= immutableSlot   -- TODO what if the immtip is a multi-leader slot?
         -> counterexample
            ("Point " <> show pt <>
             " newer than the immutable tip, but got AcquireFailurePointTooOld")
@@ -153,13 +157,13 @@ checkOutcome k chain = conjoin . map (uncurry checkResult)
         -> tabulate "Acquired" ["AcquireFailurePointTooOld"] $ property True
     checkResult VolatileTip = \case
       Right _result -> tabulate "Acquired" ["Success"] True
-      Left  failure -> counterexample ("acquire tip point resulted in " ++ show failure) False
+      Left  failure -> counterexample ("Acquiring the volatile tip resulted in " ++ show failure) False
     checkResult ImmutableTip = \case
       Right _result -> tabulate "Acquired" ["Success"] True
-      Left  failure -> counterexample ("acquire tip point resulted in " ++ show failure) False
+      Left  failure -> counterexample ("Acquiring the immutable tip resulted in " ++ show failure) False
 
-mkClient
-  :: Monad m
+mkClient ::
+     Monad m
   => [Target (Point TestBlock)]
   -> LocalStateQueryClient
        TestBlock
@@ -167,7 +171,7 @@ mkClient
        (Query TestBlock)
        m
        [(Target (Point TestBlock), Either AcquireFailure (Point TestBlock))]
-mkClient points = localStateQueryClient [(pt, BlockQuery QueryLedgerTip) | pt <- points]
+mkClient targets = localStateQueryClient [(tgt, BlockQuery QueryLedgerTip) | tgt <- targets]
 
 mkServer ::
      IOLike m


### PR DESCRIPTION
For example, I removed the replication of the Immutable/VolatileTip acquire messages, since the test is so simple that the number of those is currently irrelevant---it's misleading to replicate them, as if that was already expected to matter.