### PR TITLE
ImmutableDB: allow to lookup blocks by slot, leverage in db-{analyser,truncater}

### DIFF
--- a/ouroboros-consensus-cardano/README.md
+++ b/ouroboros-consensus-cardano/README.md
@@ -62,7 +62,10 @@ If you want to analyse blocks from the VolatileDB, consider copying them to the 
 [--analyse-from SLOT_NUMBER]
 ```
 
-This flag allows to start processing blocks from the requested slot number. A snapshot at that slot number must exist in `DB_PATH/ledger/SLOT_NUMBER_db-analyser` - where `SLOT_NUMBER` is the value provided by the user with the `--analyse-from` flag.
+This flag allows to start processing blocks from the requested slot number.
+A block with the corresponding slot number must exist in the ImmutableDB.
+
+For certain analyses, a snapshot at that slot number must exist in `DB_PATH/ledger/SLOT_NUMBER_db-analyser` - where `SLOT_NUMBER` is the value provided by the user with the `--analyse-from` flag.
 The user can use snapshots created by the node or they can create their own snapshots via db-analyser - see the `--store-ledger` command
 
 #### COMMAND

--- a/ouroboros-consensus-cardano/app/DBAnalyser/Parsers.hs
+++ b/ouroboros-consensus-cardano/app/DBAnalyser/Parsers.hs
@@ -16,10 +16,9 @@ import           Cardano.Tools.DBAnalyser.Types
 import           Data.Foldable (asum)
 #endif
 import           Options.Applicative
-import           Ouroboros.Consensus.Block (SlotNo (..))
+import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Byron.Node (PBftSignatureThreshold (..))
 import           Ouroboros.Consensus.Shelley.Node (Nonce (..))
-import           Ouroboros.Consensus.Storage.LedgerDB (DiskSnapshot (..))
 
 {-------------------------------------------------------------------------------
   Parsing
@@ -48,8 +47,8 @@ parseSelectDB :: Parser SelectDB
 parseSelectDB =
     SelectImmutableDB <$> analyseFrom
   where
-    analyseFrom :: Parser (Maybe DiskSnapshot)
-    analyseFrom = optional $ ((flip DiskSnapshot $ Just "db-analyser") . read) <$> strOption
+    analyseFrom :: Parser (WithOrigin SlotNo)
+    analyseFrom = fmap (maybe Origin (NotOrigin . SlotNo)) $ optional $ option auto
       (  long "analyse-from"
       <> metavar "SLOT_NUMBER"
       <> help "Start analysis from ledger state stored at specific slot number" )

--- a/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
+++ b/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
@@ -554,6 +554,7 @@ library unstable-cardano-tools
     ouroboros-network-framework,
     ouroboros-network-protocols,
     serialise ^>=0.2,
+    singletons,
     sop-core,
     sop-extras,
     strict-sop-core,
@@ -657,7 +658,7 @@ test-suite tools-test
   main-is: Main.hs
   build-depends:
     base,
-    ouroboros-consensus:unstable-consensus-testlib,
+    ouroboros-consensus:{ouroboros-consensus, unstable-consensus-testlib},
     ouroboros-consensus-cardano,
     tasty,
     tasty-hunit,

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Run.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Run.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE NamedFieldPuns      #-}
 {-# LANGUAGE RankNTypes          #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -11,6 +13,7 @@ import           Cardano.Tools.DBAnalyser.Types
 import           Codec.Serialise (Serialise (decode))
 import           Control.Monad.Except (runExceptT)
 import           Control.Tracer (Tracer (..), nullTracer)
+import           Data.Singletons (Sing, SingI (..))
 import qualified Debug.Trace as Debug
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config
@@ -25,7 +28,8 @@ import qualified Ouroboros.Consensus.Storage.ChainDB as ChainDB
 import           Ouroboros.Consensus.Storage.ChainDB.Impl.Args
 import           Ouroboros.Consensus.Storage.ChainDB.Impl.LgrDB (lgrHasFS)
 import qualified Ouroboros.Consensus.Storage.ImmutableDB as ImmutableDB
-import           Ouroboros.Consensus.Storage.LedgerDB (readSnapshot)
+import           Ouroboros.Consensus.Storage.LedgerDB (DiskSnapshot (..),
+                     readSnapshot)
 import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Consensus.Util.Orphans ()
 import           Ouroboros.Consensus.Util.ResourceRegistry
@@ -70,27 +74,41 @@ analyse DBAnalyserConfig{analysis, confLimit, dbDir, selectDB, validation, verbo
           immutableDbArgs = ChainDB.cdbImmDbArgs chainDbArgs
           ledgerDbFS = lgrHasFS $ ChainDB.cdbLgrDbArgs chainDbArgs
 
-      -- TODO we need to check if the snapshot exists. If not, print an
-      -- error and ask the user if she wanted to create a snapshot first and
-      -- how to do it.
-      initLedgerErr <- runExceptT $ case initializeFrom of
-        Nothing       -> pure genesisLedger
-        Just snapshot -> readSnapshot ledgerDbFS (decodeDiskExtLedgerState $ configCodec cfg) decode snapshot
-          -- TODO @readSnapshot@ has type @ExceptT ReadIncrementalErr m
-          -- (ExtLedgerState blk)@ but it also throws exceptions! This makes
-          -- error handling more challenging than it ought to be. Maybe we
-          -- can enrich the error that @readSnapthot@ return, so that it can
-          -- contain the @HasFS@ errors as well.
-      initLedger <- either (error . show) pure initLedgerErr
-      -- This marker divides the "loading" phase of the program, where the
-      -- system is principally occupied with reading snapshot data from
-      -- disk, from the "processing" phase, where we are streaming blocks
-      -- and running the ledger processing on them.
-      Debug.traceMarkerIO "SNAPSHOT_LOADED"
-      ImmutableDB.withDB (ImmutableDB.openDB immutableDbArgs runWithTempRegistry) $ \immutableDB -> do
-        result <- runAnalysis analysis $ AnalysisEnv {
+      withImmutableDB immutableDbArgs $ \(immutableDB, internal) -> do
+        SomeAnalysis (Proxy :: Proxy startFrom) ana <- pure $ runAnalysis analysis
+        startFrom <- case sing :: Sing startFrom of
+          SStartFromPoint       -> FromPoint <$> case startSlot of
+            Origin         -> pure GenesisPoint
+            NotOrigin slot -> ImmutableDB.getHashForSlot internal slot >>= \case
+              Just hash -> pure $ BlockPoint slot hash
+              Nothing   -> fail $ "No block with given slot in the ImmutableDB: " <> show slot
+          SStartFromLedgerState -> do
+            -- TODO we need to check if the snapshot exists. If not, print an
+            -- error and ask the user if she wanted to create a snapshot first and
+            -- how to do it.
+            initLedgerErr <- runExceptT $ case startSlot of
+              Origin                  -> pure genesisLedger
+              NotOrigin (SlotNo slot) -> readSnapshot
+                ledgerDbFS
+                (decodeDiskExtLedgerState $ configCodec cfg)
+                decode
+                (DiskSnapshot slot (Just "db-analyser"))
+                -- TODO @readSnapshot@ has type @ExceptT ReadIncrementalErr m
+                -- (ExtLedgerState blk)@ but it also throws exceptions! This makes
+                -- error handling more challenging than it ought to be. Maybe we
+                -- can enrich the error that @readSnapthot@ return, so that it can
+                -- contain the @HasFS@ errors as well.
+            initLedger <- either (error . show) pure initLedgerErr
+            -- This marker divides the "loading" phase of the program, where the
+            -- system is principally occupied with reading snapshot data from
+            -- disk, from the "processing" phase, where we are streaming blocks
+            -- and running the ledger processing on them.
+            Debug.traceMarkerIO "SNAPSHOT_LOADED"
+            pure $ FromLedgerState initLedger
+
+        result <- ana AnalysisEnv {
             cfg
-          , initLedger
+          , startFrom
           , db = immutableDB
           , registry
           , ledgerDbFS = ledgerDbFS
@@ -101,7 +119,12 @@ analyse DBAnalyserConfig{analysis, confLimit, dbDir, selectDB, validation, verbo
         putStrLn $ "ImmutableDB tip: " ++ show tipPoint
         pure result
   where
-    SelectImmutableDB initializeFrom = selectDB
+    SelectImmutableDB startSlot = selectDB
+
+    withImmutableDB immutableDbArgs =
+        bracket
+          (ImmutableDB.openDBInternal immutableDbArgs runWithTempRegistry)
+          (ImmutableDB.closeDB . fst)
 
     mkTracer _    False = return nullTracer
     mkTracer lock True  = do

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Types.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Types.hs
@@ -6,11 +6,10 @@ module Cardano.Tools.DBAnalyser.Types (
 import           Cardano.Tools.DBAnalyser.Analysis as AnalysisTypes
                      (AnalysisName (..), AnalysisResult (..), Limit (..),
                      NumberOfBlocks (..))
-import           Ouroboros.Consensus.Storage.LedgerDB (DiskSnapshot)
-
+import           Ouroboros.Consensus.Block
 
 data SelectDB =
-    SelectImmutableDB (Maybe DiskSnapshot)
+    SelectImmutableDB (WithOrigin SlotNo)
 
 data DBAnalyserConfig = DBAnalyserConfig {
     dbDir      :: FilePath

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBTruncater/Types.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBTruncater/Types.hs
@@ -11,9 +11,14 @@ data DBTruncaterConfig = DBTruncaterConfig {
   , verbose       :: Bool
   }
 
--- | Slot or block number of the block intended to be the new tip of the chain
--- after the ImmutableDB is truncated.
+-- | Where to truncate the ImmutableDB.
 data TruncateAfter
+    -- | Truncate after the given slot number, such that the new tip has this
+    -- exact slot number. Fail if this is not possible, ie no block has this
+    -- slot number. If there are two blocks with the same slot number (due to
+    -- EBBs), the tip will be the non-EBB.
   = TruncateAfterSlot SlotNo
+    -- | Truncate after the given block number (such that the new tip has this
+    -- block number).
   | TruncateAfterBlock BlockNo
   deriving (Show, Eq)

--- a/ouroboros-consensus-cardano/test/tools-test/Main.hs
+++ b/ouroboros-consensus-cardano/test/tools-test/Main.hs
@@ -6,6 +6,7 @@ import           Cardano.Tools.DBAnalyser.Types
 import qualified Cardano.Tools.DBImmutaliser.Run as DBImmutaliser
 import qualified Cardano.Tools.DBSynthesizer.Run as DBSynthesizer
 import           Cardano.Tools.DBSynthesizer.Types
+import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Cardano.Block
 import           Test.Tasty
 import           Test.Tasty.HUnit
@@ -62,7 +63,7 @@ testAnalyserConfig =
   DBAnalyserConfig {
       dbDir       = chainDB
     , verbose     = False
-    , selectDB    = SelectImmutableDB Nothing
+    , selectDB    = SelectImmutableDB Origin
     , validation  = Just ValidateAllBlocks
     , analysis    = CountBlocks
     , confLimit   = Unlimited

--- a/ouroboros-consensus/changelog.d/20240613_133641_alexander.esgen_immdb_slots.md
+++ b/ouroboros-consensus/changelog.d/20240613_133641_alexander.esgen_immdb_slots.md
@@ -1,0 +1,3 @@
+### Breaking
+
+- Added `getHashForSlot` to the internal ImmutableDB API.

--- a/ouroboros-consensus/changelog.d/20240613_133842_alexander.esgen_immdb_slots.md
+++ b/ouroboros-consensus/changelog.d/20240613_133842_alexander.esgen_immdb_slots.md
@@ -1,0 +1,7 @@
+### Non-Breaking
+
+- ImmutableDB: added `headerToTip`.
+
+### Breaking
+
+- ImmutableDB `blockToTip`: relaxed constraints.

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ImmutableDB/API.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ImmutableDB/API.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE DeriveGeneric       #-}
 {-# LANGUAGE DeriveTraversable   #-}
 {-# LANGUAGE DerivingVia         #-}
+{-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE NamedFieldPuns      #-}
 {-# LANGUAGE RankNTypes          #-}
@@ -21,6 +22,7 @@ module Ouroboros.Consensus.Storage.ImmutableDB.API (
   , CompareTip (..)
   , Tip (..)
   , blockToTip
+  , headerToTip
   , tipToAnchor
   , tipToPoint
   , tipToRealPoint
@@ -266,13 +268,16 @@ tipToAnchor = \case
     NotOrigin (Tip { tipSlotNo, tipHash, tipBlockNo }) ->
       AF.Anchor tipSlotNo tipHash tipBlockNo
 
-blockToTip :: (HasHeader blk, GetHeader blk) => blk -> Tip blk
-blockToTip blk = Tip {
-      tipSlotNo  = blockSlot    blk
-    , tipIsEBB   = blockToIsEBB blk
-    , tipBlockNo = blockNo      blk
-    , tipHash    = blockHash    blk
+headerToTip :: GetHeader blk => Header blk -> Tip blk
+headerToTip hdr = Tip {
+      tipSlotNo  = blockSlot     hdr
+    , tipIsEBB   = headerToIsEBB hdr
+    , tipBlockNo = blockNo       hdr
+    , tipHash    = blockHash     hdr
     }
+
+blockToTip :: GetHeader blk => blk -> Tip blk
+blockToTip = headerToTip . getHeader
 
 -- | newtype with an 'Ord' instance that only uses 'tipSlotNo' and 'tipIsEBB'
 -- and ignores the other fields.

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ImmutableDB/Model.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ImmutableDB/Model.hs
@@ -26,6 +26,7 @@ module Test.Ouroboros.Storage.ImmutableDB.Model (
   , appendBlockModel
   , deleteAfterModel
   , getBlockComponentModel
+  , getHashForSlotModel
   , getTipModel
   , iteratorCloseModel
   , iteratorHasNextModel
@@ -436,6 +437,15 @@ deleteAfterModel ::
      (HasHeader blk, GetHeader blk)
   => WithOrigin (Tip blk) -> DBModel blk -> DBModel blk
 deleteAfterModel tip = rollBackToTip tip . closeAllIterators
+
+getHashForSlotModel ::
+     (HasHeader blk)
+  => SlotNo -> DBModel blk -> Maybe (HeaderHash blk)
+getHashForSlotModel slotNo dbm = case Map.lookup slotNo (dbmSlots dbm) of
+    Just (InSlotBlock  blk) -> Just $ blockHash blk
+    Just (InSlotEBB    blk) -> Just $ blockHash blk
+    Just (InSlotBoth _ blk) -> Just $ blockHash blk
+    Nothing                 -> Nothing
 
 extractBlockComponent ::
      forall blk b.


### PR DESCRIPTION
This PR adds a new function to the internal ImmutableDB API:
```haskell
-- | Get the hash of the block in the given slot. If the slot contains both
-- an EBB and a non-EBB, return the hash of the non-EBB.
getHashForSlot :: SlotNo -> m (Maybe (HeaderHash blk))
```
It is then used in two ways:

 - In db-analyser: Many analyses do not actually need a ledger state to perform their work. This PR adds support for avoiding this redundant and long work on startup. However, the existing ImmutableDB streaming API needs a point (previously read from the ledger state), not just a slot to start streaming. This is where `getHashForSlot` comes in.

 - In db-truncater: Previously, truncating after a slot took linear time (by iterating over the entire database). With `getHashForSlot`, it is easy to now change it to take constant time. Note that the behavior changes slightly, see the commit message for details.