### PR TITLE
Praos chain order: fix issue no-related transitivity edge case

### DIFF
--- a/ouroboros-consensus-protocol/changelog.d/20240503_194253_alexander.esgen_praos_chain_order_truly_transitive.md
+++ b/ouroboros-consensus-protocol/changelog.d/20240503_194253_alexander.esgen_praos_chain_order_truly_transitive.md
@@ -1,0 +1,9 @@
+### Non-Breaking
+
+- Changed the Praos chain order such that for two blocks `A` and `B` by the same
+  issuer with the same block number, `A` is now preferred over `B` only if `A`
+  has a higher issue number *and* (new) `A` and `B` are in the same slot.
+
+  This is in line with the motiviation for the issue number tiebreaker, and
+  fixes the transitivity of the `Ord PraosChainSelectView` instance in a special
+  case.

--- a/ouroboros-consensus-protocol/test/protocol-test/Test/Consensus/Protocol/Praos/SelectView.hs
+++ b/ouroboros-consensus-protocol/test/protocol-test/Test/Consensus/Protocol/Praos/SelectView.hs
@@ -43,7 +43,7 @@ instance Crypto c => Arbitrary (PraosChainSelectView c) where
       csvChainLength <- BlockNo <$> choose (1, size)
       csvSlotNo      <- SlotNo  <$> choose (1, size)
       csvIssuer      <- elements knownIssuers
-      csvIssueNo     <- genIssueNo
+      csvIssueNo     <- choose (1, 10)
       pure PraosChainSelectView {
           csvChainLength
         , csvSlotNo
@@ -62,20 +62,6 @@ instance Crypto c => Arbitrary (PraosChainSelectView c) where
        where
          randomSeed = mkQCGen 4 -- chosen by fair dice roll
          numIssuers = 10
-
-     -- TODO Actually randomize this once the issue number tiebreaker has been
-     -- fixed to be transitive. See the document in
-     -- https://github.com/IntersectMBO/ouroboros-consensus/pull/891 for
-     -- details.
-     --
-     -- TL;DR: In an edge case, the issue number tiebreaker prevents the
-     -- chain order from being transitive. This could be fixed relatively
-     -- easily, namely by swapping the issue number tiebreaker and the VRF
-     -- tiebreaker. However, this is technically not backwards-compatible,
-     -- impacting the current pre-Conway diffusion pipelining scheme.
-     --
-     -- See https://github.com/IntersectMBO/ouroboros-consensus/issues/1075.
-     genIssueNo = pure 1
 
      -- The header VRF is a deterministic function of the issuer VRF key, the
      -- slot and the epoch nonce. Additionally, for any particular chain, the


### PR DESCRIPTION
Closes #1075

Beware that this PR has a fairly small $\dfrac{\text{severity}}{\text{subtlety}}$ ratio.

### Current non-transitivity of the chain order related to issue numbers

Before this PR, the `Ord PraosChainSelectView` instance is defined as the lexicographic-ish[^lexicographic-ish] combination of the following comparisons in descending order:

 - Chain length, preferring longer chains.
 - If the issuer identity is the same, compare by the issue/opcert number, preferring higher values, otherwise, no preference.
 - VRF tiebreaker, preferring lower values.

To see why it is not transitive, consider the following three `SelectView`s:

|              | a | b | c |
| ------------ | - | - | - |
| Chain length | l | l | l |
| Issuer       | x | y | x |
| Issue no     | 2 | o | 1 |
| VRF          | 3 | 2 | 1 |

With the current chain order, we have 

 - `a < b` and `b < c` due to the VRF tiebreaker, and
 - `c < a` due to the issue number tiebreaker (as `a` and `c` have the same issuer).

So we have have `a < b < c < a < ...`.

Note that due to `VRF a /= VRF c` and `Issuer a == Issuer c`, we must have `Slot a /= Slot c`, even though `ChainLength a == ChainLength b`. This is because VRFs are collision-resistant, and are a deterministic function of the slot, the (cold) issuer identity and the epoch nonce (which is itself determined by the slot for any given chain).

However, this case is not important for the motivating scenario of the issue number tiebreaker, namely when an attacker got hold of the hot key (but not the cold key) of issuer `x`, and the attacked SPO, the owner of the cold key of `x`, creates a new hot key with an incremented issue number, where the issue number tiebreaker is now supposed to "establish precedence"[^precedence]. In this scenario, the attacker minted `c`, and the attacked SPO minted `a`; this is however unrealistic as due to `Slot a /= Slot c`, either party could have minted on top of the other block, superseding the tiebreaker due to having a longer chain.

### Restoring transitivity

The natural fix is hence to require `Slot x == Slot y` in addition to `Issuer x == Issuer y` as the condition on whether to compare issue numbers when comparing `SelectView`s `x` and `y`.

In the example above, we then have

 - `a < b` and `b < c` due to the VRF tiebreaker (unchanged), and
 - `a < c` also due to the VRF tiebreaker (new), as the issue number tiebreaker is not armed.

Note that as already mentioned above, the condition `Slot x == Slot y && Issuer x == Issuer y` is equivalent to `VRF x == VRF y`. We could therefore use this condition in this PR, and even remove the issuer from `PraosChainSelectView`.

As a historical note, a very similar chain order was in place in the past before the current non-transitivity was accidentally introduced as a side effect in https://github.com/IntersectMBO/ouroboros-network/pull/2348. 

The approach of this PR is slightly different than (but morally the same as) the one suggested in #891; I think it is nice that the issue numbers are still compared "before" the VRFs in this approach as that matches the high-level intuition. 

---

Based on top of #1047

[^lexicographic-ish]: Usually, one only considers the lexicographic order constructed out of orders that are at least partial. However, the order "compare opcert numbers when the issuers are identical, otherwise, consider equal" on pairs of issuer identities and opcert numbers is not a partial order as it is non-transitive. Still, the same general principle applies.
[^precedence]: See ["Design Specification for Delegation and Incentives in Cardano"](https://github.com/IntersectMBO/cardano-ledger/blob/master/README.md), Section 3.7.