### PR TITLE
Ensure UTF-8 support of all terminal handles

### DIFF
--- a/ouroboros-consensus-cardano/app/db-analyser.hs
+++ b/ouroboros-consensus-cardano/app/db-analyser.hs
@@ -22,12 +22,13 @@ import           Cardano.Tools.GitRev (gitRev)
 import           Control.Monad (void)
 import qualified Data.Text as T
 import           DBAnalyser.Parsers
+import           Main.Utf8 (withStdTerminalHandles)
 import           Options.Applicative (execParser, footer, fullDesc, helper,
                      info, progDesc, (<**>))
 
 
 main :: IO ()
-main = do
+main = withStdTerminalHandles $ do
     cryptoInit
     (conf, blocktype) <- getCmdLine
     void $ case blocktype of

--- a/ouroboros-consensus-cardano/app/db-synthesizer.hs
+++ b/ouroboros-consensus-cardano/app/db-synthesizer.hs
@@ -26,11 +26,12 @@ module Main (main) where
 import           Cardano.Crypto.Init (cryptoInit)
 import           Cardano.Tools.DBSynthesizer.Run
 import           DBSynthesizer.Parsers
+import           Main.Utf8 (withStdTerminalHandles)
 import           System.Exit
 
 
 main :: IO ()
-main = do
+main = withStdTerminalHandles $ do
     cryptoInit
     (paths, creds, forgeOpts) <- parseCommandLine
     result <- initialize paths creds forgeOpts >>= either die (uncurry synthesize)

--- a/ouroboros-consensus-cardano/app/db-truncater.hs
+++ b/ouroboros-consensus-cardano/app/db-truncater.hs
@@ -5,13 +5,14 @@ import           Cardano.Tools.DBTruncater.Run
 import           Cardano.Tools.DBTruncater.Types
 import           DBAnalyser.Parsers (BlockType (..))
 import qualified DBTruncater.Parsers as DBTruncater
+import           Main.Utf8 (withStdTerminalHandles)
 import           Options.Applicative (execParser, fullDesc, helper, info,
                      progDesc, (<**>))
 import           Ouroboros.Consensus.Storage.ImmutableDB.Impl ()
 import           Prelude hiding (truncate)
 
 main :: IO ()
-main = do
+main = withStdTerminalHandles $ do
     cryptoInit
     (conf, blocktype) <- getCommandLineConfig
     case blocktype of

--- a/ouroboros-consensus-cardano/app/immdb-server.hs
+++ b/ouroboros-consensus-cardano/app/immdb-server.hs
@@ -8,12 +8,13 @@ import qualified Cardano.Tools.DBAnalyser.Block.Cardano as Cardano
 import           Cardano.Tools.DBAnalyser.HasAnalysis (mkProtocolInfo)
 import qualified Cardano.Tools.ImmDBServer.Diffusion as ImmDBServer
 import           Data.Void
+import           Main.Utf8 (withStdTerminalHandles)
 import qualified Network.Socket as Socket
 import           Options.Applicative
 import           Ouroboros.Consensus.Node.ProtocolInfo (ProtocolInfo (..))
 
 main :: IO ()
-main = do
+main = withStdTerminalHandles $ do
     cryptoInit
     Opts {immDBDir, port, configFile} <- execParser optsParser
     let sockAddr = Socket.SockAddrInet port hostAddr

--- a/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
+++ b/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
@@ -553,6 +553,7 @@ executable db-analyser
     , ouroboros-consensus
     , ouroboros-consensus-cardano:{ouroboros-consensus-cardano, unstable-cardano-tools}
     , text
+    , with-utf8
 
   other-modules:  DBAnalyser.Parsers
 
@@ -566,6 +567,7 @@ executable db-synthesizer
     , optparse-applicative
     , ouroboros-consensus
     , unstable-cardano-tools
+    , with-utf8
 
   other-modules:  DBSynthesizer.Parsers
 
@@ -580,6 +582,7 @@ executable db-truncater
     , optparse-applicative
     , ouroboros-consensus
     , ouroboros-consensus-cardano:{ouroboros-consensus-cardano, unstable-cardano-tools}
+    , with-utf8
 
   other-modules:
     DBAnalyser.Parsers
@@ -596,6 +599,7 @@ executable immdb-server
     , optparse-applicative
     , ouroboros-consensus
     , ouroboros-consensus-cardano:unstable-cardano-tools
+    , with-utf8
 
 test-suite tools-test
   import:         common-test

--- a/ouroboros-consensus-cardano/test/cardano-test/Main.hs
+++ b/ouroboros-consensus-cardano/test/cardano-test/Main.hs
@@ -17,7 +17,6 @@ import           Test.Util.TestEnv (defaultMainWithTestEnv,
 main :: IO ()
 main = do
   hSetBuffering stdout LineBuffering
-  hSetEncoding stdout utf8
   defaultMainWithTestEnv defaultTestEnvConfig tests
 
 tests :: TestTree

--- a/ouroboros-consensus-cardano/test/cardano-test/Main.hs
+++ b/ouroboros-consensus-cardano/test/cardano-test/Main.hs
@@ -1,7 +1,6 @@
 module Main (main) where
 
-import           System.IO (BufferMode (LineBuffering), hSetBuffering,
-                     hSetEncoding, stdout, utf8)
+import           System.IO (BufferMode (LineBuffering), hSetBuffering, stdout)
 import qualified Test.Consensus.Cardano.ByronCompatibility
 import qualified Test.Consensus.Cardano.Golden
 import qualified Test.Consensus.Cardano.MiniProtocol.LocalTxSubmission.Server

--- a/ouroboros-consensus/bench/ChainSync-client-bench/Main.hs
+++ b/ouroboros-consensus/bench/ChainSync-client-bench/Main.hs
@@ -10,6 +10,7 @@ import           Control.Tracer (contramap, debugTracer, nullTracer)
 import           Data.IORef (newIORef, readIORef, writeIORef)
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as Map
+import           Main.Utf8 (withStdTerminalHandles)
 import           Network.TypedProtocol.Channel
 import           Network.TypedProtocol.Driver.Simple
 import           Ouroboros.Consensus.Block
@@ -54,7 +55,7 @@ type B = TB.TestBlock
 type H = Header B
 
 main :: IO ()
-main = mainWith $ \n -> do
+main = withStdTerminalHandles $ mainWith $ \n -> do
     varCandidate <- newTVarIO $ AF.Empty AF.AnchorGenesis
 
     varServerTip <- newTVarIO TipGenesis

--- a/ouroboros-consensus/bench/mempool-bench/Main.hs
+++ b/ouroboros-consensus/bench/mempool-bench/Main.hs
@@ -20,6 +20,7 @@ import           Data.Maybe (fromMaybe)
 import           Data.Set ()
 import qualified Data.Text as Text
 import qualified Data.Text.Read as Text.Read
+import           Main.Utf8 (withStdTerminalHandles)
 import qualified Ouroboros.Consensus.Mempool.Capacity as Mempool
 import           System.Exit (die, exitFailure)
 import qualified Test.Consensus.Mempool.Mocked as Mocked
@@ -32,7 +33,7 @@ import           Test.Tasty.Options (changeOption)
 import           Test.Tasty.Runners (parseOptions, tryIngredients)
 
 main :: IO ()
-main = do
+main = withStdTerminalHandles $ do
     let csvFilePath = "mempool-benchmarks.csv"
     runBenchmarks csvFilePath
     rawValues <- parseBenchmarkResults csvFilePath

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -403,6 +403,7 @@ library unstable-consensus-testlib
     , tree-diff
     , utf8-string
     , vector
+    , with-utf8
 
 library unstable-mock-block
   import:          common-lib
@@ -670,6 +671,7 @@ benchmark mempool-bench
     , tree-diff
     , unstable-consensus-testlib
     , unstable-mempool-test-utils
+    , with-utf8
 
 benchmark ChainSync-client-bench
   import:         common-bench
@@ -689,3 +691,4 @@ benchmark ChainSync-client-bench
     , time
     , typed-protocols-examples
     , unstable-consensus-testlib
+    , with-utf8

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/TestEnv.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/TestEnv.hs
@@ -11,18 +11,21 @@ module Test.Util.TestEnv (
 
 import           Cardano.Crypto.Init (cryptoInit)
 import           Data.Proxy (Proxy (..))
+import           Main.Utf8 (withStdTerminalHandles)
 import           Options.Applicative (metavar)
 import           Test.Tasty
 import           Test.Tasty.Ingredients
 import           Test.Tasty.Options
 import           Test.Tasty.QuickCheck
 
--- | 'defaultMain' extended with 'iohkTestEnvIngredient'
+-- | 'defaultMain' extended with 'iohkTestEnvIngredient' and setting the
+-- terminal handles to UTF-8.
 defaultMainWithTestEnv :: TestEnvConfig -> TestTree -> IO ()
 defaultMainWithTestEnv testConfig testTree = do
     cryptoInit
-    defaultMainWithIngredients (testEnvIngredient : defaultIngredients) $
-      withTestEnv testConfig testTree
+    withStdTerminalHandles $
+      defaultMainWithIngredients (testEnvIngredient : defaultIngredients) $
+        withTestEnv testConfig testTree
     where
       testEnvIngredient :: Ingredient
       testEnvIngredient = includingOptions [Option (Proxy :: Proxy TestEnv)]

--- a/scripts/release/create-release.hs
+++ b/scripts/release/create-release.hs
@@ -10,6 +10,7 @@
     prettyprinter,
     text,
     turtle ^>=1.6.0,
+    with-utf8,
 -}
 {-# OPTIONS_GHC -Wall -Wextra #-}
 {-# LANGUAGE BlockArguments      #-}
@@ -30,12 +31,13 @@ import           Data.Semigroup (Max (..))
 import qualified Data.Text as Text
 import qualified Data.Text.IO as Text
 import           Data.Version
+import           Main.Utf8 (withStdTerminalHandles)
 import           Prettyprinter
 import           System.FilePath
 import           Turtle hiding (d, fp, l, o)
 
 main :: IO ()
-main = sh do
+main = withStdTerminalHandles $ sh do
 
   (isDryRun, skipGit) <- options helpDescription $
     (,) <$> switch "dry-run" 'd' "Make no changes"


### PR DESCRIPTION
This pull request introduces the use of the `with-utf8` library and its `withStdTerminalHandles` helper that ensures support of UTF-8 characters for all terminal handles. This is espcially useful for tests that want to output Unicode characters but do not in fear of having the Hydra Windows workers get an error of the form:

```
consensus-test.exe:<stdout>:commitBuffer:invalidargument(cannotencodecharacter'\8773')
```

There is also a helper `withUtf8` that could be used instead but it changes the behaviour of all the handles and it was not a risk I wanted to take, considering how much file and network manipulations Cardano libraries involve. It would also be possible to use the same `withStdTerminalHandles` but more locally, for instance only in test suites that do require this.

Other solutions for the same problem hinted above that I can think about are:

- to make Hydra Windows workers (and possibly Darwin?) issue eg `chcp 65001` to change the code page to unicode.
- to give up on Unicode in any outputs.

See https://serokell.io/blog/haskell-with-utf8 for an introduction of the `with-utf8` library.

Thank you, @amesgen, for the pointers.
