### PR TITLE
Limit on patience (LoP) and other improvements

### DIFF
--- a/ouroboros-consensus-diffusion/changelog.d/20240325_142132_niols_milestone_7_9_10_squashed.md
+++ b/ouroboros-consensus-diffusion/changelog.d/20240325_142132_niols_milestone_7_9_10_squashed.md
@@ -1,0 +1,3 @@
+### Breaking
+
+- LoP: run the ChainSync client against a leaky bucket

--- a/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
+++ b/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
@@ -219,6 +219,7 @@ test-suite consensus-test
     Test.Consensus.Genesis.Setup.Classifiers
     Test.Consensus.Genesis.Setup.GenChains
     Test.Consensus.Genesis.Tests
+    Test.Consensus.Genesis.Tests.LoE
     Test.Consensus.Genesis.Tests.LongRangeAttack
     Test.Consensus.Genesis.Tests.Uniform
     Test.Consensus.GSM

--- a/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
+++ b/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
@@ -221,6 +221,7 @@ test-suite consensus-test
     Test.Consensus.Genesis.Tests
     Test.Consensus.Genesis.Tests.LoE
     Test.Consensus.Genesis.Tests.LongRangeAttack
+    Test.Consensus.Genesis.Tests.LoP
     Test.Consensus.Genesis.Tests.Uniform
     Test.Consensus.GSM
     Test.Consensus.GSM.Model

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToNode.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToNode.hs
@@ -540,10 +540,11 @@ mkApps ::
   -> (NodeToNodeVersion -> Codecs blk addrNTN e m bCS bCS bBF bBF bTX bKA bPS)
   -> ByteLimits bCS bBF bTX bKA
   -> m ChainSyncTimeout
+  -> CsClient.ChainSyncLoPBucketConfig
   -> ReportPeerMetrics m (ConnectionId addrNTN)
   -> Handlers m addrNTN blk
   -> Apps m addrNTN bCS bBF bTX bKA bPS NodeToNodeInitiatorResult ()
-mkApps kernel Tracers {..} mkCodecs ByteLimits {..} genChainSyncTimeout ReportPeerMetrics {..} Handlers {..} =
+mkApps kernel Tracers {..} mkCodecs ByteLimits {..} genChainSyncTimeout lopBucketConfig ReportPeerMetrics {..} Handlers {..} =
     Apps {..}
   where
     aChainSyncClient
@@ -571,7 +572,9 @@ mkApps kernel Tracers {..} mkCodecs ByteLimits {..} genChainSyncTimeout ReportPe
             (getNodeCandidates kernel)
             (getNodeIdlers     kernel)
             them
-            version $ \varCandidate (startIdling, stopIdling) -> do
+            version
+            lopBucketConfig
+            $ \varCandidate (startIdling, stopIdling) (pauseLoPBucket, resumeLoPBucket, grantLoPToken) -> do
               chainSyncTimeout <- genChainSyncTimeout
               (r, trailing) <-
                 runPipelinedPeerWithLimits
@@ -591,6 +594,9 @@ mkApps kernel Tracers {..} mkCodecs ByteLimits {..} genChainSyncTimeout ReportPe
                         , CsClient.varCandidate
                         , CsClient.startIdling
                         , CsClient.stopIdling
+                        , CsClient.pauseLoPBucket
+                        , CsClient.resumeLoPBucket
+                        , CsClient.grantLoPToken
                         }
               return (ChainSyncInitiatorResult r, trailing)
 

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Node.hs
@@ -78,6 +78,8 @@ import           Ouroboros.Consensus.Fragment.InFuture (CheckInFuture,
                      ClockSkew)
 import qualified Ouroboros.Consensus.Fragment.InFuture as InFuture
 import           Ouroboros.Consensus.Ledger.Extended (ExtLedgerState (..))
+import           Ouroboros.Consensus.MiniProtocol.ChainSync.Client
+                     (ChainSyncLoPBucketConfig (..))
 import qualified Ouroboros.Consensus.MiniProtocol.ChainSync.Client.InFutureCheck as InFutureCheck
 import qualified Ouroboros.Consensus.Network.NodeToClient as NTC
 import qualified Ouroboros.Consensus.Network.NodeToNode as NTN
@@ -245,6 +247,9 @@ data LowLevelRunNodeArgs m addrNTN addrNTC versionDataNTN versionDataNTC blk
 
       -- | See 'NTN.ChainSyncTimeout'
     , llrnChainSyncTimeout :: m NTN.ChainSyncTimeout
+
+      -- | See 'CsClient.ChainSyncLoPBucketConfig'
+    , llrnChainSyncLoPBucketConfig :: ChainSyncLoPBucketConfig
 
       -- | How to run the data diffusion applications
       --
@@ -516,6 +521,7 @@ runWith RunNodeArgs{..} encAddrNtN decAddrNtN LowLevelRunNodeArgs{..} =
           (NTN.defaultCodecs codecConfig version encAddrNTN decAddrNTN)
           NTN.byteLimits
           llrnChainSyncTimeout
+          llrnChainSyncLoPBucketConfig
           (reportMetric Diffusion.peerMetricsConfiguration peerMetrics)
           (NTN.mkHandlers nodeKernelArgs nodeKernel computePeers)
 
@@ -915,6 +921,7 @@ stdLowLevelRunNodeArgsIO RunNodeArgs{ rnProtocolInfo
     pure LowLevelRunNodeArgs
       { llrnBfcSalt
       , llrnChainSyncTimeout = fromMaybe stdChainSyncTimeout srnChainSyncTimeout
+      , llrnChainSyncLoPBucketConfig = ChainSyncLoPBucketDisabled
       , llrnCustomiseHardForkBlockchainTimeArgs = id
       , llrnGsmAntiThunderingHerd
       , llrnKeepAliveRng

--- a/ouroboros-consensus-diffusion/src/unstable-diffusion-testlib/Test/ThreadNet/Network.hs
+++ b/ouroboros-consensus-diffusion/src/unstable-diffusion-testlib/Test/ThreadNet/Network.hs
@@ -1035,6 +1035,7 @@ runThreadNetwork systemTime ThreadNetworkArgs
                      , mustReplyTimeout = waitForever
                      , idleTimeout      = waitForever
                      })
+                  CSClient.ChainSyncLoPBucketDisabled
                   nullMetric
                   -- The purpose of this test is not testing protocols, so
                   -- returning constant empty list is fine if we have thorough

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/BlockTree.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/BlockTree.hs
@@ -180,11 +180,11 @@ prettyBlockTree blockTree =
           (honestFragment : adversarialFragments)
 
     printTrunk :: AF.HasHeader blk => AF.AnchoredFragment blk -> String
-    printTrunk = printLine (\_ -> "trunk:  -")
+    printTrunk = printLine (\_ -> "trunk:  ─")
 
     printBranch :: AF.HasHeader blk => AF.AnchoredFragment blk -> String
     printBranch = printLine $ \firstSlot ->
-      "      " ++ replicate (3 * fromIntegral (unSlotNo (firstSlot - veryFirstSlot))) ' ' ++ " `-"
+      "      " ++ replicate (3 * fromIntegral (unSlotNo (firstSlot - veryFirstSlot))) ' ' ++ " ╰─"
 
     printLine :: AF.HasHeader blk => (SlotNo -> String) -> AF.AnchoredFragment blk -> String
     printLine printHeader fragment =
@@ -202,7 +202,7 @@ prettyBlockTree blockTree =
         & Vector.toList . (slotRange Vector.//)
         & map (maybe "  " (printf "%2d"))
         & unwords
-        & map (\c -> if c == ' ' then '-' else c)
+        & map (\c -> if c == ' ' then '─' else c)
       where
         -- Initialize a Vector with the length of the fragment containing only Nothings
         slotRange = Vector.replicate (fromIntegral (unSlotNo lastSlot - unSlotNo firstSlot + 1)) Nothing

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup.hs
@@ -81,6 +81,8 @@ forAllGenesisTest generator schedulerConfig shrinker mkProperty =
   forAllGenRunShrinkCheck generator runner shrinker' $ \genesisTest result ->
     let cls = classifiers genesisTest
      in classify (allAdversariesSelectable cls) "All adversaries selectable" $
+        classify (allAdversariesForecastable cls) "All adversaries forecastable" $
+        classify (allAdversariesKPlus1InForecast cls) "All adversaries have k+1 blocks in forecast window after intersection" $
         classify (genesisWindowAfterIntersection cls) "Full genesis window after intersection" $
         counterexample (rgtrTrace result) $
         mkProperty genesisTest (rgtrStateView result)

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup.hs
@@ -30,7 +30,7 @@ import           Test.Util.Tracer (recordingTracerTVar)
 -- | See 'runGenesisTest'.
 data RunGenesisTestResult = RunGenesisTestResult {
   rgtrTrace :: String,
-  rgtrStateView :: StateView
+  rgtrStateView :: StateView TestBlock
   }
 
 -- | Runs the given 'GenesisTest' and 'PointSchedule' and evaluates the given
@@ -59,7 +59,7 @@ runGenesisTest' ::
   Testable prop =>
   SchedulerConfig ->
   GenesisTestFull TestBlock ->
-  (StateView -> prop) ->
+  (StateView TestBlock -> prop) ->
   Property
 runGenesisTest' schedulerConfig genesisTest makeProperty =
     counterexample rgtrTrace $ makeProperty rgtrStateView
@@ -74,8 +74,8 @@ forAllGenesisTest ::
   Testable prop =>
   Gen (GenesisTestFull TestBlock) ->
   SchedulerConfig ->
-  (GenesisTestFull TestBlock -> StateView -> [GenesisTestFull TestBlock]) ->
-  (GenesisTestFull TestBlock -> StateView -> prop) ->
+  (GenesisTestFull TestBlock -> StateView TestBlock -> [GenesisTestFull TestBlock]) ->
+  (GenesisTestFull TestBlock -> StateView TestBlock -> prop) ->
   Property
 forAllGenesisTest generator schedulerConfig shrinker mkProperty =
   forAllGenRunShrinkCheck generator runner shrinker' $ \genesisTest result ->

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup.hs
@@ -19,7 +19,7 @@ import           Test.Consensus.Genesis.Setup.Classifiers (classifiers, Classifi
 import           Test.Consensus.Genesis.Setup.GenChains
 import           Test.Consensus.PeerSimulator.Run
 import           Test.Consensus.PeerSimulator.StateView
-import           Test.Consensus.PeerSimulator.Trace (traceLinesWith)
+import           Test.Consensus.PeerSimulator.Trace (traceLinesWith, mkTracerTestBlock)
 import           Test.Consensus.PointSchedule
 import           Test.QuickCheck
 import           Test.Util.Orphans.IOLike ()
@@ -44,9 +44,9 @@ runGenesisTest schedulerConfig genesisTest =
     (recordingTracer, getTrace) <- recordingTracerTVar
     let tracer = if scDebug schedulerConfig then debugTracer else recordingTracer
 
-    traceLinesWith tracer $ prettyGenesisTest genesisTest
+    traceLinesWith tracer $ prettyGenesisTest prettyPeersSchedule genesisTest
 
-    rgtrStateView <- runPointSchedule schedulerConfig genesisTest tracer
+    rgtrStateView <- runPointSchedule schedulerConfig genesisTest (mkTracerTestBlock tracer)
     traceWith tracer (condense rgtrStateView)
     rgtrTrace <- unlines <$> getTrace
 

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup/Classifiers.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup/Classifiers.hs
@@ -93,7 +93,11 @@ classifiers GenesisTest {gtBlockTree, gtSecurityParam = SecurityParam k, gtGenes
     isForecastable bt =
       -- FIXME: We are using `scg` here but what we really mean is `sfor`.
       -- Distinguish `scg` vs. `sgen` vs. `sfor` and use the latter here.
-      let slotNos = map blockSlot $ AF.toOldestFirst $ btbFull bt in
+      -- NOTE: We only care about the difference between slot numbers so it is
+      -- not a problem to add @1@ to all of them. However, we do care VERY MUCH
+      -- that this list includes the anchor.
+      let slotNos = (succWithOrigin $ anchorToSlotNo $ anchor $ btbFull bt)
+                    : (map ((+1) . blockSlot) $ AF.toOldestFirst $ btbFull bt) in
       all (\(SlotNo prev, SlotNo next) -> next - prev <= scg) (zip slotNos (drop 1 slotNos))
 
     allAdversariesKPlus1InForecast =

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup/Classifiers.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup/Classifiers.hs
@@ -45,7 +45,7 @@ data Classifiers =
     longerThanGenesisWindow        :: Bool
   }
 
-classifiers :: GenesisTest -> Classifiers
+classifiers :: AF.HasHeader blk => GenesisTest blk schedule -> Classifiers
 classifiers GenesisTest {gtBlockTree, gtSecurityParam = SecurityParam k, gtGenesisWindow = GenesisWindow scg} =
   Classifiers {
     existsSelectableAdversary,

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup/GenChains.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup/GenChains.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DerivingStrategies        #-}
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE NamedFieldPuns            #-}
+{-# LANGUAGE NumericUnderscores        #-}
 {-# LANGUAGE RecordWildCards           #-}
 {-# LANGUAGE ScopedTypeVariables       #-}
 
@@ -121,6 +122,7 @@ genChains genNumForks = do
     gtDelay = delta,
     gtSlotLength,
     gtChainSyncTimeouts = chainSyncTimeouts gtSlotLength asc,
+    gtLoPBucketParams = LoPBucketParams { lbpCapacity = 10_000, lbpRate = 1_000 }, -- REVIEW: Do we want to generate those randomly?
     gtBlockTree = foldl' (flip BT.addBranch') (BT.mkTrunk goodChain) $ zipWith (genAdversarialFragment goodBlocks) [1..] alternativeChainSchemas,
     gtSchedule = ()
     }

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup/GenChains.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup/GenChains.hs
@@ -10,6 +10,7 @@ module Test.Consensus.Genesis.Setup.GenChains (
   , genChains
   ) where
 
+import           Cardano.Slotting.Time (slotLengthFromSec)
 import           Control.Monad (replicateM)
 import qualified Control.Monad.Except as Exn
 import           Data.List (foldl')
@@ -22,6 +23,7 @@ import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Network.AnchoredFragment (AnchoredFragment)
 import qualified Ouroboros.Network.AnchoredFragment as AF
 import qualified Test.Consensus.BlockTree as BT
+import           Test.Consensus.Network.Driver.Limits.Extras (chainSyncTimeouts)
 import           Test.Consensus.PointSchedule
 import qualified Test.Ouroboros.Consensus.ChainGenerator.Adversarial as A
 import           Test.Ouroboros.Consensus.ChainGenerator.Adversarial
@@ -98,7 +100,7 @@ genAlternativeChainSchema (testRecipeH, arHonest) =
 --     trunk: O─────1──2──3──4─────5──6──7
 --                     │           ╰─────6
 --                     ╰─────3──4─────5
-genChains :: QC.Gen Word -> QC.Gen GenesisTest
+genChains :: QC.Gen Word -> QC.Gen (GenesisTest TestBlock ())
 genChains genNumForks = do
   (asc, honestRecipe, someHonestChainSchema) <- genHonestChainSchema
 
@@ -113,15 +115,19 @@ genChains genNumForks = do
   numForks <- genNumForks
   alternativeChainSchemas <- replicateM (fromIntegral numForks) (genAlternativeChainSchema (honestRecipe, honestChainSchema))
   pure $ GenesisTest {
-    gtHonestAsc = asc,
     gtSecurityParam = SecurityParam (fromIntegral kcp),
     gtGenesisWindow = GenesisWindow (fromIntegral scg),
     gtDelay = delta,
-    gtBlockTree = foldl' (flip BT.addBranch') (BT.mkTrunk goodChain) $ zipWith (genAdversarialFragment goodBlocks) [1..] alternativeChainSchemas
+    gtSlotLength,
+    gtChainSyncTimeouts = chainSyncTimeouts gtSlotLength asc,
+    gtBlockTree = foldl' (flip BT.addBranch') (BT.mkTrunk goodChain) $ zipWith (genAdversarialFragment goodBlocks) [1..] alternativeChainSchemas,
+    gtSchedule = ()
     }
 
   where
-    genAdversarialFragment :: [TestBlock] -> Int -> (Int, [S]) -> TestFrag
+    gtSlotLength = slotLengthFromSec 20
+
+    genAdversarialFragment :: [TestBlock] -> Int -> (Int, [S]) -> AnchoredFragment TestBlock
     genAdversarialFragment goodBlocks forkNo (prefixCount, slotsA)
       = mkTestFragment (mkTestBlocks prefix slotsA forkNo)
       where

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup/GenChains.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup/GenChains.hs
@@ -66,7 +66,7 @@ genAlternativeChainSchema (testRecipeH, arHonest) =
     let H.HonestRecipe kcp scg delta _len = testRecipeH
 
     (seedPrefix :: QCGen) <- QC.arbitrary
-    let arPrefix = genPrefixBlockCount kcp seedPrefix arHonest
+    let arPrefix = genPrefixBlockCount testRecipeH seedPrefix arHonest
 
     let testRecipeA = A.AdversarialRecipe {
       A.arPrefix,

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup/GenChains.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup/GenChains.hs
@@ -117,6 +117,7 @@ genChains genNumForks = do
   pure $ GenesisTest {
     gtSecurityParam = SecurityParam (fromIntegral kcp),
     gtGenesisWindow = GenesisWindow (fromIntegral scg),
+    gtForecastRange = ForecastRange (fromIntegral scg), -- REVIEW: Do we want to generate those randomly?
     gtDelay = delta,
     gtSlotLength,
     gtChainSyncTimeouts = chainSyncTimeouts gtSlotLength asc,

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup/GenChains.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup/GenChains.hs
@@ -122,7 +122,10 @@ genChains genNumForks = do
     gtDelay = delta,
     gtSlotLength,
     gtChainSyncTimeouts = chainSyncTimeouts gtSlotLength asc,
-    gtLoPBucketParams = LoPBucketParams { lbpCapacity = 10_000, lbpRate = 1_000 }, -- REVIEW: Do we want to generate those randomly?
+    gtLoPBucketParams = LoPBucketParams { lbpCapacity = 10_000, lbpRate = 1_000 },
+    -- ^ REVIEW: Do we want to generate those randomly? For now, the chosen
+    -- values carry no special meaning. Someone needs to think about what values
+    -- would make for interesting tests.
     gtBlockTree = foldl' (flip BT.addBranch') (BT.mkTrunk goodChain) $ zipWith (genAdversarialFragment goodBlocks) [1..] alternativeChainSchemas,
     gtSchedule = ()
     }

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests.hs
@@ -1,5 +1,6 @@
 module Test.Consensus.Genesis.Tests (tests) where
 
+import qualified Test.Consensus.Genesis.Tests.LoE as LoE
 import qualified Test.Consensus.Genesis.Tests.LongRangeAttack as LongRangeAttack
 import qualified Test.Consensus.Genesis.Tests.Uniform as Uniform
 import           Test.Tasty
@@ -7,5 +8,6 @@ import           Test.Tasty
 tests :: TestTree
 tests = testGroup "Genesis tests"
     [ LongRangeAttack.tests
+    , LoE.tests
     , Uniform.tests
     ]

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests.hs
@@ -2,6 +2,7 @@ module Test.Consensus.Genesis.Tests (tests) where
 
 import qualified Test.Consensus.Genesis.Tests.LoE as LoE
 import qualified Test.Consensus.Genesis.Tests.LongRangeAttack as LongRangeAttack
+import qualified Test.Consensus.Genesis.Tests.LoP as LoP
 import qualified Test.Consensus.Genesis.Tests.Uniform as Uniform
 import           Test.Tasty
 
@@ -9,5 +10,6 @@ tests :: TestTree
 tests = testGroup "Genesis tests"
     [ LongRangeAttack.tests
     , LoE.tests
+    , LoP.tests
     , Uniform.tests
     ]

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LoE.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LoE.hs
@@ -1,0 +1,121 @@
+{-# LANGUAGE BlockArguments      #-}
+{-# LANGUAGE DerivingStrategies  #-}
+{-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE NumericUnderscores  #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications    #-}
+
+module Test.Consensus.Genesis.Tests.LoE (tests) where
+
+import           Data.Functor (($>))
+import           Ouroboros.Consensus.Util.IOLike (Time (Time), fromException)
+import           Ouroboros.Network.AnchoredFragment (HasHeader (..))
+import qualified Ouroboros.Network.AnchoredFragment as AF
+import           Ouroboros.Network.Driver.Limits
+                     (ProtocolLimitFailure (ExceededTimeLimit))
+import           Test.Consensus.BlockTree (BlockTree (..), BlockTreeBranch (..))
+import           Test.Consensus.Genesis.Setup
+import           Test.Consensus.PeerSimulator.Run (SchedulerConfig (..),
+                     defaultSchedulerConfig)
+import           Test.Consensus.PeerSimulator.StateView
+import           Test.Consensus.PointSchedule
+import           Test.Consensus.PointSchedule.Peers (PeerId (..), Peers,
+                     mkPeers)
+import           Test.Consensus.PointSchedule.Shrinking (shrinkPeerSchedules)
+import           Test.Consensus.PointSchedule.SinglePeer (scheduleBlockPoint,
+                     scheduleHeaderPoint, scheduleTipPoint)
+import           Test.Tasty
+import           Test.Tasty.QuickCheck
+import           Test.Util.Orphans.IOLike ()
+import           Test.Util.TersePrinting (tersePoint)
+import           Test.Util.TestEnv (adjustQuickCheckTests)
+
+tests :: TestTree
+tests =
+  testGroup
+    "LoE"
+    [
+      adjustQuickCheckTests (`div` 5) $
+        testProperty "adversary does not hit timeouts" (prop_adversaryHitsTimeouts False),
+      adjustQuickCheckTests (`div` 5) $
+        testProperty "adversary hits timeouts" (prop_adversaryHitsTimeouts True)
+    ]
+
+-- | Tests that the selection advances in presence of the LoE when a peer is
+-- killed by something that is not LoE-aware, eg. the timeouts.
+prop_adversaryHitsTimeouts :: Bool -> Property
+prop_adversaryHitsTimeouts timeoutsEnabled =
+  noShrinking $
+    forAllGenesisTest
+      ( do
+          gt@GenesisTest {gtBlockTree} <- genChains (pure 1)
+          let ps = delaySchedule gtBlockTree
+          pure $ gt $> ps
+      )
+      -- NOTE: Crucially, there must be timeouts for this test.
+      ( defaultSchedulerConfig
+          { scEnableChainSyncTimeouts = timeoutsEnabled,
+            scEnableLoE = True
+          }
+      )
+      shrinkPeerSchedules
+      ( \GenesisTest {gtBlockTree} StateView {svSelectedChain, svChainSyncExceptions} ->
+        tabulate "binary log buckets of the length of the honest chain" [show (round @_ @Int (2 ** (realToFrac @_ @Double (round @_ @Int (logBase 2 (realToFrac @_ @Double (1 + AF.length (btTrunk gtBlockTree))))))))] $
+        counterexample ("Selection is not the honest tip: " ++ tersePoint (AF.headPoint (btTrunk gtBlockTree)) ++ " / " ++ tersePoint (AF.castPoint (AF.headPoint svSelectedChain))) $
+          let treeTipPoint = AF.headPoint $ btTrunk gtBlockTree
+              selectedTipPoint = AF.castPoint $ AF.headPoint svSelectedChain
+              selectedCorrect = timeoutsEnabled == (treeTipPoint == selectedTipPoint)
+              exceptionsCorrect = case svChainSyncExceptions of
+                [] -> not timeoutsEnabled
+                [ChainSyncException (PeerId _) exn] ->
+                  case fromException exn of
+                    Just (ExceededTimeLimit _) -> timeoutsEnabled
+                    _                          -> False
+                _ -> False
+           in selectedCorrect && exceptionsCorrect
+      )
+  where
+    getOnlyBranch :: BlockTree blk -> BlockTreeBranch blk
+    getOnlyBranch BlockTree {btBranches} = case btBranches of
+      [branch] -> branch
+      _        -> error "tree must have exactly one alternate branch"
+
+    delaySchedule :: HasHeader blk => BlockTree blk -> Peers (PeerSchedule blk)
+    delaySchedule tree =
+      let trunkTip = case btTrunk tree of
+            (AF.Empty _)       -> error "tree must have at least one block"
+            (_ AF.:> tipBlock) -> tipBlock
+          branch = getOnlyBranch tree
+          intersectM = case btbPrefix branch of
+            (AF.Empty _)       -> Nothing
+            (_ AF.:> tipBlock) -> Just tipBlock
+          branchTip = case btbFull branch of
+            (AF.Empty _) -> error "alternate branch must have at least one block"
+            (_ AF.:> tipBlock) -> tipBlock
+       in mkPeers
+            -- Eagerly serve the honest tree, but after the adversary has
+            -- advertised its chain.
+            ( (Time 0, scheduleTipPoint trunkTip) : case intersectM of
+                Nothing ->
+                  [ (Time 0.5, scheduleHeaderPoint trunkTip),
+                    (Time 0.5, scheduleBlockPoint trunkTip)
+                  ]
+                Just intersect ->
+                  [ (Time 0.5, scheduleHeaderPoint intersect),
+                    (Time 0.5, scheduleBlockPoint intersect),
+                    (Time 5, scheduleHeaderPoint trunkTip),
+                    (Time 5, scheduleBlockPoint trunkTip)
+                  ]
+            )
+            -- The one adversarial peer advertises and serves up to the
+            -- intersection early, then waits more than the short wait timeout.
+            [ (Time 0, scheduleTipPoint branchTip) : case intersectM of
+                -- the alternate branch forks from `Origin`
+                Nothing -> [(Time 11, scheduleTipPoint branchTip)]
+                -- the alternate branch forks from `intersect`
+                Just intersect ->
+                  [ (Time 0, scheduleHeaderPoint intersect),
+                    (Time 0, scheduleBlockPoint intersect),
+                    (Time 11, scheduleBlockPoint intersect)
+                  ]
+            ]

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LoE.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LoE.hs
@@ -43,6 +43,7 @@ tests =
 
 -- | Tests that the selection advances in presence of the LoE when a peer is
 -- killed by something that is not LoE-aware, eg. the timeouts.
+-- NOTE: Same as 'LoP.prop_delayAttack' with timeouts instead of LoP.
 prop_adversaryHitsTimeouts :: Bool -> Property
 prop_adversaryHitsTimeouts timeoutsEnabled =
   noShrinking $
@@ -55,7 +56,8 @@ prop_adversaryHitsTimeouts timeoutsEnabled =
       -- NOTE: Crucially, there must be timeouts for this test.
       ( defaultSchedulerConfig
           { scEnableChainSyncTimeouts = timeoutsEnabled,
-            scEnableLoE = True
+            scEnableLoE = True,
+            scEnableLoP = False
           }
       )
       shrinkPeerSchedules

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LoP.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LoP.hs
@@ -202,9 +202,15 @@ prop_delayAttack lopEnabled =
       )
       shrinkPeerSchedules
       ( \GenesisTest {gtBlockTree} StateView {svSelectedChain, svChainSyncExceptions} ->
-          let treeTipPoint = AF.headPoint $ btTrunk gtBlockTree
+          let -- The tip of the blocktree trunk.
+              treeTipPoint = AF.headPoint $ btTrunk gtBlockTree
+              -- The tip of the selection.
               selectedTipPoint = AF.castPoint $ AF.headPoint svSelectedChain
+              -- If LoP is enabled, then the adversary should have been killed
+              -- and the selection should be the whole trunk.
               selectedCorrect = lopEnabled == (treeTipPoint == selectedTipPoint)
+              -- If LoP is enabled, then we expect exactly one `EmptyBucket`
+              -- exception in the adversary's ChainSync.
               exceptionsCorrect = case svChainSyncExceptions of
                 [] -> not lopEnabled
                 [ChainSyncException (PeerId _) exn] ->

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LoP.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LoP.hs
@@ -1,0 +1,259 @@
+{-# LANGUAGE BlockArguments      #-}
+{-# LANGUAGE DerivingStrategies  #-}
+{-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE NumericUnderscores  #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Test.Consensus.Genesis.Tests.LoP (tests) where
+
+import           Data.Functor (($>))
+import           Data.Ratio ((%))
+import qualified Ouroboros.Consensus.MiniProtocol.ChainSync.Client as CSClient
+import           Ouroboros.Consensus.Util.IOLike (DiffTime, Time (Time),
+                     fromException)
+import           Ouroboros.Consensus.Util.LeakyBucket
+                     (secondsRationalToDiffTime)
+import           Ouroboros.Network.AnchoredFragment (AnchoredFragment,
+                     HasHeader)
+import qualified Ouroboros.Network.AnchoredFragment as AF
+import           Test.Consensus.BlockTree (BlockTree (..), BlockTreeBranch (..))
+import           Test.Consensus.Genesis.Setup
+import           Test.Consensus.PeerSimulator.Run (SchedulerConfig (..),
+                     defaultSchedulerConfig)
+import           Test.Consensus.PeerSimulator.StateView
+import           Test.Consensus.PointSchedule
+import           Test.Consensus.PointSchedule.Peers (PeerId (..), Peers,
+                     mkPeers, peersOnlyHonest)
+import           Test.Consensus.PointSchedule.Shrinking (shrinkPeerSchedules)
+import           Test.Consensus.PointSchedule.SinglePeer (scheduleBlockPoint,
+                     scheduleHeaderPoint, scheduleTipPoint)
+import           Test.Tasty
+import           Test.Tasty.QuickCheck
+import           Test.Util.Orphans.IOLike ()
+import           Test.Util.TestEnv (adjustQuickCheckTests)
+
+tests :: TestTree
+tests =
+  testGroup
+    "LoP"
+    [ -- \| NOTE: Running the test that must _not_ timeout (@prop_smoke False@) takes
+      -- significantly more time than the one that does. This is because the former
+      -- does all the computation (serving the headers, validating them, serving the
+      -- block, validating them) while the former does nothing, because it timeouts
+      -- before reaching the last tick of the point schedule.
+      adjustQuickCheckTests (`div` 10) $
+        testProperty "wait just enough" (prop_wait False),
+      testProperty "wait too much" (prop_wait True),
+      testProperty "wait behind forecast horizon" prop_waitBehindForecastHorizon,
+      adjustQuickCheckTests (`div` 5) $
+        testProperty "serve just fast enough" (prop_serve False),
+      testProperty "serve too slow" (prop_serve True),
+      adjustQuickCheckTests (`div` 5) $
+        testProperty "delaying attack succeeds without LoP" (prop_delayAttack False),
+      adjustQuickCheckTests (`div` 5) $
+        testProperty "delaying attack fails with LoP" (prop_delayAttack True)
+    ]
+
+prop_wait :: Bool -> Property
+prop_wait mustTimeout =
+  forAllGenesisTest
+    ( do
+        gt@GenesisTest {gtBlockTree} <- genChains (pure 0)
+        let ps = dullSchedule 10 (btTrunk gtBlockTree)
+            gt' = gt {gtLoPBucketParams = LoPBucketParams {lbpCapacity = 10, lbpRate = 1}}
+        pure $ gt' $> ps
+    )
+    -- NOTE: Crucially, there must not be timeouts for this test.
+    (defaultSchedulerConfig {scEnableChainSyncTimeouts = False, scEnableLoP = True})
+    shrinkPeerSchedules
+    ( \_ StateView {svChainSyncExceptions} ->
+        case svChainSyncExceptions of
+          [] -> not mustTimeout
+          [ChainSyncException _pid exn] ->
+            case fromException exn of
+              Just CSClient.EmptyBucket -> mustTimeout
+              _                         -> False
+          _ -> False
+    )
+  where
+    dullSchedule :: (HasHeader blk) => DiffTime -> AnchoredFragment blk -> Peers (PeerSchedule blk)
+    dullSchedule _ (AF.Empty _) = error "requires a non-empty block tree"
+    dullSchedule timeout (_ AF.:> tipBlock) =
+      let offset :: DiffTime = if mustTimeout then 1 else -1
+       in peersOnlyHonest $
+            [ (Time 0, scheduleTipPoint tipBlock),
+              -- This last point does not matter, it is only here to leave the
+              -- connection open (aka. keep the test running) long enough to
+              -- pass the timeout by 'offset'.
+              (Time (timeout + offset), scheduleHeaderPoint tipBlock),
+              (Time (timeout + offset), scheduleBlockPoint tipBlock)
+            ]
+
+prop_waitBehindForecastHorizon :: Property
+prop_waitBehindForecastHorizon =
+  forAllGenesisTest
+    ( do
+        gt@GenesisTest {gtBlockTree} <- genChains (pure 0)
+        let ps = dullSchedule (btTrunk gtBlockTree)
+            gt' = gt {gtLoPBucketParams = LoPBucketParams {lbpCapacity = 10, lbpRate = 1}}
+        pure $ gt' $> ps
+    )
+    -- NOTE: Crucially, there must not be timeouts for this test.
+    (defaultSchedulerConfig {scEnableChainSyncTimeouts = False, scEnableLoP = True})
+    shrinkPeerSchedules
+    ( \_ StateView {svChainSyncExceptions} ->
+        case svChainSyncExceptions of
+          [] -> True
+          _  -> False
+    )
+  where
+    dullSchedule :: (HasHeader blk) => AnchoredFragment blk -> Peers (PeerSchedule blk)
+    dullSchedule (AF.Empty _) = error "requires a non-empty block tree"
+    dullSchedule (_ AF.:> tipBlock) =
+      peersOnlyHonest $
+        [ (Time 0, scheduleTipPoint tipBlock),
+          (Time 0, scheduleHeaderPoint tipBlock),
+          (Time 11, scheduleBlockPoint tipBlock)
+        ]
+
+-- | Simple test where we serve all the chain at regular intervals, but just
+-- slow enough to lose against the LoP bucket.
+--
+-- Let @c@ be the bucket capacity, @r@ be the bucket rate and @t@ be the time
+-- between blocks, then the bucket level right right before getting the token
+-- for the @k@th block will be:
+--
+-- > c - krt + (k-1)
+--
+-- (Note: if @rt ≥ 1@, otherwise it will simply be @c - rt@.) If we are to
+-- survive at least (resp. succumb before) @k > 0@ blocks, then this value will
+-- be positive (resp. negative). This is equivalent to saying that @rt@ must be
+-- lower (resp. greater) than @(c+k-1) / k@.
+--
+-- We will have two versions of this test: one where we serve the @n-1@th block
+-- but succumb before serving the @n@th block, and one where we do manage to
+-- serve the @n@th block, barely.
+prop_serve :: Bool -> Property
+prop_serve mustTimeout =
+  forAllGenesisTest
+    ( do
+        gt@GenesisTest {gtBlockTree} <- genChains (pure 0)
+        let lbpRate = borderlineRate (AF.length (btTrunk gtBlockTree))
+            ps = makeSchedule (btTrunk gtBlockTree)
+            gt' = gt {gtLoPBucketParams = LoPBucketParams {lbpCapacity, lbpRate}}
+        pure $ gt' $> ps
+    )
+    -- NOTE: Crucially, there must not be timeouts for this test.
+    (defaultSchedulerConfig {scEnableChainSyncTimeouts = False, scEnableLoP = True})
+    shrinkPeerSchedules
+    ( \_ StateView {svChainSyncExceptions} ->
+        case svChainSyncExceptions of
+          [] -> not mustTimeout
+          [ChainSyncException _pid exn] ->
+            case fromException exn of
+              Just CSClient.EmptyBucket -> mustTimeout
+              _                         -> False
+          _ -> False
+    )
+  where
+    lbpCapacity :: Integer = 10
+    timeBetweenBlocks :: Rational = 0.100
+
+    -- \| Rate that is almost the limit between surviving and succumbing to the
+    -- LoP bucket, given a number of blocks. One should not exactly use the
+    -- limit rate because it is unspecified what would happen in IOSim and it
+    -- would simply be flakey in IO.
+    borderlineRate :: (Integral n) => n -> Rational
+    borderlineRate numberOfBlocks =
+      (if mustTimeout then (105 % 100) else (95 % 100))
+        * ((fromIntegral lbpCapacity + fromIntegral numberOfBlocks - 1) / (timeBetweenBlocks * fromIntegral numberOfBlocks))
+
+    -- \| Make a schedule serving the given fragment with regularity, one block
+    -- every 'timeBetweenBlocks'. NOTE: We must do something at @Time 0@
+    -- otherwise the others times will be shifted such that the first one is 0.
+    makeSchedule :: (HasHeader blk) => AnchoredFragment blk -> Peers (PeerSchedule blk)
+    makeSchedule (AF.Empty _) = error "fragment must have at least one block"
+    makeSchedule fragment@(_ AF.:> tipBlock) =
+      peersOnlyHonest $
+        (Time 0, scheduleTipPoint tipBlock)
+          : ( flip concatMap (zip [1 ..] (AF.toOldestFirst fragment)) $ \(i, block) ->
+                [ (Time (secondsRationalToDiffTime (i * timeBetweenBlocks)), scheduleHeaderPoint block),
+                  (Time (secondsRationalToDiffTime (i * timeBetweenBlocks)), scheduleBlockPoint block)
+                ]
+            )
+
+-- NOTE: Same as 'LoE.prop_adversaryHitsTimeouts' with LoP instead of timeouts.
+prop_delayAttack :: Bool -> Property
+prop_delayAttack lopEnabled =
+  noShrinking $
+    forAllGenesisTest
+      ( do
+          gt@GenesisTest {gtBlockTree} <- genChains (pure 1)
+          let gt' = gt {gtLoPBucketParams = LoPBucketParams {lbpCapacity = 10, lbpRate = 1}}
+              ps = delaySchedule gtBlockTree
+          pure $ gt' $> ps
+      )
+      -- NOTE: Crucially, there must not be timeouts for this test.
+      ( defaultSchedulerConfig
+          { scEnableChainSyncTimeouts = False,
+            scEnableLoE = True,
+            scEnableLoP = lopEnabled
+          }
+      )
+      shrinkPeerSchedules
+      ( \GenesisTest {gtBlockTree} StateView {svSelectedChain, svChainSyncExceptions} ->
+          let treeTipPoint = AF.headPoint $ btTrunk gtBlockTree
+              selectedTipPoint = AF.castPoint $ AF.headPoint svSelectedChain
+              selectedCorrect = lopEnabled == (treeTipPoint == selectedTipPoint)
+              exceptionsCorrect = case svChainSyncExceptions of
+                [] -> not lopEnabled
+                [ChainSyncException (PeerId _) exn] ->
+                  lopEnabled == (fromException exn == Just CSClient.EmptyBucket)
+                _ -> False
+           in selectedCorrect && exceptionsCorrect
+      )
+  where
+    getOnlyBranch :: BlockTree blk -> BlockTreeBranch blk
+    getOnlyBranch BlockTree {btBranches} = case btBranches of
+      [branch] -> branch
+      _        -> error "tree must have exactly one alternate branch"
+
+    delaySchedule :: (HasHeader blk) => BlockTree blk -> Peers (PeerSchedule blk)
+    delaySchedule tree =
+      let trunkTip = case btTrunk tree of
+            (AF.Empty _)       -> error "tree must have at least one block"
+            (_ AF.:> tipBlock) -> tipBlock
+          branch = getOnlyBranch tree
+          intersectM = case btbPrefix branch of
+            (AF.Empty _)       -> Nothing
+            (_ AF.:> tipBlock) -> Just tipBlock
+          branchTip = case btbFull branch of
+            (AF.Empty _) -> error "alternate branch must have at least one block"
+            (_ AF.:> tipBlock) -> tipBlock
+       in mkPeers
+            -- Eagerly serve the honest tree, but after the adversary has
+            -- advertised its chain.
+            ( (Time 0, scheduleTipPoint trunkTip) : case intersectM of
+                Nothing ->
+                  [ (Time 0.5, scheduleHeaderPoint trunkTip),
+                    (Time 0.5, scheduleBlockPoint trunkTip)
+                  ]
+                Just intersect ->
+                  [ (Time 0.5, scheduleHeaderPoint intersect),
+                    (Time 0.5, scheduleBlockPoint intersect),
+                    (Time 5, scheduleHeaderPoint trunkTip),
+                    (Time 5, scheduleBlockPoint trunkTip)
+                  ]
+            )
+            -- Advertise the alternate branch early, but don't serve it
+            -- past the intersection, and wait for LoP bucket.
+            [ (Time 0, scheduleTipPoint branchTip) : case intersectM of
+                -- the alternate branch forks from `Origin`
+                Nothing -> [(Time 11, scheduleTipPoint branchTip)]
+                -- the alternate branch forks from `intersect`
+                Just intersect ->
+                  [ (Time 0, scheduleHeaderPoint intersect),
+                    (Time 0, scheduleBlockPoint intersect),
+                    (Time 11, scheduleBlockPoint intersect)
+                  ]
+            ]

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE BlockArguments      #-}
 {-# LANGUAGE DerivingStrategies  #-}
+{-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE NamedFieldPuns      #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -70,7 +71,7 @@ tests =
 
 theProperty ::
   GenesisTestFull TestBlock ->
-  StateView ->
+  StateView TestBlock ->
   Property
 theProperty genesisTest stateView@StateView{svSelectedChain} =
   classify genesisWindowAfterIntersection "Full genesis window after intersection" $

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/ChainSync.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/ChainSync.hs
@@ -18,6 +18,7 @@ import qualified Ouroboros.Consensus.MiniProtocol.ChainSync.Client.InFutureCheck
 import           Ouroboros.Consensus.Util.Condense (Condense (..))
 import           Ouroboros.Consensus.Util.IOLike (Exception (fromException),
                      IOLike, MonadCatch (try), StrictTVar, uncheckedNewTVarM)
+import           Ouroboros.Network.AnchoredFragment (AnchoredFragment)
 import           Ouroboros.Network.Block (Tip)
 import           Ouroboros.Network.Channel (createConnectedChannels)
 import           Ouroboros.Network.ControlMessage (ControlMessage (..))
@@ -40,7 +41,6 @@ import           Test.Consensus.PeerSimulator.StateView
                      StateViewTracers (StateViewTracers, svtChainSyncExceptionsTracer))
 import           Test.Consensus.PeerSimulator.Trace (mkChainSyncClientTracer,
                      traceUnitWith)
-import           Test.Consensus.PointSchedule (TestFragH)
 import           Test.Consensus.PointSchedule.Peers (PeerId)
 import           Test.Util.Orphans.IOLike ()
 import           Test.Util.TestBlock (TestBlock)
@@ -53,7 +53,7 @@ basicChainSyncClient :: forall m.
   Tracer m String ->
   TopLevelConfig TestBlock ->
   ChainDbView m TestBlock ->
-  StrictTVar m TestFragH ->
+  StrictTVar m (AnchoredFragment (Header TestBlock)) ->
   -- ^ A TVar containing the fragment of headers for that peer, kept up to date
   -- by the ChainSync client.
   (m (), m ()) ->
@@ -103,7 +103,7 @@ runChainSyncClient ::
   -- ^ Timeouts for this client.
   StateViewTracers m ->
   -- ^ Tracers used to record information for the future 'StateView'.
-  StrictTVar m (Map PeerId (StrictTVar m TestFragH)) ->
+  StrictTVar m (Map PeerId (StrictTVar m (AnchoredFragment (Header TestBlock)))) ->
   -- ^ A TVar containing a map of fragments of headers for each peer. This
   -- function will (via 'bracketChainSyncClient') register and de-register a
   -- TVar for the fragment of the peer.

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/ChainSync.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/ChainSync.hs
@@ -76,6 +76,9 @@ basicChainSyncClient peerId tracer cfg chainDbView varCandidate (startIdling, st
       , CSClient.varCandidate
       , CSClient.startIdling
       , CSClient.stopIdling
+      , CSClient.pauseLoPBucket = pure ()
+      , CSClient.resumeLoPBucket = pure ()
+      , CSClient.grantLoPToken = pure ()
       }
   where
     dummyHeaderInFutureCheck ::
@@ -122,7 +125,7 @@ runChainSyncClient
     -- We don't need this shared Set yet. If we need it at some point,
     -- it ought to be passed to `runChainSyncClient`.
     varIdling <- uncheckedNewTVarM $ Set.empty
-    bracketChainSyncClient nullTracer chainDbView varCandidates varIdling peerId ntnVersion $ \ varCandidate idleManagers -> do
+    bracketChainSyncClient nullTracer chainDbView varCandidates varIdling peerId ntnVersion CSClient.ChainSyncLoPBucketDisabled $ \ varCandidate idleManagers _lopBucket -> do
       res <- try $ runConnectedPeersPipelinedWithLimits
         createConnectedChannels
         nullTracer

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/ChainSync.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/ChainSync.hs
@@ -7,7 +7,7 @@ module Test.Consensus.PeerSimulator.ChainSync (runChainSyncClient) where
 
 import           Control.Exception (AsyncException (ThreadKilled))
 import           Control.Monad.Class.MonadTimer.SI (MonadTimer)
-import           Control.Tracer (Tracer, nullTracer, traceWith)
+import           Control.Tracer (Tracer (Tracer), nullTracer, traceWith)
 import           Data.Map.Strict (Map)
 import           Data.Proxy (Proxy (..))
 import qualified Data.Set as Set
@@ -18,7 +18,6 @@ import           Ouroboros.Consensus.MiniProtocol.ChainSync.Client (ChainDbView,
                      bracketChainSyncClient, chainSyncClient)
 import qualified Ouroboros.Consensus.MiniProtocol.ChainSync.Client as CSClient
 import qualified Ouroboros.Consensus.MiniProtocol.ChainSync.Client.InFutureCheck as InFutureCheck
-import           Ouroboros.Consensus.Util.Condense (Condense (..))
 import           Ouroboros.Consensus.Util.IOLike (Exception (fromException),
                      IOLike, MonadCatch (try), StrictTVar, uncheckedNewTVarM)
 import           Ouroboros.Network.AnchoredFragment (AnchoredFragment)
@@ -42,8 +41,9 @@ import           Test.Consensus.Network.Driver.Limits.Extras
 import           Test.Consensus.PeerSimulator.StateView
                      (ChainSyncException (ChainSyncException),
                      StateViewTracers (StateViewTracers, svtChainSyncExceptionsTracer))
-import           Test.Consensus.PeerSimulator.Trace (mkChainSyncClientTracer,
-                     traceUnitWith)
+import           Test.Consensus.PeerSimulator.Trace
+                     (TraceChainSyncClientTerminationEvent (..),
+                     TraceEvent (..))
 import           Test.Consensus.PointSchedule.Peers (PeerId)
 import           Test.Util.Orphans.IOLike ()
 import           Test.Util.TestBlock (TestBlock)
@@ -54,7 +54,7 @@ import           Test.Util.TestBlock (TestBlock)
 basicChainSyncClient :: forall m.
   IOLike m =>
   PeerId ->
-  Tracer m String ->
+  Tracer m (TraceEvent TestBlock) ->
   TopLevelConfig TestBlock ->
   ChainDbView m TestBlock ->
   StrictTVar m (AnchoredFragment (Header TestBlock)) ->
@@ -70,7 +70,7 @@ basicChainSyncClient peerId tracer cfg chainDbView varCandidate (startIdling, st
   chainSyncClient
     CSClient.ConfigEnv {
         CSClient.mkPipelineDecision0     = pipelineDecisionLowHighMark 10 20
-      , CSClient.tracer                  = mkChainSyncClientTracer peerId tracer
+      , CSClient.tracer                  = Tracer (traceWith tracer . TraceChainSyncClientEvent peerId)
       , CSClient.cfg
       , CSClient.chainDbView
       , CSClient.someHeaderInFutureCheck = dummyHeaderInFutureCheck
@@ -102,7 +102,7 @@ basicChainSyncClient peerId tracer cfg chainDbView varCandidate (startIdling, st
 -- 'StateViewTracers' and logged.
 runChainSyncClient ::
   (IOLike m, MonadTimer m) =>
-  Tracer m String ->
+  Tracer m (TraceEvent TestBlock) ->
   TopLevelConfig TestBlock ->
   ChainDbView m TestBlock ->
   PeerId ->
@@ -148,16 +148,19 @@ runChainSyncClient
         Left exn -> do
           traceWith svtChainSyncExceptionsTracer $ ChainSyncException peerId exn
           case fromException exn of
-            Just (ExceededSizeLimit _) -> trace "Terminating because of size limit exceeded."
-            Just (ExceededTimeLimit _) -> trace "Terminating because of time limit exceeded."
+            Just (ExceededSizeLimit _) ->
+              traceWith tracer $ TraceChainSyncClientTerminationEvent peerId TraceExceededSizeLimit
+            Just (ExceededTimeLimit _) ->
+              traceWith tracer $ TraceChainSyncClientTerminationEvent peerId TraceExceededTimeLimit
             Nothing -> pure ()
           case fromException exn of
-            Just ThreadKilled -> trace "Terminated by GDD governor."
+            Just ThreadKilled ->
+              traceWith tracer $ TraceChainSyncClientTerminationEvent peerId TraceTerminatedByGDDGovernor
             _                 -> pure ()
           case fromException exn of
-            Just CSClient.EmptyBucket -> trace "Terminating because of empty bucket."
+            Just CSClient.EmptyBucket ->
+              traceWith tracer $ TraceChainSyncClientTerminationEvent peerId TraceTerminatedByLoP
             _ -> pure ()
   where
     ntnVersion :: NodeToNodeVersion
     ntnVersion = maxBound
-    trace = traceUnitWith tracer $ "ChainSyncClient " ++ condense peerId

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/ChainSync.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/ChainSync.hs
@@ -50,6 +50,7 @@ import           Test.Util.TestBlock (TestBlock)
 -- messages and the “in future” checks are disabled.
 basicChainSyncClient :: forall m.
   IOLike m =>
+  PeerId ->
   Tracer m String ->
   TopLevelConfig TestBlock ->
   ChainDbView m TestBlock ->
@@ -59,11 +60,11 @@ basicChainSyncClient :: forall m.
   (m (), m ()) ->
   -- ^ Two monadic actions called when reaching and leaving @StIdle@.
   Consensus ChainSyncClientPipelined TestBlock m
-basicChainSyncClient tracer cfg chainDbView varCandidate (startIdling, stopIdling) =
+basicChainSyncClient peerId tracer cfg chainDbView varCandidate (startIdling, stopIdling) =
   chainSyncClient
     CSClient.ConfigEnv {
         CSClient.mkPipelineDecision0     = pipelineDecisionLowHighMark 10 20
-      , CSClient.tracer                  = mkChainSyncClientTracer tracer
+      , CSClient.tracer                  = mkChainSyncClientTracer peerId tracer
       , CSClient.cfg
       , CSClient.chainDbView
       , CSClient.someHeaderInFutureCheck = dummyHeaderInFutureCheck
@@ -128,7 +129,7 @@ runChainSyncClient
         codecChainSyncId
         chainSyncNoSizeLimits
         (timeLimitsChainSync chainSyncTimeouts)
-        (chainSyncClientPeerPipelined (basicChainSyncClient tracer cfg chainDbView varCandidate idleManagers))
+        (chainSyncClientPeerPipelined (basicChainSyncClient peerId tracer cfg chainDbView varCandidate idleManagers))
         (chainSyncServerPeer server)
       case res of
         Left exn -> do

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Config.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Config.hs
@@ -15,14 +15,16 @@ import           Ouroboros.Consensus.NodeId (CoreNodeId (CoreNodeId),
 import           Ouroboros.Consensus.Protocol.BFT
                      (BftParams (BftParams, bftNumNodes, bftSecurityParam),
                      ConsensusConfig (BftConfig, bftParams, bftSignKey, bftVerKeys))
+import           Test.Consensus.PointSchedule (ForecastRange (ForecastRange))
 import           Test.Util.Orphans.IOLike ()
 import           Test.Util.TestBlock (BlockConfig (TestBlockConfig),
                      CodecConfig (TestBlockCodecConfig),
-                     StorageConfig (TestBlockStorageConfig), TestBlock)
+                     StorageConfig (TestBlockStorageConfig), TestBlock,
+                     TestBlockLedgerConfig (..))
 
 -- REVIEW: this has not been deliberately chosen
-defaultCfg :: SecurityParam -> TopLevelConfig TestBlock
-defaultCfg secParam = TopLevelConfig {
+defaultCfg :: SecurityParam -> ForecastRange -> TopLevelConfig TestBlock
+defaultCfg secParam (ForecastRange sfor) = TopLevelConfig {
     topLevelConfigProtocol = BftConfig {
       bftParams  = BftParams {
         bftSecurityParam = secParam
@@ -34,7 +36,7 @@ defaultCfg secParam = TopLevelConfig {
       , (CoreId (CoreNodeId 1), VerKeyMockDSIGN 1)
       ]
     }
-  , topLevelConfigLedger      = eraParams
+  , topLevelConfigLedger      = TestBlockLedgerConfig eraParams (Just $ fromIntegral sfor)
   , topLevelConfigBlock       = TestBlockConfig numCoreNodes
   , topLevelConfigCodec       = TestBlockCodecConfig
   , topLevelConfigStorage     = TestBlockStorageConfig

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Handlers.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Handlers.hs
@@ -28,7 +28,6 @@ import           Data.Maybe (fromJust, fromMaybe)
 import           Ouroboros.Consensus.Block (HasHeader, HeaderHash,
                      Point (GenesisPoint), blockHash, castPoint, getHeader,
                      withOrigin)
-import           Ouroboros.Consensus.Util.Condense (Condense (..))
 import           Ouroboros.Consensus.Util.IOLike (IOLike, STM, StrictTVar,
                      readTVar, writeTVar)
 import           Ouroboros.Network.AnchoredFragment (AnchoredFragment)
@@ -45,9 +44,11 @@ import           Test.Consensus.PeerSimulator.ScheduledBlockFetchServer
 import           Test.Consensus.PeerSimulator.ScheduledChainSyncServer
                      (FindIntersect (..),
                      RequestNext (AwaitReply, RollBackward, RollForward))
+import           Test.Consensus.PeerSimulator.Trace
+                     (TraceScheduledBlockFetchServerEvent (..),
+                     TraceScheduledChainSyncServerEvent (..))
 import           Test.Consensus.PointSchedule
 import           Test.Util.Orphans.IOLike ()
-import           Test.Util.TersePrinting (terseBlock, terseFragment, tersePoint)
 import           Test.Util.TestBlock (TestBlock, TestHash (TestHash))
 
 toPoint :: (HasHeader block, HeaderHash block ~ TestHash) => WithOrigin block -> Point TestBlock
@@ -84,7 +85,7 @@ handlerFindIntersection ::
   BlockTree TestBlock ->
   [Point TestBlock] ->
   NodeState TestBlock ->
-  STM m (Maybe FindIntersect, [String])
+  STM m (Maybe FindIntersect, [TraceScheduledChainSyncServerEvent (NodeState TestBlock) TestBlock])
 handlerFindIntersection currentIntersection blockTree clientPoints points = do
   let tip' = nsTipTip points
       tipPoint = getTipPoint tip'
@@ -111,14 +112,20 @@ handlerRequestNext ::
   StrictTVar m (Point TestBlock) ->
   BlockTree TestBlock ->
   NodeState TestBlock ->
-  STM m (Maybe RequestNext, [String])
+  STM m (Maybe RequestNext, [TraceScheduledChainSyncServerEvent (NodeState TestBlock) TestBlock])
 handlerRequestNext currentIntersection blockTree points =
   runWriterT $ do
     intersection <- lift $ readTVar currentIntersection
-    trace $ "  last intersection is " ++ tersePoint intersection
+    trace $ TraceLastIntersection intersection
     withHeader intersection (nsHeader points)
   where
-    withHeader :: Point TestBlock -> WithOrigin TestBlock -> WriterT [String] (STM m) (Maybe RequestNext)
+    withHeader ::
+      Point TestBlock ->
+      WithOrigin TestBlock ->
+      WriterT
+        [TraceScheduledChainSyncServerEvent (NodeState TestBlock) TestBlock]
+        (STM m)
+        (Maybe RequestNext)
     withHeader intersection h =
       maybe noPathError (analysePath hp) (BT.findPath intersection hp blockTree)
       where
@@ -134,22 +141,21 @@ handlerRequestNext currentIntersection blockTree points =
       -- stalling as an adversarial behaviour), then we ask the client to wait;
       -- otherwise we just do nothing.
       (BT.PathAnchoredAtSource True, AF.Empty _) | getTipPoint tip' == hp -> do
-        trace "  chain has been fully served"
+        trace TraceChainIsFullyServed
         pure (Just AwaitReply)
       (BT.PathAnchoredAtSource True, AF.Empty _) -> do
-        trace "  intersection is exactly our header point"
+        trace TraceIntersectionIsHeaderPoint
         pure Nothing
       -- If the anchor is the intersection and the fragment is non-empty, then
       -- we have something to serve.
       (BT.PathAnchoredAtSource True, fragmentAhead@(next AF.:< _)) -> do
-        trace "  intersection is before our header point"
-        trace $ "  fragment ahead: " ++ terseFragment fragmentAhead
+        trace $ TraceIntersectionIsStrictAncestorOfHeaderPoint fragmentAhead
         lift $ writeTVar currentIntersection $ blockPoint next
         pure $ Just (RollForward (getHeader next) (nsTipTip points))
       -- If the anchor is not the intersection but the fragment is empty, then
       -- the intersection is further than the tip that we can serve.
       (BT.PathAnchoredAtSource False, AF.Empty _) -> do
-        trace "  intersection is further than our header point"
+        trace TraceIntersectionIsStrictDescendentOfHeaderPoint
         -- REVIEW: The following is a hack that allows the honest peer to not
         -- get disconnected when it falls behind. Why does a peer doing that not
         -- get disconnected from?
@@ -163,10 +169,7 @@ handlerRequestNext currentIntersection blockTree points =
       -- If the anchor is not the intersection and the fragment is non-empty,
       -- then we require a rollback
       (BT.PathAnchoredAtSource False, fragment) -> do
-        trace $ "  we will require a rollback to" ++ condense (AF.anchorPoint fragment)
-        trace $ "  fragment: " ++ condense fragment
-        let
-          point = AF.anchorPoint fragment
+        let point = AF.anchorPoint fragment
         lift $ writeTVar currentIntersection point
         pure $ Just (RollBackward point tip')
 
@@ -201,7 +204,7 @@ handlerBlockFetch ::
   NodeState TestBlock ->
   -- ^ The current advertised points (tip point, header point and block point).
   -- They are in the block tree.
-  STM m (Maybe BlockFetch, [String])
+  STM m (Maybe BlockFetch, [TraceScheduledBlockFetchServerEvent (NodeState TestBlock) TestBlock])
 handlerBlockFetch blockTree (ChainRange from to) NodeState {nsHeader} =
   runWriterT (serveFromBpFragment (AF.sliceRange hpChain from to))
   where
@@ -210,10 +213,10 @@ handlerBlockFetch blockTree (ChainRange from to) NodeState {nsHeader} =
     -- must refuse.
     serveFromBpFragment = \case
       Just slice -> do
-        trace ("Starting batch for slice " ++ terseFragment slice)
+        trace $ TraceStartingBatch slice
         pure (Just (StartBatch (AF.toOldestFirst slice)))
       Nothing    -> do
-        trace ("Waiting for next tick for range: " ++ tersePoint from ++ " -> " ++ tersePoint to)
+        trace $ TraceWaitingForRange from to
         pure Nothing
 
     hpChain = fragmentUpTo blockTree "header point" (toPoint nsHeader)
@@ -304,13 +307,13 @@ handlerSendBlocks ::
   IOLike m =>
   [TestBlock] ->
   NodeState TestBlock ->
-  STM m (Maybe SendBlocks, [String])
+  STM m (Maybe SendBlocks, [TraceScheduledBlockFetchServerEvent (NodeState TestBlock) TestBlock])
 handlerSendBlocks blocks NodeState {nsHeader, nsBlock} =
   runWriterT (checkDone blocks)
   where
     checkDone = \case
       [] -> do
-        trace "Batch done"
+        trace TraceBatchIsDone
         pure (Just BatchDone)
       (next : future) ->
         blocksLeft next future
@@ -319,12 +322,12 @@ handlerSendBlocks blocks NodeState {nsHeader, nsBlock} =
       | isAncestorOf (At next) nsBlock
       || compensateForScheduleRollback next
       = do
-        trace ("Sending " ++ terseBlock next)
+        trace $ TraceSendingBlock next
         pure (Just (SendBlock next future))
 
       | otherwise
       = do
-        trace "BP is behind"
+        trace TraceBlockPointIsBehind
         pure Nothing
 
     -- Here we encode the conditions for the special situation mentioned above.

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Handlers.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Handlers.hs
@@ -25,9 +25,8 @@ import           Control.Monad.Writer.Strict (MonadWriter (tell),
 import           Data.List (isSuffixOf)
 import qualified Data.List.NonEmpty as NonEmpty
 import           Data.Maybe (fromJust, fromMaybe)
-import           Ouroboros.Consensus.Block (HasHeader, HeaderHash,
-                     Point (GenesisPoint), blockHash, castPoint, getHeader,
-                     withOrigin)
+import           Ouroboros.Consensus.Block (GetHeader, HasHeader, HeaderHash,
+                     Point (GenesisPoint), blockHash, getHeader, withOrigin)
 import           Ouroboros.Consensus.Util.IOLike (IOLike, STM, StrictTVar,
                      readTVar, writeTVar)
 import           Ouroboros.Network.AnchoredFragment (AnchoredFragment)
@@ -51,14 +50,14 @@ import           Test.Consensus.PointSchedule
 import           Test.Util.Orphans.IOLike ()
 import           Test.Util.TestBlock (TestBlock, TestHash (TestHash))
 
-toPoint :: (HasHeader block, HeaderHash block ~ TestHash) => WithOrigin block -> Point TestBlock
-toPoint = castPoint . withOrigin GenesisPoint blockPoint
-
 -- | More efficient implementation of a check used in some of the handlers,
 -- determining whether the first argument is on the chain that ends in the
 -- second argument.
 -- We would usually call @withinFragmentBounds@ for this, but since we're
 -- using 'TestBlock', looking at the hash is cheaper.
+--
+-- TODO: Unify with 'Test.UtilTestBlock.isAncestorOf' which basically does the
+-- same thing except not on 'WithOrigin'.
 isAncestorOf ::
   HasHeader blk1 =>
   HasHeader blk2 =>
@@ -80,12 +79,12 @@ isAncestorOf Origin _ = True
 -- Extracts the fragment up to the current advertised tip from the block tree,
 -- then searches for any of the client's points in it.
 handlerFindIntersection ::
-  IOLike m =>
-  StrictTVar m (Point TestBlock) ->
-  BlockTree TestBlock ->
-  [Point TestBlock] ->
-  NodeState TestBlock ->
-  STM m (Maybe FindIntersect, [TraceScheduledChainSyncServerEvent (NodeState TestBlock) TestBlock])
+  (IOLike m, HasHeader blk) =>
+  StrictTVar m (Point blk) ->
+  BlockTree blk ->
+  [Point blk] ->
+  NodeState blk ->
+  STM m (Maybe (FindIntersect blk), [TraceScheduledChainSyncServerEvent (NodeState blk) blk])
 handlerFindIntersection currentIntersection blockTree clientPoints points = do
   let tip' = nsTipTip points
       tipPoint = getTipPoint tip'
@@ -107,12 +106,12 @@ handlerFindIntersection currentIntersection blockTree clientPoints points = do
 -- - header point before intersection (special case for the point scheduler architecture)
 -- - Anchor != intersection
 handlerRequestNext ::
-  forall m .
-  IOLike m =>
-  StrictTVar m (Point TestBlock) ->
-  BlockTree TestBlock ->
-  NodeState TestBlock ->
-  STM m (Maybe RequestNext, [TraceScheduledChainSyncServerEvent (NodeState TestBlock) TestBlock])
+  forall m blk.
+  (IOLike m, HasHeader blk, GetHeader blk) =>
+  StrictTVar m (Point blk) ->
+  BlockTree blk ->
+  NodeState blk ->
+  STM m (Maybe (RequestNext blk), [TraceScheduledChainSyncServerEvent (NodeState blk) blk])
 handlerRequestNext currentIntersection blockTree points =
   runWriterT $ do
     intersection <- lift $ readTVar currentIntersection
@@ -120,16 +119,16 @@ handlerRequestNext currentIntersection blockTree points =
     withHeader intersection (nsHeader points)
   where
     withHeader ::
-      Point TestBlock ->
-      WithOrigin TestBlock ->
+      Point blk ->
+      WithOrigin blk ->
       WriterT
-        [TraceScheduledChainSyncServerEvent (NodeState TestBlock) TestBlock]
+        [TraceScheduledChainSyncServerEvent (NodeState blk) blk]
         (STM m)
-        (Maybe RequestNext)
+        (Maybe (RequestNext blk))
     withHeader intersection h =
       maybe noPathError (analysePath hp) (BT.findPath intersection hp blockTree)
       where
-        hp = toPoint h
+        hp = withOrigin GenesisPoint blockPoint h
 
     noPathError = error "serveHeader: intersection and headerPoint should always be in the block tree"
 
@@ -179,9 +178,9 @@ handlerRequestNext currentIntersection blockTree points =
 
 -- REVIEW: We call this a lot, and I assume it creates some significant overhead.
 -- We should figure out a cheaper way to achieve what we're doing with the result.
--- Since we're in TestBlock, we can at least check whether a block can extend another block,
+-- Since we're in blk, we can at least check whether a block can extend another block,
 -- but then we won't be able to generalize later.
-fragmentUpTo :: BlockTree TestBlock -> String -> Point TestBlock -> AnchoredFragment TestBlock
+fragmentUpTo :: HasHeader blk => BlockTree blk -> String -> Point blk -> AnchoredFragment blk
 fragmentUpTo blockTree desc b =
   fromMaybe fatal (BT.findFragment b blockTree)
   where
@@ -193,18 +192,18 @@ fragmentUpTo blockTree desc b =
 -- block point moved to a fork without serving all blocks corresponding to
 -- advertised headers, serve them. Otherwise, stall.
 handlerBlockFetch ::
-  forall m .
-  IOLike m =>
-  BlockTree TestBlock ->
+  forall m blk.
+  (IOLike m, HasHeader blk) =>
+  BlockTree blk ->
   -- ^ The tree of blocks in this scenario -- aka. the “universe”.
-  ChainRange (Point TestBlock) ->
+  ChainRange (Point blk) ->
   -- ^ A requested range of blocks. If the client behaves correctly, they
   -- correspond to headers that have been sent before, and if the scheduled
   -- ChainSync server behaves correctly, then they are all in the block tree.
-  NodeState TestBlock ->
+  NodeState blk ->
   -- ^ The current advertised points (tip point, header point and block point).
   -- They are in the block tree.
-  STM m (Maybe BlockFetch, [TraceScheduledBlockFetchServerEvent (NodeState TestBlock) TestBlock])
+  STM m (Maybe (BlockFetch blk), [TraceScheduledBlockFetchServerEvent (NodeState blk) blk])
 handlerBlockFetch blockTree (ChainRange from to) NodeState {nsHeader} =
   runWriterT (serveFromBpFragment (AF.sliceRange hpChain from to))
   where
@@ -219,7 +218,7 @@ handlerBlockFetch blockTree (ChainRange from to) NodeState {nsHeader} =
         trace $ TraceWaitingForRange from to
         pure Nothing
 
-    hpChain = fragmentUpTo blockTree "header point" (toPoint nsHeader)
+    hpChain = fragmentUpTo blockTree "header point" (withOrigin GenesisPoint blockPoint nsHeader)
 
     trace = tell . pure
 
@@ -307,7 +306,7 @@ handlerSendBlocks ::
   IOLike m =>
   [TestBlock] ->
   NodeState TestBlock ->
-  STM m (Maybe SendBlocks, [TraceScheduledBlockFetchServerEvent (NodeState TestBlock) TestBlock])
+  STM m (Maybe (SendBlocks TestBlock), [TraceScheduledBlockFetchServerEvent (NodeState TestBlock) TestBlock])
 handlerSendBlocks blocks NodeState {nsHeader, nsBlock} =
   runWriterT (checkDone blocks)
   where

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Run.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Run.hs
@@ -20,7 +20,8 @@ import           Data.Functor (void)
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           Ouroboros.Consensus.Config (TopLevelConfig (..))
-import           Ouroboros.Consensus.Genesis.Governor (updateLoEFragStall)
+import           Ouroboros.Consensus.Genesis.Governor
+                     (reprocessLoEBlocksOnCandidateChange, updateLoEFragStall)
 import           Ouroboros.Consensus.MiniProtocol.ChainSync.Client (ChainDbView)
 import qualified Ouroboros.Consensus.MiniProtocol.ChainSync.Client as CSClient
 import           Ouroboros.Consensus.Storage.ChainDB.API
@@ -254,6 +255,7 @@ runPointSchedule schedulerConfig genesisTest tracer0 =
           = pure nullTracer
     stateTracer <- mkStateTracer
     startBlockFetchLogic registry chainDb fetchClientRegistry getCandidates
+    void $ forkLinkedThread registry "ChainSel trigger" (reprocessLoEBlocksOnCandidateChange chainDb getCandidates)
     runScheduler tracer stateTracer gtSchedule (psrPeers resources)
     snapshotStateView stateViewTracers chainDb
   where

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Run.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Run.hs
@@ -22,7 +22,9 @@ import qualified Data.Map.Strict as Map
 import           Ouroboros.Consensus.Config (TopLevelConfig (..))
 import           Ouroboros.Consensus.Genesis.Governor
                      (reprocessLoEBlocksOnCandidateChange, updateLoEFragStall)
-import           Ouroboros.Consensus.MiniProtocol.ChainSync.Client (ChainDbView)
+import           Ouroboros.Consensus.MiniProtocol.ChainSync.Client (ChainDbView,
+                     ChainSyncLoPBucketConfig (..),
+                     ChainSyncLoPBucketEnabledConfig (..))
 import qualified Ouroboros.Consensus.MiniProtocol.ChainSync.Client as CSClient
 import           Ouroboros.Consensus.Storage.ChainDB.API
 import qualified Ouroboros.Consensus.Storage.ChainDB.API as ChainDB
@@ -53,8 +55,8 @@ import           Test.Consensus.PeerSimulator.StateView
 import           Test.Consensus.PeerSimulator.Trace
 import qualified Test.Consensus.PointSchedule as PointSchedule
 import           Test.Consensus.PointSchedule (GenesisTest (GenesisTest),
-                     GenesisTestFull, NodeState, PeersSchedule,
-                     peersStatesRelative, prettyPeersSchedule)
+                     GenesisTestFull, LoPBucketParams (..), NodeState,
+                     PeersSchedule, peersStatesRelative, prettyPeersSchedule)
 import           Test.Consensus.PointSchedule.Peers (Peer (..), PeerId,
                      getPeerIds)
 import           Test.Util.ChainDB
@@ -88,6 +90,10 @@ data SchedulerConfig =
     -- Just for the purpose of testing that the selection indeed doesn't
     -- advance.
     , scEnableLoE               :: Bool
+
+    -- | Whether to enable to LoP. The parameters of the LoP come from
+    -- 'GenesisTest'. TODO: Same separation for timeouts.
+    , scEnableLoP               :: Bool
   }
 
 -- | Default scheduler config
@@ -98,7 +104,8 @@ defaultSchedulerConfig =
     scDebug = False,
     scTrace = True,
     scTraceState = False,
-    scEnableLoE = False
+    scEnableLoE = False,
+    scEnableLoP = False
   }
 
 -- | Enable debug tracing during a scheduler test.
@@ -123,6 +130,7 @@ startChainSyncConnectionThread ::
   SharedResources m ->
   ChainSyncResources m ->
   ChainSyncTimeout ->
+  ChainSyncLoPBucketConfig ->
   StateViewTracers m ->
   StrictTVar m (Map PeerId (StrictTVar m (AnchoredFragment (Header TestBlock)))) ->
   m ()
@@ -135,12 +143,13 @@ startChainSyncConnectionThread
   SharedResources {srPeerId}
   ChainSyncResources {csrServer}
   chainSyncTimeouts_
+  chainSyncLoPBucketConfig
   tracers
   varCandidates =
     void $
     forkLinkedThread registry ("ChainSyncClient" <> condense srPeerId) $
     bracketSyncWithFetchClient fetchClientRegistry srPeerId $
-    runChainSyncClient tracer cfg chainDbView srPeerId csrServer chainSyncTimeouts_ tracers varCandidates
+    runChainSyncClient tracer cfg chainDbView srPeerId csrServer chainSyncTimeouts_ chainSyncLoPBucketConfig tracers varCandidates
 
 -- | Start the BlockFetch client, using the supplied 'FetchClientRegistry' to
 -- register it for synchronization with the ChainSync client.
@@ -239,7 +248,7 @@ runPointSchedule schedulerConfig genesisTest tracer0 =
     fetchClientRegistry <- newFetchClientRegistry
     let chainDbView = CSClient.defaultChainDbView chainDb
     for_ (psrPeers resources) $ \PeerResources {prShared, prChainSync} -> do
-      startChainSyncConnectionThread registry tracer config chainDbView fetchClientRegistry prShared prChainSync chainSyncTimeouts_ stateViewTracers (psrCandidates resources)
+      startChainSyncConnectionThread registry tracer config chainDbView fetchClientRegistry prShared prChainSync chainSyncTimeouts_ chainSyncLoPBucketConfig stateViewTracers (psrCandidates resources)
       PeerSimulator.BlockFetch.startKeepAliveThread registry fetchClientRegistry (srPeerId prShared)
     for_ (psrPeers resources) $ \PeerResources {prShared, prBlockFetch} ->
       startBlockFetchConnectionThread registry fetchClientRegistry (pure Continue) prShared prBlockFetch
@@ -264,6 +273,7 @@ runPointSchedule schedulerConfig genesisTest tracer0 =
       , gtBlockTree
       , gtSchedule
       , gtChainSyncTimeouts
+      , gtLoPBucketParams = LoPBucketParams { lbpCapacity, lbpRate }
       , gtForecastRange
       } = genesisTest
 
@@ -275,6 +285,11 @@ runPointSchedule schedulerConfig genesisTest tracer0 =
       if scEnableChainSyncTimeouts schedulerConfig
         then gtChainSyncTimeouts
         else chainSyncNoTimeouts
+
+    chainSyncLoPBucketConfig =
+      if scEnableLoP schedulerConfig
+        then ChainSyncLoPBucketEnabled ChainSyncLoPBucketEnabledConfig { csbcCapacity = lbpCapacity, csbcRate = lbpRate }
+        else ChainSyncLoPBucketDisabled
 
 -- | Create a ChainDB and start a BlockRunner that operate on the peers'
 -- candidate fragments.

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Run.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Run.hs
@@ -262,9 +262,10 @@ runPointSchedule schedulerConfig genesisTest tracer0 =
       , gtBlockTree
       , gtSchedule
       , gtChainSyncTimeouts
+      , gtForecastRange
       } = genesisTest
 
-    config = defaultCfg k
+    config = defaultCfg k gtForecastRange
 
     tracer = if scTrace schedulerConfig then tracer0 else nullTracer
 

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Run.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Run.hs
@@ -233,7 +233,7 @@ runPointSchedule schedulerConfig genesisTest tracer0 =
     stateViewTracers <- defaultStateViewTracers
     resources <- makePeerSimulatorResources tracer gtBlockTree (getPeerIds gtSchedule)
     let getCandidates = traverse readTVar =<< readTVar (psrCandidates resources)
-        updateLoEFrag = updateLoEFragStall k getCandidates
+        updateLoEFrag = updateLoEFragStall getCandidates
     chainDb <- mkChainDb schedulerConfig tracer config registry updateLoEFrag
     fetchClientRegistry <- newFetchClientRegistry
     let chainDbView = CSClient.defaultChainDbView chainDb

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/ScheduledBlockFetchServer.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/ScheduledBlockFetchServer.hs
@@ -20,17 +20,16 @@ import           Test.Consensus.PeerSimulator.ScheduledServer
 import           Test.Consensus.PeerSimulator.Trace
 import           Test.Consensus.PointSchedule (NodeState)
 import           Test.Consensus.PointSchedule.Peers (PeerId)
-import           Test.Util.TestBlock (TestBlock)
 
 -- | Return values for the 'handlerSendBlocks'.
-data SendBlocks =
-  SendBlock TestBlock [TestBlock]
+data SendBlocks blk =
+  SendBlock blk [blk]
   |
   BatchDone
 
 -- | Return values for the 'handlerBlockFetch'.
-data BlockFetch =
-  StartBatch [TestBlock]
+data BlockFetch blk =
+  StartBatch [blk]
   -- ^ As a response to the client request, we should send the blocks in the
   -- given batch.
   |
@@ -39,28 +38,28 @@ data BlockFetch =
   deriving (Eq, Show)
 
 -- | Handlers for the scheduled BlockFetch server.
-data BlockFetchServerHandlers m state =
+data BlockFetchServerHandlers m state blk =
   BlockFetchServerHandlers {
-    bfshBlockFetch :: ChainRange (Point TestBlock) -> state -> STM m (Maybe BlockFetch, [TraceScheduledBlockFetchServerEvent state TestBlock]),
-    bfshSendBlocks :: [TestBlock] -> state -> STM m (Maybe SendBlocks, [TraceScheduledBlockFetchServerEvent state TestBlock])
+    bfshBlockFetch :: ChainRange (Point blk) -> state -> STM m (Maybe (BlockFetch blk), [TraceScheduledBlockFetchServerEvent state blk]),
+    bfshSendBlocks :: [blk] -> state -> STM m (Maybe (SendBlocks blk), [TraceScheduledBlockFetchServerEvent state blk])
   }
 
 -- | Resources used by a scheduled BlockFetch server. This comprises a generic
 -- 'ScheduledServer' and BlockFetch-specific handlers.
-data ScheduledBlockFetchServer m state =
+data ScheduledBlockFetchServer m state blk =
   ScheduledBlockFetchServer {
-    sbfsServer   :: ScheduledServer m state,
-    sbfsTracer   :: Tracer m (TraceScheduledBlockFetchServerEvent state TestBlock),
-    sbfsHandlers :: BlockFetchServerHandlers m state
+    sbfsServer   :: ScheduledServer m state blk,
+    sbfsTracer   :: Tracer m (TraceScheduledBlockFetchServerEvent state blk),
+    sbfsHandlers :: BlockFetchServerHandlers m state blk
   }
 
 -- | Make a 'BlockFetchServer' able to run with the normal infrastructure from a
 -- 'ScheduledBlockFetchServer'.
 scheduledBlockFetchServer ::
-  forall m a .
+  forall m state blk.
   IOLike m =>
-  ScheduledBlockFetchServer m a ->
-  BlockFetchServer TestBlock (Point TestBlock) m ()
+  ScheduledBlockFetchServer m state blk ->
+  BlockFetchServer blk (Point blk) m ()
 scheduledBlockFetchServer ScheduledBlockFetchServer {sbfsServer, sbfsTracer, sbfsHandlers} =
   server
   where
@@ -91,10 +90,10 @@ runScheduledBlockFetchServer ::
   IOLike m =>
   PeerId ->
   STM m () ->
-  STM m (Maybe (NodeState TestBlock)) ->
-  Tracer m (TraceEvent TestBlock) ->
-  BlockFetchServerHandlers m (NodeState TestBlock) ->
-  BlockFetchServer TestBlock (Point TestBlock) m ()
+  STM m (Maybe (NodeState blk)) ->
+  Tracer m (TraceEvent blk) ->
+  BlockFetchServerHandlers m (NodeState blk) blk ->
+  BlockFetchServer blk (Point blk) m ()
 runScheduledBlockFetchServer ssPeerId ssTickStarted ssCurrentState tracer sbfsHandlers =
   scheduledBlockFetchServer ScheduledBlockFetchServer {
     sbfsServer = ScheduledServer {

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/ScheduledChainSyncServer.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/ScheduledChainSyncServer.hs
@@ -14,7 +14,6 @@ module Test.Consensus.PeerSimulator.ScheduledChainSyncServer (
 
 import           Control.Tracer (Tracer (Tracer), traceWith)
 import           Ouroboros.Consensus.Block.Abstract (Point (..))
-import           Ouroboros.Consensus.Util.Condense (Condense (..))
 import           Ouroboros.Consensus.Util.IOLike (IOLike, MonadSTM (STM))
 import           Ouroboros.Network.Block (Tip (..))
 import           Ouroboros.Network.Protocol.ChainSync.Server
@@ -24,8 +23,11 @@ import           Ouroboros.Network.Protocol.ChainSync.Server
                      ServerStNext (SendMsgRollBackward, SendMsgRollForward))
 import           Test.Consensus.PeerSimulator.ScheduledServer
                      (ScheduledServer (..), awaitOnlineState, runHandler)
-import           Test.Consensus.PeerSimulator.Trace (traceUnitWith)
-import           Test.Util.TersePrinting (terseHeader, terseTip)
+import           Test.Consensus.PeerSimulator.Trace
+                     (TraceEvent (TraceScheduledChainSyncServerEvent),
+                     TraceScheduledChainSyncServerEvent (..))
+import           Test.Consensus.PointSchedule (NodeState)
+import           Test.Consensus.PointSchedule.Peers (PeerId)
 import           Test.Util.TestBlock (Header (..), TestBlock)
 
 -- | Pure representation of the messages produced by the handler for the @StNext@
@@ -36,7 +38,6 @@ data RequestNext =
   RollBackward (Point TestBlock) (Tip TestBlock)
   |
   AwaitReply
-  deriving (Eq, Show)
 
 -- | Pure representation of the messages produced by the handler for the @StIntersect@
 -- protocol state of a ChainSync server.
@@ -44,24 +45,24 @@ data FindIntersect =
   IntersectFound (Point TestBlock) (Tip TestBlock)
   |
   IntersectNotFound (Tip TestBlock)
-  deriving (Eq, Show)
 
 -- | Handlers for the request a ChainSync server might receive from a client.
 -- These take an abstract argument that corresponds to the state of a point
 -- schedule tick and return the simplified protocol message types.
 --
 -- See 'runHandlerWithTrace' for the meaning of @[String]@.
-data ChainSyncServerHandlers m a =
+data ChainSyncServerHandlers m state =
   ChainSyncServerHandlers {
-    csshRequestNext      :: a -> STM m (Maybe RequestNext, [String]),
-    csshFindIntersection :: [Point TestBlock] -> a -> STM m (Maybe FindIntersect, [String])
+    csshRequestNext      :: state -> STM m (Maybe RequestNext, [TraceScheduledChainSyncServerEvent state TestBlock]),
+    csshFindIntersection :: [Point TestBlock] -> state -> STM m (Maybe FindIntersect, [TraceScheduledChainSyncServerEvent state TestBlock])
   }
 
 -- | Resources used by a ChainSync server mock.
-data ScheduledChainSyncServer m a =
+data ScheduledChainSyncServer m state =
   ScheduledChainSyncServer {
-    scssServer   :: ScheduledServer m a,
-    scssHandlers :: ChainSyncServerHandlers m a
+    scssServer   :: ScheduledServer m state,
+    scssTracer   :: Tracer m (TraceScheduledChainSyncServerEvent state TestBlock),
+    scssHandlers :: ChainSyncServerHandlers m state
   }
 
 -- | Declare a mock ChainSync protocol server in its typed-protocols encoding
@@ -76,11 +77,10 @@ data ScheduledChainSyncServer m a =
 -- This architecture allows the server's behavior to be defined with a simple
 -- interface separated from the scheduling and protocol plumbing infrastructure.
 scheduledChainSyncServer ::
-  Condense a =>
   IOLike m =>
   ScheduledChainSyncServer m a ->
   ChainSyncServer (Header TestBlock) (Point TestBlock) (Tip TestBlock) m ()
-scheduledChainSyncServer ScheduledChainSyncServer {scssHandlers, scssServer} =
+scheduledChainSyncServer ScheduledChainSyncServer {scssHandlers, scssTracer, scssServer} =
   go
   where
     ChainSyncServerHandlers {csshRequestNext, csshFindIntersection} = scssHandlers
@@ -93,17 +93,14 @@ scheduledChainSyncServer ScheduledChainSyncServer {scssHandlers, scssServer} =
       }
 
     recvMsgRequestNext =
-      runHandler scssServer "MsgRequestNext" csshRequestNext $ \case
+      runHandler scssServer "MsgRequestNext" csshRequestNext scssTracer $ \case
         RollForward header tip -> do
-          trace $ "  gotta serve " ++ terseHeader header
-          trace $ "  tip is      " ++ terseTip tip
-          trace "done handling MsgRequestNext"
+          trace $ TraceRollForward header tip
           pure $ Left $ SendMsgRollForward header tip go
         RollBackward point tip -> do
-          trace "done handling MsgRequestNext"
+          trace $ TraceRollBackward point tip
           pure $ Left $ SendMsgRollBackward point tip go
-        AwaitReply -> do
-          trace "done handling MsgRequestNext"
+        AwaitReply ->
           pure $ Right $ do -- beginning of the continuation
             restart >>= \case
               -- If we get 'Right', then we still do not have anything to serve
@@ -119,32 +116,29 @@ scheduledChainSyncServer ScheduledChainSyncServer {scssHandlers, scssServer} =
         restart = awaitOnlineState scssServer *> recvMsgRequestNext
 
     recvMsgFindIntersect pts =
-      runHandler scssServer "MsgFindIntersect" (csshFindIntersection pts) $ \case
+      runHandler scssServer "MsgFindIntersect" (csshFindIntersection pts) scssTracer $ \case
         IntersectNotFound tip -> do
-          trace "  no intersection found"
-          trace "done handling MsgFindIntersect"
+          trace TraceIntersectionNotFound
           pure $ SendMsgIntersectNotFound tip go
         IntersectFound intersection tip -> do
-          trace $ "  intersection found: " ++ condense intersection
-          trace "done handling MsgFindIntersect"
+          trace $ TraceIntersectionFound intersection
           pure $ SendMsgIntersectFound intersection tip go
 
     recvMsgDoneClient =
-      trace "received MsgDoneClient"
+      trace TraceClientIsDone
 
-    trace = traceWith (ssTracer scssServer)
+    trace = traceWith scssTracer
 
 -- | Construct a ChainSync server for the peer simulator.
 --
 -- See 'scheduledChainSyncServer'.
 runScheduledChainSyncServer ::
-  Condense a =>
   IOLike m =>
-  String ->
+  PeerId ->
   STM m () ->
-  STM m (Maybe a) ->
-  Tracer m String ->
-  ChainSyncServerHandlers m a ->
+  STM m (Maybe (NodeState TestBlock)) ->
+  Tracer m (TraceEvent TestBlock) ->
+  ChainSyncServerHandlers m (NodeState TestBlock) ->
   ChainSyncServer (Header TestBlock) (Point TestBlock) (Tip TestBlock) m ()
 runScheduledChainSyncServer ssPeerId ssTickStarted ssCurrentState tracer scssHandlers =
   scheduledChainSyncServer ScheduledChainSyncServer {
@@ -152,7 +146,8 @@ runScheduledChainSyncServer ssPeerId ssTickStarted ssCurrentState tracer scssHan
       ssPeerId,
       ssTickStarted,
       ssCurrentState,
-      ssTracer = Tracer (traceUnitWith tracer ("ScheduledChainSyncServer " ++ ssPeerId))
+      ssCommonTracer = Tracer (traceWith tracer . TraceScheduledChainSyncServerEvent ssPeerId . TraceHandlerEventCS)
     },
+    scssTracer = Tracer (traceWith tracer . TraceScheduledChainSyncServerEvent ssPeerId),
     scssHandlers
   }

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/StateView.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/StateView.hs
@@ -13,12 +13,13 @@ import           Control.Exception (AsyncException (ThreadKilled),
                      fromException)
 import           Control.Tracer (Tracer)
 import           Data.Maybe (mapMaybe)
+import           Ouroboros.Consensus.Block (Header)
 import           Ouroboros.Consensus.Storage.ChainDB (ChainDB)
 import qualified Ouroboros.Consensus.Storage.ChainDB as ChainDB
 import           Ouroboros.Consensus.Util.Condense (Condense (condense))
 import           Ouroboros.Consensus.Util.IOLike (IOLike, SomeException,
                      atomically)
-import           Test.Consensus.PointSchedule (TestFragH)
+import           Ouroboros.Network.AnchoredFragment (AnchoredFragment)
 import           Test.Consensus.PointSchedule.Peers (PeerId)
 import           Test.Util.TersePrinting (terseHFragment)
 import           Test.Util.TestBlock (TestBlock)
@@ -42,7 +43,7 @@ instance Condense ChainSyncException where
 -- information about the mocked peers (for instance the exceptions raised in the
 -- mocked ChainSync server threads).
 data StateView = StateView {
-    svSelectedChain       :: TestFragH,
+    svSelectedChain       :: AnchoredFragment (Header TestBlock),
     svChainSyncExceptions :: [ChainSyncException]
   }
   deriving Show

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
@@ -14,6 +14,9 @@ import           Ouroboros.Network.AnchoredFragment (AnchoredFragment,
 import qualified Ouroboros.Network.AnchoredFragment as AF
 import           Test.Consensus.BlockTree (BlockTree (..), BlockTreeBranch (..))
 import           Test.Consensus.Genesis.Setup
+import           Test.Consensus.Genesis.Setup.Classifiers
+                     (Classifiers (allAdversariesKPlus1InForecast),
+                     allAdversariesForecastable, classifiers)
 import           Test.Consensus.PeerSimulator.Run (defaultSchedulerConfig)
 import           Test.Consensus.PeerSimulator.StateView
 import           Test.Consensus.PointSchedule
@@ -30,7 +33,6 @@ import           Test.Util.TestEnv (adjustQuickCheckTests)
 tests :: TestTree
 tests = testGroup "rollback" [
   adjustQuickCheckTests (`div` 2) $
-  localOption (QuickCheckMaxRatio 100) $
   testProperty "can rollback" prop_rollback
   ,
   adjustQuickCheckTests (`div` 2) $
@@ -48,7 +50,11 @@ prop_rollback = do
         -- Create a block tree with @1@ alternative chain, such that we can rollback
         -- from the trunk to that chain.
         gt@GenesisTest{gtSecurityParam, gtBlockTree} <- genChains (pure 1)
-        pure gt {gtSchedule =  rollbackSchedule (fromIntegral (maxRollbacks gtSecurityParam)) gtBlockTree})
+        -- TODO: Trim block tree, the rollback schedule does not use all of it
+        let cls = classifiers gt
+        if allAdversariesForecastable cls && allAdversariesKPlus1InForecast cls
+          then pure gt {gtSchedule = rollbackSchedule (fromIntegral (maxRollbacks gtSecurityParam)) gtBlockTree}
+          else discard)
 
     defaultSchedulerConfig
 

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
@@ -67,5 +67,9 @@ prop_timeouts mustTimeout = do
        in peersOnlyHonest $ [
             (Time 0, scheduleTipPoint tipBlock),
             (Time 0, scheduleHeaderPoint tipBlock),
-            (Time (timeout + offset), scheduleBlockPoint tipBlock)
+            (Time 0, scheduleBlockPoint tipBlock),
+            -- This last point does not matter, it is only here to leave the
+            -- connection open (aka. keep the test running) long enough to
+            -- pass the timeout by 'offset'.
+            (Time (timeout + offset), scheduleTipPoint tipBlock)
             ]

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
@@ -1,23 +1,27 @@
+{-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
 module Test.Consensus.PeerSimulator.Tests.Timeouts (tests) where
 
-import           Data.List.NonEmpty (NonEmpty ((:|)))
+import           Data.Functor (($>))
 import           Data.Maybe (fromJust)
-import           Ouroboros.Consensus.Block (getHeader)
 import           Ouroboros.Consensus.Util.Condense
-import           Ouroboros.Consensus.Util.IOLike (DiffTime, fromException)
+import           Ouroboros.Consensus.Util.IOLike (DiffTime, Time (Time),
+                     fromException)
 import qualified Ouroboros.Network.AnchoredFragment as AF
-import           Ouroboros.Network.Block (tipFromHeader)
 import           Ouroboros.Network.Driver.Limits
                      (ProtocolLimitFailure (ExceededTimeLimit))
-import           Ouroboros.Network.Point (WithOrigin (At))
 import           Ouroboros.Network.Protocol.ChainSync.Codec (mustReplyTimeout)
 import           Test.Consensus.BlockTree (btTrunk)
 import           Test.Consensus.Genesis.Setup
-import           Test.Consensus.PeerSimulator.Run (SchedulerConfig (..),
+import           Test.Consensus.PeerSimulator.Run
+                     (SchedulerConfig (scEnableChainSyncTimeouts),
                      defaultSchedulerConfig)
 import           Test.Consensus.PeerSimulator.StateView
 import           Test.Consensus.PointSchedule
-import           Test.Consensus.PointSchedule.Peers (Peer (..), PeerId (..))
+import           Test.Consensus.PointSchedule.Peers (peersOnlyHonest)
+import           Test.Consensus.PointSchedule.SinglePeer (scheduleBlockPoint,
+                     scheduleHeaderPoint, scheduleTipPoint)
 import           Test.QuickCheck
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
@@ -25,50 +29,43 @@ import           Test.Util.Orphans.IOLike ()
 import           Test.Util.TestEnv (adjustQuickCheckTests)
 
 tests :: TestTree
-tests = adjustQuickCheckTests (`div` 10) $ testProperty "timeouts" prop_timeouts
+tests = testGroup "timeouts" [
+  adjustQuickCheckTests (`div` 10) $ testProperty "does time out" (prop_timeouts True),
+  adjustQuickCheckTests (`div` 10) $ testProperty "does not time out" (prop_timeouts False)
+  ]
 
-prop_timeouts :: Gen Property
-prop_timeouts = do
-  genesisTest <- genChains (pure 0)
+prop_timeouts :: Bool -> Property
+prop_timeouts mustTimeout = do
+  forAllGenesisTest
 
-  -- Use higher tick duration to avoid the test taking really long
-  let scSchedule' = PointScheduleConfig {pscTickDuration = 1}
+    (do gt@GenesisTest{gtChainSyncTimeouts, gtBlockTree} <- genChains (pure 0)
+        let schedule = dullSchedule (fromJust $ mustReplyTimeout gtChainSyncTimeouts) (btTrunk gtBlockTree)
+        pure $ gt $> schedule
+    )
 
-      schedulerConfig = defaultSchedulerConfig scSchedule' (gtHonestAsc genesisTest)
+    (defaultSchedulerConfig { scEnableChainSyncTimeouts = True })
 
-      schedule =
-        dullSchedule
-          scSchedule'
-          (fromJust $ mustReplyTimeout (scChainSyncTimeouts schedulerConfig))
-          (btTrunk $ gtBlockTree genesisTest)
+    (\_ _ -> [])
 
-  -- NOTE: Because the scheduler configuration depends on the generated
-  -- 'GenesisTest' itself, we cannot rely on helpers such as
-  -- 'forAllGenesisTest'.
-  pure $
-    runGenesisTest' schedulerConfig genesisTest schedule $ \stateView ->
+    (\_ stateView ->
       case svChainSyncExceptions stateView of
         [] ->
-          counterexample ("result: " ++ condense (svSelectedChain stateView)) False
+          counterexample ("result: " ++ condense (svSelectedChain stateView)) (not mustTimeout)
         [exn] ->
           case fromException $ cseException exn of
-            Just (ExceededTimeLimit _) -> property True
+            Just (ExceededTimeLimit _) -> property mustTimeout
             _ -> counterexample ("exception: " ++ show exn) False
         exns ->
           counterexample ("exceptions: " ++ show exns) False
+    )
 
   where
-
-    -- A schedule that advertises all the points of the chain from the start but
-    -- contains just one too many ticks, therefore reaching the timeouts.
-    dullSchedule :: PointScheduleConfig -> DiffTime -> TestFrag -> PointSchedule
-    dullSchedule _ _ (AF.Empty _) = error "requires a non-empty block tree"
-    dullSchedule scheduleConfig timeout (_ AF.:> tipBlock) =
-      let tipPoint = TipPoint $ tipFromHeader tipBlock
-          headerPoint = HeaderPoint $ At (getHeader tipBlock)
-          blockPoint = BlockPoint (At tipBlock)
-          state = Peer HonestPeer $ NodeOnline $ AdvertisedPoints tipPoint headerPoint blockPoint
-          tick = Tick { active = state, duration = pscTickDuration scheduleConfig, number = 0 }
-          maximumNumberOfTicks = round $ timeout / pscTickDuration scheduleConfig
-      in
-      PointSchedule (tick :| replicate maximumNumberOfTicks tick) (HonestPeer :| [])
+    dullSchedule :: AF.HasHeader blk => DiffTime -> AF.AnchoredFragment blk -> PeersSchedule blk
+    dullSchedule _ (AF.Empty _) = error "requires a non-empty block tree"
+    dullSchedule timeout (_ AF.:> tipBlock) =
+      let offset :: DiffTime = if mustTimeout then 1 else -1
+       in peersOnlyHonest $ [
+            (Time 0, scheduleTipPoint tipBlock),
+            (Time 0, scheduleHeaderPoint tipBlock),
+            (Time (timeout + offset), scheduleBlockPoint tipBlock)
+            ]

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Trace.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Trace.hs
@@ -42,6 +42,10 @@ mkCdbTracer tracer =
           trace $ "Did not add block due to LoE: " ++ terseRealPoint point
         IgnoreBlockOlderThanK point ->
           trace $ "Ignored block older than k: " ++ terseRealPoint point
+        ChainSelectionLoEDebug curChain loeFrag0 -> do
+          trace $ "Current chain: " ++ terseHFragment curChain
+          trace $ "LoE fragment: " ++ terseHFragment loeFrag0
+
         _ -> pure ()
     _ -> pure ()
   where

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Trace.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Trace.hs
@@ -56,7 +56,6 @@ mkCdbTracer tracer =
     trace = traceUnitWith tracer "ChainDB"
 
 mkChainSyncClientTracer ::
-  IOLike m =>
   PeerId ->
   Tracer m String ->
   Tracer m (TraceChainSyncClientEvent TestBlock)
@@ -74,7 +73,15 @@ mkChainSyncClientTracer pid tracer =
       trace $ "Validated header: " ++ terseHeader header
     TraceDownloadedHeader header ->
       trace $ "Downloaded header: " ++ terseHeader header
-    _ -> pure ()
+    TraceGaveLoPToken didGive header bestBlockNo ->
+      trace $
+        (if didGive then "Gave" else "Did not give")
+        ++ " LoP token to " ++ terseHeader header
+        ++ " compared to " ++ show bestBlockNo
+    TraceException exception ->
+      trace $ "Threw an exception: " ++ show exception
+    TraceTermination result ->
+      trace $ "Terminated with result: " ++ show result
   where
     trace = traceUnitWith tracer ("ChainSyncClient " ++ condense pid)
 

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Trace.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Trace.hs
@@ -18,12 +18,11 @@ import           Ouroboros.Consensus.MiniProtocol.ChainSync.Client
                      (TraceChainSyncClientEvent (..))
 import qualified Ouroboros.Consensus.Storage.ChainDB.Impl as ChainDB.Impl
 import           Ouroboros.Consensus.Storage.ChainDB.Impl.Types
-                     (SelectionChangedInfo (..), TraceAddBlockEvent (..))
-import           Ouroboros.Consensus.Util.Condense (Condense (..))
+                     (TraceAddBlockEvent (..))
 import           Ouroboros.Consensus.Util.IOLike (IOLike, MonadMonotonicTime,
                      Time (Time), getMonotonicTime)
-import           Test.Util.TersePrinting (terseHFragment, tersePoint,
-                     terseRealPoint)
+import           Test.Util.TersePrinting (terseHFragment, terseHeader,
+                     tersePoint, terseRealPoint)
 import           Test.Util.TestBlock (TestBlock)
 import           Text.Printf (printf)
 
@@ -35,16 +34,14 @@ mkCdbTracer tracer =
   Tracer $ \case
     ChainDB.Impl.TraceAddBlockEvent event ->
       case event of
-        AddedToCurrentChain _ SelectionChangedInfo {newTipPoint} _ _ -> do
-          trace "Added to current chain"
-          trace $ "New tip: " ++ terseRealPoint newTipPoint
-        SwitchedToAFork _ SelectionChangedInfo {newTipPoint} _ newFragment -> do
-          trace "Switched to a fork"
-          trace $ "New tip: " ++ terseRealPoint newTipPoint
-          trace $ "New fragment: " ++ terseHFragment newFragment
-        StoreButDontChange block -> do
-          trace "Did not add block due to LoE"
-          trace $ "Block: " ++ condense block
+        AddedToCurrentChain _ _ _ newFragment ->
+          trace $ "Added to current chain; now: " ++ terseHFragment newFragment
+        SwitchedToAFork _ _ _ newFragment ->
+          trace $ "Switched to a fork; now: " ++ terseHFragment newFragment
+        StoreButDontChange point ->
+          trace $ "Did not add block due to LoE: " ++ terseRealPoint point
+        IgnoreBlockOlderThanK point ->
+          trace $ "Ignored block older than k: " ++ terseRealPoint point
         _ -> pure ()
     _ -> pure ()
   where
@@ -60,6 +57,14 @@ mkChainSyncClientTracer tracer =
       trace $ "Rolled back to: " ++ tersePoint point
     TraceFoundIntersection point _ourTip _theirTip ->
       trace $ "Found intersection at: " ++ tersePoint point
+    TraceWaitingBeyondForecastHorizon slot ->
+      trace $ "Waiting for " ++ show slot ++ " beyond forecast horizon"
+    TraceAccessingForecastHorizon slot ->
+      trace $ "Accessing " ++ show slot ++ ", previously beyond forecast horizon"
+    TraceValidatedHeader header ->
+      trace $ "Validated header: " ++ terseHeader header
+    TraceDownloadedHeader header ->
+      trace $ "Downloaded header: " ++ terseHeader header
     _ -> pure ()
   where
     trace = traceUnitWith tracer "ChainSyncClient"

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
@@ -21,7 +21,8 @@
 -- and once it fulfills the state's criteria, it yields control back to the scheduler,
 -- who then activates the next tick's peer.
 module Test.Consensus.PointSchedule (
-    GenesisTest (..)
+    ForecastRange (..)
+  , GenesisTest (..)
   , GenesisTestFull
   , GenesisWindow (..)
   , NodeState (..)
@@ -300,10 +301,14 @@ uniformPoints BlockTree {btTrunk, btBranches} g = do
 newtype GenesisWindow = GenesisWindow { unGenesisWindow :: Word64 }
   deriving (Show)
 
+newtype ForecastRange = ForecastRange { unForecastRange :: Word64 }
+  deriving (Show)
+
 -- | All the data used by point schedule tests.
 data GenesisTest blk schedule = GenesisTest {
   gtSecurityParam     :: SecurityParam,
   gtGenesisWindow     :: GenesisWindow,
+  gtForecastRange     :: ForecastRange, -- REVIEW: Do we want to allow infinite forecast ranges?
   gtDelay             :: Delta,
   gtBlockTree         :: BlockTree blk,
   gtChainSyncTimeouts :: ChainSyncTimeout,
@@ -318,6 +323,7 @@ prettyGenesisTest genesisTest =
   [ "GenesisTest:"
   , "  gtSecurityParam: " ++ show (maxRollbacks gtSecurityParam)
   , "  gtGenesisWindow: " ++ show (unGenesisWindow gtGenesisWindow)
+  , "  gtForecastRange: " ++ show (unForecastRange gtForecastRange)
   , "  gtDelay: " ++ show delta
   , "  gtSlotLength: " ++ show gtSlotLength
   , "  gtChainSyncTimeouts: "
@@ -331,6 +337,7 @@ prettyGenesisTest genesisTest =
     GenesisTest {
         gtSecurityParam
       , gtGenesisWindow
+      , gtForecastRange
       , gtDelay = Delta delta
       , gtBlockTree
       , gtChainSyncTimeouts = ChainSyncTimeout{canAwaitTimeout, intersectTimeout, mustReplyTimeout}

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
@@ -325,8 +325,8 @@ data GenesisTest blk schedule = GenesisTest {
 
 type GenesisTestFull blk = GenesisTest blk (PeersSchedule blk)
 
-prettyGenesisTest :: GenesisTest TestBlock schedule -> [String]
-prettyGenesisTest genesisTest =
+prettyGenesisTest :: (schedule -> [String]) -> GenesisTest TestBlock schedule -> [String]
+prettyGenesisTest prettySchedule genesisTest =
   [ "GenesisTest:"
   , "  gtSecurityParam: " ++ show (maxRollbacks gtSecurityParam)
   , "  gtGenesisWindow: " ++ show (unGenesisWindow gtGenesisWindow)
@@ -343,6 +343,8 @@ prettyGenesisTest genesisTest =
   , "  gtBlockTree:"
   ] ++ map (("    " ++) . terseFragment) (allFragments gtBlockTree)
     ++ map ("    " ++) (prettyBlockTree gtBlockTree)
+    ++ ["  gtSchedule:"]
+    ++ map ("    " ++) (prettySchedule gtSchedule)
   where
     GenesisTest {
         gtSecurityParam
@@ -353,7 +355,7 @@ prettyGenesisTest genesisTest =
       , gtChainSyncTimeouts = ChainSyncTimeout{canAwaitTimeout, intersectTimeout, mustReplyTimeout}
       , gtLoPBucketParams = LoPBucketParams{lbpCapacity, lbpRate}
       , gtSlotLength
-      , gtSchedule = _
+      , gtSchedule
       } = genesisTest
 
 instance Functor (GenesisTest blk) where

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
@@ -25,6 +25,7 @@ module Test.Consensus.PointSchedule (
   , GenesisTest (..)
   , GenesisTestFull
   , GenesisWindow (..)
+  , LoPBucketParams (..)
   , NodeState (..)
   , PeerSchedule
   , PeersSchedule
@@ -304,6 +305,11 @@ newtype GenesisWindow = GenesisWindow { unGenesisWindow :: Word64 }
 newtype ForecastRange = ForecastRange { unForecastRange :: Word64 }
   deriving (Show)
 
+data LoPBucketParams = LoPBucketParams {
+  lbpCapacity :: Integer,
+  lbpRate     :: Rational
+  }
+
 -- | All the data used by point schedule tests.
 data GenesisTest blk schedule = GenesisTest {
   gtSecurityParam     :: SecurityParam,
@@ -312,6 +318,7 @@ data GenesisTest blk schedule = GenesisTest {
   gtDelay             :: Delta,
   gtBlockTree         :: BlockTree blk,
   gtChainSyncTimeouts :: ChainSyncTimeout,
+  gtLoPBucketParams   :: LoPBucketParams,
   gtSlotLength        :: SlotLength,
   gtSchedule          :: schedule
   }
@@ -330,6 +337,9 @@ prettyGenesisTest genesisTest =
   , "    canAwait = " ++ show canAwaitTimeout
   , "    intersect = " ++ show intersectTimeout
   , "    mustReply = " ++ show mustReplyTimeout
+  , "  gtLoPBucketParams: "
+  , "    lbpCapacity = " ++ show lbpCapacity ++ " tokens"
+  , "    lbpRate = " ++ show lbpRate ++ " ≅ " ++ printf "%.2f" (fromRational lbpRate :: Float) ++ " tokens per second"
   , "  gtBlockTree:"
   ] ++ map (("    " ++) . terseFragment) (allFragments gtBlockTree)
     ++ map ("    " ++) (prettyBlockTree gtBlockTree)
@@ -341,6 +351,7 @@ prettyGenesisTest genesisTest =
       , gtDelay = Delta delta
       , gtBlockTree
       , gtChainSyncTimeouts = ChainSyncTimeout{canAwaitTimeout, intersectTimeout, mustReplyTimeout}
+      , gtLoPBucketParams = LoPBucketParams{lbpCapacity, lbpRate}
       , gtSlotLength
       , gtSchedule = _
       } = genesisTest

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Peers.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Peers.hs
@@ -35,7 +35,9 @@ import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           Data.String (IsString (fromString))
 import           GHC.Generics (Generic)
-import           Ouroboros.Consensus.Util.Condense (Condense (condense))
+import           Ouroboros.Consensus.Util.Condense (Condense (..),
+                     CondenseList (..), PaddingDirection (..),
+                     condenseListWithPadding)
 
 -- | Identifier used to index maps and specify which peer is active during a tick.
 data PeerId =
@@ -52,6 +54,9 @@ instance Condense PeerId where
   condense = \case
     HonestPeer -> "honest"
     PeerId name -> name
+
+instance CondenseList PeerId where
+  condenseList = condenseListWithPadding PadRight
 
 instance Hashable PeerId
 
@@ -75,6 +80,13 @@ instance Traversable Peer where
 
 instance Condense a => Condense (Peer a) where
   condense Peer {name, value} = condense name ++ ": " ++ condense value
+
+instance CondenseList a => CondenseList (Peer a) where
+  condenseList peers =
+    zipWith
+      (\name value -> name ++ ": " ++ value)
+      (condenseList $ name <$> peers)
+      (condenseList $ value <$> peers)
 
 -- | General-purpose functor for a set of peers.
 --

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Shrinking.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Shrinking.hs
@@ -1,6 +1,9 @@
 {-# LANGUAGE NamedFieldPuns #-}
 
-module Test.Consensus.PointSchedule.Shrinking (shrinkPeerSchedules) where
+module Test.Consensus.PointSchedule.Shrinking (
+    shrinkPeerSchedules
+  , trimBlockTree'
+  ) where
 
 import           Data.Containers.ListUtils (nubOrd)
 import           Data.Functor ((<&>))

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Shrinking.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Shrinking.hs
@@ -28,7 +28,7 @@ import           Test.Util.TestBlock (TestBlock, isAncestorOf,
 -- schedule.
 shrinkPeerSchedules ::
   GenesisTestFull TestBlock ->
-  StateView ->
+  StateView TestBlock ->
   [GenesisTestFull TestBlock]
 shrinkPeerSchedules genesisTest _stateView =
   shrinkOtherPeers shrinkPeerSchedule (gtSchedule genesisTest) <&> \shrunkSchedule ->

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Shrinking.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Shrinking.hs
@@ -11,8 +11,9 @@ import           Ouroboros.Network.AnchoredFragment (AnchoredFragment,
 import           Test.Consensus.BlockTree (BlockTree (..), BlockTreeBranch (..),
                      addBranch', mkTrunk)
 import           Test.Consensus.PeerSimulator.StateView (StateView)
-import           Test.Consensus.PointSchedule (GenesisTest (gtBlockTree),
-                     PeerSchedule, peerSchedulesBlocks)
+import           Test.Consensus.PointSchedule
+                     (GenesisTest (gtBlockTree, gtSchedule), GenesisTestFull,
+                     PeerSchedule, PeersSchedule, peerSchedulesBlocks)
 import           Test.Consensus.PointSchedule.Peers (Peers (..))
 import           Test.QuickCheck (shrinkList)
 import           Test.Util.TestBlock (TestBlock, isAncestorOf,
@@ -23,18 +24,17 @@ import           Test.Util.TestBlock (TestBlock, isAncestorOf,
 -- block tree is trimmed to keep only parts that are necessary for the shrunk
 -- schedule.
 shrinkPeerSchedules ::
-  GenesisTest ->
-  Peers PeerSchedule ->
+  GenesisTestFull TestBlock ->
   StateView ->
-  [(GenesisTest, Peers PeerSchedule)]
-shrinkPeerSchedules genesisTest schedule _stateView =
-  shrinkOtherPeers shrinkPeerSchedule schedule <&> \shrunkSchedule ->
+  [GenesisTestFull TestBlock]
+shrinkPeerSchedules genesisTest _stateView =
+  shrinkOtherPeers shrinkPeerSchedule (gtSchedule genesisTest) <&> \shrunkSchedule ->
     let trimmedBlockTree = trimBlockTree' shrunkSchedule (gtBlockTree genesisTest)
-     in (genesisTest{gtBlockTree = trimmedBlockTree}, shrunkSchedule)
+     in genesisTest{gtSchedule = shrunkSchedule, gtBlockTree = trimmedBlockTree}
 
 -- | Shrink a 'PeerSchedule' by removing ticks from it. The other ticks are kept
 -- unchanged.
-shrinkPeerSchedule :: PeerSchedule -> [PeerSchedule]
+shrinkPeerSchedule :: (PeerSchedule blk) -> [PeerSchedule blk]
 shrinkPeerSchedule = shrinkList (const [])
 
 -- | Shrink the 'others' field of a 'Peers' structure by attempting to remove
@@ -47,7 +47,7 @@ shrinkOtherPeers shrink Peers{honest, others} =
 -- | Remove blocks from the given block tree that are not necessary for the
 -- given peer schedules. If entire branches are unused, they are removed. If the
 -- trunk is unused, then it remains as an empty anchored fragment.
-trimBlockTree' :: Peers PeerSchedule -> BlockTree TestBlock -> BlockTree TestBlock
+trimBlockTree' :: PeersSchedule TestBlock -> BlockTree TestBlock -> BlockTree TestBlock
 trimBlockTree' = keepOnlyAncestorsOf . peerSchedulesBlocks
 
 -- | Given some blocks and a block tree, keep only the prefix of the block tree

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/SinglePeer.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/SinglePeer.hs
@@ -235,6 +235,7 @@ peerScheduleFromTipPoints
   -> m [(Time, SchedulePoint blk)]
 peerScheduleFromTipPoints g psp tipPoints trunk0 branches0 = do
     let trunk0v = Vector.fromList $ AF.toOldestFirst trunk0
+        -- NOTE: Is this still correct? Shouldn't it be `withOrigin 0 (+1)`?
         firstTrunkBlockNo = withOrigin 1 (+1) $ AF.anchorBlockNo trunk0
         branches0v = map (Vector.fromList . AF.toOldestFirst) branches0
         anchorBlockIndices =

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/SinglePeer/Indices.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/SinglePeer/Indices.hs
@@ -23,6 +23,7 @@ module Test.Consensus.PointSchedule.SinglePeer.Indices (
   ) where
 
 import           Control.Monad (forM, replicateM)
+import           Control.Monad.Class.MonadTime.SI (Time (Time), addTime)
 import           Data.List (sort)
 import           Data.Time.Clock (DiffTime, diffTimeToPicoseconds,
                      picosecondsToDiffTime)
@@ -127,18 +128,18 @@ rollbacksTipPoints g k = mapM walkBranch
 -- >   -> m {v:[DiffTime] | isSorted v && length v == length slots}
 --
 tipPointSchedule
-  :: forall g m. R.StatefulGen g m => g -> DiffTime -> (DiffTime, DiffTime) -> [SlotNo] -> m [DiffTime]
+  :: forall g m. R.StatefulGen g m => g -> DiffTime -> (DiffTime, DiffTime) -> [SlotNo] -> m [Time]
 tipPointSchedule _g slotLength (a, b) _slots
     | slotLength <= b = error "tipPointSchedule: slotLength <= maximum delay"
     | b < a = error "tipPointSchedule: empty delay interval"
 tipPointSchedule g slotLength msgDelayInterval slots = do
     let -- pairs of times corresponding to the start and end of each interval
         -- between tip points
-        slotTimes = map toDiffTime slots
-        timePairs = zip slotTimes $ (drop 1 slotTimes) ++ [last slotTimes + 1]
+        slotTimes = map slotTime slots
+        timePairs = zip slotTimes $ (drop 1 slotTimes) ++ [addTime 1 (last slotTimes)]
     go timePairs
   where
-    go :: [(DiffTime, DiffTime)] -> m [DiffTime]
+    go :: [(Time, Time)] -> m [Time]
     go [] = pure []
     go xs = do
       -- While the slots are increasing, assign a time to each point
@@ -147,12 +148,12 @@ tipPointSchedule g slotLength msgDelayInterval slots = do
       let (pointSeq, newBranch) = span (\(a, b) -> a < b) xs
       times <- forM pointSeq $ \(s, _) -> do
                  delay <- uniformRMDiffTime msgDelayInterval g
-                 pure $ s + delay
+                 pure $ addTime delay s
       (times', xss) <- case newBranch of
         [] -> pure ([], [])
         ((seqLast, _) : branches) -> do
           delay <- uniformRMDiffTime msgDelayInterval g
-          let lastTime = seqLast + delay
+          let lastTime = addTime delay seqLast
           (times', xss) <- handleDelayedTipPoints lastTime branches
           pure (lastTime : times', xss)
       -- When the slots are not increasing, we must be doing a rollback.
@@ -160,37 +161,46 @@ tipPointSchedule g slotLength msgDelayInterval slots = do
       times'' <- go xss
       pure $ times ++ times' ++ times''
 
-    -- | The start of each slot in the schedule
-    toDiffTime :: SlotNo -> DiffTime
-    toDiffTime (SlotNo s) = fromIntegral s * slotLength
+    -- | The amount of time taken by the given number of slots.
+    slotsDiffTime :: Int -> DiffTime
+    slotsDiffTime s = fromIntegral s * slotLength
 
-    -- | Assign times to tip points in past slots. A past slots is
+    -- | The time at the start of the slot.
+    slotTime :: SlotNo -> Time
+    slotTime (SlotNo s) = Time (slotsDiffTime (fromIntegral s))
+
+    -- | Assign times to tip points in past slots. A past slot is
     -- any earlier slot than the first parameter.
     --
     -- Yields the assigned times and the remaining tip points which
     -- aren't in the past.
-    handleDelayedTipPoints :: DiffTime -> [(DiffTime, DiffTime)] -> m ([DiffTime], [(DiffTime, DiffTime)])
+    handleDelayedTipPoints :: Time -> [(Time, Time)] -> m ([Time], [(Time, Time)])
     handleDelayedTipPoints lastTime xss = do
-      let (pointSeq, newBranch) = span (\(a, _) -> a + fst msgDelayInterval <= lastTime) xss
+      let (pointSeq, newBranch) = span (\(a, _) -> addTime (fst msgDelayInterval) a <= lastTime) xss
           nseq = length pointSeq
           -- The first point in xss that is not in the past
           firstLater = case newBranch of
             -- If there is no later point, pick an arbitrary later time interval
             -- to sample from
-            []           -> lastTime + toDiffTime (toEnum nseq)
-            ((a, _) : _) -> a + fst msgDelayInterval
-      times <- replicateM nseq (uniformRMDiffTime (lastTime, firstLater) g)
+            []           -> addTime (slotsDiffTime (toEnum nseq)) lastTime
+            ((a, _) : _) -> addTime (fst msgDelayInterval) a
+      times <- replicateM nseq (uniformRMTime (lastTime, firstLater) g)
       pure (sort times, newBranch)
 
+-- | Uniformely choose a relative 'DiffTime' in the given range.
 uniformRMDiffTime :: R.StatefulGen g m => (DiffTime, DiffTime) -> g -> m DiffTime
 uniformRMDiffTime (a, b) g =
     picosecondsToDiffTime <$>
       R.uniformRM (diffTimeToPicoseconds a, diffTimeToPicoseconds b) g
 
+-- | Uniformely choose an absolute 'Time' in the given range.
+uniformRMTime :: R.StatefulGen g m => (Time, Time) -> g -> m Time
+uniformRMTime (Time a, Time b) g = Time <$> uniformRMDiffTime (a, b) g
+
 data HeaderPointSchedule = HeaderPointSchedule {
-    hpsTrunk  :: [(DiffTime, Int)] -- ^ header points up to the intersection
-  , hpsBranch :: [(DiffTime, Int)] -- ^ header points after the intersection
-                                   -- indices are relative to the branch
+    hpsTrunk  :: [(Time, Int)] -- ^ header points up to the intersection
+  , hpsBranch :: [(Time, Int)] -- ^ header points after the intersection
+                               -- indices are relative to the branch
   }
   deriving (Show)
 
@@ -241,13 +251,13 @@ headerPointSchedule
   :: forall g m. (HasCallStack, R.StatefulGen g m)
   => g
   -> (DiffTime, DiffTime)
-  -> [(Maybe Int, [(DiffTime, Int)])]
+  -> [(Maybe Int, [(Time, Int)])]
   -> m [HeaderPointSchedule]
 headerPointSchedule g msgDelayInterval xs =
    let -- Pair each  branch with the maximum time at which its header points
        -- should be offered
        xs' = zip xs $ map (Just . fst . headCallStack . snd) (drop 1 xs) ++ [Nothing]
-    in snd <$> mapAccumM genHPBranchSchedule (0, 0) xs'
+    in snd <$> mapAccumM genHPBranchSchedule (Time 0, 0) xs'
 
   where
     -- | @genHPBranchSchedule (tNext, trunkNextHp) ((mi, tps), mtMax)@ generates
@@ -269,9 +279,9 @@ headerPointSchedule g msgDelayInterval xs =
     -- Returns the time at which the last header point was offered, the next
     -- header point to offer and the schedule for the branch.
     genHPBranchSchedule
-      :: (DiffTime, Int)
-      -> ((Maybe Int, [(DiffTime, Int)]), Maybe DiffTime)
-      -> m ((DiffTime, Int), HeaderPointSchedule)
+      :: (Time, Int)
+      -> ((Maybe Int, [(Time, Int)]), Maybe Time)
+      -> m ((Time, Int), HeaderPointSchedule)
     genHPBranchSchedule (tNext, trunkNextHp) ((_mi, []), _mtMax) =
       pure ((tNext, trunkNextHp), HeaderPointSchedule [] [])
     genHPBranchSchedule (tNext, trunkNextHp) ((Nothing, tps), mtMax) = do
@@ -291,20 +301,20 @@ headerPointSchedule g msgDelayInterval xs =
     -- The delay of each tipPoint is sampled from @msgDelayInterval@.
     --
     generatePerTipPointTimes
-      :: Maybe DiffTime
-      -> (DiffTime, Int)
-      -> (DiffTime, Int)
-      -> m ((DiffTime, Int), [(DiffTime, Int)])
+      :: Maybe Time
+      -> (Time, Int)
+      -> (Time, Int)
+      -> m ((Time, Int), [(Time, Int)])
     generatePerTipPointTimes mtMax (tNext0, nextHp0) (tTip, tp) = do
        t <- uniformRMDiffTime msgDelayInterval g
-       go (max tNext0 (tTip + t)) nextHp0 []
+       go (max tNext0 (addTime t tTip)) nextHp0 []
       where
-        go :: DiffTime -> Int -> [(DiffTime, Int)] -> m ((DiffTime, Int), [(DiffTime, Int)])
+        go :: Time -> Int -> [(Time, Int)] -> m ((Time, Int), [(Time, Int)])
         go tNext nextHp acc = do
           if maybe False (tNext >) mtMax || nextHp > tp then
             pure ((tNext, nextHp), reverse acc)
           else do
-            t <- (+tNext) <$> uniformRMDiffTime msgDelayInterval g
+            t <- (`addTime` tNext) <$> uniformRMDiffTime msgDelayInterval g
             go t (nextHp+1) ((tNext, nextHp) : acc)
 
 mapAccumM :: Monad m => (s -> x -> m (s, y)) -> s -> [x] -> m (s, [y])

--- a/ouroboros-consensus/bench/ChainSync-client-bench/Main.hs
+++ b/ouroboros-consensus/bench/ChainSync-client-bench/Main.hs
@@ -137,6 +137,9 @@ oneBenchRun
               , CSClient.varCandidate
               , CSClient.startIdling = pure ()
               , CSClient.stopIdling  = pure ()
+              , CSClient.pauseLoPBucket = pure ()
+              , CSClient.resumeLoPBucket = pure ()
+              , CSClient.grantLoPToken = pure ()
               }
 
     server :: ChainSyncServer H (Point B) (Tip B) IO ()

--- a/ouroboros-consensus/bench/ChainSync-client-bench/Main.hs
+++ b/ouroboros-consensus/bench/ChainSync-client-bench/Main.hs
@@ -235,7 +235,7 @@ topConfig = TopLevelConfig {
                        , (CoreId (CoreNodeId 1), VerKeyMockDSIGN 1)
                        ]
       }
-  , topLevelConfigLedger      = eraParams
+  , topLevelConfigLedger      = TB.testBlockLedgerConfigFrom eraParams
   , topLevelConfigBlock       = TB.TestBlockConfig numCoreNodes
   , topLevelConfigCodec       = TB.TestBlockCodecConfig
   , topLevelConfigStorage     = TB.TestBlockStorageConfig

--- a/ouroboros-consensus/bench/mempool-bench/Bench/Consensus/Mempool/TestBlock.hs
+++ b/ouroboros-consensus/bench/mempool-bench/Bench/Consensus/Mempool/TestBlock.hs
@@ -40,7 +40,8 @@ import qualified Ouroboros.Consensus.Mempool as Mempool
 import           Test.Util.TestBlock (LedgerState (TestLedger),
                      PayloadSemantics (PayloadDependentError, PayloadDependentState, applyPayload),
                      TestBlockWith, applyDirectlyToPayloadDependentState,
-                     lastAppliedPoint, payloadDependentState)
+                     lastAppliedPoint, payloadDependentState,
+                     testBlockLedgerConfigFrom)
 
 {-------------------------------------------------------------------------------
   MempoolTestBlock
@@ -72,7 +73,7 @@ initialLedgerState = TestLedger {
     }
 
 sampleLedgerConfig :: Ledger.LedgerConfig TestBlock
-sampleLedgerConfig =
+sampleLedgerConfig = testBlockLedgerConfigFrom $
   HardFork.defaultEraParams (Consensus.SecurityParam 10) (Time.slotLengthFromSec 2)
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus/changelog.d/20240325_142132_niols_milestone_7_9_10_squashed.md
+++ b/ouroboros-consensus/changelog.d/20240325_142132_niols_milestone_7_9_10_squashed.md
@@ -1,0 +1,3 @@
+### Breaking
+
+- LoP: run the ChainSync client against a leaky bucket

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -239,6 +239,7 @@ library
     Ouroboros.Consensus.Util.FileLock
     Ouroboros.Consensus.Util.HList
     Ouroboros.Consensus.Util.IOLike
+    Ouroboros.Consensus.Util.LeakyBucket
     Ouroboros.Consensus.Util.MonadSTM.NormalForm
     Ouroboros.Consensus.Util.MonadSTM.RAWLock
     Ouroboros.Consensus.Util.MonadSTM.StrictSVar
@@ -560,18 +561,21 @@ test-suite infra-test
     Test.Ouroboros.Consensus.ChainGenerator.Tests.BitVector
     Test.Ouroboros.Consensus.ChainGenerator.Tests.Counting
     Test.Ouroboros.Consensus.ChainGenerator.Tests.Honest
+    Test.Ouroboros.Consensus.Util.LeakyBucket.Tests
     Test.Util.ChainUpdates.Tests
     Test.Util.Schedule.Tests
     Test.Util.Split.Tests
 
   build-depends:
     , base
+    , io-sim
     , mtl
     , ouroboros-consensus:{ouroboros-consensus, unstable-consensus-testlib}
     , QuickCheck
     , random
     , tasty
     , tasty-quickcheck
+    , time
     , unstable-consensus-testlib
     , vector
 

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Genesis/Governor.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Genesis/Governor.hs
@@ -18,8 +18,6 @@ import           Control.Monad.Except ()
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           Ouroboros.Consensus.Block.Abstract (GetHeader, Header)
-import           Ouroboros.Consensus.Config.SecurityParam
-                     (SecurityParam (SecurityParam))
 import           Ouroboros.Consensus.Storage.ChainDB.API
                      (UpdateLoEFrag (UpdateLoEFrag))
 import           Ouroboros.Consensus.Util.AnchoredFragment (stripCommonPrefix)

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Genesis/Governor.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Genesis/Governor.hs
@@ -34,30 +34,23 @@ updateLoEFragUnconditional ::
   MonadSTM m =>
   UpdateLoEFrag m blk
 updateLoEFragUnconditional =
-  UpdateLoEFrag $ \ curChain _ setLoEFrag -> atomically (setLoEFrag curChain)
+  UpdateLoEFrag $ \ curChain _ -> pure curChain
 
--- | Compute the fragment between the immutable tip, as given by the anchor
--- of @curChain@, and the earliest intersection of the @candidates@.
--- This excludes the selection from the set of intersected fragments since we
--- need to be able to select k+1 blocks on a new chain when a fork's peer is
--- killed on which we had selected k blocks, where the selection would
--- otherwise keep the LoE fragment at the killed peer's intersection.
+-- | Compute the fragment @loeFrag@ between the immutable tip and the
+-- earliest intersection between @curChain@ and any of the @candidates@.
+--
+-- The immutable tip is the anchor of @curChain@.
+--
+-- The function also yields the suffixes of the intersection of @loeFrag@ with
+-- every candidate fragment.
 sharedCandidatePrefix ::
   GetHeader blk =>
-  SecurityParam ->
   AnchoredFragment (Header blk) ->
   Map peer (AnchoredFragment (Header blk)) ->
-  AnchoredFragment (Header blk)
-sharedCandidatePrefix (SecurityParam k) curChain candidates =
-  trunc
+  (AnchoredFragment (Header blk), Map peer (AnchoredFragment (Header blk)))
+sharedCandidatePrefix curChain candidates =
+  stripCommonPrefix (AF.anchor curChain) immutableTipSuffixes
   where
-    trunc | excess > 0 = snd (AF.splitAt excess shared)
-          | otherwise = shared
-
-    excess = AF.length shared - fromIntegral k
-
-    shared = fst (stripCommonPrefix (AF.anchor curChain) immutableTipSuffixes)
-
     immutableTip = AF.anchorPoint curChain
 
     splitAfterImmutableTip frag =
@@ -84,11 +77,10 @@ sharedCandidatePrefix (SecurityParam k) curChain candidates =
 updateLoEFragStall ::
   MonadSTM m =>
   GetHeader blk =>
-  SecurityParam ->
   STM m (Map peer (AnchoredFragment (Header blk))) ->
   UpdateLoEFrag m blk
-updateLoEFragStall k getCandidates =
-  UpdateLoEFrag $ \ curChain _ setLoEFrag ->
+updateLoEFragStall getCandidates =
+  UpdateLoEFrag $ \ curChain _ ->
     atomically $ do
       candidates <- getCandidates
-      setLoEFrag (sharedCandidatePrefix k curChain candidates)
+      pure (fst (sharedCandidatePrefix curChain candidates))

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Genesis/Governor.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Genesis/Governor.hs
@@ -10,7 +10,8 @@
 {-# LANGUAGE UndecidableInstances #-}
 
 module Ouroboros.Consensus.Genesis.Governor (
-    updateLoEFragStall
+    reprocessLoEBlocksOnCandidateChange
+  , updateLoEFragStall
   , updateLoEFragUnconditional
   ) where
 
@@ -19,10 +20,10 @@ import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           Ouroboros.Consensus.Block.Abstract (GetHeader, Header)
 import           Ouroboros.Consensus.Storage.ChainDB.API
-                     (UpdateLoEFrag (UpdateLoEFrag))
 import           Ouroboros.Consensus.Util.AnchoredFragment (stripCommonPrefix)
 import           Ouroboros.Consensus.Util.MonadSTM.NormalForm
                      (MonadSTM (STM, atomically))
+import           Ouroboros.Consensus.Util.STM (blockUntilChanged)
 import           Ouroboros.Network.AnchoredFragment (AnchoredFragment)
 import qualified Ouroboros.Network.AnchoredFragment as AF
 
@@ -82,3 +83,20 @@ updateLoEFragStall getCandidates =
     atomically $ do
       candidates <- getCandidates
       pure (fst (sharedCandidatePrefix curChain candidates))
+
+-- | Background task that wakes up whenever a candidate fragment changes and
+-- triggers ChainSel for any block that has been postponed because of the LoE.
+reprocessLoEBlocksOnCandidateChange ::
+  Ord peer =>
+  MonadSTM m =>
+  GetHeader blk =>
+  ChainDB m blk ->
+  STM m (Map peer (AnchoredFragment (Header blk))) ->
+  m ()
+reprocessLoEBlocksOnCandidateChange chainDb getCandidates =
+  spin mempty
+  where
+    spin prev =
+      atomically (blockUntilChanged (Map.map AF.headPoint) prev getCandidates) >>= \ (_, newTips) -> do
+        reprocessLoEAsync chainDb
+        spin newTips

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/API.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/API.hs
@@ -140,6 +140,9 @@ data ChainDB m blk = ChainDB {
       -- NOTE: back pressure can be applied when overloaded.
       addBlockAsync      :: InvalidBlockPunishment m -> blk -> m (AddBlockPromise m blk)
 
+      -- | Trigger reprocessing of blocks postponed by the LoE.
+    , reprocessLoEAsync  :: m ()
+
       -- | Get the current chain fragment
       --
       -- Suppose the current chain is

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl.hs
@@ -157,7 +157,7 @@ openDBInternal args launchBgTasks = runWithTempRegistry $ do
                           varFutureBlocks
                           (Args.cdbCheckInFuture args)
                           (Args.cdbLoE args)
-      traceWith initChainSelTracer InitalChainSelected
+      traceWith initChainSelTracer InitialChainSelected
 
       let chain  = VF.validatedFragment chainAndLedger
           ledger = VF.validatedLedger   chainAndLedger
@@ -174,7 +174,7 @@ openDBInternal args launchBgTasks = runWithTempRegistry $ do
       varKillBgThreads   <- newTVarIO $ return ()
       copyFuse           <- newFuse "copy to immutable db"
       chainSelFuse       <- newFuse "chain selection"
-      blocksToAdd        <- newBlocksToAdd (Args.cdbBlocksToAddSize args)
+      chainSelQueue      <- newChainSelQueue (Args.cdbBlocksToAddSize args)
 
       let env = CDB { cdbImmutableDB     = immutableDB
                     , cdbVolatileDB      = volatileDB
@@ -199,13 +199,14 @@ openDBInternal args launchBgTasks = runWithTempRegistry $ do
                     , cdbChunkInfo       = Args.cdbChunkInfo args
                     , cdbCheckIntegrity  = Args.cdbCheckIntegrity args
                     , cdbCheckInFuture   = Args.cdbCheckInFuture args
-                    , cdbBlocksToAdd     = blocksToAdd
+                    , cdbChainSelQueue   = chainSelQueue
                     , cdbFutureBlocks    = varFutureBlocks
                     , cdbLoE             = Args.cdbLoE args
                     }
       h <- fmap CDBHandle $ newTVarIO $ ChainDbOpen env
       let chainDB = API.ChainDB
             { addBlockAsync         = getEnv2    h ChainSel.addBlockAsync
+            , reprocessLoEAsync     = getEnv     h ChainSel.reprocessLoEAsync
             , getCurrentChain       = getEnvSTM  h Query.getCurrentChain
             , getLedgerDB           = getEnvSTM  h Query.getLedgerDB
             , getTipBlock           = getEnv     h Query.getTipBlock

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl.hs
@@ -175,7 +175,6 @@ openDBInternal args launchBgTasks = runWithTempRegistry $ do
       copyFuse           <- newFuse "copy to immutable db"
       chainSelFuse       <- newFuse "chain selection"
       blocksToAdd        <- newBlocksToAdd (Args.cdbBlocksToAddSize args)
-      varLoEFrag         <- newTVarIO (AF.Empty AF.AnchorGenesis)
 
       let env = CDB { cdbImmutableDB     = immutableDB
                     , cdbVolatileDB      = volatileDB
@@ -202,7 +201,6 @@ openDBInternal args launchBgTasks = runWithTempRegistry $ do
                     , cdbCheckInFuture   = Args.cdbCheckInFuture args
                     , cdbBlocksToAdd     = blocksToAdd
                     , cdbFutureBlocks    = varFutureBlocks
-                    , cdbLoEFrag         = varLoEFrag
                     , cdbLoE             = Args.cdbLoE args
                     }
       h <- fmap CDBHandle $ newTVarIO $ ChainDbOpen env
@@ -220,7 +218,6 @@ openDBInternal args launchBgTasks = runWithTempRegistry $ do
             , stream                = Iterator.stream  h
             , newFollower           = Follower.newFollower h
             , getIsInvalidBlock     = getEnvSTM  h Query.getIsInvalidBlock
-            , setLoEFrag            = writeTVar varLoEFrag
             , closeDB               = closeDB h
             , isOpen                = isOpen  h
             }

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/ChainSel.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/ChainSel.hs
@@ -37,7 +37,6 @@ import           Data.Maybe.Strict (StrictMaybe (..), isSNothing,
                      strictMaybeToMaybe)
 import           Data.Set (Set)
 import qualified Data.Set as Set
-import           Data.Word (Word64)
 import           GHC.Stack (HasCallStack)
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config
@@ -58,7 +57,8 @@ import           Ouroboros.Consensus.Ledger.Inspect
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
 import           Ouroboros.Consensus.Storage.ChainDB.API (AddBlockPromise (..),
                      AddBlockResult (..), BlockComponent (..), ChainType (..),
-                     InvalidBlockReason (..), LoE (..), processLoE)
+                     InvalidBlockReason (..), LoE (..), LoELimit (..),
+                     processLoE)
 import           Ouroboros.Consensus.Storage.ChainDB.API.Types.InvalidBlockPunishment
                      (InvalidBlockPunishment)
 import qualified Ouroboros.Consensus.Storage.ChainDB.API.Types.InvalidBlockPunishment as InvalidBlockPunishment
@@ -107,7 +107,7 @@ initialChainSelection ::
   -> LoE m blk
   -> m (ChainAndLedger blk)
 initialChainSelection immutableDB volatileDB lgrDB tracer cfg varInvalid
-                      varFutureBlocks futureCheck loELimit = do
+                      varFutureBlocks futureCheck loE = do
     -- We follow the steps from section "## Initialization" in ChainDB.md
 
     (i :: Anchor blk, succsOf, ledger) <- atomically $ do
@@ -171,9 +171,9 @@ initialChainSelection immutableDB volatileDB lgrDB tracer cfg varInvalid
         suffixesAfterI :: [NonEmpty (HeaderHash blk)]
         suffixesAfterI = Paths.maximalCandidates succsOf limit (AF.anchorToPoint i)
           where
-            limit = case loELimit of
-              LoEEnabled _ -> k
-              LoEDisabled  -> maxBound
+            limit = case loE of
+              LoEEnabled _ -> LoELimit k
+              LoEDisabled  -> LoEUnlimited
 
         constructChain ::
              NonEmpty (HeaderHash blk)
@@ -465,31 +465,22 @@ chainSelectionForBlock ::
   -> InvalidBlockPunishment m
   -> Electric m (Point blk)
 chainSelectionForBlock cdb@CDB{..} blockCache hdr punish = electric $ do
-    (invalid, succsOf', lookupBlockInfo, lookupBlockInfo', curChain, tipPoint, ledgerDB, loeFrag)
+    (invalid, succsOf', lookupBlockInfo, lookupBlockInfo', curChain, tipPoint, ledgerDB)
       <- atomically $ do
-          (invalid, succsOf, lookupBlockInfo, curChain, tipPoint, ledgerDB, loeFrag) <-
-                (,,,,,,)
+          (invalid, succsOf, lookupBlockInfo, curChain, tipPoint, ledgerDB) <-
+                (,,,,,)
             <$> (forgetFingerprint <$> readTVar cdbInvalid)
             <*> VolatileDB.filterByPredecessor  cdbVolatileDB
             <*> VolatileDB.getBlockInfo         cdbVolatileDB
             <*> Query.getCurrentChain           cdb
             <*> Query.getTipPoint               cdb
             <*> LgrDB.getCurrent                cdbLgrDB
-            <*> readTVar                        cdbLoEFrag
 
           -- Let these two functions ignore invalid blocks
           let lookupBlockInfo' = ignoreInvalid    cdb invalid lookupBlockInfo
               succsOf'         = ignoreInvalidSuc cdb invalid succsOf
 
-              loeFrag' = case cross curChain loeFrag of
-                Just (_, frag) -> frag
-                -- We don't crash if the LoE fragment doesn't intersect with the selection
-                -- because we update the selection _after_ updating the LoE fragment, which
-                -- means it could move to another fork or beyond the end of the LF, depending
-                -- on the implementation of @updateLoEFrag@.
-                Nothing        -> AF.Empty (AF.anchor curChain)
-
-          pure (invalid, succsOf', lookupBlockInfo, lookupBlockInfo', curChain, tipPoint, ledgerDB, loeFrag')
+          pure (invalid, succsOf', lookupBlockInfo, lookupBlockInfo', curChain, tipPoint, ledgerDB)
 
     let curChainAndLedger :: ChainAndLedger blk
         curChainAndLedger =
@@ -505,7 +496,17 @@ chainSelectionForBlock cdb@CDB{..} blockCache hdr punish = electric $ do
     -- The preconditions
     assert (isJust $ lookupBlockInfo (headerHash hdr)) $ return ()
 
-    processLoE curChain (LgrDB.ledgerDbCurrent ledgerDB) (writeTVar cdbLoEFrag) cdbLoE
+    loeFrag0 <- processLoE curChain (LgrDB.ledgerDbCurrent ledgerDB) cdbLoE
+
+    let loeFrag = case cross curChain loeFrag0 of
+          Just (_, frag) -> frag
+          -- We don't crash if the LoE fragment doesn't intersect with the selection
+          -- because we update the selection _after_ updating the LoE fragment, which
+          -- means it could move to another fork or beyond the end of the LF, depending
+          -- on the implementation of @processLoE@.
+          Nothing        -> AF.Empty (AF.anchor curChain)
+
+    traceWith addBlockTracer (ChainSelectionLoEDebug curChain loeFrag0)
 
     if
       -- The chain might have grown since we added the block such that the
@@ -530,21 +531,24 @@ chainSelectionForBlock cdb@CDB{..} blockCache hdr punish = electric $ do
       | pointHash tipPoint == headerPrevHash hdr
         -- TODO could be optimized if necessary/easy enough
       , let newBlockFrag = curChain AF.:> hdr
-      , Just maxExtra <- computeLoEMaxExtra loELimit loeFrag newBlockFrag -> do
+      , Just maxExtra <- computeLoEMaxExtra cdbLoE loeFrag newBlockFrag -> do
         -- ### Add to current chain
         traceWith addBlockTracer (TryAddToCurrentChain p)
         addToCurrentChain succsOf' curChainAndLedger maxExtra
 
+      -- The block is reachable from the current selection
+      -- and it doesn't fit after the current selection
       | Just diff <- Paths.isReachable lookupBlockInfo' curChain p
         -- TODO could be optimized if necessary/easy enough
       , let curChain' =
               AF.mapAnchoredFragment (castHeaderFields . getHeaderFields) curChain
       , Just newBlockFrag <- Diff.apply curChain' diff
-      , Just maxExtra <- computeLoEMaxExtra loELimit loeFrag newBlockFrag -> do
+      , Just maxExtra <- computeLoEMaxExtra cdbLoE loeFrag newBlockFrag -> do
         -- ### Switch to a fork
         traceWith addBlockTracer (TrySwitchToAFork p diff)
         switchToAFork succsOf' lookupBlockInfo' curChainAndLedger maxExtra diff
 
+      -- We cannot reach the block from the current selection
       | otherwise -> do
         -- ### Store but don't change the current chain
         traceWith addBlockTracer (StoreButDontChange p)
@@ -555,10 +559,6 @@ chainSelectionForBlock cdb@CDB{..} blockCache hdr punish = electric $ do
     -- will first copy the blocks/headers to trim (from the end of the
     -- fragment) from the VolatileDB to the ImmutableDB.
   where
-    loELimit = case cdbLoE of
-      LoEEnabled _ -> k
-      LoEDisabled  -> maxBound
-
     SecurityParam k = configSecurityParam cdbTopLevelConfig
 
     p :: RealPoint blk
@@ -598,7 +598,7 @@ chainSelectionForBlock cdb@CDB{..} blockCache hdr punish = electric $ do
       => (ChainHash blk -> Set (HeaderHash blk))
       -> ChainAndLedger blk
          -- ^ The current chain and ledger
-      -> Word64
+      -> LoELimit
          -- ^ How many extra blocks to select after @b@ at most.
       -> m (Point blk)
     addToCurrentChain succsOf curChainAndLedger maxExtra = do
@@ -668,7 +668,7 @@ chainSelectionForBlock cdb@CDB{..} blockCache hdr punish = electric $ do
       -> LookupBlockInfo blk
       -> ChainAndLedger blk
          -- ^ The current chain (anchored at @i@) and ledger
-      -> Word64
+      -> LoELimit
          -- ^ How many extra blocks to select after @b@ at most.
       -> ChainDiff (HeaderFields blk)
          -- ^ Header fields for @(x,b]@
@@ -718,12 +718,22 @@ chainSelectionForBlock cdb@CDB{..} blockCache hdr punish = electric $ do
         curChain    = VF.validatedFragment curChainAndLedger
         curTip      = castPoint $ AF.headPoint curChain
 
-    -- | How many extra blocks to select at most after the block @b@ that is
-    -- currently being processed, according to the LoE. If not even @b@ is
-    -- allowed to be selected, return 'Nothing'.
+    -- | How many extra blocks to select at most after the tip of @newBlockFrag@
+    -- according to the LoE.
+    --
+    -- There are two cases to consider:
+    --
+    -- 1. If @newBlockFrag@ and @loeFrag@ are on the same chain, then we cannot
+    --    select more than @loeLimit@ blocks after @loeFrag@.
+    --
+    -- 2. If @newBlockFrag@ and @loeFrag@ are on different chains, then we
+    --   cannot select more than @loeLimit@ blocks after their intersection.
+    --
+    -- In any case, 'Nothing' is returned if @newBlockFrag@ extends beyond
+    -- what LoE allows.
     computeLoEMaxExtra ::
          (HasHeader x, HeaderHash x ~ HeaderHash blk)
-      => Word64
+      => LoE m blk
          -- ^ How many blocks can be selected beyond the LoE.
       -> AnchoredFragment (Header blk)
          -- ^ The fragment with the LoE as its tip, with the same anchor as
@@ -731,13 +741,23 @@ chainSelectionForBlock cdb@CDB{..} blockCache hdr punish = electric $ do
       -> AnchoredFragment x
          -- ^ The fragment with the new block @b@ as its tip, with the same
          -- anchor as @curChain@.
-      -> Maybe Word64
-    computeLoEMaxExtra loeLimit loeFrag newBlockFrag
-      | budgetAlreadyUsed > loeLimit = Nothing
-      | otherwise                    = Just $ loeLimit - budgetAlreadyUsed
+      -> Maybe LoELimit
+    computeLoEMaxExtra (LoEEnabled _) loeFrag newBlockFrag =
+        -- Both fragments are on the same chain
+        if loeSuffixLength == 0 || rollback == 0 then
+          if rollback > k + loeSuffixLength
+            then Nothing
+            else Just $ LoELimit $ k + loeSuffixLength - rollback
+        else
+          if rollback > k
+            then Nothing
+            else Just $ LoELimit $ k - rollback
       where
-        -- How many blocks did we already select beyond the LoE, including @b@.
-        budgetAlreadyUsed = Diff.getRollback $ Diff.diff newBlockFrag loeFrag
+        d = Diff.diff newBlockFrag loeFrag
+        rollback = Diff.getRollback d
+        loeSuffixLength = fromIntegral $ AF.length (Diff.getSuffix d)
+    computeLoEMaxExtra LoEDisabled _ _ =
+      Just LoEUnlimited
 
     mkSelectionChangedInfo ::
          AnchoredFragment (Header blk) -- ^ old chain

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Types.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Types.hs
@@ -268,14 +268,12 @@ data ChainDbEnv m blk = CDB
     -- The number of blocks from the future is bounded by the number of
     -- upstream peers multiplied by the max clock skew divided by the slot
     -- length.
-  , cdbLoEFrag         :: !(StrictTVar m (AnchoredFragment (Header blk)))
+  , cdbLoE             :: LoE m blk
     -- ^ Fragment whose tip indicates the Limit on Eagerness, i.e. we are not
     -- allowed to select a chain from which we could not switch back to a chain
     -- containing it. The fragment is usually anchored at a recent immutable
     -- tip; if it does not, it will conservatively be treated as the empty
     -- fragment anchored in the current immutable tip.
-  , cdbLoE             :: LoE m blk
-    -- ^ See 'Args.cdbLoELimit'.
   } deriving (Generic)
 
 -- | We include @blk@ in 'showTypeOf' because it helps resolving type families
@@ -648,6 +646,9 @@ data TraceAddBlockEvent blk =
     -- | The block doesn't fit onto any other block, so we store it and ignore
     -- it.
   | StoreButDontChange (RealPoint blk)
+
+    -- | Debugging information about chain selection and LoE
+  | ChainSelectionLoEDebug (AnchoredFragment (Header blk)) (AnchoredFragment (Header blk))
 
     -- | The new block fits onto the current chain (first
     -- fragment) and we have successfully used it to extend our (new) current

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Types.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Types.hs
@@ -42,11 +42,13 @@ module Ouroboros.Consensus.Storage.ChainDB.Impl.Types (
   , FutureBlocks
     -- * Blocks to add
   , BlockToAdd (..)
-  , BlocksToAdd
+  , ChainSelMessage (..)
+  , ChainSelQueue
   , addBlockToAdd
-  , closeBlocksToAdd
-  , getBlockToAdd
-  , newBlocksToAdd
+  , addReprocessLoEBlocks
+  , closeChainSelQueue
+  , getChainSelMessage
+  , newChainSelQueue
     -- * Trace types
   , SelectionChangedInfo (..)
   , TraceAddBlockEvent (..)
@@ -64,6 +66,7 @@ module Ouroboros.Consensus.Storage.ChainDB.Impl.Types (
 import           Control.Tracer
 import           Data.Foldable (traverse_)
 import           Data.Map.Strict (Map)
+import           Data.Maybe (mapMaybe)
 import           Data.Maybe.Strict (StrictMaybe (..))
 import           Data.Set (Set)
 import           Data.Typeable
@@ -248,7 +251,7 @@ data ChainDbEnv m blk = CDB
   , cdbChunkInfo       :: !ImmutableDB.ChunkInfo
   , cdbCheckIntegrity  :: !(blk -> Bool)
   , cdbCheckInFuture   :: !(CheckInFuture m blk)
-  , cdbBlocksToAdd     :: !(BlocksToAdd m blk)
+  , cdbChainSelQueue   :: !(ChainSelQueue m blk)
     -- ^ Queue of blocks that still have to be added.
   , cdbFutureBlocks    :: !(StrictTVar m (FutureBlocks m blk))
     -- ^ Blocks from the future
@@ -269,11 +272,12 @@ data ChainDbEnv m blk = CDB
     -- upstream peers multiplied by the max clock skew divided by the slot
     -- length.
   , cdbLoE             :: LoE m blk
-    -- ^ Fragment whose tip indicates the Limit on Eagerness, i.e. we are not
-    -- allowed to select a chain from which we could not switch back to a chain
-    -- containing it. The fragment is usually anchored at a recent immutable
-    -- tip; if it does not, it will conservatively be treated as the empty
-    -- fragment anchored in the current immutable tip.
+    -- ^ Configure the Limit on Eagerness. If this is 'LoEEnabled', it contains
+    -- a hook that returns the LoE fragment, which indicates the latest rollback
+    -- point, i.e. we are not allowed to select a chain from which we could not
+    -- switch back to a chain containing it. The fragment is usually anchored at
+    -- a recent immutable tip; if it does not, it will conservatively be treated
+    -- as the empty fragment anchored in the current immutable tip.
   } deriving (Generic)
 
 -- | We include @blk@ in 'showTypeOf' because it helps resolving type families
@@ -441,10 +445,10 @@ type FutureBlocks m blk = Map (HeaderHash blk) (Header blk, InvalidBlockPunishme
 -- | FIFO queue used to add blocks asynchronously to the ChainDB. Blocks are
 -- read from this queue by a background thread, which processes the blocks
 -- synchronously.
-newtype BlocksToAdd m blk = BlocksToAdd (TBQueue m (BlockToAdd m blk))
-  deriving NoThunks via OnlyCheckWhnfNamed "BlocksToAdd" (BlocksToAdd m blk)
+newtype ChainSelQueue m blk = ChainSelQueue (TBQueue m (ChainSelMessage m blk))
+  deriving NoThunks via OnlyCheckWhnfNamed "ChainSelQueue" (ChainSelQueue m blk)
 
--- | Entry in the 'BlocksToAdd' queue: a block together with the 'TMVar's used
+-- | Entry in the 'ChainSelQueue' queue: a block together with the 'TMVar's used
 -- to implement 'AddBlockPromise'.
 data BlockToAdd m blk = BlockToAdd
   { blockPunish           :: !(InvalidBlockPunishment m)
@@ -457,20 +461,27 @@ data BlockToAdd m blk = BlockToAdd
     -- ^ Used for the 'blockProcessed' field of 'AddBlockPromise'.
   }
 
--- | Create a new 'BlocksToAdd' with the given size.
-newBlocksToAdd :: IOLike m => Word -> m (BlocksToAdd m blk)
-newBlocksToAdd queueSize = BlocksToAdd <$>
+-- | Different async tasks for triggering ChainSel
+data ChainSelMessage m blk
+  -- | Add a new block
+  = ChainSelAddBlock !(BlockToAdd m blk)
+  -- | Reprocess blocks that have been postponed by the LoE
+  | ChainSelReprocessLoEBlocks
+
+-- | Create a new 'ChainSelQueue' with the given size.
+newChainSelQueue :: IOLike m => Word -> m (ChainSelQueue m blk)
+newChainSelQueue queueSize = ChainSelQueue <$>
     atomically (newTBQueue (fromIntegral queueSize))
 
--- | Add a block to the 'BlocksToAdd' queue. Can block when the queue is full.
+-- | Add a block to the 'ChainSelQueue' queue. Can block when the queue is full.
 addBlockToAdd ::
      (IOLike m, HasHeader blk)
   => Tracer m (TraceAddBlockEvent blk)
-  -> BlocksToAdd m blk
+  -> ChainSelQueue m blk
   -> InvalidBlockPunishment m
   -> blk
   -> m (AddBlockPromise m blk)
-addBlockToAdd tracer (BlocksToAdd queue) punish blk = do
+addBlockToAdd tracer (ChainSelQueue queue) punish blk = do
     varBlockWrittenToDisk <- newEmptyTMVarIO
     varBlockProcessed     <- newEmptyTMVarIO
     let !toAdd = BlockToAdd
@@ -481,7 +492,7 @@ addBlockToAdd tracer (BlocksToAdd queue) punish blk = do
           }
     traceWith tracer $ AddedBlockToQueue (blockRealPoint blk) RisingEdge
     queueSize <- atomically $ do
-      writeTBQueue  queue toAdd
+      writeTBQueue  queue (ChainSelAddBlock toAdd)
       lengthTBQueue queue
     traceWith tracer $
       AddedBlockToQueue (blockRealPoint blk) (FallingEdgeWith (fromIntegral queueSize))
@@ -490,19 +501,34 @@ addBlockToAdd tracer (BlocksToAdd queue) punish blk = do
       , blockProcessed          = readTMVar varBlockProcessed
       }
 
--- | Get the oldest block from the 'BlocksToAdd' queue. Can block when the
--- queue is empty.
-getBlockToAdd :: IOLike m => BlocksToAdd m blk -> m (BlockToAdd m blk)
-getBlockToAdd (BlocksToAdd queue) = atomically $ readTBQueue queue
+-- | Try to add blocks again that were postponed due to the LoE.
+addReprocessLoEBlocks
+  :: IOLike m
+  => Tracer m (TraceAddBlockEvent blk)
+  -> ChainSelQueue m blk
+  -> m ()
+addReprocessLoEBlocks tracer (ChainSelQueue queue) = do
+  traceWith tracer $ AddedReprocessLoEBlocksToQueue
+  atomically $ writeTBQueue queue ChainSelReprocessLoEBlocks
 
--- | Flush the 'BlocksToAdd' queue and notify the waiting threads.
+-- | Get the oldest message from the 'ChainSelQueue' queue. Can block when the
+-- queue is empty.
+getChainSelMessage :: IOLike m => ChainSelQueue m blk -> m (ChainSelMessage m blk)
+getChainSelMessage (ChainSelQueue queue) = atomically $ readTBQueue queue
+
+-- | Flush the 'ChainSelQueue' queue and notify the waiting threads.
 --
-closeBlocksToAdd :: IOLike m => BlocksToAdd m blk -> STM m ()
-closeBlocksToAdd (BlocksToAdd queue) = do
-  as <- flushTBQueue queue
+closeChainSelQueue :: IOLike m => ChainSelQueue m blk -> STM m ()
+closeChainSelQueue (ChainSelQueue queue) = do
+  as <- mapMaybe blockAdd <$> flushTBQueue queue
   traverse_ (\a -> tryPutTMVar (varBlockProcessed a)
                               (FailedToAddBlock "Queue flushed"))
             as
+  where
+    blockAdd = \case
+      ChainSelAddBlock ab -> Just ab
+      ChainSelReprocessLoEBlocks -> Nothing
+
 
 {-------------------------------------------------------------------------------
   Trace types
@@ -628,6 +654,13 @@ data TraceAddBlockEvent blk =
     -- ChainDB.
   | PoppedBlockFromQueue (Enclosing' (RealPoint blk))
 
+    -- | A message was added to the queue that requests that ChainSel reprocess
+    -- blocks that were postponed by the LoE.
+  | AddedReprocessLoEBlocksToQueue
+
+    -- | ChainSel will reprocess blocks that were postponed by the LoE.
+  | PoppedReprocessLoEBlocksFromQueue
+
     -- | The block is from the future, i.e., its slot number is greater than
     -- the current slot (the second argument).
   | BlockInTheFuture (RealPoint blk) SlotNo
@@ -749,7 +782,7 @@ data TraceInitChainSelEvent blk =
     StartedInitChainSelection
     -- ^ An event traced when inital chain selection has started during the
     -- initialization of ChainDB
-  | InitalChainSelected
+  | InitialChainSelected
     -- ^ An event traced when inital chain has been selected
   | InitChainSelValidation (TraceValidationEvent blk)
     -- ^ An event traced during validation performed while performing initial

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Util/LeakyBucket.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Util/LeakyBucket.hs
@@ -50,13 +50,13 @@ import           Prelude hiding (init)
 -- | Configuration of a leaky bucket.
 data Config m = Config
   { -- | Initial and maximal capacity of the bucket, in number of tokens.
-    capacity       :: Rational,
+    capacity       :: !Rational,
     -- | Tokens per second leaking off the bucket.
-    rate           :: Rational,
+    rate           :: !Rational,
     -- | Whether to fill to capacity on overflow or to do nothing.
-    fillOnOverflow :: Bool,
+    fillOnOverflow :: !Bool,
     -- | A monadic action to trigger when the bucket is empty.
-    onEmpty        :: m ()
+    onEmpty        :: !(m ())
   }
 
 -- | A configuration for a bucket that does nothing.
@@ -71,10 +71,10 @@ dummyConfig =
 
 -- | State of a leaky bucket, giving the level and the associated time.
 data State cfg = State
-  { level  :: Rational,
-    time   :: Time,
-    paused :: Bool,
-    config :: cfg
+  { level  :: !Rational,
+    time   :: !Time,
+    paused :: !Bool,
+    config :: !cfg
   }
   deriving (Eq, Show)
 
@@ -90,13 +90,13 @@ data Handlers m = Handlers
   { -- | Refill the bucket by the given amount and returns whether the bucket
     -- overflew. The bucket may silently get filled to full capacity or not get
     -- filled depending on 'fillOnOverflow'.
-    fill         :: Rational -> m Overflew,
+    fill         :: !(Rational -> m Overflew),
     -- | Pause or resume the bucket. Pausing stops the bucket from leaking until
     -- it is resumed. It is still possible to fill it during that time. @setPaused
     -- True@ and @setPaused False@ are idempotent.
-    setPaused    :: Bool -> m (),
+    setPaused    :: !(Bool -> m ()),
     -- | Dynamically update the configuration of the bucket.
-    updateConfig :: (Config m -> Config m) -> m ()
+    updateConfig :: !((Config m -> Config m) -> m ())
   }
 
 -- | Create a bucket with the given configuration, then run the action against

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Util/LeakyBucket.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Util/LeakyBucket.hs
@@ -1,0 +1,246 @@
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE LambdaCase          #-}
+{-# LANGUAGE MultiWayIf          #-}
+{-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE NumericUnderscores  #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+-- | This module implements a “leaky bucket”. One defines a bucket with a
+-- capacity and a leaking rate; a race (in the sense of Async) starts against
+-- the bucket which leaks at the given rate. The user is provided with a
+-- function to refill the bucket by a certain amount. If the bucket ever goes
+-- empty, both threads are cancelled.
+--
+-- This can be used for instance to enforce a minimal rate of a peer: they race
+-- against the bucket and refill the bucket by a certain amount whenever they do
+-- a “good” action.
+--
+-- NOTE: Even though the imagery is the same, this is different from what is
+-- usually called a “token bucket” or “leaky bucket” in the litterature where it
+-- is mostly used for rate limiting.
+--
+-- REVIEW: Could be used as leaky bucket used for rate limiting algorithms. All
+-- the infrastructure is here (put 'onEmpty' to @pure ()@ and you're good to go)
+-- but it has not been tested with that purpose in mind.
+module Ouroboros.Consensus.Util.LeakyBucket (
+    Config (..)
+  , Handlers (..)
+  , State (..)
+  , diffTimeToSecondsRational
+  , dummyConfig
+  , evalAgainstBucket
+  , execAgainstBucket
+  , runAgainstBucket
+  , secondsRationalToDiffTime
+  ) where
+
+import           Data.Ratio ((%))
+import           Data.Time (DiffTime)
+import           Data.Time.Clock (diffTimeToPicoseconds)
+import           Ouroboros.Consensus.Util.IOLike
+                     (MonadAsync (Async, async, uninterruptibleCancel),
+                     MonadCatch (handle), MonadDelay (threadDelay),
+                     MonadFork (throwTo), MonadMask, MonadMonotonicTime,
+                     MonadSTM, MonadThread (ThreadId, myThreadId),
+                     MonadThrow (finally), SomeException, StrictTVar, Time,
+                     atomically, diffTime, getMonotonicTime, readTVar,
+                     readTVarIO, uncheckedNewTVarM, writeTVar)
+import           Prelude hiding (init)
+
+-- | Configuration of a leaky bucket.
+data Config m = Config
+  { -- | Initial and maximal capacity of the bucket, in number of tokens.
+    capacity       :: Rational,
+    -- | Tokens per second leaking off the bucket.
+    rate           :: Rational,
+    -- | Whether to fill to capacity on overflow or to do nothing.
+    fillOnOverflow :: Bool,
+    -- | A monadic action to trigger when the bucket is empty.
+    onEmpty        :: m ()
+  }
+
+-- | A configuration for a bucket that does nothing.
+dummyConfig :: (Applicative m) => Config m
+dummyConfig =
+  Config
+    { capacity = 0,
+      rate = 0,
+      fillOnOverflow = True,
+      onEmpty = pure ()
+    }
+
+-- | State of a leaky bucket, giving the level and the associated time.
+data State cfg = State
+  { level  :: Rational,
+    time   :: Time,
+    paused :: Bool,
+    config :: cfg
+  }
+  deriving (Eq, Show)
+
+-- | A bucket is simply a TVar of a state.
+type Bucket m = StrictTVar m (State (Config m))
+
+-- | Whether filling the bucket overflew.
+newtype Overflew = Overflew Bool
+
+-- | The handlers to a bucket: contains the API to interact with a running
+-- bucket.
+data Handlers m = Handlers
+  { -- | Refill the bucket by the given amount and returns whether the bucket
+    -- overflew. The bucket may silently get filled to full capacity or not get
+    -- filled depending on 'fillOnOverflow'.
+    fill         :: Rational -> m Overflew,
+    -- | Pause or resume the bucket. Pausing stops the bucket from leaking until
+    -- it is resumed. It is still possible to fill it during that time. @setPaused
+    -- True@ and @setPaused False@ are idempotent.
+    setPaused    :: Bool -> m (),
+    -- | Dynamically update the configuration of the bucket.
+    updateConfig :: (Config m -> Config m) -> m ()
+  }
+
+-- | Create a bucket with the given configuration, then run the action against
+-- that bucket. Returns when the action terminates or the bucket empties. In the
+-- first case, return the value returned by the action. In the second case,
+-- return @Nothing@.
+execAgainstBucket ::
+  (MonadDelay m, MonadAsync m, MonadFork m, MonadMask m) =>
+  Config m ->
+  (Handlers m -> m a) ->
+  m a
+execAgainstBucket config action = snd <$> runAgainstBucket config action
+
+-- | Same as 'execAgainstBucket' but returns the 'State' of the bucket when the
+-- action terminates. Exposed for testing purposes.
+evalAgainstBucket ::
+  (MonadDelay m, MonadAsync m, MonadFork m, MonadMask m) =>
+  Config m ->
+  (Handlers m -> m a) ->
+  m (State (Config m))
+evalAgainstBucket config action = fst <$> runAgainstBucket config action
+
+-- | Same as 'execAgainstBucket' but also returns the 'State' of the bucket when
+-- the action terminates. Exposed for testing purposes.
+runAgainstBucket ::
+  forall m a.
+  (MonadDelay m, MonadAsync m, MonadFork m, MonadMask m) =>
+  Config m ->
+  (Handlers m -> m a) ->
+  m (State (Config m), a)
+runAgainstBucket config action = do
+  bucket <- init config
+  tid <- myThreadId
+  thread <- uncheckedNewTVarM Nothing
+  startThread thread bucket tid
+  finally
+    ( do
+        result <-
+          action $
+            Handlers
+              { fill = (snd <$>) . snapshotFill bucket,
+                setPaused = setPaused bucket,
+                updateConfig = updateConfig thread bucket tid
+              }
+        state <- snapshot bucket
+        pure (state, result)
+    )
+    (stopThread thread)
+  where
+    startThread :: StrictTVar m (Maybe (Async m ())) -> Bucket m -> ThreadId m -> m ()
+    startThread thread bucket tid =
+      readTVarIO thread >>= \case
+        Just _ -> error "LeakyBucket: startThread called when a thread is already running"
+        Nothing -> (atomically . writeTVar thread) =<< leak bucket tid
+
+    stopThread :: StrictTVar m (Maybe (Async m ())) -> m ()
+    stopThread thread =
+      readTVarIO thread >>= \case
+        Just thread' -> uninterruptibleCancel thread'
+        Nothing -> pure ()
+
+    setPaused :: Bucket m -> Bool -> m ()
+    setPaused bucket paused = do
+      newState <- snapshot bucket
+      atomically $ writeTVar bucket newState {paused}
+
+    updateConfig :: StrictTVar m (Maybe (Async m ())) -> Bucket m -> ThreadId m -> (Config m -> Config m) -> m ()
+    updateConfig thread bucket tid = \f -> do
+      -- FIXME: All of that should be in one STM transaction.
+      State {level, time, paused, config = oldConfig} <- snapshot bucket
+      let newConfig@Config {capacity = newCapacity, rate = newRate} = f oldConfig
+          newLevel = min newCapacity level
+      if
+        | newRate <= 0 -> stopThread thread
+        | newRate > rate oldConfig -> stopThread thread >> startThread thread bucket tid
+        | otherwise -> pure ()
+      atomically $ writeTVar bucket State {level = newLevel, time, paused, config = newConfig}
+
+-- | Initialise a bucket given a configuration. The bucket starts full at the
+-- time where one calls 'init'.
+init :: (MonadMonotonicTime m, MonadSTM m) => Config m -> m (Bucket m)
+init config@Config {capacity} = do
+  time <- getMonotonicTime
+  uncheckedNewTVarM $ State {time, level = capacity, paused = False, config}
+
+-- | Monadic action that calls 'threadDelay' until the bucket is empty, then
+-- returns @()@. It receives the 'ThreadId' argument of the action's thread,
+-- which it uses to throw exceptions at it.
+leak :: (MonadDelay m, MonadCatch m, MonadFork m, MonadAsync m) => Bucket m -> ThreadId m -> m (Maybe (Async m ()))
+leak bucket actionThreadId = do
+  State {config = Config {rate}} <- snapshot bucket
+  if rate <= 0
+    then pure Nothing
+    else Just <$> async go
+  where
+    go = do
+      State {level, config = Config {rate, onEmpty}} <- snapshot bucket
+      let timeToWait = secondsRationalToDiffTime (level / rate)
+      -- NOTE: It is possible that @timeToWait == 0@ while @level > 0@ when @level@
+      -- is so tiny that @level / rate@ rounds down to 0 picoseconds. In that case,
+      -- it is safe to assume that it is just zero.
+      if level <= 0 || timeToWait == 0
+        then handle (\(e :: SomeException) -> throwTo actionThreadId e) onEmpty
+        else threadDelay timeToWait >> go
+
+-- | Take a snapshot of the bucket, that is compute its state at the current
+-- time.
+snapshot :: (MonadSTM m, MonadMonotonicTime m) => Bucket m -> m (State (Config m))
+snapshot bucket = fst <$> snapshotFill bucket 0
+
+-- | Same as 'snapshot' but also adds the given quantity to the resulting
+-- level and returns whether this action overflew the bucket.
+--
+-- REVIEW: What to do when 'toAdd' is negative?
+--
+-- REVIEW: Really, this should all be an STM transaction. Now there is the risk
+-- that two snapshot-taking transactions interleave with the time measurement to
+-- get a slightly imprecise state (which is not the worst because everything
+-- should happen very fast). There is also the bigger risk that when we snapshot
+-- and then do something (eg. in the 'setPaused' handler) we interleave with
+-- something else. It cannot easily be an STM transaction, though, because we
+-- need to measure the time, and @io-classes@'s STM does not allow running IO in
+-- an STM.
+snapshotFill :: (MonadSTM m, MonadMonotonicTime m) => Bucket m -> Rational -> m (State (Config m), Overflew)
+snapshotFill bucket toAdd = do
+  newTime <- getMonotonicTime
+  atomically $ do
+    State {level, time, paused, config} <- readTVar bucket
+    let Config {rate, capacity, fillOnOverflow} = config
+        elapsed = diffTime newTime time
+        leaked = if paused then 0 else (diffTimeToSecondsRational elapsed * rate)
+        levelLeaked = max 0 (level - leaked)
+        levelFilled = min capacity (levelLeaked + toAdd)
+        overflew = levelLeaked + toAdd > capacity
+        newLevel = if not overflew || fillOnOverflow then levelFilled else levelLeaked
+        newState = State {time = newTime, level = newLevel, paused, config}
+    writeTVar bucket newState
+    pure (newState, Overflew overflew)
+
+-- | Convert a 'DiffTime' to a 'Rational' number of seconds. This is similar to
+-- 'diffTimeToSeconds' but with picoseconds precision.
+diffTimeToSecondsRational :: DiffTime -> Rational
+diffTimeToSecondsRational = (% 1_000_000_000_000) . diffTimeToPicoseconds
+
+-- | Alias of 'realToFrac' to make code more readable and typing more explicit.
+secondsRationalToDiffTime :: Rational -> DiffTime
+secondsRationalToDiffTime = realToFrac

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Consensus/ChainGenerator/Params.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Consensus/ChainGenerator/Params.hs
@@ -100,7 +100,7 @@ genKSD :: QC.Gen (Kcp, Scg, Delta)
 genKSD = sized1 $ \sz -> do
     -- k > 1 so we can ensure an alternative schema loses the density comparison
     -- without having to deactivate the first active slot
-    k <- (+ 2) <$> QC.choose (0, 2 * sz)
-    s <- (+ k) <$> QC.choose (0, 3 * sz)   -- ensures @k / s <= 1@
+    k <- (+ 2) <$> QC.choose (0, sz)
+    s <- (+ k) <$> QC.choose (0, 2 * sz)   -- ensures @k / s <= 1@
     d <- QC.choose (0, max 0 $ min (div sz 4) (s-1)) -- ensures @d < s@
     pure (Kcp k, Scg s, Delta d)

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/ChainDB.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/ChainDB.hs
@@ -19,9 +19,7 @@ import           Ouroboros.Consensus.Config
                      (TopLevelConfig (topLevelConfigLedger))
 import           Ouroboros.Consensus.Fragment.InFuture (CheckInFuture (..))
 import qualified Ouroboros.Consensus.Fragment.Validated as VF
-import           Ouroboros.Consensus.HardFork.History.EraParams (EraParams,
-                     eraEpochSize)
-import           Ouroboros.Consensus.Ledger.Basics (LedgerConfig)
+import           Ouroboros.Consensus.HardFork.History.EraParams (eraEpochSize)
 import           Ouroboros.Consensus.Ledger.Extended (ExtLedgerState)
 import           Ouroboros.Consensus.Storage.ChainDB hiding
                      (TraceFollowerEvent (..))
@@ -36,6 +34,7 @@ import           System.FS.API (SomeHasFS (..))
 import qualified System.FS.Sim.MockFS as Mock
 import           System.FS.Sim.MockFS
 import           System.FS.Sim.STM (simHasFS)
+import           Test.Util.TestBlock (TestBlock, TestBlockLedgerConfig (..))
 
 -- | A vector with an element for each database of a node
 --
@@ -71,8 +70,8 @@ data MinimalChainDbArgs m blk = MinimalChainDbArgs {
   }
 
 -- | Utility function to get a default chunk info in case we have EraParams available.
-mkTestChunkInfo :: LedgerConfig blk ~ EraParams => TopLevelConfig blk -> ImmutableDB.ChunkInfo
-mkTestChunkInfo = simpleChunkInfo . eraEpochSize . topLevelConfigLedger
+mkTestChunkInfo :: TopLevelConfig TestBlock -> ImmutableDB.ChunkInfo
+mkTestChunkInfo = simpleChunkInfo . eraEpochSize . tblcHardForkParams . topLevelConfigLedger
 
 -- | Creates a default set of of arguments for ChainDB tests.
 fromMinimalChainDbArgs ::

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/TestBlock.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/TestBlock.hs
@@ -71,11 +71,13 @@ module Test.Util.TestBlock (
   , testInitLedgerWithState
     -- * Support for tests
   , Permutation (..)
+  , TestBlockLedgerConfig (..)
   , isAncestorOf
   , isDescendentOf
   , isStrictAncestorOf
   , isStrictDescendentOf
   , permute
+  , testBlockLedgerConfigFrom
   , unsafeTestBlockWithPayload
   , updateToNextNumeral
   ) where
@@ -543,7 +545,19 @@ testInitExtLedgerWithState st = ExtLedgerState {
     , headerState = genesisHeaderState ()
     }
 
-type instance LedgerCfg (LedgerState (TestBlockWith ptype)) = HardFork.EraParams
+data TestBlockLedgerConfig = TestBlockLedgerConfig {
+  tblcHardForkParams :: HardFork.EraParams,
+  -- | `Nothing` means an infinite forecast range.
+  -- Instead of SlotNo, it should be something like "SlotRange"
+  tblcForecastRange  :: Maybe SlotNo
+}
+  deriving (Show, Eq, Generic)
+  deriving anyclass (NoThunks)
+
+testBlockLedgerConfigFrom :: HardFork.EraParams -> TestBlockLedgerConfig
+testBlockLedgerConfigFrom eraParams = TestBlockLedgerConfig eraParams Nothing
+
+type instance LedgerCfg (LedgerState (TestBlockWith ptype)) = TestBlockLedgerConfig
 
 instance GetTip (LedgerState (TestBlockWith ptype)) where
   getTip = castPoint . lastAppliedPoint
@@ -576,7 +590,8 @@ instance (PayloadSemantics ptype) => ValidateEnvelope (TestBlockWith ptype) wher
 
 instance (PayloadSemantics ptype) => LedgerSupportsProtocol (TestBlockWith ptype) where
   protocolLedgerView   _ _  = ()
-  ledgerViewForecastAt _    = trivialForecast
+  ledgerViewForecastAt cfg state =
+    constantForecastInRange (tblcForecastRange cfg) () (getTipSlot state)
 
 singleNodeTestConfigWith ::
      CodecConfig (TestBlockWith ptype)
@@ -590,7 +605,7 @@ singleNodeTestConfigWith codecConfig storageConfig k = TopLevelConfig {
         , bftSignKey = SignKeyMockDSIGN 0
         , bftVerKeys = Map.singleton (CoreId (CoreNodeId 0)) (VerKeyMockDSIGN 0)
         }
-    , topLevelConfigLedger      = eraParams
+    , topLevelConfigLedger      = ledgerCfgParams
     , topLevelConfigBlock       = TestBlockConfig numCoreNodes
     , topLevelConfigCodec       = codecConfig
     , topLevelConfigStorage     = storageConfig
@@ -603,8 +618,11 @@ singleNodeTestConfigWith codecConfig storageConfig k = TopLevelConfig {
     numCoreNodes :: NumCoreNodes
     numCoreNodes = NumCoreNodes 1
 
-    eraParams :: HardFork.EraParams
-    eraParams = HardFork.defaultEraParams k slotLength
+    ledgerCfgParams :: TestBlockLedgerConfig
+    ledgerCfgParams = TestBlockLedgerConfig {
+      tblcHardForkParams = HardFork.defaultEraParams k slotLength,
+      tblcForecastRange = Nothing
+    }
 
 
 {-------------------------------------------------------------------------------
@@ -624,7 +642,7 @@ data instance StorageConfig TestBlock = TestBlockStorageConfig
 
 instance HasHardForkHistory TestBlock where
   type HardForkIndices TestBlock = '[TestBlock]
-  hardForkSummary = neverForksHardForkSummary id
+  hardForkSummary = neverForksHardForkSummary tblcHardForkParams
 
 data instance BlockQuery TestBlock result where
   QueryLedgerTip :: BlockQuery TestBlock (Point TestBlock)

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/Mempool/Fairness.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/Mempool/Fairness.hs
@@ -32,7 +32,8 @@ import           System.Random (randomIO)
 import           Test.Consensus.Mempool.Fairness.TestBlock
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.HUnit (testCase, (@?), (@?=))
-import           Test.Util.TestBlock (testInitLedgerWithState)
+import           Test.Util.TestBlock (testBlockLedgerConfigFrom,
+                     testInitLedgerWithState)
 
 tests :: TestTree
 tests = testGroup "Mempool fairness"
@@ -84,11 +85,11 @@ testTxSizeFairness TestParams { mempoolMaxCapacity, smallTxSize, largeTxSize, nr
               Mempool.getCurrentLedgerState = pure $ testInitLedgerWithState ()
           }
 
-      sampleLedgerConfig =
+      eraParams =
           HardFork.defaultEraParams (Consensus.SecurityParam 10) (Time.slotLengthFromSec 2)
     mempool <- Mempool.openMempoolWithoutSyncThread
                    ledgerItf
-                   sampleLedgerConfig
+                   (testBlockLedgerConfigFrom eraParams)
                    (Mempool.mkCapacityBytesOverride mempoolMaxCapacity)
                    Tracer.nullTracer
                    genTxSize

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/MiniProtocol/ChainSync/Client.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/MiniProtocol/ChainSync/Client.hs
@@ -596,7 +596,7 @@ runChainSync skew securityParam (ClientUpdates clientUpdates)
                            , (CoreId (CoreNodeId 1), VerKeyMockDSIGN 1)
                            ]
           }
-      , topLevelConfigLedger      = eraParams
+      , topLevelConfigLedger      = testBlockLedgerConfigFrom eraParams
       , topLevelConfigBlock       = TestBlockConfig numCoreNodes
       , topLevelConfigCodec       = TestBlockCodecConfig
       , topLevelConfigStorage     = TestBlockStorageConfig

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/MiniProtocol/LocalStateQuery/Server.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/MiniProtocol/LocalStateQuery/Server.hs
@@ -238,7 +238,7 @@ testCfg securityParam = TopLevelConfig {
         , bftSignKey = SignKeyMockDSIGN 0
         , bftVerKeys = Map.singleton (CoreId (CoreNodeId 0)) (VerKeyMockDSIGN 0)
         }
-    , topLevelConfigLedger      = eraParams
+    , topLevelConfigLedger      = testBlockLedgerConfigFrom eraParams
     , topLevelConfigBlock       = TestBlockConfig numCoreNodes
     , topLevelConfigCodec       = TestBlockCodecConfig
     , topLevelConfigStorage     = TestBlockStorageConfig

--- a/ouroboros-consensus/test/infra-test/Main.hs
+++ b/ouroboros-consensus/test/infra-test/Main.hs
@@ -14,6 +14,7 @@ module Main (main) where
 
 import qualified Ouroboros.Consensus.Util.Tests (tests)
 import qualified Test.Ouroboros.Consensus.ChainGenerator.Tests (tests)
+import qualified Test.Ouroboros.Consensus.Util.LeakyBucket.Tests (tests)
 import           Test.Tasty (TestTree, testGroup)
 import qualified Test.Util.ChainUpdates.Tests (tests)
 import qualified Test.Util.Schedule.Tests (tests)
@@ -29,6 +30,7 @@ tests =
   testGroup "test-infra"
   [ Ouroboros.Consensus.Util.Tests.tests
   , Test.Ouroboros.Consensus.ChainGenerator.Tests.tests
+  , Test.Ouroboros.Consensus.Util.LeakyBucket.Tests.tests
   , Test.Util.ChainUpdates.Tests.tests
   , Test.Util.Schedule.Tests.tests
   , Test.Util.Split.Tests.tests

--- a/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/Util/LeakyBucket/Tests.hs
+++ b/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/Util/LeakyBucket/Tests.hs
@@ -19,7 +19,7 @@ import           Data.Ratio ((%))
 import           Data.Time.Clock (DiffTime, picosecondsToDiffTime)
 import           Ouroboros.Consensus.Util.IOLike (Exception (displayException),
                      MonadAsync, MonadCatch (try), MonadDelay, MonadFork,
-                     MonadMask, MonadThrow (throwIO), SomeException,
+                     MonadMask, MonadThrow (throwIO), NoThunks, SomeException,
                      Time (Time), addTime, fromException, threadDelay)
 import           Ouroboros.Consensus.Util.LeakyBucket
 import           Test.QuickCheck (Arbitrary (arbitrary), Gen, Property,
@@ -134,7 +134,7 @@ stripConfig state = state{config=()}
 
 -- | 'evalAgainstBucket' followed by 'stripConfig'.
 stripEvalAgainstBucket ::
-  (MonadDelay m, MonadAsync m, MonadFork m, MonadMask m) =>
+  (MonadDelay m, MonadAsync m, MonadFork m, MonadMask m, NoThunks (m ())) =>
   Config m ->
   (Handlers m -> m a) ->
   m (State ())

--- a/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/Util/LeakyBucket/Tests.hs
+++ b/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/Util/LeakyBucket/Tests.hs
@@ -5,6 +5,10 @@
 {-# LANGUAGE RankNTypes          #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
+-- | This module contains various tests for the leaky bucket. Some, prefixed by
+-- “play”, are simple, manual tests; two concern (non-)propagation of exceptions
+-- between the bucket thread and the action's thread; the last one compares a
+-- run of the actual bucket implementation against a model.
 module Test.Ouroboros.Consensus.Util.LeakyBucket.Tests (tests) where
 
 import           Control.Monad (foldM, void)
@@ -30,10 +34,10 @@ tests = testGroup "Ouroboros.Consensus.Util.LeakyBucket" [
   testProperty "play a bit" prop_playABit,
   testProperty "play too long" prop_playTooLong,
   testProperty "play too long harmless" prop_playTooLongHarmless,
+  testProperty "play with pause" prop_playWithPause,
+  testProperty "play with pause too long" prop_playWithPauseTooLong,
   testProperty "wait almost too long" (prop_noRefill (-1)),
   testProperty "wait just too long" (prop_noRefill 1),
-  testProperty "pause for a time" prop_playWithPause,
-  testProperty "resume too quickly" prop_playWithPauseTooLong,
   testProperty "propagates exceptions" prop_propagateExceptions,
   testProperty "propagates exceptions (IO)" prop_propagateExceptionsIO,
   testProperty "catch exception" prop_catchException,

--- a/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/Util/LeakyBucket/Tests.hs
+++ b/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/Util/LeakyBucket/Tests.hs
@@ -1,0 +1,343 @@
+{-# LANGUAGE LambdaCase          #-}
+{-# LANGUAGE MultiWayIf          #-}
+{-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE NumericUnderscores  #-}
+{-# LANGUAGE RankNTypes          #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Test.Ouroboros.Consensus.Util.LeakyBucket.Tests (tests) where
+
+import           Control.Monad (foldM, void)
+import           Control.Monad.IOSim (IOSim, runSimOrThrow)
+import           Data.Either (isLeft, isRight)
+import           Data.Functor ((<&>))
+import           Data.Ratio ((%))
+import           Data.Time.Clock (DiffTime, picosecondsToDiffTime)
+import           Ouroboros.Consensus.Util.IOLike (Exception (displayException),
+                     MonadAsync, MonadCatch (try), MonadDelay, MonadFork,
+                     MonadMask, MonadThrow (throwIO), SomeException,
+                     Time (Time), addTime, fromException, threadDelay)
+import           Ouroboros.Consensus.Util.LeakyBucket
+import           Test.QuickCheck (Arbitrary (arbitrary), Gen, Property,
+                     classify, counterexample, forAll, frequency, ioProperty,
+                     listOf1, scale, suchThat, (===))
+import           Test.Tasty (TestTree, testGroup)
+import           Test.Tasty.QuickCheck (property, testProperty)
+import           Test.Util.TestEnv (adjustQuickCheckTests)
+
+tests :: TestTree
+tests = testGroup "Ouroboros.Consensus.Util.LeakyBucket" [
+  testProperty "play a bit" prop_playABit,
+  testProperty "play too long" prop_playTooLong,
+  testProperty "play too long harmless" prop_playTooLongHarmless,
+  testProperty "wait almost too long" (prop_noRefill (-1)),
+  testProperty "wait just too long" (prop_noRefill 1),
+  testProperty "pause for a time" prop_playWithPause,
+  testProperty "resume too quickly" prop_playWithPauseTooLong,
+  testProperty "propagates exceptions" prop_propagateExceptions,
+  testProperty "propagates exceptions (IO)" prop_propagateExceptionsIO,
+  testProperty "catch exception" prop_catchException,
+  adjustQuickCheckTests (* 10) $ testProperty "random" prop_random
+  ]
+
+--------------------------------------------------------------------------------
+-- Dummy configuration
+--------------------------------------------------------------------------------
+
+newtype Capacity = Capacity { unCapacity :: Rational }
+  deriving Show
+
+instance Arbitrary Capacity where
+  arbitrary = Capacity <$> arbitrary `suchThat` (> 0)
+
+newtype Rate = Rate { unRate :: Rational }
+  deriving Show
+
+instance Arbitrary Rate where
+  arbitrary = Rate <$> arbitrary `suchThat` (> 0)
+
+newtype FillOnOverflow = FillOnOverflow { unFillOnOverflow :: Bool }
+  deriving Show
+
+instance Arbitrary FillOnOverflow where
+  arbitrary = FillOnOverflow <$> arbitrary
+
+-- | Whether to throw on empty bucket.
+newtype ThrowOnEmpty = ThrowOnEmpty { unThrowOnEmpty :: Bool }
+  deriving (Eq, Show)
+
+instance Arbitrary ThrowOnEmpty where
+  arbitrary = ThrowOnEmpty <$> arbitrary
+
+data TestConfig = TestConfig
+  { testCapacity     :: Rational,
+    testRate         :: Rational,
+    testThrowOnEmpty :: Bool
+  }
+  deriving (Eq, Show)
+
+instance Arbitrary TestConfig where
+  arbitrary =
+    TestConfig
+      <$> (unCapacity <$> arbitrary)
+      <*> (unRate <$> arbitrary)
+      <*> (unThrowOnEmpty <$> arbitrary)
+
+data EmptyBucket = EmptyBucket
+  deriving (Eq, Show)
+
+instance Exception EmptyBucket
+
+-- | Make an actual configuration from a test configuration.
+mkConfig :: MonadThrow m => TestConfig -> Config m
+mkConfig TestConfig {testCapacity, testRate, testThrowOnEmpty} =
+  Config
+    { capacity = testCapacity,
+      rate = testRate,
+      fillOnOverflow = True,
+      onEmpty =
+        if testThrowOnEmpty
+          then (throwIO EmptyBucket)
+          else (pure ())
+    }
+
+-- | Make a configuration that fills on overflow and throws 'EmptyBucket' on
+-- empty bucket.
+configThrow :: MonadThrow m => Capacity -> Rate -> Config m
+configThrow (Capacity testCapacity) (Rate testRate) =
+  mkConfig TestConfig{testCapacity, testRate, testThrowOnEmpty = True}
+
+-- | A configuration with capacity and rate 1, that fills on overflow and throws
+-- 'EmptyBucket' on empty bucket.
+config11Throw :: MonadThrow m => Config m
+config11Throw = configThrow (Capacity 1) (Rate 1)
+
+-- | Make a configuration that fills on overflow and does nothing on empty
+-- bucket.
+configPure :: MonadThrow m => Capacity -> Rate -> Config m
+configPure (Capacity testCapacity) (Rate testRate) =
+  mkConfig TestConfig{testCapacity, testRate, testThrowOnEmpty = False}
+
+-- | A configuration with capacity 1 and rate 1, that fills on overflow and does
+-- nothing on empty bucket.
+config11Pure :: MonadThrow m => Config m
+config11Pure = configPure (Capacity 1) (Rate 1)
+
+-- | Strip the configuration from a 'State', so as to make it comparable,
+-- showable, etc.
+stripConfig :: State cfg -> State ()
+stripConfig state = state{config=()}
+
+-- | 'evalAgainstBucket' followed by 'stripConfig'.
+stripEvalAgainstBucket ::
+  (MonadDelay m, MonadAsync m, MonadFork m, MonadMask m) =>
+  Config m ->
+  (Handlers m -> m a) ->
+  m (State ())
+stripEvalAgainstBucket config action = stripConfig <$> evalAgainstBucket config action
+
+-- | Alias for 'runSimOrThrow' by analogy to 'ioProperty'.
+ioSimProperty :: forall a. (forall s. IOSim s a) -> a
+ioSimProperty = runSimOrThrow
+
+-- | QuickCheck helper to check that a code threw the given exception.
+shouldThrow :: (MonadCatch m, Show a, Exception e, Eq e) => m a -> e -> m Property
+shouldThrow a e =
+  try a <&> \case
+    Left exn
+      | fromException exn == Just e -> property True
+      | otherwise -> counterexample ("Expected exception " ++ show e ++ "; got exception " ++ show exn) False
+    Right result -> counterexample ("Expected exception " ++ show e ++ "; got " ++ show result) False
+
+-- | QuickCheck helper to check that a code evaluated to the given value.
+shouldEvaluateTo :: (MonadCatch m, Eq a, Show a) => m a -> a -> m Property
+shouldEvaluateTo a v =
+  try a <&> \case
+    Right result
+      | result == v -> property True
+      | otherwise -> counterexample ("Expected " ++ show v ++ "; got " ++ show result) False
+    Left (exn :: SomeException) -> counterexample ("Expected " ++ show v ++ "; got exception " ++ displayException exn) False
+
+-- | Number of picoseconds in a second (@10^12@).
+picosecondsPerSecond :: Integer
+picosecondsPerSecond = 1_000_000_000_000
+
+--------------------------------------------------------------------------------
+-- Simple properties
+--------------------------------------------------------------------------------
+
+-- | One test case where we wait a bit, then fill, then wait some more. We then
+-- should observe a state with a positive level.
+prop_playABit :: Property
+prop_playABit =
+  ioSimProperty $
+    stripEvalAgainstBucket config11Throw (\handlers -> do
+      threadDelay 0.5
+      void $ fill handlers 67
+      threadDelay 0.9
+    ) `shouldEvaluateTo` State{level = 1 % 10, time = Time 1.4, paused = False, config = ()}
+
+-- | One test case similar to 'prop_playABit' but we wait a bit too long and
+-- should observe the triggering of the 'onEmpty' action.
+prop_playTooLong :: Property
+prop_playTooLong =
+  ioSimProperty $
+    stripEvalAgainstBucket config11Throw (\handlers -> do
+      threadDelay 0.5
+      void $ fill handlers 67
+      threadDelay 1.1
+    ) `shouldThrow` EmptyBucket
+
+-- | One test case similar to 'prop_playTooLong' but 'onEmpty' does nothing and
+-- therefore we should still observe a state at the end.
+prop_playTooLongHarmless :: Property
+prop_playTooLongHarmless =
+  ioSimProperty $
+    stripEvalAgainstBucket config11Pure (\handlers -> do
+      threadDelay 0.5
+      void $ fill handlers 67
+      threadDelay 1.1
+    ) `shouldEvaluateTo` State{level = 0, time = Time 1.6, paused = False, config = ()}
+
+prop_playWithPause :: Property
+prop_playWithPause =
+  ioSimProperty $
+    stripEvalAgainstBucket config11Throw (\handlers -> do
+      threadDelay 0.5
+      setPaused handlers True
+      threadDelay 1.5
+      setPaused handlers False
+      threadDelay 0.4
+    ) `shouldEvaluateTo` State{level = 1 % 10, time = Time 2.4, paused = False, config = ()}
+
+prop_playWithPauseTooLong :: Property
+prop_playWithPauseTooLong =
+  ioSimProperty $
+    stripEvalAgainstBucket config11Throw (\handlers -> do
+      threadDelay 0.5
+      setPaused handlers True
+      threadDelay 1.5
+      setPaused handlers False
+      threadDelay 0.6
+    ) `shouldThrow` EmptyBucket
+
+-- | A bunch of test cases where we wait exactly as much as the bucket runs
+-- except for a given offset. If the offset is negative, we should get a
+-- state. If the offset is positive, we should get an exception. NOTE: Do not
+-- use an offset of @0@. NOTE: Considering the precision, we *need* IOSim for
+-- this test.
+prop_noRefill :: Integer -> Capacity -> Rate -> Property
+prop_noRefill offset capacity@(Capacity c) rate@(Rate r) = do
+  -- NOTE: The @-1@ is to ensure that we do not test the situation where the
+  -- bucket empties at the *exact* same time (curtesy of IOSim) as the action.
+  let ps = floor (c / r * fromInteger picosecondsPerSecond) + offset
+      time = picosecondsToDiffTime ps
+      level = c - (ps % picosecondsPerSecond) * r
+  if
+    | offset < 0 ->
+      ioSimProperty $
+        stripEvalAgainstBucket (configThrow capacity rate) (\_ -> threadDelay time)
+        `shouldEvaluateTo` State{level, time = Time time, paused = False, config = ()}
+    | offset > 0 ->
+      ioSimProperty $
+        stripEvalAgainstBucket (configThrow capacity rate) (\_ -> threadDelay time)
+        `shouldThrow` EmptyBucket
+    | otherwise ->
+      error "prop_noRefill: do not use an offset of 0"
+
+--------------------------------------------------------------------------------
+-- Exception propagation
+--------------------------------------------------------------------------------
+
+-- | A dummy exception that we will use to outrun the bucket.
+data NoPlumberException = NoPlumberException
+  deriving (Eq, Show)
+instance Exception NoPlumberException
+
+-- | One test to check that throwing an exception in the action does propagate
+-- outside of @*AgainstBucket@.
+prop_propagateExceptions :: Property
+prop_propagateExceptions =
+  ioSimProperty $
+    stripEvalAgainstBucket config11Throw (\_ -> throwIO NoPlumberException)
+      `shouldThrow`
+    NoPlumberException
+
+-- | Same as 'prop_propagateExceptions' except it runs in IO.
+prop_propagateExceptionsIO :: Property
+prop_propagateExceptionsIO =
+  ioProperty $
+    stripEvalAgainstBucket config11Throw (\_ -> throwIO NoPlumberException)
+      `shouldThrow`
+    NoPlumberException
+
+-- | One test to show that we can catch the 'EmptyBucket' exception from the
+-- action itself, but that it is not wrapped in 'ExceptionInLinkedThread'.
+prop_catchException :: Property
+prop_catchException =
+  ioSimProperty $
+    execAgainstBucket config11Throw (\_ -> try $ threadDelay 1000)
+      `shouldEvaluateTo`
+    Left EmptyBucket
+
+--------------------------------------------------------------------------------
+-- Against a model
+--------------------------------------------------------------------------------
+
+-- | Abstract “actions” to be run. We can either wait by some time or refill the
+-- bucket by some value.
+data Action = ThreadDelay DiffTime | Fill Rational | SetPaused Bool
+  deriving (Eq, Show)
+
+-- | Random generation of 'Action's. The scales and frequencies are taken such
+-- that we explore as many interesting cases as possible.
+genAction :: Gen Action
+genAction = frequency [
+  (1, ThreadDelay . picosecondsToDiffTime <$> scale (* fromInteger picosecondsPerSecond) (arbitrary `suchThat` (>= 0))),
+  (1, Fill <$> scale (* 1_000_000_000_000_000) (arbitrary `suchThat` (>= 0))),
+  (1, SetPaused <$> arbitrary)
+  ]
+
+-- | How to run the 'Action's in a monad.
+applyActions :: MonadDelay m => Handlers m -> [Action] -> m ()
+applyActions handlers = mapM_ $ \case
+  ThreadDelay t -> threadDelay t
+  Fill t -> void $ fill handlers t
+  SetPaused p -> setPaused handlers p
+
+-- | A model of what we expect the 'Action's to lead to, either an 'EmptyBucket'
+-- exception (if the bucket won the race) or a 'State' (otherwise).
+modelActions :: TestConfig -> [Action] -> Either EmptyBucket (State TestConfig)
+modelActions config =
+  foldM go $ State{level = testCapacity config, time = Time 0, paused = False, config}
+  where
+    go :: State TestConfig -> Action -> Either EmptyBucket (State TestConfig)
+    go state@State{time, level, paused, config=TestConfig{testCapacity, testRate, testThrowOnEmpty}} = \case
+      Fill t ->
+        Right state{level = min testCapacity (level + t)}
+      ThreadDelay t ->
+        let newTime = addTime t time
+            newLevel = if paused then level else max 0 (level - diffTimeToSecondsRational t * testRate)
+         in if newLevel <= 0 && testThrowOnEmpty
+              then Left EmptyBucket
+              else Right state{time = newTime, level = newLevel}
+      SetPaused p ->
+        Right state{paused = p}
+
+-- | A bunch of test cases where we generate a list of 'Action's ,run them via
+-- 'applyActions' and compare the result to that of 'modelActions'.
+prop_random :: TestConfig -> Property
+prop_random testConfig =
+  forAll (listOf1 genAction) $ \actions ->
+    let modelResult = modelActions testConfig actions
+        nbActions = length actions
+     in classify (isLeft modelResult) "bucket finished empty" $
+        classify (isRight modelResult) "bucket finished non-empty" $
+        classify (nbActions <= 10) "<= 10 actions" $
+        classify (10 < nbActions && nbActions <= 20) "11-20 actions" $
+        classify (20 < nbActions && nbActions <= 50) "21-50 actions" $
+        classify (50 < nbActions) "> 50 actions" $
+        runSimOrThrow (
+          try $ stripEvalAgainstBucket (mkConfig testConfig) $
+            flip applyActions actions
+        ) === (stripConfig <$> modelResult)

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
@@ -1672,7 +1672,7 @@ traceEventName = \case
     TraceInitChainSelEvent      ev    -> "InitChainSel."      <> case ev of
       InitChainSelValidation    ev' -> constrName ev'
       StartedInitChainSelection     -> "StartedInitChainSelection"
-      InitalChainSelected           -> "InitalChainSelected"
+      InitialChainSelected          -> "InitialChainSelected"
     TraceOpenEvent              ev    -> "Open."              <> constrName ev
     TraceGCEvent                ev    -> "GC."                <> constrName ev
     TraceIteratorEvent          ev    -> "Iterator."          <> constrName ev

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/LedgerDB/InMemory.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/LedgerDB/InMemory.hs
@@ -275,7 +275,9 @@ csBlockConfig = csBlockConfig' . csSecParam
 csBlockConfig' :: SecurityParam -> LedgerDbCfg (LedgerState TestBlock)
 csBlockConfig' secParam = LedgerDbCfg {
       ledgerDbCfgSecParam = secParam
-    , ledgerDbCfg         = HardFork.defaultEraParams secParam slotLength
+    , ledgerDbCfg         =
+          testBlockLedgerConfigFrom
+        $ HardFork.defaultEraParams secParam slotLength
     }
   where
     slotLength = slotLengthFromSec 20


### PR DESCRIPTION
This PR implements Limit on Patience, forecasting for `TestBlock`, re-triggering of chain selection and some improvements to the chain generators, point schedules and peers simulator.

Please, note that this PR targets the branch of https://github.com/IntersectMBO/ouroboros-consensus/pull/925.

### Limit on Patience

The Limit on Patience (LoP) is a mechanism that prevents a node from stalling synchronisation by sending headers (therefore surviving network-level timeouts) that do not help us move forward on a chain. This is irrelevant on a Praos node but does matter once the Limit of Eagerness (LoE; see https://github.com/IntersectMBO/ouroboros-consensus/pull/925) comes into play, as the LoE makes us wait on disagreeing peers.

The LoP is based on a bucket mechanism: the ChainSync client runs in parallel with a bucket that starts with a certain amount of tokens and leaks tokens at a certain rate. When the peer sends a header better than anything they have sent before (in term of block number), they are granted a token. If the bucket empties, the ChainSync client is terminated. This ensures a form of liveness of a peer. This mechanism is paused when the ChainSync client is not requesting headers from the peer and when it waits for headers to get into forecast range. Note also that, if a peer asks for a rollback, then they have to send all the headers of the fork without getting new tokens. The precise parameters (capacity and rate of the bucket) for main net are to be determined in future work.

8402c02d00a07f2e2ed9d1726c3142d01aff16f9 adds a `LeakyBucket` module for this use-case and tests for that module. ae43401cc56a413a3bcf07b1d1e77f3b661fcc46 implements the LoP mechanism itself in the ChainSync client, and dfc03aaf311492e09db00cc66791179b9c15caef adds peer simulator-based tests for the LoP. Those tests are to be considered as “smoke tests” more than full system tests. They check various aspects of the Limit on Patience, but we will need to wait for a third component (killing peers based on the density of their chains) before being able to test all of Genesis together.

### Other improvements

- **Forecasting for `TestBlock`:** Because the bucket of the LoP has to be paused when the ChainSync client waits for headers to get into forecast range, we felt the need to test this situation and therefore felt the need to add the possibility of a finite forecast range on `TestBlock`s. This is added in 4c6138b12a65cf6d0a4a1b8b01a6baac64f41356.

- **Re-triggering of chain selection**: Tests with the LoP uncovered situations where the chain selection logic was not triggered on a peer's disconnection. This is problematic because that prevents the LoE from updating and therefore from syncing with other not-yet-disconnected peers. A test case exhibiting such a situation without LoP but with regular ChainSync timeouts can be found in 3b308eefd304b032a46ac95f60dc502bd67bcdd9. The changes to the chain selection logic can be found in 0a18f91163b1631aac4c137915c475a4272f0c62.

- **Ensuring that alternative chains have more than `k` blocks**: Each of our PRs brings its lot of improvements to the chain generator, and this one is not exception. Because all our tests were requiring this of their inputs, we now only generate alternative chains that have more than `k` blocks. The change can be found in 17beed72d525d9a4a7d544597cd8d881d7c0cfdd.

- **Improvements and cleanups to point schedules and tests**: Each of our PRs brings its lot of improvements to the point schedule and peer simulator-based test infrastructure, and this one is no exception. Mostly, we get rid of some not-so-useful-anymore types, polish some types here and there and improve traces in 1835aaf348edb59490e93166ecaa038a279f9982 and we generalise away from `TestBlock` in point schedules and the peer simulator where possible in 94dc83196902954fa691b9cefffc89bdea6e832b and 35ec9599c8715dad38e9a5a6996f71ff88729fee.