### PR TITLE
Update haskell.nix, remove workarounds

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -36,10 +36,3 @@ import: ./asserts.cabal
 if(os(windows))
   constraints:
     bitvec -simd
-
--- Workaround for a haskell.nix bug around pre-installed libraries. Might be
--- fixed by https://github.com/input-output-hk/haskell.nix/pull/2218.
-extra-packages: Cabal
-if os(windows)
-  constraints: time ^>=1.14
-  allow-newer: *:time

--- a/flake.lock
+++ b/flake.lock
@@ -313,11 +313,11 @@
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1718701646,
-        "narHash": "sha256-068rEjRFuasfvuapoPrzrfm+b6kHGeOmFyrEwg92eBU=",
+        "lastModified": 1718797200,
+        "narHash": "sha256-ueFxTuZrQ3ZT/Fj5sSeUWlqKa4+OkUU1xW0E+q/XTfw=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "c019b636f237668d8bbd52c5729732bc0e4f887c",
+        "rev": "cb139fa956158397aa398186bb32dd26f7318784",
         "type": "github"
       },
       "original": {
@@ -825,11 +825,11 @@
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1716942040,
-        "narHash": "sha256-YxHXqVGGHTy0PkVExdK9z6zHAJbGEd/9rwZdV+RaAU4=",
+        "lastModified": 1718756571,
+        "narHash": "sha256-8rL8viTbuE9/yV1of6SWp2tHmhVMD2UmkOfmN5KDbKg=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "686ed0e27db02a273ed04aa41788cc787052b706",
+        "rev": "027672fb6fd45828b0e623c8152572d4058429ad",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
https://github.com/input-output-hk/haskell.nix/pull/2218 was merged, which allows us to remove the workarounds introduced in #1142