### PR TITLE
[WIP] Introduce shrinking for honest peers

### DIFF
--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Shrinking.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Shrinking.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE LambdaCase     #-}
 {-# LANGUAGE NamedFieldPuns #-}
 
 module Test.Consensus.PointSchedule.Shrinking (
@@ -19,6 +20,7 @@ import           Test.Consensus.PointSchedule
                      (GenesisTest (gtBlockTree, gtSchedule), GenesisTestFull,
                      PeerSchedule, PeersSchedule, peerSchedulesBlocks)
 import           Test.Consensus.PointSchedule.Peers (Peers (..))
+import           Test.Consensus.PointSchedule.SinglePeer (SchedulePoint (..))
 import           Test.QuickCheck (shrinkList)
 import           Test.Util.TestBlock (TestBlock, isAncestorOf,
                      isStrictAncestorOf)
@@ -32,9 +34,16 @@ shrinkPeerSchedules ::
   StateView TestBlock ->
   [GenesisTestFull TestBlock]
 shrinkPeerSchedules genesisTest _stateView =
-  shrinkOtherPeers shrinkPeerSchedule (gtSchedule genesisTest) <&> \shrunkSchedule ->
-    let trimmedBlockTree = trimBlockTree' shrunkSchedule (gtBlockTree genesisTest)
-     in genesisTest{gtSchedule = shrunkSchedule, gtBlockTree = trimmedBlockTree}
+  let trimmedBlockTree sch = trimBlockTree' sch (gtBlockTree genesisTest)
+      shrunkOthers = shrinkOtherPeers shrinkPeerSchedule (gtSchedule genesisTest) <&>
+        \shrunkSchedule -> genesisTest
+          { gtSchedule = shrunkSchedule
+          , gtBlockTree = trimmedBlockTree shrunkSchedule
+          }
+      shrunkHonest = shrinkHonestPeer shrinkHonestSchedule (gtSchedule genesisTest) <&>
+        -- No need to update the tree here, shrinking the honest peer never discards blocks
+        \shrunkSchedule -> genesisTest {gtSchedule = shrunkSchedule}
+  in shrunkOthers ++ shrunkHonest
 
 -- | Shrink a 'Peers PeerSchedule' by removing adversaries. This does not affect
 -- the honest peer; and it does not remove ticks from the schedules of the
@@ -59,6 +68,39 @@ shrinkOtherPeers :: (a -> [a]) -> Peers a -> [Peers a]
 shrinkOtherPeers shrink Peers{honest, others} =
   map (Peers honest . Map.fromList) $
     shrinkList (traverse (traverse shrink)) $ Map.toList others
+
+-- | Shrink on the `honest` field of a `Peers` structure using the given shrinking function
+shrinkHonestPeer :: (a -> [a]) -> Peers a -> [Peers a]
+shrinkHonestPeer shrink Peers{honest, others} =
+  map (\h -> Peers h others) $ traverse shrink honest
+
+-- | We shrink an honest peer schedule by either:
+-- * locally re-ordering it (with TipPoint < HeaderPoint < BlockPoint),
+-- * collapsing a point with it predecessor if it has the same type.
+-- With the additional restriction that we never collapse the last point,
+-- in order to keep the same end time.
+shrinkHonestSchedule :: (PeerSchedule blk) -> [PeerSchedule blk]
+shrinkHonestSchedule sch =
+  mapMaybe
+    (\case
+      (hd, pre:suc:guard:tl) -> case (snd pre, snd suc) of
+          (ScheduleTipPoint    _, ScheduleTipPoint    _) -> collapse
+          (ScheduleTipPoint    _, ScheduleHeaderPoint _) -> Nothing
+          (ScheduleTipPoint    _, ScheduleBlockPoint  _) -> Nothing
+          (ScheduleHeaderPoint _, ScheduleTipPoint    _) -> reorder
+          (ScheduleHeaderPoint _, ScheduleHeaderPoint _) -> collapse
+          (ScheduleHeaderPoint _, ScheduleBlockPoint  _) -> Nothing
+          (ScheduleBlockPoint  _, ScheduleTipPoint    _) -> reorder
+          (ScheduleBlockPoint  _, ScheduleHeaderPoint _) -> reorder
+          (ScheduleBlockPoint  _, ScheduleBlockPoint  _) -> collapse
+        where
+          (timePre, pointPre) = pre
+          (timeSuc, pointSuc) = suc
+          reorder  = Just $ hd ++ (timePre, pointSuc):(timeSuc, pointPre):guard:tl
+          collapse = Just $ hd ++ (timePre, pointSuc)                    :guard:tl
+      _ -> Nothing
+    )
+    (map (\i -> splitAt i sch) [0..length sch])
 
 -- | Remove blocks from the given block tree that are not necessary for the
 -- given peer schedules. If entire branches are unused, they are removed. If the


### PR DESCRIPTION
This PR introduces shrinking for honest peers schedule.

We shrink an honest peer schedule by either:
* locally re-ordering it (with `TipPoint` < `HeaderPoint` < `BlockPoint`),
* collapsing a point with it predecessor if it has the same type.

With the additional restriction that we never collapse the last point, in order to keep the same end time.

This is an example of a newly shrunk schedule:
```
gtBlockTree:                                                                                   
  G | 1-0 2-1 3-2 4-3 5-4 6-5 7-6 8-7                                                          
  G | 1-0 2-1 3-2 4-4[1] 5-7                                                                                                                                                                             
  slots:    0  1  2  3  4  5  6  7                                                                                                                                                                       
  trunk:  ──1──2──3──4──5──6──7──8                                                             
                  ╰─────4────────5                                                                                                                                                                       
gtSchedule:                                                                                    
  0: honest   : TP 8-7          | HP G   | BP G   @ 0.000000                                   
  1: adversary: TP 5-7[3x0,1,0] | HP G   | BP G   @ 0.000000                                                                                                                                             
  2: adversary: TP 5-7[3x0,1,0] | HP 3-2 | BP G   @ 0.000000                                                                                                                                             
  3: adversary: TP 5-7[3x0,1,0] | HP 3-2 | BP 3-2 @ 0.000000                                   
  4: honest   : TP 8-7          | HP 3-2 | BP G   @ 0.500000                                   
  5: honest   : TP 8-7          | HP 3-2 | BP 3-2 @ 0.500000                                                                                                                                             
  6: honest   : TP 8-7          | HP 8-7 | BP 3-2 @ 5.000000
  7: honest   : TP 8-7          | HP 8-7 | BP 8-7 @ 5.000000
  8: adversary: TP 5-7[3x0,1,0] | HP 3-2 | BP 3-2 @ 11.000000
```