### PR TITLE
Add an extra case to `isIncorrectClaimedFlag` for Babbage and later eras

### DIFF
--- a/ouroboros-consensus-cardano/changelog.d/20240306_124033_damian.nadales_937_invalid_script_collateral_not_claimed.md
+++ b/ouroboros-consensus-cardano/changelog.d/20240306_124033_damian.nadales_937_invalid_script_collateral_not_claimed.md
@@ -1,0 +1,3 @@
+### Patch
+
+- Bugfix: Add an extra case to `isIncorrectClaimedFlag` for `Babbage` and `Conway` (https://github.com/IntersectMBO/ouroboros-consensus/issues/973).

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Eras.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Eras.hs
@@ -314,6 +314,7 @@ applyAlonzoBasedTx globals ledgerEnv mempoolState wti tx = do
                -- reject the transaction, protecting the local wallet
 
 class SupportsTwoPhaseValidation era where
+  -- NOTE: this class won't be needed once https://github.com/IntersectMBO/cardano-ledger/issues/4167 is implemented.
   isIncorrectClaimedFlag :: proxy era -> SL.PredicateFailure (Core.EraRule "LEDGER" era) -> Bool
 
 instance SupportsTwoPhaseValidation (AlonzoEra c) where

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Eras.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Eras.hs
@@ -349,6 +349,17 @@ instance SupportsTwoPhaseValidation (BabbageEra c) where
                 )
             )
         ) -> True
+    SL.UtxowFailure
+      ( Babbage.UtxoFailure
+          ( Babbage.AlonzoInBabbageUtxoPredFailure
+              ( Alonzo.UtxosFailure
+                  ( Alonzo.ValidationTagMismatch
+                      (Alonzo.IsValid _claimedFlag)
+                      _validationErrs
+                  )
+              )
+          )
+      ) -> True
     _ -> False
 
 instance SupportsTwoPhaseValidation (ConwayEra c) where

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Eras.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Eras.hs
@@ -379,8 +379,18 @@ instance SupportsTwoPhaseValidation (ConwayEra c) where
                 )
             )
         ) -> True
+    SL.ConwayUtxowFailure
+      ( Babbage.UtxoFailure
+          ( Babbage.AlonzoInBabbageUtxoPredFailure
+              ( Alonzo.UtxosFailure
+                  ( Alonzo.ValidationTagMismatch
+                      (Alonzo.IsValid _claimedFlag)
+                      _validationErrs
+                  )
+              )
+          )
+      ) -> True
     _ -> False
-
 
 {-------------------------------------------------------------------------------
   Tx family wrapper

--- a/ouroboros-consensus/changelog.d/20240306_124416_damian.nadales_937_invalid_script_collateral_not_claimed.md
+++ b/ouroboros-consensus/changelog.d/20240306_124416_damian.nadales_937_invalid_script_collateral_not_claimed.md
@@ -1,0 +1,3 @@
+<!--
+(Empty) No relevant change. Added to keep the CI script happy.
+-->

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/SupportsMempool.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/SupportsMempool.hs
@@ -53,6 +53,7 @@ data WhetherToIntervene
     -- ^ We trust local clients, so if a problematic-yet-valid transaction
     -- arrives over NTC, we reject it in order to avoid the ledger penalizing
     -- them for it.
+    deriving (Show)
 
 class ( UpdateLedger blk
       , NoThunks (GenTx blk)


### PR DESCRIPTION
This accounts for the other case in which a `ValidationTagMismatch` can be found in an `UtxowFailure`.

Closes #973 