### PR TITLE
Fix minor bug in `prtlSeqChecks` of formal spec

### DIFF
--- a/docs/formal-spec/chain.tex
+++ b/docs/formal-spec/chain.tex
@@ -843,7 +843,7 @@ The transition uses a few helper functions defined in Figure~\ref{fig:funcs:chai
   \end{align*}
   %
   \begin{align*}
-      & \fun{prtlSeqChecks} \to \LastAppliedBlock^? \to \BHeader \to \Bool \\
+      & \fun{prtlSeqChecks} \in \LastAppliedBlock^? \to \BHeader \to \Bool \\
       & \fun{prtlSeqChecks}~\var{lab}~\var{bh} =
         \begin{cases}
           \mathsf{True}


### PR DESCRIPTION
The first → in the signature of $\textsf{prtlSeqChecks}$ must be changed to $\in$.
