### PR TITLE
db-analyser: support full block application in `--store-ledger`

### DIFF
--- a/ouroboros-consensus-cardano/README.md
+++ b/ouroboros-consensus-cardano/README.md
@@ -127,6 +127,12 @@ Lastly the user can provide the analysis that should be run on the chain:
   slot number, it will create one on the next available slot number (and issue a
   warning about this fact).
 
+  By default, for better performance, blocks are only *re*applied, skipping eg
+  validation of signatures and Plutus scripts. If desired (eg when investigating
+  a Ledger bug), one can use `--full-ledger-validation` to also perform these
+  checks. If there is an error on block application, the previous ledger state
+  is stored.
+
 * `--count-blocks` prints out the number of blocks it saw on the chain
 
 * `--benchmark-ledger-ops` applies the main ledger calculations to each block in

--- a/ouroboros-consensus-cardano/README.md
+++ b/ouroboros-consensus-cardano/README.md
@@ -91,12 +91,12 @@ User should run this if they are dealing with a `cardano` chain.
 
 The user can limit the maximum number of blocks that db-analyser will process.
 
-### Database validation
+### Database validation, via --db-validation
 
 The tool provides two database validation policies:
 
 - `validate-all-blocks`, which will cause the tool to validate all chunks on the
-  immutable and volatile databases.
+  immutable database.
 - `minimum-block-validation`, which will cause the tool to validate only the
   most recent chunk in the immutable database.
 

--- a/ouroboros-consensus-cardano/app/DBAnalyser/Parsers.hs
+++ b/ouroboros-consensus-cardano/app/DBAnalyser/Parsers.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE ApplicativeDo #-}
 {-# LANGUAGE CPP           #-}
+{-# LANGUAGE LambdaCase    #-}
 
 module DBAnalyser.Parsers (
     BlockType (..)
@@ -55,16 +56,18 @@ parseSelectDB =
 
 
 parseValidationPolicy :: Parser (Maybe ValidateBlocks)
-parseValidationPolicy = optional $ asum [
-      flag' ValidateAllBlocks $ mconcat [
-          long "validate-all-blocks"
-        , help "Validate all blocks of the Immutable DB"
-        ]
-    , flag' MinimumBlockValidation $ mconcat [
-          long "minimum-block-validation"
-        , help "Validate a minimum part of the Immutable DB"
-        ]
-    ]
+parseValidationPolicy =
+    optional $ option reader $ mconcat [
+        long "db-validation"
+      , help $ "The extent of the ChainDB on-disk files validation. This is "
+            <> "completely unrelated to validation of the ledger rules. "
+            <> "Possible values: validate-all-blocks, minimum-block-validation."
+      ]
+  where
+    reader = maybeReader $ \case
+        "validate-all-blocks"      -> Just ValidateAllBlocks
+        "minimum-block-validation" -> Just MinimumBlockValidation
+        _                          -> Nothing
 
 parseAnalysis :: Parser AnalysisName
 parseAnalysis = asum [

--- a/ouroboros-consensus-cardano/app/DBAnalyser/Parsers.hs
+++ b/ouroboros-consensus-cardano/app/DBAnalyser/Parsers.hs
@@ -9,6 +9,7 @@ module DBAnalyser.Parsers (
   ) where
 
 import           Cardano.Crypto (RequiresNetworkMagic (..))
+import           Cardano.Tools.DBAnalyser.Analysis
 import           Cardano.Tools.DBAnalyser.Block.Byron
 import           Cardano.Tools.DBAnalyser.Block.Cardano
 import           Cardano.Tools.DBAnalyser.Block.Shelley
@@ -117,10 +118,19 @@ parseAnalysis = asum [
     ]
 
 storeLedgerParser :: Parser AnalysisName
-storeLedgerParser = (StoreLedgerStateAt . SlotNo) <$> option auto
-  (  long "store-ledger"
-  <> metavar "SLOT_NUMBER"
-  <> help "Store ledger state at specific slot number" )
+storeLedgerParser = do
+  slot <- SlotNo <$> option auto
+    (  long "store-ledger"
+    <> metavar "SLOT_NUMBER"
+    <> help "Store ledger state at specific slot number" )
+  ledgerValidation <- flag LedgerReapply LedgerApply
+    (  long "full-ledger-validation"
+    <> help (  "Use full block application while applying blocks to ledger states, "
+            <> "also validating signatures and scripts. "
+            <> "This is much slower than block reapplication (the default)."
+            )
+    )
+  pure $ StoreLedgerStateAt slot ledgerValidation
 
 checkNoThunksParser :: Parser AnalysisName
 checkNoThunksParser = CheckNoThunksEvery <$> option auto

--- a/ouroboros-consensus-cardano/app/db-analyser.hs
+++ b/ouroboros-consensus-cardano/app/db-analyser.hs
@@ -4,8 +4,8 @@
 
 -- | Database analysis tool.
 --
--- Usage: db-analyser --db PATH [--analyse-from SLOT_NUMBER]
---                    [--validate-all-blocks | --minimum-block-validation]
+-- Usage: db-analyser --db PATH [--verbose] [--analyse-from SLOT_NUMBER]
+--                    [--db-validation ARG]
 --                    [--show-slot-block-no | --count-tx-outputs |
 --                      --show-block-header-size | --show-block-txs-size |
 --                      --show-ebbs | --store-ledger SLOT_NUMBER | --count-blocks |

--- a/ouroboros-consensus-cardano/app/db-analyser.hs
+++ b/ouroboros-consensus-cardano/app/db-analyser.hs
@@ -8,10 +8,11 @@
 --                    [--db-validation ARG]
 --                    [--show-slot-block-no | --count-tx-outputs |
 --                      --show-block-header-size | --show-block-txs-size |
---                      --show-ebbs | --store-ledger SLOT_NUMBER | --count-blocks |
---                      --checkThunks BLOCK_COUNT | --trace-ledger |
---                      --repro-mempool-and-forge INT | --benchmark-ledger-ops
---                      [--out-file FILE] |
+--                      --show-ebbs | --store-ledger SLOT_NUMBER
+--                      [--full-ledger-validation] |
+--                      --count-blocks | --checkThunks BLOCK_COUNT |
+--                      --trace-ledger | --repro-mempool-and-forge INT |
+--                      --benchmark-ledger-ops [--out-file FILE] |
 --                      --get-block-application-metrics NUM [--out-file FILE]]
 --                    [--num-blocks-to-process INT] COMMAND
 module Main (main) where

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Types.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Types.hs
@@ -20,6 +20,6 @@ data DBAnalyserConfig = DBAnalyserConfig {
   , confLimit  :: Limit
   }
 
--- | Whether to validate the on-disk files of the ChainDB. This is completely
+-- | The extent of the ChainDB on-disk files validation. This is completely
 -- unrelated to validation of the ledger rules.
 data ValidateBlocks = ValidateAllBlocks | MinimumBlockValidation

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Types.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Types.hs
@@ -20,4 +20,6 @@ data DBAnalyserConfig = DBAnalyserConfig {
   , confLimit  :: Limit
   }
 
+-- | Whether to validate the on-disk files of the ChainDB. This is completely
+-- unrelated to validation of the ledger rules.
 data ValidateBlocks = ValidateAllBlocks | MinimumBlockValidation


### PR DESCRIPTION
This PR adds support for full validation of blocks according to the ledger rules for `--store-ledger`. This is useful to validate changes against an existing DB. In particular, if there is an error, a ledger state just before the offending block will be stored.

Also, in a separate commit, we address the third point of #35 in order to avoid users being confused when seeing both `--validate-all-blocks` and `--full-ledger-validation`.