### PR TITLE
Fix indentation of `variant` in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         variant: [default, no-thunks]
         exclude:
           - variant:
-            ${{ (github.event.type == 'schedule' || github.event.inputs.nothunks) && 'default' || 'no-thunks' }}
+              ${{ (github.event.type == 'schedule' || github.event.inputs.nothunks) && 'default' || 'no-thunks' }}
     env:
       # Modify this value to "invalidate" the Cabal cache.
       CABAL_CACHE_VERSION: "2024-01-29"


### PR DESCRIPTION
# Description

Fixes bad indentation in `.github/workflows/ci.yml` introduced as part of a rebase in #1127 