### PR TITLE
Bump `NodeToNodeVersion` part of `latestReleasedNodeVersion`  to `NodeToNodeV_13`

### DIFF
--- a/ouroboros-consensus-cardano/changelog.d/20240313_114743_alexander.esgen_use_ntn_v_13.md
+++ b/ouroboros-consensus-cardano/changelog.d/20240313_114743_alexander.esgen_use_ntn_v_13.md
@@ -1,0 +1,4 @@
+### Non-Breaking
+
+- Bump `NodeToNodeVersion` part of `latestReleasedNodeVersion` to
+  `NodeToNodeV_13` from `NodeToNodeV_11`.

--- a/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/Node.hs
+++ b/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/Node.hs
@@ -481,7 +481,7 @@ instance CardanoHardForkConstraints c
       , (NodeToClientV_16, CardanoNodeToClientVersion12)
       ]
 
-  latestReleasedNodeVersion _prx = (Just NodeToNodeV_11, Just NodeToClientV_15)
+  latestReleasedNodeVersion _prx = (Just NodeToNodeV_13, Just NodeToClientV_15)
 
 {-------------------------------------------------------------------------------
   ProtocolInfo


### PR DESCRIPTION
This bumps the `NodeToNodeVersion` part of `latestReleasedNodeVersion` to `NodeToNodeV_13` from `NodeToNodeV_11`.

 - `NodeToNodeV_12` does nothing, see https://github.com/IntersectMBO/ouroboros-network/pull/4825
 - `NodeToNodeV_13`, which enables the latest version of PeerSharing.