### PR TITLE
Fix minor bug in `CHAINHEAD` of formal spec

### DIFF
--- a/docs/formal-spec/chain.tex
+++ b/docs/formal-spec/chain.tex
@@ -784,7 +784,7 @@ following:
     \LastAppliedBlock =
     \left(
       \begin{array}{r@{~\in~}lr}
-        \var{b_\ell} & \Slot & \text{last block number} \\
+        \var{b_\ell} & \BlockNo & \text{last block number} \\
         \var{s_\ell} & \Slot & \text{last slot} \\
         \var{h} & \HashHeader & \text{latest header hash} \\
       \end{array}


### PR DESCRIPTION
In Figure 16, the type of $b_\ell$ must be changed from $\textsf{Slot}$ to $\textsf{BlockNo}$.