### PR TITLE
Update DiskPolicyArgs with StdRunNodeArgs

### DIFF
--- a/ouroboros-consensus-diffusion/changelog.d/20240306_115339_javier.sagredo_fix_snapshot_interval.md
+++ b/ouroboros-consensus-diffusion/changelog.d/20240306_115339_javier.sagredo_fix_snapshot_interval.md
@@ -1,0 +1,22 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+### Patch
+
+- Bugfix: DiskPolicyArgs were not being passed down to the ChainDB which resulted in default values for SnapshotInterval.
+
+<!--
+### Non-Breaking
+
+- A bullet item for the Non-Breaking category.
+
+-->
+<!--
+### Breaking
+
+- A bullet item for the Breaking category.
+
+-->

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Node.hs
@@ -964,7 +964,9 @@ stdLowLevelRunNodeArgsIO RunNodeArgs{ rnProtocolInfo
          ChainDbArgs Defaults IO blk
       -> ChainDbArgs Defaults IO blk
     updateChainDbDefaults =
-        (\x -> x { ChainDB.cdbTracer = srnTraceChainDB }) .
+        (\x -> x { ChainDB.cdbTracer         = srnTraceChainDB
+                 , ChainDB.cdbDiskPolicyArgs = srnDiskPolicyArgs
+                 }) .
         (if not srnChainDbValidateOverride then id else \x -> x
           { ChainDB.cdbImmutableDbValidation = ValidateAllChunks
           , ChainDB.cdbVolatileDbValidation  = ValidateAll


### PR DESCRIPTION
The value read from the configuration was passed in the StdRunNodeArgs but it was not set in the ChainDB args which later on configure the LedgerDB.


