### PR TITLE
PeerSharingAPI fix - backport

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -8,6 +8,7 @@ on:
   pull_request:
     branches:
       - main
+      - 'cardano-node-*-backports'
   merge_group:
 
 jobs:

--- a/cabal.project
+++ b/cabal.project
@@ -16,7 +16,7 @@ index-state:
   -- Bump this if you need newer packages from Hackage
   , hackage.haskell.org 2024-03-14T23:28:52Z
   -- Bump this if you need newer packages from CHaP
-  , cardano-haskell-packages 2024-03-15T17:07:52Z
+  , cardano-haskell-packages 2024-04-04T19:09:56Z
 
 packages:
   ouroboros-consensus

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1710945682,
-        "narHash": "sha256-xp1txUjrtCuKHAy0nvz/lu0MlNdNnzvP8l2p9MFB73Y=",
+        "lastModified": 1712304473,
+        "narHash": "sha256-AXf+FiTVt4Jte0lQ1rb1tvUNfl+xgvJHbE4zktu3bbQ=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "8df2bf06e4525ec39c106cd2593e3c5fd7f2b081",
+        "rev": "465a71bd629a80522fed1fd643f8bf4dd5f9ab6f",
         "type": "github"
       },
       "original": {

--- a/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
+++ b/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
@@ -258,7 +258,7 @@ test-suite byron-test
     , ouroboros-consensus:{ouroboros-consensus, unstable-consensus-testlib}
     , ouroboros-network-mock
     , QuickCheck
-    , small-steps
+    , small-steps                                                            <1.1
     , small-steps-test
     , tasty
     , tasty-quickcheck

--- a/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
+++ b/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
@@ -526,7 +526,7 @@ library unstable-cardano-tools
     , nothunks
     , ouroboros-consensus            ^>=0.16
     , ouroboros-consensus-cardano
-    , ouroboros-consensus-diffusion  ^>=0.12
+    , ouroboros-consensus-diffusion  ^>=0.14
     , ouroboros-consensus-protocol   ^>=0.7
     , ouroboros-network
     , ouroboros-network-api

--- a/ouroboros-consensus-diffusion/CHANGELOG.md
+++ b/ouroboros-consensus-diffusion/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 # Changelog entries
 
+<a id='changelog-0.14.0.0'></a>
+## 0.14.0.0 — 2024-04-08
+
+### Non-Breaking
+
+- Updated `ouroboros-consensus-diffusion` to use `ouroboros-network-0.14.0.0`.
+  `LowLevelRounNodeArgs` and `NodeKernel` records hold
+  `PublicPeerSelectionState` variable.
+
 <a id='changelog-0.12.0.0'></a>
 ## 0.12.0.0 — 2024-03-15
 

--- a/ouroboros-consensus-diffusion/changelog.d/20240404_233318_coot_peerSharingAPI_fix.md
+++ b/ouroboros-consensus-diffusion/changelog.d/20240404_233318_coot_peerSharingAPI_fix.md
@@ -1,0 +1,5 @@
+### Non-Breaking
+
+- Updated `ouroboros-consensus-diffusion` to use `ouroboros-network-0.14.0.0`.
+  `LowLevelRounNodeArgs` and `NodeKernel` records hold
+  `PublicPeerSelectionState` variable.

--- a/ouroboros-consensus-diffusion/changelog.d/20240404_233318_coot_peerSharingAPI_fix.md
+++ b/ouroboros-consensus-diffusion/changelog.d/20240404_233318_coot_peerSharingAPI_fix.md
@@ -1,5 +1,0 @@
-### Non-Breaking
-
-- Updated `ouroboros-consensus-diffusion` to use `ouroboros-network-0.14.0.0`.
-  `LowLevelRounNodeArgs` and `NodeKernel` records hold
-  `PublicPeerSelectionState` variable.

--- a/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
+++ b/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
@@ -81,7 +81,7 @@ library
     , io-classes                   ^>=1.4.1
     , mtl
     , ouroboros-consensus          ^>=0.16
-    , ouroboros-network            ^>=0.13
+    , ouroboros-network            ^>=0.14
     , ouroboros-network-api        ^>=0.7.1
     , ouroboros-network-framework  ^>=0.12
     , ouroboros-network-protocols  ^>=0.8.1

--- a/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
+++ b/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
@@ -1,6 +1,6 @@
 cabal-version:   3.0
 name:            ouroboros-consensus-diffusion
-version:         0.12.0.0
+version:         0.14.0.0
 synopsis:        Integration for the Ouroboros Network layer
 description:
   Top level integration for consensus & network layers of the Ouroboros blockchain protocol.

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Node.hs
@@ -57,6 +57,7 @@ module Ouroboros.Consensus.Node (
 import qualified Codec.CBOR.Decoding as CBOR
 import qualified Codec.CBOR.Encoding as CBOR
 import           Codec.Serialise (DeserialiseFailure)
+import qualified Control.Concurrent.Class.MonadSTM.Strict as StrictSTM
 import           Control.DeepSeq (NFData)
 import           Control.Monad.Class.MonadTime.SI (MonadTime)
 import           Control.Monad.Class.MonadTimer.SI (MonadTimer)
@@ -193,6 +194,7 @@ data RunNodeArgs m addrNTN addrNTC blk (p2p :: Diffusion.P2P) = RunNodeArgs {
     , rnGetUseBootstrapPeers :: STM m UseBootstrapPeers
     }
 
+
 -- | Arguments that usually only tests /directly/ specify.
 --
 -- A non-testing invocation probably wouldn't explicitly provide these values to
@@ -270,6 +272,8 @@ data LowLevelRunNodeArgs m addrNTN addrNTC versionDataNTN versionDataNTC blk
 
       -- | Maximum clock skew
     , llrnMaxClockSkew :: ClockSkew
+
+    , llrnPublicPeerSelectionStateVar :: StrictSTM.StrictTVar m (Diffusion.PublicPeerSelectionState addrNTN)
     }
 
 {-------------------------------------------------------------------------------
@@ -429,6 +433,7 @@ runWith RunNodeArgs{..} encAddrNtN decAddrNtN LowLevelRunNodeArgs{..} =
                     (Just durationUntilTooOld)
                     gsmMarkerFileView
                     rnGetUseBootstrapPeers
+                    llrnPublicPeerSelectionStateVar
           nodeKernel <- initNodeKernel nodeKernelArgs
           rnNodeKernelHook registry nodeKernel
 
@@ -693,6 +698,7 @@ mkNodeKernelArgs ::
   -> Maybe (GSM.WrapDurationUntilTooOld m blk)
   -> GSM.MarkerFileView m
   -> STM m UseBootstrapPeers
+  -> StrictSTM.StrictTVar m (Diffusion.PublicPeerSelectionState addrNTN)
   -> m (NodeKernelArgs m addrNTN (ConnectionId addrNTC) blk)
 mkNodeKernelArgs
   registry
@@ -708,6 +714,7 @@ mkNodeKernelArgs
   gsmDurationUntilTooOld
   gsmMarkerFileView
   getUseBootstrapPeers
+  publicPeerSelectionStateVar
   = do
     let (kaRng, psRng) = split rng
     return NodeKernelArgs
@@ -731,6 +738,7 @@ mkNodeKernelArgs
       , getUseBootstrapPeers
       , keepAliveRng = kaRng
       , peerSharingRng = psRng
+      , publicPeerSelectionStateVar
       }
   where
     defaultBlockFetchConfiguration :: BlockFetchConfiguration
@@ -839,6 +847,7 @@ stdRunDataDiffusion ::
        IO
   -> Diffusion.ExtraTracers p2p
   -> Diffusion.Arguments
+       IO
        Socket      RemoteAddress
        LocalSocket LocalAddress
   -> Diffusion.ExtraArguments p2p IO
@@ -863,6 +872,7 @@ data StdRunNodeArgs m blk (p2p :: Diffusion.P2P) = StdRunNodeArgs
   , srnDatabasePath                 :: FilePath
     -- ^ Location of the DBs
   , srnDiffusionArguments           :: Diffusion.Arguments
+                                         IO
                                          Socket      RemoteAddress
                                          LocalSocket LocalAddress
   , srnDiffusionArgumentsExtra      :: Diffusion.ExtraArguments p2p m
@@ -949,6 +959,8 @@ stdLowLevelRunNodeArgsIO RunNodeArgs{ rnProtocolInfo
       , llrnMaxCaughtUpAge = secondsToNominalDiffTime $ 20 * 60   -- 20 min
       , llrnMaxClockSkew =
           InFuture.defaultClockSkew
+      , llrnPublicPeerSelectionStateVar =
+          Diffusion.daPublicPeerSelectionVar srnDiffusionArguments
       }
   where
     mkHasFS :: ChainDB.RelativeMountPoint -> SomeHasFS IO

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
@@ -29,6 +29,7 @@ module Ouroboros.Consensus.NodeKernel (
 
 
 import qualified Control.Concurrent.Class.MonadSTM as LazySTM
+import qualified Control.Concurrent.Class.MonadSTM.Strict as StrictSTM
 import           Control.DeepSeq (force)
 import           Control.Monad
 import qualified Control.Monad.Class.MonadTimer.SI as SI
@@ -85,6 +86,7 @@ import           Ouroboros.Network.AnchoredFragment (AnchoredFragment,
 import qualified Ouroboros.Network.AnchoredFragment as AF
 import           Ouroboros.Network.Block (castTip, tipFromHeader)
 import           Ouroboros.Network.BlockFetch
+import           Ouroboros.Network.Diffusion (PublicPeerSelectionState)
 import           Ouroboros.Network.NodeToNode (ConnectionId,
                      MiniProtocolParameters (..))
 import           Ouroboros.Network.PeerSelection.Bootstrap (UseBootstrapPeers)
@@ -168,6 +170,8 @@ data NodeKernelArgs m addrNTN addrNTC blk = NodeKernelArgs {
     , gsmArgs                 :: GsmNodeKernelArgs m blk
     , getUseBootstrapPeers    :: STM m UseBootstrapPeers
     , peerSharingRng          :: StdGen
+    , publicPeerSelectionStateVar
+                              :: StrictSTM.StrictTVar m (PublicPeerSelectionState addrNTN)
     }
 
 initNodeKernel ::
@@ -186,6 +190,7 @@ initNodeKernel args@NodeKernelArgs { registry, cfg, tracers
                                    , blockFetchConfiguration
                                    , gsmArgs
                                    , peerSharingRng
+                                   , publicPeerSelectionStateVar
                                    } = do
     -- using a lazy 'TVar', 'BlockForging' does not have a 'NoThunks' instance.
     blockForgingVar :: LazySTM.TMVar m [BlockForging m blk] <- LazySTM.newTMVarIO []
@@ -243,7 +248,8 @@ initNodeKernel args@NodeKernelArgs { registry, cfg, tracers
           TooOld      -> GSM.enterOnlyBootstrap gsm
           YoungEnough -> GSM.enterCaughtUp      gsm
 
-    peerSharingAPI <- newPeerSharingAPI peerSharingRng
+    peerSharingAPI <- newPeerSharingAPI publicPeerSelectionStateVar
+                                        peerSharingRng
                                         ps_POLICY_PEER_SHARE_STICKY_TIME
                                         ps_POLICY_PEER_SHARE_MAX_PEERS
 
@@ -272,7 +278,7 @@ initNodeKernel args@NodeKernelArgs { registry, cfg, tracers
       , getPeerSharingRegistry  = peerSharingRegistry
       , getTracers              = tracers
       , setBlockForging         = \a -> atomically . LazySTM.putTMVar blockForgingVar $! a
-      , getPeerSharingAPI      = peerSharingAPI
+      , getPeerSharingAPI       = peerSharingAPI
       }
   where
     blockForgingController :: InternalState m remotePeer localPeer blk

--- a/ouroboros-consensus-diffusion/src/unstable-diffusion-testlib/Test/ThreadNet/Network.hs
+++ b/ouroboros-consensus-diffusion/src/unstable-diffusion-testlib/Test/ThreadNet/Network.hs
@@ -106,6 +106,8 @@ import           Ouroboros.Network.NodeToNode (ConnectionId (..),
                      MiniProtocolParameters (..), ResponderContext (..))
 import           Ouroboros.Network.PeerSelection.Bootstrap
                      (UseBootstrapPeers (..))
+import           Ouroboros.Network.PeerSelection.Governor
+                     (makePublicPeerSelectionStateVar)
 import           Ouroboros.Network.PeerSelection.PeerMetric (nullMetric)
 import           Ouroboros.Network.Point (WithOrigin (..))
 import qualified Ouroboros.Network.Protocol.ChainSync.Type as CS
@@ -972,6 +974,7 @@ runThreadNetwork systemTime ThreadNetworkArgs
       let rng = case seed of
                     Seed s -> mkStdGen s
           (kaRng, psRng) = split rng
+      publicPeerSelectionStateVar <- makePublicPeerSelectionStateVar
       let nodeKernelArgs = NodeKernelArgs
             { tracers
             , registry
@@ -1013,6 +1016,7 @@ runThreadNetwork systemTime ThreadNetworkArgs
                 , gsmMinCaughtUpDuration = 0
                 }
             , getUseBootstrapPeers = pure DontUseBootstrapPeers
+            , publicPeerSelectionStateVar
             }
 
       nodeKernel <- initNodeKernel nodeKernelArgs

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -261,7 +261,7 @@ library
     , cardano-binary
     , cardano-crypto-class
     , cardano-prelude
-    , cardano-slotting
+    , cardano-slotting             ^>=0.1
     , cardano-strict-containers
     , cborg                        ^>=0.2.2
     , containers                   >=0.5    && <0.7


### PR DESCRIPTION
# Description

This PR is a backport of #1041 to `cardano-node-8.9-backports` branch.

- **ouroboros-consensus-diffusion: PublicPeerSelectionState**
- **release ouroboros-consensus-diffusion-0.14.0.0**
