### PR TITLE
Move chain sync timeouts from `SchedulerConfig` to `GenesisTest`

### DIFF
--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup.hs
@@ -14,9 +14,7 @@ module Test.Consensus.Genesis.Setup (
 
 import           Control.Monad.IOSim (runSimOrThrow)
 import           Control.Tracer (debugTracer, traceWith)
-import           Data.Foldable (for_)
 import           Ouroboros.Consensus.Util.Condense
-import           Test.Consensus.BlockTree (allFragments)
 import           Test.Consensus.Genesis.Setup.Classifiers (classifiers, Classifiers (..))
 import           Test.Consensus.Genesis.Setup.GenChains
 import           Test.Consensus.PeerSimulator.Run
@@ -26,7 +24,6 @@ import           Test.Consensus.PointSchedule
 import           Test.Consensus.PointSchedule.Peers (Peers)
 import           Test.QuickCheck
 import           Test.Util.Orphans.IOLike ()
-import           Test.Util.TersePrinting (terseFragment)
 import           Test.Util.QuickCheck (forAllGenRunShrinkCheck)
 import           Test.Util.Tracer (recordingTracerTVar)
 
@@ -47,9 +44,6 @@ runGenesisTest schedulerConfig genesisTest =
     (recordingTracer, getTrace) <- recordingTracerTVar
     let tracer = if scDebug schedulerConfig then debugTracer else recordingTracer
 
-    -- FIXME: should also go in 'prettyGenesisTest' (or 'prettyBlockTree')
-    for_ (allFragments gtBlockTree) (traceWith tracer . terseFragment)
-
     traceLinesWith tracer $ prettyGenesisTest genesisTest
 
     rgtrStateView <- runPointSchedule schedulerConfig genesisTest tracer
@@ -57,8 +51,6 @@ runGenesisTest schedulerConfig genesisTest =
     rgtrTrace <- unlines <$> getTrace
 
     pure $ RunGenesisTestResult {rgtrTrace, rgtrStateView}
-  where
-    GenesisTest {gtBlockTree} = genesisTest
 
 -- | Variant of 'runGenesisTest' that also takes a property on the final
 -- 'StateView' and returns a QuickCheck property. The trace is printed in case

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup.hs
@@ -16,8 +16,6 @@ import           Control.Monad.IOSim (runSimOrThrow)
 import           Control.Tracer (debugTracer, traceWith)
 import           Data.Foldable (for_)
 import           Ouroboros.Consensus.Util.Condense
-import           Ouroboros.Network.Protocol.ChainSync.Codec
-                     (ChainSyncTimeout (..))
 import           Test.Consensus.BlockTree (allFragments)
 import           Test.Consensus.Genesis.Setup.Classifiers (classifiers, Classifiers (..))
 import           Test.Consensus.Genesis.Setup.GenChains
@@ -52,13 +50,7 @@ runGenesisTest schedulerConfig genesisTest =
     -- FIXME: should also go in 'prettyGenesisTest' (or 'prettyBlockTree')
     for_ (allFragments gtBlockTree) (traceWith tracer . terseFragment)
 
-    traceLinesWith tracer $ [
-      "SchedulerConfig:",
-      "  ChainSyncTimeouts:",
-      "    canAwait = " ++ show (canAwaitTimeout scChainSyncTimeouts),
-      "    intersect = " ++ show (intersectTimeout scChainSyncTimeouts),
-      "    mustReply = " ++ show (mustReplyTimeout scChainSyncTimeouts)
-      ] ++ prettyGenesisTest genesisTest
+    traceLinesWith tracer $ prettyGenesisTest genesisTest
 
     rgtrStateView <- runPointSchedule schedulerConfig genesisTest tracer
     traceWith tracer (condense rgtrStateView)
@@ -66,7 +58,6 @@ runGenesisTest schedulerConfig genesisTest =
 
     pure $ RunGenesisTestResult {rgtrTrace, rgtrStateView}
   where
-    SchedulerConfig {scChainSyncTimeouts} = schedulerConfig
     GenesisTest {gtBlockTree} = genesisTest
 
 -- | Variant of 'runGenesisTest' that also takes a property on the final

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LongRangeAttack.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LongRangeAttack.hs
@@ -12,7 +12,7 @@ import qualified Ouroboros.Network.AnchoredFragment as AF
 import           Test.Consensus.Genesis.Setup
 import           Test.Consensus.Genesis.Setup.Classifiers
                      (allAdversariesSelectable, classifiers)
-import           Test.Consensus.PeerSimulator.Run (noTimeoutsSchedulerConfig)
+import           Test.Consensus.PeerSimulator.Run (defaultSchedulerConfig)
 import           Test.Consensus.PeerSimulator.StateView
 import           Test.Consensus.PointSchedule
 import           Test.Consensus.PointSchedule.Shrinking (shrinkPeerSchedules)
@@ -39,7 +39,7 @@ prop_longRangeAttack =
           then pure $ gt $> ps
           else discard)
 
-    noTimeoutsSchedulerConfig
+    defaultSchedulerConfig
 
     shrinkPeerSchedules
 

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
@@ -26,7 +26,7 @@ import           Test.Consensus.Genesis.Setup.Classifiers
 import           Test.Consensus.Network.Driver.Limits.Extras
                      (chainSyncNoTimeouts)
 import           Test.Consensus.PeerSimulator.Run (SchedulerConfig (..),
-                     noTimeoutsSchedulerConfig)
+                     defaultSchedulerConfig)
 import           Test.Consensus.PeerSimulator.StateView
 import           Test.Consensus.PointSchedule
 import           Test.Consensus.PointSchedule.Peers (PeerId (..), Peers (..),
@@ -132,8 +132,7 @@ prop_serveAdversarialBranches =
 
     (genChains (QC.choose (1, 4)) `enrichedWith` genUniformSchedulePoints)
 
-    (noTimeoutsSchedulerConfig
-       {scTraceState = False, scTrace = False})
+    (defaultSchedulerConfig {scTraceState = False, scTrace = False})
 
     shrinkPeerSchedules
 
@@ -174,8 +173,7 @@ prop_leashingAttackStalling =
 
     (genChains (QC.choose (1, 4)) `enrichedWith` genLeashingSchedule)
 
-    (noTimeoutsSchedulerConfig
-      {scTrace = False})
+    (defaultSchedulerConfig {scTrace = False})
 
     shrinkPeerSchedules
 
@@ -219,8 +217,7 @@ prop_leashingAttackTimeLimited =
 
     (genChains (QC.choose (1, 4)) `enrichedWith` genTimeLimitedSchedule)
 
-    (noTimeoutsSchedulerConfig
-      {scTrace = False})
+    (defaultSchedulerConfig {scTrace = False})
 
     shrinkPeerSchedules
 
@@ -280,13 +277,13 @@ prop_loeStalling :: Property
 prop_loeStalling =
   forAllGenesisTest
 
-    (genChains (QC.choose (1, 4)) `enrichedWith` genUniformSchedulePoints)
+    (do gt <- genChains (QC.choose (1, 4))
+                `enrichedWith`
+              genUniformSchedulePoints
+        pure gt {gtChainSyncTimeouts = chainSyncNoTimeouts {canAwaitTimeout = shortWait}}
+    )
 
-    (noTimeoutsSchedulerConfig {
-      scTrace = False,
-      scEnableLoE = True,
-      scChainSyncTimeouts = chainSyncNoTimeouts {canAwaitTimeout = shortWait}
-    })
+    (defaultSchedulerConfig {scTrace = False, scEnableLoE = True})
 
     shrinkPeerSchedules
 

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
@@ -14,7 +14,7 @@ import           Ouroboros.Network.AnchoredFragment (AnchoredFragment,
 import qualified Ouroboros.Network.AnchoredFragment as AF
 import           Test.Consensus.BlockTree (BlockTree (..), BlockTreeBranch (..))
 import           Test.Consensus.Genesis.Setup
-import           Test.Consensus.PeerSimulator.Run (noTimeoutsSchedulerConfig)
+import           Test.Consensus.PeerSimulator.Run (defaultSchedulerConfig)
 import           Test.Consensus.PeerSimulator.StateView
 import           Test.Consensus.PointSchedule
 import           Test.Consensus.PointSchedule.Peers (Peers, peersOnlyHonest)
@@ -46,7 +46,7 @@ prop_rollback = do
     (do gt@GenesisTest{gtSecurityParam, gtBlockTree} <- genChains (pure 1)
         pure gt {gtSchedule =  rollbackSchedule (fromIntegral (maxRollbacks gtSecurityParam)) gtBlockTree})
 
-    noTimeoutsSchedulerConfig
+    defaultSchedulerConfig
 
     (\_ _ -> [])
 
@@ -62,7 +62,7 @@ prop_cannotRollback =
     (do gt@GenesisTest{gtSecurityParam, gtBlockTree} <- genChains (pure 1)
         pure gt {gtSchedule = rollbackSchedule (fromIntegral (maxRollbacks gtSecurityParam + 1)) gtBlockTree})
 
-    noTimeoutsSchedulerConfig
+    defaultSchedulerConfig
 
     (\_ _ -> [])
 

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
@@ -64,7 +64,7 @@ import           Ouroboros.Network.Point (WithOrigin (At))
 import qualified System.Random.Stateful as Random
 import           System.Random.Stateful (STGenM, StatefulGen, runSTGen_)
 import           Test.Consensus.BlockTree (BlockTree (..), BlockTreeBranch (..),
-                     prettyBlockTree)
+                     allFragments, prettyBlockTree)
 import           Test.Consensus.PointSchedule.Peers (Peer (..), Peers (..),
                      mkPeers, peersList)
 import           Test.Consensus.PointSchedule.SinglePeer
@@ -76,8 +76,8 @@ import           Test.Consensus.PointSchedule.SinglePeer.Indices
 import           Test.Ouroboros.Consensus.ChainGenerator.Params (Delta (Delta))
 import           Test.QuickCheck (Gen, arbitrary)
 import           Test.QuickCheck.Random (QCGen)
-import           Test.Util.TersePrinting (terseBlock, terseHeader, terseTip,
-                     terseWithOrigin)
+import           Test.Util.TersePrinting (terseBlock, terseFragment,
+                     terseHeader, terseTip, terseWithOrigin)
 import           Test.Util.TestBlock (Header, TestBlock)
 
 ----------------------------------------------------------------------------------------------------
@@ -345,7 +345,8 @@ prettyGenesisTest genesisTest =
   , "    intersect = " ++ show intersectTimeout
   , "    mustReply = " ++ show mustReplyTimeout
   , "  gtBlockTree:"
-  ] ++ (("    " ++) <$> prettyBlockTree gtBlockTree)
+  ] ++ map (("    " ++) . terseFragment) (allFragments gtBlockTree)
+    ++ map ("    " ++) (prettyBlockTree gtBlockTree)
   where
     GenesisTest {
         gtSecurityParam


### PR DESCRIPTION
The idea is that the value of the timeouts depends on the chain, asc, slot length, etc., so it makes more sense to have them defined in `GenesisTest` imo. This will also avoid having us move `Asc` around only to build a `SchedulerConfig`. We keep a boolean flag `scEnableChainSyncTimeouts` in `SchedulerConfig` describing whether we should follow those timeouts when running the scheduler.

In `SchedulerConfig`:

- Remove `scChainSyncTimeouts`; replace it by a boolean flag `scEnableChainSyncTimeouts`.
- Remove `*SchedulerConfig` and replace by `defaultSchedulerConfig`.
- Remove `scSlotLength`

In `GenesisTest`:

- Add `gtSlotLength`; fill it in `GenChains`.
- Add `gtChainSyncTimeouts`; fill it in `GenChains`.
- Remove `gtHonestAsc`.