### PR TITLE
Add LoE to the ChainDB QSM test

### DIFF
--- a/ouroboros-consensus/changelog.d/20240724_170351_alexander.esgen_loe_chaindb_qsm.md
+++ b/ouroboros-consensus/changelog.d/20240724_170351_alexander.esgen_loe_chaindb_qsm.md
@@ -1,0 +1,3 @@
+### Breaking
+
+- ChainDB: allow to trigger chain selection synchronously

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Genesis/Governor.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Genesis/Governor.hs
@@ -32,7 +32,7 @@ module Ouroboros.Consensus.Genesis.Governor (
   , sharedCandidatePrefix
   ) where
 
-import           Control.Monad (guard, when)
+import           Control.Monad (guard, void, when)
 import           Control.Tracer (Tracer, traceWith)
 import           Data.Bifunctor (second)
 import           Data.Containers.ListUtils (nubOrd)
@@ -142,7 +142,7 @@ gddWatcher cfg tracer chainDb getGsmState getHandles varLoEFrag =
         -- The chain selection only depends on the LoE tip, so there
         -- is no point in retriggering it if the LoE tip hasn't changed.
         when (AF.headHash oldLoEFrag /= AF.headHash loeFrag) $
-          ChainDB.triggerChainSelectionAsync chainDb
+          void $ ChainDB.triggerChainSelectionAsync chainDb
 
 -- | Pure snapshot of the dynamic data the GDD operates on.
 data GDDStateView m blk peer = GDDStateView {

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Background.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Background.hs
@@ -525,7 +525,8 @@ addBlockRunner fuse cdb@CDB{..} = forever $ do
         (lift $ getChainSelMessage cdbChainSelQueue)
         (\message -> lift $ atomically $ do
           case message of
-            ChainSelReprocessLoEBlocks -> pure ()
+            ChainSelReprocessLoEBlocks varProcessed ->
+              void $ tryPutTMVar varProcessed ()
             ChainSelAddBlock BlockToAdd{varBlockWrittenToDisk, varBlockProcessed} -> do
               _ <- tryPutTMVar varBlockWrittenToDisk
                               False
@@ -535,7 +536,7 @@ addBlockRunner fuse cdb@CDB{..} = forever $ do
           closeChainSelQueue cdbChainSelQueue)
         (\message -> do
           lift $ case message of
-            ChainSelReprocessLoEBlocks ->
+            ChainSelReprocessLoEBlocks _ ->
               trace PoppedReprocessLoEBlocksFromQueue
             ChainSelAddBlock BlockToAdd{blockToAdd} ->
               trace $ PoppedBlockFromQueue $ FallingEdgeWith $

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/Orphans/Arbitrary.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/Orphans/Arbitrary.hs
@@ -53,6 +53,7 @@ import           Ouroboros.Consensus.Ledger.Query
 import           Ouroboros.Consensus.Ledger.SupportsMempool
 import           Ouroboros.Consensus.Node.ProtocolInfo
 import           Ouroboros.Consensus.Protocol.Abstract (ChainDepState)
+import           Ouroboros.Consensus.Storage.ChainDB.API (LoE (..))
 import           Ouroboros.Consensus.Storage.ImmutableDB.Chunks.Internal
                      (ChunkNo (..), ChunkSize (..), RelativeSlot (..))
 import           Ouroboros.Consensus.Storage.ImmutableDB.Chunks.Layout
@@ -407,3 +408,12 @@ instance Arbitrary Index.CacheConfig where
     -- TODO create a Cmd that advances time, so this is being exercised too.
     expireUnusedAfter <- (fromIntegral :: Int -> DiffTime) <$> choose (1, 100)
     return Index.CacheConfig {Index.pastChunksToCache, Index.expireUnusedAfter}
+
+{-------------------------------------------------------------------------------
+  LoE
+-------------------------------------------------------------------------------}
+
+instance Arbitrary a => Arbitrary (LoE a) where
+  arbitrary = oneof [pure LoEDisabled, LoEEnabled <$> arbitrary]
+  shrink LoEDisabled    = []
+  shrink (LoEEnabled x) = LoEDisabled : map LoEEnabled (shrink x)

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/Orphans/ToExpr.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/Orphans/ToExpr.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DeriveGeneric        #-}
 {-# LANGUAGE DerivingStrategies   #-}
 {-# LANGUAGE FlexibleContexts     #-}
+{-# LANGUAGE FlexibleInstances    #-}
 {-# LANGUAGE StandaloneDeriving   #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -18,9 +19,12 @@ import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Storage.ChainDB (InvalidBlockReason)
+import           Ouroboros.Consensus.Storage.ChainDB.API (LoE (..))
 import           Ouroboros.Consensus.Storage.ChainDB.Impl.LgrDB
 import           Ouroboros.Consensus.Storage.ImmutableDB
 import           Ouroboros.Consensus.Util.STM (Fingerprint, WithFingerprint)
+import           Ouroboros.Network.AnchoredFragment (AnchoredFragment)
+import qualified Ouroboros.Network.AnchoredFragment as Fragment
 import           Ouroboros.Network.Block (MaxSlotNo)
 import           Ouroboros.Network.Mock.Chain
 import           Ouroboros.Network.Mock.ProducerState
@@ -36,6 +40,14 @@ import           Test.Util.ToExpr ()
 instance ToExpr (HeaderHash blk) => ToExpr (Point blk)
 instance ToExpr (HeaderHash blk) => ToExpr (RealPoint blk)
 instance (ToExpr slot, ToExpr hash) => ToExpr (Block slot hash)
+
+deriving instance ( ToExpr blk
+                  , ToExpr (HeaderHash blk)
+                  )
+                 => ToExpr (Fragment.Anchor blk)
+
+instance (ToExpr blk, ToExpr (HeaderHash blk)) => ToExpr (AnchoredFragment blk) where
+  toExpr f = toExpr (Fragment.anchor f, Fragment.toOldestFirst f)
 
 {-------------------------------------------------------------------------------
   ouroboros-consensus
@@ -72,6 +84,8 @@ instance ToExpr ChunkInfo where
   toExpr = defaultExprViaShow
 instance ToExpr FsError where
   toExpr fsError = App (show fsError) []
+
+deriving instance ToExpr a => ToExpr (LoE a)
 
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/StateMachine/Utils/RunOnRepl.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/StateMachine/Utils/RunOnRepl.hs
@@ -30,10 +30,11 @@
 -- Then, the model and system under tests can be tested for lockstep agreement
 -- by running:
 --
--- > quickCheckCmdsLockStep someClockSkew someChunkInfo counterexample
+-- > quickCheckCmdsLockStep someLoE someClockSkew someChunkInfo counterexample
 --
 -- Where 'someClockSkew' and 'someChunkInfo' are the ones given by the
--- counterexample found by quickcheck-statemachine.
+-- counterexample found by quickcheck-statemachine, and 'someLoE' is @LoEEnabled
+-- ()@ or @LoEDisabled@.
 module Test.Ouroboros.Storage.ChainDB.StateMachine.Utils.RunOnRepl (
     -- * Running the counterexamples
     quickCheckCmdsLockStep
@@ -78,7 +79,7 @@ import           Ouroboros.Consensus.Block (BlockNo (BlockNo),
                      ChainHash (BlockHash, GenesisHash), EpochNo (EpochNo),
                      SlotNo (SlotNo))
 import           Ouroboros.Consensus.Storage.ChainDB
-                     (ChainType (TentativeChain))
+                     (ChainType (TentativeChain), LoE)
 import           Ouroboros.Consensus.Storage.ImmutableDB
                      (ChunkInfo (UniformChunkSize),
                      ChunkSize (ChunkSize, chunkCanContainEBB, numRegularBlocks))
@@ -113,9 +114,10 @@ pattern Command cmd rsp xs =
   StateMachine.Types.Command (StateMachine.At cmd) (StateMachine.At rsp) xs
 
 quickCheckCmdsLockStep ::
-     MaxClockSkew
+     LoE ()
+  -> MaxClockSkew
   -> SmallChunkInfo
   -> Commands (StateMachine.At Cmd TestBlock IO) (StateMachine.At Resp TestBlock IO)
   -> IO ()
-quickCheckCmdsLockStep maxClockSkew chunkInfo cmds =
-  quickCheck $ runCmdsLockstep maxClockSkew chunkInfo cmds
+quickCheckCmdsLockStep loe maxClockSkew chunkInfo cmds =
+  quickCheck $ runCmdsLockstep loe maxClockSkew chunkInfo cmds


### PR DESCRIPTION
Closes #541

This PR adds a new instruction to the ChainDB q-s-m test, which updates the Limit on Eagerness (LoE) fragment and retriggers chain selection. This requires a model implementation of the LoE.

As a preparatory change, we add a way to trigger chain selection synchronously (ie such that we can wait for it to finish), which is only used in tests.