### PR TITLE
Add `release` label for CI

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -30,6 +30,7 @@ jobs:
     - env:
         BASE_REF: ${{ github.event.pull_request.base.ref }}
         NO_CHANGELOG_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'no changelog') }}
+        RELEASE_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'release') }}
       run: ./scripts/ci/check-changelogs.sh
 
   check-cabal-files:


### PR DESCRIPTION
# Description

A `release` label can be set to check that there are no remaining fragments, and also avoid the check for new fragments (same as `no changelog`)
