### PR TITLE
Generalise where possible in the peer simulator

### DIFF
--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup.hs
@@ -30,7 +30,7 @@ import           Test.Util.Tracer (recordingTracerTVar)
 -- | See 'runGenesisTest'.
 data RunGenesisTestResult = RunGenesisTestResult {
   rgtrTrace :: String,
-  rgtrStateView :: StateView
+  rgtrStateView :: StateView TestBlock
   }
 
 -- | Runs the given 'GenesisTest' and 'PointSchedule' and evaluates the given
@@ -59,7 +59,7 @@ runGenesisTest' ::
   Testable prop =>
   SchedulerConfig ->
   GenesisTestFull TestBlock ->
-  (StateView -> prop) ->
+  (StateView TestBlock -> prop) ->
   Property
 runGenesisTest' schedulerConfig genesisTest makeProperty =
     counterexample rgtrTrace $ makeProperty rgtrStateView
@@ -74,8 +74,8 @@ forAllGenesisTest ::
   Testable prop =>
   Gen (GenesisTestFull TestBlock) ->
   SchedulerConfig ->
-  (GenesisTestFull TestBlock -> StateView -> [GenesisTestFull TestBlock]) ->
-  (GenesisTestFull TestBlock -> StateView -> prop) ->
+  (GenesisTestFull TestBlock -> StateView TestBlock -> [GenesisTestFull TestBlock]) ->
+  (GenesisTestFull TestBlock -> StateView TestBlock -> prop) ->
   Property
 forAllGenesisTest generator schedulerConfig shrinker mkProperty =
   forAllGenRunShrinkCheck generator runner shrinker' $ \genesisTest result ->

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup.hs
@@ -19,7 +19,7 @@ import           Test.Consensus.Genesis.Setup.Classifiers (classifiers, Classifi
 import           Test.Consensus.Genesis.Setup.GenChains
 import           Test.Consensus.PeerSimulator.Run
 import           Test.Consensus.PeerSimulator.StateView
-import           Test.Consensus.PeerSimulator.Trace (traceLinesWith)
+import           Test.Consensus.PeerSimulator.Trace (traceLinesWith, mkTracerTestBlock)
 import           Test.Consensus.PointSchedule
 import           Test.QuickCheck
 import           Test.Util.Orphans.IOLike ()
@@ -44,9 +44,9 @@ runGenesisTest schedulerConfig genesisTest =
     (recordingTracer, getTrace) <- recordingTracerTVar
     let tracer = if scDebug schedulerConfig then debugTracer else recordingTracer
 
-    traceLinesWith tracer $ prettyGenesisTest genesisTest
+    traceLinesWith tracer $ prettyGenesisTest prettyPeersSchedule genesisTest
 
-    rgtrStateView <- runPointSchedule schedulerConfig genesisTest tracer
+    rgtrStateView <- runPointSchedule schedulerConfig genesisTest (mkTracerTestBlock tracer)
     traceWith tracer (condense rgtrStateView)
     rgtrTrace <- unlines <$> getTrace
 

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE BlockArguments      #-}
 {-# LANGUAGE DerivingStrategies  #-}
+{-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE NamedFieldPuns      #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -65,7 +66,7 @@ tests =
 
 theProperty ::
   GenesisTestFull TestBlock ->
-  StateView ->
+  StateView TestBlock ->
   Property
 theProperty genesisTest stateView@StateView{svSelectedChain} =
   classify genesisWindowAfterIntersection "Full genesis window after intersection" $

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/ChainSync.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/ChainSync.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE NamedFieldPuns      #-}
 {-# LANGUAGE NumericUnderscores  #-}
 {-# LANGUAGE RecordWildCards     #-}
@@ -13,11 +14,14 @@ import           Data.Proxy (Proxy (..))
 import qualified Data.Set as Set
 import           Ouroboros.Consensus.Block (Header, Point)
 import           Ouroboros.Consensus.Config (TopLevelConfig (..))
+import           Ouroboros.Consensus.Ledger.SupportsProtocol
+                     (LedgerSupportsProtocol)
 import           Ouroboros.Consensus.MiniProtocol.ChainSync.Client (ChainDbView,
                      ChainSyncLoPBucketConfig, Consensus,
                      bracketChainSyncClient, chainSyncClient)
 import qualified Ouroboros.Consensus.MiniProtocol.ChainSync.Client as CSClient
 import qualified Ouroboros.Consensus.MiniProtocol.ChainSync.Client.InFutureCheck as InFutureCheck
+import           Ouroboros.Consensus.Util (ShowProxy)
 import           Ouroboros.Consensus.Util.IOLike (Exception (fromException),
                      IOLike, MonadCatch (try), StrictTVar, uncheckedNewTVarM)
 import           Ouroboros.Network.AnchoredFragment (AnchoredFragment)
@@ -46,18 +50,18 @@ import           Test.Consensus.PeerSimulator.Trace
                      TraceEvent (..))
 import           Test.Consensus.PointSchedule.Peers (PeerId)
 import           Test.Util.Orphans.IOLike ()
-import           Test.Util.TestBlock (TestBlock)
 
-basicChainSyncClient :: forall m.
-  IOLike m =>
+basicChainSyncClient ::
+  forall m blk.
+  (IOLike m, LedgerSupportsProtocol blk) =>
   PeerId ->
-  Tracer m (TraceEvent TestBlock) ->
-  TopLevelConfig TestBlock ->
-  ChainDbView m TestBlock ->
-  StrictTVar m (AnchoredFragment (Header TestBlock)) ->
+  Tracer m (TraceEvent blk) ->
+  TopLevelConfig blk ->
+  ChainDbView m blk ->
+  StrictTVar m (AnchoredFragment (Header blk)) ->
   (m (), m ()) ->
   (m (), m (), m ()) ->
-  Consensus ChainSyncClientPipelined TestBlock m
+  Consensus ChainSyncClientPipelined blk m
 basicChainSyncClient peerId tracer cfg chainDbView varCandidate (startIdling, stopIdling) (pauseLoPBucket, resumeLoPBucket, grantLoPToken) =
   chainSyncClient
     CSClient.ConfigEnv {
@@ -80,7 +84,7 @@ basicChainSyncClient peerId tracer cfg chainDbView varCandidate (startIdling, st
       }
   where
     dummyHeaderInFutureCheck ::
-      InFutureCheck.SomeHeaderInFutureCheck m TestBlock
+      InFutureCheck.SomeHeaderInFutureCheck m blk
     dummyHeaderInFutureCheck =
       InFutureCheck.SomeHeaderInFutureCheck InFutureCheck.HeaderInFutureCheck
       { InFutureCheck.proxyArrival = Proxy
@@ -90,16 +94,16 @@ basicChainSyncClient peerId tracer cfg chainDbView varCandidate (startIdling, st
       }
 
 runChainSyncClient ::
-  (IOLike m, MonadTimer m) =>
-  Tracer m (TraceEvent TestBlock) ->
-  TopLevelConfig TestBlock ->
-  ChainDbView m TestBlock ->
+  (IOLike m, MonadTimer m, LedgerSupportsProtocol blk, ShowProxy blk, ShowProxy (Header blk)) =>
+  Tracer m (TraceEvent blk) ->
+  TopLevelConfig blk ->
+  ChainDbView m blk ->
   PeerId ->
-  ChainSyncServer (Header TestBlock) (Point TestBlock) (Tip TestBlock) m () ->
+  ChainSyncServer (Header blk) (Point blk) (Tip blk) m () ->
   ChainSyncTimeout ->
   ChainSyncLoPBucketConfig ->
   StateViewTracers m ->
-  StrictTVar m (Map PeerId (StrictTVar m (AnchoredFragment (Header TestBlock)))) ->
+  StrictTVar m (Map PeerId (StrictTVar m (AnchoredFragment (Header blk)))) ->
   m ()
 runChainSyncClient
   tracer

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/ScheduledBlockFetchServer.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/ScheduledBlockFetchServer.hs
@@ -12,48 +12,46 @@ module Test.Consensus.PeerSimulator.ScheduledBlockFetchServer (
 
 import           Control.Tracer
 import           Ouroboros.Consensus.Block (Point)
-import           Ouroboros.Consensus.Util.Condense (Condense)
 import           Ouroboros.Consensus.Util.IOLike (IOLike, MonadSTM (STM))
 import           Ouroboros.Network.BlockFetch.ClientState (ChainRange)
 import           Ouroboros.Network.Protocol.BlockFetch.Server
 import           Test.Consensus.PeerSimulator.ScheduledServer
                      (ScheduledServer (..), awaitOnlineState, runHandler)
 import           Test.Consensus.PeerSimulator.Trace
-import           Test.Util.TersePrinting (terseBlock)
+import           Test.Consensus.PointSchedule (NodeState)
+import           Test.Consensus.PointSchedule.Peers (PeerId)
 import           Test.Util.TestBlock (TestBlock)
 
 data SendBlocks =
   SendBlock TestBlock [TestBlock]
   |
   BatchDone
-  deriving (Eq, Show)
 
 data BlockFetch =
   StartBatch [TestBlock]
   |
   NoBlocks
-  deriving (Eq, Show)
 
-data BlockFetchServerHandlers m a =
+data BlockFetchServerHandlers m state =
   BlockFetchServerHandlers {
-    bfshBlockFetch :: ChainRange (Point TestBlock) -> a -> STM m (Maybe BlockFetch, [String]),
-    bfshSendBlocks :: [TestBlock] -> a -> STM m (Maybe SendBlocks, [String])
+    bfshBlockFetch :: ChainRange (Point TestBlock) -> state -> STM m (Maybe BlockFetch, [TraceScheduledBlockFetchServerEvent state TestBlock]),
+    bfshSendBlocks :: [TestBlock] -> state -> STM m (Maybe SendBlocks, [TraceScheduledBlockFetchServerEvent state TestBlock])
   }
 
 -- | Resources used by a BlockFetch server mock.
-data ScheduledBlockFetchServer m a =
+data ScheduledBlockFetchServer m state =
   ScheduledBlockFetchServer {
-    sbfsServer   :: ScheduledServer m a,
-    sbfsHandlers :: BlockFetchServerHandlers m a
+    sbfsServer   :: ScheduledServer m state,
+    sbfsTracer   :: Tracer m (TraceScheduledBlockFetchServerEvent state TestBlock),
+    sbfsHandlers :: BlockFetchServerHandlers m state
   }
 
 scheduledBlockFetchServer ::
   forall m a .
-  Condense a =>
   IOLike m =>
   ScheduledBlockFetchServer m a ->
   BlockFetchServer TestBlock (Point TestBlock) m ()
-scheduledBlockFetchServer ScheduledBlockFetchServer {sbfsServer, sbfsHandlers} =
+scheduledBlockFetchServer ScheduledBlockFetchServer {sbfsServer, sbfsTracer, sbfsHandlers} =
   server
   where
     server = BlockFetchServer blockFetch ()
@@ -61,34 +59,31 @@ scheduledBlockFetchServer ScheduledBlockFetchServer {sbfsServer, sbfsHandlers} =
     BlockFetchServerHandlers {bfshBlockFetch, bfshSendBlocks} = sbfsHandlers
 
     blockFetch range =
-      runHandler sbfsServer "BlockFetch" (bfshBlockFetch range) $ \case
+      runHandler sbfsServer "BlockFetch" (bfshBlockFetch range) sbfsTracer $ \case
         StartBatch blocks -> do
-          trace $ "  sending blocks: " ++ unwords (terseBlock <$> blocks)
-          trace "done handling BlockFetch"
+          trace $ TraceSendingBlocks blocks
           pure $ SendMsgStartBatch (sendBlocks blocks)
         NoBlocks -> do
-          trace "  no blocks available"
-          trace "done handling BlockFetch"
+          trace $ TraceNoBlocks
           pure (SendMsgNoBlocks (server <$ awaitOnlineState sbfsServer))
 
     sendBlocks bs =
-      runHandler sbfsServer "SendBlocks" (bfshSendBlocks bs) $ \case
+      runHandler sbfsServer "SendBlocks" (bfshSendBlocks bs) sbfsTracer $ \case
         SendBlock blk blks -> pure (SendMsgBlock blk (sendBlocks blks))
         BatchDone -> pure (SendMsgBatchDone (pure server))
 
-    trace = traceWith (ssTracer sbfsServer)
+    trace = traceWith sbfsTracer
 
 -- | Construct a BlockFetch server for the peer simulator.
 --
 -- See 'scheduledBlockFetchServer'.
 runScheduledBlockFetchServer ::
-  Condense a =>
   IOLike m =>
-  String ->
+  PeerId ->
   STM m () ->
-  STM m (Maybe a) ->
-  Tracer m String ->
-  BlockFetchServerHandlers m a ->
+  STM m (Maybe (NodeState TestBlock)) ->
+  Tracer m (TraceEvent TestBlock) ->
+  BlockFetchServerHandlers m (NodeState TestBlock) ->
   BlockFetchServer TestBlock (Point TestBlock) m ()
 runScheduledBlockFetchServer ssPeerId ssTickStarted ssCurrentState tracer sbfsHandlers =
   scheduledBlockFetchServer ScheduledBlockFetchServer {
@@ -96,7 +91,8 @@ runScheduledBlockFetchServer ssPeerId ssTickStarted ssCurrentState tracer sbfsHa
       ssPeerId,
       ssTickStarted,
       ssCurrentState,
-      ssTracer = Tracer (traceUnitWith tracer ("ScheduledBlockFetchServer " ++ ssPeerId))
+      ssCommonTracer = Tracer (traceWith tracer . TraceScheduledBlockFetchServerEvent ssPeerId . TraceHandlerEventBF)
     },
+    sbfsTracer = Tracer (traceWith tracer . TraceScheduledBlockFetchServerEvent ssPeerId),
     sbfsHandlers
   }

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/ScheduledChainSyncServer.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/ScheduledChainSyncServer.hs
@@ -14,7 +14,6 @@ module Test.Consensus.PeerSimulator.ScheduledChainSyncServer (
 
 import           Control.Tracer (Tracer (Tracer), traceWith)
 import           Ouroboros.Consensus.Block.Abstract (Point (..))
-import           Ouroboros.Consensus.Util.Condense (Condense (..))
 import           Ouroboros.Consensus.Util.IOLike (IOLike, MonadSTM (STM))
 import           Ouroboros.Network.Block (Tip (..))
 import           Ouroboros.Network.Protocol.ChainSync.Server
@@ -24,8 +23,11 @@ import           Ouroboros.Network.Protocol.ChainSync.Server
                      ServerStNext (SendMsgRollBackward, SendMsgRollForward))
 import           Test.Consensus.PeerSimulator.ScheduledServer
                      (ScheduledServer (..), awaitOnlineState, runHandler)
-import           Test.Consensus.PeerSimulator.Trace (traceUnitWith)
-import           Test.Util.TersePrinting (terseHeader, terseTip)
+import           Test.Consensus.PeerSimulator.Trace
+                     (TraceEvent (TraceScheduledChainSyncServerEvent),
+                     TraceScheduledChainSyncServerEvent (..))
+import           Test.Consensus.PointSchedule (NodeState)
+import           Test.Consensus.PointSchedule.Peers (PeerId)
 import           Test.Util.TestBlock (Header (..), TestBlock)
 
 -- | Pure representation of the messages produced by the handler for the @StNext@
@@ -36,7 +38,6 @@ data RequestNext =
   RollBackward (Point TestBlock) (Tip TestBlock)
   |
   AwaitReply
-  deriving (Eq, Show)
 
 -- | Pure representation of the messages produced by the handler for the @StIntersect@
 -- protocol state of a ChainSync server.
@@ -44,24 +45,24 @@ data FindIntersect =
   IntersectFound (Point TestBlock) (Tip TestBlock)
   |
   IntersectNotFound (Tip TestBlock)
-  deriving (Eq, Show)
 
 -- | Handlers for the request a ChainSync server might receive from a client.
 -- These take an abstract argument that corresponds to the state of a point
 -- schedule tick and return the simplified protocol message types.
 --
 -- See 'runHandlerWithTrace' for the meaning of @[String]@.
-data ChainSyncServerHandlers m a =
+data ChainSyncServerHandlers m state =
   ChainSyncServerHandlers {
-    csshRequestNext      :: a -> STM m (Maybe RequestNext, [String]),
-    csshFindIntersection :: [Point TestBlock] -> a -> STM m (Maybe FindIntersect, [String])
+    csshRequestNext      :: state -> STM m (Maybe RequestNext, [TraceScheduledChainSyncServerEvent state TestBlock]),
+    csshFindIntersection :: [Point TestBlock] -> state -> STM m (Maybe FindIntersect, [TraceScheduledChainSyncServerEvent state TestBlock])
   }
 
 -- | Resources used by a ChainSync server mock.
-data ScheduledChainSyncServer m a =
+data ScheduledChainSyncServer m state =
   ScheduledChainSyncServer {
-    scssServer   :: ScheduledServer m a,
-    scssHandlers :: ChainSyncServerHandlers m a
+    scssServer   :: ScheduledServer m state,
+    scssTracer   :: Tracer m (TraceScheduledChainSyncServerEvent state TestBlock),
+    scssHandlers :: ChainSyncServerHandlers m state
   }
 
 -- | Declare a mock ChainSync protocol server in its typed-protocols encoding
@@ -76,11 +77,10 @@ data ScheduledChainSyncServer m a =
 -- This architecture allows the server's behavior to be defined with a simple
 -- interface separated from the scheduling and protocol plumbing infrastructure.
 scheduledChainSyncServer ::
-  Condense a =>
   IOLike m =>
   ScheduledChainSyncServer m a ->
   ChainSyncServer (Header TestBlock) (Point TestBlock) (Tip TestBlock) m ()
-scheduledChainSyncServer ScheduledChainSyncServer {scssHandlers, scssServer} =
+scheduledChainSyncServer ScheduledChainSyncServer {scssHandlers, scssTracer, scssServer} =
   go
   where
     ChainSyncServerHandlers {csshRequestNext, csshFindIntersection} = scssHandlers
@@ -93,17 +93,14 @@ scheduledChainSyncServer ScheduledChainSyncServer {scssHandlers, scssServer} =
       }
 
     recvMsgRequestNext =
-      runHandler scssServer "MsgRequestNext" csshRequestNext $ \case
+      runHandler scssServer "MsgRequestNext" csshRequestNext scssTracer $ \case
         RollForward header tip -> do
-          trace $ "  gotta serve " ++ terseHeader header
-          trace $ "  tip is      " ++ terseTip tip
-          trace "done handling MsgRequestNext"
+          trace $ TraceRollForward header tip
           pure $ Left $ SendMsgRollForward header tip go
         RollBackward point tip -> do
-          trace "done handling MsgRequestNext"
+          trace $ TraceRollBackward point tip
           pure $ Left $ SendMsgRollBackward point tip go
-        AwaitReply -> do
-          trace "done handling MsgRequestNext"
+        AwaitReply ->
           pure $ Right $ do -- beginning of the continuation
             restart >>= \case
               -- If we get 'Right', then we still do not have anything to serve
@@ -119,32 +116,29 @@ scheduledChainSyncServer ScheduledChainSyncServer {scssHandlers, scssServer} =
         restart = awaitOnlineState scssServer *> recvMsgRequestNext
 
     recvMsgFindIntersect pts =
-      runHandler scssServer "MsgFindIntersect" (csshFindIntersection pts) $ \case
+      runHandler scssServer "MsgFindIntersect" (csshFindIntersection pts) scssTracer $ \case
         IntersectNotFound tip -> do
-          trace "  no intersection found"
-          trace "done handling MsgFindIntersect"
+          trace TraceIntersectionNotFound
           pure $ SendMsgIntersectNotFound tip go
         IntersectFound intersection tip -> do
-          trace $ "  intersection found: " ++ condense intersection
-          trace "done handling MsgFindIntersect"
+          trace $ TraceIntersectionFound intersection
           pure $ SendMsgIntersectFound intersection tip go
 
     recvMsgDoneClient =
-      trace "received MsgDoneClient"
+      trace TraceClientIsDone
 
-    trace = traceWith (ssTracer scssServer)
+    trace = traceWith scssTracer
 
 -- | Construct a ChainSync server for the peer simulator.
 --
 -- See 'scheduledChainSyncServer'.
 runScheduledChainSyncServer ::
-  Condense a =>
   IOLike m =>
-  String ->
+  PeerId ->
   STM m () ->
-  STM m (Maybe a) ->
-  Tracer m String ->
-  ChainSyncServerHandlers m a ->
+  STM m (Maybe (NodeState TestBlock)) ->
+  Tracer m (TraceEvent TestBlock) ->
+  ChainSyncServerHandlers m (NodeState TestBlock) ->
   ChainSyncServer (Header TestBlock) (Point TestBlock) (Tip TestBlock) m ()
 runScheduledChainSyncServer ssPeerId ssTickStarted ssCurrentState tracer scssHandlers =
   scheduledChainSyncServer ScheduledChainSyncServer {
@@ -152,7 +146,8 @@ runScheduledChainSyncServer ssPeerId ssTickStarted ssCurrentState tracer scssHan
       ssPeerId,
       ssTickStarted,
       ssCurrentState,
-      ssTracer = Tracer (traceUnitWith tracer ("ScheduledChainSyncServer " ++ ssPeerId))
+      ssCommonTracer = Tracer (traceWith tracer . TraceScheduledChainSyncServerEvent ssPeerId . TraceHandlerEventCS)
     },
+    scssTracer = Tracer (traceWith tracer . TraceScheduledChainSyncServerEvent ssPeerId),
     scssHandlers
   }

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/ScheduledServer.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/ScheduledServer.hs
@@ -16,21 +16,20 @@ import           Ouroboros.Consensus.Util.IOLike (IOLike,
 import           Test.Consensus.PeerSimulator.Trace
                      (TraceScheduledServerHandlerEvent (..))
 import           Test.Consensus.PointSchedule.Peers (PeerId)
-import           Test.Util.TestBlock (TestBlock)
 
-data ScheduledServer m state =
+data ScheduledServer m state blk =
   ScheduledServer {
     ssPeerId       :: PeerId,
     ssCurrentState :: STM m (Maybe state),
     ssTickStarted  :: STM m (),
-    ssCommonTracer :: Tracer m (TraceScheduledServerHandlerEvent state TestBlock)
+    ssCommonTracer :: Tracer m (TraceScheduledServerHandlerEvent state blk)
   }
 
-nextTickState :: IOLike m => ScheduledServer m a -> m (Maybe a)
+nextTickState :: IOLike m => ScheduledServer m state blk -> m (Maybe state)
 nextTickState ScheduledServer {ssCurrentState, ssTickStarted} =
   atomically (ssTickStarted >> ssCurrentState)
 
-retryOffline :: IOLike m => ScheduledServer m a -> Maybe a -> m a
+retryOffline :: IOLike m => ScheduledServer m state blk -> Maybe state -> m state
 retryOffline server = maybe (awaitOnlineState server) pure
 
 -- | Block until the peer simulator has updated the concurrency primitive that
@@ -38,7 +37,7 @@ retryOffline server = maybe (awaitOnlineState server) pure
 -- If the new state is 'Nothing', the point schedule has declared this peer as
 -- offline for the current tick, so it will not resume operation and wait for
 -- the next update.
-awaitOnlineState :: IOLike m => ScheduledServer m a -> m a
+awaitOnlineState :: IOLike m => ScheduledServer m state blk -> m state
 awaitOnlineState server =
   retryOffline server =<< nextTickState server
 
@@ -48,7 +47,7 @@ awaitOnlineState server =
 -- Since processing of a tick always ends when the handler finishes
 -- after serving the last point, this function is only relevant for the
 -- initial state update.
-ensureCurrentState :: IOLike m => ScheduledServer m a -> m a
+ensureCurrentState :: IOLike m => ScheduledServer m state blk -> m state
 ensureCurrentState server =
   retryOffline server =<< atomically (ssCurrentState server)
 
@@ -79,7 +78,7 @@ runHandlerWithTrace tracer handler = do
 -- message with the server's continuation in it.
 runHandler ::
   IOLike m =>
-  ScheduledServer m state ->
+  ScheduledServer m state blk ->
   String ->
   (state -> STM m (Maybe msg, [traceMsg])) ->
   Tracer m traceMsg ->

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/ScheduledServer.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/ScheduledServer.hs
@@ -8,18 +8,22 @@ module Test.Consensus.PeerSimulator.ScheduledServer (
   , runHandler
   , runHandlerWithTrace
   ) where
-import           Control.Tracer (Tracer (Tracer), traceWith)
+
+import           Control.Tracer (Tracer, traceWith)
 import           Data.Foldable (traverse_)
-import           Ouroboros.Consensus.Util.Condense (Condense (condense))
 import           Ouroboros.Consensus.Util.IOLike (IOLike,
                      MonadSTM (STM, atomically))
+import           Test.Consensus.PeerSimulator.Trace
+                     (TraceScheduledServerHandlerEvent (..))
+import           Test.Consensus.PointSchedule.Peers (PeerId)
+import           Test.Util.TestBlock (TestBlock)
 
-data ScheduledServer m a =
+data ScheduledServer m state =
   ScheduledServer {
-    ssPeerId       :: String,
-    ssCurrentState :: STM m (Maybe a),
+    ssPeerId       :: PeerId,
+    ssCurrentState :: STM m (Maybe state),
     ssTickStarted  :: STM m (),
-    ssTracer       :: Tracer m String
+    ssCommonTracer :: Tracer m (TraceScheduledServerHandlerEvent state TestBlock)
   }
 
 nextTickState :: IOLike m => ScheduledServer m a -> m (Maybe a)
@@ -55,9 +59,9 @@ ensureCurrentState server =
 -- protocol result and emit them here.
 runHandlerWithTrace ::
   IOLike m =>
-  Tracer m String ->
-  STM m (a, [String]) ->
-  m a
+  Tracer m traceMsg ->
+  STM m (state, [traceMsg]) ->
+  m state
 runHandlerWithTrace tracer handler = do
   (result, handlerMessages) <- atomically handler
   traverse_ (traceWith tracer) handlerMessages
@@ -75,24 +79,24 @@ runHandlerWithTrace tracer handler = do
 -- message with the server's continuation in it.
 runHandler ::
   IOLike m =>
-  Condense a =>
-  ScheduledServer m a ->
+  ScheduledServer m state ->
   String ->
-  (a -> STM m (Maybe msg, [String])) ->
+  (state -> STM m (Maybe msg, [traceMsg])) ->
+  Tracer m traceMsg ->
   (msg -> m h) ->
   m h
-runHandler server@ScheduledServer{ssTracer} handlerName handler dispatchMessage =
+runHandler server@ScheduledServer{ssCommonTracer} handlerName handler handlerTracer dispatchMessage =
   run
   where
     run = do
       currentState <- ensureCurrentState server
-      trace ("handling " ++ handlerName)
-      trace ("  state is " ++ condense currentState)
-      maybe restart dispatchMessage =<< runHandlerWithTrace handlerTracer (handler currentState)
+      traceWith ssCommonTracer $ TraceHandling handlerName currentState
+      maybe restart done =<< runHandlerWithTrace handlerTracer (handler currentState)
 
     restart = do
-      trace "  cannot serve at this point; waiting for node state and starting again"
+      traceWith ssCommonTracer $ TraceRestarting handlerName
       awaitOnlineState server *> run
 
-    trace = traceWith ssTracer
-    handlerTracer = Tracer $ \ msg -> traceWith ssTracer (handlerName ++ " | " ++ msg)
+    done msg = do
+      traceWith ssCommonTracer $ TraceDoneHandling handlerName
+      dispatchMessage msg

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
@@ -325,8 +325,8 @@ data GenesisTest blk schedule = GenesisTest {
 
 type GenesisTestFull blk = GenesisTest blk (PeersSchedule blk)
 
-prettyGenesisTest :: GenesisTest TestBlock schedule -> [String]
-prettyGenesisTest genesisTest =
+prettyGenesisTest :: (schedule -> [String]) -> GenesisTest TestBlock schedule -> [String]
+prettyGenesisTest prettySchedule genesisTest =
   [ "GenesisTest:"
   , "  gtSecurityParam: " ++ show (maxRollbacks gtSecurityParam)
   , "  gtGenesisWindow: " ++ show (unGenesisWindow gtGenesisWindow)
@@ -343,6 +343,8 @@ prettyGenesisTest genesisTest =
   , "  gtBlockTree:"
   ] ++ map (("    " ++) . terseFragment) (allFragments gtBlockTree)
     ++ map ("    " ++) (prettyBlockTree gtBlockTree)
+    ++ ["  gtSchedule:"]
+    ++ map ("    " ++) (prettySchedule gtSchedule)
   where
     GenesisTest {
         gtSecurityParam
@@ -353,7 +355,7 @@ prettyGenesisTest genesisTest =
       , gtChainSyncTimeouts = ChainSyncTimeout{canAwaitTimeout, intersectTimeout, mustReplyTimeout}
       , gtLoPBucketParams = LoPBucketParams{lbpCapacity, lbpRate}
       , gtSlotLength
-      , gtSchedule = _
+      , gtSchedule
       } = genesisTest
 
 instance Functor (GenesisTest blk) where

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Shrinking.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Shrinking.hs
@@ -28,7 +28,7 @@ import           Test.Util.TestBlock (TestBlock, isAncestorOf,
 -- schedule.
 shrinkPeerSchedules ::
   GenesisTestFull TestBlock ->
-  StateView ->
+  StateView TestBlock ->
   [GenesisTestFull TestBlock]
 shrinkPeerSchedules genesisTest _stateView =
   shrinkOtherPeers shrinkPeerSchedule (gtSchedule genesisTest) <&> \shrunkSchedule ->


### PR DESCRIPTION
_Builds on top of https://github.com/IntersectMBO/ouroboros-consensus/pull/967._

Two main parts of this PR:

1. Introduce a peer simulator-specific `TraceEvent` and move all tracing to using this, with specialised tracing for `TestBlock`.
2. Generalise away from `TestBlock` where possible in the whole peer simulator. There are very few places that actually rely on the `TestBlock`, mostly in the scheduled block fetch server to check ancestry of blocks.