### PR TITLE
Fix bug when calling `OCERT` from `PRTCL`

### DIFF
--- a/docs/formal-spec/chain.tex
+++ b/docs/formal-spec/chain.tex
@@ -586,7 +586,7 @@ The states for this transition consists of:
         \end{array}\right)}
     }\\~\\
       {
-        \var{pd}\vdash\var{cs}\trans{\hyperref[fig:rules:ocert]{ocert}}{\var{bh}}\var{cs'}
+        \dom{\var{pd}}\vdash\var{cs}\trans{\hyperref[fig:rules:ocert]{ocert}}{\var{bh}}\var{cs'}
       }
       \\~\\
       \fun{praosVrfChecks}~\eta_0~\var{pd}~\ActiveSlotCoeff~\var{bhb}


### PR DESCRIPTION
Currently, when calling the `OCERT` rule from the `PRTCL` rule, the pool distribution $pd$ is used as the environment for the call, instead of the correct environment $`\text{dom}\;pd`$.