### PR TITLE
Add a `db-analyser` analysis to get the UTxO size per slot

### DIFF
--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -16,7 +16,7 @@ hsPkgs.shellFor {
 
     # release management
     pkgs.scriv
-    (pkgs.python3.withPackages (p: [ p.beautifulsoup4 p.html5lib ]))
+    (pkgs.python3.withPackages (p: [ p.beautifulsoup4 p.html5lib p.matplotlib p.pandas ]))
   ];
 
   # This is the place for tools that are required to be built with the same GHC

--- a/ouroboros-consensus-cardano/README.md
+++ b/ouroboros-consensus-cardano/README.md
@@ -177,6 +177,11 @@ Lastly the user can provide the analysis that should be run on the chain:
   - time spent in the mutator in microseconds
   - time spent in GC in microseconds
 
+* `--get-block-application-metrics NUM` computes different block application metrics every `NUM` blocks.
+It currently outputs block number, slot number, UTxO size in MB, and UTxO map size.
+In the [`scripts`](./scripts) directory we provide a `plot_utxo-growth.py` script that can be used to plot the these results.
+See this file for usage information.
+
 If no analysis flag is provided, then the ChainDB will be opened, all the chunks
 in the immutable and volatile databases will be validated (see
 [validation](#database-validation)), and the tool will exit.

--- a/ouroboros-consensus-cardano/app/DBAnalyser/Parsers.hs
+++ b/ouroboros-consensus-cardano/app/DBAnalyser/Parsers.hs
@@ -113,6 +113,7 @@ parseAnalysis = asum [
         , metavar "INT"
         ]
     , benchmarkLedgerOpsParser
+    , getBlockApplicationMetrics
     , pure OnlyValidation
     ]
 
@@ -149,6 +150,22 @@ benchmarkLedgerOpsParser =
                   <> " Prints one line of stats per block to the given output file "
                   <> " (defaults to stdout)."
           ]
+
+getBlockApplicationMetrics :: Parser AnalysisName
+getBlockApplicationMetrics =  do
+  fGetBlockApplicationMetrics <- partialGetBlockApplicationMetricsParser
+  mOutputFile                 <- pMaybeOutputFile
+  pure $ fGetBlockApplicationMetrics mOutputFile
+  where
+    partialGetBlockApplicationMetricsParser =
+          GetBlockApplicationMetrics . NumberOfBlocks
+      <$> option auto (mconcat [ long    "get-block-application-metrics"
+                               , metavar "NUM"
+                               , help $  "Compute block application metrics every 'NUM' blocks (it currently supports slot and block numbers and UTxO size). "
+                                 <> "Stores the result to the given output file "
+                                 <> " (defaults to stdout)."
+                               ]
+                      )
 
 pMaybeOutputFile :: Parser (Maybe FilePath)
 pMaybeOutputFile =

--- a/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
+++ b/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
@@ -463,6 +463,7 @@ library unstable-cardano-tools
     Cardano.Tools.DBAnalyser.Block.Byron
     Cardano.Tools.DBAnalyser.Block.Cardano
     Cardano.Tools.DBAnalyser.Block.Shelley
+    Cardano.Tools.DBAnalyser.CSV
     Cardano.Tools.DBAnalyser.HasAnalysis
     Cardano.Tools.DBAnalyser.Run
     Cardano.Tools.DBAnalyser.Types
@@ -514,6 +515,7 @@ library unstable-cardano-tools
     , cardano-slotting
     , cardano-strict-containers
     , cborg                          ^>=0.2.2
+    , compact
     , containers                     >=0.5    && <0.7
     , contra-tracer
     , directory

--- a/ouroboros-consensus-cardano/scripts/plot_utxo_growth.py
+++ b/ouroboros-consensus-cardano/scripts/plot_utxo_growth.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+
+"""
+Plot UTxO growth in the Cardano blockchain.
+
+This script uses the output of `db-analyser --get-block-application-metrics`.
+
+This script assumes the CSV file path is provided as first argument.
+"""
+
+import sys
+import matplotlib.pyplot as pyplot
+import pandas as pandas
+
+if len(sys.argv) != 2:
+   print("no arguments passed")
+   sys.exit(1)
+
+ledger_stats = pandas.read_csv(sys.argv[1], skipinitialspace = True)
+
+slot_numbers = ledger_stats['Slot Number']
+utxo_size = ledger_stats["UTxO size (via Compact)"] / 1_000_000
+
+# See https://github.com/IntersectMBO/cardano-ledger/wiki/First-Block-of-Each-Era
+first_slot_each_era = [4492800,  # Shelley
+                       16588800, # Allegra
+                       23068800, # Mary
+                       39916975, # Alonzo
+                       43372972, # Alonzo'
+                       72316896, # Babbage
+                       84844885  # Babbage'
+                       ]
+
+fig, ax1 = pyplot.subplots()
+
+pyplot.vlines(first_slot_each_era, 0, max(utxo_size), colors="red")
+pyplot.grid()
+
+utxo_size_color = 'tab:blue'
+ax1.set_xlabel('Slot Number')
+ax1.set_ylabel('UTxO size (MB)', color = utxo_size_color)
+ax1.plot(slot_numbers, utxo_size, color = utxo_size_color)
+ax1.tick_params(axis='y', color = utxo_size_color)
+
+ax2 = ax1.twinx() # Instantiate a second axes that shares the same x-axis
+
+map_size_color = 'tab:green'
+ax2.set_ylabel('UTxO map size', color=map_size_color)
+ax2.plot(slot_numbers, ledger_stats["UTxO map size"], color = map_size_color)
+ax2.tick_params(axis='y', color = map_size_color)
+
+pyplot.show()

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Block/Byron.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Block/Byron.hs
@@ -39,6 +39,9 @@ instance HasAnalysis ByronBlock where
     blockStats blk = [ decimal $ length $ blockTxSizes blk
                      , decimal $ sum $ blockTxSizes blk
                      ]
+    -- For the time being we do not support any block application
+    -- metrics for the Byron era only.
+    blockApplicationMetrics = []
 
 instance HasProtocolInfo ByronBlock where
     data Args ByronBlock =

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Block/Shelley.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Block/Shelley.hs
@@ -100,6 +100,10 @@ instance ( ShelleyCompatible proto era
       txs = case Shelley.shelleyBlockRaw blk of
         SL.Block _ body -> Core.fromTxSeq @era body
 
+    -- For the time being we do not support any block application
+    -- metrics for Shelley-only eras.
+  blockApplicationMetrics = []
+
 class PerEraAnalysis era where
     txExUnitsSteps :: Maybe (Core.Tx era -> Word64)
 

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/CSV.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/CSV.hs
@@ -1,0 +1,68 @@
+{-# LANGUAGE GeneralisedNewtypeDeriving #-}
+
+-- | This module provides functionality for helping writing data values as CSV entries.
+--
+-- A couple of 'db-analyzer` analysis produce CSV files, which contain
+-- the analysis' results. A way to populate these files is to write
+-- the headers first, and then, line by line, write the rows that
+-- contain the data. Each column in a row containing data must
+-- correspond to a given header. To make it easier to maintain this
+-- correspondence between headers and data, we usually specify a CSV
+-- builder as:
+--
+-- > [(Builder, a -> IO Builder)]
+--
+-- where each first component of each tuple in the list represents a
+-- header, and each second component determines how the value that
+-- corresponds to that header is computed, given a certain value that
+-- is needed to compute a row in the resulting CSV.
+--
+-- We use 'Text.Builder' to efficiently intercalate values with the CSV 'Separator'.
+--
+module Cardano.Tools.DBAnalyser.CSV (
+    Separator (Separator, unSeparator)
+  , computeAndWriteLine
+  , computeAndWriteLinePure
+  , computeColumns
+  , computeColumnsPure
+  , writeHeaderLine
+  , writeLine
+  ) where
+
+import           Data.String (IsString)
+import qualified Data.Text.IO as Text.IO
+import qualified System.IO as IO
+import qualified Text.Builder as Builder
+import           Text.Builder (Builder)
+
+newtype Separator = Separator { unSeparator :: Builder }
+  deriving (Show, IsString, Monoid, Semigroup)
+
+writeHeaderLine :: IO.Handle -> Separator -> [(Builder, a)] -> IO ()
+writeHeaderLine handle (Separator separator) =
+      Text.IO.hPutStrLn handle
+    . Builder.run
+    . Builder.intercalate separator
+    . fmap fst
+
+writeLine :: IO.Handle -> Separator -> [Builder] -> IO ()
+writeLine handle (Separator separator) =
+      Text.IO.hPutStrLn handle
+    . Builder.run
+    . Builder.intercalate separator
+
+computeAndWriteLine :: IO.Handle -> Separator -> [(a, b -> IO Builder)] -> b -> IO ()
+computeAndWriteLine handle separator csvBuilder b = do
+  computeColumns (fmap snd csvBuilder) b >>= writeLine handle separator
+
+computeAndWriteLinePure :: IO.Handle -> Separator -> [(a, b -> Builder)] -> b -> IO ()
+computeAndWriteLinePure handle separator csvBuilder b =
+    writeLine handle separator $ computeColumnsPure (fmap snd csvBuilder) b
+
+computeColumns :: [a -> IO Builder] -> a -> IO [Builder]
+computeColumns fBuilders a =
+  sequence $ fmap ($ a) fBuilders
+
+computeColumnsPure :: [a -> Builder] -> a -> [Builder]
+computeColumnsPure fBuilders a =
+  fmap ($ a) fBuilders

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/HasAnalysis.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/HasAnalysis.hs
@@ -39,6 +39,25 @@ class (HasAnnTip blk, GetPrevHash blk, Condense (HeaderHash blk)) => HasAnalysis
   -- | This method was introduced for the sake of the 'BenchmarkLedgerOps' pass.
   blockStats     :: blk -> [Builder]
 
+  -- | This function allows to define different metrics about block application.
+  --
+  -- The block application metrics will be stored in a CSV file. This
+  -- method is used by 'db-analyser' to define the headers of the
+  -- resulting data, and how to compute, for a given row, each column
+  -- of the metrics.
+  --
+  -- The first component of each element in 'blockApplicationMetrics'
+  -- represents a header in the resulting CSV file.
+  --
+  -- Given a block application 'x :: WithLedgerState blk', the metrics
+  -- for that block application are calculated using the second
+  -- component of 'blockApplicationMetrics'.
+  --
+  -- The block application metrics are mapped to an IO action because
+  -- certain metrics such as the size of data need to be performed in
+  -- the IO monad.
+  blockApplicationMetrics :: [(Builder, WithLedgerState blk -> IO Builder)]
+
 class HasProtocolInfo blk where
   data Args blk
   mkProtocolInfo :: Args blk -> IO (ProtocolInfo blk)

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Types.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Types.hs
@@ -5,7 +5,8 @@ module Cardano.Tools.DBAnalyser.Types (
   ) where
 
 import           Cardano.Tools.DBAnalyser.Analysis as AnalysisTypes
-                     (AnalysisName (..), AnalysisResult (..), Limit (..))
+                     (AnalysisName (..), AnalysisResult (..), Limit (..),
+                     NumberOfBlocks (..))
 import           Ouroboros.Consensus.Storage.LedgerDB (DiskSnapshot)
 
 


### PR DESCRIPTION
This patch adds a new analysis to `db-analyser`: `--get-block-application-metrics N`. Currently, for each block every `N`, we compute the block slot, block number, UTxO size, and UTxO map size. The analysis can be extended to other metrics extracted from the previous ledger state, current block, and ledger state resulting from applying said block.