### PR TITLE
Use `safe-wild-cards` forcing us to account for new fields

### DIFF
--- a/ouroboros-consensus-diffusion/changelog.d/20240318_155619_alexander.esgen_safe_wild_cards.md
+++ b/ouroboros-consensus-diffusion/changelog.d/20240318_155619_alexander.esgen_safe_wild_cards.md
@@ -1,0 +1,3 @@
+### Patch
+
+- Start using `safe-wild-cards` internally.

--- a/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
+++ b/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
@@ -86,6 +86,7 @@ library
     , ouroboros-network-framework  ^>=0.11.1
     , ouroboros-network-protocols  ^>=0.8
     , random
+    , safe-wild-cards              ^>=1.0
     , serialise                    ^>=0.2
     , si-timers                    ^>=1.4
     , strict-stm                   ^>=1.4


### PR DESCRIPTION
The problem fixed by #985 was caused by a new field not being used as it was only bound by `RecordWildCards`, which does not warn when some of the fields are unused.

This PR introduces the [`safe-wild-cards` library][safe-wild-cards] which is exactly about addressing this problem.

There are some concerns about this:

 - `TemplateHaskell` is known to sometimes have a negative effect on recompilation avoidance, and is generally annoying with cross compilation (however, we already use TH in tests, and eg cardano-node also uses it in the "main" code, so that isn't a show stopper).
 - `TemplateHaskell` has the weird stage restriction, which makes it necessary to shuffle some things around here. See the [*Note* at the bottom][safe-wild-cards] for an explanation why this is necessary.

Potential alternatives include:

 - (lightweight but more tedious) Use a more manual approach to avoid forgetting to handle fields (eg also pattern-matching on the bare constructor `StdRunNodeArgs _ _ _ ... = ...`).
 - (heavyweight) Refactor our configuration code to use some record library, such that the logic for passing down configuration values is "automatic" instead of requiring sth like `updateChainDbDefaults` in the current code.  
 - Wait until [this GHC proposal](https://github.com/brandon-leapyear/ghc-proposals/blob/patch-1/proposals/0436-recordwildcards-total.rst) has been implemented.

[safe-wild-cards]: https://hackage.haskell.org/package/safe-wild-cards-1.0.0.1/docs/SafeWildCards.html#v:fields 