### PR TITLE
Bump up ouroboros-network versions.

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -40,8 +40,8 @@ if(os(windows))
 source-repository-package
   type: git
   location: https://github.com/IntersectMBO/ouroboros-network
-  tag: 431bb599940d2947b2cb99d3ae29b7f2c4cdd36d
-  --sha256: 1a62hqddpnc0j5r7nl54q79nrxyw77dphpsgp68hxij210dkpvca
+  tag: 116ac066fa6b32a926c49399c549f92b28cac7d4
+  --sha256: sha256-RLnxMm8qZE3zOtYy+6wwxih1kFGOPUTRT3CBdtHbawE=
   subdir:
     ouroboros-network-api
     ouroboros-network-protocols

--- a/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
+++ b/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
@@ -91,7 +91,7 @@ library
     ouroboros-consensus ^>=0.18,
     ouroboros-network ^>=0.16,
     ouroboros-network-api ^>=0.7.2,
-    ouroboros-network-framework ^>=0.13,
+    ouroboros-network-framework ^>=0.13.1,
     ouroboros-network-protocols ^>=0.8.1,
     random,
     safe-wild-cards ^>=1.0,


### PR DESCRIPTION
- `source-repository-package` commit is pointed to the latest master of `ouroboros-network`
- `ouroboros-consensus-diffusion` uses slightly (minor) higher lower bound on the version of `ouroboros-network-framework`.