### PR TITLE
Disable BlockFetch timeouts in stalling leashing attack

### DIFF
--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
@@ -233,6 +233,10 @@ prop_leashingAttackStalling =
             { mustReplyTimeout = Nothing
             , idleTimeout = Nothing
             }
+         , gtBlockFetchTimeouts = (gtBlockFetchTimeouts gt)
+            { busyTimeout = Nothing
+            , streamingTimeout = Nothing
+            }
          }
 
     dropRandomPoints :: [(Time, SchedulePoint blk)] -> QC.Gen [(Time, SchedulePoint blk)]


### PR DESCRIPTION
It makes no sense disabling ChainSync timeouts and keeping BlockFetch ones. Also, it caused some aberrant behaviour in some instances of the test.