### PR TITLE
Use the version of cardano-git-rev in the cardano-base repo

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -14,7 +14,7 @@ repository cardano-haskell-packages
 -- update either of these.
 index-state:
   -- Bump this if you need newer packages from Hackage
-  , hackage.haskell.org 2024-02-23T10:26:05Z
+  , hackage.haskell.org 2024-03-14T23:28:52Z
   -- Bump this if you need newer packages from CHaP
   , cardano-haskell-packages 2024-03-15T17:07:52Z
 

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1710523863,
-        "narHash": "sha256-D4Poy7wV+hchmKlSYYBBVRAoN3idvawkKvcu5nVPswE=",
+        "lastModified": 1710945682,
+        "narHash": "sha256-xp1txUjrtCuKHAy0nvz/lu0MlNdNnzvP8l2p9MFB73Y=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "9505fbf131d988594d284825fec20a0d65e43123",
+        "rev": "8df2bf06e4525ec39c106cd2593e3c5fd7f2b081",
         "type": "github"
       },
       "original": {
@@ -225,11 +225,11 @@
     "hackageNix": {
       "flake": false,
       "locked": {
-        "lastModified": 1708647761,
-        "narHash": "sha256-1WiRX2IqiopPq3sQTBPF7BswDacfGB9UUNnN9PYgrXA=",
+        "lastModified": 1710980597,
+        "narHash": "sha256-3WiA93vz5XSHnW/7AacBCmB2m9EQ9zD1rW9d3Tw7vSE=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "6a164db037c9cb2fd7ea946e7a0d62d7d8f53766",
+        "rev": "37b89d394bdfd1e6225daff4411f97c979e8d69c",
         "type": "github"
       },
       "original": {

--- a/ouroboros-consensus-cardano/changelog.d/20240312_160736_erikd_git_rev_a.md
+++ b/ouroboros-consensus-cardano/changelog.d/20240312_160736_erikd_git_rev_a.md
@@ -1,0 +1,4 @@
+### Non-Breaking
+
+- Use the version of cardano-git-rev in the cardano-base repo.
+

--- a/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
+++ b/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
@@ -498,7 +498,7 @@ library unstable-cardano-tools
     , cardano-crypto
     , cardano-crypto-class
     , cardano-crypto-wrapper
-    , cardano-git-rev                <0.2
+    , cardano-git-rev                ^>=0.2.1
     , cardano-ledger-allegra
     , cardano-ledger-alonzo
     , cardano-ledger-api

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/GitRev.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/GitRev.hs
@@ -23,5 +23,6 @@ gitRev
                [||T.pack (giHash gitInfo) <> if giDirty gitInfo then "-dirty" else ""||]
              -- In case of failure, try cardano-git-rev (where the commit hash
              -- can be embedded later).
-             Left _ -> [||Cardano.Git.Rev.gitRev||]
+             Left _ -> [||otherRev||]
           )
+    otherRev = $(Cardano.Git.Rev.gitRev)


### PR DESCRIPTION
# Description

This PR targets branch `cardano-node-8.9-backports`.

This is a cherry-pick of https://github.com/IntersectMBO/ouroboros-consensus/pull/991

`cardano-cli` needs cardano-git-rev > 0.2, and current ouroboros-consensus-cardano-0.14.1.0 requires `cardano-git-rev < 0.2`.

That constraint blocks new `cardano-cli` release:
https://github.com/IntersectMBO/cardano-haskell-packages/actions/runs/8373243058/job/22926023317?pr=709#step:7:267
