### PR TITLE
ci.yml: github.event.type => github.event_name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         variant: [default, no-thunks]
         exclude:
           - variant:
-              ${{ (github.event_name == 'schedule' || github.event.inputs.nothunks) && 'default' || 'no-thunks' }}
+              ${{ (github.event_name == 'schedule' || inputs.nothunks) && 'default' || 'no-thunks' }}
     env:
       # Modify this value to "invalidate" the Cabal cache.
       CABAL_CACHE_VERSION: "2024-01-29"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         variant: [default, no-thunks]
         exclude:
           - variant:
-              ${{ (github.event.type == 'schedule' || github.event.inputs.nothunks) && 'default' || 'no-thunks' }}
+              ${{ (github.event_name == 'schedule' || github.event.inputs.nothunks) && 'default' || 'no-thunks' }}
     env:
       # Modify this value to "invalidate" the Cabal cache.
       CABAL_CACHE_VERSION: "2024-01-29"


### PR DESCRIPTION
# Description

Fixes `github.event.type` being checked when determining which variants to run during the scheduled nightly CI run, rather than `github.event_name`