### PR TITLE
Various cleanup of the schedules

### DIFF
--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup.hs
@@ -26,6 +26,7 @@ import           Test.Consensus.PointSchedule.Peers (Peers)
 import           Test.QuickCheck
 import           Test.Util.Orphans.IOLike ()
 import           Test.Util.QuickCheck (forAllGenRunShrinkCheck)
+import           Test.Util.TestBlock (TestBlock)
 import           Test.Util.Tracer (recordingTracerTVar)
 
 -- | See 'runGenesisTest'.
@@ -38,7 +39,7 @@ data RunGenesisTestResult = RunGenesisTestResult {
 -- property on the final 'StateView'.
 runGenesisTest ::
   SchedulerConfig ->
-  GenesisTest (Peers PeerSchedule) ->
+  GenesisTest (Peers (PeerSchedule TestBlock)) ->
   RunGenesisTestResult
 runGenesisTest schedulerConfig genesisTest =
   runSimOrThrow $ do
@@ -59,7 +60,7 @@ runGenesisTest schedulerConfig genesisTest =
 runGenesisTest' ::
   Testable prop =>
   SchedulerConfig ->
-  GenesisTest (Peers PeerSchedule) ->
+  GenesisTest (Peers (PeerSchedule TestBlock)) ->
   (StateView -> prop) ->
   Property
 runGenesisTest' schedulerConfig genesisTest makeProperty =
@@ -73,10 +74,10 @@ runGenesisTest' schedulerConfig genesisTest makeProperty =
 -- property holds on the resulting 'StateView'.
 forAllGenesisTest ::
   Testable prop =>
-  Gen (GenesisTest (Peers PeerSchedule)) ->
+  Gen (GenesisTest (Peers (PeerSchedule TestBlock))) ->
   SchedulerConfig ->
-  (GenesisTest (Peers PeerSchedule) -> StateView -> [GenesisTest (Peers PeerSchedule)]) ->
-  (GenesisTest (Peers PeerSchedule) -> StateView -> prop) ->
+  (GenesisTest (Peers (PeerSchedule TestBlock)) -> StateView -> [GenesisTest (Peers (PeerSchedule TestBlock))]) ->
+  (GenesisTest (Peers (PeerSchedule TestBlock)) -> StateView -> prop) ->
   Property
 forAllGenesisTest generator schedulerConfig shrinker mkProperty =
   forAllGenRunShrinkCheck generator runner shrinker' $ \genesisTest result ->

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup.hs
@@ -39,7 +39,7 @@ data RunGenesisTestResult = RunGenesisTestResult {
 -- property on the final 'StateView'.
 runGenesisTest ::
   SchedulerConfig ->
-  GenesisTest (Peers (PeerSchedule TestBlock)) ->
+  GenesisTest TestBlock (Peers (PeerSchedule TestBlock)) ->
   RunGenesisTestResult
 runGenesisTest schedulerConfig genesisTest =
   runSimOrThrow $ do
@@ -60,7 +60,7 @@ runGenesisTest schedulerConfig genesisTest =
 runGenesisTest' ::
   Testable prop =>
   SchedulerConfig ->
-  GenesisTest (Peers (PeerSchedule TestBlock)) ->
+  GenesisTest TestBlock (Peers (PeerSchedule TestBlock)) ->
   (StateView -> prop) ->
   Property
 runGenesisTest' schedulerConfig genesisTest makeProperty =
@@ -74,10 +74,10 @@ runGenesisTest' schedulerConfig genesisTest makeProperty =
 -- property holds on the resulting 'StateView'.
 forAllGenesisTest ::
   Testable prop =>
-  Gen (GenesisTest (Peers (PeerSchedule TestBlock))) ->
+  Gen (GenesisTest TestBlock (Peers (PeerSchedule TestBlock))) ->
   SchedulerConfig ->
-  (GenesisTest (Peers (PeerSchedule TestBlock)) -> StateView -> [GenesisTest (Peers (PeerSchedule TestBlock))]) ->
-  (GenesisTest (Peers (PeerSchedule TestBlock)) -> StateView -> prop) ->
+  (GenesisTest TestBlock (Peers (PeerSchedule TestBlock)) -> StateView -> [GenesisTest TestBlock (Peers (PeerSchedule TestBlock))]) ->
+  (GenesisTest TestBlock (Peers (PeerSchedule TestBlock)) -> StateView -> prop) ->
   Property
 forAllGenesisTest generator schedulerConfig shrinker mkProperty =
   forAllGenRunShrinkCheck generator runner shrinker' $ \genesisTest result ->

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup.hs
@@ -22,7 +22,6 @@ import           Test.Consensus.PeerSimulator.Run
 import           Test.Consensus.PeerSimulator.StateView
 import           Test.Consensus.PeerSimulator.Trace (traceLinesWith)
 import           Test.Consensus.PointSchedule
-import           Test.Consensus.PointSchedule.Peers (Peers)
 import           Test.QuickCheck
 import           Test.Util.Orphans.IOLike ()
 import           Test.Util.QuickCheck (forAllGenRunShrinkCheck)
@@ -39,7 +38,7 @@ data RunGenesisTestResult = RunGenesisTestResult {
 -- property on the final 'StateView'.
 runGenesisTest ::
   SchedulerConfig ->
-  GenesisTest TestBlock (Peers (PeerSchedule TestBlock)) ->
+  GenesisTestFull TestBlock ->
   RunGenesisTestResult
 runGenesisTest schedulerConfig genesisTest =
   runSimOrThrow $ do
@@ -60,7 +59,7 @@ runGenesisTest schedulerConfig genesisTest =
 runGenesisTest' ::
   Testable prop =>
   SchedulerConfig ->
-  GenesisTest TestBlock (Peers (PeerSchedule TestBlock)) ->
+  GenesisTestFull TestBlock ->
   (StateView -> prop) ->
   Property
 runGenesisTest' schedulerConfig genesisTest makeProperty =
@@ -74,10 +73,10 @@ runGenesisTest' schedulerConfig genesisTest makeProperty =
 -- property holds on the resulting 'StateView'.
 forAllGenesisTest ::
   Testable prop =>
-  Gen (GenesisTest TestBlock (Peers (PeerSchedule TestBlock))) ->
+  Gen (GenesisTestFull TestBlock) ->
   SchedulerConfig ->
-  (GenesisTest TestBlock (Peers (PeerSchedule TestBlock)) -> StateView -> [GenesisTest TestBlock (Peers (PeerSchedule TestBlock))]) ->
-  (GenesisTest TestBlock (Peers (PeerSchedule TestBlock)) -> StateView -> prop) ->
+  (GenesisTestFull TestBlock -> StateView -> [GenesisTestFull TestBlock]) ->
+  (GenesisTestFull TestBlock -> StateView -> prop) ->
   Property
 forAllGenesisTest generator schedulerConfig shrinker mkProperty =
   forAllGenRunShrinkCheck generator runner shrinker' $ \genesisTest result ->

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup/Classifiers.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup/Classifiers.hs
@@ -57,7 +57,7 @@ data Classifiers =
     longerThanGenesisWindow        :: Bool
   }
 
-classifiers :: GenesisTest schedule -> Classifiers
+classifiers :: AF.HasHeader blk => GenesisTest blk schedule -> Classifiers
 classifiers GenesisTest {gtBlockTree, gtSecurityParam = SecurityParam k, gtGenesisWindow = GenesisWindow scg} =
   Classifiers {
     existsSelectableAdversary,

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup/GenChains.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup/GenChains.hs
@@ -100,7 +100,7 @@ genAlternativeChainSchema (testRecipeH, arHonest) =
 --     trunk: O─────1──2──3──4─────5──6──7
 --                     │           ╰─────6
 --                     ╰─────3──4─────5
-genChains :: QC.Gen Word -> QC.Gen (GenesisTest ())
+genChains :: QC.Gen Word -> QC.Gen (GenesisTest TestBlock ())
 genChains genNumForks = do
   (asc, honestRecipe, someHonestChainSchema) <- genHonestChainSchema
 

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup/GenChains.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup/GenChains.hs
@@ -128,7 +128,7 @@ genChains genNumForks = do
   where
     gtSlotLength = slotLengthFromSec 20
 
-    genAdversarialFragment :: [TestBlock] -> Int -> (Int, [S]) -> TestFrag
+    genAdversarialFragment :: [TestBlock] -> Int -> (Int, [S]) -> AnchoredFragment TestBlock
     genAdversarialFragment goodBlocks forkNo (prefixCount, slotsA)
       = mkTestFragment (mkTestBlocks prefix slotsA forkNo)
       where

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LongRangeAttack.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LongRangeAttack.hs
@@ -8,7 +8,7 @@
 module Test.Consensus.Genesis.Tests.LongRangeAttack (tests) where
 
 import           Data.Functor (($>))
-import           Ouroboros.Consensus.Block.Abstract (HeaderHash)
+import           Ouroboros.Consensus.Block.Abstract (Header, HeaderHash)
 import           Ouroboros.Network.AnchoredFragment (headAnchor)
 import qualified Ouroboros.Network.AnchoredFragment as AF
 import           Test.Consensus.Genesis.Setup
@@ -60,7 +60,7 @@ prop_longRangeAttack =
     (\_ -> not . isHonestTestFragH . svSelectedChain)
 
   where
-    isHonestTestFragH :: TestFragH -> Bool
+    isHonestTestFragH :: AF.AnchoredFragment (Header TestBlock) -> Bool
     isHonestTestFragH frag = case headAnchor frag of
         AF.AnchorGenesis   -> True
         AF.Anchor _ hash _ -> isHonestTestHeaderHash hash

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
@@ -67,7 +67,7 @@ tests =
     ]
 
 theProperty ::
-  GenesisTest TestBlock (Peers (PeerSchedule TestBlock)) ->
+  GenesisTestFull TestBlock ->
   StateView ->
   Property
 theProperty genesisTest stateView@StateView{svSelectedChain} =
@@ -144,7 +144,7 @@ prop_serveAdversarialBranches =
 
     theProperty
 
-genUniformSchedulePoints :: GenesisTest TestBlock schedule -> QC.Gen (Peers (PeerSchedule TestBlock))
+genUniformSchedulePoints :: GenesisTest TestBlock () -> QC.Gen (PeersSchedule TestBlock)
 genUniformSchedulePoints gt = stToGen (uniformPoints (gtBlockTree gt))
 
 -- Note [Leashing attacks]
@@ -189,7 +189,7 @@ prop_leashingAttackStalling =
     -- | Produces schedules that might cause the node under test to stall.
     --
     -- This is achieved by dropping random points from the schedule of each peer
-    genLeashingSchedule :: GenesisTest TestBlock () -> QC.Gen (Peers (PeerSchedule TestBlock))
+    genLeashingSchedule :: GenesisTest TestBlock () -> QC.Gen (PeersSchedule TestBlock)
     genLeashingSchedule genesisTest = do
       Peers honest advs0 <- genUniformSchedulePoints genesisTest
       advs <- mapM (mapM dropRandomPoints) advs0
@@ -231,7 +231,7 @@ prop_leashingAttackTimeLimited =
 
   where
     -- | A schedule which doesn't run past the last event of the honest peer
-    genTimeLimitedSchedule :: GenesisTest TestBlock () -> QC.Gen (Peers (PeerSchedule TestBlock))
+    genTimeLimitedSchedule :: GenesisTest TestBlock () -> QC.Gen (PeersSchedule TestBlock)
     genTimeLimitedSchedule genesisTest = do
       Peers honest advs0 <- genUniformSchedulePoints genesisTest
       let timeLimit = estimateTimeBound (value honest) (map value $ Map.elems advs0)

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
@@ -19,6 +19,7 @@ import qualified Data.Map.Strict as Map
 import           Data.Maybe (mapMaybe)
 import           Data.Word (Word64)
 import           GHC.Stack (HasCallStack)
+import           Ouroboros.Consensus.Block (WithOrigin (NotOrigin))
 import           Ouroboros.Consensus.Util.Condense (condense)
 import qualified Ouroboros.Network.AnchoredFragment as AF
 import           Ouroboros.Network.Block (blockNo, blockSlot, unBlockNo)
@@ -125,8 +126,8 @@ theProperty genesisTest stateView@StateView{svSelectedChain} =
     Classifiers {genesisWindowAfterIntersection, longerThanGenesisWindow} = classifiers genesisTest
 
 fromBlockPoint :: (Time, SchedulePoint blk) -> Maybe (Time, blk)
-fromBlockPoint (t, ScheduleBlockPoint bp) = Just (t, bp)
-fromBlockPoint _                          = Nothing
+fromBlockPoint (t, ScheduleBlockPoint (NotOrigin bp)) = Just (t, bp)
+fromBlockPoint _                                      = Nothing
 
 -- | Tests that the immutable tip is not delayed and stays honest with the
 -- adversarial peers serving adversarial branches.

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
@@ -67,7 +67,7 @@ tests =
     ]
 
 theProperty ::
-  GenesisTest (Peers (PeerSchedule TestBlock)) ->
+  GenesisTest TestBlock (Peers (PeerSchedule TestBlock)) ->
   StateView ->
   Property
 theProperty genesisTest stateView@StateView{svSelectedChain} =
@@ -144,7 +144,7 @@ prop_serveAdversarialBranches =
 
     theProperty
 
-genUniformSchedulePoints :: GenesisTest schedule -> QC.Gen (Peers (PeerSchedule TestBlock))
+genUniformSchedulePoints :: GenesisTest TestBlock schedule -> QC.Gen (Peers (PeerSchedule TestBlock))
 genUniformSchedulePoints gt = stToGen (uniformPoints (gtBlockTree gt))
 
 -- Note [Leashing attacks]
@@ -189,7 +189,7 @@ prop_leashingAttackStalling =
     -- | Produces schedules that might cause the node under test to stall.
     --
     -- This is achieved by dropping random points from the schedule of each peer
-    genLeashingSchedule :: GenesisTest () -> QC.Gen (Peers (PeerSchedule TestBlock))
+    genLeashingSchedule :: GenesisTest TestBlock () -> QC.Gen (Peers (PeerSchedule TestBlock))
     genLeashingSchedule genesisTest = do
       Peers honest advs0 <- genUniformSchedulePoints genesisTest
       advs <- mapM (mapM dropRandomPoints) advs0
@@ -231,7 +231,7 @@ prop_leashingAttackTimeLimited =
 
   where
     -- | A schedule which doesn't run past the last event of the honest peer
-    genTimeLimitedSchedule :: GenesisTest () -> QC.Gen (Peers (PeerSchedule TestBlock))
+    genTimeLimitedSchedule :: GenesisTest TestBlock () -> QC.Gen (Peers (PeerSchedule TestBlock))
     genTimeLimitedSchedule genesisTest = do
       Peers honest advs0 <- genUniformSchedulePoints genesisTest
       let timeLimit = estimateTimeBound (value honest) (map value $ Map.elems advs0)

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/ChainSync.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/ChainSync.hs
@@ -18,6 +18,7 @@ import qualified Ouroboros.Consensus.MiniProtocol.ChainSync.Client.InFutureCheck
 import           Ouroboros.Consensus.Util.Condense (Condense (..))
 import           Ouroboros.Consensus.Util.IOLike (Exception (fromException),
                      IOLike, MonadCatch (try), StrictTVar, uncheckedNewTVarM)
+import           Ouroboros.Network.AnchoredFragment (AnchoredFragment)
 import           Ouroboros.Network.Block (Tip)
 import           Ouroboros.Network.Channel (createConnectedChannels)
 import           Ouroboros.Network.ControlMessage (ControlMessage (..))
@@ -40,7 +41,6 @@ import           Test.Consensus.PeerSimulator.StateView
                      StateViewTracers (StateViewTracers, svtChainSyncExceptionsTracer))
 import           Test.Consensus.PeerSimulator.Trace (mkChainSyncClientTracer,
                      traceUnitWith)
-import           Test.Consensus.PointSchedule (TestFragH)
 import           Test.Consensus.PointSchedule.Peers (PeerId)
 import           Test.Util.Orphans.IOLike ()
 import           Test.Util.TestBlock (TestBlock)
@@ -51,7 +51,7 @@ basicChainSyncClient :: forall m.
   Tracer m String ->
   TopLevelConfig TestBlock ->
   ChainDbView m TestBlock ->
-  StrictTVar m TestFragH ->
+  StrictTVar m (AnchoredFragment (Header TestBlock)) ->
   (m (), m ()) ->
   Consensus ChainSyncClientPipelined TestBlock m
 basicChainSyncClient tracer cfg chainDbView varCandidate (startIdling, stopIdling) =
@@ -91,7 +91,7 @@ runChainSyncClient ::
   ChainSyncServer (Header TestBlock) (Point TestBlock) (Tip TestBlock) m () ->
   ChainSyncTimeout ->
   StateViewTracers m ->
-  StrictTVar m (Map PeerId (StrictTVar m TestFragH)) ->
+  StrictTVar m (Map PeerId (StrictTVar m (AnchoredFragment (Header TestBlock)))) ->
   m ()
 runChainSyncClient
   tracer

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Handlers.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Handlers.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE LambdaCase          #-}
+{-# LANGUAGE NamedFieldPuns      #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies        #-}
 {-# LANGUAGE TypeOperators       #-}

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Handlers.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Handlers.hs
@@ -57,7 +57,7 @@ handlerFindIntersection ::
   StrictTVar m (Point TestBlock) ->
   BlockTree TestBlock ->
   [Point TestBlock] ->
-  NodeState ->
+  NodeState TestBlock ->
   STM m (Maybe FindIntersect, [String])
 handlerFindIntersection currentIntersection blockTree clientPoints points = do
   let tip' = nsTipTip points
@@ -84,7 +84,7 @@ handlerRequestNext ::
   IOLike m =>
   StrictTVar m (Point TestBlock) ->
   BlockTree TestBlock ->
-  NodeState ->
+  NodeState TestBlock ->
   STM m (Maybe RequestNext, [String])
 handlerRequestNext currentIntersection blockTree points =
   runWriterT $ do
@@ -158,7 +158,7 @@ handlerBlockFetch ::
   IOLike m =>
   BlockTree TestBlock ->
   ChainRange (Point TestBlock) ->
-  NodeState ->
+  NodeState TestBlock ->
   STM m (Maybe BlockFetch, [String])
 handlerBlockFetch blockTree (ChainRange from to) NodeState {nsBlock, nsHeader} =
   runWriterT (serveFromBpFragment (AF.sliceRange bpChain from to))

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Handlers.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Handlers.hs
@@ -4,7 +4,7 @@
 {-# LANGUAGE TypeOperators       #-}
 
 -- | Business logic of the ChainSync and BlockFetch protocol handlers that operate
--- on the 'AdvertisedPoints' of a point schedule.
+-- on the 'NodeState' of a point schedule.
 --
 -- These are separated from the scheduling related mechanics of the
 -- server mocks that the peer simulator uses, in
@@ -56,7 +56,7 @@ handlerFindIntersection ::
   StrictTVar m (Point TestBlock) ->
   BlockTree TestBlock ->
   [Point TestBlock] ->
-  AdvertisedPoints ->
+  NodeState ->
   STM m (Maybe FindIntersect, [String])
 handlerFindIntersection currentIntersection blockTree clientPoints points = do
   let TipPoint tip' = tip points
@@ -83,7 +83,7 @@ handlerRequestNext ::
   IOLike m =>
   StrictTVar m (Point TestBlock) ->
   BlockTree TestBlock ->
-  AdvertisedPoints ->
+  NodeState ->
   STM m (Maybe RequestNext, [String])
 handlerRequestNext currentIntersection blockTree points =
   runWriterT $ do
@@ -157,9 +157,9 @@ handlerBlockFetch ::
   IOLike m =>
   BlockTree TestBlock ->
   ChainRange (Point TestBlock) ->
-  AdvertisedPoints ->
+  NodeState ->
   STM m (Maybe BlockFetch, [String])
-handlerBlockFetch blockTree (ChainRange from to) AdvertisedPoints {header = HeaderPoint hp, block = BlockPoint bp} =
+handlerBlockFetch blockTree (ChainRange from to) NodeState {header = HeaderPoint hp, block = BlockPoint bp} =
   runWriterT (serveFromBpFragment (AF.sliceRange bpChain from to))
   where
     -- Check whether the requested range is contained in the fragment before the block point.

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Resources.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Resources.hs
@@ -113,7 +113,7 @@ data PeerSimulatorResources m =
     psrPeers      :: Map PeerId (PeerResources m),
 
     -- | The shared candidate fragments used by ChainDB, ChainSync and BlockFetch.
-    psrCandidates :: StrictTVar m (Map PeerId (StrictTVar m TestFragH))
+    psrCandidates :: StrictTVar m (Map PeerId (StrictTVar m (AF.AnchoredFragment (Header TestBlock))))
   }
 
 -- | Create 'ChainSyncServerHandlers' for our default implementation using 'NodeState'.

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Run.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Run.hs
@@ -33,6 +33,7 @@ import           Ouroboros.Consensus.Util.IOLike (IOLike,
                      MonadDelay (threadDelay), MonadSTM (atomically),
                      StrictTVar, readTVar)
 import           Ouroboros.Consensus.Util.ResourceRegistry
+import           Ouroboros.Network.AnchoredFragment (AnchoredFragment)
 import           Ouroboros.Network.BlockFetch (FetchClientRegistry,
                      bracketSyncWithFetchClient, newFetchClientRegistry)
 import           Ouroboros.Network.ControlMessage (ControlMessage (..),
@@ -52,7 +53,7 @@ import           Test.Consensus.PeerSimulator.StateView
 import           Test.Consensus.PeerSimulator.Trace
 import qualified Test.Consensus.PointSchedule as PointSchedule
 import           Test.Consensus.PointSchedule (GenesisTest (GenesisTest),
-                     NodeState, PeerSchedule, TestFragH, peersStatesRelative,
+                     NodeState, PeerSchedule, peersStatesRelative,
                      prettyPeersSchedule)
 import           Test.Consensus.PointSchedule.Peers (Peer (..), PeerId, Peers,
                      getPeerIds)
@@ -123,7 +124,7 @@ startChainSyncConnectionThread ::
   ChainSyncResources m ->
   ChainSyncTimeout ->
   StateViewTracers m ->
-  StrictTVar m (Map PeerId (StrictTVar m TestFragH)) ->
+  StrictTVar m (Map PeerId (StrictTVar m (AnchoredFragment (Header TestBlock)))) ->
   m ()
 startChainSyncConnectionThread
   registry

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Run.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Run.hs
@@ -51,9 +51,9 @@ import           Test.Consensus.PeerSimulator.StateDiagram
 import           Test.Consensus.PeerSimulator.StateView
 import           Test.Consensus.PeerSimulator.Trace
 import qualified Test.Consensus.PointSchedule as PointSchedule
-import           Test.Consensus.PointSchedule (GenesisTest (GenesisTest),
-                     NodeState, PeerSchedule, TestFragH, peersStatesRelative,
-                     prettyPeersSchedule)
+import           Test.Consensus.PointSchedule (AdvertisedPoints,
+                     GenesisTest (GenesisTest), PeerSchedule, TestFragH,
+                     peersStatesRelative, prettyPeersSchedule)
 import           Test.Consensus.PointSchedule.Peers (Peer (..), PeerId, Peers,
                      getPeerIds)
 import           Test.Util.ChainDB
@@ -170,7 +170,7 @@ dispatchTick ::
   Tracer m String ->
   Tracer m () ->
   Map PeerId (PeerResources m) ->
-  (Int, (DiffTime, Peer NodeState)) ->
+  (Int, (DiffTime, Peer AdvertisedPoints)) ->
   m ()
 dispatchTick tracer stateTracer peers (number, (duration, Peer pid state)) =
   case peers Map.!? pid of

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Run.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Run.hs
@@ -51,9 +51,9 @@ import           Test.Consensus.PeerSimulator.StateDiagram
 import           Test.Consensus.PeerSimulator.StateView
 import           Test.Consensus.PeerSimulator.Trace
 import qualified Test.Consensus.PointSchedule as PointSchedule
-import           Test.Consensus.PointSchedule (AdvertisedPoints,
-                     GenesisTest (GenesisTest), PeerSchedule, TestFragH,
-                     peersStatesRelative, prettyPeersSchedule)
+import           Test.Consensus.PointSchedule (GenesisTest (GenesisTest),
+                     NodeState, PeerSchedule, TestFragH, peersStatesRelative,
+                     prettyPeersSchedule)
 import           Test.Consensus.PointSchedule.Peers (Peer (..), PeerId, Peers,
                      getPeerIds)
 import           Test.Util.ChainDB
@@ -170,7 +170,7 @@ dispatchTick ::
   Tracer m String ->
   Tracer m () ->
   Map PeerId (PeerResources m) ->
-  (Int, (DiffTime, Peer AdvertisedPoints)) ->
+  (Int, (DiffTime, Peer NodeState)) ->
   m ()
 dispatchTick tracer stateTracer peers (number, (duration, Peer pid state)) =
   case peers Map.!? pid of

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Run.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Run.hs
@@ -171,7 +171,7 @@ dispatchTick ::
   Tracer m String ->
   Tracer m () ->
   Map PeerId (PeerResources m) ->
-  (Int, (DiffTime, Peer NodeState)) ->
+  (Int, (DiffTime, Peer (NodeState TestBlock))) ->
   m ()
 dispatchTick tracer stateTracer peers (number, (duration, Peer pid state)) =
   case peers Map.!? pid of

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Run.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Run.hs
@@ -39,7 +39,6 @@ import           Ouroboros.Network.BlockFetch (FetchClientRegistry,
 import           Ouroboros.Network.ControlMessage (ControlMessage (..),
                      ControlMessageSTM)
 import           Ouroboros.Network.Protocol.ChainSync.Codec
-import           Test.Consensus.Genesis.Setup.GenChains (GenesisTest)
 import           Test.Consensus.Network.Driver.Limits.Extras
 import qualified Test.Consensus.PeerSimulator.BlockFetch as PeerSimulator.BlockFetch
 import           Test.Consensus.PeerSimulator.BlockFetch (runBlockFetchClient,
@@ -53,9 +52,9 @@ import           Test.Consensus.PeerSimulator.StateView
 import           Test.Consensus.PeerSimulator.Trace
 import qualified Test.Consensus.PointSchedule as PointSchedule
 import           Test.Consensus.PointSchedule (GenesisTest (GenesisTest),
-                     NodeState, PeerSchedule, peersStatesRelative,
-                     prettyPeersSchedule)
-import           Test.Consensus.PointSchedule.Peers (Peer (..), PeerId, Peers,
+                     GenesisTestFull, NodeState, PeersSchedule,
+                     peersStatesRelative, prettyPeersSchedule)
+import           Test.Consensus.PointSchedule.Peers (Peer (..), PeerId,
                      getPeerIds)
 import           Test.Util.ChainDB
 import           Test.Util.Orphans.IOLike ()
@@ -202,7 +201,7 @@ runScheduler ::
   IOLike m =>
   Tracer m String ->
   Tracer m () ->
-  Peers (PeerSchedule TestBlock) ->
+  PeersSchedule TestBlock ->
   Map PeerId (PeerResources m) ->
   m ()
 runScheduler tracer stateTracer ps peers = do
@@ -226,7 +225,7 @@ runPointSchedule ::
   forall m.
   (IOLike m, MonadTime m, MonadTimer m) =>
   SchedulerConfig ->
-  GenesisTest TestBlock (Peers (PeerSchedule TestBlock)) ->
+  GenesisTestFull TestBlock ->
   Tracer m String ->
   m StateView
 runPointSchedule schedulerConfig genesisTest tracer0 =

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Run.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Run.hs
@@ -202,7 +202,7 @@ runScheduler ::
   IOLike m =>
   Tracer m String ->
   Tracer m () ->
-  Peers PeerSchedule ->
+  Peers (PeerSchedule TestBlock) ->
   Map PeerId (PeerResources m) ->
   m ()
 runScheduler tracer stateTracer ps peers = do
@@ -226,7 +226,7 @@ runPointSchedule ::
   forall m.
   (IOLike m, MonadTime m, MonadTimer m) =>
   SchedulerConfig ->
-  GenesisTest (Peers PeerSchedule) ->
+  GenesisTest (Peers (PeerSchedule TestBlock)) ->
   Tracer m String ->
   m StateView
 runPointSchedule schedulerConfig genesisTest tracer0 =

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Run.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Run.hs
@@ -226,7 +226,7 @@ runPointSchedule ::
   forall m.
   (IOLike m, MonadTime m, MonadTimer m) =>
   SchedulerConfig ->
-  GenesisTest (Peers (PeerSchedule TestBlock)) ->
+  GenesisTest TestBlock (Peers (PeerSchedule TestBlock)) ->
   Tracer m String ->
   m StateView
 runPointSchedule schedulerConfig genesisTest tracer0 =

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/StateDiagram.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/StateDiagram.hs
@@ -474,7 +474,7 @@ addTipPoint pid (NotOrigin b) TreeSlots {lastSlot, branches} =
 
 addTipPoint _ _ treeSlots = treeSlots
 
-addPoints :: Map PeerId NodeState -> TreeSlots -> TreeSlots
+addPoints :: Map PeerId (NodeState TestBlock) -> TreeSlots -> TreeSlots
 addPoints peerPoints treeSlots =
   foldl' step treeSlots (Map.toList peerPoints)
   where
@@ -836,7 +836,7 @@ data PeerSimState =
     pssBlockTree  :: BlockTree TestBlock,
     pssSelection  :: AF.AnchoredFragment (Header TestBlock),
     pssCandidates :: Map PeerId (AF.AnchoredFragment (Header TestBlock)),
-    pssPoints     :: Map PeerId NodeState
+    pssPoints     :: Map PeerId (NodeState TestBlock)
   }
 
 -- TODO add an aspect for the last block of each branch?
@@ -901,7 +901,7 @@ peerSimStateDiagramSTMTracer ::
   BlockTree TestBlock ->
   STM m (AF.AnchoredFragment (Header TestBlock)) ->
   STM m (Map PeerId (AF.AnchoredFragment (Header TestBlock))) ->
-  STM m (Map PeerId (Maybe NodeState)) ->
+  STM m (Map PeerId (Maybe (NodeState TestBlock))) ->
   m (Tracer m ())
 peerSimStateDiagramSTMTracer stringTracer pssBlockTree selectionVar candidatesVar pointsVar = do
   peerCache <- uncheckedNewTVarM mempty
@@ -929,7 +929,7 @@ peerSimStateDiagramSTMTracerDebug ::
   BlockTree TestBlock ->
   STM m (AF.AnchoredFragment (Header TestBlock)) ->
   STM m (Map PeerId (AF.AnchoredFragment (Header TestBlock))) ->
-  STM m (Map PeerId (Maybe NodeState)) ->
+  STM m (Map PeerId (Maybe (NodeState TestBlock))) ->
   m (Tracer m ())
 peerSimStateDiagramSTMTracerDebug =
   peerSimStateDiagramSTMTracer debugTracer

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/StateView.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/StateView.hs
@@ -13,12 +13,13 @@ import           Control.Exception (AsyncException (ThreadKilled),
                      fromException)
 import           Control.Tracer (Tracer)
 import           Data.Maybe (mapMaybe)
+import           Ouroboros.Consensus.Block (Header)
 import           Ouroboros.Consensus.Storage.ChainDB (ChainDB)
 import qualified Ouroboros.Consensus.Storage.ChainDB as ChainDB
 import           Ouroboros.Consensus.Util.Condense (Condense (condense))
 import           Ouroboros.Consensus.Util.IOLike (IOLike, SomeException,
                      atomically)
-import           Test.Consensus.PointSchedule (TestFragH)
+import           Ouroboros.Network.AnchoredFragment (AnchoredFragment)
 import           Test.Consensus.PointSchedule.Peers (PeerId)
 import           Test.Util.TersePrinting (terseHFragment)
 import           Test.Util.TestBlock (TestBlock)
@@ -42,7 +43,7 @@ instance Condense ChainSyncException where
 -- information about the mocked peers (for instance the exceptions raised in the
 -- mocked ChainSync server threads).
 data StateView = StateView {
-    svSelectedChain       :: TestFragH,
+    svSelectedChain       :: AnchoredFragment (Header TestBlock),
     svChainSyncExceptions :: [ChainSyncException]
   }
   deriving Show

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
@@ -82,7 +82,7 @@ prop_cannotRollback =
 -- chain of the given block tree.
 --
 -- PRECONDITION: Block tree with at least one alternative chain.
-rollbackSchedule :: Int -> BlockTree TestBlock -> Peers PeerSchedule
+rollbackSchedule :: AF.HasHeader blk => Int -> BlockTree blk -> Peers (PeerSchedule blk)
 rollbackSchedule n blockTree =
     let branch = firstBranch blockTree
         trunkSuffix = AF.takeOldest n (btbTrunkSuffix branch)

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
@@ -92,9 +92,9 @@ rollbackSchedule n blockTree =
           ]
     in peersOnlyHonest $ zip (map (Time . (/30)) [0..]) schedulePoints
   where
-    banalSchedulePoints :: AnchoredFragment TestBlock -> [SchedulePoint]
+    banalSchedulePoints :: AnchoredFragment blk -> [SchedulePoint blk]
     banalSchedulePoints = concatMap banalSchedulePoints' . toOldestFirst
-    banalSchedulePoints' :: TestBlock -> [SchedulePoint]
+    banalSchedulePoints' :: blk -> [SchedulePoint blk]
     banalSchedulePoints' block = [ScheduleTipPoint block, ScheduleHeaderPoint block, ScheduleBlockPoint block]
 
 -- | Whether the alternative chain has more than 'k' blocks after the

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
@@ -104,13 +104,13 @@ rollbackSchedule n blockTree =
 -- PRECONDITION: Block tree with exactly one alternative chain, otherwise
 -- this property does not make sense. With no alternative chain, this will
 -- even crash.
-alternativeChainIsLongEnough :: SecurityParam -> BlockTree TestBlock -> Bool
+alternativeChainIsLongEnough :: AF.HasHeader blk => SecurityParam -> BlockTree blk -> Bool
 alternativeChainIsLongEnough (SecurityParam k) blockTree =
   let BlockTreeBranch{btbSuffix} = firstBranch blockTree
       lengthSuffix = AF.length btbSuffix
    in lengthSuffix > fromIntegral k
 
-firstBranch :: BlockTree TestBlock -> BlockTreeBranch TestBlock
+firstBranch :: BlockTree blk -> BlockTreeBranch blk
 firstBranch tree = case btBranches tree of
   b:_ -> b
   _   -> error "The block tree must have at least one branch"

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
@@ -20,7 +20,7 @@ import           Test.Consensus.Genesis.Setup.Classifiers
 import           Test.Consensus.PeerSimulator.Run (defaultSchedulerConfig)
 import           Test.Consensus.PeerSimulator.StateView
 import           Test.Consensus.PointSchedule
-import           Test.Consensus.PointSchedule.Peers (Peers, peersOnlyHonest)
+import           Test.Consensus.PointSchedule.Peers (peersOnlyHonest)
 import           Test.Consensus.PointSchedule.SinglePeer (SchedulePoint (..),
                      scheduleBlockPoint, scheduleHeaderPoint, scheduleTipPoint)
 import           Test.QuickCheck
@@ -82,7 +82,7 @@ prop_cannotRollback =
 -- chain of the given block tree.
 --
 -- PRECONDITION: Block tree with at least one alternative chain.
-rollbackSchedule :: AF.HasHeader blk => Int -> BlockTree blk -> Peers (PeerSchedule blk)
+rollbackSchedule :: AF.HasHeader blk => Int -> BlockTree blk -> PeersSchedule blk
 rollbackSchedule n blockTree =
     let branch = firstBranch blockTree
         trunkSuffix = AF.takeOldest n (btbTrunkSuffix branch)

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
@@ -21,7 +21,8 @@ import           Test.Consensus.PeerSimulator.Run (defaultSchedulerConfig)
 import           Test.Consensus.PeerSimulator.StateView
 import           Test.Consensus.PointSchedule
 import           Test.Consensus.PointSchedule.Peers (Peers, peersOnlyHonest)
-import           Test.Consensus.PointSchedule.SinglePeer (SchedulePoint (..))
+import           Test.Consensus.PointSchedule.SinglePeer (SchedulePoint (..),
+                     scheduleBlockPoint, scheduleHeaderPoint, scheduleTipPoint)
 import           Test.QuickCheck
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
@@ -95,7 +96,7 @@ rollbackSchedule n blockTree =
     banalSchedulePoints :: AnchoredFragment blk -> [SchedulePoint blk]
     banalSchedulePoints = concatMap banalSchedulePoints' . toOldestFirst
     banalSchedulePoints' :: blk -> [SchedulePoint blk]
-    banalSchedulePoints' block = [ScheduleTipPoint block, ScheduleHeaderPoint block, ScheduleBlockPoint block]
+    banalSchedulePoints' block = [scheduleTipPoint block, scheduleHeaderPoint block, scheduleBlockPoint block]
 
 -- | Whether the alternative chain has more than 'k' blocks after the
 -- intersection with the honest chain.

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
@@ -19,7 +19,7 @@ import           Test.Consensus.PeerSimulator.Run
                      defaultSchedulerConfig)
 import           Test.Consensus.PeerSimulator.StateView
 import           Test.Consensus.PointSchedule
-import           Test.Consensus.PointSchedule.Peers (Peers, peersOnlyHonest)
+import           Test.Consensus.PointSchedule.Peers (peersOnlyHonest)
 import           Test.Consensus.PointSchedule.SinglePeer (scheduleBlockPoint,
                      scheduleHeaderPoint, scheduleTipPoint)
 import           Test.QuickCheck
@@ -60,7 +60,7 @@ prop_timeouts mustTimeout = do
     )
 
   where
-    dullSchedule :: AF.HasHeader blk => DiffTime -> AF.AnchoredFragment blk -> Peers (PeerSchedule blk)
+    dullSchedule :: AF.HasHeader blk => DiffTime -> AF.AnchoredFragment blk -> PeersSchedule blk
     dullSchedule _ (AF.Empty _) = error "requires a non-empty block tree"
     dullSchedule timeout (_ AF.:> tipBlock) =
       let offset :: DiffTime = if mustTimeout then 1 else -1

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
@@ -26,6 +26,7 @@ import           Test.QuickCheck
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
 import           Test.Util.Orphans.IOLike ()
+import           Test.Util.TestBlock (TestBlock)
 import           Test.Util.TestEnv (adjustQuickCheckTests)
 
 tests :: TestTree
@@ -60,7 +61,7 @@ prop_timeouts mustTimeout = do
     )
 
   where
-    dullSchedule :: DiffTime -> TestFrag -> Peers PeerSchedule
+    dullSchedule :: DiffTime -> AF.AnchoredFragment TestBlock -> Peers PeerSchedule
     dullSchedule _ (AF.Empty _) = error "requires a non-empty block tree"
     dullSchedule timeout (_ AF.:> tipBlock) =
       let offset :: DiffTime = if mustTimeout then 1 else -1

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
@@ -26,7 +26,6 @@ import           Test.QuickCheck
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
 import           Test.Util.Orphans.IOLike ()
-import           Test.Util.TestBlock (TestBlock)
 import           Test.Util.TestEnv (adjustQuickCheckTests)
 
 tests :: TestTree
@@ -61,7 +60,7 @@ prop_timeouts mustTimeout = do
     )
 
   where
-    dullSchedule :: DiffTime -> AF.AnchoredFragment TestBlock -> Peers PeerSchedule
+    dullSchedule :: AF.HasHeader blk => DiffTime -> AF.AnchoredFragment blk -> Peers (PeerSchedule blk)
     dullSchedule _ (AF.Empty _) = error "requires a non-empty block tree"
     dullSchedule timeout (_ AF.:> tipBlock) =
       let offset :: DiffTime = if mustTimeout then 1 else -1

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
@@ -20,7 +20,8 @@ import           Test.Consensus.PeerSimulator.Run
 import           Test.Consensus.PeerSimulator.StateView
 import           Test.Consensus.PointSchedule
 import           Test.Consensus.PointSchedule.Peers (Peers, peersOnlyHonest)
-import           Test.Consensus.PointSchedule.SinglePeer (SchedulePoint (..))
+import           Test.Consensus.PointSchedule.SinglePeer (scheduleBlockPoint,
+                     scheduleHeaderPoint, scheduleTipPoint)
 import           Test.QuickCheck
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
@@ -64,11 +65,11 @@ prop_timeouts mustTimeout = do
     dullSchedule timeout (_ AF.:> tipBlock) =
       let offset :: DiffTime = if mustTimeout then 1 else -1
        in peersOnlyHonest $ [
-            (Time 0, ScheduleTipPoint tipBlock),
-            (Time 0, ScheduleHeaderPoint tipBlock),
-            (Time 0, ScheduleBlockPoint tipBlock),
+            (Time 0, scheduleTipPoint tipBlock),
+            (Time 0, scheduleHeaderPoint tipBlock),
+            (Time 0, scheduleBlockPoint tipBlock),
             -- This last point does not matter, it is only here to leave the
             -- connection open (aka. keep the test running) long enough to
             -- pass the timeout by 'offset'.
-            (Time (timeout + offset), ScheduleTipPoint tipBlock)
+            (Time (timeout + offset), scheduleTipPoint tipBlock)
             ]

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
@@ -9,9 +9,9 @@
 
 -- | Data types and generators for point schedules.
 --
--- Each generator takes a set of 'AnchoredFragment's corresponding to the tested peers'
--- chains, and converts them to a point schedule consisting of a sequence of states
--- ('AdvertisedPoints'), each of which is associated with a single peer.
+-- Each generator takes a set of 'AnchoredFragment's corresponding to the tested
+-- peers' chains, and converts them to a point schedule consisting of a sequence
+-- of 'NodeState's, each of which is associated with a single peer.
 --
 -- When a schedule is executed in a test, each tick is processed in order.
 -- The peer associated with the current tick is considered "active", which means that

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
@@ -227,7 +227,7 @@ peersStatesRelative peers =
       durations = snd (mapAccumL (\ prev start -> (start, diffTime start prev)) (Time 0) (drop 1 starts)) ++ [0.1]
    in zip durations states
 
-type PeerSchedule = [(Time, SchedulePoint)]
+type PeerSchedule = [(Time, SchedulePoint TestBlock)]
 
 -- | List of all blocks appearing in the schedule.
 peerScheduleBlocks :: PeerSchedule -> [TestBlock]

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
@@ -27,8 +27,6 @@ module Test.Consensus.PointSchedule (
   , HeaderPoint (..)
   , NodeState (..)
   , PeerSchedule
-  , TestFrag
-  , TestFragH
   , TipPoint (..)
   , enrichedWith
   , genesisNodeState
@@ -61,7 +59,6 @@ import           Ouroboros.Consensus.Protocol.Abstract (SecurityParam,
 import           Ouroboros.Consensus.Util.Condense (Condense (..),
                      CondenseList (..), PaddingDirection (..),
                      condenseListWithPadding)
-import           Ouroboros.Network.AnchoredFragment (AnchoredFragment)
 import qualified Ouroboros.Network.AnchoredFragment as AF
 import           Ouroboros.Network.Block (Tip (..), tipFromHeader)
 import           Ouroboros.Network.Point (WithOrigin (At), withOrigin)
@@ -88,10 +85,6 @@ import           Text.Printf (printf)
 ----------------------------------------------------------------------------------------------------
 -- Data types
 ----------------------------------------------------------------------------------------------------
-
-type TestFrag = AnchoredFragment TestBlock
-
-type TestFragH = AnchoredFragment (Header TestBlock)
 
 -- | The current tip that a ChainSync server should advertise to the client in
 -- a tick.

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
@@ -113,9 +113,9 @@ instance CondenseList (NodeState TestBlock) where
           " | HP " ++ header ++
           " | BP " ++ block
       )
-      (padListWith PadLeft $ map (terseWithOrigin terseBlock . nsTip) points)
-      (padListWith PadLeft $ map (terseWithOrigin terseBlock . nsHeader) points)
-      (padListWith PadLeft $ map (terseWithOrigin terseBlock . nsBlock) points)
+      (padListWith PadRight $ map (terseWithOrigin terseBlock . nsTip) points)
+      (padListWith PadRight $ map (terseWithOrigin terseBlock . nsHeader) points)
+      (padListWith PadRight $ map (terseWithOrigin terseBlock . nsBlock) points)
 
 genesisNodeState :: NodeState blk
 genesisNodeState =

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
@@ -301,18 +301,18 @@ newtype ForecastRange = ForecastRange { unForecastRange :: Word64 }
   deriving (Show)
 
 -- | All the data used by point schedule tests.
-data GenesisTest schedule = GenesisTest {
+data GenesisTest blk schedule = GenesisTest {
   gtSecurityParam     :: SecurityParam,
   gtGenesisWindow     :: GenesisWindow,
   gtForecastRange     :: ForecastRange, -- REVIEW: Do we want to allow infinite forecast ranges?
   gtDelay             :: Delta,
-  gtBlockTree         :: BlockTree TestBlock,
+  gtBlockTree         :: BlockTree blk,
   gtChainSyncTimeouts :: ChainSyncTimeout,
   gtSlotLength        :: SlotLength,
   gtSchedule          :: schedule
   }
 
-prettyGenesisTest :: GenesisTest schedule -> [String]
+prettyGenesisTest :: GenesisTest TestBlock schedule -> [String]
 prettyGenesisTest genesisTest =
   [ "GenesisTest:"
   , "  gtSecurityParam: " ++ show (maxRollbacks gtSecurityParam)
@@ -339,7 +339,7 @@ prettyGenesisTest genesisTest =
       , gtSchedule = _
       } = genesisTest
 
-instance Functor GenesisTest where
+instance Functor (GenesisTest blk) where
   fmap f gt@GenesisTest{gtSchedule} = gt {gtSchedule = f gtSchedule}
 
 enrichedWith :: (Functor f, Monad m) => m (f a) -> (f a -> m b) -> m (f b)

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Shrinking.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Shrinking.hs
@@ -27,9 +27,9 @@ import           Test.Util.TestBlock (TestBlock, isAncestorOf,
 -- block tree is trimmed to keep only parts that are necessary for the shrunk
 -- schedule.
 shrinkPeerSchedules ::
-  GenesisTest (Peers (PeerSchedule TestBlock)) ->
+  GenesisTest TestBlock (Peers (PeerSchedule TestBlock)) ->
   StateView ->
-  [GenesisTest (Peers (PeerSchedule TestBlock))]
+  [GenesisTest TestBlock (Peers (PeerSchedule TestBlock))]
 shrinkPeerSchedules genesisTest _stateView =
   shrinkOtherPeers shrinkPeerSchedule (gtSchedule genesisTest) <&> \shrunkSchedule ->
     let trimmedBlockTree = trimBlockTree' shrunkSchedule (gtBlockTree genesisTest)

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Shrinking.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Shrinking.hs
@@ -15,8 +15,8 @@ import           Test.Consensus.BlockTree (BlockTree (..), BlockTreeBranch (..),
                      addBranch', mkTrunk)
 import           Test.Consensus.PeerSimulator.StateView (StateView)
 import           Test.Consensus.PointSchedule
-                     (GenesisTest (gtBlockTree, gtSchedule), PeerSchedule,
-                     peerSchedulesBlocks)
+                     (GenesisTest (gtBlockTree, gtSchedule), GenesisTestFull,
+                     PeerSchedule, PeersSchedule, peerSchedulesBlocks)
 import           Test.Consensus.PointSchedule.Peers (Peers (..))
 import           Test.QuickCheck (shrinkList)
 import           Test.Util.TestBlock (TestBlock, isAncestorOf,
@@ -27,9 +27,9 @@ import           Test.Util.TestBlock (TestBlock, isAncestorOf,
 -- block tree is trimmed to keep only parts that are necessary for the shrunk
 -- schedule.
 shrinkPeerSchedules ::
-  GenesisTest TestBlock (Peers (PeerSchedule TestBlock)) ->
+  GenesisTestFull TestBlock ->
   StateView ->
-  [GenesisTest TestBlock (Peers (PeerSchedule TestBlock))]
+  [GenesisTestFull TestBlock]
 shrinkPeerSchedules genesisTest _stateView =
   shrinkOtherPeers shrinkPeerSchedule (gtSchedule genesisTest) <&> \shrunkSchedule ->
     let trimmedBlockTree = trimBlockTree' shrunkSchedule (gtBlockTree genesisTest)
@@ -50,7 +50,7 @@ shrinkOtherPeers shrink Peers{honest, others} =
 -- | Remove blocks from the given block tree that are not necessary for the
 -- given peer schedules. If entire branches are unused, they are removed. If the
 -- trunk is unused, then it remains as an empty anchored fragment.
-trimBlockTree' :: Peers (PeerSchedule TestBlock) -> BlockTree TestBlock -> BlockTree TestBlock
+trimBlockTree' :: PeersSchedule TestBlock -> BlockTree TestBlock -> BlockTree TestBlock
 trimBlockTree' = keepOnlyAncestorsOf . peerSchedulesBlocks
 
 -- | Given some blocks and a block tree, keep only the prefix of the block tree

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Shrinking.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Shrinking.hs
@@ -27,9 +27,9 @@ import           Test.Util.TestBlock (TestBlock, isAncestorOf,
 -- block tree is trimmed to keep only parts that are necessary for the shrunk
 -- schedule.
 shrinkPeerSchedules ::
-  GenesisTest (Peers PeerSchedule) ->
+  GenesisTest (Peers (PeerSchedule TestBlock)) ->
   StateView ->
-  [GenesisTest (Peers PeerSchedule)]
+  [GenesisTest (Peers (PeerSchedule TestBlock))]
 shrinkPeerSchedules genesisTest _stateView =
   shrinkOtherPeers shrinkPeerSchedule (gtSchedule genesisTest) <&> \shrunkSchedule ->
     let trimmedBlockTree = trimBlockTree' shrunkSchedule (gtBlockTree genesisTest)
@@ -37,7 +37,7 @@ shrinkPeerSchedules genesisTest _stateView =
 
 -- | Shrink a 'PeerSchedule' by removing ticks from it. The other ticks are kept
 -- unchanged.
-shrinkPeerSchedule :: PeerSchedule -> [PeerSchedule]
+shrinkPeerSchedule :: (PeerSchedule blk) -> [PeerSchedule blk]
 shrinkPeerSchedule = shrinkList (const [])
 
 -- | Shrink the 'others' field of a 'Peers' structure by attempting to remove
@@ -50,7 +50,7 @@ shrinkOtherPeers shrink Peers{honest, others} =
 -- | Remove blocks from the given block tree that are not necessary for the
 -- given peer schedules. If entire branches are unused, they are removed. If the
 -- trunk is unused, then it remains as an empty anchored fragment.
-trimBlockTree' :: Peers PeerSchedule -> BlockTree TestBlock -> BlockTree TestBlock
+trimBlockTree' :: Peers (PeerSchedule TestBlock) -> BlockTree TestBlock -> BlockTree TestBlock
 trimBlockTree' = keepOnlyAncestorsOf . peerSchedulesBlocks
 
 -- | Given some blocks and a block tree, keep only the prefix of the block tree

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Tests.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Tests.hs
@@ -254,20 +254,20 @@ prop_peerScheduleFromTipPoints seed (PeerScheduleFromTipPointsInput psp tps trun
             noReturnToAncestors (filter isBlockPoint $ map snd ss)
           )
   where
-    showPoint :: SchedulePoint -> String
+    showPoint :: AF.HasHeader blk => SchedulePoint blk -> String
     showPoint (ScheduleTipPoint b)    = "TP " ++ show (blockHash b)
     showPoint (ScheduleHeaderPoint b) = "HP " ++ show (blockHash b)
     showPoint (ScheduleBlockPoint b)  = "BP " ++ show (blockHash b)
 
-    isTipPoint :: SchedulePoint -> Bool
+    isTipPoint :: SchedulePoint blk -> Bool
     isTipPoint (ScheduleTipPoint _) = True
     isTipPoint _                    = False
 
-    isHeaderPoint :: SchedulePoint -> Bool
+    isHeaderPoint :: SchedulePoint blk -> Bool
     isHeaderPoint (ScheduleHeaderPoint _) = True
     isHeaderPoint _                       = False
 
-    isBlockPoint :: SchedulePoint -> Bool
+    isBlockPoint :: SchedulePoint blk -> Bool
     isBlockPoint (ScheduleBlockPoint _) = True
     isBlockPoint _                      = False
 
@@ -281,7 +281,7 @@ isAncestorBlock b0 b1 =
       else Just LT
     else Nothing
 
-noReturnToAncestors :: [SchedulePoint] -> QC.Property
+noReturnToAncestors :: [SchedulePoint TestBlock] -> QC.Property
 noReturnToAncestors = go []
   where
     go _ [] = QC.property True


### PR DESCRIPTION
This PR brings various improvements to the schedules. Most importantly:

- Get rid of the old type `NodeState = NodeOffline | NodeOnline AdvertisedPoints` because we never actually used `NodeOffline` and there was no observable difference between a tick with `NodeOffline` and no tick. The old `AdvertisedPoints` takes its place and gets named `NodeState`. We also remove the types `TipPoint`, `HeaderPoint` and `BlockPoint`.

- Make the `SchedulePoint`s carry `WithOrigin TestBlock`s and not just `TestBlock`s. Although not used by the current generators, it does make sense to add this and causes only a minimal diff. In some places, we actually would need this (cc @nbacquey).

- Generalise quite a few types and functions to any `blk` and not just `TestBlock`. This makes more explicit the places where we actually use features of `TestBlock`s. This will also allow reuse of schedule generators with other blocks if anyone ever wishes to do this. @amesgen> At this point, the peer simulator is still stuck with `TestBlock`s, but this is only for printing purposes. We could consider going for tracing in a similar way as other parts of the code with a type `TracePeerSimulatorEvent blk`. Do you think that this is valuable or will nobody ever want to use the peer simulator with other block types?

The commits can be read in order.