### PR TITLE
Refactor `PointSchedule` to add an optional extra delay at the end

### DIFF
--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup/Classifiers.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup/Classifiers.hs
@@ -164,7 +164,7 @@ resultClassifiers GenesisTest{gtSchedule} RunGenesisTestResult{rgtrStateView} =
     StateView{svPeerSimulatorResults} = rgtrStateView
 
     adversaries :: [PeerId]
-    adversaries = fmap AdversarialPeer $ Map.keys $ adversarialPeers $ unPointSchedule gtSchedule
+    adversaries = fmap AdversarialPeer $ Map.keys $ adversarialPeers $ psSchedule gtSchedule
 
     adversariesCount = fromIntegral $ length adversaries
 
@@ -248,19 +248,19 @@ scheduleClassifiers GenesisTest{gtSchedule = schedule} =
           peerSch
 
     rollbacks :: Peers Bool
-    rollbacks = hasRollback <$> unPointSchedule schedule
+    rollbacks = hasRollback <$> psSchedule schedule
 
     adversaryRollback = any id $ adversarialPeers rollbacks
     honestRollback = any id $ honestPeers rollbacks
 
-    allAdversariesEmpty = all id $ adversarialPeers $ null <$> unPointSchedule schedule
+    allAdversariesEmpty = all id $ adversarialPeers $ null <$> psSchedule schedule
 
     isTrivial :: PeerSchedule TestBlock -> Bool
     isTrivial = \case
       []             -> True
       (t0, _):points -> all ((== t0) . fst) points
 
-    allAdversariesTrivial = all id $ adversarialPeers $ isTrivial <$> unPointSchedule schedule
+    allAdversariesTrivial = all id $ adversarialPeers $ isTrivial <$> psSchedule schedule
 
 simpleHash ::
   HeaderHash block ~ TestHash =>

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/CSJ.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/CSJ.hs
@@ -126,9 +126,9 @@ prop_CSJ happy synchronized =
   where
     genDuplicatedHonestSchedule :: GenesisTest TestBlock () -> Gen (PointSchedule TestBlock)
     genDuplicatedHonestSchedule gt@GenesisTest {gtExtraHonestPeers} = do
-      ps@PointSchedule {unPointSchedule = Peers {honestPeers, adversarialPeers}} <- genUniformSchedulePoints gt
+      ps@PointSchedule {psSchedule = Peers {honestPeers, adversarialPeers}} <- genUniformSchedulePoints gt
       pure $ ps {
-        unPointSchedule =
+        psSchedule =
           Peers.unionWithKey
             (\_ _ _ -> error "should not happen")
             ( peers'

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/DensityDisconnect.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/DensityDisconnect.hs
@@ -471,7 +471,7 @@ prop_densityDisconnectTriggersChainSel =
 
     ( \GenesisTest {gtBlockTree, gtSchedule} stateView@StateView {svTipBlock} ->
         let
-          othersCount = Map.size (adversarialPeers $ unPointSchedule gtSchedule)
+          othersCount = Map.size (adversarialPeers $ psSchedule gtSchedule)
           exnCorrect = case exceptionsByComponent ChainSyncClient stateView of
             [fromException -> Just DensityTooLow] -> True
             []                 | othersCount == 0 -> True
@@ -498,7 +498,7 @@ prop_densityDisconnectTriggersChainSel =
             (AF.Empty _)       -> Origin
             (_ AF.:> tipBlock) -> At tipBlock
           advTip = getOnlyBranchTip tree
-       in PointSchedule $ peers'
+       in mkPointSchedule $ peers'
             -- Eagerly serve the honest tree, but after the adversary has
             -- advertised its chain up to the intersection.
             [[(Time 0, scheduleTipPoint trunkTip),

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LoE.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LoE.hs
@@ -88,7 +88,7 @@ prop_adversaryHitsTimeouts timeoutsEnabled =
             (AF.Empty _)       -> Nothing
             (_ AF.:> tipBlock) -> Just tipBlock
           branchTip = getOnlyBranchTip tree
-       in PointSchedule $ peers'
+          psSchedule = peers'
             -- Eagerly serve the honest tree, but after the adversary has
             -- advertised its chain.
             [ (Time 0, scheduleTipPoint trunkTip) : case intersectM of
@@ -107,11 +107,13 @@ prop_adversaryHitsTimeouts timeoutsEnabled =
             -- intersection early, then waits more than the short wait timeout.
             [ (Time 0, scheduleTipPoint branchTip) : case intersectM of
                 -- the alternate branch forks from `Origin`
-                Nothing -> [(Time 11, scheduleTipPoint branchTip)]
+                Nothing -> []
                 -- the alternate branch forks from `intersect`
                 Just intersect ->
                   [ (Time 0, scheduleHeaderPoint intersect),
-                    (Time 0, scheduleBlockPoint intersect),
-                    (Time 11, scheduleBlockPoint intersect)
+                    (Time 0, scheduleBlockPoint intersect)
                   ]
             ]
+          -- We want to wait more than the short wait timeout
+          psMinEndTime = Time 11
+       in PointSchedule {psSchedule, psMinEndTime}

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/LinkedThreads.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/LinkedThreads.hs
@@ -21,8 +21,8 @@ import           Test.Consensus.PeerSimulator.Run (defaultSchedulerConfig)
 import           Test.Consensus.PeerSimulator.StateView
 import           Test.Consensus.PointSchedule
 import           Test.Consensus.PointSchedule.Peers (peersOnlyHonest)
-import           Test.Consensus.PointSchedule.SinglePeer (scheduleBlockPoint,
-                     scheduleHeaderPoint, scheduleTipPoint)
+import           Test.Consensus.PointSchedule.SinglePeer (scheduleHeaderPoint,
+                     scheduleTipPoint)
 import           Test.QuickCheck
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
@@ -67,8 +67,9 @@ prop_chainSyncKillsBlockFetch = do
       let (firstBlock, secondBlock) = case AF.toOldestFirst $ btTrunk gtBlockTree of
             b1 : b2 : _ -> (b1, b2)
             _           -> error "block tree must have two blocks"
-       in PointSchedule $ peersOnlyHonest $
+          psSchedule = peersOnlyHonest $
             [ (Time 0, scheduleTipPoint secondBlock),
-              (Time 0, scheduleHeaderPoint firstBlock),
-              (Time (timeout + 1), scheduleBlockPoint firstBlock)
+              (Time 0, scheduleHeaderPoint firstBlock)
             ]
+          psMinEndTime = Time $ timeout + 1
+       in PointSchedule {psSchedule, psMinEndTime}

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
@@ -95,7 +95,7 @@ rollbackSchedule n blockTree =
           , banalSchedulePoints trunkSuffix
           , banalSchedulePoints (btbSuffix branch)
           ]
-    in PointSchedule $ peersOnlyHonest $ zip (map (Time . (/30)) [0..]) schedulePoints
+    in mkPointSchedule $ peersOnlyHonest $ zip (map (Time . (/30)) [0..]) schedulePoints
   where
     banalSchedulePoints :: AnchoredFragment blk -> [SchedulePoint blk]
     banalSchedulePoints = concatMap banalSchedulePoints' . toOldestFirst

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
@@ -63,12 +63,11 @@ prop_timeouts mustTimeout = do
     dullSchedule _ (AF.Empty _) = error "requires a non-empty block tree"
     dullSchedule timeout (_ AF.:> tipBlock) =
       let offset :: DiffTime = if mustTimeout then 1 else -1
-       in PointSchedule $ peersOnlyHonest $ [
-            (Time 0, scheduleTipPoint tipBlock),
-            (Time 0, scheduleHeaderPoint tipBlock),
-            (Time 0, scheduleBlockPoint tipBlock),
-            -- This last point does not matter, it is only here to leave the
-            -- connection open (aka. keep the test running) long enough to
-            -- pass the timeout by 'offset'.
-            (Time (timeout + offset), scheduleTipPoint tipBlock)
+          psSchedule = peersOnlyHonest $ [
+              (Time 0, scheduleTipPoint tipBlock),
+              (Time 0, scheduleHeaderPoint tipBlock),
+              (Time 0, scheduleBlockPoint tipBlock)
             ]
+          -- This keeps the test running long enough to pass the timeout by 'offset'.
+          psMinEndTime = Time $ timeout + offset
+       in PointSchedule {psSchedule, psMinEndTime}

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Trace.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Trace.hs
@@ -64,6 +64,8 @@ data TraceSchedulerEvent blk
     TraceBeginningOfTime
   | -- | Right after running the last tick of the schedule.
     TraceEndOfTime
+  | -- | An extra optional delay to keep the simulation running
+    TraceExtraDelay DiffTime
   | -- | When beginning a new tick. Contains the tick number (counting from
     -- @0@), the duration of the tick, the states, the current chain, the
     -- candidate fragment, and the jumping states.
@@ -195,6 +197,13 @@ traceSchedulerEventTestBlockWith setTickTime tracer0 _tracer = \case
       traceLinesWith tracer0
         [ "╶──────────────────────────────────────────────────────────────────────────────╴",
           "Finished running point schedule"
+        ]
+    TraceExtraDelay delay -> do
+      time <- getMonotonicTime
+      traceLinesWith tracer0
+        [ "┌──────────────────────────────────────────────────────────────────────────────┐",
+          "└─ " ++ prettyTime time,
+          "Waiting an extra delay to keep the simulation running for: " ++ prettyTime (Time delay)
         ]
     TraceNewTick number duration (Peer pid state) currentChain mCandidateFrag jumpingStates -> do
       time <- getMonotonicTime

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Shrinking/Tests.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Shrinking/Tests.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE LambdaCase        #-}
+{-# LANGUAGE NamedFieldPuns    #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 -- | Test properties of the shrinking functions
@@ -40,24 +41,24 @@ lastM []     = Nothing
 lastM [a]    = Just a
 lastM (_:ps) = lastM ps
 
-samePeers :: PointSchedule blk -> PointSchedule blk -> Bool
+samePeers :: Peers (PeerSchedule blk) -> Peers (PeerSchedule blk) -> Bool
 samePeers sch1 sch2 =
-  (keys $ adversarialPeers $ unPointSchedule sch1)
-    == (keys $ adversarialPeers $ unPointSchedule sch2)
+  (keys $ adversarialPeers sch1)
+    == (keys $ adversarialPeers sch2)
 
 -- | Checks whether at least one peer schedule in the second given peers schedule
 -- is shorter than its corresponding one in the fist given peers schedule. “Shorter”
 -- here means that it executes in less time.
-isShorterThan :: PointSchedule blk -> PointSchedule blk -> Bool
+isShorterThan :: Peers (PeerSchedule blk) -> Peers (PeerSchedule blk) -> Bool
 isShorterThan original shrunk =
   samePeers original shrunk
   && (or $ zipWith
     (\oldSch newSch -> (fst <$> lastM newSch) < (fst <$> lastM oldSch))
-    (toList $ unPointSchedule original)
-    (toList $ unPointSchedule shrunk)
+    (toList original)
+    (toList shrunk)
   )
 
-doesNotChangeFinalState :: Eq blk => PointSchedule blk -> PointSchedule blk -> Bool
+doesNotChangeFinalState :: Eq blk => Peers (PeerSchedule blk) -> Peers (PeerSchedule blk) -> Bool
 doesNotChangeFinalState original shrunk =
   samePeers original shrunk
   && (and $ zipWith
@@ -66,8 +67,8 @@ doesNotChangeFinalState original shrunk =
       lastHP oldSch == lastHP newSch &&
       lastBP oldSch == lastBP newSch
     )
-    (toList $ unPointSchedule original)
-    (toList $ unPointSchedule shrunk)
+    (toList original)
+    (toList shrunk)
   )
   where
     lastTP :: PeerSchedule blk -> Maybe (SchedulePoint blk)
@@ -77,20 +78,20 @@ doesNotChangeFinalState original shrunk =
     lastBP :: PeerSchedule blk -> Maybe (SchedulePoint blk)
     lastBP sch = lastM $ mapMaybe (\case (_, p@(ScheduleBlockPoint  _)) -> Just p ; _ -> Nothing) sch
 
-checkShrinkProperty :: (PointSchedule TestBlock -> PointSchedule TestBlock -> Bool) -> Property
+checkShrinkProperty :: (Peers (PeerSchedule TestBlock) -> Peers (PeerSchedule TestBlock) -> Bool) -> Property
 checkShrinkProperty prop =
   forAllBlind
     (genChains (choose (1, 4)) >>= genUniformSchedulePoints)
-    (\schedule ->
+    (\sch@PointSchedule{psSchedule, psMinEndTime} ->
       conjoin $ map
       (\shrunk ->
           counterexample
           (  "Original schedule:\n"
-          ++ unlines (map ("    " ++) $ prettyPointSchedule schedule)
+          ++ unlines (map ("    " ++) $ prettyPointSchedule sch)
           ++ "\nShrunk schedule:\n"
-          ++ unlines (map ("    " ++) $ prettyPointSchedule shrunk)
+          ++ unlines (map ("    " ++) $ prettyPointSchedule $ PointSchedule shrunk psMinEndTime)
           )
-          (prop schedule shrunk)
+          (prop psSchedule shrunk)
       )
-      (shrinkHonestPeers schedule)
+      (shrinkHonestPeers psSchedule)
     )


### PR DESCRIPTION
TODO:
- [x] Consider introducing a new type for the extra delay in `peersStates` instead of duplicating the last `Peer (NodeState blk)`
