### PR TITLE
Mempool API: generalize types of `addTxs` and `addLocalTxs`

### DIFF
--- a/ouroboros-consensus/changelog.d/20240212_141854_alexander.esgen_the_answer_is_traverse.md
+++ b/ouroboros-consensus/changelog.d/20240212_141854_alexander.esgen_the_answer_is_traverse.md
@@ -1,0 +1,4 @@
+### Breaking
+
+- Mempool API: generalize types of `addTxs` and `addLocalTxs` to any
+  `Traversable`.

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/API.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/API.hs
@@ -249,10 +249,10 @@ isMempoolTxRejected _                   = False
 --
 -- See 'addTx' for further details.
 addTxs ::
-     forall m blk. MonadSTM m
+     forall m blk t. (MonadSTM m, Traversable t)
   => Mempool m blk
-  -> [GenTx blk]
-  -> m [MempoolAddTxResult blk]
+  -> t (GenTx blk)
+  -> m (t (MempoolAddTxResult blk))
 addTxs mempool = mapM (addTx mempool AddTxForRemotePeer)
 
 -- | A wrapper around 'addTx' that adds a sequence of transactions on behalf of
@@ -263,10 +263,10 @@ addTxs mempool = mapM (addTx mempool AddTxForRemotePeer)
 --
 -- See 'addTx' for further details.
 addLocalTxs ::
-     forall m blk. MonadSTM m
+     forall m blk t. (MonadSTM m, Traversable t)
   => Mempool m blk
-  -> [GenTx blk]
-  -> m [MempoolAddTxResult blk]
+  -> t (GenTx blk)
+  -> m (t (MempoolAddTxResult blk))
 addLocalTxs mempool = mapM (addTx mempool AddTxForLocalClient)
 
 -- | Who are we adding a tx on behalf of, a remote peer or a local client?


### PR DESCRIPTION
This allows us to get rid of an `error` call.

Inspired by https://oleg.fi/gists/posts/2023-10-12-use-traversals-for-batch-operations.html
