### PR TITLE
Store the fork history for HP in the node state for BlockFetch

### DIFF
--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LoE.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LoE.hs
@@ -83,11 +83,13 @@ prop_adversaryHitsTimeouts timeoutsEnabled =
 
     delaySchedule :: HasHeader blk => BlockTree blk -> Peers (PeerSchedule blk)
     delaySchedule tree =
-      let trunkTip = case btTrunk tree of
+      let trunk = btTrunk tree
+          trunkTip = case trunk of
             (AF.Empty _)       -> error "tree must have at least one block"
             (_ AF.:> tipBlock) -> tipBlock
           branch = getOnlyBranch tree
-          intersectM = case btbPrefix branch of
+          prefix = btbPrefix branch
+          intersectM = case prefix of
             (AF.Empty _)       -> Nothing
             (_ AF.:> tipBlock) -> Just tipBlock
           branchTip = case btbFull branch of
@@ -98,13 +100,13 @@ prop_adversaryHitsTimeouts timeoutsEnabled =
             -- advertised its chain.
             ( (Time 0, scheduleTipPoint trunkTip) : case intersectM of
                 Nothing ->
-                  [ (Time 0.5, scheduleHeaderPoint trunkTip),
+                  [ (Time 0.5, scheduleHeaderPoint trunk),
                     (Time 0.5, scheduleBlockPoint trunkTip)
                   ]
                 Just intersect ->
-                  [ (Time 0.5, scheduleHeaderPoint intersect),
+                  [ (Time 0.5, scheduleHeaderPoint prefix),
                     (Time 0.5, scheduleBlockPoint intersect),
-                    (Time 5, scheduleHeaderPoint trunkTip),
+                    (Time 5, scheduleHeaderPoint trunk),
                     (Time 5, scheduleBlockPoint trunkTip)
                   ]
             )
@@ -115,7 +117,7 @@ prop_adversaryHitsTimeouts timeoutsEnabled =
                 Nothing -> [(Time 11, scheduleTipPoint branchTip)]
                 -- the alternate branch forks from `intersect`
                 Just intersect ->
-                  [ (Time 0, scheduleHeaderPoint intersect),
+                  [ (Time 0, scheduleHeaderPoint prefix),
                     (Time 0, scheduleBlockPoint intersect),
                     (Time 11, scheduleBlockPoint intersect)
                   ]

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Resources.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Resources.hs
@@ -156,14 +156,14 @@ makeBlockFetchResources ::
   STM m () ->
   SharedResources m TestBlock ->
   BlockFetchResources m TestBlock
-makeBlockFetchResources bfrTickStarted SharedResources {srPeerId, srTracer, srBlockTree, srCurrentState} =
+makeBlockFetchResources bfrTickStarted SharedResources {srPeerId, srTracer, srCurrentState} =
   BlockFetchResources {
     bfrTickStarted,
     bfrServer
   }
   where
     handlers = BlockFetchServerHandlers {
-      bfshBlockFetch = handlerBlockFetch srBlockTree,
+      bfshBlockFetch = handlerBlockFetch,
       bfshSendBlocks = handlerSendBlocks
     }
     bfrServer =

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Run.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Run.hs
@@ -217,6 +217,7 @@ dispatchTick tracer stateTracer peers (number, (duration, Peer pid state)) =
 -- client.
 runScheduler ::
   IOLike m =>
+  HasHeader blk =>
   Tracer m (TraceSchedulerEvent blk) ->
   Tracer m () ->
   PeersSchedule blk ->

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/LinkedThreads.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/LinkedThreads.hs
@@ -73,13 +73,14 @@ prop_chainSyncKillsBlockFetch = do
             _ -> False
     )
   where
-    dullSchedule :: GenesisTest blk () -> DiffTime -> PeersSchedule blk
+    dullSchedule :: AF.HasHeader blk => GenesisTest blk () -> DiffTime -> PeersSchedule blk
     dullSchedule GenesisTest {gtBlockTree} timeout =
-      let (firstBlock, secondBlock) = case AF.toOldestFirst $ btTrunk gtBlockTree of
+      let trunk = btTrunk gtBlockTree
+          (firstBlock, secondBlock) = case AF.toOldestFirst trunk of
             b1 : b2 : _ -> (b1, b2)
             _           -> error "block tree must have two blocks"
        in peersOnlyHonest $
             [ (Time 0, scheduleTipPoint secondBlock),
-              (Time 0, scheduleHeaderPoint firstBlock),
+              (Time 0, scheduleHeaderPoint (AF.takeOldest 1 trunk)),
               (Time (timeout + 1), scheduleBlockPoint firstBlock)
             ]

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
@@ -62,11 +62,11 @@ prop_timeouts mustTimeout = do
   where
     dullSchedule :: AF.HasHeader blk => DiffTime -> AF.AnchoredFragment blk -> PeersSchedule blk
     dullSchedule _ (AF.Empty _) = error "requires a non-empty block tree"
-    dullSchedule timeout (_ AF.:> tipBlock) =
+    dullSchedule timeout chain@(_ AF.:> tipBlock) =
       let offset :: DiffTime = if mustTimeout then 1 else -1
        in peersOnlyHonest $ [
             (Time 0, scheduleTipPoint tipBlock),
-            (Time 0, scheduleHeaderPoint tipBlock),
+            (Time 0, scheduleHeaderPoint chain),
             (Time 0, scheduleBlockPoint tipBlock),
             -- This last point does not matter, it is only here to leave the
             -- connection open (aka. keep the test running) long enough to

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Tests.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Tests.hs
@@ -28,7 +28,8 @@ import           Test.QuickCheck.Random
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
 import qualified Test.Util.QuickCheck as QC
-import           Test.Util.TersePrinting (terseBlock, terseWithOrigin)
+import           Test.Util.TersePrinting (terseBlock, tersePoint,
+                     terseWithOrigin)
 import           Test.Util.TestBlock (TestBlock, TestHash (unTestHash),
                      firstBlock, modifyFork, successorBlock, tbSlot)
 import           Test.Util.TestEnv
@@ -257,7 +258,7 @@ prop_peerScheduleFromTipPoints seed (PeerScheduleFromTipPointsInput psp tps trun
   where
     showPoint :: SchedulePoint TestBlock -> String
     showPoint (ScheduleTipPoint b)    = "TP " ++ terseWithOrigin terseBlock b
-    showPoint (ScheduleHeaderPoint b) = "HP " ++ terseWithOrigin terseBlock b
+    showPoint (ScheduleHeaderPoint b) = "HP " ++ tersePoint (AF.headPoint b)
     showPoint (ScheduleBlockPoint b)  = "BP " ++ terseWithOrigin terseBlock b
 
     isTipPoint :: SchedulePoint blk -> Bool


### PR DESCRIPTION
PoC for storing all chains visited by HP in the node state to allow BlockFetch to send blocks from before fork switches.