### PR TITLE
PDFs: add as Hydra build products

### DIFF
--- a/nix/pdfs.nix
+++ b/nix/pdfs.nix
@@ -35,6 +35,11 @@ final: prev: {
 
       cp tech-reports/**/*.pdf $out/
       cp formal-spec/consensus-spec.pdf $out/
+
+      mkdir -p $out/nix-support
+      for pdf in $out/*.pdf; do
+        echo "file binary-dist $pdf" >> $out/nix-support/hydra-build-products
+      done
     '';
   };
 }


### PR DESCRIPTION
You can now download the PDFs also from Hydra, eg from https://ci.iog.io/job/IntersectMBO-ouroboros-consensus/pullrequest-1066/x86_64-linux.native.consensus-pdfs/latest for this PR