### PR TITLE
Use cardano-git-rev from cardano-base repo

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -14,9 +14,9 @@ repository cardano-haskell-packages
 -- update either of these.
 index-state:
   -- Bump this if you need newer packages from Hackage
-  , hackage.haskell.org 2024-02-23T10:26:05Z
+  , hackage.haskell.org 2024-03-14T23:28:52Z
   -- Bump this if you need newer packages from CHaP
-  , cardano-haskell-packages 2024-02-23T10:34:09Z
+  , cardano-haskell-packages 2024-03-14T22:56:07Z
 
 packages:
   ouroboros-consensus

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1708685993,
-        "narHash": "sha256-Z4fzXgAFk3r8Qp7/ULVPAGgfNLyKTo8mfmopAx37GoI=",
+        "lastModified": 1710457755,
+        "narHash": "sha256-EFXhO+PVzq/KGRL60zOOWY/QzyqYlaErNwCwH9K8Gds=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "332b9de768d674be0e56deb2fc2daad707ee2e0a",
+        "rev": "5d14724eb875b0acefa341a38c45200b4a2c14cb",
         "type": "github"
       },
       "original": {
@@ -225,11 +225,11 @@
     "hackageNix": {
       "flake": false,
       "locked": {
-        "lastModified": 1708647761,
-        "narHash": "sha256-1WiRX2IqiopPq3sQTBPF7BswDacfGB9UUNnN9PYgrXA=",
+        "lastModified": 1710375729,
+        "narHash": "sha256-L4aXTQeVFNNni1a1ktZ6aMj2QPl9vZg244V5M0ZlUPw=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "6a164db037c9cb2fd7ea946e7a0d62d7d8f53766",
+        "rev": "42b004321911ea41f0b117393f758dbc929655c3",
         "type": "github"
       },
       "original": {

--- a/ouroboros-consensus-cardano/changelog.d/20240312_160736_erikd_git_rev_a.md
+++ b/ouroboros-consensus-cardano/changelog.d/20240312_160736_erikd_git_rev_a.md
@@ -1,0 +1,4 @@
+### Non-Breaking
+
+- Use the version of cardano-git-rev in the cardano-base repo.
+

--- a/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
+++ b/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
@@ -499,7 +499,7 @@ library unstable-cardano-tools
     , cardano-crypto
     , cardano-crypto-class
     , cardano-crypto-wrapper
-    , cardano-git-rev
+    , cardano-git-rev                ^>=0.2.1
     , cardano-ledger-allegra
     , cardano-ledger-alonzo
     , cardano-ledger-api

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/GitRev.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/GitRev.hs
@@ -23,5 +23,6 @@ gitRev
                [||T.pack (giHash gitInfo) <> if giDirty gitInfo then "-dirty" else ""||]
              -- In case of failure, try cardano-git-rev (where the commit hash
              -- can be embedded later).
-             Left _ -> [||Cardano.Git.Rev.gitRev||]
+             Left _ -> [||otherRev||]
           )
+    otherRev = $(Cardano.Git.Rev.gitRev)


### PR DESCRIPTION
# Description
The `cardano-git-rev` package has been moved from the `cardano-node` repo  to `cardano-base`. `gitRev` has also changed from being a function to a TH splice (needed for it to work correctly).

Also note that:

- New code should be properly tested (even if it does not add new features).
- The fix for a regression should include a test that reproduces said regression.
