### PR TITLE
db-immutaliser

### DIFF
--- a/ouroboros-consensus-cardano/README.md
+++ b/ouroboros-consensus-cardano/README.md
@@ -264,6 +264,26 @@ gnuplot -e "bench_data='ledger-ops-cost.csv'" \
 The plot will be written to a file named `results.png`. See the script file for
 more usage options.
 
+## db-immutaliser
+
+Copy a specific chain from a volatile DB to an immutable DB, such that other
+tools that expect an immutable DB can process the corresponding blocks.
+
+Currently, it will copy the longest chain that extends the immutable tip, but it
+will not perform any validation (and therefore, it does not require a ledger
+snapshot).
+
+Basic usage:
+```sh
+cabal run db-immutaliser -- \
+  --immutable-db /path/to/db1/immutable \
+  --volatile-db /path/to/db2/volatile \
+  --config /path/to/config.json
+```
+
+The `config.json` should be in the same format (Node configuration) as for eg
+db-analyser.
+
 ## db-synthesizer
 
 ### About

--- a/ouroboros-consensus-cardano/README.md
+++ b/ouroboros-consensus-cardano/README.md
@@ -52,37 +52,17 @@ we explain each command line option.
 
 #### --db PATH
 
-The tool works on a cardano-node's ChainDB. Thus the user must provide an obligatory `--db PATH` argument pointing to the particular DB.
+The tool works on a cardano-node's ChainDB (in fact, only on the ImmutableDB and the ledger snapshots). Thus the user must provide an obligatory `--db PATH` argument pointing to the particular DB.
 
-#### --verbose
+If you want to analyse blocks from the VolatileDB, consider copying them to the ImmutableDB via db-immutaliser.
 
-db-analyser will get quite noisy
-
-#### --only-immutable-db
-
-By default db-analyser will process all blocks from the chain database
-(`ChainDB`), from the genesis block up to the chain tip. In order to do this it
-must first properly initialize the whole database. That means that before it
-even starts processing blocks it will:
-
-1. look for the latest snapshot stored in DB_PATH/ledger. The latest snapshot is determined by looking at the highest snapshot number. The storage layer of consensus expects the snapshot file names to be of the form `<SNAPSHOT NUMBER_SUFFIX>`, this is, a snapshot number, optionally followed by the `_` character and an arbitrary suffix. For instance, given snapshots files with these names `101_foo`, `100_db-analyser`, `99`, the file with the highest snapshot number is `101_foo`.
-2. load that snapshot into memory
-3. start replaying blocks
-   * starting from that ledger state
-   * while updating the ledger state in the process for each replayed block
-   * keeping the intermediate results (ledger states) in memory while replaying blocks that live in the volatile DB (less than k blocks from the tip)
-
-This may heavily impact any profiling that the user might be interested in doing.
-
-To counter that problem `--only-immutable-db` flag was introduced.
+#### --analyse-from
 
 ```
-[--only-immutable-db [--analyse-from SLOT_NUMBER]]
+[--analyse-from SLOT_NUMBER]
 ```
 
-When enabled, db-analyser will work only with blocks from immutableDB, thus initialization described above will not happen.
-
-This flag comes with an additional `--analyse-from` flag. It allows to start processing blocks from the requested slot number. A snapshot at that slot number must exist in `DB_PATH/ledger/SLOT_NUMBER_db-analyser` - where `SLOT_NUMBER` is the value provided by the user with the `--analyse-from` flag.
+This flag allows to start processing blocks from the requested slot number. A snapshot at that slot number must exist in `DB_PATH/ledger/SLOT_NUMBER_db-analyser` - where `SLOT_NUMBER` is the value provided by the user with the `--analyse-from` flag.
 The user can use snapshots created by the node or they can create their own snapshots via db-analyser - see the `--store-ledger` command
 
 #### COMMAND
@@ -206,7 +186,7 @@ want to take a snapshot of the ledger state for slot `100`. Then we can run:
 cabal run exe:db-analyser -- cardano \
     --config $NODE_HOME/configuration/cardano/mainnet-config.json \
     --db $NODE_HOME/mainnet/db \
-    --only-immutable-db --store-ledger 100
+    --store-ledger 100
 ```
 
 If we had a previous snapshot of the ledger state, say corresponding to slot
@@ -217,7 +197,7 @@ cabal run exe:db-analyser -- cardano \
     --config $NODE_HOME/configuration/cardano/mainnet-config.json \
     --db $NODE_HOME/mainnet/db \
     --analyse-from 50 \
-    --only-immutable-db --store-ledger 100
+    --store-ledger 100
 ```
 
 #### Running the ledger operations benchmark
@@ -231,8 +211,7 @@ cabal run exe:db-analyser -- cardano
     --db $NODE_HOME/mainnet/db \
     --analyse-from 100 \
     --benchmark-ledger-ops \
-    --out-file ledger-ops-cost.csv \
-    --only-immutable-db
+    --out-file ledger-ops-cost.csv
 ```
 
 The benchmarking command can be combined with `--num-blocks-to-process` to
@@ -246,7 +225,6 @@ cabal run exe:db-analyser -- cardano
     --benchmark-ledger-ops \
     --out-file ledger-ops-cost.csv \
     --num-blocks-to-process 200
-    --only-immutable-db
 ```
 
 ##### Plotting the benchmark results

--- a/ouroboros-consensus-cardano/app/DBAnalyser/Parsers.hs
+++ b/ouroboros-consensus-cardano/app/DBAnalyser/Parsers.hs
@@ -1,7 +1,11 @@
 {-# LANGUAGE ApplicativeDo #-}
 {-# LANGUAGE CPP           #-}
 
-module DBAnalyser.Parsers (parseCmdLine, blockTypeParser, BlockType (..)) where
+module DBAnalyser.Parsers (
+    BlockType (..)
+  , blockTypeParser
+  , parseCmdLine
+  ) where
 
 import           Cardano.Crypto (RequiresNetworkMagic (..))
 import           Cardano.Tools.DBAnalyser.Block.Byron
@@ -41,16 +45,9 @@ parseDBAnalyserConfig = DBAnalyserConfig
     <*> parseLimit
 
 parseSelectDB :: Parser SelectDB
-parseSelectDB = asum [
-    SelectImmutableDB . snd <$> ((,) <$> onlyImmutableDB <*> analyseFrom)
-  , pure SelectChainDB
-  ]
+parseSelectDB =
+    SelectImmutableDB <$> analyseFrom
   where
-    onlyImmutableDB = flag' () (mconcat [
-        long "only-immutable-db"
-      , help "Validate only the Immutable DB (e.g. do not do ledger validation)"
-      ])
-
     analyseFrom :: Parser (Maybe DiskSnapshot)
     analyseFrom = optional $ ((flip DiskSnapshot $ Just "db-analyser") . read) <$> strOption
       (  long "analyse-from"
@@ -62,11 +59,11 @@ parseValidationPolicy :: Parser (Maybe ValidateBlocks)
 parseValidationPolicy = optional $ asum [
       flag' ValidateAllBlocks $ mconcat [
           long "validate-all-blocks"
-        , help "Validate all blocks of the Volatile and Immutable DB"
+        , help "Validate all blocks of the Immutable DB"
         ]
     , flag' MinimumBlockValidation $ mconcat [
           long "minimum-block-validation"
-        , help "Validate a minimum part of the Volatile and Immutable DB"
+        , help "Validate a minimum part of the Immutable DB"
         ]
     ]
 

--- a/ouroboros-consensus-cardano/app/db-analyser.hs
+++ b/ouroboros-consensus-cardano/app/db-analyser.hs
@@ -4,15 +4,16 @@
 
 -- | Database analysis tool.
 --
--- Usage: db-analyser --db PATH [--verbose]
---                    [--only-immutable-db [--analyse-from SLOT_NUMBER]]
+-- Usage: db-analyser --db PATH [--analyse-from SLOT_NUMBER]
 --                    [--validate-all-blocks | --minimum-block-validation]
 --                    [--show-slot-block-no | --count-tx-outputs |
 --                      --show-block-header-size | --show-block-txs-size |
 --                      --show-ebbs | --store-ledger SLOT_NUMBER | --count-blocks |
 --                      --checkThunks BLOCK_COUNT | --trace-ledger |
 --                      --repro-mempool-and-forge INT | --benchmark-ledger-ops
---                      [--out-file FILE]] [--num-blocks-to-process INT] COMMAND
+--                      [--out-file FILE] |
+--                      --get-block-application-metrics NUM [--out-file FILE]]
+--                    [--num-blocks-to-process INT] COMMAND
 module Main (main) where
 
 import           Cardano.Crypto.Init (cryptoInit)

--- a/ouroboros-consensus-cardano/app/db-immutaliser.hs
+++ b/ouroboros-consensus-cardano/app/db-immutaliser.hs
@@ -1,0 +1,40 @@
+{-# LANGUAGE ApplicativeDo  #-}
+{-# LANGUAGE NamedFieldPuns #-}
+
+module Main (main) where
+
+import           Cardano.Crypto.Init (cryptoInit)
+import           Cardano.Tools.DBImmutaliser.Run (DBDirs (..), Opts (..))
+import qualified Cardano.Tools.DBImmutaliser.Run as DBImmutaliser
+import           Main.Utf8 (withStdTerminalHandles)
+import           Options.Applicative
+main :: IO ()
+main = withStdTerminalHandles $ do
+    cryptoInit
+    DBImmutaliser.run =<< execParser optsParser
+
+optsParser :: ParserInfo Opts
+optsParser =
+    info (helper <*> parse) $ fullDesc <> progDesc desc
+  where
+    desc = "Copy a specific chain out of a VolatileDB into an ImmutableDB"
+
+    parse = do
+      dbDirs <- do
+        immDBDir <- strOption $ mconcat
+          [ long "immutable-db"
+          , help "Path to the ImmutableDB"
+          , metavar "PATH"
+          ]
+        volDBDir <- strOption $ mconcat
+          [ long "volatile-db"
+          , help "Path to the VolatileDB"
+          , metavar "PATH"
+          ]
+        pure DBDirs {immDBDir, volDBDir}
+      configFile <- strOption $ mconcat
+        [ long "config"
+        , help "Path to config file, in the same format as for the node or db-analyser"
+        , metavar "PATH"
+        ]
+      pure Opts {dbDirs, configFile}

--- a/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
+++ b/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
@@ -485,6 +485,7 @@ library unstable-cardano-tools
     Cardano.Tools.DBAnalyser.HasAnalysis
     Cardano.Tools.DBAnalyser.Run
     Cardano.Tools.DBAnalyser.Types
+    Cardano.Tools.DBImmutaliser.Run
     Cardano.Tools.DBSynthesizer.Forging
     Cardano.Tools.DBSynthesizer.Orphans
     Cardano.Tools.DBSynthesizer.Run
@@ -593,6 +594,17 @@ executable db-analyser
       "-with-rtsopts=-T -I0 -A16m -N2 --disable-delayed-os-memory-return"
 
   other-modules: DBAnalyser.Parsers
+
+executable db-immutaliser
+  import: common-exe
+  hs-source-dirs: app
+  main-is: db-immutaliser.hs
+  build-depends:
+    base,
+    cardano-crypto-class,
+    optparse-applicative,
+    ouroboros-consensus-cardano:unstable-cardano-tools,
+    with-utf8,
 
 executable db-synthesizer
   import: common-exe

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Types.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Types.hs
@@ -10,8 +10,7 @@ import           Ouroboros.Consensus.Storage.LedgerDB (DiskSnapshot)
 
 
 data SelectDB =
-    SelectChainDB
-  | SelectImmutableDB (Maybe DiskSnapshot)
+    SelectImmutableDB (Maybe DiskSnapshot)
 
 data DBAnalyserConfig = DBAnalyserConfig {
     dbDir      :: FilePath

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBImmutaliser/Run.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBImmutaliser/Run.hs
@@ -1,0 +1,204 @@
+{-# LANGUAGE DeriveTraversable    #-}
+{-# LANGUAGE DerivingStrategies   #-}
+{-# LANGUAGE FlexibleContexts     #-}
+{-# LANGUAGE NamedFieldPuns       #-}
+{-# LANGUAGE ScopedTypeVariables  #-}
+{-# LANGUAGE StandaloneDeriving   #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Cardano.Tools.DBImmutaliser.Run (
+    Opts (..)
+  , run
+    -- * Setup
+  , DBDirs (..)
+  , withDBs
+    -- * Immutalise
+  , TraceImmutalisationEvent (..)
+  , immutalise
+  ) where
+
+import qualified Cardano.Tools.DBAnalyser.Block.Cardano as Cardano
+import           Cardano.Tools.DBAnalyser.HasAnalysis (mkProtocolInfo)
+import           Control.Tracer (Tracer, stdoutTracer, traceWith)
+import           Data.Foldable (for_)
+import           Data.Functor.Contravariant ((>$<))
+import           Data.List.NonEmpty (NonEmpty)
+import qualified Data.List.NonEmpty as NE
+import           Data.Semigroup (Arg (..), ArgMax, Max (..))
+import           Data.Traversable (for)
+import           Ouroboros.Consensus.Block
+import           Ouroboros.Consensus.Config
+import           Ouroboros.Consensus.Ledger.SupportsProtocol
+import           Ouroboros.Consensus.Node.InitStorage
+import           Ouroboros.Consensus.Node.ProtocolInfo (ProtocolInfo (..))
+import           Ouroboros.Consensus.Protocol.Abstract
+import           Ouroboros.Consensus.Storage.ChainDB.API (LoELimit (..))
+import qualified Ouroboros.Consensus.Storage.ChainDB.Impl.Paths as Paths
+import           Ouroboros.Consensus.Storage.Common (BlockComponent (..))
+import           Ouroboros.Consensus.Storage.ImmutableDB (ImmutableDB,
+                     ImmutableDbArgs (..), Tip, tipToPoint)
+import qualified Ouroboros.Consensus.Storage.ImmutableDB as ImmutableDB
+import           Ouroboros.Consensus.Storage.VolatileDB (VolatileDB,
+                     VolatileDbArgs (..))
+import qualified Ouroboros.Consensus.Storage.VolatileDB.API as VolatileDB
+import qualified Ouroboros.Consensus.Storage.VolatileDB.Impl as VolatileDB
+import           Ouroboros.Consensus.Util.Args
+import           Ouroboros.Consensus.Util.IOLike
+import           Ouroboros.Consensus.Util.ResourceRegistry
+import           Ouroboros.Network.Block (MaxSlotNo)
+import           System.FS.API (SomeHasFS (..))
+import           System.FS.API.Types (MountPoint (..))
+import           System.FS.IO (ioHasFS)
+
+data Opts = Opts {
+    dbDirs     :: DBDirs FilePath
+  , configFile :: FilePath
+  }
+
+run :: Opts -> IO ()
+run Opts {dbDirs, configFile} = do
+    let dbDirs' = SomeHasFS . ioHasFS . MountPoint <$> dbDirs
+        args    = Cardano.CardanoBlockArgs configFile Nothing
+    ProtocolInfo{pInfoConfig = cfg} <- mkProtocolInfo args
+    withRegistry $ \registry ->
+      withDBs cfg registry dbDirs' $
+        immutalise (configBlock cfg) (show >$< stdoutTracer)
+
+{-------------------------------------------------------------------------------
+  Setup
+-------------------------------------------------------------------------------}
+
+data DBDirs a = DBDirs {
+    immDBDir :: a
+  , volDBDir :: a
+  }
+  deriving stock (Functor, Foldable, Traversable)
+
+withDBs ::
+     forall m blk a.
+     ( IOLike m
+     , ConvertRawHash blk
+     , LedgerSupportsProtocol blk
+     , ImmutableDB.ImmutableDbSerialiseConstraints blk
+     , VolatileDB.VolatileDbSerialiseConstraints blk
+     , NodeInitStorage blk
+     )
+  => TopLevelConfig blk
+  -> ResourceRegistry m
+  -> DBDirs (SomeHasFS m)
+  -> (ImmutableDB m blk -> VolatileDB m blk -> m a)
+  -> m a
+withDBs cfg registry dbDirs f =
+    ImmutableDB.withDB (ImmutableDB.openDB immDBArgs runWithTempRegistry) $ \immDB ->
+    VolatileDB.withDB  (VolatileDB.openDB  volDBArgs runWithTempRegistry) $ \volDB -> do
+      f immDB volDB
+  where
+    codecCfg   = configCodec   cfg
+    storageCfg = configStorage cfg
+
+    immDBArgs :: Complete ImmutableDbArgs m blk
+    immDBArgs = ImmutableDB.defaultArgs {
+          immCheckIntegrity = nodeCheckIntegrity storageCfg
+        , immChunkInfo      = nodeImmutableDbChunkInfo storageCfg
+        , immCodecConfig    = codecCfg
+        , immRegistry       = registry
+        , immHasFS          = immDBDir dbDirs
+        }
+
+    volDBArgs :: Complete VolatileDbArgs m blk
+    volDBArgs = VolatileDB.defaultArgs {
+          volCheckIntegrity = nodeCheckIntegrity (configStorage cfg)
+        , volCodecConfig    = codecCfg
+        , volHasFS          = volDBDir dbDirs
+        }
+
+{-------------------------------------------------------------------------------
+  Immutalise
+-------------------------------------------------------------------------------}
+
+data TraceImmutalisationEvent blk =
+    TraceStartImmutalisation
+      -- | Tip of the ImmutableDB.
+      (WithOrigin (Tip blk))
+      -- | 'MaxSlotNo' of the VolatileDB.
+      MaxSlotNo
+  | -- | No blocks in the VolatileDB extend the immutable tip.
+    TraceNoVolatileCandidate
+  | -- | Found a volatile candidate extending the immutable tip.
+    TraceFoundCandidate
+      -- | Hash of the candidate tip.
+      (HeaderHash blk)
+      -- | Blocks to be added to the ImmutableDB.
+      Int
+      -- | 'SelectView' of the candidate tip.
+      (SelectView (BlockProtocol blk))
+  | TraceCopiedtoImmutableDB
+      -- | New tip of the ImmutableDB.
+      (WithOrigin (Tip blk))
+
+deriving stock instance
+  ( ConsensusProtocol (BlockProtocol blk)
+  , StandardHash blk
+  ) => Show (TraceImmutalisationEvent blk)
+
+-- data ImmutalisationException =
+
+-- | Copy a specific chain from the given 'VolatileDB' to the 'ImmutableDB',
+-- such that other tools that only work with an 'ImmutableDB' can process the
+-- corresponding blocks.
+--
+-- This function requires exclusive access to the databases.
+--
+-- Currently, this will pick the best (according to the 'SelectView') chain
+-- extending the immutable tip, and it will _not_ do any kind of validation.
+--
+-- Future work might include customizing this behavior, like:
+--
+--   * picking the best _valid_ chain (requires reading a ledger snapshot and/or
+--     replaying)
+--
+--   * picking a chain that contains particular points (user input)
+immutalise ::
+     forall m blk.
+     ( IOLike m
+     , BlockSupportsProtocol blk
+     )
+  => BlockConfig blk
+  -> Tracer m (TraceImmutalisationEvent blk)
+  -> ImmutableDB m blk
+  -> VolatileDB m blk
+  -> m ()
+immutalise bcfg tracer immDB volDB = do
+    immTip       <- atomically $ ImmutableDB.getTip immDB
+    volMaxSlotNo <- atomically $ VolatileDB.getMaxSlotNo volDB
+    traceWith tracer $ TraceStartImmutalisation immTip volMaxSlotNo
+
+    succsOf <- atomically $ VolatileDB.filterByPredecessor volDB
+    let candidates =
+          Paths.maximalCandidates succsOf LoEUnlimited (tipToPoint immTip)
+    candidatesAndTipHdrs <- for candidates $ \candidate -> do
+      tipHdr <-
+        VolatileDB.getKnownBlockComponent volDB GetHeader (NE.last candidate)
+      pure (candidate, tipHdr)
+    let mBestCandidate ::
+             Maybe (ArgMax (SelectView (BlockProtocol blk)) (NonEmpty (HeaderHash blk)))
+        mBestCandidate = mconcat $ do
+          (candidate, tipHdr) <- candidatesAndTipHdrs
+          pure $ Just $ Max $ Arg (selectView bcfg tipHdr) candidate
+
+    case mBestCandidate of
+      Nothing                       -> do
+        traceWith tracer TraceNoVolatileCandidate
+      Just (Max (Arg sv candidate)) -> do
+        traceWith tracer $ TraceFoundCandidate
+          (NE.last candidate)
+          (NE.length candidate)
+          sv
+
+        -- Copy the candidate blocks from volDB to immDB.
+        for_ candidate $ \hdrHash -> do
+          blk <- VolatileDB.getKnownBlockComponent volDB GetBlock hdrHash
+          ImmutableDB.appendBlock immDB blk
+
+        newImmTip <- atomically $ ImmutableDB.getTip immDB
+        traceWith tracer $ TraceCopiedtoImmutableDB newImmTip

--- a/ouroboros-consensus-cardano/test/tools-test/Main.hs
+++ b/ouroboros-consensus-cardano/test/tools-test/Main.hs
@@ -3,6 +3,7 @@ module Main (main) where
 import qualified Cardano.Tools.DBAnalyser.Block.Cardano as Cardano
 import qualified Cardano.Tools.DBAnalyser.Run as DBAnalyser
 import           Cardano.Tools.DBAnalyser.Types
+import qualified Cardano.Tools.DBImmutaliser.Run as DBImmutaliser
 import qualified Cardano.Tools.DBSynthesizer.Run as DBSynthesizer
 import           Cardano.Tools.DBSynthesizer.Types
 import           Ouroboros.Consensus.Cardano.Block
@@ -46,12 +47,22 @@ testNodeCredentials =
       , credBulkFile  = Just "test/tools-test/disk/config/bulk-creds-k2.json"
     }
 
+testImmutaliserConfig :: DBImmutaliser.Opts
+testImmutaliserConfig =
+  DBImmutaliser.Opts {
+      DBImmutaliser.dbDirs = DBImmutaliser.DBDirs {
+          DBImmutaliser.immDBDir = chainDB <> "/immutable"
+        , DBImmutaliser.volDBDir = chainDB <> "/volatile"
+        }
+   , DBImmutaliser.configFile = nodeConfig
+   }
+
 testAnalyserConfig :: DBAnalyserConfig
 testAnalyserConfig =
   DBAnalyserConfig {
       dbDir       = chainDB
     , verbose     = False
-    , selectDB    = SelectChainDB
+    , selectDB    = SelectImmutableDB Nothing
     , validation  = Just ValidateAllBlocks
     , analysis    = CountBlocks
     , confLimit   = Unlimited
@@ -64,7 +75,8 @@ testBlockArgs = Cardano.CardanoBlockArgs nodeConfig Nothing
 --
 -- 1. step: synthesize a ChainDB from scratch and count the amount of blocks forged.
 -- 2. step: append to the previous ChainDB and coutn the amount of blocks forged.
--- 3. step: analyze the ChainDB resulting from previous steps and confirm the total block count.
+-- 3. step: copy the VolatileDB into the ImmutableDB.
+-- 3. step: analyze the ImmutableDB resulting from previous steps and confirm the total block count.
 
 --
 blockCountTest :: (String -> IO ()) -> Assertion
@@ -83,6 +95,9 @@ blockCountTest logStep = do
     resultAppend <- DBSynthesizer.synthesize genTxs options {confOptions = testSynthOptionsAppend} protocol
     let blockCountAppend = resultForged resultAppend
     blockCountAppend > 0 @? "no blocks have been forged during append step"
+
+    logStep "copy volatile to immutable DB"
+    DBImmutaliser.run testImmutaliserConfig
 
     logStep "running analysis"
     resultAnalysis <- DBAnalyser.analyse testAnalyserConfig testBlockArgs


### PR DESCRIPTION
This PR adds a new small developer tool, db-immutaliser, which can be used to copy a chain from a volatile DB to an immutable DB.

 - Tools like immdb-server or the external [cardano-streamer](https://github.com/lehins/cardano-streamer) by @lehins currently only work with the immutable part of a ChainDB. Instead of adding support to all of these tools to also work with a volatile DB, db-immutaliser can solve that task in a composable manner.

   (Context: This PR was motivated by @lehins tracking down a Ledger bug at ZuriHac using his cardano-streamer, where the block exhibiting the bug turned out to reside in the VolatileDB.)

 - Our other prominent tool, db-analyser, has support for running with a full ChainDB (including a VolatileDB), but it is basically never used (in particular, it does not support `--analyse-from`), and it unconditionally requires loading a ledger snapshot for initial chain selection[^1]. In contrast, db-immutaliser works without a ledger snapshot ATM, using the best volatile chain without performing any validation. It could be extended if validating the volatile chain is crucial.

   Therefore, this PR also removes support for using the full ChainDB, making `--only-immutable-db` the default.

[^1]: Currently, using db-analyser with the ImmutableDB *also* always requires a ledger snapshot, but at least it only requires one for the given slot specified by `--analyse-from`, and this can also be fixed much more simply than for the full ChainDB case.