### PR TITLE
refactor ChainSync state

### DIFF
--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToNode.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToNode.hs
@@ -571,13 +571,11 @@ mkApps kernel Tracers {..} mkCodecs ByteLimits {..} genChainSyncTimeout lopBucke
         CsClient.bracketChainSyncClient
             (contramap (TraceLabelPeer them) (Node.chainSyncClientTracer (getTracers kernel)))
             (CsClient.defaultChainDbView (getChainDB kernel))
-            (getNodeStates kernel)
             (getChainSyncHandles kernel)
             them
             version
             lopBucketConfig
             $ \csState -> do
-            -- $ \varCandidate (startIdling, stopIdling) (pauseLoPBucket, resumeLoPBucket, grantLoPToken) setTheirTip setLatestSlot -> do
               chainSyncTimeout <- genChainSyncTimeout
               (r, trailing) <-
                 runPipelinedPeerWithLimits
@@ -597,7 +595,6 @@ mkApps kernel Tracers {..} mkCodecs ByteLimits {..} genChainSyncTimeout lopBucke
                         , CsClient.setCandidate = csvSetCandidate csState
                         , CsClient.idling = csvIdling csState
                         , CsClient.loPBucket = csvLoPBucket csState
-                        , CsClient.setTheirTip = csvSetTheirTip csState
                         , CsClient.setLatestSlot = csvSetLatestSlot csState
                         }
               return (ChainSyncInitiatorResult r, trailing)

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
@@ -210,7 +210,7 @@ initNodeKernel args@NodeKernelArgs { registry, cfg, tracers
                                 (configBlock cfg)
                                 headers
                                 (csCandidate state)
-              , GSM.peerIsIdle                = \ _ state -> pure (csIdling state)
+              , GSM.peerIsIdle                = csIdling
               , GSM.durationUntilTooOld       =
                       gsmDurationUntilTooOld
                   <&> \wd (_headers, lst) ->

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/GSM.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/GSM.hs
@@ -172,7 +172,7 @@ prop_sequential1 ::
 prop_sequential1 j0 cmds = runSimQC $ do
     -- these variables are part of the 'GSM.GsmView'
     varSelection  <- newTVarIO (mSelection $ initModel j0)
-    varCandidates <- newTVarIO Map.empty
+    varStates     <- newTVarIO Map.empty
     varIdlers     <- newTVarIO Set.empty
     varJudgment   <- newTVarIO j0
     varMarker     <- newTVarIO (toMarker j0)
@@ -186,7 +186,7 @@ prop_sequential1 j0 cmds = runSimQC $ do
     let vars =
             Vars
                 varSelection
-                varCandidates
+                varStates
                 varIdlers
                 varJudgment
                 varMarker
@@ -202,13 +202,13 @@ prop_sequential1 j0 cmds = runSimQC $ do
           ,
             GSM.candidateOverSelection = candidateOverSelection
           ,
+            GSM.peerIsIdle = \ peer _ -> Set.member peer <$> readTVar varIdlers
+          ,
             GSM.durationUntilTooOld = Just durationUntilTooOld
           ,
             GSM.equivalent = (==)   -- unsound, but harmless in this test
           ,
-            GSM.getChainSyncCandidates = readTVar varCandidates
-          ,
-            GSM.getChainSyncIdlers = readTVar varIdlers
+            GSM.getChainSyncStates = readTVar varStates
           ,
             GSM.getCurrentSelection = readTVar varSelection
           ,

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/GSM/Model.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/GSM/Model.hs
@@ -99,11 +99,9 @@ data Response r =
 
 type Model :: (Type -> Type) -> Type
 data Model r = Model {
-    mCandidates :: Map.Map UpstreamPeer Candidate
+    mCandidates :: Map.Map UpstreamPeer PeerState
   ,
     mClock      :: SI.Time
-  ,
-    mIdlers     :: Set.Set UpstreamPeer
   ,
     mNotables   :: Set.Set Notable
   ,
@@ -126,8 +124,6 @@ initModel j = Model {
     mCandidates = Map.empty
   ,
     mClock = SI.Time 0
-  ,
-    mIdlers = Set.empty
   ,
     mNotables = Set.empty
   ,
@@ -172,7 +168,7 @@ precondition model = pre $ \case
     StartIdling peer ->
         "idle after disconnect" `atom` (peer `Map.member` cands)
      QSM..&&
-        "double idle" `atom` (peer `Set.notMember` idlers)
+        "double idle" `atom` (Idling False == maybe (Idling False) psIdling (cands Map.!? peer))
     TimePasses dur ->
         "non-positive duration" `atom` (0 < dur)
      QSM..&&
@@ -180,8 +176,6 @@ precondition model = pre $ \case
   where
     Model {
         mCandidates = cands
-      ,
-        mIdlers = idlers
       } = model
 
     pre f cmd = f cmd QSM..// show cmd
@@ -191,25 +185,21 @@ transition model cmd resp = fixupModelState cmd $ case (cmd, resp) of
     (Disconnect peer, Unit) ->
         model' {
             mCandidates = Map.delete peer cands
-          ,
-            mIdlers = Set.delete peer idlers
           }
     (ExtendSelection sdel, Unit) ->
         model' { mSelection = Selection (b + 1) (s + sdel) }
     (ModifyCandidate peer bdel, Unit) ->
         model' {
-            mCandidates = Map.insertWith plusC peer (Candidate bdel) cands
-          ,
-            mIdlers = Set.delete peer idlers
+            mCandidates = Map.alter (plusC bdel) peer cands
           }
     (NewCandidate peer bdel, Unit) ->
-        model' { mCandidates = Map.insert peer (Candidate (b + bdel)) cands }
+        model' { mCandidates = Map.insert peer (PeerState (Candidate (b + bdel)) (Idling False)) cands }
     (ReadJudgment, ReadThisJudgment{}) ->
         model'
     (ReadMarker, ReadThisMarker{}) ->
         model'
     (StartIdling peer, Unit) ->
-        model' { mIdlers = Set.insert peer idlers }
+        model' { mCandidates = Map.adjust (\ (PeerState c _) -> PeerState c (Idling True)) peer cands }
     (TimePasses dur, Unit) ->
         addNotableWhen BigDurN (dur > 300)
       $ model {
@@ -224,14 +214,13 @@ transition model cmd resp = fixupModelState cmd $ case (cmd, resp) of
       ,
         mClock = clk
       ,
-        mIdlers = idlers
-      ,
         mSelection = Selection b s
       } = model
 
     model' = model { mPrev = WhetherPrevTimePasses False }
 
-    plusC (Candidate x) (Candidate y) = Candidate (x + y)
+    plusC x (Just (PeerState (Candidate y) i)) = Just (PeerState (Candidate (x + y)) i)
+    plusC x Nothing = Just (PeerState (Candidate x) (Idling False))
 
 -- | Update the 'mState', assuming that's the only stale field in the given
 -- 'Model'
@@ -269,8 +258,6 @@ fixupModelState cmd model =
       ,
         mClock = clk
       ,
-        mIdlers = idlers
-      ,
         mSelection = sel
       ,
         mState = st
@@ -283,10 +270,10 @@ fixupModelState cmd model =
 
     some = 0 < Map.size cands
 
-    allIdling = idlers == Map.keysSet cands
+    allIdling = all isIdling cands
 
-    ok cand =
-        GSM.WhetherCandidateIsBetter False == candidateOverSelection sel cand
+    ok peer =
+        GSM.WhetherCandidateIsBetter False == candidateOverSelection sel peer
 
     -- the first time the node would transition to OnlyBootstrap
     expiry          timestamp = expiryAge `max` expiryThrashing timestamp
@@ -368,7 +355,7 @@ generator ub model = Just $ QC.frequency $
  <>
     [ (,) 20 $ pure ReadMarker ]
  <>
-    [ (,) 50 $ StartIdling <$> elements oldNotIdling | notNull oldNotIdling ]
+    [ (,) 50 $ StartIdling <$> elements (Map.keys oldNotIdling) | not (Map.null oldNotIdling) ]
  <>
     [ (,) 100 $ TimePasses <$> genTimePassesDur | prev == WhetherPrevTimePasses False ]
   where
@@ -376,8 +363,6 @@ generator ub model = Just $ QC.frequency $
         mCandidates = cands
       ,
         mClock = clk
-      ,
-        mIdlers = idlers
       ,
         mPrev = prev
       ,
@@ -393,7 +378,7 @@ generator ub model = Just $ QC.frequency $
         Nothing   -> []
         Just peer -> [ minBound .. peer ] \\ old
 
-    oldNotIdling = old \\ Set.toList idlers
+    oldNotIdling = psCandidate <$> Map.filter (not . isIdling) cands
 
     genTimePassesDur = QC.frequency $
         [ (,) 10 $ choose (1, 70) ]
@@ -420,7 +405,7 @@ generator ub model = Just $ QC.frequency $
           [ (,)
               peer
               (filter (/= 0) [ b + offset - c | offset <- [-lim .. lim] ])
-          | (peer, Candidate c) <- Map.assocs cands
+          | (peer, PeerState (Candidate c) _) <- Map.assocs cands
           ]
 
 
@@ -497,6 +482,14 @@ newtype Candidate = Candidate B
   deriving stock    (Eq, Ord, Generic, Show)
   deriving anyclass (TD.ToExpr)
 
+newtype Idling = Idling Bool
+  deriving stock    (Eq, Ord, Generic, Show)
+  deriving anyclass (TD.ToExpr)
+
+data PeerState = PeerState { psCandidate :: !Candidate, psIdling :: !Idling }
+  deriving stock    (Eq, Ord, Generic, Show)
+  deriving anyclass (TD.ToExpr)
+
 data MarkerState = Present | Absent
   deriving stock    (Eq, Ord, Generic, Read, Show)
   deriving anyclass (TD.ToExpr)
@@ -566,9 +559,9 @@ instance QC.Arbitrary MarkerState where
 
 candidateOverSelection ::
      Selection
-  -> Candidate
+  -> PeerState
   -> GSM.CandidateVersusSelection
-candidateOverSelection (Selection b _s) (Candidate b') =
+candidateOverSelection (Selection b _s) (PeerState (Candidate b') _) =
     -- TODO this ignores CandidateDoesNotIntersect, which seems harmless, but
     -- I'm not quite sure
     GSM.WhetherCandidateIsBetter (b < b')
@@ -601,7 +594,7 @@ thrashLimit = 8   -- seconds
 
 selectionIsBehind :: Model r -> Bool
 selectionIsBehind model =
-    any (\(Candidate b') -> b' > b) cands
+    any (\(PeerState (Candidate b') _) -> b' > b) cands
   where
     Model {
         mCandidates = cands
@@ -658,3 +651,6 @@ boringDur model dur =
             "boringDur state" `atom` (gap < 0 || 0 /= n)
 
     secondsToPicoseconds x = x * 10 ^ (12 :: Int)
+
+isIdling :: PeerState -> Bool
+isIdling (PeerState {psIdling = Idling i}) = i

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/DensityDisconnect.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/DensityDisconnect.hs
@@ -9,7 +9,7 @@ import           Control.Monad.Class.MonadTime.SI (Time (..))
 import           Data.Bifunctor (second)
 import           Data.Foldable (minimumBy, toList)
 import           Data.Function (on)
-import           Data.Functor (($>))
+import           Data.Functor (($>), (<&>))
 import           Data.List (intercalate)
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
@@ -20,6 +20,8 @@ import           Ouroboros.Consensus.Config.SecurityParam
                      (SecurityParam (SecurityParam), maxRollbacks)
 import           Ouroboros.Consensus.Genesis.Governor (densityDisconnect,
                      sharedCandidatePrefix)
+import           Ouroboros.Consensus.MiniProtocol.ChainSync.Client
+                     (ChainSyncState (..))
 import           Ouroboros.Network.AnchoredFragment (AnchoredFragment)
 import qualified Ouroboros.Network.AnchoredFragment as AF
 import           Ouroboros.Network.Block (HasHeader, Tip (TipGenesis),
@@ -115,9 +117,17 @@ staticCandidates GenesisTest {gtSecurityParam, gtGenesisWindow, gtBlockTree} =
 prop_densityDisconnectStatic :: Property
 prop_densityDisconnectStatic =
   forAll gen $ \ StaticCandidates {k, sgen, suffixes, loeFrag} -> do
-    let (disconnect, _) = densityDisconnect sgen k suffixes mempty mempty loeFrag
+    let (disconnect, _) = densityDisconnect sgen k (mkState <$> suffixes) suffixes loeFrag
     not (null disconnect) && HonestPeer `notElem` disconnect
   where
+    mkState :: AnchoredFragment (Header TestBlock) -> ChainSyncState TestBlock
+    mkState frag =
+      ChainSyncState {
+        csCandidate = frag,
+        csLatestSlot = Just (AF.headSlot frag),
+        csIdling = False,
+        csTip = Nothing
+      }
     gen = do
       gt <- genChains (QC.choose (1, 4))
       elements (staticCandidates gt)
@@ -253,8 +263,17 @@ evolveBranches EvolvingPeers {k, sgen, peers = initialPeers} =
       let
           curChain = selection (value (firstBranch ps))
           next = updatePeer movePeer target ps
-          (loeFrag, suffixes) = sharedCandidatePrefix curChain (candidate . value <$> toMap next)
-          disconnect = fst (densityDisconnect sgen k suffixes mempty mempty loeFrag)
+          candidates = candidate . value <$> toMap next
+          states =
+            candidates <&> \ csCandidate ->
+              ChainSyncState {
+                csCandidate,
+                csIdling = False,
+                csLatestSlot = Just (AF.headSlot csCandidate),
+                csTip = Nothing
+              }
+          (loeFrag, suffixes) = sharedCandidatePrefix curChain candidates
+          disconnect = fst (densityDisconnect sgen k states suffixes loeFrag)
       either (pure . second (result loeFrag)) step (updatePeers sgen target disconnect next)
       where
         result f final = EvolvingPeers {k, sgen, peers = final, loeFrag = f}

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/DensityDisconnect.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/DensityDisconnect.hs
@@ -125,8 +125,7 @@ prop_densityDisconnectStatic =
       ChainSyncState {
         csCandidate = frag,
         csLatestSlot = Just (AF.headSlot frag),
-        csIdling = False,
-        csTip = Nothing
+        csIdling = False
       }
     gen = do
       gt <- genChains (QC.choose (1, 4))
@@ -269,8 +268,7 @@ evolveBranches EvolvingPeers {k, sgen, peers = initialPeers} =
               ChainSyncState {
                 csCandidate,
                 csIdling = False,
-                csLatestSlot = Just (AF.headSlot csCandidate),
-                csTip = Nothing
+                csLatestSlot = Just (AF.headSlot csCandidate)
               }
           (loeFrag, suffixes) = sharedCandidatePrefix curChain candidates
           disconnect = fst (densityDisconnect sgen k states suffixes loeFrag)

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/ChainSync.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/ChainSync.hs
@@ -18,21 +18,20 @@ import           Control.Monad.Class.MonadTimer.SI (MonadTimer)
 import           Control.Tracer (Tracer (Tracer), nullTracer, traceWith)
 import           Data.Map.Strict (Map)
 import           Data.Proxy (Proxy (..))
-import           Data.Set (Set)
 import           Network.TypedProtocol.Codec (AnyMessage)
-import           Ouroboros.Consensus.Block (Header, Point, SlotNo)
+import           Ouroboros.Consensus.Block (Header, Point)
 import           Ouroboros.Consensus.Config (TopLevelConfig (..))
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
                      (LedgerSupportsProtocol)
 import           Ouroboros.Consensus.MiniProtocol.ChainSync.Client (ChainDbView,
-                     ChainSyncClientHandle, ChainSyncLoPBucketConfig, Consensus,
-                     Their, bracketChainSyncClient, chainSyncClient)
+                     ChainSyncClientHandle, ChainSyncLoPBucketConfig,
+                     ChainSyncState, ChainSyncStateView (..), Consensus,
+                     bracketChainSyncClient, chainSyncClient)
 import qualified Ouroboros.Consensus.MiniProtocol.ChainSync.Client as CSClient
 import qualified Ouroboros.Consensus.MiniProtocol.ChainSync.Client.InFutureCheck as InFutureCheck
 import           Ouroboros.Consensus.Util (ShowProxy)
 import           Ouroboros.Consensus.Util.IOLike (Exception (fromException),
-                     IOLike, MonadCatch (try), STM, StrictTVar)
-import           Ouroboros.Network.AnchoredFragment (AnchoredFragment)
+                     IOLike, MonadCatch (try), StrictTVar)
 import           Ouroboros.Network.Block (Tip)
 import           Ouroboros.Network.Channel (Channel)
 import           Ouroboros.Network.ControlMessage (ControlMessage (..))
@@ -72,27 +71,14 @@ basicChainSyncClient ::
   Tracer m (TraceEvent blk) ->
   TopLevelConfig blk ->
   ChainDbView m blk ->
-  StrictTVar m (AnchoredFragment (Header blk)) ->
-  -- ^ A TVar containing the fragment of headers for that peer, kept up to date
-  -- by the ChainSync client.
-  (m (), m ()) ->
-  -- ^ Two monadic actions called when reaching and leaving @StIdle@.
-  (m (), m (), m ()) ->
-  -- ^ Three monadic actions called to pause and resume the LoP bucket and to
-  -- add a token to the LoP bucket.
-  (Their (Tip blk) -> STM m ()) ->
-  (SlotNo -> STM m ()) ->
+  ChainSyncStateView m blk ->
   Consensus ChainSyncClientPipelined blk m
 basicChainSyncClient
     peerId
     tracer
     cfg
     chainDbView
-    varCandidate
-    (startIdling, stopIdling)
-    (pauseLoPBucket, resumeLoPBucket, grantLoPToken)
-    setTheirTip
-    setLatestSlot =
+    csState =
   chainSyncClient
     CSClient.ConfigEnv {
         CSClient.mkPipelineDecision0     = pipelineDecisionLowHighMark 10 20
@@ -105,14 +91,11 @@ basicChainSyncClient
         CSClient.version             = maxBound
       , CSClient.controlMessageSTM   = return Continue
       , CSClient.headerMetricsTracer = nullTracer
-      , CSClient.varCandidate
-      , CSClient.startIdling
-      , CSClient.stopIdling
-      , CSClient.pauseLoPBucket
-      , CSClient.resumeLoPBucket
-      , CSClient.grantLoPToken
-      , CSClient.setTheirTip
-      , CSClient.setLatestSlot
+      , CSClient.setCandidate = csvSetCandidate csState
+      , CSClient.idling = csvIdling csState
+      , CSClient.loPBucket = csvLoPBucket csState
+      , CSClient.setTheirTip = csvSetTheirTip csState
+      , CSClient.setLatestSlot = csvSetLatestSlot csState
       }
   where
     dummyHeaderInFutureCheck ::
@@ -141,12 +124,11 @@ runChainSyncClient ::
   -- ^ Configuration for the LoP bucket.
   StateViewTracers blk m ->
   -- ^ Tracers used to record information for the future 'StateView'.
-  StrictTVar m (Map PeerId (StrictTVar m (AnchoredFragment (Header blk)))) ->
+  StrictTVar m (Map PeerId (StrictTVar m (ChainSyncState blk))) ->
   -- ^ A TVar containing a map of fragments of headers for each peer. This
   -- function will (via 'bracketChainSyncClient') register and de-register a
   -- TVar for the fragment of the peer.
   StrictTVar m (Map PeerId (ChainSyncClientHandle m blk)) ->
-  StrictTVar m (Set PeerId) ->
   Channel m (AnyMessage (ChainSync (Header blk) (Point blk) (Tip blk))) ->
   m ()
 runChainSyncClient
@@ -159,18 +141,16 @@ runChainSyncClient
   StateViewTracers {svtPeerSimulatorResultsTracer}
   varCandidates
   varHandles
-  varIdling
   channel = do
     bracketChainSyncClient
       nullTracer
       chainDbView
       varCandidates
-      varIdling
       varHandles
       peerId
       (maxBound :: NodeToNodeVersion)
       lopBucketConfig
-      $ \varCandidate idleManagers lopBucket setTip setLatestSlot -> do
+      $ \csState -> do
         res <-
           try $
             runPipelinedPeerWithLimits
@@ -185,11 +165,7 @@ runChainSyncClient
                   tracer
                   cfg
                   chainDbView
-                  varCandidate
-                  idleManagers
-                  lopBucket
-                  setTip
-                  setLatestSlot))
+                  csState))
         case res of
           Right res' -> traceWith svtPeerSimulatorResultsTracer $
             PeerSimulatorResult peerId $ SomeChainSyncClientResult $ Right res'

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Resources.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Resources.hs
@@ -117,10 +117,7 @@ data PeerSimulatorResources m blk =
     -- | Resources for individual peers.
     psrPeers   :: Map PeerId (PeerResources m blk),
 
-    -- | The shared state used by ChainDB, ChainSync and BlockFetch.
-    psrStates  :: StrictTVar m (Map PeerId (StrictTVar m (ChainSyncState blk))),
-
-    -- | Handlers to interact with the ChainSync client of each peer.
+    -- | Handles to interact with the ChainSync client of each peer.
     -- See 'ChainSyncClientHandle' for more details.
     psrHandles :: StrictTVar m (Map PeerId (ChainSyncClientHandle m TestBlock))
   }
@@ -240,6 +237,5 @@ makePeerSimulatorResources tracer blockTree peers = do
   resources <- for peers $ \ peerId -> do
     peerResources <- makePeerResources tracer blockTree peerId
     pure (peerId, peerResources)
-  psrStates <- uncheckedNewTVarM mempty
   psrHandles <- uncheckedNewTVarM mempty
-  pure PeerSimulatorResources {psrStates, psrPeers = Map.fromList $ toList resources, psrHandles}
+  pure PeerSimulatorResources {psrPeers = Map.fromList $ toList resources, psrHandles}

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
@@ -167,6 +167,8 @@ prettyPeersSchedule peers =
 -- Finally, drops the first state, since all points being 'Origin' (in particular the tip) has no
 -- useful effects in the simulator, but it could set the tip in the GDD governor to 'Origin', which
 -- causes slow nodes to be disconnected right away.
+--
+-- TODO Remove dropping the first state in favor of better GDD logic
 peerStates :: Peer (PeerSchedule blk) -> [(Time, Peer (NodeState blk))]
 peerStates Peer {name, value = schedulePoints} =
   drop 1 (zip (Time 0 : (map shiftTime times)) (Peer name <$> scanl' modPoint genesisNodeState points))

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Genesis/Governor.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Genesis/Governor.hs
@@ -32,8 +32,7 @@ import           Data.Containers.ListUtils (nubOrd)
 import           Data.Foldable (for_)
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import           Data.Set (Set)
-import qualified Data.Set as Set
+import           Data.Maybe (maybeToList)
 import           Data.Void
 import           Data.Word (Word64)
 import           GHC.Generics (Generic)
@@ -50,7 +49,7 @@ import           Ouroboros.Consensus.Ledger.Extended (ExtLedgerState,
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
                      (LedgerSupportsProtocol)
 import           Ouroboros.Consensus.MiniProtocol.ChainSync.Client
-                     (ChainSyncClientHandle (..))
+                     (ChainSyncClientHandle (..), ChainSyncState (..))
 import           Ouroboros.Consensus.Storage.ChainDB.API (ChainDB,
                      triggerChainSelectionAsync)
 import qualified Ouroboros.Consensus.Storage.ChainDB.API as ChainDB
@@ -203,29 +202,27 @@ densityDisconnect ::
      )
   => GenesisWindow
   -> SecurityParam
+  -> Map peer (ChainSyncState blk)
   -> Map peer (AnchoredFragment (Header blk))
-  -> Set peer
-  -> Map peer SlotNo
   -> AnchoredFragment (Header blk)
   -> ([peer], Map peer (DensityBounds blk))
-densityDisconnect (GenesisWindow sgen) (SecurityParam k) candidateSuffixes caughtUpPeers latestSlots loeFrag =
+densityDisconnect (GenesisWindow sgen) (SecurityParam k) states candidateSuffixes loeFrag =
   (losingPeers, densityBounds)
   where
     densityBounds = Map.fromList $ do
       (peer, fragment) <- Map.toList competingFrags
-      -- Skip peers that haven't advertised their tip yet.
+      state <- maybeToList (states Map.!? peer)
+      -- Skip peers that haven't sent any headers yet.
       -- They should be disconnected by timeouts instead.
-      -- TODO We probably need an alternative approach for this now
-      -- that we don't use the tip anymore
+      latestSlot' <- maybeToList (csLatestSlot state)
       let candidateSuffix = candidateSuffixes Map.! peer
 
-          caughtUp = Set.member peer caughtUpPeers
-
-          latestSlot = case (AF.headSlot candidateSuffix, latestSlots Map.!? peer) of
-            (Origin, Nothing) -> NoLatestSlot
-            (Origin, Just latest) -> LatestSlot latest
-            (NotOrigin cand, Nothing) -> LatestSlot cand
-            (NotOrigin cand, Just latest) -> LatestSlot (max cand latest)
+          -- TODO When is the latest slot set to Origin?
+          latestSlot = case (AF.headSlot candidateSuffix, latestSlot') of
+            (Origin, Origin)                   -> NoLatestSlot
+            (Origin, NotOrigin latest)         -> LatestSlot latest
+            (NotOrigin cand, Origin)           -> LatestSlot cand
+            (NotOrigin cand, NotOrigin latest) -> LatestSlot (max cand latest)
 
           -- If the peer has more headers that it hasn't sent yet, each slot between the latest header we know of and
           -- the end of the Genesis window could contain a block, so the upper bound for the total number of blocks in
@@ -234,7 +231,7 @@ densityDisconnect (GenesisWindow sgen) (SecurityParam k) candidateSuffixes caugh
           -- candidate fragment extends beyond it or because we are waiting to validate a header beyond the forecast
           -- horizon that we already received), there can be no headers in between and 'potentialSlots' is 0.
           SlotNo potentialSlots
-            | caughtUp
+            | not (csIdling state)
             = 0
             | otherwise
             = case latestSlot of
@@ -335,23 +332,19 @@ updateLoEFragGenesis ::
      )
   => TopLevelConfig blk
   -> Tracer m (TraceGDDEvent peer blk)
-  -> STM m (Map peer (AnchoredFragment (Header blk)))
+  -> STM m (Map peer (ChainSyncState blk))
   -> STM m (Map peer (ChainSyncClientHandle m blk))
-  -> STM m (Set peer)
   -> UpdateLoEFrag m blk
-updateLoEFragGenesis cfg tracer getCandidates getHandles getCaughtUpPeers =
+updateLoEFragGenesis cfg tracer getStates getHandles =
   UpdateLoEFrag $ \ curChain immutableLedgerSt -> do
-    (candidates, candidateSuffixes, handles, caughtUpPeers, latestSlots, loeFrag) <- atomically $ do
-      candidates <- getCandidates
+    (states, candidates, candidateSuffixes, handles, loeFrag) <- atomically $ do
+      states <- getStates
       handles <- getHandles
-      caughtUpPeers <- getCaughtUpPeers
       let
+        candidates = csCandidate <$> states
         (loeFrag, candidateSuffixes) =
           sharedCandidatePrefix curChain candidates
-      latestSlots <-
-        flip Map.traverseWithKey candidateSuffixes $ \peer _ ->
-          cschLatestSlot (handles Map.! peer)
-      pure (candidates, candidateSuffixes, handles, caughtUpPeers, latestSlots, loeFrag)
+      pure (states, candidates, candidateSuffixes, handles, loeFrag)
 
     let msgen :: Maybe GenesisWindow
         -- This could also use 'runWithCachedSummary' if deemed desirable.
@@ -379,7 +372,7 @@ updateLoEFragGenesis cfg tracer getCandidates getHandles getCaughtUpPeers =
     whenJust msgen $ \sgen -> do
       let
         (losingPeers, bounds) =
-          densityDisconnect sgen (configSecurityParam cfg) candidateSuffixes caughtUpPeers latestSlots loeFrag
+          densityDisconnect sgen (configSecurityParam cfg) states candidateSuffixes loeFrag
         loeHead = AF.headAnchor loeFrag
 
       traceWith tracer TraceGDDEvent {sgen, curChain, bounds, candidates, candidateSuffixes, losingPeers, loeHead}

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Genesis/Governor.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Genesis/Governor.hs
@@ -332,14 +332,13 @@ updateLoEFragGenesis ::
      )
   => TopLevelConfig blk
   -> Tracer m (TraceGDDEvent peer blk)
-  -> STM m (Map peer (ChainSyncState blk))
   -> STM m (Map peer (ChainSyncClientHandle m blk))
   -> UpdateLoEFrag m blk
-updateLoEFragGenesis cfg tracer getStates getHandles =
+updateLoEFragGenesis cfg tracer getHandles =
   UpdateLoEFrag $ \ curChain immutableLedgerSt -> do
     (states, candidates, candidateSuffixes, handles, loeFrag) <- atomically $ do
-      states <- getStates
       handles <- getHandles
+      states <- traverse (readTVar . cschState) handles
       let
         candidates = csCandidate <$> states
         (loeFrag, candidateSuffixes) =


### PR DESCRIPTION
This is step 1 of an effort to bundle some of the arguments to various ChainSync functions.

We plan to add some abstraction for the actions in `ChainSyncStateView` in a future changeset.

The names of these types should probably be improved, but that doesn't have to happen now, so we can unblock @facundominguez.

@amesgen I updated the GSM model to replicate the state changes, please lmk if that's cool.