### PR TITLE
Fix wrong use of `hBBodyHash` in `CHAINHEAD` in the formal spec

### DIFF
--- a/docs/formal-spec/chain.tex
+++ b/docs/formal-spec/chain.tex
@@ -924,7 +924,7 @@ The transition uses a few helper functions defined in Figure~\ref{fig:funcs:chai
               \eta_c' \\
         \end{array}\right)}
       } \\~\\~\\
-      \var{lab'}\leteq (\hBBlockNo{bhb},~\var{s},~\hBBodyHash{bhb} ) \\
+      \var{lab'}\leteq (\hBBlockNo{bhb},~\var{s},~\headerHash{bh} ) \\
     }
     {
       \var{nes}


### PR DESCRIPTION
In the definition of `CHAINHEAD`, the expression $`\textsf{hBBodyHash} \; bhb`$ must be changed to $`\textsf{headerHash} \; bh`$.