### PR TITLE
Eliminate overheads of GDD

### DIFF
--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Genesis/Governor.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Genesis/Governor.hs
@@ -404,8 +404,10 @@ densityDisconnect (GenesisWindow sgen) (SecurityParam k) states candidateSuffixe
     firstSlotAfterGenesisWindow =
         succWithOrigin loeIntersectionSlot + SlotNo sgen
 
+    -- This is performance sensitive. We used to call @takeWhileOldest@ here,
+    -- which would reconstruct much of the original fragment.
     dropBeyondGenesisWindow =
-      AF.takeWhileOldest ((< firstSlotAfterGenesisWindow) . blockSlot)
+      AF.dropWhileNewest ((>= firstSlotAfterGenesisWindow) . blockSlot)
 
 -- Note [Chain disagreement]
 -- ~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
There are two optimizations in this PR.

### Eliminating map/list conversions
At a few places we might introduce maps to convert them immediately to lists. This change wasn't measured in isolation, but I include it because it looks harmless.

### Avoid reconstructing the candidateSuffixes in densityDisconnect
This one came from using `AF.takeWhileOldest` which reconstructed much of the long fragments to which it was applied. It accounted for most of the overhead of genesis (near 15 minutes in a syncing of 1_000_000 blocks that took 60 minutes).