### PR TITLE
Have GDD disconnect peers with disagreeing chains of equal density

### DIFF
--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/BlockTree.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/BlockTree.hs
@@ -80,7 +80,7 @@ mkTrunk btTrunk = BlockTree { btTrunk, btBranches = [] }
 
 -- | Add a branch to an existing block tree.
 --
--- PRECONDITION: The given fragment intersects with the trunk or its anchor.
+-- Yields @Nothing@ if the given fragment does not intersect with the trunk or its anchor.
 --
 -- FIXME: we should enforce that the branch's prefix shares the same anchor as
 -- the trunk.
@@ -95,7 +95,7 @@ addBranch branch bt = do
   let btbFull = fromJust $ AF.join btbPrefix btbSuffix
   pure $ bt { btBranches = BlockTreeBranch { .. } : btBranches bt }
 
--- | Same as @addBranch@ but assumes that the precondition holds.
+-- | Same as @addBranch@ but calls to 'error' if the former yields 'Nothing'.
 addBranch' :: AF.HasHeader blk => AF.AnchoredFragment blk -> BlockTree blk -> BlockTree blk
 addBranch' branch blockTree =
   fromMaybe (error "addBranch': precondition does not hold") $ addBranch branch blockTree

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/DensityDisconnect.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/DensityDisconnect.hs
@@ -336,13 +336,17 @@ prop_densityDisconnectTriggersChainSel =
 
     shrinkByRemovingAdversaries
 
-    ( \GenesisTest {gtBlockTree} stateView@StateView {svTipBlock} ->
+    ( \GenesisTest {gtBlockTree, gtSchedule} stateView@StateView {svTipBlock} ->
         let
+          othersCount = Map.size (others gtSchedule)
           exnCorrect = case exceptionsByComponent ChainSyncClient stateView of
             [fromException -> Just DensityTooLow] -> True
+            []                 | othersCount == 0 -> True
             _                                     -> False
           tipPointCorrect = Just (getTrunkTip gtBlockTree) == svTipBlock
-        in exnCorrect && tipPointCorrect
+        in counterexample "Unexpected exceptions" exnCorrect
+            .&&.
+           counterexample "The tip of the final selection is not the expected one" tipPointCorrect
     )
 
   where

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Genesis/Governor.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Genesis/Governor.hs
@@ -269,8 +269,11 @@ densityDisconnect (GenesisWindow sgen) (SecurityParam k) states candidateSuffixe
       guard $ AF.lastPoint frag0 /= AF.lastPoint frag1
       -- peer1 offers more than k blocks
       guard offersMoreThanK
-      -- peer1 definitely has higher density than peer0
-      guard $ lb1 > ub0
+      -- peer1 has the same or better density than peer0
+      --
+      -- This matters to ChainSync jumping, where dynamo and objector
+      -- could offer chains of equal density.
+      guard $ lb1 >= ub0
       pure peer0
 
     loeIntersectionSlot = AF.headSlot loeFrag

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Genesis/Governor.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Genesis/Governor.hs
@@ -260,10 +260,19 @@ densityDisconnect (GenesisWindow sgen) (SecurityParam k) states candidateSuffixe
       pure (peer, DensityBounds {fragment, offersMoreThanK, lowerBound, upperBound, hasBlockAfter, latestSlot, idling})
 
     losingPeers = nubOrd $ do
-      (peer0 , DensityBounds {fragment = frag0, upperBound = ub0}) <-
+      (peer0 , DensityBounds { fragment = frag0
+                             , upperBound = ub0
+                             , hasBlockAfter = hasBlockAfter0
+                             , idling = idling0
+                             }) <-
         Map.toList densityBounds
       (_peer1, DensityBounds {fragment = frag1, offersMoreThanK, lowerBound = lb1 }) <-
         Map.toList densityBounds
+      -- Don't disconnect peer0 if it sent no headers after the intersection yet
+      -- and it is not idling.
+      --
+      -- See Note [Chain disagreement]
+      guard $ idling0 || not (AF.null frag0) || hasBlockAfter0
       -- ensure that the two peer fragments don't share any
       -- headers after the LoE
       guard $ AF.lastPoint frag0 /= AF.lastPoint frag1
@@ -286,6 +295,30 @@ densityDisconnect (GenesisWindow sgen) (SecurityParam k) states candidateSuffixe
 
     competingFrags =
       Map.map dropBeyondGenesisWindow candidateSuffixes
+
+-- Note [Chain disagreement]
+-- ~~~~~~~~~~~~~~~~~~~~~~~~~
+--
+-- Imagine two peers serving the following chain:
+--
+-- > k: 1
+-- > sgen: 2
+-- >
+-- >   0 1 2
+-- > G---1-2
+--
+-- Say peer1 sent no headers yet and peer2 sent 2 headers.
+-- The intersection of both is G, the density of peer2's chain is 2,
+-- while the upperbound of the density of peer1 is also 2.
+--
+-- Before this commit, GDD would disconnect peer1 as it cannot improve
+-- the density of peer2's chain. For this decision to be correct, however,
+-- it is essential that both chains disagree after the intersection.
+--
+-- To know if the chains will dissagree we defer disconnecting peer1
+-- until it declares to have no more headers, or until it sends one header
+-- after the intersection. If both chains agree on the next header after
+-- the intersection, we don't disconnect peer1 either.
 
 data TraceGDDEvent peer blk =
   TraceGDDEvent {


### PR DESCRIPTION
Before this change, the GDD would tolerate different chains having the same density. This is problematic to ChainSync jumping if the only active peers (dynamo and objector) disagree with chains of the same density, and GDD cannot disconnect any of them.