### PR TITLE
Recover chainsel idempotency

### DIFF
--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
@@ -53,6 +53,7 @@ import           Control.Monad.ST (ST)
 import           Data.Foldable (toList)
 import           Data.Functor (($>))
 import           Data.List (mapAccumL, partition, scanl')
+import qualified Data.Map.Strict as Map
 import           Data.Maybe (catMaybes, fromMaybe, mapMaybe)
 import           Data.Time (DiffTime)
 import           Data.Word (Word64)
@@ -96,6 +97,9 @@ prettyPeersSchedule ::
   PeersSchedule blk ->
   [String]
 prettyPeersSchedule peers =
+  [ "honest peers: 1"
+  , "adversaries: " ++ show (Map.size (others peers))
+  ] ++
   zipWith3
     (\number time peerState ->
       number ++ ": " ++ peerState ++ " @ " ++ time

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Genesis/Governor.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Genesis/Governor.hs
@@ -39,7 +39,7 @@ module Ouroboros.Consensus.Genesis.Governor (
   , updateLoEFragUnconditional
   ) where
 
-import           Control.Monad (guard)
+import           Control.Monad (guard, when)
 import           Control.Tracer (Tracer, traceWith)
 import           Data.Containers.ListUtils (nubOrd)
 import           Data.Foldable (for_)
@@ -168,8 +168,12 @@ runGdd loEUpdater varLoEFrag chainDb getTrigger =
         curLedger <- ChainDB.getCurrentLedger chainDb
         pure (newTrigger, curChain, curLedger)
       loeFrag <- updateLoEFrag loEUpdater curChain curLedger
-      atomically $ writeTVar varLoEFrag loeFrag
-      triggerChainSelectionAsync chainDb
+      oldLoEFrag <- atomically $
+        readTVar varLoEFrag <* writeTVar varLoEFrag loeFrag
+      -- The chain selection only depends on the LoE tip, so there
+      -- is no point in retriggering it if the LoE tip hasn't changed.
+      when (AF.headHash oldLoEFrag /= AF.headHash loeFrag) $
+        triggerChainSelectionAsync chainDb
       spin newTrigger
 
 data DensityBounds blk =

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Genesis/Governor.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Genesis/Governor.hs
@@ -168,8 +168,7 @@ runGdd loEUpdater varLoEFrag chainDb getTrigger =
         curLedger <- ChainDB.getCurrentLedger chainDb
         pure (newTrigger, curChain, curLedger)
       loeFrag <- updateLoEFrag loEUpdater curChain curLedger
-      oldLoEFrag <- atomically $
-        readTVar varLoEFrag <* writeTVar varLoEFrag loeFrag
+      oldLoEFrag <- atomically $ swapTVar varLoEFrag loeFrag
       -- The chain selection only depends on the LoE tip, so there
       -- is no point in retriggering it if the LoE tip hasn't changed.
       when (AF.headHash oldLoEFrag /= AF.headHash loeFrag) $

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/ChainSel.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/ChainSel.hs
@@ -708,15 +708,15 @@ chainSelectionForBlock cdb@CDB{..} blockCache hdr punish = electric $ do
         curHead     = AF.headAnchor curChain
 
     -- Either frag extends loe or loe extends frag
+    --
+    -- PRECONDITION: @AF.withinFragmentBounds (AF.anchorPoint frag) loe@
     followsLoEFrag :: LoE (AnchoredFragment (Header blk))
                    -> AnchoredFragment (Header blk)
                    -> Bool
     followsLoEFrag LoEDisabled _ = True
     followsLoEFrag (LoEEnabled loe) frag =
-      case AF.intersect frag loe of
-        Just (_, _, AF.Empty{}, _) -> True
-        Just (_, _, _, AF.Empty{}) -> True
-        _                          -> False
+         AF.withinFragmentBounds (AF.headPoint loe) frag
+      || AF.withinFragmentBounds (AF.headPoint frag) loe
 
     -- | We have found a 'ChainDiff' through the VolatileDB connecting the new
     -- block to the current chain. We'll call the intersection/anchor @x@.

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/ChainSel.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/ChainSel.hs
@@ -783,11 +783,16 @@ chainSelectionForBlock cdb@CDB{..} blockCache hdr punish = electric $ do
     -- | How many extra blocks to select at most after the tip of @newBlockFrag@
     -- according to the LoE.
     --
-    -- In no case the selection is allowed to be extended by more than k blocks.
-    -- We don't control from what chain those blocks would be selected at this
-    -- point. If we allowed more than k blocks, the immutable tip could enter an
-    -- adversarial branch.
+    -- There are two cases to consider:
     --
+    -- 1. If @newBlockFrag@ and @loeFrag@ are on the same chain, then we cannot
+    --    select more than @loeLimit@ blocks after @loeFrag@.
+    --
+    -- 2. If @newBlockFrag@ and @loeFrag@ are on different chains, then we
+    --   cannot select more than @loeLimit@ blocks after their intersection.
+    --
+    -- In any case, 'Nothing' is returned if @newBlockFrag@ extends beyond
+    -- what LoE allows.
     computeLoEMaxExtra ::
          (HasHeader x, HeaderHash x ~ HeaderHash blk)
       => LoE (AnchoredFragment (Header blk))
@@ -797,13 +802,20 @@ chainSelectionForBlock cdb@CDB{..} blockCache hdr punish = electric $ do
          -- ^ The fragment with the new block @b@ as its tip, with the same
          -- anchor as @curChain@.
       -> Maybe LoELimit
-    computeLoEMaxExtra (LoEEnabled loeFrag) newBlockFrag
-        | rollback > k  = Nothing
-        | otherwise = Just $ LoELimit $ k - rollback
-       where
-         d = Diff.diff newBlockFrag loeFrag
-         rollback = Diff.getRollback d
-
+    computeLoEMaxExtra (LoEEnabled loeFrag) newBlockFrag =
+        -- Both fragments are on the same chain
+        if loeSuffixLength == 0 || rollback == 0 then
+          if rollback > k + loeSuffixLength
+            then Nothing
+            else Just $ LoELimit $ k + loeSuffixLength - rollback
+        else
+          if rollback > k
+            then Nothing
+            else Just $ LoELimit $ k - rollback
+      where
+        d = Diff.diff newBlockFrag loeFrag
+        rollback = Diff.getRollback d
+        loeSuffixLength = fromIntegral $ AF.length (Diff.getSuffix d)
     computeLoEMaxExtra LoEDisabled _ =
       Just LoEUnlimited
 

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/ChainSel.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/ChainSel.hs
@@ -671,10 +671,9 @@ chainSelectionForBlock cdb@CDB{..} blockCache hdr punish = electric $ do
               return $ AF.fromOldestFirst curHead (hdr : hdrs)
 
         let chainDiffs = NE.nonEmpty
-              $ NE.filter ( preferAnchoredCandidate (bcfg chainSelEnv) curChain
-                          . Diff.getSuffix
-                          )
-              $ fmap Diff.extend candidates
+              $ map Diff.extend
+              $ NE.filter (preferAnchoredCandidate (bcfg chainSelEnv) curChain)
+                candidates
         -- All candidates are longer than the current chain, so they will be
         -- preferred over it, /unless/ the block we just added is an EBB,
         -- which has the same 'BlockNo' as the block before it, so when


### PR DESCRIPTION
This PR forces chain selection to pick selections that follow the LoE fragment. That is, either they extend the LoE fragment, or they are extended by the LoE fragment.

Additionally, we no longer trigger the GDD when the selection changes. This was used in the past as a convoluted mechanism to trigger chain selection repeteadly until no more changes were done to the selection.

Also we relax the amount of blocks that can be selected again. We can select up to `k` blocks after the youngest intersection of all candidate fragments. Before we would select only up to `k` blocks from the intersection of the LoE fragment and the current selection.

Lastly, we avoid triggering chain selection on every downloaded header. We do this by retriggering chain selection only when GDD changes the tip of the LoE fragment.
