### PR TITLE
Integrate #4795

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -14,9 +14,9 @@ repository cardano-haskell-packages
 -- update either of these.
 index-state:
   -- Bump this if you need newer packages from Hackage
-  , hackage.haskell.org 2024-01-28T20:27:47Z
+  , hackage.haskell.org 2024-02-05T10:42:33Z
   -- Bump this if you need newer packages from CHaP
-  , cardano-haskell-packages 2024-01-28T20:24:54Z
+  , cardano-haskell-packages 2024-02-05T00:15:54Z
 
 packages:
   ouroboros-consensus
@@ -31,3 +31,14 @@ tests: true
 benchmarks: true
 
 import: ./asserts.cabal
+
+source-repository-package
+    type: git
+    location: https://github.com/input-output-hk/ouroboros-network/
+    tag: 3e60e562ccec1395212a2b75cf7c7865db6a9a0e
+    subdir: ouroboros-network
+            ouroboros-network-framework
+            ouroboros-network-api
+            ouroboros-network-testing
+            ouroboros-network-protocols
+    --sha256: sha256-at3wlzorez8RqYB6EksfsoRE4ryCxILD4d/End9p/c4=

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1706476881,
-        "narHash": "sha256-y+PxZ4FUZPGdl3yU+YuTo2MMxnFlYv7r/I4X4i1wt/s=",
+        "lastModified": 1707094936,
+        "narHash": "sha256-lvZbh1KFdoj/xXTW5xSrIdnKdAVrtjlatt+OuEU7ovk=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "2a8faa2f2d80bdda655e4f9b1e3cc1bc1dde4159",
+        "rev": "a6a150aed19885bd3fc1ddaf9dd3019adc7e6cfb",
         "type": "github"
       },
       "original": {
@@ -225,11 +225,11 @@
     "hackageNix": {
       "flake": false,
       "locked": {
-        "lastModified": 1706401491,
-        "narHash": "sha256-UR9U45S9ISuuHYTUmoApJuCDi6+BNJFk18bJoRYY2qI=",
+        "lastModified": 1707092608,
+        "narHash": "sha256-sN3NqWrAz9nGSQzWnrDALbA6oVgQ3n19zY+6hLXBYko=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "5969e45d359a9a8d06036343f67f949993e19edb",
+        "rev": "5c4bbb4f270e26905f0b9cf0ed8ca7a224dc9c82",
         "type": "github"
       },
       "original": {

--- a/ouroboros-consensus-diffusion/changelog.d/20240205_151901_armandoifsantos_4782.md
+++ b/ouroboros-consensus-diffusion/changelog.d/20240205_151901_armandoifsantos_4782.md
@@ -1,0 +1,24 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Patch
+
+- A bullet item for the Patch category.
+
+-->
+<!--
+### Non-Breaking
+
+- A bullet item for the Non-Breaking category.
+
+-->
+### Breaking
+
+- Added `PeerSharingAPI` to `NodeKernel`
+- Added `peerSharingRng` to `NodeKernelArgs`
+- Refactored some diffusion functions to remove `computePeers` callback
+

--- a/ouroboros-consensus-diffusion/src/unstable-diffusion-testlib/Test/ThreadNet/Network.hs
+++ b/ouroboros-consensus-diffusion/src/unstable-diffusion-testlib/Test/ThreadNet/Network.hs
@@ -112,7 +112,7 @@ import           Ouroboros.Network.Protocol.PeerSharing.Type (PeerSharing)
 import           Ouroboros.Network.Protocol.TxSubmission2.Type
 import qualified System.FS.Sim.MockFS as Mock
 import           System.FS.Sim.MockFS (MockFS)
-import           System.Random (mkStdGen)
+import           System.Random (mkStdGen, split)
 import           Test.ThreadNet.TxGen
 import           Test.ThreadNet.Util.NodeJoinPlan
 import           Test.ThreadNet.Util.NodeRestarts
@@ -966,8 +966,9 @@ runThreadNetwork systemTime ThreadNetworkArgs
         , hfbtMaxClockRewind = secondsToNominalDiffTime 0
         }
 
-      let kaRng = case seed of
+      let rng = case seed of
                     Seed s -> mkStdGen s
+          (kaRng, psRng) = split rng
       let nodeKernelArgs = NodeKernelArgs
             { tracers
             , registry
@@ -982,6 +983,7 @@ runThreadNetwork systemTime ThreadNetworkArgs
             , blockFetchSize          = estimateBlockSize
             , mempoolCapacityOverride = NoMempoolCapacityBytesOverride
             , keepAliveRng            = kaRng
+            , peerSharingRng          = psRng
             , miniProtocolParameters  = MiniProtocolParameters {
                   chainSyncPipeliningHighMark = 4,
                   chainSyncPipeliningLowMark  = 2,
@@ -1025,7 +1027,7 @@ runThreadNetwork systemTime ThreadNetworkArgs
                   -- The purpose of this test is not testing protocols, so
                   -- returning constant empty list is fine if we have thorough
                   -- tests about the peer sharing protocol itself.
-                  (NTN.mkHandlers nodeKernelArgs nodeKernel (\_ -> return []))
+                  (NTN.mkHandlers nodeKernelArgs nodeKernel)
 
       -- In practice, a robust wallet/user can persistently add a transaction
       -- until it appears on the chain. This thread adds robustness for the


### PR DESCRIPTION
# Description

This PR integrates changes in [ouroboros-network #4795](IntersectMBO/ouroboros-network#4795). Which basically removes the `computePeers` callback from diffusion functions and provides a cleaner interface for consensus.

Note: This PR probably depends on #808 to be merged since bootstrap peers work has already been merged in ouroboros-network.
