### PR TITLE
consensus-diffusion: add lower bound on io-sim

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -48,6 +48,6 @@ source-repository-package
 source-repository-package
     type: git
     location: https://github.com/input-output-hk/io-sim
-    tag: 85d633d6f9c76ffb678b36396c8fd39b2ff7219e
+    tag: 619ad497246368cef00445563c8e5bc7daf4aee7
     subdir: io-sim
-    --sha256: 10f54xg88wq2w7ylg3n33f1yiswd6w4dam7fvl12raiqj0rk21qm
+    --sha256: 0x29iz99gjw91svas0sf51pzg1z4ks4mlc9z233k3rrz8c64h8g9

--- a/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
+++ b/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
@@ -250,7 +250,7 @@ test-suite consensus-test
     , fs-sim                                                                 ^>=0.2
     , hashable
     , io-classes
-    , io-sim
+    , io-sim                                                                 ^>= 1.4.1.0
     , mtl
     , nothunks
     , ouroboros-consensus-diffusion


### PR DESCRIPTION
The GSM QSM test will fail if the io-sim dep doesn't include a recent bug fix.