### PR TITLE
Fix test: leashing attack with limited time

### DIFF
--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup.hs
@@ -104,6 +104,8 @@ forAllGenesisTest generator schedulerConfig shrinker mkProperty =
         classify (genesisWindowAfterIntersection cls) "Full genesis window after intersection" $
         classify (adversaryRollback schCls) "An adversary did a rollback" $
         classify (honestRollback schCls) "The honest peer did a rollback" $
+        classify (allAdversariesEmpty schCls) "All adversaries have empty schedules" $
+        classify (allAdversariesTrivial schCls) "All adversaries have trivial schedules" $
         tabulate "Adversaries killed by LoP" [printf "%.1f%%" $ adversariesKilledByLoP resCls] $
         tabulate "Adversaries killed by GDD" [printf "%.1f%%" $ adversariesKilledByGDD resCls] $
         tabulate "Adversaries killed by Timeout" [printf "%.1f%%" $ adversariesKilledByTimeout resCls] $

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/BlockFetch.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/BlockFetch.hs
@@ -95,6 +95,10 @@ startBlockFetchLogic registry tracer chainDb fetchClientRegistry getCandidates =
             -- do not serialize the blocks.
             (\_hdr -> 1000)
             slotForgeTime
+            -- Initially, we tried FetchModeBulkSync, but adversaries had the
+            -- opportunity to delay syncing by not responding to block requests.
+            -- The BlockFetch logic would then wait for the timeout to expire
+            -- before trying to download the block from another peer.
             (pure FetchModeDeadline)
 
         -- Values taken from
@@ -110,7 +114,7 @@ startBlockFetchLogic registry tracer chainDb fetchClientRegistry getCandidates =
             -- advanced to allow completion of the batch.
             --
             bfcMaxConcurrencyBulkSync = 50
-          , bfcMaxConcurrencyDeadline = 2
+          , bfcMaxConcurrencyDeadline = 50
           , bfcMaxRequestsInflight = 10
           , bfcDecisionLoopInterval = 0
           , bfcSalt = 0

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/BlockFetch.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/BlockFetch.hs
@@ -95,7 +95,7 @@ startBlockFetchLogic registry tracer chainDb fetchClientRegistry getCandidates =
             -- do not serialize the blocks.
             (\_hdr -> 1000)
             slotForgeTime
-            (pure FetchModeBulkSync)
+            (pure FetchModeDeadline)
 
         -- Values taken from
         -- ouroboros-consensus-diffusion/src/unstable-diffusion-testlib/Test/ThreadNet/Network.hs


### PR DESCRIPTION
- [x] Sometimes BlockFetch client doesn't get the block from the adversary and gets stalled
- [x] Compute time bounds according to real bucket parameters
- [x] Label empty schedules & trivial schedules
- [ ] ~Complete empty schedules with a dummy initial adversary point, to start the LoP~
- [ ] ~Enable timeouts only if a reasonable portion of tests are nonempty/nontrivial~
- [x] Extend the schedule so that adversary disconnection can happen