### PR TITLE
Refactor chain ordering away from `Ord`

### DIFF
--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Node/DiffusionPipelining.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Node/DiffusionPipelining.hs
@@ -121,13 +121,14 @@ instance
           }
 
   applyTentativeHeaderView _ thv st
-    | LegacyShelleyTentativeHeaderView thv' <- thv
+    | LegacyShelleyTentativeHeaderView sv' <- thv
     , LegacyShelleyTentativeHeaderState st' <- st
-    = LegacyShelleyTentativeHeaderState <$>
-        applyTentativeHeaderView
-          (Proxy @(SelectViewDiffusionPipelining (ShelleyBlock proto era)))
-          thv'
-          st'
+    = do
+        case st' of
+          NoLastInvalidSelectView  -> pure ()
+          LastInvalidSelectView sv -> guard $ compareChains sv sv' == LT
+        pure $ LegacyShelleyTentativeHeaderState $ LastInvalidSelectView sv'
+
     | ShelleyTentativeHeaderView bno hdrIdentity <- thv
     , ShelleyTentativeHeaderState lastBlockNo badIdentities <- st
     = case compare (NotOrigin bno) lastBlockNo of

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Node/DiffusionPipelining.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Node/DiffusionPipelining.hs
@@ -126,7 +126,7 @@ instance
     = do
         case st' of
           NoLastInvalidSelectView  -> pure ()
-          LastInvalidSelectView sv -> guard $ compareChains sv sv' == LT
+          LastInvalidSelectView sv -> guard $ compareChains () sv sv' == LT
         pure $ LegacyShelleyTentativeHeaderState $ LastInvalidSelectView sv'
 
     | ShelleyTentativeHeaderView bno hdrIdentity <- thv

--- a/ouroboros-consensus-protocol/changelog.d/20240409_141920_alexander.esgen_remove_ord_selectview.md
+++ b/ouroboros-consensus-protocol/changelog.d/20240409_141920_alexander.esgen_remove_ord_selectview.md
@@ -1,0 +1,3 @@
+### Breaking
+
+- Added `ChainOrder` instance for `PraosChainSelectView`, and `Ord` instance.

--- a/ouroboros-consensus-protocol/changelog.d/20240409_142625_alexander.esgen_remove_ord_selectview.md
+++ b/ouroboros-consensus-protocol/changelog.d/20240409_142625_alexander.esgen_remove_ord_selectview.md
@@ -1,0 +1,3 @@
+### Non-Breaking
+
+- Adapted instances for new `ChainOrderConfig`.

--- a/ouroboros-consensus-protocol/src/ouroboros-consensus-protocol/Ouroboros/Consensus/Protocol/Praos/Common.hs
+++ b/ouroboros-consensus-protocol/src/ouroboros-consensus-protocol/Ouroboros/Consensus/Protocol/Praos/Common.hs
@@ -41,15 +41,7 @@ newtype MaxMajorProtVer = MaxMajorProtVer
   deriving (Eq, Show, Generic)
   deriving newtype NoThunks
 
--- | View of the ledger tip for chain selection.
---
--- We order between chains as follows:
---
--- 1. By chain length, with longer chains always preferred.
--- 2. If the tip of each chain was issued by the same agent, then we prefer
---    the chain whose tip has the highest ocert issue number.
--- 3. By a VRF value from the chain tip, with lower values preferred. See
---    @pTieBreakVRFValue@ for which one is used.
+-- | View of the tip of a header fragment for chain selection.
 data PraosChainSelectView c = PraosChainSelectView
   { csvChainLength :: BlockNo,
     csvSlotNo      :: SlotNo,
@@ -59,8 +51,15 @@ data PraosChainSelectView c = PraosChainSelectView
   }
   deriving (Show, Eq, Generic, NoThunks)
 
-instance Crypto c => Ord (PraosChainSelectView c) where
-  compare =
+-- | We order between chains as follows:
+--
+-- 1. By chain length, with longer chains always preferred.
+-- 2. If the tip of each chain was issued by the same agent, then we prefer
+--    the chain whose tip has the highest ocert issue number.
+-- 3. By a VRF value from the chain tip, with lower values preferred. See
+--    @pTieBreakVRFValue@ for which one is used.
+instance Crypto c => ChainOrder (PraosChainSelectView c) where
+  compareChains =
     mconcat
       [ compare `on` csvChainLength,
         whenSame csvIssuer (compare `on` csvIssueNo),

--- a/ouroboros-consensus-protocol/src/ouroboros-consensus-protocol/Ouroboros/Consensus/Protocol/Praos/Common.hs
+++ b/ouroboros-consensus-protocol/src/ouroboros-consensus-protocol/Ouroboros/Consensus/Protocol/Praos/Common.hs
@@ -59,7 +59,9 @@ data PraosChainSelectView c = PraosChainSelectView
 -- 3. By a VRF value from the chain tip, with lower values preferred. See
 --    @pTieBreakVRFValue@ for which one is used.
 instance Crypto c => ChainOrder (PraosChainSelectView c) where
-  compareChains =
+  type ChainOrderConfig (PraosChainSelectView c) = ()
+
+  compareChains () =
     mconcat
       [ compare `on` csvChainLength,
         whenSame csvIssuer (compare `on` csvIssueNo),

--- a/ouroboros-consensus/changelog.d/20240409_141920_alexander.esgen_remove_ord_selectview.md
+++ b/ouroboros-consensus/changelog.d/20240409_141920_alexander.esgen_remove_ord_selectview.md
@@ -1,0 +1,3 @@
+### Breaking
+
+- Require `ChainOrder` for `SelectView` instead of `Ord`.

--- a/ouroboros-consensus/changelog.d/20240409_142625_alexander.esgen_remove_ord_selectview.md
+++ b/ouroboros-consensus/changelog.d/20240409_142625_alexander.esgen_remove_ord_selectview.md
@@ -1,0 +1,3 @@
+### Breaking
+
+- Added `ChainOrderConfig` and adapted instances accordingly.

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Block/SupportsDiffusionPipelining.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Block/SupportsDiffusionPipelining.hs
@@ -225,8 +225,8 @@ instance BlockSupportsDiffusionPipelining (DisableDiffusionPipelining blk) where
 -- >   instance BlockSupportsProtocol blk
 -- >   => BlockSupportsDiffusionPipelining MyBlock
 --
--- This requires that the 'SelectView' is totally ordered, in particular that
--- the order is transitive.
+-- This requires that the 'SelectView' is totally ordered via 'Ord', in
+-- particular that the order is transitive.
 --
 -- For example, if @'SelectView' ~ 'BlockNo'@, this means that a header can be
 -- pipelined if it has a larger block number than the last tentative trap
@@ -255,6 +255,7 @@ deriving anyclass instance ConsensusProtocol proto => NoThunks (SelectViewTentat
 instance
   ( BlockSupportsProtocol blk
   , Show (SelectView (BlockProtocol blk))
+  , Ord (SelectView (BlockProtocol blk))
   ) => BlockSupportsDiffusionPipelining (SelectViewDiffusionPipelining blk) where
   type TentativeHeaderState (SelectViewDiffusionPipelining blk) =
     SelectViewTentativeState (BlockProtocol blk)

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Block/SupportsProtocol.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Block/SupportsProtocol.hs
@@ -34,3 +34,13 @@ class ( GetHeader blk
                      => BlockConfig blk
                      -> Header blk -> SelectView (BlockProtocol blk)
   selectView _ = blockNo
+
+  projectChainOrderConfig ::
+       BlockConfig blk
+    -> ChainOrderConfig (SelectView (BlockProtocol blk))
+
+  default projectChainOrderConfig ::
+       ChainOrderConfig (SelectView (BlockProtocol blk)) ~ ()
+    => BlockConfig blk
+    -> ChainOrderConfig (SelectView (BlockProtocol blk))
+  projectChainOrderConfig _ = ()

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/AcrossEras.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/AcrossEras.hs
@@ -21,6 +21,7 @@
 module Ouroboros.Consensus.HardFork.Combinator.AcrossEras (
     -- * Value for /each/ era
     PerEraBlockConfig (..)
+  , PerEraChainOrderConfig (..)
   , PerEraCodecConfig (..)
   , PerEraConsensusConfig (..)
   , PerEraLedgerConfig (..)
@@ -97,11 +98,12 @@ import           Ouroboros.Consensus.Util.Condense (Condense (..))
   Value for /each/ era
 -------------------------------------------------------------------------------}
 
-newtype PerEraBlockConfig     xs = PerEraBlockConfig     { getPerEraBlockConfig     :: NP BlockConfig                xs }
-newtype PerEraCodecConfig     xs = PerEraCodecConfig     { getPerEraCodecConfig     :: NP CodecConfig                xs }
-newtype PerEraConsensusConfig xs = PerEraConsensusConfig { getPerEraConsensusConfig :: NP WrapPartialConsensusConfig xs }
-newtype PerEraLedgerConfig    xs = PerEraLedgerConfig    { getPerEraLedgerConfig    :: NP WrapPartialLedgerConfig    xs }
-newtype PerEraStorageConfig   xs = PerEraStorageConfig   { getPerEraStorageConfig   :: NP StorageConfig              xs }
+newtype PerEraBlockConfig      xs = PerEraBlockConfig      { getPerEraBlockConfig      :: NP BlockConfig                xs }
+newtype PerEraChainOrderConfig xs = PerEraChainOrderConfig { getPerEraChainOrderConfig :: NP WrapChainOrderConfig       xs }
+newtype PerEraCodecConfig      xs = PerEraCodecConfig      { getPerEraCodecConfig      :: NP CodecConfig                xs }
+newtype PerEraConsensusConfig  xs = PerEraConsensusConfig  { getPerEraConsensusConfig  :: NP WrapPartialConsensusConfig xs }
+newtype PerEraLedgerConfig     xs = PerEraLedgerConfig     { getPerEraLedgerConfig     :: NP WrapPartialLedgerConfig    xs }
+newtype PerEraStorageConfig    xs = PerEraStorageConfig    { getPerEraStorageConfig    :: NP StorageConfig              xs }
 
 newtype PerEraProtocolParams  xs = PerEraProtocolParams  { getPerEraProtocolParams  :: NP ProtocolParams             xs }
 

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Protocol.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Protocol.hs
@@ -69,8 +69,8 @@ newtype HardForkSelectView xs = HardForkSelectView {
   deriving (Show, Eq)
   deriving newtype (NoThunks)
 
-instance CanHardFork xs => Ord (HardForkSelectView xs) where
-  compare (HardForkSelectView l) (HardForkSelectView r) =
+instance CanHardFork xs => ChainOrder (HardForkSelectView xs) where
+  compareChains (HardForkSelectView l) (HardForkSelectView r) =
      acrossEraSelection
        hardForkChainSel
        (mapWithBlockNo getOneEraSelectView l)

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Protocol/ChainSel.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Protocol/ChainSel.hs
@@ -42,6 +42,10 @@ data AcrossEraSelection :: Type -> Type -> Type where
   -- | Two eras using the same 'SelectView'. In this case, we can just compare
   -- chains even across eras, as the chain ordering is fully captured by
   -- 'SelectView' and its 'ChainOrder' instance.
+  --
+  -- We use the 'ChainOrderConfig' of the 'SelectView' in the newer era when
+  -- invoking 'compareChains'. (We could also make this choice configurable
+  -- here.)
   CompareSameSelectView ::
        SelectView (BlockProtocol x) ~ SelectView (BlockProtocol y)
     => AcrossEraSelection x y
@@ -52,53 +56,62 @@ data AcrossEraSelection :: Type -> Type -> Type where
 
 acrossEras ::
      forall blk blk'. SingleEraBlock blk
-  => WithBlockNo WrapSelectView blk
+  => ChainOrderConfig (SelectView (BlockProtocol blk'))
+  -> WithBlockNo WrapSelectView blk
   -> WithBlockNo WrapSelectView blk'
   -> AcrossEraSelection blk blk'
   -> Ordering
-acrossEras (WithBlockNo bnoL (WrapSelectView l))
-           (WithBlockNo bnoR (WrapSelectView r)) = \case
+acrossEras cfg (WithBlockNo bnoL (WrapSelectView l))
+               (WithBlockNo bnoR (WrapSelectView r)) = \case
     CompareBlockNo        -> compare bnoL bnoR
-    CompareSameSelectView -> compareChains l r
+    CompareSameSelectView -> compareChains cfg l r
 
 acrossEraSelection ::
      All SingleEraBlock              xs
-  => Tails AcrossEraSelection        xs
+  => NP WrapChainOrderConfig         xs
+  -> Tails AcrossEraSelection        xs
   -> WithBlockNo (NS WrapSelectView) xs
   -> WithBlockNo (NS WrapSelectView) xs
   -> Ordering
-acrossEraSelection = \ffs l r ->
-    goLeft ffs (distribBlockNo l, distribBlockNo r)
+acrossEraSelection = \cfg ffs l r ->
+    goLeft cfg ffs (distribBlockNo l, distribBlockNo r)
   where
     goLeft ::
          All SingleEraBlock                xs
-      => Tails AcrossEraSelection          xs
+      => NP WrapChainOrderConfig           xs
+      -> Tails AcrossEraSelection          xs
       -> ( NS (WithBlockNo WrapSelectView) xs
          , NS (WithBlockNo WrapSelectView) xs
          )
       -> Ordering
-    goLeft TNil            = \(a, _) -> case a of {}
-    goLeft (TCons fs ffs') = \case
-        (Z a, Z b) -> compareChains (dropBlockNo a) (dropBlockNo b)
-        (Z a, S b) ->          goRight a fs b
-        (S a, Z b) -> invert $ goRight b fs a
-        (S a, S b) -> goLeft ffs' (a, b)
+    goLeft _             TNil            = \(a, _) -> case a of {}
+    goLeft (cfg :* cfgs) (TCons fs ffs') = \case
+        (Z a, Z b) -> compareChains cfg' (dropBlockNo a) (dropBlockNo b)
+        (Z a, S b) ->          goRight a cfgs fs b
+        (S a, Z b) -> invert $ goRight b cfgs fs a
+        (S a, S b) -> goLeft cfgs ffs' (a, b)
+      where
+        cfg' = unwrapChainOrderConfig cfg
 
     goRight ::
          forall x xs. (SingleEraBlock x, All SingleEraBlock xs)
       => WithBlockNo WrapSelectView x
+      -> NP WrapChainOrderConfig         xs
       -> NP (AcrossEraSelection     x)   xs
       -> NS (WithBlockNo WrapSelectView) xs
       -> Ordering
     goRight a = go
       where
         go :: forall xs'. All SingleEraBlock  xs'
-           => NP (AcrossEraSelection x)       xs'
+           => NP WrapChainOrderConfig         xs'
+           -> NP (AcrossEraSelection x)       xs'
            -> NS (WithBlockNo WrapSelectView) xs'
            -> Ordering
-        go Nil          b  = case b of {}
-        go (f :* _)  (Z b) = acrossEras a b f
-        go (_ :* fs) (S b) = go fs b
+        go _             Nil          b  = case b of {}
+        go (cfg :* _   ) (f :* _)  (Z b) = acrossEras cfg' a b f
+          where
+            cfg' = unwrapChainOrderConfig cfg
+        go (_   :* cfgs) (_ :* fs) (S b) = go cfgs fs b
 
 {-------------------------------------------------------------------------------
   WithBlockNo

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Protocol/ChainSel.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Protocol/ChainSel.hs
@@ -41,7 +41,7 @@ data AcrossEraSelection :: Type -> Type -> Type where
 
   -- | Two eras using the same 'SelectView'. In this case, we can just compare
   -- chains even across eras, as the chain ordering is fully captured by
-  -- 'SelectView' and its 'Ord' instance.
+  -- 'SelectView' and its 'ChainOrder' instance.
   CompareSameSelectView ::
        SelectView (BlockProtocol x) ~ SelectView (BlockProtocol y)
     => AcrossEraSelection x y
@@ -59,7 +59,7 @@ acrossEras ::
 acrossEras (WithBlockNo bnoL (WrapSelectView l))
            (WithBlockNo bnoR (WrapSelectView r)) = \case
     CompareBlockNo        -> compare bnoL bnoR
-    CompareSameSelectView -> compare l r
+    CompareSameSelectView -> compareChains l r
 
 acrossEraSelection ::
      All SingleEraBlock              xs
@@ -79,7 +79,7 @@ acrossEraSelection = \ffs l r ->
       -> Ordering
     goLeft TNil            = \(a, _) -> case a of {}
     goLeft (TCons fs ffs') = \case
-        (Z a, Z b) -> compare (dropBlockNo a) (dropBlockNo b)
+        (Z a, Z b) -> compareChains (dropBlockNo a) (dropBlockNo b)
         (Z a, S b) ->          goRight a fs b
         (S a, Z b) -> invert $ goRight b fs a
         (S a, S b) -> goLeft ffs' (a, b)

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Dual.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Dual.hs
@@ -288,6 +288,8 @@ instance Bridge m a => BlockSupportsProtocol (DualBlock m a) where
   validateView cfg = validateView (dualBlockConfigMain cfg) . dualHeaderMain
   selectView   cfg = selectView   (dualBlockConfigMain cfg) . dualHeaderMain
 
+  projectChainOrderConfig = projectChainOrderConfig . dualBlockConfigMain
+
 {-------------------------------------------------------------------------------
   Ledger errors
 -------------------------------------------------------------------------------}

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Protocol/MockChainSel.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Protocol/MockChainSel.hs
@@ -6,9 +6,9 @@ module Ouroboros.Consensus.Protocol.MockChainSel (
   , selectUnvalidatedChain
   ) where
 
-import           Data.List (sortOn)
+import           Data.Function (on)
+import           Data.List (sortBy)
 import           Data.Maybe (listToMaybe, mapMaybe)
-import           Data.Ord (Down (..))
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Network.Mock.Chain (Chain)
 import qualified Ouroboros.Network.Mock.Chain as Chain
@@ -38,7 +38,7 @@ selectChain :: forall proxy p hdr l. ConsensusProtocol p
 selectChain p view ours =
       listToMaybe
     . map snd
-    . sortOn (Down . fst)
+    . sortBy (flip compareChains `on` fst)
     . mapMaybe selectPreferredCandidate
   where
     -- | Only retain a candidate if it is preferred over the current chain. As

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Protocol/ModChainSel.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Protocol/ModChainSel.hs
@@ -21,7 +21,7 @@ newtype instance ConsensusConfig (ModChainSel p s) = McsConsensusConfig {
   deriving (Generic)
 
 instance ( ConsensusProtocol p
-         , Ord  s
+         , ChainOrder s
          , Show s
          , Typeable s
          , NoThunks s

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Protocol/PBFT.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Protocol/PBFT.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DeriveAnyClass            #-}
 {-# LANGUAGE DeriveGeneric             #-}
+{-# LANGUAGE DerivingVia               #-}
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE FlexibleContexts          #-}
 {-# LANGUAGE FlexibleInstances         #-}
@@ -135,7 +136,9 @@ data PBftSelectView = PBftSelectView {
       pbftSelectViewBlockNo :: BlockNo
     , pbftSelectViewIsEBB   :: IsEBB
     }
-  deriving (Show, Eq, Generic, NoThunks)
+  deriving stock (Show, Eq, Generic)
+  deriving anyclass (NoThunks)
+  deriving (ChainOrder) via TotalChainOrder PBftSelectView
 
 mkPBftSelectView :: GetHeader blk => Header blk -> PBftSelectView
 mkPBftSelectView hdr = PBftSelectView {

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/TypeFamilyWrappers.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/TypeFamilyWrappers.hs
@@ -149,6 +149,8 @@ deriving instance Eq (ValidationErr (BlockProtocol blk)) => Eq (WrapValidationEr
 
 deriving instance Ord (SelectView (BlockProtocol blk)) => Ord (WrapSelectView blk)
 
+deriving instance ChainOrder (SelectView (BlockProtocol blk)) => ChainOrder (WrapSelectView blk)
+
 deriving instance Show (ChainDepState (BlockProtocol blk)) => Show (WrapChainDepState blk)
 deriving instance Show (LedgerView    (BlockProtocol blk)) => Show (WrapLedgerView    blk)
 deriving instance Show (SelectView    (BlockProtocol blk)) => Show (WrapSelectView    blk)

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/TypeFamilyWrappers.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/TypeFamilyWrappers.hs
@@ -25,6 +25,7 @@ module Ouroboros.Consensus.TypeFamilyWrappers (
     -- * Protocol based
   , WrapCanBeLeader (..)
   , WrapChainDepState (..)
+  , WrapChainOrderConfig (..)
   , WrapConsensusConfig (..)
   , WrapIsLeader (..)
   , WrapLedgerView (..)
@@ -84,14 +85,15 @@ newtype WrapValidatedGenTx        blk = WrapValidatedGenTx        { unwrapValida
   Consensus based
 -------------------------------------------------------------------------------}
 
-newtype WrapCanBeLeader     blk = WrapCanBeLeader     { unwrapCanBeLeader     :: CanBeLeader     (BlockProtocol blk) }
-newtype WrapChainDepState   blk = WrapChainDepState   { unwrapChainDepState   :: ChainDepState   (BlockProtocol blk) }
-newtype WrapConsensusConfig blk = WrapConsensusConfig { unwrapConsensusConfig :: ConsensusConfig (BlockProtocol blk) }
-newtype WrapIsLeader        blk = WrapIsLeader        { unwrapIsLeader        :: IsLeader        (BlockProtocol blk) }
-newtype WrapLedgerView      blk = WrapLedgerView      { unwrapLedgerView      :: LedgerView      (BlockProtocol blk) }
-newtype WrapSelectView      blk = WrapSelectView      { unwrapSelectView      :: SelectView      (BlockProtocol blk) }
-newtype WrapValidateView    blk = WrapValidateView    { unwrapValidateView    :: ValidateView    (BlockProtocol blk) }
-newtype WrapValidationErr   blk = WrapValidationErr   { unwrapValidationErr   :: ValidationErr   (BlockProtocol blk) }
+newtype WrapCanBeLeader      blk = WrapCanBeLeader      { unwrapCanBeLeader      :: CanBeLeader                  (BlockProtocol blk)  }
+newtype WrapChainDepState    blk = WrapChainDepState    { unwrapChainDepState    :: ChainDepState                (BlockProtocol blk)  }
+newtype WrapChainOrderConfig blk = WrapChainOrderConfig { unwrapChainOrderConfig :: ChainOrderConfig (SelectView (BlockProtocol blk)) }
+newtype WrapConsensusConfig  blk = WrapConsensusConfig  { unwrapConsensusConfig  :: ConsensusConfig              (BlockProtocol blk)  }
+newtype WrapIsLeader         blk = WrapIsLeader         { unwrapIsLeader         :: IsLeader                     (BlockProtocol blk)  }
+newtype WrapLedgerView       blk = WrapLedgerView       { unwrapLedgerView       :: LedgerView                   (BlockProtocol blk)  }
+newtype WrapSelectView       blk = WrapSelectView       { unwrapSelectView       :: SelectView                   (BlockProtocol blk)  }
+newtype WrapValidateView     blk = WrapValidateView     { unwrapValidateView     :: ValidateView                 (BlockProtocol blk)  }
+newtype WrapValidationErr    blk = WrapValidationErr    { unwrapValidationErr    :: ValidationErr                (BlockProtocol blk)  }
 
 {-------------------------------------------------------------------------------
   Versioning

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Util/AnchoredFragment.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Util/AnchoredFragment.hs
@@ -22,6 +22,7 @@ import           Data.Maybe (isJust)
 import           Data.Word (Word64)
 import           GHC.Stack
 import           Ouroboros.Consensus.Block
+import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Util.Assert
 import           Ouroboros.Network.AnchoredFragment (AnchoredFragment,
                      AnchoredSeq (Empty, (:>)))
@@ -112,7 +113,7 @@ compareAnchoredFragments cfg frag1 frag2 =
           else GT
       (_ :> tip, _ :> tip') ->
         -- Case 4
-        compare
+        compareChains
           (selectView cfg tip)
           (selectView cfg tip')
   where

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Util/AnchoredFragment.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Util/AnchoredFragment.hs
@@ -114,6 +114,7 @@ compareAnchoredFragments cfg frag1 frag2 =
       (_ :> tip, _ :> tip') ->
         -- Case 4
         compareChains
+          (projectChainOrderConfig cfg)
           (selectView cfg tip)
           (selectView cfg tip')
   where

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/TestBlock.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/TestBlock.hs
@@ -748,6 +748,7 @@ treePreferredChain =
       fromMaybe Genesis
     . selectUnvalidatedChain
         (Proxy @(BlockProtocol TestBlock))
+        () -- ChainOrderConfig
         blockNo
         Genesis
     . treeToChains

--- a/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Node.hs
+++ b/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Node.hs
@@ -60,6 +60,7 @@ instance BlockSupportsMetrics (SimpleBlock c ext) where
 deriving via SelectViewDiffusionPipelining (SimpleBlock c ext) instance
   ( BlockSupportsProtocol (SimpleBlock c ext)
   , Show (SelectView (BlockProtocol (SimpleBlock c ext)))
+  , Ord  (SelectView (BlockProtocol (SimpleBlock c ext)))
   ) => BlockSupportsDiffusionPipelining (SimpleBlock c ext)
 
 instance ( LedgerSupportsProtocol      (SimpleBlock SimpleMockCrypto ext)
@@ -68,6 +69,7 @@ instance ( LedgerSupportsProtocol      (SimpleBlock SimpleMockCrypto ext)
          , Show (ForgeStateUpdateError (SimpleBlock SimpleMockCrypto ext))
          , Serialise ext
          , RunMockBlock SimpleMockCrypto ext
+         , Ord (SelectView (BlockProtocol (SimpleBlock SimpleMockCrypto ext)))
          ) => RunNode (SimpleBlock SimpleMockCrypto ext)
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/Model.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/Model.hs
@@ -437,6 +437,7 @@ addBlock cfg blk m = Model {
         fromMaybe (currentChain m, currentLedger m)
       . selectChain
           (Proxy @(BlockProtocol blk))
+          (projectChainOrderConfig (configBlock cfg))
           (selectView (configBlock cfg) . getHeader)
           (currentChain m)
       $ consideredCandidates
@@ -1004,6 +1005,7 @@ wipeVolatileDB cfg m =
         isSameAsImmutableDbChain
       $ selectChain
           (Proxy @(BlockProtocol blk))
+          (projectChainOrderConfig (configBlock cfg))
           (selectView (configBlock cfg) . getHeader)
           Chain.genesis
       $ snd

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/TestBlock.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/TestBlock.hs
@@ -97,6 +97,7 @@ import           Ouroboros.Consensus.Ledger.SupportsProtocol
 import           Ouroboros.Consensus.Node.ProtocolInfo
 import           Ouroboros.Consensus.Node.Run
 import           Ouroboros.Consensus.NodeId
+import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Protocol.BFT
 import           Ouroboros.Consensus.Protocol.ModChainSel
 import           Ouroboros.Consensus.Protocol.Signed
@@ -459,7 +460,9 @@ data BftWithEBBsSelectView = BftWithEBBsSelectView {
     , bebbChainLength :: !ChainLength
     , bebbHash        :: !TestHeaderHash
     }
-  deriving (Show, Eq, Generic, NoThunks)
+  deriving stock (Show, Eq, Generic)
+  deriving anyclass (NoThunks)
+  deriving (ChainOrder) via TotalChainOrder BftWithEBBsSelectView
 
 instance Ord BftWithEBBsSelectView where
   compare (BftWithEBBsSelectView lBlockNo lIsEBB lChainLength lHash)


### PR DESCRIPTION
Closes #939

This PR is intended to be reviewed commit-by-commit.

This PR undoes some of the changes of https://github.com/IntersectMBO/ouroboros-network/pull/2743.

WIP: still needs more docs

