### PR TITLE
Enter ChainSync jumping - Governor-less approach

### DIFF
--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToNode.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToNode.hs
@@ -541,10 +541,11 @@ mkApps ::
   -> ByteLimits bCS bBF bTX bKA
   -> m ChainSyncTimeout
   -> CsClient.ChainSyncLoPBucketConfig
+  -> CsClient.CSJConfig
   -> ReportPeerMetrics m (ConnectionId addrNTN)
   -> Handlers m addrNTN blk
   -> Apps m addrNTN bCS bBF bTX bKA bPS NodeToNodeInitiatorResult ()
-mkApps kernel Tracers {..} mkCodecs ByteLimits {..} genChainSyncTimeout lopBucketConfig ReportPeerMetrics {..} Handlers {..} =
+mkApps kernel Tracers {..} mkCodecs ByteLimits {..} genChainSyncTimeout lopBucketConfig csjConfig ReportPeerMetrics {..} Handlers {..} =
     Apps {..}
   where
     aChainSyncClient
@@ -573,6 +574,7 @@ mkApps kernel Tracers {..} mkCodecs ByteLimits {..} genChainSyncTimeout lopBucke
             them
             version
             lopBucketConfig
+            csjConfig
             $ \csState -> do
               chainSyncTimeout <- genChainSyncTimeout
               (r, trailing) <-
@@ -594,6 +596,7 @@ mkApps kernel Tracers {..} mkCodecs ByteLimits {..} genChainSyncTimeout lopBucke
                         , CsClient.idling = csvIdling csState
                         , CsClient.loPBucket = csvLoPBucket csState
                         , CsClient.setLatestSlot = csvSetLatestSlot csState
+                        , CsClient.jumping = csvJumping csState
                         }
               return (ChainSyncInitiatorResult r, trailing)
 

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Node.hs
@@ -80,7 +80,7 @@ import           Ouroboros.Consensus.Fragment.InFuture (CheckInFuture,
 import qualified Ouroboros.Consensus.Fragment.InFuture as InFuture
 import           Ouroboros.Consensus.Ledger.Extended (ExtLedgerState (..))
 import           Ouroboros.Consensus.MiniProtocol.ChainSync.Client
-                     (ChainSyncLoPBucketConfig (..))
+                     (CSJConfig (..), ChainSyncLoPBucketConfig (..))
 import qualified Ouroboros.Consensus.MiniProtocol.ChainSync.Client.InFutureCheck as InFutureCheck
 import qualified Ouroboros.Consensus.Network.NodeToClient as NTC
 import qualified Ouroboros.Consensus.Network.NodeToNode as NTN
@@ -251,6 +251,9 @@ data LowLevelRunNodeArgs m addrNTN addrNTC versionDataNTN versionDataNTC blk
 
       -- | See 'CsClient.ChainSyncLoPBucketConfig'
     , llrnChainSyncLoPBucketConfig :: ChainSyncLoPBucketConfig
+
+      -- | See 'CsClient.CSJConfig'
+    , llrnCSJConfig :: CSJConfig
 
       -- | How to run the data diffusion applications
       --
@@ -519,6 +522,7 @@ runWith RunNodeArgs{..} encAddrNtN decAddrNtN LowLevelRunNodeArgs{..} =
           NTN.byteLimits
           llrnChainSyncTimeout
           llrnChainSyncLoPBucketConfig
+          llrnCSJConfig
           (reportMetric Diffusion.peerMetricsConfiguration peerMetrics)
           (NTN.mkHandlers nodeKernelArgs nodeKernel)
 
@@ -889,6 +893,7 @@ stdLowLevelRunNodeArgsIO RunNodeArgs{ rnProtocolInfo
       { llrnBfcSalt
       , llrnChainSyncTimeout = fromMaybe stdChainSyncTimeout srnChainSyncTimeout
       , llrnChainSyncLoPBucketConfig = ChainSyncLoPBucketDisabled
+      , llrnCSJConfig = CSJDisabled
       , llrnCustomiseHardForkBlockchainTimeArgs = id
       , llrnGsmAntiThunderingHerd
       , llrnKeepAliveRng

--- a/ouroboros-consensus-diffusion/src/unstable-diffusion-testlib/Test/ThreadNet/Network.hs
+++ b/ouroboros-consensus-diffusion/src/unstable-diffusion-testlib/Test/ThreadNet/Network.hs
@@ -1058,6 +1058,7 @@ runThreadNetwork systemTime ThreadNetworkArgs
                      , idleTimeout      = waitForever
                      })
                   CSClient.ChainSyncLoPBucketDisabled
+                  CSClient.CSJDisabled
                   nullMetric
                   -- The purpose of this test is not testing protocols, so
                   -- returning constant empty list is fine if we have thorough

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup/GenChains.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup/GenChains.hs
@@ -130,6 +130,7 @@ genChains genNumForks = do
     -- ^ REVIEW: Do we want to generate those randomly? For now, the chosen
     -- values carry no special meaning. Someone needs to think about what values
     -- would make for interesting tests.
+    gtCSJParams = CSJParams $ fromIntegral scg,
     gtBlockTree = foldl' (flip BT.addBranch') (BT.mkTrunk goodChain) $ zipWith (genAdversarialFragment goodBlocks) [1..] alternativeChainSchemas,
     gtSchedule = ()
     }

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
@@ -150,7 +150,11 @@ prop_serveAdversarialBranches = forAllGenesisTest
     (genChains (QC.choose (1, 4)) `enrichedWith` genUniformSchedulePoints)
 
     (defaultSchedulerConfig
-       {scTraceState = False, scTrace = False, scEnableLoE = True})
+       { scTraceState = False
+       , scTrace = False
+       , scEnableLoE = True
+       , scEnableCSJ = True
+       })
 
     -- We cannot shrink by removing points from the adversarial schedules.
     -- Otherwise, the immutable tip could get stuck because a peer doesn't
@@ -195,6 +199,7 @@ prop_leashingAttackStalling =
       { scTrace = False
       , scEnableLoE = True
       , scEnableLoP = True
+      , scEnableCSJ = True
       }
 
     shrinkPeerSchedules
@@ -253,6 +258,7 @@ prop_leashingAttackTimeLimited =
       , scEnableLoE = True
       , scEnableLoP = True
       , scEnableBlockFetchTimeouts = False
+      , scEnableCSJ = True
       }
 
     shrinkPeerSchedules

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
@@ -22,6 +22,7 @@
 -- who then activates the next tick's peer.
 module Test.Consensus.PointSchedule (
     BlockFetchTimeout (..)
+  , CSJParams (..)
   , ForecastRange (..)
   , GenesisTest (..)
   , GenesisTestFull
@@ -444,6 +445,11 @@ data LoPBucketParams = LoPBucketParams {
   lbpRate     :: Rational
   }
 
+data CSJParams = CSJParams {
+    csjpJumpSize :: SlotNo
+  }
+  deriving Show
+
 -- | Similar to 'ChainSyncTimeout' for BlockFetch. Only the states in which the
 -- server has agency are specified. REVIEW: Should it be upstreamed to
 -- ouroboros-network-protocols?
@@ -462,6 +468,7 @@ data GenesisTest blk schedule = GenesisTest
     gtChainSyncTimeouts  :: ChainSyncTimeout,
     gtBlockFetchTimeouts :: BlockFetchTimeout,
     gtLoPBucketParams    :: LoPBucketParams,
+    gtCSJParams          :: CSJParams,
     gtSlotLength         :: SlotLength,
     gtSchedule           :: schedule
   }
@@ -482,6 +489,7 @@ prettyGenesisTest prettySchedule genesisTest =
   , "  gtForecastRange: " ++ show (unForecastRange gtForecastRange)
   , "  gtDelay: " ++ show delta
   , "  gtSlotLength: " ++ show gtSlotLength
+  , "  gtCSJParams: " ++ show gtCSJParams
   , "  gtChainSyncTimeouts: "
   , "    canAwait = " ++ show canAwaitTimeout
   , "    intersect = " ++ show intersectTimeout
@@ -510,6 +518,7 @@ prettyGenesisTest prettySchedule genesisTest =
       , gtBlockFetchTimeouts = BlockFetchTimeout{busyTimeout, streamingTimeout}
       , gtLoPBucketParams = LoPBucketParams{lbpCapacity, lbpRate}
       , gtSlotLength
+      , gtCSJParams
       , gtSchedule
       } = genesisTest
 

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Peers.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Peers.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveAnyClass        #-}
 {-# LANGUAGE DeriveGeneric         #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE FlexibleContexts      #-}
@@ -38,6 +39,7 @@ import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           Data.String (IsString (fromString))
 import           GHC.Generics (Generic)
+import           NoThunks.Class (NoThunks)
 import           Ouroboros.Consensus.Util.Condense (Condense (..),
                      CondenseList (..), PaddingDirection (..),
                      condenseListWithPadding)
@@ -47,7 +49,7 @@ data PeerId =
   HonestPeer
   |
   PeerId String
-  deriving (Eq, Generic, Show, Ord)
+  deriving (Eq, Generic, Show, Ord, NoThunks)
 
 instance IsString PeerId where
   fromString "honest" = HonestPeer

--- a/ouroboros-consensus/bench/ChainSync-client-bench/Main.hs
+++ b/ouroboros-consensus/bench/ChainSync-client-bench/Main.hs
@@ -138,6 +138,7 @@ oneBenchRun
               , CSClient.setLatestSlot       = \_ -> pure ()
               , CSClient.idling              = CSClient.noIdling
               , CSClient.loPBucket           = CSClient.noLoPBucket
+              , CSClient.jumping     = CSClient.noJumping
               }
 
     server :: ChainSyncServer H (Point B) (Tip B) IO ()

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -169,6 +169,7 @@ library
     Ouroboros.Consensus.MiniProtocol.BlockFetch.Server
     Ouroboros.Consensus.MiniProtocol.ChainSync.Client
     Ouroboros.Consensus.MiniProtocol.ChainSync.Client.InFutureCheck
+    Ouroboros.Consensus.MiniProtocol.ChainSync.Client.Jumping
     Ouroboros.Consensus.MiniProtocol.ChainSync.Client.State
     Ouroboros.Consensus.MiniProtocol.ChainSync.Server
     Ouroboros.Consensus.MiniProtocol.LocalStateQuery.Server

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -169,6 +169,7 @@ library
     Ouroboros.Consensus.MiniProtocol.BlockFetch.Server
     Ouroboros.Consensus.MiniProtocol.ChainSync.Client
     Ouroboros.Consensus.MiniProtocol.ChainSync.Client.InFutureCheck
+    Ouroboros.Consensus.MiniProtocol.ChainSync.Client.State
     Ouroboros.Consensus.MiniProtocol.ChainSync.Server
     Ouroboros.Consensus.MiniProtocol.LocalStateQuery.Server
     Ouroboros.Consensus.MiniProtocol.LocalTxMonitor.Server

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ChainSync/Client.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ChainSync/Client.hs
@@ -1094,6 +1094,7 @@ knownIntersectionStateTop cfgEnv dynEnv intEnv =
                               } = kis'
                         atomically $ do
                           setCandidate theirFrag
+                          setLatestSlot dynEnv (AF.headSlot theirFrag)
                         return $
                             requestNext
                                 kis'

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ChainSync/Client.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ChainSync/Client.hs
@@ -95,6 +95,7 @@ import           Ouroboros.Consensus.Ledger.Basics (LedgerState)
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
 import qualified Ouroboros.Consensus.MiniProtocol.ChainSync.Client.InFutureCheck as InFutureCheck
+import           Ouroboros.Consensus.MiniProtocol.ChainSync.Client.State
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Storage.ChainDB (ChainDB,
@@ -182,53 +183,6 @@ newtype Their a = Their { unTheir :: a }
 newtype Our a = Our { unOur :: a }
   deriving stock   (Eq)
   deriving newtype (Show, NoThunks)
-
--- | A ChainSync client's state that's used by other components, like the GDD.
-data ChainSyncState blk = ChainSyncState {
-
-    -- | The current candidate fragment.
-    csCandidate  :: !(AnchoredFragment (Header blk))
-
-    -- | This ChainSync client should ensure that its peer sets this flag while
-    -- and only while both of the following conditions are satisfied: the
-    -- peer's latest message has been fully processed (especially that its
-    -- candidate has been updated; previous argument) and its latest message
-    -- did not claim that it already has headers that extend its candidate.
-    --
-    -- It's more important that the flag is unset promptly than it is for the
-    -- flag to be set promptly, because of how this is used by the GSM to
-    -- determine that the node is done syncing.
-  , csIdling     :: !Bool
-
-    -- | When the client receives a new header, it updates this field before
-    -- processing it further, and the latest slot may refer to a header beyond
-    -- the forecast horizon while the candidate fragment isn't extended yet, to
-    -- signal to GDD that the density is known up to this slot.
-  , csLatestSlot :: !(Maybe (WithOrigin SlotNo))
-  }
-  deriving stock (Generic)
-
-deriving anyclass instance (
-  HasHeader blk,
-  NoThunks (Header blk)
-  ) => NoThunks (ChainSyncState blk)
-
--- | An interface to a ChainSync client that's used by other components, like
--- the GDD governor.
-data ChainSyncClientHandle m blk = ChainSyncClientHandle {
-    -- | Disconnects from the peer when the GDD considers it adversarial
-    cschGDDKill :: !(m ())
-
-    -- | Data shared between the client and external components like GDD.
-  , cschState   :: !(StrictTVar m (ChainSyncState blk))
-  }
-  deriving stock (Generic)
-
-deriving anyclass instance (
-  IOLike m,
-  HasHeader blk,
-  NoThunks (Header blk)
-  ) => NoThunks (ChainSyncClientHandle m blk)
 
 -- | Convenience function for reading a nested set of TVars and extracting some
 -- data from 'ChainSyncState'.

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ChainSync/Client/Jumping.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ChainSync/Client/Jumping.hs
@@ -1,0 +1,724 @@
+{-# LANGUAGE DeriveAnyClass       #-}
+{-# LANGUAGE DeriveGeneric        #-}
+{-# LANGUAGE DerivingStrategies   #-}
+{-# LANGUAGE FlexibleContexts     #-}
+{-# LANGUAGE FlexibleInstances    #-}
+{-# LANGUAGE LambdaCase           #-}
+{-# LANGUAGE NamedFieldPuns       #-}
+{-# LANGUAGE RankNTypes           #-}
+{-# LANGUAGE ScopedTypeVariables  #-}
+{-# LANGUAGE StandaloneDeriving   #-}
+{-# LANGUAGE TupleSections        #-}
+{-# LANGUAGE TypeApplications     #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+-- | ChainSync jumping (CSJ) is an optimization for the ChainSync protocol that
+-- allows nodes to sync without downloading headers from all of the honest
+-- peers. This load is undesirable as it slows down all the peers involved.
+--
+-- The idea is to download the headers of a chain from a single peer (the
+-- dynamo) and then ask periodically to the other peers (the jumpers) whether
+-- they agree with the dynamo's chain.
+--
+-- When the jumpers disagree with the dynamo, the jumper with the oldest
+-- intersection is asked to compete with the dynamo in the GDD logic. If the
+-- dynamo is disconnected, a new dynamo is elected and the objector is demoted
+-- to a jumper.
+--
+-- If the objector is disconnected, the syncing process continues with the
+-- dynamo and the remaining jumpers.
+--
+-- The main property of the algorithm is that it never
+-- downloads headers from more than two plausibly honest peers at a time (a
+-- dynamo and an objector). All other peers are either waiting their turn to
+-- compete with the dynamo, or are in agreement with it, or are disengaged
+-- (see next section).
+--
+-- The algorithm might still download headers redundantly from peers that do
+-- historical rollbacks. These rollbacks, however, constitute dishonest
+-- behavior, and CSJ does not concern itself with avoiding load to dishonest
+-- peers. Avoiding the load induced by dishonest peers on the syncing node would
+-- require additionally to disconnect peers that do historical rollbacks. This
+-- is not done by CSJ.
+--
+-- Interactions with the Genesis Density Disconnection logic
+-- ---------------------------------------------------------
+--
+-- It is possible that neither the dynamo nor the objector are disconnected.
+-- This could happen if:
+-- 1. They both serve the same chain, or
+-- 2. They both claim to have no more headers.
+--
+-- To avoid (1) CSJ checks that the objector disagrees with the dynamo at the
+-- point it claimed to disagree as a jumper. If the objector agrees with the
+-- dynamo, it is disengaged. A disengaged peer is not asked to jump or act as
+-- dynamo or objector. Instead, it continues to offer headers for the rest of
+-- the syncing. When the objector is disengaged, a new objector is elected
+-- among the dissenting jumpers. If there are no dissenting jumpers left, the
+-- syncing continues with the dynamo and the remaining jumpers.
+--
+-- To prevent the dynamo from agreeing with the objector instead, the dynamo is
+-- not allowed to rollback before the last jump it requested. If the dynamo
+-- tries to rollback before the last jump, it is disengaged and a new dynamo is
+-- elected.
+--
+-- To avoid (2) CSJ disengages a peer as soon as it claims to have no more
+-- headers. Syncing continues with a new elected dynamo or objector depending on
+-- the disengaged peer's role.
+--
+-- CSJ finishes and is turned off when all peers have been disengaged.
+--
+-- Interactions with the ChainSync client
+-- --------------------------------------
+--
+-- The ChainSync client interacts with CSJ through some callbacks that determine
+-- when the client should pause, download headers, or ask about agreement with
+-- a given point (jumping). See the 'Jumping' type for more details.
+--
+-- Interactions with the Limit on Patience
+-- ---------------------------------------
+--
+-- Jumpers don't leak the Limit on Patience (LoP) bucket until they are promoted
+-- to dynamos or objectors. And the leaking is stopped as soon as they are
+-- disengaged or demoted.
+--
+-- If a jumper refrains from answering to jumps, they will be disconnected with
+-- the 'intersectTimeout' (in 'ChainSyncTimeout').
+--
+-- A jumper answering just before the timeout will not delay the syncing
+-- process by a large amount. If they agree with the dynamo, the dynamo will be
+-- busy downloading headers and validating blocks while the jumper answers. If
+-- the jumper disagrees with the dynamo, CSJ will look for the precise
+-- intersection with the dynamo's chain. This could take a few minutes, but it
+-- is a path that will end up in one of the dynamo and the jumper being
+-- disconnected or disengaged.
+--
+--
+-- Overview of the state transitions
+-- ---------------------------------
+--
+-- See 'ChainSyncJumpingState' for the implementation of the states.
+--
+-- >                j       ╔════════╗
+-- >            ╭────────── ║ Dynamo ║ ◀─────────╮
+-- >            │           ╚════════╝           │f
+-- >            ▼                  ▲             │
+-- >    ┌────────────┐             │     k     ┌──────────┐
+-- >    │ Disengaged │ ◀───────────│────────── │ Objector │
+-- >    └────────────┘       ╭─────│────────── └──────────┘
+-- >                         │     │             ▲    ▲ │
+-- >                        g│     │e         b  │    │ │
+-- >                         │     │       ╭─────╯   i│ │c
+-- >                 ╭╌╌╌╌╌╌╌▼╌╌╌╌╌╌╌╌╌╌╌╌╌│╌╌╌╌╌╌╌╌╌╌│╌▼╌╌╌╮
+-- >                 ┆ ╔═══════╗  a   ┌──────┐  d   ┌─────┐ |
+-- >                 ┆ ║ Happy ║ ───▶ │ LFI* │ ───▶ │ FI* │ |
+-- >                 ┆ ╚═══════╝ ◀─╮  └──────┘      └─────┘ |
+-- >                 ┆ Jumper      ╰─────┴────────────╯h    |
+-- >                 ╰╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╯
+--
+-- *: LookingForIntersection and FoundIntersection, abbreviated for this
+--    drawing only; this abbreviation will not be used elsewhere.
+--
+-- A new peer starts as the dynamo if there is no other peer or as a Happy
+-- jumper otherwise. The dynamo periodically requests jumps from happy
+-- jumpers who, in the ideal case, accept them.
+--
+-- In the event that a jumper rejects a jump, it goes from Happy to LFI* (a).
+-- From there starts a back-and-forth of intersection search messages until
+-- the exact point of disagreement with the dynamo is found.
+--
+-- Once the exact point of disagreement is found, and if there is no objector
+-- yet, the jumper becomes the objector (b). If there is an objector, then we
+-- compare the intersections of the objector and the jumper. If the jumper's
+-- intersection is strictly older, then the jumper replaces the objector (b+c).
+-- Otherwise, the jumper is marked as FI* (d).
+--
+-- If the dynamo disconnects or is disengaged, one peer is elected as the new
+-- dynamo (e|f) and all other peers revert to being happy jumpers (g+h).
+--
+-- If the objector disconnects or is disengaged, and there are FI* jumpers, then
+-- the one with the oldest intersection with the dynamo gets elected (i).
+--
+-- If the dynamo rolls back to a point older than the last jump it requested, it
+-- is disengaged (j) and a new dynamo is elected (e|f).
+--
+-- If the objector agrees with the dynamo, it is disengaged (k). If there are
+-- FI* jumpers, then one of them gets elected as the new objector (i).
+--
+-- If dynamo or objector claim to have no more headers, they are disengaged
+-- (j|k).
+--
+module Ouroboros.Consensus.MiniProtocol.ChainSync.Client.Jumping (
+    Context
+  , ContextWith (..)
+  , Instruction (..)
+  , JumpResult (..)
+  , Jumping (..)
+  , makeContext
+  , mkJumping
+  , noJumping
+  , registerClient
+  , unregisterClient
+  ) where
+
+import           Cardano.Slotting.Slot (SlotNo (..), WithOrigin (..))
+import           Control.Monad (forM, forM_, when)
+import           Data.List (sortOn)
+import           Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import           Data.Maybe (catMaybes)
+import           GHC.Generics (Generic)
+import           Ouroboros.Consensus.Block (HasHeader (getHeaderFields), Header,
+                     Point (..), castPoint, pointSlot)
+import           Ouroboros.Consensus.Ledger.SupportsProtocol
+                     (LedgerSupportsProtocol)
+import           Ouroboros.Consensus.MiniProtocol.ChainSync.Client.State
+                     (ChainSyncClientHandle (..),
+                     ChainSyncJumpingJumperState (..),
+                     ChainSyncJumpingState (..), ChainSyncState (..),
+                     JumpInfo (..))
+import           Ouroboros.Consensus.Util.IOLike hiding (handle)
+import qualified Ouroboros.Network.AnchoredFragment as AF
+
+-- | Hooks for ChainSync jumping.
+data Jumping m blk = Jumping
+  { -- | Get the next instruction to execute, which can be either to run normal
+    -- ChainSync or to jump to a given point. When the peer is a jumper and
+    -- there is no jump request, 'jgNextInstruction' blocks until a jump request
+    -- is made.
+    jgNextInstruction   :: !(m (Instruction blk)),
+
+    -- | To be called whenever the peer claims to have no more headers.
+    jgOnAwaitReply      :: !(m ()),
+
+    -- | To be called whenever a header is received from the peer
+    -- before it is validated.
+    jgOnRollForward     :: !(Point (Header blk) -> m ()),
+
+    -- | To be called whenever a peer rolls back.
+    jgOnRollBackward    :: !(WithOrigin SlotNo -> m ()),
+
+    -- | Process the result of a jump, either accepted or rejected.
+    --
+    -- The jump result is used to decide on the next jumps or whether to elect
+    -- an objector.
+    jgProcessJumpResult :: !(JumpResult blk -> m ()),
+
+    -- | To be called to update the last known jump possible to the tip of
+    -- the peers candidate fragment. The ChainSync clients for all peers should
+    -- call this function in case they are or they become dynamos.
+    --
+    -- JumpInfo is meant to be a snapshot of the @KnownIntersectionState@ of
+    -- the ChainSync client. See 'JumpInfo' for more details.
+    jgUpdateJumpInfo    :: !(JumpInfo blk -> STM m ())
+  }
+  deriving stock (Generic)
+
+deriving anyclass instance
+  ( IOLike m,
+    HasHeader blk,
+    NoThunks (Header blk)
+  ) =>
+  NoThunks (Jumping m blk)
+
+-- | No-op implementation of CSJ
+noJumping :: (MonadSTM m) => Jumping m blk
+noJumping =
+  Jumping
+    { jgNextInstruction = pure RunNormally
+    , jgOnAwaitReply = pure ()
+    , jgOnRollForward = const $ pure ()
+    , jgOnRollBackward = const $ pure ()
+    , jgProcessJumpResult = const $ pure ()
+    , jgUpdateJumpInfo = const $ pure ()
+    }
+
+-- | Create the callbacks for a given peer.
+mkJumping ::
+  ( MonadSTM m,
+    Eq peer,
+    LedgerSupportsProtocol blk
+  ) =>
+  PeerContext m peer blk ->
+  Jumping m blk
+mkJumping peerContext = Jumping
+  { jgNextInstruction = atomically $ nextInstruction peerContext
+  , jgOnAwaitReply = atomically $ onAwaitReply peerContext
+  , jgOnRollForward = atomically . onRollForward peerContext
+  , jgOnRollBackward = atomically . onRollBackward peerContext
+  , jgProcessJumpResult = atomically . processJumpResult peerContext
+  , jgUpdateJumpInfo = updateJumpInfo peerContext
+  }
+
+-- | A context for ChainSync jumping
+--
+-- Invariants:
+--
+-- - If 'handlesVar' is not empty, then there is exactly one dynamo in it.
+-- - There is at most one objector in 'handlesVar'.
+-- - If there exist 'FoundIntersection' jumpers in 'handlesVar', then there
+--   is an objector and the intersection of the objector with the dynamo is
+--   at least as old as the oldest intersection of the `FoundIntersection` jumpers
+--   with the dynamo.
+data ContextWith peerField handleField m peer blk = Context
+  { peer       :: !peerField,
+    handle     :: !handleField,
+    csjEnabled :: !(StrictTVar m Bool),
+    handlesVar :: !(StrictTVar m (Map peer (ChainSyncClientHandle m blk))),
+    jumpSize   :: !SlotNo
+  }
+
+-- | A non-specific, generic context for ChainSync jumping.
+type Context = ContextWith () ()
+
+-- | A peer-specific context for ChainSync jumping. This is a 'ContextWith'
+-- pointing on the handler of the peer in question.
+--
+-- Invariant: The binding from 'peer' to 'handle' is present in 'handlesVar'.
+type PeerContext m peer blk = ContextWith peer (ChainSyncClientHandle m blk) m peer blk
+
+makeContext ::
+  MonadSTM m =>
+  StrictTVar m (Map peer (ChainSyncClientHandle m blk)) ->
+  SlotNo ->
+  -- ^ The size of jumps, in number of slots.
+  STM m (Context m peer blk)
+makeContext h jumpSize = do
+  enabledTVar <- newTVar True
+  pure $ Context () () enabledTVar h jumpSize
+
+-- | Get a generic context from a peer context by stripping away the
+-- peer-specific fields.
+stripContext :: PeerContext m peer blk -> Context m peer blk
+stripContext context = context {peer = (), handle = ()}
+
+-- | Instruction from the jumping governor, either to run normal ChainSync, or
+-- to jump to follow a dynamo with the given fragment.
+data Instruction blk
+  = RunNormally
+  | -- | Jump to the tip of the given fragment.
+    JumpTo !(JumpInfo blk)
+  deriving (Generic)
+
+deriving instance (HasHeader (Header blk), Eq (Header blk)) => Eq (Instruction blk)
+
+instance (HasHeader (Header blk), Show (Header blk)) => Show (Instruction blk) where
+  showsPrec p = \case
+    RunNormally -> showString "RunNormally"
+    JumpTo jumpInfo ->
+      showParen (p > 10) $ showString "JumpTo " . shows (AF.headPoint $ jTheirFragment jumpInfo)
+
+deriving anyclass instance
+  ( HasHeader blk,
+    LedgerSupportsProtocol blk,
+    NoThunks (Header blk)
+  ) => NoThunks (Instruction blk)
+
+-- | The result of a jump request, either accepted or rejected.
+data JumpResult blk
+  = AcceptedJump !(JumpInfo blk)
+  | RejectedJump !(JumpInfo blk)
+  deriving (Generic)
+
+deriving instance (HasHeader (Header blk), Eq (Header blk)) => Eq (JumpResult blk)
+
+instance (HasHeader (Header blk), Show (Header blk)) => Show (JumpResult blk) where
+  showsPrec p = \case
+    AcceptedJump jumpInfo ->
+      showParen (p > 10) $ showString "AcceptedJump " . shows (AF.headPoint $ jTheirFragment jumpInfo)
+    RejectedJump jumpInfo ->
+      showParen (p > 10) $ showString "RejectedJump " . shows (AF.headPoint $ jTheirFragment jumpInfo)
+
+deriving anyclass instance
+  ( HasHeader blk,
+    LedgerSupportsProtocol blk,
+    NoThunks (Header blk)
+  ) => NoThunks (JumpResult blk)
+
+-- | Run the given action if CSJ is enabled. Otherwise, return the given
+-- value.
+whenEnabled :: MonadSTM m => PeerContext m peer blk -> a -> STM m a -> STM m a
+whenEnabled context x action = do
+  readTVar (csjEnabled context) >>= \case
+    False -> pure x
+    True -> action
+
+-- | Compute the next instruction for the given peer. In the majority of cases,
+-- this consists in reading the peer's handle, having the dynamo and objector
+-- run normally and the jumpers wait for the next jump. As such, this function
+-- mostly only reads from and writes to the handle of the peer. For the dynamo, every once in a
+-- while, we need to indicate to the jumpers that they need to jump, and this
+-- requires writing to a TVar for every jumper.
+nextInstruction ::
+  ( MonadSTM m ) =>
+  PeerContext m peer blk ->
+  STM m (Instruction blk)
+nextInstruction context = whenEnabled context RunNormally $
+  readTVar (cschJumping (handle context)) >>= \case
+    Disengaged -> pure RunNormally
+    Dynamo{} -> pure RunNormally
+    Objector _ -> pure RunNormally
+    Jumper nextJumpVar _ _ -> do
+      readTVar nextJumpVar >>= \case
+        Nothing -> retry
+        Just jumpInfo -> do
+          writeTVar nextJumpVar Nothing
+          pure $ JumpTo jumpInfo
+
+-- | This function is called when we receive a 'MsgRollForward' message before
+-- validating it.
+--
+-- We request jumpers to jump here if the next header received by the dynamo is
+-- at least jump size slots after the last jump.
+--
+-- We also check that the Objector disagrees with the header sent at its
+-- rejected jump. If it agrees to it, we disengage it.
+--
+onRollForward :: forall m peer blk.
+  ( MonadSTM m,
+    LedgerSupportsProtocol blk
+  ) =>
+  PeerContext m peer blk ->
+  Point (Header blk) ->
+  STM m ()
+onRollForward context point = whenEnabled context () $
+  readTVar (cschJumping (handle context)) >>= \case
+    Objector badPoint
+      | badPoint == castPoint point -> do
+          disengage (handle context)
+          electNewObjector (stripContext context)
+      | otherwise -> pure ()
+    Disengaged -> pure ()
+    Jumper{} -> pure ()
+    Dynamo lastJumpSlot
+      | pointSlot point >= ((jumpSize context +) <$> lastJumpSlot) -> do
+          mJumpInfo <- readTVar (cschJumpInfo (handle context))
+          setJumps mJumpInfo
+      | otherwise -> pure ()
+  where
+    setJumps Nothing = error "onRollForward: Dynamo without jump info"
+    setJumps (Just jumpInfo) = do
+        writeTVar (cschJumping (handle context)) $
+          Dynamo $ pointSlot $ AF.headPoint $ jTheirFragment jumpInfo
+        handles <- readTVar (handlesVar context)
+        forM_ (Map.elems handles) $ \h ->
+          readTVar (cschJumping h) >>= \case
+            Jumper nextJumpVar _ Happy -> writeTVar nextJumpVar (Just jumpInfo)
+            _ -> pure ()
+
+-- | This function is called when we receive a 'MsgRollBackward' message.
+--
+-- Here we check if the peer is trying to roll back to a point before the last
+-- jump. If so, we disengage the peer. This prevents adversaries from sending
+-- as objectors the same chain as the dynamo.
+--
+onRollBackward :: forall m peer blk.
+  ( MonadSTM m,
+    Eq peer,
+    LedgerSupportsProtocol blk
+  ) =>
+  PeerContext m peer blk ->
+  WithOrigin SlotNo ->
+  STM m ()
+onRollBackward context slot = whenEnabled context () $
+  readTVar (cschJumping (handle context)) >>= \case
+    Objector badPoint
+      | slot < pointSlot badPoint -> do
+          disengage (handle context)
+          electNewObjector (stripContext context)
+      | otherwise -> pure ()
+    Disengaged -> pure ()
+    Jumper{} -> pure ()
+    Dynamo lastJumpSlot
+      | slot < lastJumpSlot -> do
+          disengage (handle context)
+          electNewDynamo (stripContext context)
+      | otherwise -> pure ()
+
+-- | This function is called when we receive a 'MsgAwaitReply' message.
+--
+-- If this is the dynamo, we need to elect a new dynamo as no more headers
+-- are available.
+onAwaitReply ::
+  ( MonadSTM m,
+    Eq peer,
+    LedgerSupportsProtocol blk
+  ) =>
+  PeerContext m peer blk ->
+  STM m ()
+onAwaitReply context = whenEnabled context () $
+  readTVar (cschJumping (handle context)) >>= \case
+    Dynamo{} -> do
+      disengage (handle context)
+      electNewDynamo (stripContext context)
+    Objector{} -> do
+      disengage (handle context)
+      electNewObjector (stripContext context)
+    Jumper{} ->
+      -- A jumper might be receiving a 'MsgAwaitReply' message if it was
+      -- previously an objector and a new dynamo was elected.
+      disengage (handle context)
+    Disengaged ->
+      pure ()
+
+-- | Process the result of a jump. In the happy case, this only consists in
+-- updating the peer's handle to take the new candidate fragment and the new
+-- last jump point into account. When disagreeing with the dynamo, though, we
+-- enter a phase of several jumps to pinpoint exactly where the disagreement
+-- occurs. Once this phase is finished, we trigger the election of a new
+-- objector, which might update many TVars.
+processJumpResult :: forall m peer blk.
+  ( MonadSTM m,
+    LedgerSupportsProtocol blk
+  ) =>
+  PeerContext m peer blk ->
+  JumpResult blk ->
+  STM m ()
+processJumpResult context jumpResult = whenEnabled context () $
+  readTVar (cschJumping (handle context)) >>= \case
+    Dynamo _ -> pure ()
+    Disengaged -> pure ()
+    Objector _ -> pure ()
+    Jumper nextJumpVar goodPoint jumperState ->
+        case jumpResult of
+          AcceptedJump jumpInfo -> do
+            -- The jump was accepted; we set the jumper's candidate fragment to
+            -- the dynamo's candidate fragment up to the accepted point.
+            --
+            -- The candidate fragments of jumpers don't grow otherwise, as only the
+            -- objector and the dynamo request further headers.
+            let fragment = jTheirFragment jumpInfo
+            modifyTVar (cschState (handle context)) $ \csState ->
+              csState {csCandidate = fragment, csLatestSlot = Just (AF.headSlot fragment) }
+            writeTVar (cschJumpInfo (handle context)) $ Just jumpInfo
+            case jumperState of
+              LookingForIntersection badJumpInfo ->
+                -- @AF.headPoint fragment@ is in @badFragment@, as the jumper
+                -- looking for an intersection is the only client asking for its
+                -- jumps.
+                lookForIntersection nextJumpVar (AF.headPoint fragment) badJumpInfo
+              Happy ->
+                writeTVar (cschJumping (handle context)) $
+                  Jumper nextJumpVar (AF.headPoint fragment) Happy
+              FoundIntersection{} ->
+                -- Only happy jumpers are asked to jump by the dynamo, and only
+                -- jumpers looking for an intersection are asked to jump by
+                -- themselves.
+                error "processJumpResult: Jumpers in state FoundIntersection shouldn't be further jumping."
+
+          RejectedJump badJumpInfo -> do
+            -- @goodPoint@ is in @jTheirFragment jumpInfo@. If the jump was
+            -- requested by the dynamo, this holds because the dynamo is not
+            -- allowed to rollback before the jumps that it requests.
+            --
+            -- If the jump was requested by the jumper, this holds because the
+            -- jumper is looking for an intersection, and such jumper only asks
+            -- for jumps that meet this condition.
+            lookForIntersection nextJumpVar goodPoint badJumpInfo
+  where
+    -- Avoid redundant constraint "HasHeader blk" reported by some ghc's
+    _ = getHeaderFields @blk
+    -- | Given a good point (where we know we agree with the dynamo) and a bad
+    -- fragment (where we know the tip disagrees with the dynamo), either decide
+    -- that we know the intersection for sure (if the bad point is the successor
+    -- of the good point) or program a jump somewhere in the middle to refine
+    -- those points.
+    --
+    -- PRECONDITION: The good point is in the bad fragment.
+    lookForIntersection nextJumpVar goodPoint badJumpInfo = do
+      let badFragment = jTheirFragment badJumpInfo
+      case snd <$> AF.splitAfterPoint badFragment goodPoint of
+        Nothing ->
+          error "processJumpResult: goodPoint not in badFragment"
+        Just nextFragment -> do
+          let len = AF.length nextFragment
+          if len <= 1 then do
+            -- If the fragment only contains the bad tip, we know the
+            -- intersection is the good point.
+            maybeElectNewObjector nextJumpVar goodPoint (AF.headPoint badFragment)
+          else do
+            let middlePoint = len `div` 2
+                theirFragment = AF.dropNewest middlePoint badFragment
+            writeTVar nextJumpVar $ Just
+              badJumpInfo { jTheirFragment = theirFragment }
+            writeTVar (cschJumping (handle context)) $
+              Jumper nextJumpVar goodPoint (LookingForIntersection badJumpInfo)
+
+    maybeElectNewObjector nextJumpVar goodPoint badPoint =
+      findObjector (stripContext context) >>= \case
+        Nothing ->
+          -- There is no objector yet. Promote the jumper to objector.
+          writeTVar (cschJumping (handle context)) (Objector badPoint)
+        Just (objectorPoint, objectorHandle)
+          | pointSlot objectorPoint <= pointSlot badPoint ->
+              -- The objector's intersection is still old enough. Keep it.
+              writeTVar (cschJumping (handle context)) $
+                Jumper nextJumpVar goodPoint (FoundIntersection badPoint)
+          | otherwise -> do
+              -- Found an earlier intersection. Demote the old objector and
+              -- promote the jumper to objector.
+              newJumper Nothing (FoundIntersection objectorPoint) >>=
+                writeTVar (cschJumping objectorHandle)
+              writeTVar (cschJumping (handle context)) (Objector badPoint)
+
+updateJumpInfo ::
+  (MonadSTM m) =>
+  PeerContext m peer blk ->
+  JumpInfo blk ->
+  STM m ()
+updateJumpInfo context jumpInfo = whenEnabled context () $
+  writeTVar (cschJumpInfo (handle context)) $ Just jumpInfo
+
+-- | Find the dynamo in a TVar containing a map of handles. Returns then handle
+-- of the dynamo, or 'Nothing' if there is none.
+getDynamo ::
+  (MonadSTM m) =>
+  StrictTVar m (Map peer (ChainSyncClientHandle m blk)) ->
+  STM m (Maybe (ChainSyncClientHandle m blk))
+getDynamo handlesVar = do
+  handles <- Map.elems <$> readTVar handlesVar
+  findM (\handle -> isDynamo <$> readTVar (cschJumping handle)) handles
+  where
+    isDynamo (Dynamo _) = True
+    isDynamo _          = False
+
+-- | Disengage a peer, meaning that it will no longer be asked to jump or
+-- act as dynamo or objector.
+disengage :: MonadSTM m => ChainSyncClientHandle m blk -> STM m ()
+disengage handle = writeTVar (cschJumping handle) Disengaged
+
+-- | Convenience function that, given an intersection point and a jumper state,
+-- make a fresh 'Jumper' constructor.
+newJumper ::
+  ( MonadSTM m,
+    LedgerSupportsProtocol blk
+  ) =>
+  Maybe (JumpInfo blk) ->
+  ChainSyncJumpingJumperState blk ->
+  STM m (ChainSyncJumpingState m blk)
+newJumper jumpInfo jumperState = do
+  nextJumpVar <- newTVar jumpInfo
+  let goodPoint = maybe GenesisPoint (AF.anchorPoint . jTheirFragment) jumpInfo
+  pure $ Jumper nextJumpVar goodPoint jumperState
+
+-- | Register a new ChainSync client to a context, returning a 'PeerContext' for
+-- that peer. If there is no dynamo, the peer starts as dynamo; otherwise, it
+-- starts as a jumper.
+registerClient ::
+  ( Ord peer,
+    LedgerSupportsProtocol blk,
+    IOLike m
+  ) =>
+  Context m peer blk ->
+  peer ->
+  StrictTVar m (ChainSyncState blk) ->
+  -- | A function to make a client handle from a jumping state.
+  (StrictTVar m (ChainSyncJumpingState m blk) -> ChainSyncClientHandle m blk) ->
+  STM m (PeerContext m peer blk)
+registerClient context peer csState mkHandle = do
+  csjState <- getDynamo (handlesVar context) >>= \case
+    Nothing -> do
+      fragment <- csCandidate <$> readTVar csState
+      pure $ Dynamo $ pointSlot $ AF.anchorPoint fragment
+    Just handle -> do
+      mJustInfo <- readTVar (cschJumpInfo handle)
+      newJumper mJustInfo Happy
+  cschJumping <- newTVar csjState
+  let handle = mkHandle cschJumping
+  modifyTVar (handlesVar context) $ Map.insert peer handle
+  pure $ context {peer, handle}
+
+-- | Unregister a client from a 'PeerContext'; this might trigger the election
+-- of a new dynamo or objector if the peer was one of these two.
+unregisterClient ::
+  ( MonadSTM m,
+    Ord peer,
+    LedgerSupportsProtocol blk
+  ) =>
+  PeerContext m peer blk ->
+  STM m ()
+unregisterClient context = do
+  modifyTVar (handlesVar context) $ Map.delete (peer context)
+  let context' = stripContext context
+  readTVar (cschJumping (handle context)) >>= \case
+    Disengaged -> pure ()
+    Jumper{} -> pure ()
+    Objector{} -> electNewObjector context'
+    Dynamo _ -> electNewDynamo context'
+
+-- | Choose an unspecified new non-idling dynamo and demote all other peers to
+-- jumpers.
+electNewDynamo ::
+  ( MonadSTM m,
+    Eq peer,
+    LedgerSupportsProtocol blk
+  ) =>
+  Context m peer blk ->
+  STM m ()
+electNewDynamo context = do
+  peerStates <- Map.toList <$> readTVar (handlesVar context)
+  mDynamo <- findNonDisengaged peerStates
+  case mDynamo of
+    Nothing -> writeTVar (csjEnabled context) False
+    Just (dynId, dynamo) -> do
+      fragment <- csCandidate <$> readTVar (cschState dynamo)
+      mJustInfo <- readTVar (cschJumpInfo dynamo)
+      -- We assume no rollbacks are possible earlier than the anchor of the
+      -- candidate fragment
+      writeTVar (cschJumping dynamo) $
+        Dynamo $ pointSlot $ AF.headPoint fragment
+      forM_ peerStates $ \(peer, st) ->
+        when (peer /= dynId) $ do
+          jumpingState <- readTVar (cschJumping st)
+          when (not (isDisengaged jumpingState)) $
+            writeTVar (cschJumping st) =<< newJumper mJustInfo Happy
+  where
+    findNonDisengaged =
+      findM $ \(_, st) -> not . isDisengaged <$> readTVar (cschJumping st)
+    isDisengaged Disengaged = True
+    isDisengaged _          = False
+
+findM :: Monad m => (a -> m Bool) -> [a] -> m (Maybe a)
+findM _ [] = pure Nothing
+findM p (x : xs) = p x >>= \case
+  True -> pure (Just x)
+  False -> findM p xs
+
+-- | Find the objector in a context, if there is one.
+findObjector ::
+  (MonadSTM m) =>
+  Context m peer blk ->
+  STM m (Maybe (Point (Header blk), ChainSyncClientHandle m blk))
+findObjector context = do
+  readTVar (handlesVar context) >>= go . Map.toList
+  where
+    go [] = pure Nothing
+    go ((_, handle):xs) =
+      readTVar (cschJumping handle) >>= \case
+        Objector badPoint -> pure $ Just (badPoint, handle)
+        _ -> go xs
+
+-- | Look into all dissenting jumper and promote the one with the oldest
+-- intersection with the dynamo as the new objector.
+electNewObjector ::
+  (MonadSTM m) =>
+  Context m peer blk ->
+  STM m ()
+electNewObjector context = do
+  peerStates <- Map.toList <$> readTVar (handlesVar context)
+  dissentingJumpers <- collectDissentingJumpers peerStates
+  let sortedJumpers = sortOn (pointSlot . fst) dissentingJumpers
+  case sortedJumpers of
+    (badPoint, handle):_ ->
+      writeTVar (cschJumping handle) $ Objector badPoint
+    _ ->
+      pure ()
+  where
+    collectDissentingJumpers peerStates =
+      fmap catMaybes $
+      forM peerStates $ \(_, handle) ->
+        readTVar (cschJumping handle) >>= \case
+          Jumper _ _ (FoundIntersection badPoint) ->
+            pure $ Just (badPoint, handle)
+          _ ->
+            pure Nothing

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ChainSync/Client/State.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ChainSync/Client/State.hs
@@ -2,19 +2,31 @@
 {-# LANGUAGE DeriveGeneric        #-}
 {-# LANGUAGE DerivingStrategies   #-}
 {-# LANGUAGE FlexibleContexts     #-}
+{-# LANGUAGE ScopedTypeVariables  #-}
 {-# LANGUAGE StandaloneDeriving   #-}
+{-# LANGUAGE TypeApplications     #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Ouroboros.Consensus.MiniProtocol.ChainSync.Client.State (
     ChainSyncClientHandle (..)
+  , ChainSyncJumpingJumperState (..)
+  , ChainSyncJumpingState (..)
   , ChainSyncState (..)
+  , JumpInfo (..)
   ) where
 
 import           Cardano.Slotting.Slot (SlotNo, WithOrigin)
+import           Data.Function (on)
+import           Data.Typeable (Proxy (..), typeRep)
 import           GHC.Generics (Generic)
-import           Ouroboros.Consensus.Block (HasHeader, Header)
-import           Ouroboros.Consensus.Util.IOLike (IOLike, NoThunks, StrictTVar)
-import           Ouroboros.Network.AnchoredFragment (AnchoredFragment)
+import           Ouroboros.Consensus.Block (HasHeader, Header, Point)
+import           Ouroboros.Consensus.HeaderStateHistory (HeaderStateHistory)
+import           Ouroboros.Consensus.Ledger.SupportsProtocol
+                     (LedgerSupportsProtocol)
+import           Ouroboros.Consensus.Util.IOLike (IOLike, NoThunks (..),
+                     StrictTVar)
+import           Ouroboros.Network.AnchoredFragment (AnchoredFragment,
+                     headPoint)
 
 -- | A ChainSync client's state that's used by other components, like the GDD or
 -- the jumping governor.
@@ -53,15 +65,114 @@ deriving anyclass instance (
 -- the GDD governor.
 data ChainSyncClientHandle m blk = ChainSyncClientHandle {
     -- | Disconnects from the peer when the GDD considers it adversarial
-    cschGDDKill :: !(m ())
+    cschGDDKill  :: !(m ())
 
     -- | Data shared between the client and external components like GDD.
-  , cschState   :: !(StrictTVar m (ChainSyncState blk))
+  , cschState    :: !(StrictTVar m (ChainSyncState blk))
+
+    -- | The state of the peer with respect to ChainSync jumping.
+  , cschJumping  :: !(StrictTVar m (ChainSyncJumpingState m blk))
+
+    -- | ChainSync state needed to jump to the tip of the candidate fragment of
+    -- the peer.
+  , cschJumpInfo :: !(StrictTVar m (Maybe (JumpInfo blk)))
   }
   deriving stock (Generic)
 
 deriving anyclass instance (
   IOLike m,
   HasHeader blk,
+  LedgerSupportsProtocol blk,
   NoThunks (Header blk)
   ) => NoThunks (ChainSyncClientHandle m blk)
+
+-- | State of a peer with respect to ChainSync jumping.
+data ChainSyncJumpingState m blk
+  = -- | The dynamo, of which there is exactly one unless there are no peers,
+    -- runs the normal ChainSync protocol and is morally supposed to give us
+    -- _the_ chain. This might not be true and the dynamo might be not be
+    -- honest, but the goal of the algorithm is to eventually have an honest,
+    -- alert peer as dynamo.
+    Dynamo
+      -- | The last slot at which we triggered jumps for the jumpers.
+      !(WithOrigin SlotNo)
+  | -- | The objector, of which there is at most one, also runs normal
+    -- ChainSync. It is a former jumper that disagreed with the dynamo. When
+    -- that happened, we spun it up to let normal ChainSync and Genesis decide
+    -- which one to disconnect from.
+    Objector
+      -- | The point where the objector dissented with the dynamo when it was a
+      -- jumper.
+      !(Point (Header blk))
+  | -- | Headers continue to be downloaded from 'Disengaged' peers. They
+    -- are not requested to jump, nor elected as dynamos or objectors.
+    Disengaged
+  | -- | The jumpers can be in arbitrary numbers. They are queried regularly to
+    -- see if they agree with the chain that the dynamo is serving; otherwise,
+    -- they become candidates to be the objector. See
+    -- 'ChainSyncJumpingJumperState' for more details.
+    Jumper
+      -- | A TVar containing the next jump to be executed.
+      !(StrictTVar m (Maybe (JumpInfo blk)))
+      -- | The youngest point where the jumper agrees with the dynamo.
+      !(Point (Header blk))
+      -- | More precisely, the state of the jumper.
+      !(ChainSyncJumpingJumperState blk)
+  deriving (Generic)
+
+deriving anyclass instance
+  ( IOLike m,
+    HasHeader blk,
+    LedgerSupportsProtocol blk,
+    NoThunks (Header blk)
+  ) => NoThunks (ChainSyncJumpingState m blk)
+
+-- | The ChainSync state required for jumps
+--
+-- The jump info is mostly a snapshot of the @KnownIntersectionState@ of the
+-- dynamo, with the difference that 'jTheirFragment' might be a proper prefix of
+-- the original candidate fragment.
+--
+-- This can happen if we need to look for an intersection when the jumper
+-- rejects a jump.
+data JumpInfo blk = JumpInfo
+  { jMostRecentIntersection  :: !(Point blk)
+  , jOurFragment             :: !(AnchoredFragment (Header blk))
+  , jTheirFragment           :: !(AnchoredFragment (Header blk))
+  , jTheirHeaderStateHistory :: !(HeaderStateHistory blk)
+  }
+  deriving (Generic)
+
+instance (HasHeader (Header blk)) => Eq (JumpInfo blk) where
+  (==) = (==) `on` headPoint . jTheirFragment
+
+instance LedgerSupportsProtocol blk => NoThunks (JumpInfo blk) where
+  showTypeOf _ = show $ typeRep (Proxy @(JumpInfo blk))
+
+-- | The specific state of a jumper peer. This state is to be understood as “to
+-- the best of our knowledge”, that is “last time we asked them”. For instance,
+-- a jumper might be marked as 'Happy' even though its chain has been differing
+-- from the dynamo's for hundreds of blocks, if we haven't asked them to jump
+-- since then.
+data ChainSyncJumpingJumperState blk
+  = -- | The jumper is happy with the dynamo.
+    Happy
+  | -- | The jumper disagrees with the dynamo and we are searching where exactly
+    -- that happens. All we know is a point where the jumper agrees with the
+    -- dynamo (in the 'Jumper' constructor) and a point where the jumper
+    -- disagrees with the dynamo, carried by this constructor.
+    --
+    -- INVARIANT: The point in the 'Jumper' constructor is in the given fragment.
+    LookingForIntersection !(JumpInfo blk)
+  | -- | The jumper disagrees with the dynamo and we have determined the latest
+    -- point where dynamo and jumper agree. This point is stored in the 'Jumper'
+    -- constructor of 'ChainSyncJumpingState'. This constructor carries the
+    -- oldest point of disagreement.
+    FoundIntersection !(Point (Header blk))
+  deriving (Generic)
+
+deriving anyclass instance
+  ( HasHeader blk,
+    LedgerSupportsProtocol blk,
+    NoThunks (Header blk)
+  ) => NoThunks (ChainSyncJumpingJumperState blk)

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ChainSync/Client/State.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ChainSync/Client/State.hs
@@ -23,7 +23,9 @@ data ChainSyncState blk = ChainSyncState {
     -- | The current candidate fragment.
     csCandidate  :: !(AnchoredFragment (Header blk))
 
-    -- | This ChainSync client should ensure that its peer sets this flag while
+    -- | Whether the last message sent by the peer was MsgAwaitReply.
+    --
+    -- This ChainSync client should ensure that its peer sets this flag while
     -- and only while both of the following conditions are satisfied: the
     -- peer's latest message has been fully processed (especially that its
     -- candidate has been updated; previous argument) and its latest message

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ChainSync/Client/State.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ChainSync/Client/State.hs
@@ -1,0 +1,65 @@
+{-# LANGUAGE DeriveAnyClass       #-}
+{-# LANGUAGE DeriveGeneric        #-}
+{-# LANGUAGE DerivingStrategies   #-}
+{-# LANGUAGE FlexibleContexts     #-}
+{-# LANGUAGE StandaloneDeriving   #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Ouroboros.Consensus.MiniProtocol.ChainSync.Client.State (
+    ChainSyncClientHandle (..)
+  , ChainSyncState (..)
+  ) where
+
+import           Cardano.Slotting.Slot (SlotNo, WithOrigin)
+import           GHC.Generics (Generic)
+import           Ouroboros.Consensus.Block (HasHeader, Header)
+import           Ouroboros.Consensus.Util.IOLike (IOLike, NoThunks, StrictTVar)
+import           Ouroboros.Network.AnchoredFragment (AnchoredFragment)
+
+-- | A ChainSync client's state that's used by other components, like the GDD or
+-- the jumping governor.
+data ChainSyncState blk = ChainSyncState {
+
+    -- | The current candidate fragment.
+    csCandidate  :: !(AnchoredFragment (Header blk))
+
+    -- | This ChainSync client should ensure that its peer sets this flag while
+    -- and only while both of the following conditions are satisfied: the
+    -- peer's latest message has been fully processed (especially that its
+    -- candidate has been updated; previous argument) and its latest message
+    -- did not claim that it already has headers that extend its candidate.
+    --
+    -- It's more important that the flag is unset promptly than it is for the
+    -- flag to be set promptly, because of how this is used by the GSM to
+    -- determine that the node is done syncing.
+  , csIdling     :: !Bool
+
+    -- | When the client receives a new header, it updates this field before
+    -- processing it further, and the latest slot may refer to a header beyond
+    -- the forecast horizon while the candidate fragment isn't extended yet, to
+    -- signal to GDD that the density is known up to this slot.
+  , csLatestSlot :: !(Maybe (WithOrigin SlotNo))
+  }
+  deriving stock (Generic)
+
+deriving anyclass instance (
+  HasHeader blk,
+  NoThunks (Header blk)
+  ) => NoThunks (ChainSyncState blk)
+
+-- | An interface to a ChainSync client that's used by other components, like
+-- the GDD governor.
+data ChainSyncClientHandle m blk = ChainSyncClientHandle {
+    -- | Disconnects from the peer when the GDD considers it adversarial
+    cschGDDKill :: !(m ())
+
+    -- | Data shared between the client and external components like GDD.
+  , cschState   :: !(StrictTVar m (ChainSyncState blk))
+  }
+  deriving stock (Generic)
+
+deriving anyclass instance (
+  IOLike m,
+  HasHeader blk,
+  NoThunks (Header blk)
+  ) => NoThunks (ChainSyncClientHandle m blk)

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/MiniProtocol/ChainSync/Client.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/MiniProtocol/ChainSync/Client.hs
@@ -81,13 +81,13 @@ import qualified Ouroboros.Consensus.HeaderStateHistory as HeaderStateHistory
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Extended hiding (ledgerState)
 import           Ouroboros.Consensus.MiniProtocol.ChainSync.Client
-                     (ChainDbView (..), ChainSyncClientException,
-                     ChainSyncClientResult (..), ChainSyncLoPBucketConfig (..),
-                     ChainSyncState (..), ChainSyncStateView (..),
-                     ConfigEnv (..), Consensus, DynamicEnv (..), Our (..),
-                     Their (..), TraceChainSyncClientEvent (..),
-                     bracketChainSyncClient, chainSyncClient, chainSyncStateFor,
-                     viewChainSyncState)
+                     (CSJConfig (..), ChainDbView (..),
+                     ChainSyncClientException, ChainSyncClientResult (..),
+                     ChainSyncLoPBucketConfig (..), ChainSyncState (..),
+                     ChainSyncStateView (..), ConfigEnv (..), Consensus,
+                     DynamicEnv (..), Our (..), Their (..),
+                     TraceChainSyncClientEvent (..), bracketChainSyncClient,
+                     chainSyncClient, chainSyncStateFor, viewChainSyncState)
 import qualified Ouroboros.Consensus.MiniProtocol.ChainSync.Client.InFutureCheck as InFutureCheck
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion
                      (NodeToNodeVersion)
@@ -405,11 +405,14 @@ runChainSync skew securityParam (ClientUpdates clientUpdates)
         lopBucketConfig :: ChainSyncLoPBucketConfig
         lopBucketConfig = ChainSyncLoPBucketDisabled
 
+        csjConfig :: CSJConfig
+        csjConfig = CSJDisabled
+
         client :: ChainSyncStateView m TestBlock
                -> Consensus ChainSyncClientPipelined
                     TestBlock
                     m
-        client ChainSyncStateView {csvSetCandidate, csvSetLatestSlot, csvIdling, csvLoPBucket} =
+        client ChainSyncStateView {csvSetCandidate, csvSetLatestSlot, csvIdling, csvLoPBucket, csvJumping} =
             chainSyncClient
               ConfigEnv {
                   chainDbView
@@ -427,6 +430,7 @@ runChainSync skew securityParam (ClientUpdates clientUpdates)
                 , idling = csvIdling
                 , loPBucket = csvLoPBucket
                 , setLatestSlot = csvSetLatestSlot
+                , jumping = csvJumping
                 }
 
     -- Set up the server
@@ -500,6 +504,7 @@ runChainSync skew securityParam (ClientUpdates clientUpdates)
                  serverId
                  maxBound
                  lopBucketConfig
+                 csjConfig
                  $ \csState -> do
                    atomically $ do
                      handles <- readTVar varHandles


### PR DESCRIPTION
- [x] Enable CSJ in existing tests.
- [ ] Add a changelog entry, prepare milestone PR
- [x] Review and add tracing information to allow debugging of tests.
- [ ] Write a test that checks that CSJ syncs up by downloading from at most one peer in the happy path.
- [ ] Write a test that checks that CSJ syncs up by downloading from at most one honest peer at a time in any path, when CSJ is finished.
- [x] Explain CSJ implementation in a code note
- [x] Fix bucket leaking resuming in ChainSync. Noted by @amesgen.
- [x] Detect jumper rollbacks when they become objectors.
- [X] Disengage dynamos that rollback earlier than their last requested jump, and objectors that rollback to earlier than their rejected jump. Disengaging means continuing to download headers from the peer, but never asking it to jump, or to be dynamos or objectors.
- [x] Disengage from CSJ all peers that send MsgAwaitReply. Makes simpler to reason that GDD doesn't block.
- [x] Recover back the logic that enabled only one objector at a time. This logic can work again after [this discussion in slack](https://moduscreate.slack.com/archives/C05CEUFFH7Z/p1713524908238559) and [these changes to GDD](https://github.com/IntersectMBO/ouroboros-consensus/pull/1068).


---
Optional:
- [ ] Disable historical rollbacks of dynamos and historical rollbacks of jumpers. Jumper rollbacks might be detected when they send as objectors a header that agrees with the dynamo. This task is optional because peers making historical rollbacks don't induce asymmetric load in the network if they are kept connected. Jumpers might also show rollbacks by accepting jumps that they previously rejected, but these don't seem to affect syncing.

---
- [x] Make CSJ possible enable/disable and enable it by default.
- [x] Make the jump size configurable
- [x] Pause LoP for jumpers. Perhaps when jgNextInstruction returns JumpTo.
it varies with the eras. We should do the same as the GDD governor to get it.
- [x] Don't read more tvars than necessary in getDynamo
- [x] Turn off CSJ when all peers are idle (therefore no dynamo can be elected).
- [x] Get rid of buggy `fromJust` calls
- [x] Ask jumpers to jump to the tip of the dynamo's candidate fragment when the dynamo is freshly elected. Otherwise, if the new dynamo is blocked, no jumps might occur.
- [x] Update GDD to disconnect nodes with empty genesis windows

This one was sidestepped in a9f4c97 by eliminating the dependency on the genesis window:
- [ ] Find the genesis window for csj needs. At the moment it is given in `bracketChainSyncClient` as a configuration parameter, but this does not make much sense as it varies with the eras. We should do the same as the GDD governor to get it. 