### PR TITLE
Rework the arguments for the DBs

### DIFF
--- a/ouroboros-consensus-cardano/changelog.d/chaindb-args-javier.md
+++ b/ouroboros-consensus-cardano/changelog.d/chaindb-args-javier.md
@@ -1,0 +1,1 @@
+<!-- Empty to satisfy CI, only unstable libraries changed -->

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBTruncater/Run.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBTruncater/Run.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE NamedFieldPuns      #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications    #-}
 {-# LANGUAGE ViewPatterns        #-}
 
 module Cardano.Tools.DBTruncater.Run (truncate) where
@@ -46,12 +47,13 @@ truncate DBTruncaterConfig{ dbDir, truncateAfter, verbose } args = do
       chunkInfo = Node.nodeImmutableDbChunkInfo (configStorage config)
       immutableDBArgs :: ImmutableDbArgs Identity IO block
       immutableDBArgs =
-        (ImmutableDB.defaultArgs fs)
+        (ImmutableDB.defaultArgs @IO)
           { immTracer = immutableDBTracer
           , immRegistry = registry
           , immCheckIntegrity = nodeCheckIntegrity (configStorage config)
           , immCodecConfig = configCodec config
           , immChunkInfo = chunkInfo
+          , immHasFS = fs
           }
 
     withDB immutableDBArgs $ \(immutableDB, internal) -> do

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/ImmDBServer/Diffusion.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/ImmDBServer/Diffusion.hs
@@ -93,15 +93,13 @@ run immDBDir sockAddr cfg = withRegistry \registry ->
         immDB
         networkMagic
   where
-    immDBArgs registry = defaultImmDBArgs {
+    immDBArgs registry = ImmutableDB.defaultArgs {
           immCheckIntegrity = nodeCheckIntegrity storageCfg
         , immChunkInfo      = nodeImmutableDbChunkInfo storageCfg
         , immCodecConfig    = codecCfg
         , immRegistry       = registry
+        , immHasFS          = SomeHasFS $ ioHasFS $ MountPoint immDBDir
         }
-      where
-        defaultImmDBArgs =
-          ImmutableDB.defaultArgs $ SomeHasFS $ ioHasFS $ MountPoint immDBDir
 
     codecCfg     = configCodec cfg
     storageCfg   = configStorage cfg

--- a/ouroboros-consensus-diffusion/changelog.d/chaindb-args-javier.md
+++ b/ouroboros-consensus-diffusion/changelog.d/chaindb-args-javier.md
@@ -1,0 +1,5 @@
+### Breaking
+
+- `ChainDbArgs` re-exported by `Ouroboros.Consensus.Node` had breaking changes upstream. See `ouroboros-consensus`' changelog for details.
+- Removed `mkChainDbArgs`.
+- New `llrnMkHasFS` field in `LowLevelRunNodeArgs`

--- a/ouroboros-consensus/changelog.d/chaindb-args-javier.md
+++ b/ouroboros-consensus/changelog.d/chaindb-args-javier.md
@@ -1,0 +1,18 @@
+### Breaking
+
+- Tweak the ChainDB arguments:
+  - Remove unused fields in `CDB`:
+    - `cdbTraceLedger` this was *always* set to nullTracer, furthermore it would trace the whole LedgerDB.
+    - `cdbChunkInfo` was never accessed from the ChainDB.
+    - `cdbCheckIntegrity` was never accessed from the ChainDB.
+  - Transform `ChainDbArgs` into an isomorphic product of the different arguments of the inner databases.
+  - Define most common operations on `ChainDbArgs` as separate functions: `ensureValidateAll`, `updateTracer` and `updateDiskPolicyArgs`
+- Tweak the LgrDB arguments:
+  - `LgrDB.cfg` and `LgrDbArgs.lgrConfig` are now `LedgerDbCfg (ExtLedgerState blk)` instead of `TopLevelConfig blk`.
+  - `defaultArgs` no longer expects a filesystem.
+- Tweak the ImmutableDB arguments:
+  - `defaultArgs` no longer expects a filesystem.
+- Tweak the VolatileDB arguments:
+  - `defaultArgs` no longer expects a filesystem.
+- Hide the `Identity`/`Defaults` types in `Ouroboros.Consensus.Util.Args` in favor of `Complete`/`Incomplete`.
+- Expose `noDefault` to replace `NoDefault`.

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/ChainSel.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/ChainSel.hs
@@ -904,7 +904,6 @@ chainSelectionForBlock cdb@CDB{..} blockCache hdr punish = electric $ do
           mkTraceEvent events selChangedInfo curChain newChain
         whenJust (strictMaybeToMaybe prevTentativeHeader) $ traceWith $
           PipeliningEvent . OutdatedTentativeHeader >$< addBlockTracer
-        traceWith cdbTraceLedger newLedger
 
         return $ castPoint $ AF.headPoint newChain
       where

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Types.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Types.hs
@@ -88,8 +88,8 @@ import           Ouroboros.Consensus.Storage.ChainDB.API (AddBlockPromise (..),
                      UnknownRange)
 import           Ouroboros.Consensus.Storage.ChainDB.API.Types.InvalidBlockPunishment
                      (InvalidBlockPunishment)
-import           Ouroboros.Consensus.Storage.ChainDB.Impl.LgrDB (LedgerDB',
-                     LgrDB, LgrDbSerialiseConstraints)
+import           Ouroboros.Consensus.Storage.ChainDB.Impl.LgrDB (LgrDB,
+                     LgrDbSerialiseConstraints)
 import qualified Ouroboros.Consensus.Storage.ChainDB.Impl.LgrDB as LgrDB
 import           Ouroboros.Consensus.Storage.ImmutableDB (ImmutableDB,
                      ImmutableDbSerialiseConstraints)
@@ -236,7 +236,6 @@ data ChainDbEnv m blk = CDB
   , cdbCopyFuse        :: !(Fuse m)
   , cdbChainSelFuse    :: !(Fuse m)
   , cdbTracer          :: !(Tracer m (TraceEvent blk))
-  , cdbTraceLedger     :: !(Tracer m (LedgerDB' blk))
   , cdbRegistry        :: !(ResourceRegistry m)
     -- ^ Resource registry that will be used to (re)start the background
     -- threads, see 'cdbBgThreads'.
@@ -248,8 +247,6 @@ data ChainDbEnv m blk = CDB
     -- garbage collections.
   , cdbKillBgThreads   :: !(StrictTVar m (m ()))
     -- ^ A handle to kill the background threads.
-  , cdbChunkInfo       :: !ImmutableDB.ChunkInfo
-  , cdbCheckIntegrity  :: !(blk -> Bool)
   , cdbCheckInFuture   :: !(CheckInFuture m blk)
   , cdbChainSelQueue   :: !(ChainSelQueue m blk)
     -- ^ Queue of blocks that still have to be added.

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Util/Args.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Util/Args.hs
@@ -13,18 +13,18 @@
 -- >     , hasDefault   :: Bool
 -- >     }
 -- >
--- > defaultArgs :: Args Defaults
+-- > defaultArgs :: Incomplete Args
 -- > defaultArgs = Args {
--- >       hasNoDefault = NoDefault
+-- >       hasNoDefault = noDefault
 -- >     , hasDefault   = False
 -- >     }
 -- >
--- > theArgs :: Args Identity
+-- > theArgs :: Complete Args
 -- > theArgs = defaultArgs {
 -- >       hasNoDefault = 0
 -- >     }
 -- >
--- > useArgs :: Args Identity -> (Int, Bool)
+-- > useArgs :: Complete Args -> (Int, Bool)
 -- > useArgs (Args a b) = (a, b)
 --
 -- Leaving out the 'hasNoDefault' field from 'theArgs' will result in a type
@@ -33,10 +33,10 @@ module Ouroboros.Consensus.Util.Args (
     Defaults (..)
   , HKD
   , MapHKD (..)
-    -- * Re-exported for convenience
+    -- * Types
   , Complete
-  , Identity (..)
   , Incomplete
+  , noDefault
   ) where
 
 import           Data.Functor.Identity (Identity (..))
@@ -44,6 +44,9 @@ import           Data.Kind
 
 data Defaults t = NoDefault
   deriving (Functor)
+
+noDefault :: Defaults t
+noDefault = NoDefault
 
 type family HKD f a where
   HKD Identity a = a

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/ChainDB.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/ChainDB.hs
@@ -14,26 +14,32 @@ module Test.Util.ChainDB (
 
 
 import           Control.Tracer (nullTracer)
-import           Data.Functor.Identity (Identity)
+import           Ouroboros.Consensus.Block.Abstract
 import           Ouroboros.Consensus.Config
-                     (TopLevelConfig (topLevelConfigLedger))
+                     (TopLevelConfig (topLevelConfigLedger), configCodec)
 import           Ouroboros.Consensus.Fragment.InFuture (CheckInFuture (..))
 import qualified Ouroboros.Consensus.Fragment.Validated as VF
 import           Ouroboros.Consensus.HardFork.History.EraParams (eraEpochSize)
 import           Ouroboros.Consensus.Ledger.Extended (ExtLedgerState)
+import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Storage.ChainDB hiding
                      (TraceFollowerEvent (..))
+import           Ouroboros.Consensus.Storage.ChainDB.Impl.Args
+import           Ouroboros.Consensus.Storage.ChainDB.Impl.LgrDB
+import           Ouroboros.Consensus.Storage.ImmutableDB
 import qualified Ouroboros.Consensus.Storage.ImmutableDB as ImmutableDB
-import           Ouroboros.Consensus.Storage.ImmutableDB.Chunks.Internal
-                     (simpleChunkInfo)
-import qualified Ouroboros.Consensus.Storage.LedgerDB as LedgerDB
+import           Ouroboros.Consensus.Storage.LedgerDB (configLedgerDb)
+import qualified Ouroboros.Consensus.Storage.LedgerDB.DiskPolicy as LedgerDB
+import           Ouroboros.Consensus.Storage.VolatileDB
 import qualified Ouroboros.Consensus.Storage.VolatileDB as VolatileDB
+import           Ouroboros.Consensus.Util.Args
 import           Ouroboros.Consensus.Util.IOLike hiding (invariant)
 import           Ouroboros.Consensus.Util.ResourceRegistry (ResourceRegistry)
 import           System.FS.API (SomeHasFS (..))
 import qualified System.FS.Sim.MockFS as Mock
 import           System.FS.Sim.MockFS
 import           System.FS.Sim.STM (simHasFS)
+import           Test.Util.Orphans.NoThunks ()
 import           Test.Util.TestBlock (TestBlock, TestBlockLedgerConfig (..))
 
 -- | A vector with an element for each database of a node
@@ -77,38 +83,53 @@ mkTestChunkInfo = simpleChunkInfo . eraEpochSize . tblcHardForkParams . topLevel
 fromMinimalChainDbArgs ::
      ( MonadThrow m
      , MonadSTM m
+     , ConsensusProtocol (BlockProtocol blk)
      )
-  => MinimalChainDbArgs m blk -> ChainDbArgs Identity m blk
+  => MinimalChainDbArgs m blk -> Complete ChainDbArgs m blk
 fromMinimalChainDbArgs MinimalChainDbArgs {..} = ChainDbArgs {
-    cdbHasFSImmutableDB       = SomeHasFS $ simHasFS (nodeDBsImm mcdbNodeDBs')
-  , cdbHasFSVolatileDB        = SomeHasFS $ simHasFS (nodeDBsVol mcdbNodeDBs')
-  , cdbHasFSLgrDB             = SomeHasFS $ simHasFS (nodeDBsLgr mcdbNodeDBs')
-  , cdbHasFSGsmDB             = SomeHasFS $ simHasFS (nodeDBsGsm mcdbNodeDBs')
-
-  , cdbImmutableDbValidation  = ImmutableDB.ValidateAllChunks
-  , cdbVolatileDbValidation   = VolatileDB.ValidateAll
-  , cdbMaxBlocksPerFile       = VolatileDB.mkBlocksPerFile 4
-  , cdbDiskPolicyArgs         = LedgerDB.defaultDiskPolicyArgs
-  -- Keep 2 ledger snapshots, and take a new snapshot at least every 2 * k seconds, where k is the
-  -- security parameter.
-  , cdbTopLevelConfig         = mcdbTopLevelConfig
-  , cdbChunkInfo              = mcdbChunkInfo
-  , cdbCheckIntegrity         = const True
-  -- Getting a verified block component does not do any integrity checking, both for the
-  -- ImmutableDB, as the VolatileDB. This is done in @extractBlockComponent@ in the iterator for the
-  -- ImmutableDB, and in @getBlockComponent@ for the VolatileDB.
-  , cdbGenesis                = return mcdbInitLedger
-  , cdbCheckInFuture          = CheckInFuture $ \vf -> pure (VF.validatedFragment vf, [])
-  -- Blocks are never in the future.
-  , cdbImmutableDbCacheConfig = ImmutableDB.CacheConfig 2 60
-  -- Cache at most 2 chunks and expire each chunk after 60 seconds of being unused.
-  , cdbTracer                 = nullTracer
-  , cdbTraceLedger            = nullTracer
-  , cdbRegistry               = mcdbRegistry
-  , cdbGcDelay                = 1
-  , cdbGcInterval             = 1
-  , cdbBlocksToAddSize        = 1
-  , cdbLoE                    = LoEDisabled
-  }
-  where
-    mcdbNodeDBs' = unsafeToUncheckedStrictTVar <$> mcdbNodeDBs
+      cdbImmDbArgs = ImmutableDbArgs {
+            immCacheConfig      = ImmutableDB.CacheConfig 2 60
+            -- Cache at most 2 chunks and expire each chunk after 60 seconds of
+            -- being unused.
+          , immCheckIntegrity   = const True
+            -- Getting a verified block component does not do any integrity
+            -- checking, both for the ImmutableDB, as the VolatileDB. This is
+            -- done in @extractBlockComponent@ in the iterator for the
+            -- ImmutableDB, and in @getBlockComponent@ for the VolatileDB.
+          , immChunkInfo        = mcdbChunkInfo
+          , immHasFS            = SomeHasFS $ simHasFS (unsafeToUncheckedStrictTVar $ nodeDBsImm mcdbNodeDBs)
+          , immRegistry         = mcdbRegistry
+          , immTracer           = nullTracer
+          , immCodecConfig      = configCodec mcdbTopLevelConfig
+          , immValidationPolicy = ImmutableDB.ValidateAllChunks
+          }
+    , cdbVolDbArgs = VolatileDbArgs {
+          volCheckIntegrity   = const True
+        , volCodecConfig      = configCodec mcdbTopLevelConfig
+        , volHasFS            = SomeHasFS $ simHasFS (unsafeToUncheckedStrictTVar $ nodeDBsVol mcdbNodeDBs)
+        , volMaxBlocksPerFile = VolatileDB.mkBlocksPerFile 4
+        , volTracer           = nullTracer
+        , volValidationPolicy = VolatileDB.ValidateAll
+        }
+    , cdbLgrDbArgs = LgrDbArgs {
+          lgrDiskPolicyArgs   = LedgerDB.DiskPolicyArgs LedgerDB.DefaultSnapshotInterval LedgerDB.DefaultNumOfDiskSnapshots
+          -- Keep 2 ledger snapshots, and take a new snapshot at least every 2 *
+          -- k seconds, where k is the security parameter.
+        , lgrGenesis          = return mcdbInitLedger
+        , lgrHasFS            = SomeHasFS $ simHasFS (unsafeToUncheckedStrictTVar $ nodeDBsLgr mcdbNodeDBs)
+        , lgrTracer           = nullTracer
+        , lgrConfig           = configLedgerDb mcdbTopLevelConfig
+        }
+    , cdbsArgs = ChainDbSpecificArgs {
+          cdbsBlocksToAddSize = 1
+        , cdbsCheckInFuture   = CheckInFuture $ \vf -> pure (VF.validatedFragment vf, [])
+          -- Blocks are never in the future
+        , cdbsGcDelay         = 1
+        , cdbsHasFSGsmDB      = SomeHasFS $ simHasFS (unsafeToUncheckedStrictTVar $ nodeDBsGsm mcdbNodeDBs)
+        , cdbsGcInterval      = 1
+        , cdbsRegistry        = mcdbRegistry
+        , cdbsTracer          = nullTracer
+        , cdbsTopLevelConfig  = mcdbTopLevelConfig
+        , cdbsLoE             = LoEDisabled
+        }
+    }

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/Orphans/NoThunks.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/Orphans/NoThunks.hs
@@ -1,5 +1,7 @@
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE NamedFieldPuns    #-}
+{-# LANGUAGE DeriveAnyClass     #-}
+{-# LANGUAGE FlexibleInstances  #-}
+{-# LANGUAGE NamedFieldPuns     #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 module Test.Util.Orphans.NoThunks () where
 
@@ -12,6 +14,9 @@ import           Data.Proxy
 import           NoThunks.Class (NoThunks (..))
 import           Ouroboros.Consensus.Util.MonadSTM.NormalForm
 import           Ouroboros.Consensus.Util.NormalForm.StrictMVar
+import           System.FS.API.Types
+import           System.FS.Sim.FsTree
+import           System.FS.Sim.MockFS
 
 instance NoThunks a => NoThunks (StrictSVar (IOSim s) a) where
   showTypeOf _ = "StrictSVar IOSim"
@@ -30,3 +35,16 @@ instance NoThunks a => NoThunks (StrictTVar (IOSim s) a) where
   wNoThunks ctxt tvar = do
       a <- unsafeSTToIO $ lazyToStrictST $ inspectTVar (Proxy :: Proxy (IOSim s)) $ toLazyTVar tvar
       noThunks ctxt a
+
+{-------------------------------------------------------------------------------
+  fs-sim
+-------------------------------------------------------------------------------}
+
+deriving instance NoThunks FsPath
+deriving instance NoThunks MockFS
+deriving instance NoThunks a => NoThunks (FsTree a)
+deriving instance NoThunks HandleMock
+deriving instance NoThunks HandleState
+deriving instance NoThunks OpenHandleState
+deriving instance NoThunks ClosedHandleState
+deriving instance NoThunks FilePtr

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/MiniProtocol/BlockFetch/Client.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/MiniProtocol/BlockFetch/Client.hs
@@ -41,8 +41,8 @@ import           Ouroboros.Consensus.Config
 import qualified Ouroboros.Consensus.MiniProtocol.BlockFetch.ClientInterface as BlockFetchClientInterface
 import           Ouroboros.Consensus.Node.ProtocolInfo (NumCoreNodes (..))
 import qualified Ouroboros.Consensus.Storage.ChainDB.API as ChainDB
-import           Ouroboros.Consensus.Storage.ChainDB.Impl (ChainDbArgs (..))
 import qualified Ouroboros.Consensus.Storage.ChainDB.Impl as ChainDBImpl
+import qualified Ouroboros.Consensus.Storage.ChainDB.Impl.Args as ChainDB
 import           Ouroboros.Consensus.Util.Condense (Condense (..))
 import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Consensus.Util.ResourceRegistry
@@ -246,7 +246,7 @@ runBlockFetchTest BlockFetchClientTestSetup{..} = withRegistry \registry -> do
                 , mcdbNodeDBs = nodeDBs
                 }
           -- TODO: Test with more interesting behaviour for cdbCheckInFuture
-          pure $ args { cdbTracer = cdbTracer }
+          pure $ ChainDB.updateTracer cdbTracer args
         (_, (chainDB, ChainDBImpl.Internal{intAddBlockRunner})) <-
           allocate
             registry

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/MiniProtocol/LocalStateQuery/Server.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/MiniProtocol/LocalStateQuery/Server.hs
@@ -38,7 +38,8 @@ import qualified Ouroboros.Consensus.Storage.ChainDB.Impl.BlockCache as BlockCac
 import           Ouroboros.Consensus.Storage.ChainDB.Impl.LgrDB (LgrDB,
                      LgrDbArgs (..), mkLgrDB)
 import qualified Ouroboros.Consensus.Storage.ChainDB.Impl.LgrDB as LgrDB
-import           Ouroboros.Consensus.Storage.LedgerDB (defaultDiskPolicyArgs)
+import           Ouroboros.Consensus.Storage.LedgerDB (configLedgerDb,
+                     defaultDiskPolicyArgs)
 import qualified Ouroboros.Consensus.Storage.LedgerDB as LgrDB (ledgerDbPast,
                      ledgerDbTip, ledgerDbWithAnchor)
 import           Ouroboros.Consensus.Util.IOLike
@@ -213,7 +214,7 @@ initLgrDB k chain = do
     blockMapping = Map.fromList
       [(blockRealPoint b, b) | b <- Chain.toOldestFirst chain]
 
-    cfg = testCfg k
+    cfg = configLedgerDb $ testCfg k
 
     genesisLedgerDB = LgrDB.ledgerDbWithAnchor testInitExtLedger
 
@@ -221,12 +222,11 @@ initLgrDB k chain = do
     noopTrace = const $ pure ()
 
     args = LgrDbArgs
-      { lgrTopLevelConfig       = cfg
+      { lgrConfig               = cfg
       , lgrHasFS                = SomeHasFS (error "lgrHasFS" :: HasFS m ())
       , lgrDiskPolicyArgs       = defaultDiskPolicyArgs
       , lgrGenesis              = return testInitExtLedger
       , lgrTracer               = nullTracer
-      , lgrTraceLedger          = nullTracer
       }
 
 testCfg :: SecurityParam -> TopLevelConfig TestBlock

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/FollowerPromptness.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/FollowerPromptness.hs
@@ -33,8 +33,8 @@ import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.Storage.ChainDB.API (ChainDB)
 import qualified Ouroboros.Consensus.Storage.ChainDB.API as ChainDB
 import qualified Ouroboros.Consensus.Storage.ChainDB.API.Types.InvalidBlockPunishment as Punishment
-import           Ouroboros.Consensus.Storage.ChainDB.Impl (ChainDbArgs (..))
 import qualified Ouroboros.Consensus.Storage.ChainDB.Impl as ChainDBImpl
+import qualified Ouroboros.Consensus.Storage.ChainDB.Impl.Args as ChainDB
 import           Ouroboros.Consensus.Util.Condense (Condense (..))
 import           Ouroboros.Consensus.Util.Enclose
 import           Ouroboros.Consensus.Util.IOLike
@@ -174,7 +174,7 @@ runFollowerPromptnessTest FollowerPromptnessTestSetup{..} = withRegistry \regist
               mcdbRegistry       = registry
           mcdbNodeDBs <- emptyNodeDBs
           let cdbArgs = fromMinimalChainDbArgs MinimalChainDbArgs{..}
-          pure $ cdbArgs { cdbTracer = cdbTracer }
+          pure $ ChainDB.updateTracer cdbTracer cdbArgs
         (_, (chainDB, ChainDBImpl.Internal{intAddBlockRunner})) <-
           allocate
             registry

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/Unit.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/Unit.hs
@@ -35,6 +35,7 @@ import qualified Ouroboros.Consensus.Storage.ChainDB.API as API
 import qualified Ouroboros.Consensus.Storage.ChainDB.API.Types.InvalidBlockPunishment as API
 import           Ouroboros.Consensus.Storage.ChainDB.Impl (TraceEvent)
 import           Ouroboros.Consensus.Storage.ChainDB.Impl.Args
+import qualified Ouroboros.Consensus.Storage.ChainDB.Impl.Args as ChainDB
 import           Ouroboros.Consensus.Storage.Common (StreamFrom (..),
                      StreamTo (..))
 import           Ouroboros.Consensus.Storage.ImmutableDB.Chunks as ImmutableDB
@@ -424,7 +425,7 @@ withTestChainDbEnv topLevelConfig chunkInfo extLedgerState cont
     closeChainDbEnv (env, _) = do
       readTVarIO (varDB env) >>= close
       closeRegistry (registry env)
-      closeRegistry (cdbRegistry $ args env)
+      closeRegistry (cdbsRegistry $ cdbsArgs $ args env)
 
     chainDbArgs registry nodeDbs tracer =
       let args = fromMinimalChainDbArgs MinimalChainDbArgs
@@ -434,7 +435,7 @@ withTestChainDbEnv topLevelConfig chunkInfo extLedgerState cont
             , mcdbRegistry = registry
             , mcdbNodeDBs = nodeDbs
             }
-      in args { cdbTracer = tracer }
+      in ChainDB.updateTracer tracer args
 
 
 instance IOLike m => SupportsUnitTest (SystemM blk m) where


### PR DESCRIPTION
- Tweak the ChainDB arguments:
  - Remove unused fields in `CDB`: 
    - `cdbTraceLedger` this was *always* set to nullTracer, furthermore it would trace the whole LedgerDB. 
    - `cdbChunkInfo` was never accessed from the ChainDB. 
    - `cdbCheckIntegrity` was never accessed from the ChainDB.
  - Transform `ChainDbArgs` into an isomorphic product of the different arguments of the inner databases.
  - Define most common operations on `ChainDbArgs` as separate functions: `ensureValidateAll`, `updateTracer` and `updateDiskPolicyArgs`
- Tweak the LgrDB arguments:
  - `LgrDB.cfg` and `LgrDbArgs.lgrConfig` are now `LedgerDbCfg (ExtLedgerState blk)` instead of `TopLevelConfig blk`.
  - `defaultArgs` no longer expects a filesystem.
- Tweak the ImmutableDB arguments:
  - `defaultArgs` no longer expects a filesystem.
- Tweak the VolatileDB arguments:
  - `defaultArgs` no longer expects a filesystem.
- Hide the `Identity`/`Defaults` types in `Ouroboros.Consensus.Util.Args` in favor of `Complete`/`Incomplete`.
- Expose `noDefault` to replace `NoDefault`.