### PR TITLE
ChainSync client: remove redundant intersection check

### DIFF
--- a/ouroboros-consensus/changelog.d/20240426_144237_alexander.esgen_chainsync_client_simplify_nextStep.md
+++ b/ouroboros-consensus/changelog.d/20240426_144237_alexander.esgen_chainsync_client_simplify_nextStep.md
@@ -1,0 +1,4 @@
+### Non-Breaking
+
+- ChainSync client: removed redundant intersection check with selection (we
+  already do that on every RollForward).


### PR DESCRIPTION
This step has caused confusions in the past.

See the commit description of the single commit.