### PR TITLE
Add a BlockFetch leashing attack

### DIFF
--- a/ouroboros-consensus-diffusion/changelog.d/20240531_155304_alexander.esgen_milestone_13.md
+++ b/ouroboros-consensus-diffusion/changelog.d/20240531_155304_alexander.esgen_milestone_13.md
@@ -1,0 +1,12 @@
+### Breaking
+
+- Integrated all Genesis components into the NodeKernel. In particular,
+  `RunNodeArgs` now has a new field
+
+  ```haskell
+  rnGenesisConfig :: GenesisConfig
+  ```
+
+  This can be set to `Ouroboros.Consensus.Node.Genesis.disableGenesisConfig` to
+  keep the Praos behavior, or to `enableGenesisConfigDefault` to enable Genesis
+  with preliminary parameter choices.

--- a/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
+++ b/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
@@ -65,6 +65,7 @@ library
     Ouroboros.Consensus.Node.Exit
     Ouroboros.Consensus.Node.ExitPolicy
     Ouroboros.Consensus.Node.GSM
+    Ouroboros.Consensus.Node.Genesis
     Ouroboros.Consensus.Node.Recovery
     Ouroboros.Consensus.Node.RethrowPolicy
     Ouroboros.Consensus.Node.Tracers

--- a/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
+++ b/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
@@ -266,6 +266,7 @@ test-suite consensus-test
     Test.Consensus.PointSchedule.SinglePeer
     Test.Consensus.PointSchedule.SinglePeer.Indices
     Test.Consensus.PointSchedule.Tests
+    Test.Util.PartialAccessors
     Test.Util.TersePrinting
 
   build-depends:

--- a/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
+++ b/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
@@ -243,6 +243,7 @@ test-suite consensus-test
     Test.Consensus.Network.AnchoredFragment.Extras
     Test.Consensus.Node
     Test.Consensus.PeerSimulator.BlockFetch
+    Test.Consensus.PeerSimulator.CSJInvariants
     Test.Consensus.PeerSimulator.ChainSync
     Test.Consensus.PeerSimulator.Config
     Test.Consensus.PeerSimulator.Handlers

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToNode.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToNode.hs
@@ -41,7 +41,7 @@ import qualified Codec.CBOR.Decoding as CBOR
 import           Codec.CBOR.Encoding (Encoding)
 import qualified Codec.CBOR.Encoding as CBOR
 import           Codec.CBOR.Read (DeserialiseFailure)
-import           Control.Concurrent.Class.MonadSTM.Strict.TVar as TVar.Unchecked
+import qualified Control.Concurrent.Class.MonadSTM.Strict.TVar as TVar.Unchecked
 import           Control.Monad.Class.MonadTime.SI (MonadTime)
 import           Control.Monad.Class.MonadTimer.SI (MonadTimer)
 import           Control.Tracer
@@ -570,6 +570,7 @@ mkApps kernel Tracers {..} mkCodecs ByteLimits {..} genChainSyncTimeout lopBucke
             (contramap (TraceLabelPeer them) (Node.chainSyncClientTracer (getTracers kernel)))
             (CsClient.defaultChainDbView (getChainDB kernel))
             (getChainSyncHandles kernel)
+            (getGsmState       kernel)
             them
             version
             lopBucketConfig

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Node.hs
@@ -629,7 +629,7 @@ runWith RunNodeArgs{..} encAddrNtN decAddrNtN LowLevelRunNodeArgs{..} =
               LedgerPeersConsensusInterface {
                   lpGetLatestSlot = getImmTipSlot kernel,
                   lpGetLedgerPeers = fromMaybe [] <$> getPeersFromCurrentLedger kernel (const True),
-                  lpGetLedgerStateJudgement = getLedgerStateJudgement kernel
+                  lpGetLedgerStateJudgement = GSM.gsmStateToLedgerJudgement <$> getGsmState kernel
                 },
             Diffusion.daUpdateOutboundConnectionsState =
               let varOcs = getOutboundConnectionsState kernel in \newOcs -> do

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Node.hs
@@ -89,6 +89,9 @@ import           Ouroboros.Consensus.Node.DbLock
 import           Ouroboros.Consensus.Node.DbMarker
 import           Ouroboros.Consensus.Node.ErrorPolicy
 import           Ouroboros.Consensus.Node.ExitPolicy
+import           Ouroboros.Consensus.Node.Genesis (GenesisConfig (..),
+                     GenesisNodeKernelArgs, GenesisSwitch (..),
+                     mkGenesisNodeKernelArgs)
 import           Ouroboros.Consensus.Node.GSM (GsmNodeKernelArgs (..))
 import qualified Ouroboros.Consensus.Node.GSM as GSM
 import           Ouroboros.Consensus.Node.InitStorage
@@ -193,6 +196,8 @@ data RunNodeArgs m addrNTN addrNTC blk (p2p :: Diffusion.P2P) = RunNodeArgs {
     , rnPeerSharing :: PeerSharing
 
     , rnGetUseBootstrapPeers :: STM m UseBootstrapPeers
+
+    , rnGenesisConfig :: GenesisSwitch GenesisConfig
     }
 
 
@@ -249,11 +254,7 @@ data LowLevelRunNodeArgs m addrNTN addrNTC versionDataNTN versionDataNTC blk
       -- | See 'NTN.ChainSyncTimeout'
     , llrnChainSyncTimeout :: m NTN.ChainSyncTimeout
 
-      -- | See 'CsClient.ChainSyncLoPBucketConfig'
-    , llrnChainSyncLoPBucketConfig :: ChainSyncLoPBucketConfig
-
-      -- | See 'CsClient.CSJConfig'
-    , llrnCSJConfig :: CSJConfig
+    , llrnGenesisConfig :: GenesisSwitch GenesisConfig
 
       -- | How to run the data diffusion applications
       --
@@ -413,6 +414,9 @@ runWith RunNodeArgs{..} encAddrNtN decAddrNtN LowLevelRunNodeArgs{..} =
                          llrnMaxClockSkew
                          systemTime
 
+        (genesisArgs, setLoEinChainDbArgs) <-
+          mkGenesisNodeKernelArgs llrnGenesisConfig
+
         let maybeValidateAll
               | lastShutDownWasClean
               = id
@@ -428,7 +432,8 @@ runWith RunNodeArgs{..} encAddrNtN decAddrNtN LowLevelRunNodeArgs{..} =
                      initLedger
                      llrnMkHasFS
                      llrnChainDbArgsDefaults
-                     (  maybeValidateAll
+                     (  setLoEinChainDbArgs
+                      . maybeValidateAll
                       . llrnCustomiseChainDbArgs
                      )
 
@@ -474,6 +479,7 @@ runWith RunNodeArgs{..} encAddrNtN decAddrNtN LowLevelRunNodeArgs{..} =
                     gsmMarkerFileView
                     rnGetUseBootstrapPeers
                     llrnPublicPeerSelectionStateVar
+                    genesisArgs
           nodeKernel <- initNodeKernel nodeKernelArgs
           rnNodeKernelHook registry nodeKernel
 
@@ -521,8 +527,12 @@ runWith RunNodeArgs{..} encAddrNtN decAddrNtN LowLevelRunNodeArgs{..} =
           (NTN.defaultCodecs codecConfig version encAddrNTN decAddrNTN)
           NTN.byteLimits
           llrnChainSyncTimeout
-          llrnChainSyncLoPBucketConfig
-          llrnCSJConfig
+          (case llrnGenesisConfig of
+             GenesisEnabled gcfg -> gcsChainSyncLoPBucketConfig gcfg
+             GenesisDisabled     -> ChainSyncLoPBucketDisabled)
+          (case llrnGenesisConfig of
+             GenesisEnabled gcfg -> gcsCSJConfig gcfg
+             GenesisDisabled     -> CSJDisabled)
           (reportMetric Diffusion.peerMetricsConfiguration peerMetrics)
           (NTN.mkHandlers nodeKernelArgs nodeKernel)
 
@@ -711,6 +721,7 @@ mkNodeKernelArgs ::
   -> GSM.MarkerFileView m
   -> STM m UseBootstrapPeers
   -> StrictSTM.StrictTVar m (Diffusion.PublicPeerSelectionState addrNTN)
+  -> GenesisSwitch (GenesisNodeKernelArgs m blk)
   -> m (NodeKernelArgs m addrNTN (ConnectionId addrNTC) blk)
 mkNodeKernelArgs
   registry
@@ -727,6 +738,7 @@ mkNodeKernelArgs
   gsmMarkerFileView
   getUseBootstrapPeers
   publicPeerSelectionStateVar
+  genesisArgs
   = do
     let (kaRng, psRng) = split rng
     return NodeKernelArgs
@@ -751,6 +763,7 @@ mkNodeKernelArgs
       , keepAliveRng = kaRng
       , peerSharingRng = psRng
       , publicPeerSelectionStateVar
+      , genesisArgs
       }
 
 -- | We allow the user running the node to customise the 'NodeKernelArgs'
@@ -852,6 +865,7 @@ stdLowLevelRunNodeArgsIO ::
 stdLowLevelRunNodeArgsIO RunNodeArgs{ rnProtocolInfo
                                     , rnEnableP2P
                                     , rnPeerSharing
+                                    , rnGenesisConfig
                                     }
                          $(SafeWildCards.fields 'StdRunNodeArgs) = do
     llrnBfcSalt               <- stdBfcSaltIO
@@ -860,8 +874,7 @@ stdLowLevelRunNodeArgsIO RunNodeArgs{ rnProtocolInfo
     pure LowLevelRunNodeArgs
       { llrnBfcSalt
       , llrnChainSyncTimeout = fromMaybe Diffusion.defaultChainSyncTimeout srnChainSyncTimeout
-      , llrnChainSyncLoPBucketConfig = ChainSyncLoPBucketDisabled
-      , llrnCSJConfig = CSJDisabled
+      , llrnGenesisConfig = rnGenesisConfig
       , llrnCustomiseHardForkBlockchainTimeArgs = id
       , llrnGsmAntiThunderingHerd
       , llrnKeepAliveRng

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Node/Genesis.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Node/Genesis.hs
@@ -1,0 +1,112 @@
+{-# LANGUAGE DeriveTraversable   #-}
+{-# LANGUAGE DerivingStrategies  #-}
+{-# LANGUAGE LambdaCase          #-}
+{-# LANGUAGE NumericUnderscores  #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Ouroboros.Consensus.Node.Genesis (
+    GenesisConfig (..)
+  , GenesisNodeKernelArgs (..)
+  , GenesisSwitch (..)
+  , defaultGenesisConfig
+  , mkGenesisNodeKernelArgs
+  , setGetLoEFragment
+  ) where
+
+import           Control.Monad (join)
+import           Ouroboros.Consensus.Block
+import           Ouroboros.Consensus.MiniProtocol.ChainSync.Client
+                     (CSJConfig (..), CSJEnabledConfig (..),
+                     ChainSyncLoPBucketConfig (..),
+                     ChainSyncLoPBucketEnabledConfig (..))
+import qualified Ouroboros.Consensus.Node.GsmState as GSM
+import           Ouroboros.Consensus.Storage.ChainDB (ChainDbArgs)
+import qualified Ouroboros.Consensus.Storage.ChainDB as ChainDB
+import qualified Ouroboros.Consensus.Storage.ChainDB.Impl.Args as ChainDB
+import           Ouroboros.Consensus.Util.Args
+import           Ouroboros.Consensus.Util.IOLike
+import           Ouroboros.Network.AnchoredFragment (AnchoredFragment)
+import qualified Ouroboros.Network.AnchoredFragment as AF
+
+-- We have multiple other Genesis-related types of a similar shape ('LoE', LoP
+-- and CSJ configs), maybe unify?
+data GenesisSwitch a =
+    GenesisDisabled
+  | GenesisEnabled !a
+  deriving stock (Show, Functor, Foldable, Traversable)
+
+-- | Aggregating the various configs for Genesis-related subcomponents.
+data GenesisConfig = GenesisConfig {
+    gcsChainSyncLoPBucketConfig :: !ChainSyncLoPBucketConfig
+  , gcsCSJConfig                :: !CSJConfig
+  }
+
+-- TODO justification/derivation from other parameters
+defaultGenesisConfig :: GenesisConfig
+defaultGenesisConfig = GenesisConfig {
+      gcsChainSyncLoPBucketConfig = ChainSyncLoPBucketEnabled ChainSyncLoPBucketEnabledConfig {
+          csbcCapacity = 100_000 -- number of tokens
+        , csbcRate     = 500 -- tokens per second leaking, 1/2ms
+        }
+    , gcsCSJConfig = CSJEnabled CSJEnabledConfig {
+          csjcJumpSize = 3 * 2160 * 20 -- mainnet forecast range
+        }
+    }
+
+-- | Genesis-related arguments needed by the NodeKernel initialization logic.
+data GenesisNodeKernelArgs m blk = GenesisNodeKernelArgs {
+    -- | A TVar containing an action that returns the 'ChainDB.GetLoEFragment'
+    -- action. We use this extra indirection to update this action after we
+    -- opened the ChainDB (which happens before we initialize the NodeKernel).
+    -- After that, this TVar will not be modified again.
+    gnkaGetLoEFragment :: !(StrictTVar m (ChainDB.GetLoEFragment m blk))
+  }
+
+-- | Create the initial 'GenesisNodeKernelArgs" (with a temporary
+-- 'ChainDB.GetLoEFragment' that will be replaced via 'setGetLoEFragment') and a
+-- function to update the 'ChainDbArgs' accordingly.
+mkGenesisNodeKernelArgs ::
+     forall m blk a. (IOLike m, GetHeader blk)
+  => GenesisSwitch a
+  -> m ( GenesisSwitch (GenesisNodeKernelArgs m blk)
+       , Complete ChainDbArgs m blk -> Complete ChainDbArgs m blk
+       )
+mkGenesisNodeKernelArgs = \case
+    GenesisDisabled  -> pure (GenesisDisabled, id)
+    GenesisEnabled{} -> do
+      varGetLoEFragment <- newTVarIO $ pure $
+        -- Use the most conservative LoE fragment until 'setGetLoEFragment' is
+        -- called.
+        ChainDB.LoEEnabled $ AF.Empty AF.AnchorGenesis
+      let getLoEFragment        = join $ readTVarIO varGetLoEFragment
+          updateChainDbArgs cfg = cfg { ChainDB.cdbsArgs =
+               (ChainDB.cdbsArgs cfg) { ChainDB.cdbsLoE = getLoEFragment }
+            }
+          gnka = GenesisEnabled $ GenesisNodeKernelArgs varGetLoEFragment
+      pure (gnka, updateChainDbArgs)
+
+-- | Set 'gnkaGetLoEFragment' to the actual logic for determining the current
+-- LoE fragment.
+setGetLoEFragment ::
+     forall m blk. (IOLike m, GetHeader blk)
+  => STM m GSM.GsmState
+  -> STM m (AnchoredFragment (Header blk))
+     -- ^ The LoE fragment.
+  -> GenesisNodeKernelArgs m blk
+  -> m ()
+setGetLoEFragment readGsmState readLoEFragment ctx =
+    atomically $ writeTVar (gnkaGetLoEFragment ctx) getLoEFragment
+  where
+    getLoEFragment :: ChainDB.GetLoEFragment m blk
+    getLoEFragment = atomically $ readGsmState >>= \case
+        -- When the HAA can currently not be guaranteed, we should not select
+        -- any blocks that would cause our immutable tip to advance, so we
+        -- return the most conservative LoE fragment.
+        GSM.PreSyncing ->
+          pure $ ChainDB.LoEEnabled $ AF.Empty AF.AnchorGenesis
+        -- When we are syncing, return the current LoE fragment.
+        GSM.Syncing    ->
+          ChainDB.LoEEnabled <$> readLoEFragment
+        -- When we are caught up, the LoE is disabled.
+        GSM.CaughtUp   ->
+          pure ChainDB.LoEDisabled

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Node/Tracers.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Node/Tracers.hs
@@ -23,6 +23,7 @@ import           Data.Time (UTCTime)
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Forecast (OutsideForecastRange)
+import           Ouroboros.Consensus.Genesis.Governor (TraceGDDEvent)
 import           Ouroboros.Consensus.Ledger.SupportsMempool
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
 import           Ouroboros.Consensus.Mempool (MempoolSize, TraceEventMempool)
@@ -65,6 +66,7 @@ data Tracers' remotePeer localPeer blk f = Tracers
   , keepAliveClientTracer         :: f (TraceKeepAliveClient remotePeer)
   , consensusErrorTracer          :: f SomeException
   , gsmTracer                     :: f (TraceGsmEvent (Tip blk))
+  , gddTracer                     :: f (TraceGDDEvent remotePeer blk)
   }
 
 instance (forall a. Semigroup (f a))
@@ -86,6 +88,7 @@ instance (forall a. Semigroup (f a))
       , keepAliveClientTracer         = f keepAliveClientTracer
       , consensusErrorTracer          = f consensusErrorTracer
       , gsmTracer                     = f gsmTracer
+      , gddTracer                     = f gddTracer
       }
     where
       f :: forall a. Semigroup a
@@ -115,6 +118,7 @@ nullTracers = Tracers
     , keepAliveClientTracer         = nullTracer
     , consensusErrorTracer          = nullTracer
     , gsmTracer                     = nullTracer
+    , gddTracer                     = nullTracer
     }
 
 showTracers :: ( Show blk
@@ -147,6 +151,7 @@ showTracers tr = Tracers
     , keepAliveClientTracer         = showTracing tr
     , consensusErrorTracer          = showTracing tr
     , gsmTracer                     = showTracing tr
+    , gddTracer                     = showTracing tr
     }
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus-diffusion/src/unstable-diffusion-testlib/Test/ThreadNet/Network.hs
+++ b/ouroboros-consensus-diffusion/src/unstable-diffusion-testlib/Test/ThreadNet/Network.hs
@@ -74,7 +74,7 @@ import qualified Ouroboros.Consensus.MiniProtocol.ChainSync.Client as CSClient
 import qualified Ouroboros.Consensus.MiniProtocol.ChainSync.Client.InFutureCheck as InFutureCheck
 import qualified Ouroboros.Consensus.Network.NodeToNode as NTN
 import           Ouroboros.Consensus.Node.ExitPolicy
-import           Ouroboros.Consensus.Node.Genesis (GenesisSwitch (..))
+import           Ouroboros.Consensus.Node.Genesis
 import qualified Ouroboros.Consensus.Node.GSM as GSM
 import           Ouroboros.Consensus.Node.InitStorage
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion
@@ -1034,7 +1034,9 @@ runThreadNetwork systemTime ThreadNetworkArgs
                 }
             , getUseBootstrapPeers = pure DontUseBootstrapPeers
             , publicPeerSelectionStateVar
-            , genesisArgs          = GenesisDisabled
+            , genesisArgs          = GenesisNodeKernelArgs {
+                  gnkaGetLoEFragment = LoEAndGDDDisabled
+                }
             }
 
       nodeKernel <- initNodeKernel nodeKernelArgs

--- a/ouroboros-consensus-diffusion/src/unstable-diffusion-testlib/Test/ThreadNet/Network.hs
+++ b/ouroboros-consensus-diffusion/src/unstable-diffusion-testlib/Test/ThreadNet/Network.hs
@@ -74,6 +74,7 @@ import qualified Ouroboros.Consensus.MiniProtocol.ChainSync.Client as CSClient
 import qualified Ouroboros.Consensus.MiniProtocol.ChainSync.Client.InFutureCheck as InFutureCheck
 import qualified Ouroboros.Consensus.Network.NodeToNode as NTN
 import           Ouroboros.Consensus.Node.ExitPolicy
+import           Ouroboros.Consensus.Node.Genesis (GenesisSwitch (..))
 import qualified Ouroboros.Consensus.Node.GSM as GSM
 import           Ouroboros.Consensus.Node.InitStorage
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion
@@ -1033,6 +1034,7 @@ runThreadNetwork systemTime ThreadNetworkArgs
                 }
             , getUseBootstrapPeers = pure DontUseBootstrapPeers
             , publicPeerSelectionStateVar
+            , genesisArgs          = GenesisDisabled
             }
 
       nodeKernel <- initNodeKernel nodeKernelArgs

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup.hs
@@ -59,7 +59,7 @@ runGenesisTest schedulerConfig genesisTest =
     (recordingTracer, getTrace) <- recordingTracerM
     let tracer = if scDebug schedulerConfig then debugTracer else recordingTracer
 
-    traceLinesWith tracer $ prettyGenesisTest prettyPeersSchedule genesisTest
+    traceLinesWith tracer $ prettyGenesisTest prettyPointSchedule genesisTest
 
     rgtrStateView <- runPointSchedule schedulerConfig genesisTest =<< tracerTestBlock tracer
     traceWith tracer (condense rgtrStateView)

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup/Classifiers.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup/Classifiers.hs
@@ -164,7 +164,7 @@ resultClassifiers GenesisTest{gtSchedule} RunGenesisTestResult{rgtrStateView} =
     StateView{svPeerSimulatorResults} = rgtrStateView
 
     adversaries :: [PeerId]
-    adversaries = fmap AdversarialPeer $ Map.keys $ adversarialPeers gtSchedule
+    adversaries = fmap AdversarialPeer $ Map.keys $ adversarialPeers $ unPointSchedule gtSchedule
 
     adversariesCount = fromIntegral $ length adversaries
 
@@ -248,19 +248,19 @@ scheduleClassifiers GenesisTest{gtSchedule = schedule} =
           peerSch
 
     rollbacks :: Peers Bool
-    rollbacks = hasRollback <$> schedule
+    rollbacks = hasRollback <$> unPointSchedule schedule
 
     adversaryRollback = any id $ adversarialPeers rollbacks
     honestRollback = any id $ honestPeers rollbacks
 
-    allAdversariesEmpty = all id $ adversarialPeers $ null <$> schedule
+    allAdversariesEmpty = all id $ adversarialPeers $ null <$> unPointSchedule schedule
 
     isTrivial :: PeerSchedule TestBlock -> Bool
     isTrivial = \case
       []             -> True
       (t0, _):points -> all ((== t0) . fst) points
 
-    allAdversariesTrivial = all id $ adversarialPeers $ isTrivial <$> schedule
+    allAdversariesTrivial = all id $ adversarialPeers $ isTrivial <$> unPointSchedule schedule
 
 simpleHash ::
   HeaderHash block ~ TestHash =>

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup/Classifiers.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup/Classifiers.hs
@@ -164,7 +164,7 @@ resultClassifiers GenesisTest{gtSchedule} RunGenesisTestResult{rgtrStateView} =
     StateView{svPeerSimulatorResults} = rgtrStateView
 
     adversaries :: [PeerId]
-    adversaries = fmap AdversarialPeer $ Map.keys $ adversarialPeers $ unPointSchedule gtSchedule
+    adversaries = fmap AdversarialPeer $ Map.keys $ adversarialPeers $ psSchedule gtSchedule
 
     adversariesCount = fromIntegral $ length adversaries
 
@@ -248,19 +248,19 @@ scheduleClassifiers GenesisTest{gtSchedule = schedule} =
           peerSch
 
     rollbacks :: Peers Bool
-    rollbacks = hasRollback <$> unPointSchedule schedule
+    rollbacks = hasRollback <$> psSchedule schedule
 
     adversaryRollback = any id $ adversarialPeers rollbacks
     honestRollback = any id $ honestPeers rollbacks
 
-    allAdversariesEmpty = all id $ adversarialPeers $ null <$> unPointSchedule schedule
+    allAdversariesEmpty = all id $ adversarialPeers $ null <$> psSchedule schedule
 
     isTrivial :: PeerSchedule TestBlock -> Bool
     isTrivial = \case
       []             -> True
       (t0, _):points -> all ((== t0) . fst) points
 
-    allAdversariesTrivial = all id $ adversarialPeers $ isTrivial <$> unPointSchedule schedule
+    allAdversariesTrivial = all id $ adversarialPeers $ isTrivial <$> psSchedule schedule
 
 simpleHash ::
   HeaderHash block ~ TestHash =>

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup/Classifiers.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup/Classifiers.hs
@@ -38,8 +38,7 @@ import           Test.Consensus.Network.AnchoredFragment.Extras (slotLength)
 import           Test.Consensus.PeerSimulator.StateView
                      (PeerSimulatorResult (..), StateView (..), pscrToException)
 import           Test.Consensus.PointSchedule
-import           Test.Consensus.PointSchedule.Peers (Peer (..), PeerId (..),
-                     Peers (..))
+import           Test.Consensus.PointSchedule.Peers (PeerId (..), Peers (..))
 import           Test.Consensus.PointSchedule.SinglePeer (SchedulePoint (..))
 import           Test.Util.Orphans.IOLike ()
 import           Test.Util.TestBlock (TestBlock, TestHash (TestHash),
@@ -165,15 +164,15 @@ resultClassifiers GenesisTest{gtSchedule} RunGenesisTestResult{rgtrStateView} =
     StateView{svPeerSimulatorResults} = rgtrStateView
 
     adversaries :: [PeerId]
-    adversaries = Map.keys $ others gtSchedule
+    adversaries = fmap AdversarialPeer $ Map.keys $ adversarialPeers gtSchedule
 
     adversariesCount = fromIntegral $ length adversaries
 
     adversariesExceptions :: [(PeerId, SomeException)]
     adversariesExceptions = mapMaybe
       (\PeerSimulatorResult{psePeerId, pseResult} -> case psePeerId of
-        HonestPeer -> Nothing
-        pid        -> (pid,) <$> pscrToException pseResult
+        HonestPeer _ -> Nothing
+        pid          -> (pid,) <$> pscrToException pseResult
       )
       svPeerSimulatorResults
 
@@ -251,18 +250,17 @@ scheduleClassifiers GenesisTest{gtSchedule = schedule} =
     rollbacks :: Peers Bool
     rollbacks = hasRollback <$> schedule
 
-    adversaryRollback = any value $ others rollbacks
+    adversaryRollback = any id $ adversarialPeers rollbacks
+    honestRollback = any id $ honestPeers rollbacks
 
-    honestRollback = value $ honest rollbacks
-
-    allAdversariesEmpty = all value $ others $ null <$> schedule
+    allAdversariesEmpty = all id $ adversarialPeers $ null <$> schedule
 
     isTrivial :: PeerSchedule TestBlock -> Bool
     isTrivial = \case
       []             -> True
       (t0, _):points -> all ((== t0) . fst) points
 
-    allAdversariesTrivial = all value $ others $ isTrivial <$> schedule
+    allAdversariesTrivial = all id $ adversarialPeers $ isTrivial <$> schedule
 
 simpleHash ::
   HeaderHash block ~ TestHash =>

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup/GenChains.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup/GenChains.hs
@@ -8,6 +8,7 @@
 module Test.Consensus.Genesis.Setup.GenChains (
     GenesisTest (..)
   , genChains
+  , genChainsWithExtraHonestPeers
   ) where
 
 import           Cardano.Slotting.Time (SlotLength, getSlotLength,
@@ -94,6 +95,9 @@ genAlternativeChainSchema (testRecipeH, arHonest) =
         let H.ChainSchema _ v = A.uniformAdversarialChain (Just alternativeAsc) testRecipeA'' seed
         pure $ Just (prefixCount, Vector.toList (getVector v))
 
+genChains :: QC.Gen Word -> QC.Gen (GenesisTest TestBlock ())
+genChains  = genChainsWithExtraHonestPeers (pure 0)
+
 -- | Random generator for a block tree. The block tree contains one trunk (the
 -- “honest” chain) and as many branches as given as a parameter (the
 -- “alternative” chains or “bad” chains). For instance, one such tree could be
@@ -103,8 +107,10 @@ genAlternativeChainSchema (testRecipeH, arHonest) =
 --     trunk: O─────1──2──3──4─────5──6──7
 --                     │           ╰─────6
 --                     ╰─────3──4─────5
-genChains :: QC.Gen Word -> QC.Gen (GenesisTest TestBlock ())
-genChains genNumForks = do
+-- For now, the @extraHonestPeers@ generator is only used to fill the GenesisTest field.
+-- However, in the future it could also be used to generate "short forks" near the tip of the trunk.
+genChainsWithExtraHonestPeers :: QC.Gen Word -> QC.Gen Word -> QC.Gen (GenesisTest TestBlock ())
+genChainsWithExtraHonestPeers genNumExtraHonest genNumForks = do
   (asc, honestRecipe, someHonestChainSchema) <- genHonestChainSchema
 
   H.SomeHonestChainSchema _ _ honestChainSchema <- pure someHonestChainSchema
@@ -116,6 +122,7 @@ genChains genNumForks = do
       HonestRecipe (Kcp kcp) (Scg scg) delta _len = honestRecipe
 
   numForks <- genNumForks
+  gtExtraHonestPeers <- genNumExtraHonest
   alternativeChainSchemas <- replicateM (fromIntegral numForks) (genAlternativeChainSchema (honestRecipe, honestChainSchema))
   pure $ GenesisTest {
     gtSecurityParam = SecurityParam (fromIntegral kcp),
@@ -131,6 +138,7 @@ genChains genNumForks = do
     -- would make for interesting tests.
     gtCSJParams = CSJParams $ fromIntegral scg,
     gtBlockTree = foldl' (flip BT.addBranch') (BT.mkTrunk goodChain) $ zipWith (genAdversarialFragment goodBlocks) [1..] alternativeChainSchemas,
+    gtExtraHonestPeers,
     gtSchedule = ()
     }
 

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/CSJ.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/CSJ.hs
@@ -22,6 +22,7 @@ import           Test.Consensus.PeerSimulator.Trace (TraceEvent (..))
 import           Test.Consensus.PointSchedule
 import qualified Test.Consensus.PointSchedule.Peers as Peers
 import           Test.Consensus.PointSchedule.Peers (Peers (..), peers')
+import           Test.Consensus.PointSchedule.Shrinking (shrinkPeerSchedules)
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
 import           Test.Util.Orphans.IOLike ()
@@ -88,11 +89,7 @@ prop_CSJ happy synchronized =
       , scEnableLoP = True
       }
     )
-    ( -- NOTE: Shrinking makes the tests fail because the peers reject jumps
-      -- because their TP is G. This makes them into objectors and they then
-      -- start serving headers.
-      \_ _ -> []
-    )
+    shrinkPeerSchedules
     ( \gt StateView{svTrace} ->
         let
           -- The list of 'TraceDownloadedHeader' events that are not newer than

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/CSJ.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/CSJ.hs
@@ -124,17 +124,19 @@ prop_CSJ happy synchronized =
           receivedHeadersAtMostOnceFromHonestPeers
     )
   where
-    genDuplicatedHonestSchedule :: GenesisTest TestBlock () -> Gen (PeersSchedule TestBlock)
+    genDuplicatedHonestSchedule :: GenesisTest TestBlock () -> Gen (PointSchedule TestBlock)
     genDuplicatedHonestSchedule gt@GenesisTest {gtExtraHonestPeers} = do
-      Peers {honestPeers, adversarialPeers} <- genUniformSchedulePoints gt
-      pure $
-        Peers.unionWithKey
-          (\_ _ _ -> error "should not happen")
-          ( peers'
-              (replicate (fromIntegral gtExtraHonestPeers + 1) (getHonestPeer honestPeers))
-              []
-          )
-          (Peers Map.empty adversarialPeers)
+      ps@PointSchedule {unPointSchedule = Peers {honestPeers, adversarialPeers}} <- genUniformSchedulePoints gt
+      pure $ ps {
+        unPointSchedule =
+          Peers.unionWithKey
+            (\_ _ _ -> error "should not happen")
+            ( peers'
+                (replicate (fromIntegral gtExtraHonestPeers + 1) (getHonestPeer honestPeers))
+                []
+            )
+            (Peers Map.empty adversarialPeers)
+        }
 
     isNewerThanJumpSizeFromTip :: GenesisTestFull TestBlock -> Header TestBlock -> Bool
     isNewerThanJumpSizeFromTip gt hdr =

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/CSJ.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/CSJ.hs
@@ -126,9 +126,9 @@ prop_CSJ happy synchronized =
   where
     genDuplicatedHonestSchedule :: GenesisTest TestBlock () -> Gen (PointSchedule TestBlock)
     genDuplicatedHonestSchedule gt@GenesisTest {gtExtraHonestPeers} = do
-      ps@PointSchedule {unPointSchedule = Peers {honestPeers, adversarialPeers}} <- genUniformSchedulePoints gt
+      ps@PointSchedule {psSchedule = Peers {honestPeers, adversarialPeers}} <- genUniformSchedulePoints gt
       pure $ ps {
-        unPointSchedule =
+        psSchedule =
           Peers.unionWithKey
             (\_ _ _ -> error "should not happen")
             ( peers'

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/CSJ.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/CSJ.hs
@@ -3,10 +3,10 @@
 
 module Test.Consensus.Genesis.Tests.CSJ (tests) where
 
-import           Data.Containers.ListUtils (nubOrd)
 import           Data.List (nub)
+import qualified Data.Map.Strict as Map
 import           Data.Maybe (mapMaybe)
-import           Ouroboros.Consensus.Block (blockSlot, succWithOrigin)
+import           Ouroboros.Consensus.Block (Header, blockSlot, succWithOrigin)
 import           Ouroboros.Consensus.MiniProtocol.ChainSync.Client
                      (TraceChainSyncClientEvent (..))
 import           Ouroboros.Consensus.Util.Condense (PaddingDirection (..),
@@ -20,52 +20,67 @@ import           Test.Consensus.PeerSimulator.Run (SchedulerConfig (..),
 import           Test.Consensus.PeerSimulator.StateView (StateView (..))
 import           Test.Consensus.PeerSimulator.Trace (TraceEvent (..))
 import           Test.Consensus.PointSchedule
+import qualified Test.Consensus.PointSchedule.Peers as Peers
 import           Test.Consensus.PointSchedule.Peers (Peers (..), peers')
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
 import           Test.Util.Orphans.IOLike ()
 import           Test.Util.PartialAccessors
-import           Test.Util.TestBlock (Header, TestBlock)
+import           Test.Util.TestBlock (TestBlock)
 import           Test.Util.TestEnv (adjustQuickCheckMaxSize)
 
 tests :: TestTree
 tests =
   adjustQuickCheckMaxSize (`div` 5) $
-  testGroup
-    "CSJ"
-    [ testGroup "Happy Path"
-      [ testProperty "synchronous" $ prop_happyPath True
-      , testProperty "asynchronous" $ prop_happyPath False
+    testGroup
+      "CSJ"
+      [ testGroup
+          "Happy Path"
+          [ testProperty "honest peers are synchronised" $ prop_CSJ True True,
+            testProperty "honest peers do their own thing" $ prop_CSJ True False
+          ],
+        testGroup
+          "With some adversaries"
+          [ testProperty "honest peers are synchronised" $ prop_CSJ False True,
+            testProperty "honest peers do their own thing" $ prop_CSJ False False
+          ]
       ]
-    ]
 
--- | Test of the “happy path” scenario of ChainSync Jumping (CSJ).
+-- | Test of ChainSync Jumping (CSJ).
 --
--- This test features one chain (ie. a block tree that is only trunk) and only
--- honest peers and syncs the chain in question with CSJ enabled. What we expect
--- to observe is that one of the honest peers becomes the dynamo while the
--- others become jumpers. Because the jumpers will agree to all the jumps, the
--- whole syncing should happen with CSJ without objectors.
+-- This test features several peers the all sync the “honest” chain (ie. the
+-- trunk of the block tree) with CSJ enabled. What we expect to observe is that
+-- one of the honest peers becomes the dynamo while the others become jumpers.
+-- Because the jumpers will agree to all the jumps, the whole syncing should
+-- happen with CSJ.
 --
--- The final property is that headers should only ever be downloaded once and
--- only from one peer (the dynamo). This is true except when almost caught-up:
--- when the dynamo is caught-up, it gets disengaged and one of the jumpers takes
--- its place and starts serving headers. This might lead to duplication of
--- headers, but only in a window of @jumpSize@ slots near the tip of the chain.
+-- There are two variants of this test: the “happy path” variant features no
+-- adversaries. As such, everything should happen with one dynamo and no
+-- objector. Another variant adds adversaries, so we expect to see some
+-- dynamo-vs-objector action.
 --
--- The boolean differentiates between “synchronous” and “asynchronous”
--- scenarios. In a synchronous scenario, all the honest peers have the same
--- schedule: they serve the chain exactly in the same way. In the asynchronous
--- scenario, a random schedule is generated for each peer (but they still serve
--- the same chain).
-prop_happyPath :: Bool -> Property
-prop_happyPath synchronized =
+-- Regardless, the final property is that “honest” headers should only ever be
+-- downloaded at most once from honest peers. They may however be downloaded
+-- several times from adversaries. This is true except when almost caught-up:
+-- when the dynamo or objector is caught-up, it gets disengaged and one of the
+-- jumpers takes its place and starts serving headers. This might lead to
+-- duplication of headers, but only in a window of @jumpSize@ slots near the tip
+-- of the chain.
+--
+-- The first boolean differentiates between the “happy path” variant and the
+-- variant with adversaries; the second boolean differentiates between
+-- “synchronous” and “asynchronous” scenarios. In a synchronous scenario, all
+-- the honest peers have the same schedule: they serve the chain exactly in the
+-- same way. In the asynchronous scenario, a random schedule is generated for
+-- each peer (but they still serve the same chain).
+prop_CSJ :: Bool -> Bool -> Property
+prop_CSJ happy synchronized =
   forAllGenesisTest
     ( if synchronized
-        then genChainsWithExtraHonestPeers (choose (2, 4)) (pure 0)
-          `enrichedWith` genUniformSchedulePoints
-        else genChains (pure 0)
+        then genChains (if happy then pure 0 else choose (2, 4))
           `enrichedWith` genDuplicatedHonestSchedule
+        else genChainsWithExtraHonestPeers (choose (2, 4)) (if happy then pure 0 else choose (2, 4))
+          `enrichedWith` genUniformSchedulePoints
     )
     ( defaultSchedulerConfig
       { scEnableCSJ = True
@@ -83,43 +98,46 @@ prop_happyPath synchronized =
           -- The list of 'TraceDownloadedHeader' events that are not newer than
           -- jumpSize from the tip of the chain. These are the ones that we
           -- expect to see only once per header if CSJ works properly.
-          headerDownloadEvents =
+          headerHonestDownloadEvents =
             mapMaybe
               (\case
                 TraceChainSyncClientEvent pid (TraceDownloadedHeader hdr)
                   | not (isNewerThanJumpSizeFromTip gt hdr)
+                  , Peers.HonestPeer _ <- pid
                   -> Just (pid, hdr)
                 _ -> Nothing
               )
               svTrace
-          receivedHeadersOnlyOnce = length (nub $ snd <$> headerDownloadEvents) == length headerDownloadEvents
-          -- NOTE: If all the headers are newer than jumpSize from the tip, then
-          -- 'headerDownloadEvents' is empty and the following condition would
-          -- violated if we used @==@.
-          receivedHeadersFromOnlyOnePeer = length (nubOrd $ fst <$> headerDownloadEvents) <= 1
+          receivedHeadersAtMostOnceFromHonestPeers =
+            length (nub $ snd <$> headerHonestDownloadEvents) == length headerHonestDownloadEvents
         in
           tabulate ""
-            [ if headerDownloadEvents == []
-                then "All headers may be downloaded twice (uninteresting test)"
+            [ if headerHonestDownloadEvents == []
+                then "All headers are within the last jump window"
                 else "There exist headers that have to be downloaded exactly once"
             ] $
           counterexample
           ("Downloaded headers (except jumpSize slots near the tip):\n" ++
             ( unlines $ fmap ("  " ++) $ zipWith
               (\peer header -> peer ++ " | " ++ header)
-              (condenseListWithPadding PadRight $ fst <$> headerDownloadEvents)
-              (condenseListWithPadding PadRight $ snd <$> headerDownloadEvents)
+              (condenseListWithPadding PadRight $ fst <$> headerHonestDownloadEvents)
+              (condenseListWithPadding PadRight $ snd <$> headerHonestDownloadEvents)
             )
           )
-          (receivedHeadersOnlyOnce && receivedHeadersFromOnlyOnePeer)
+          receivedHeadersAtMostOnceFromHonestPeers
     )
   where
     genDuplicatedHonestSchedule :: GenesisTest TestBlock () -> Gen (PeersSchedule TestBlock)
-    genDuplicatedHonestSchedule gt@GenesisTest{gtExtraHonestPeers} = do
-      Peers {honestPeers} <- genUniformSchedulePoints gt
-      pure $ peers'
-        (replicate (fromIntegral gtExtraHonestPeers + 1) (getHonestPeer honestPeers))
-        []
+    genDuplicatedHonestSchedule gt@GenesisTest {gtExtraHonestPeers} = do
+      Peers {honestPeers, adversarialPeers} <- genUniformSchedulePoints gt
+      pure $
+        Peers.unionWithKey
+          (\_ _ _ -> error "should not happen")
+          ( peers'
+              (replicate (fromIntegral gtExtraHonestPeers + 1) (getHonestPeer honestPeers))
+              []
+          )
+          (Peers Map.empty adversarialPeers)
 
     isNewerThanJumpSizeFromTip :: GenesisTestFull TestBlock -> Header TestBlock -> Bool
     isNewerThanJumpSizeFromTip gt hdr =

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/DensityDisconnect.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/DensityDisconnect.hs
@@ -471,7 +471,7 @@ prop_densityDisconnectTriggersChainSel =
 
     ( \GenesisTest {gtBlockTree, gtSchedule} stateView@StateView {svTipBlock} ->
         let
-          othersCount = Map.size (adversarialPeers gtSchedule)
+          othersCount = Map.size (adversarialPeers $ unPointSchedule gtSchedule)
           exnCorrect = case exceptionsByComponent ChainSyncClient stateView of
             [fromException -> Just DensityTooLow] -> True
             []                 | othersCount == 0 -> True
@@ -490,7 +490,7 @@ prop_densityDisconnectTriggersChainSel =
     --    which should allow the GDD to realize that the chain
     --    is not dense enough, and that the whole of the honest
     --    chain should be selected.
-    lowDensitySchedule :: HasHeader blk => BlockTree blk -> Peers (PeerSchedule blk)
+    lowDensitySchedule :: HasHeader blk => BlockTree blk -> PointSchedule blk
     lowDensitySchedule tree =
       let trunkTip = getTrunkTip tree
           branch = getOnlyBranch tree
@@ -498,7 +498,7 @@ prop_densityDisconnectTriggersChainSel =
             (AF.Empty _)       -> Origin
             (_ AF.:> tipBlock) -> At tipBlock
           advTip = getOnlyBranchTip tree
-       in peers'
+       in PointSchedule $ peers'
             -- Eagerly serve the honest tree, but after the adversary has
             -- advertised its chain up to the intersection.
             [[(Time 0, scheduleTipPoint trunkTip),

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/DensityDisconnect.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/DensityDisconnect.hs
@@ -498,7 +498,8 @@ prop_densityDisconnectTriggersChainSel =
             (AF.Empty _)       -> Origin
             (_ AF.:> tipBlock) -> At tipBlock
           advTip = getOnlyBranchTip tree
-       in mkPointSchedule $ peers'
+       in PointSchedule {
+            psSchedule = peers'
             -- Eagerly serve the honest tree, but after the adversary has
             -- advertised its chain up to the intersection.
             [[(Time 0, scheduleTipPoint trunkTip),
@@ -513,4 +514,7 @@ prop_densityDisconnectTriggersChainSel =
               (Time 0, ScheduleBlockPoint intersect),
               (Time 1, scheduleHeaderPoint advTip),
               (Time 1, scheduleBlockPoint advTip)
-            ]]
+            ]],
+            psStartOrder = [],
+            psMinEndTime = Time 0
+          }

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/DensityDisconnect.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/DensityDisconnect.hs
@@ -86,7 +86,7 @@ data StaticCandidates =
   StaticCandidates {
     k        :: SecurityParam,
     sgen     :: GenesisWindow,
-    suffixes :: Map PeerId (AnchoredFragment (Header TestBlock)),
+    suffixes :: [(PeerId, AnchoredFragment (Header TestBlock))],
     tips     :: Map PeerId (Tip TestBlock),
     loeFrag  :: AnchoredFragment (Header TestBlock)
   }
@@ -111,17 +111,17 @@ staticCandidates GenesisTest {gtSecurityParam, gtGenesisWindow, gtBlockTree} =
       }
       where
         (loeFrag, suffixes) =
-          sharedCandidatePrefix curChain (toHeaders <$> candidates)
+          sharedCandidatePrefix curChain (second toHeaders <$> candidates)
 
     selections = selection <$> branches
 
     selection branch =
       AF.takeOldest (AF.length (btbPrefix branch) + fromIntegral (maxRollbacks gtSecurityParam)) (btbFull branch)
 
-    tips = branchTip <$> candidates
+    tips = branchTip <$> Map.fromList candidates
 
-    candidates :: Map PeerId (AnchoredFragment TestBlock)
-    candidates = Map.fromList (zip (HonestPeer 1 : enumerateAdversaries) chains)
+    candidates :: [(PeerId, AnchoredFragment TestBlock)]
+    candidates = zip (HonestPeer 1 : enumerateAdversaries) chains
 
     chains = btTrunk gtBlockTree : (btbFull <$> branches)
 
@@ -132,7 +132,7 @@ staticCandidates GenesisTest {gtSecurityParam, gtGenesisWindow, gtBlockTree} =
 prop_densityDisconnectStatic :: Property
 prop_densityDisconnectStatic =
   forAll gen $ \ StaticCandidates {k, sgen, suffixes, loeFrag} -> do
-    let (disconnect, _) = densityDisconnect sgen k (mkState <$> suffixes) suffixes loeFrag
+    let (disconnect, _) = densityDisconnect sgen k (mkState <$> Map.fromList suffixes) suffixes loeFrag
     counterexample "it should disconnect some node" (not (null disconnect))
       .&&.
      counterexample "it should not disconnect the honest peers"
@@ -223,7 +223,7 @@ data UpdateEvent = UpdateEvent {
     -- | Peers that have been disconnected in the current step
   , killed   :: Set PeerId
     -- | The GDD data
-  , bounds   :: Map PeerId (DensityBounds TestBlock)
+  , bounds   :: [(PeerId, DensityBounds TestBlock)]
     -- | The current chains
   , tree     :: BlockTree (Header TestBlock)
   , loeFrag  :: AnchoredFragment (Header TestBlock)
@@ -381,7 +381,7 @@ evolveBranches EvolvingPeers {k, sgen, peers = initialPeers, fullTree} =
               csLatestSlot = Just (AF.headSlot csCandidate)
             }
         -- Run GDD.
-        (loeFrag, suffixes) = sharedCandidatePrefix curChain candidates
+        (loeFrag, suffixes) = sharedCandidatePrefix curChain (Map.toList candidates)
         (killedNow, bounds) = first Set.fromList $ densityDisconnect sgen k states suffixes loeFrag
         event = UpdateEvent {
           target,

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/DensityDisconnect.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/DensityDisconnect.hs
@@ -471,7 +471,7 @@ prop_densityDisconnectTriggersChainSel =
 
     ( \GenesisTest {gtBlockTree, gtSchedule} stateView@StateView {svTipBlock} ->
         let
-          othersCount = Map.size (adversarialPeers $ unPointSchedule gtSchedule)
+          othersCount = Map.size (adversarialPeers $ psSchedule gtSchedule)
           exnCorrect = case exceptionsByComponent ChainSyncClient stateView of
             [fromException -> Just DensityTooLow] -> True
             []                 | othersCount == 0 -> True
@@ -498,7 +498,7 @@ prop_densityDisconnectTriggersChainSel =
             (AF.Empty _)       -> Origin
             (_ AF.:> tipBlock) -> At tipBlock
           advTip = getOnlyBranchTip tree
-       in PointSchedule $ peers'
+       in mkPointSchedule $ peers'
             -- Eagerly serve the honest tree, but after the adversary has
             -- advertised its chain up to the intersection.
             [[(Time 0, scheduleTipPoint trunkTip),

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LoE.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LoE.hs
@@ -88,7 +88,7 @@ prop_adversaryHitsTimeouts timeoutsEnabled =
             (AF.Empty _)       -> Nothing
             (_ AF.:> tipBlock) -> Just tipBlock
           branchTip = getOnlyBranchTip tree
-       in PointSchedule $ peers'
+          psSchedule = peers'
             -- Eagerly serve the honest tree, but after the adversary has
             -- advertised its chain.
             [ (Time 0, scheduleTipPoint trunkTip) : case intersectM of
@@ -107,11 +107,13 @@ prop_adversaryHitsTimeouts timeoutsEnabled =
             -- intersection early, then waits more than the short wait timeout.
             [ (Time 0, scheduleTipPoint branchTip) : case intersectM of
                 -- the alternate branch forks from `Origin`
-                Nothing -> [(Time 11, scheduleTipPoint branchTip)]
+                Nothing -> []
                 -- the alternate branch forks from `intersect`
                 Just intersect ->
                   [ (Time 0, scheduleHeaderPoint intersect),
-                    (Time 0, scheduleBlockPoint intersect),
-                    (Time 11, scheduleBlockPoint intersect)
+                    (Time 0, scheduleBlockPoint intersect)
                   ]
             ]
+          -- We want to wait more than the short wait timeout
+          psMinEndTime = Time 11
+       in PointSchedule {psSchedule, psMinEndTime}

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LoE.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LoE.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DerivingStrategies  #-}
 {-# LANGUAGE NamedFieldPuns      #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications    #-}
 {-# LANGUAGE ViewPatterns        #-}
 
 module Test.Consensus.Genesis.Tests.LoE (tests) where
@@ -116,4 +115,4 @@ prop_adversaryHitsTimeouts timeoutsEnabled =
             ]
           -- We want to wait more than the short wait timeout
           psMinEndTime = Time 11
-       in PointSchedule {psSchedule, psMinEndTime}
+       in PointSchedule {psSchedule, psStartOrder = [], psMinEndTime}

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LoE.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LoE.hs
@@ -19,13 +19,14 @@ import           Test.Consensus.PeerSimulator.Run (SchedulerConfig (..),
                      defaultSchedulerConfig)
 import           Test.Consensus.PeerSimulator.StateView
 import           Test.Consensus.PointSchedule
-import           Test.Consensus.PointSchedule.Peers (Peers, mkPeers)
+import           Test.Consensus.PointSchedule.Peers (Peers, peers')
 import           Test.Consensus.PointSchedule.Shrinking (shrinkPeerSchedules)
 import           Test.Consensus.PointSchedule.SinglePeer (scheduleBlockPoint,
                      scheduleHeaderPoint, scheduleTipPoint)
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
 import           Test.Util.Orphans.IOLike ()
+import           Test.Util.PartialAccessors
 import           Test.Util.TestEnv (adjustQuickCheckTests)
 
 tests :: TestTree
@@ -76,27 +77,18 @@ prop_adversaryHitsTimeouts timeoutsEnabled =
            in selectedCorrect && exceptionsCorrect
       )
   where
-    getOnlyBranch :: BlockTree blk -> BlockTreeBranch blk
-    getOnlyBranch BlockTree {btBranches} = case btBranches of
-      [branch] -> branch
-      _        -> error "tree must have exactly one alternate branch"
-
     delaySchedule :: HasHeader blk => BlockTree blk -> Peers (PeerSchedule blk)
     delaySchedule tree =
-      let trunkTip = case btTrunk tree of
-            (AF.Empty _)       -> error "tree must have at least one block"
-            (_ AF.:> tipBlock) -> tipBlock
+      let trunkTip = getTrunkTip tree
           branch = getOnlyBranch tree
           intersectM = case btbPrefix branch of
             (AF.Empty _)       -> Nothing
             (_ AF.:> tipBlock) -> Just tipBlock
-          branchTip = case btbFull branch of
-            (AF.Empty _) -> error "alternate branch must have at least one block"
-            (_ AF.:> tipBlock) -> tipBlock
-       in mkPeers
+          branchTip = getOnlyBranchTip tree
+       in peers'
             -- Eagerly serve the honest tree, but after the adversary has
             -- advertised its chain.
-            ( (Time 0, scheduleTipPoint trunkTip) : case intersectM of
+            [ (Time 0, scheduleTipPoint trunkTip) : case intersectM of
                 Nothing ->
                   [ (Time 0.5, scheduleHeaderPoint trunkTip),
                     (Time 0.5, scheduleBlockPoint trunkTip)
@@ -107,7 +99,7 @@ prop_adversaryHitsTimeouts timeoutsEnabled =
                     (Time 5, scheduleHeaderPoint trunkTip),
                     (Time 5, scheduleBlockPoint trunkTip)
                   ]
-            )
+            ]
             -- The one adversarial peer advertises and serves up to the
             -- intersection early, then waits more than the short wait timeout.
             [ (Time 0, scheduleTipPoint branchTip) : case intersectM of

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LoE.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LoE.hs
@@ -19,7 +19,7 @@ import           Test.Consensus.PeerSimulator.Run (SchedulerConfig (..),
                      defaultSchedulerConfig)
 import           Test.Consensus.PeerSimulator.StateView
 import           Test.Consensus.PointSchedule
-import           Test.Consensus.PointSchedule.Peers (Peers, peers')
+import           Test.Consensus.PointSchedule.Peers (peers')
 import           Test.Consensus.PointSchedule.Shrinking (shrinkPeerSchedules)
 import           Test.Consensus.PointSchedule.SinglePeer (scheduleBlockPoint,
                      scheduleHeaderPoint, scheduleTipPoint)
@@ -80,7 +80,7 @@ prop_adversaryHitsTimeouts timeoutsEnabled =
            in selectedCorrect && exceptionsCorrect
       )
   where
-    delaySchedule :: HasHeader blk => BlockTree blk -> Peers (PeerSchedule blk)
+    delaySchedule :: HasHeader blk => BlockTree blk -> PointSchedule blk
     delaySchedule tree =
       let trunkTip = getTrunkTip tree
           branch = getOnlyBranch tree
@@ -88,7 +88,7 @@ prop_adversaryHitsTimeouts timeoutsEnabled =
             (AF.Empty _)       -> Nothing
             (_ AF.:> tipBlock) -> Just tipBlock
           branchTip = getOnlyBranchTip tree
-       in peers'
+       in PointSchedule $ peers'
             -- Eagerly serve the honest tree, but after the adversary has
             -- advertised its chain.
             [ (Time 0, scheduleTipPoint trunkTip) : case intersectM of

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LoE.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LoE.hs
@@ -45,6 +45,9 @@ tests =
 -- NOTE: Same as 'LoP.prop_delayAttack' with timeouts instead of LoP.
 prop_adversaryHitsTimeouts :: Bool -> Property
 prop_adversaryHitsTimeouts timeoutsEnabled =
+  -- Here we can't shrink because we exploit the properties of the point schedule to wait
+  -- at the end of the test for the adversaries to get disconnected, by adding an extra point.
+  -- If this point gets removed by the shrinker, we lose that property and the test becomes useless.
   noShrinking $
     forAllGenesisTest
       ( do

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LoP.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LoP.hs
@@ -180,6 +180,9 @@ prop_serve mustTimeout =
 -- NOTE: Same as 'LoE.prop_adversaryHitsTimeouts' with LoP instead of timeouts.
 prop_delayAttack :: Bool -> Property
 prop_delayAttack lopEnabled =
+  -- Here we can't shrink because we exploit the properties of the point schedule to wait
+  -- at the end of the test for the adversaries to get disconnected, by adding an extra point.
+  -- If this point gets removed by the shrinker, we lose that property and the test becomes useless.
   noShrinking $
     forAllGenesisTest
       ( do

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
@@ -151,11 +151,19 @@ prop_serveAdversarialBranches = forAllGenesisTest
        , scTrace = False
        , scEnableLoE = True
        , scEnableCSJ = True
+       , scEnableLoP = False
+       , scEnableChainSyncTimeouts = False
+       , scEnableBlockFetchTimeouts = False
        })
 
     -- We cannot shrink by removing points from the adversarial schedules.
-    -- Otherwise, the immutable tip could get stuck because a peer doesn't
-    -- send any blocks or headers.
+    -- Removing ticks could make an adversary unable to serve any blocks or headers.
+    -- Because LoP and timeouts are disabled, this would cause the immutable tip
+    -- to get stuck indefinitely, as the adversary wouldn't get disconnected.
+    --
+    -- We don't enable timeouts in this test and we don't wait long enough for
+    -- timeouts to expire. The leashing attack tests are testing the timeouts
+    -- together with LoP.
     shrinkByRemovingAdversaries
 
     theProperty

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
@@ -288,6 +288,7 @@ prop_leashingAttackTimeLimited =
           advs = fmap (takePointsUntil timeLimit) advs0
       pure $ PointSchedule
         { psSchedule = Peers honests advs
+        , psStartOrder = []
         , psMinEndTime = timeLimit
         }
 

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
@@ -66,11 +66,8 @@ tests =
     -- See Note [Leashing attacks]
     testProperty "stalling leashing attack" prop_leashingAttackStalling,
     testProperty "time limited leashing attack" prop_leashingAttackTimeLimited,
-    adjustQuickCheckTests (`div` 10) $
     testProperty "serve adversarial branches" prop_serveAdversarialBranches,
-    adjustQuickCheckTests (`div` 100) $
     testProperty "the LoE stalls the chain, but the immutable tip is honest" prop_loeStalling,
-    adjustQuickCheckTests (`div` 100) $
     -- This is a crude way of ensuring that we don't get chains with more than 100 blocks,
     -- because this test writes the immutable chain to disk and `instance Binary TestBlock`
     -- chokes on long chains.
@@ -357,10 +354,10 @@ prop_loeStalling =
         pure gt {gtChainSyncTimeouts = chainSyncNoTimeouts {canAwaitTimeout = shortWait}}
     )
 
-    (defaultSchedulerConfig {
+    defaultSchedulerConfig {
       scEnableLoE = True,
-      scEnableChainSyncTimeouts = True
-    })
+      scEnableCSJ = True
+    }
 
     shrinkPeerSchedules
 
@@ -395,8 +392,12 @@ prop_downtime = forAllGenesisTest
     (genChains (QC.choose (1, 4)) `enrichedWith` \ gt ->
       ensureScheduleDuration gt <$> stToGen (uniformPointsWithDowntime (gtSecurityParam gt) (gtBlockTree gt)))
 
-    (defaultSchedulerConfig
-       {scEnableLoE = True, scEnableLoP = True, scDowntime = Just 11})
+    defaultSchedulerConfig
+      { scEnableLoE = True
+      , scEnableLoP = True
+      , scDowntime = Just 11
+      , scEnableCSJ = True
+      }
 
     shrinkPeerSchedules
 

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
@@ -40,8 +40,7 @@ import           Test.Consensus.PeerSimulator.Run (SchedulerConfig (..),
                      defaultSchedulerConfig)
 import           Test.Consensus.PeerSimulator.StateView
 import           Test.Consensus.PointSchedule
-import           Test.Consensus.PointSchedule.Peers (PeerId (..), Peers (..),
-                     value)
+import           Test.Consensus.PointSchedule.Peers (Peers (..), isHonestPeerId)
 import           Test.Consensus.PointSchedule.Shrinking
                      (shrinkByRemovingAdversaries, shrinkPeerSchedules)
 import           Test.Consensus.PointSchedule.SinglePeer
@@ -52,6 +51,7 @@ import           Test.QuickCheck
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
 import           Test.Util.Orphans.IOLike ()
+import           Test.Util.PartialAccessors
 import           Test.Util.QuickCheck (le)
 import           Test.Util.TestBlock (TestBlock)
 import           Test.Util.TestEnv (adjustQuickCheckMaxSize,
@@ -89,13 +89,13 @@ theProperty genesisTest stateView@StateView{svSelectedChain} =
   -- to the governor that the density is too low.
   longerThanGenesisWindow ==>
   conjoin [
-    counterexample "The honest peer was disconnected" (HonestPeer `notElem` disconnected),
+    counterexample "An honest peer was disconnected" (not $ any isHonestPeerId disconnected),
     counterexample ("The immutable tip is not honest: " ++ show immutableTip) $
     property (isHonest immutableTipHash),
     immutableTipIsRecent
   ]
   where
-    advCount = Map.size (others (gtSchedule genesisTest))
+    advCount = Map.size (adversarialPeers (gtSchedule genesisTest))
 
     immutableTipIsRecent =
       counterexample ("Age of the immutable tip: " ++ show immutableTipAge) $
@@ -129,7 +129,7 @@ theProperty genesisTest stateView@StateView{svSelectedChain} =
       [] -> "No peers were disconnected"
       peers -> "Some peers were disconnected: " ++ intercalate ", " (condense <$> peers)
 
-    honestTipSlot = At $ blockSlot $ snd $ last $ mapMaybe fromBlockPoint $ value $ honest $ gtSchedule genesisTest
+    honestTipSlot = At $ blockSlot $ snd $ last $ mapMaybe fromBlockPoint $ getHonestPeer $ honestPeers $ gtSchedule genesisTest
 
     GenesisTest {gtBlockTree, gtGenesisWindow = GenesisWindow s, gtDelay = Delta d} = genesisTest
 
@@ -161,7 +161,12 @@ prop_serveAdversarialBranches = forAllGenesisTest
     theProperty
 
 genUniformSchedulePoints :: GenesisTest TestBlock () -> QC.Gen (PeersSchedule TestBlock)
-genUniformSchedulePoints gt = stToGen (uniformPoints (gtBlockTree gt))
+genUniformSchedulePoints gt = stToGen (uniformPoints pointsGeneratorParams (gtBlockTree gt))
+  where
+    pointsGeneratorParams = PointsGeneratorParams
+      { pgpExtraHonestPeers = fromIntegral $ gtExtraHonestPeers gt
+      , pgpDowntime = NoDowntime
+      }
 
 -- Note [Leashing attacks]
 --
@@ -212,7 +217,7 @@ prop_leashingAttackStalling =
     genLeashingSchedule :: GenesisTest TestBlock () -> QC.Gen (PeersSchedule TestBlock)
     genLeashingSchedule genesisTest = do
       Peers honest advs0 <- ensureScheduleDuration genesisTest <$> genUniformSchedulePoints genesisTest
-      advs <- mapM (mapM dropRandomPoints) advs0
+      advs <- mapM dropRandomPoints advs0
       pure $ Peers honest advs
 
     disableBoringTimeouts gt =
@@ -266,15 +271,15 @@ prop_leashingAttackTimeLimited =
     -- | A schedule which doesn't run past the last event of the honest peer
     genTimeLimitedSchedule :: GenesisTest TestBlock () -> QC.Gen (PeersSchedule TestBlock)
     genTimeLimitedSchedule genesisTest = do
-      Peers honest advs0 <- genUniformSchedulePoints genesisTest
+      Peers honests advs0 <- genUniformSchedulePoints genesisTest
       let timeLimit = estimateTimeBound
             (gtChainSyncTimeouts genesisTest)
             (gtLoPBucketParams genesisTest)
-            (value honest)
-            (map value $ Map.elems advs0)
-          advs = fmap (fmap (takePointsUntil timeLimit)) advs0
-          extendedHonest = extendScheduleUntil timeLimit <$> honest
-      pure $ Peers extendedHonest advs
+            (getHonestPeer honests)
+            (Map.elems advs0)
+          advs = fmap (takePointsUntil timeLimit) advs0
+          extendedHonests = extendScheduleUntil timeLimit <$> honests
+      pure $ Peers extendedHonests advs
 
     takePointsUntil limit = takeWhile ((<= limit) . fst)
 
@@ -390,7 +395,7 @@ prop_downtime :: Property
 prop_downtime = forAllGenesisTest
 
     (genChains (QC.choose (1, 4)) `enrichedWith` \ gt ->
-      ensureScheduleDuration gt <$> stToGen (uniformPointsWithDowntime (gtSecurityParam gt) (gtBlockTree gt)))
+      ensureScheduleDuration gt <$> stToGen (uniformPoints (pointsGeneratorParams gt) (gtBlockTree gt)))
 
     defaultSchedulerConfig
       { scEnableLoE = True
@@ -402,3 +407,9 @@ prop_downtime = forAllGenesisTest
     shrinkPeerSchedules
 
     theProperty
+
+  where
+    pointsGeneratorParams gt = PointsGeneratorParams
+      { pgpExtraHonestPeers = fromIntegral (gtExtraHonestPeers gt)
+      , pgpDowntime = DowntimeWithSecurityParam (gtSecurityParam gt)
+      }

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/CSJInvariants.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/CSJInvariants.hs
@@ -19,7 +19,7 @@ import           Data.Typeable (Typeable)
 import           Ouroboros.Consensus.Block (Point, StandardHash, castPoint)
 import qualified Ouroboros.Consensus.MiniProtocol.ChainSync.Client.State as CSState
 import           Ouroboros.Consensus.Util.IOLike (Exception, MonadSTM (STM),
-                     MonadThrow (throwIO), StrictTVar, readTVar)
+                     MonadThrow (throwIO), readTVar)
 import           Ouroboros.Consensus.Util.STM (Watcher (..))
 
 --------------------------------------------------------------------------------
@@ -109,10 +109,10 @@ readAndView ::
   forall m peer blk.
   ( MonadSTM m
   ) =>
-  StrictTVar m (Map peer (CSState.ChainSyncClientHandle m blk)) ->
+  STM m (Map peer (CSState.ChainSyncClientHandle m blk)) ->
   STM m (View peer blk)
-readAndView handles =
-  traverse (fmap idealiseState . readTVar . CSState.cschJumping) =<< readTVar handles
+readAndView readHandles =
+  traverse (fmap idealiseState . readTVar . CSState.cschJumping) =<< readHandles
   where
     -- Idealise the state of a ChainSync peer with respect to ChainSync jumping.
     -- In particular, we get rid of non-comparable information such as the TVars
@@ -170,7 +170,7 @@ watcher ::
     Typeable blk,
     StandardHash blk
   ) =>
-  StrictTVar m (Map peer (CSState.ChainSyncClientHandle m blk)) ->
+  STM m (Map peer (CSState.ChainSyncClientHandle m blk)) ->
   Watcher m (View peer blk) (View peer blk)
 watcher handles =
   Watcher

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/CSJInvariants.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/CSJInvariants.hs
@@ -1,0 +1,183 @@
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE RankNTypes     #-}
+
+-- | This module provides a watcher of the invariants that are specific to the
+-- ChainSync jumping (CSJ) implementation. Those invariants are typically
+-- documented in the codebase but are not checked in any way, yet they are
+-- crucial for CSJ to work properly. This watcher monitors the ChainSync
+-- handlers and throws a 'Violation' exception when an invariant stops holding.
+-- It is intended for testing purposes.
+module Test.Consensus.PeerSimulator.CSJInvariants (
+    Violation
+  , watcher
+  ) where
+
+import           Control.Monad (forM_, when)
+import           Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import           Data.Typeable (Typeable)
+import           Ouroboros.Consensus.Block (Point, StandardHash, castPoint)
+import qualified Ouroboros.Consensus.MiniProtocol.ChainSync.Client.State as CSState
+import           Ouroboros.Consensus.Util.IOLike (Exception, MonadSTM (STM),
+                     MonadThrow (throwIO), StrictTVar, readTVar)
+import           Ouroboros.Consensus.Util.STM (Watcher (..))
+
+--------------------------------------------------------------------------------
+-- Idealised view of the ChainSync client's state
+--------------------------------------------------------------------------------
+
+-- | Our idealised view of the ChainSync client's state with respect to
+-- ChainSync jumping in particular.
+type View peer blk = Map peer (State blk)
+
+-- | Idealised version of 'ChainSyncJumpingState'.
+data State blk
+  = Dynamo
+  | Objector
+      -- | The point where the objector dissented with the dynamo when it was a
+      -- jumper.
+      !(Point blk)
+  | Disengaged
+  | Jumper !(JumperState blk)
+  deriving (Show, Eq)
+
+-- | Idealised version of 'ChainSyncJumpingJumperState'.
+data JumperState blk
+  = Happy
+      -- | Latest accepted jump, if there is one
+      !(Maybe (Point blk))
+  | LookingForIntersection
+      -- | Latest accepted jump
+      !(Point blk)
+      -- | Earliest rejected jump
+      !(Point blk)
+  | FoundIntersection
+      -- | Latest accepted jump
+      !(Point blk)
+      -- | Earliest rejected jump
+      !(Point blk)
+  deriving (Show, Eq)
+
+--------------------------------------------------------------------------------
+-- Invariants on views
+--------------------------------------------------------------------------------
+
+allInvariants :: [Invariant peer blk]
+allInvariants =
+  [ thereIsAlwaysOneDynamoUnlessDisengaged,
+    thereIsAlwaysAtMostOneObjector
+  ]
+
+thereIsAlwaysOneDynamoUnlessDisengaged :: Invariant peer blk
+thereIsAlwaysOneDynamoUnlessDisengaged =
+  Invariant
+    { name = "There is always one dynamo, unless all are disengaged",
+      check = \view ->
+        null (filter (not . isDisengaged) $ Map.elems view)
+          || length (filter isDynamo $ Map.elems view) == 1
+    }
+
+thereIsAlwaysAtMostOneObjector :: Invariant peer blk
+thereIsAlwaysAtMostOneObjector =
+  Invariant
+    { name = "There is always at most one objector",
+      check = \view ->
+        length (filter isObjector $ Map.elems view) <= 1
+    }
+
+--------------------------------------------------------------------------------
+-- Helpers for the invariants
+--------------------------------------------------------------------------------
+
+isDynamo :: State blk -> Bool
+isDynamo (Dynamo {}) = True
+isDynamo _           = False
+
+isObjector :: State blk -> Bool
+isObjector (Objector {}) = True
+isObjector _             = False
+
+isDisengaged :: State blk -> Bool
+isDisengaged (Disengaged {}) = True
+isDisengaged _               = False
+
+--------------------------------------------------------------------------------
+-- Invariant enforcement implementation
+--------------------------------------------------------------------------------
+
+readAndView ::
+  forall m peer blk.
+  ( MonadSTM m
+  ) =>
+  StrictTVar m (Map peer (CSState.ChainSyncClientHandle m blk)) ->
+  STM m (View peer blk)
+readAndView handles =
+  traverse (fmap idealiseState . readTVar . CSState.cschJumping) =<< readTVar handles
+  where
+    -- Idealise the state of a ChainSync peer with respect to ChainSync jumping.
+    -- In particular, we get rid of non-comparable information such as the TVars
+    -- it may contain.
+    idealiseState :: CSState.ChainSyncJumpingState m blk -> State blk
+    idealiseState (CSState.Dynamo {}) = Dynamo
+    idealiseState (CSState.Objector _ point _) = Objector $ idealiseJumpInfo point
+    idealiseState (CSState.Disengaged _) = Disengaged
+    idealiseState (CSState.Jumper _ state) = Jumper $ idealiseJumperState state
+    -- Idealise the jumper state by stripping away everything that is more of a
+    -- technical necessity and not actually relevant for the invariants.
+    idealiseJumperState :: CSState.ChainSyncJumpingJumperState blk -> JumperState blk
+    idealiseJumperState (CSState.Happy _ lastAccepted) = Happy $ idealiseJumpInfo <$> lastAccepted
+    idealiseJumperState (CSState.LookingForIntersection lastAccepted firstRejected) =
+      LookingForIntersection (idealiseJumpInfo lastAccepted) (idealiseJumpInfo firstRejected)
+    idealiseJumperState (CSState.FoundIntersection _ lastAccepted firstRejected) =
+      FoundIntersection (idealiseJumpInfo lastAccepted) (castPoint firstRejected)
+    -- Jumpers actually carry a lot of information regarding the jump. From our
+    -- idealised point of view, we only care about the points where the jumpers
+    -- agree or disagree with the dynamo.
+    idealiseJumpInfo :: CSState.JumpInfo blk -> Point blk
+    idealiseJumpInfo = CSState.jMostRecentIntersection
+
+-- | The type of an invariant. Basically a glorified pair of a name and a check
+-- function.
+data Invariant peer blk = Invariant
+  { name  :: !String,
+    check :: !(View peer blk -> Bool)
+  }
+
+-- | An exception that is thrown when an invariant is violated. It carries the
+-- name of the invariant and the view of the state that triggered the invariant
+-- violation.
+data Violation peer blk = Violation !String !(View peer blk)
+  deriving (Eq, Show)
+
+instance
+  ( Typeable blk,
+    StandardHash blk,
+    Eq peer,
+    Show peer,
+    Typeable peer
+  ) =>
+  Exception (Violation peer blk)
+
+-- | The watcher of ChainSync jumping invariants. It receives the ChainSync
+-- handles and monitors them for changes. When a change is detected, it runs all
+-- the invariants and throws 'Violation' if any of the invariants is violated.
+watcher ::
+  ( MonadSTM m,
+    MonadThrow m,
+    Eq peer,
+    Show peer,
+    Typeable peer,
+    Typeable blk,
+    StandardHash blk
+  ) =>
+  StrictTVar m (Map peer (CSState.ChainSyncClientHandle m blk)) ->
+  Watcher m (View peer blk) (View peer blk)
+watcher handles =
+  Watcher
+    { wFingerprint = id,
+      wInitial = Nothing,
+      wReader = readAndView handles,
+      wNotify =
+        forM_ allInvariants . \view Invariant {name, check} ->
+          when (not $ check view) $ throwIO $ Violation name view
+    }

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/ChainSync.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/ChainSync.hs
@@ -26,6 +26,7 @@ import           Ouroboros.Consensus.MiniProtocol.ChainSync.Client
                      Consensus, bracketChainSyncClient, chainSyncClient)
 import qualified Ouroboros.Consensus.MiniProtocol.ChainSync.Client as CSClient
 import qualified Ouroboros.Consensus.MiniProtocol.ChainSync.Client.InFutureCheck as InFutureCheck
+import           Ouroboros.Consensus.Node.GsmState (GsmState (Syncing))
 import           Ouroboros.Consensus.Util (ShowProxy)
 import           Ouroboros.Consensus.Util.IOLike (Exception (fromException),
                      IOLike, MonadCatch (try), StrictTVar)
@@ -139,11 +140,12 @@ runChainSyncClient
   csjConfig
   StateViewTracers {svtPeerSimulatorResultsTracer}
   varHandles
-  channel = do
+  channel =
     bracketChainSyncClient
       nullTracer
       chainDbView
       varHandles
+      (pure Syncing)
       peerId
       (maxBound :: NodeToNodeVersion)
       lopBucketConfig

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/ChainSync.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/ChainSync.hs
@@ -13,7 +13,6 @@ module Test.Consensus.PeerSimulator.ChainSync (
 import           Control.Exception (SomeException)
 import           Control.Monad.Class.MonadTimer.SI (MonadTimer)
 import           Control.Tracer (Tracer (Tracer), nullTracer, traceWith)
-import           Data.Map.Strict (Map)
 import           Data.Proxy (Proxy (..))
 import           Network.TypedProtocol.Codec (AnyMessage)
 import           Ouroboros.Consensus.Block (Header, Point)
@@ -21,15 +20,16 @@ import           Ouroboros.Consensus.Config (TopLevelConfig (..))
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
                      (LedgerSupportsProtocol)
 import           Ouroboros.Consensus.MiniProtocol.ChainSync.Client
-                     (CSJConfig (..), ChainDbView, ChainSyncClientHandle,
-                     ChainSyncLoPBucketConfig, ChainSyncStateView (..),
-                     Consensus, bracketChainSyncClient, chainSyncClient)
+                     (CSJConfig (..), ChainDbView,
+                     ChainSyncClientHandleCollection, ChainSyncLoPBucketConfig,
+                     ChainSyncStateView (..), Consensus, bracketChainSyncClient,
+                     chainSyncClient)
 import qualified Ouroboros.Consensus.MiniProtocol.ChainSync.Client as CSClient
 import qualified Ouroboros.Consensus.MiniProtocol.ChainSync.Client.InFutureCheck as InFutureCheck
 import           Ouroboros.Consensus.Node.GsmState (GsmState (Syncing))
 import           Ouroboros.Consensus.Util (ShowProxy)
 import           Ouroboros.Consensus.Util.IOLike (Exception (fromException),
-                     IOLike, MonadCatch (try), StrictTVar)
+                     IOLike, MonadCatch (try))
 import           Ouroboros.Network.Block (Tip)
 import           Ouroboros.Network.Channel (Channel)
 import           Ouroboros.Network.ControlMessage (ControlMessage (..))
@@ -124,7 +124,7 @@ runChainSyncClient ::
   -- ^ Configuration for ChainSync Jumping
   StateViewTracers blk m ->
   -- ^ Tracers used to record information for the future 'StateView'.
-  StrictTVar m (Map PeerId (ChainSyncClientHandle m blk)) ->
+  ChainSyncClientHandleCollection PeerId m blk ->
   -- ^ A TVar containing a map of states for each peer. This
   -- function will (via 'bracketChainSyncClient') register and de-register a
   -- TVar for the state of the peer.

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/NodeLifecycle.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/NodeLifecycle.hs
@@ -135,7 +135,7 @@ mkChainDb resources = do
             , mcdbNodeDBs        = lrCdb
             })
       pure $ args { ChainDB.cdbsArgs = (ChainDB.cdbsArgs args) {
-        cdbsLoE = readTVarIO <$> lrLoEVar
+        cdbsLoE = traverse readTVarIO lrLoEVar
         } }
     (_, (chainDB, internal)) <- allocate
         lrRegistry

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/NodeLifecycle.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/NodeLifecycle.hs
@@ -19,6 +19,8 @@ import           Data.Set (Set)
 import qualified Data.Set as Set
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config (TopLevelConfig (..))
+import           Ouroboros.Consensus.MiniProtocol.ChainSync.Client
+                     (ChainSyncClientHandleCollection (..))
 import           Ouroboros.Consensus.Storage.ChainDB.API
 import qualified Ouroboros.Consensus.Storage.ChainDB.API as ChainDB
 import qualified Ouroboros.Consensus.Storage.ChainDB.Impl as ChainDB
@@ -204,7 +206,7 @@ lifecycleStop resources LiveNode {lnStateViewTracers, lnCopyToImmDb, lnPeers} = 
   releaseAll lrRegistry
   -- Reset the resources in TVars that were allocated by the simulator
   atomically $ do
-    modifyTVar psrHandles (const mempty)
+    cschcRemoveAllHandles psrHandles
     case lrLoEVar of
       LoEEnabled var -> modifyTVar var (const (AF.Empty AF.AnchorGenesis))
       LoEDisabled    -> pure ()

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Run.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Run.hs
@@ -16,6 +16,7 @@ import           Control.Monad.Class.MonadTimer.SI (MonadTimer)
 import           Control.Tracer (Tracer (..), nullTracer, traceWith)
 import           Data.Foldable (for_)
 import           Data.Functor (void)
+import qualified Data.List.NonEmpty as NonEmpty
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           Ouroboros.Consensus.Block
@@ -460,7 +461,7 @@ runPointSchedule ::
   m (StateView TestBlock)
 runPointSchedule schedulerConfig genesisTest tracer0 =
   withRegistry $ \registry -> do
-    peerSim <- makePeerSimulatorResources tracer gtBlockTree (getPeerIds gtSchedule)
+    peerSim <- makePeerSimulatorResources tracer gtBlockTree (NonEmpty.fromList $ getPeerIds gtSchedule)
     lifecycle <- nodeLifecycle schedulerConfig genesisTest tracer registry peerSim
     (chainDb, stateViewTracers) <- runScheduler
       (Tracer $ traceWith tracer . TraceSchedulerEvent)

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Run.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Run.hs
@@ -10,7 +10,7 @@ module Test.Consensus.PeerSimulator.Run (
   , runPointSchedule
   ) where
 
-import           Control.Monad (foldM, forM)
+import           Control.Monad (foldM, forM, void)
 import           Control.Monad.Class.MonadTime (MonadTime)
 import           Control.Monad.Class.MonadTimer.SI (MonadTimer)
 import           Control.Tracer (Tracer (..), nullTracer, traceWith)
@@ -47,6 +47,7 @@ import           Ouroboros.Network.Util.ShowProxy (ShowProxy)
 import qualified Test.Consensus.PeerSimulator.BlockFetch as BlockFetch
 import qualified Test.Consensus.PeerSimulator.ChainSync as ChainSync
 import           Test.Consensus.PeerSimulator.Config
+import qualified Test.Consensus.PeerSimulator.CSJInvariants as CSJInvariants
 import           Test.Consensus.PeerSimulator.NodeLifecycle
 import           Test.Consensus.PeerSimulator.Resources
 import           Test.Consensus.PeerSimulator.StateDiagram
@@ -373,6 +374,8 @@ startNode schedulerConfig genesisTest interval = do
           (pure GSM.Syncing) -- TODO actually run GSM
           (readTVar handles)
           var
+
+  void $ forkLinkedWatcher lrRegistry "CSJ invariants watcher" $ CSJInvariants.watcher handles
   where
     LiveResources {lrRegistry, lrTracer, lrConfig, lrPeerSim, lrLoEVar} = resources
 

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Run.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Run.hs
@@ -56,7 +56,8 @@ import           Test.Consensus.PeerSimulator.StateView
 import           Test.Consensus.PeerSimulator.Trace
 import           Test.Consensus.PointSchedule (BlockFetchTimeout,
                      CSJParams (..), GenesisTest (..), GenesisTestFull,
-                     LoPBucketParams (..), PeersSchedule, peersStatesRelative)
+                     LoPBucketParams (..), PointSchedule (..),
+                     peersStatesRelative)
 import           Test.Consensus.PointSchedule.NodeState (NodeState)
 import           Test.Consensus.PointSchedule.Peers (Peer (..), PeerId,
                      getPeerIds)
@@ -268,7 +269,7 @@ runScheduler ::
   IOLike m =>
   Tracer m (TraceSchedulerEvent blk) ->
   StrictTVar m (Map PeerId (ChainSyncClientHandle m blk)) ->
-  PeersSchedule blk ->
+  PointSchedule blk ->
   Map PeerId (PeerResources m blk) ->
   NodeLifecycle blk m ->
   m (ChainDB m blk, StateViewTracers blk m)
@@ -467,7 +468,7 @@ runPointSchedule ::
   m (StateView TestBlock)
 runPointSchedule schedulerConfig genesisTest tracer0 =
   withRegistry $ \registry -> do
-    peerSim <- makePeerSimulatorResources tracer gtBlockTree (NonEmpty.fromList $ getPeerIds gtSchedule)
+    peerSim <- makePeerSimulatorResources tracer gtBlockTree (NonEmpty.fromList $ getPeerIds $ unPointSchedule gtSchedule)
     lifecycle <- nodeLifecycle schedulerConfig genesisTest tracer registry peerSim
     (chainDb, stateViewTracers) <- runScheduler
       (Tracer $ traceWith tracer . TraceSchedulerEvent)

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Run.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Run.hs
@@ -362,17 +362,10 @@ startNode schedulerConfig genesisTest interval = do
   -- The block fetch logic needs to be started after the block fetch clients
   -- otherwise, an internal assertion fails because getCandidates yields more
   -- peer fragments than registered clients.
-  let getCurrentChain = ChainDB.getCurrentChain lnChainDb
-
-      gdd = updateLoEFragGenesis lrConfig (mkGDDTracerTestBlock lrTracer) (readTVar handles)
-      -- We make GDD rerun every time the anchor or the blocks of the
-      -- selection change.
-      gddTrigger = do
-        s <- viewChainSyncState handles (\ s -> (csLatestSlot s, csIdling s))
-        c <- getCurrentChain
-        return (s, [AF.anchorToHash $ AF.headAnchor c])
-
   BlockFetch.startBlockFetchLogic lrRegistry lrTracer lnChainDb fetchClientRegistry getCandidates
+
+  let gdd = updateLoEFragGenesis lrConfig (mkGDDTracerTestBlock lrTracer) (readTVar handles)
+      gddTrigger = viewChainSyncState handles (\ s -> (csLatestSlot s, csIdling s))
   for_ lrLoEVar $ \ var -> do
       forkLinkedThread lrRegistry "LoE updater background" $
         void $ runGdd gdd var lnChainDb gddTrigger

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/StateDiagram.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/StateDiagram.hs
@@ -598,11 +598,6 @@ instance Condense RenderCell where
     CellEllipsis -> " .. "
     RenderCell _ cell -> condense cell
 
-renderPeerId :: PeerId -> String
-renderPeerId = \case
-  HonestPeer -> "honest"
-  PeerId p -> p
-
 slotWidth :: NonEmpty Cell -> SlotWidth
 slotWidth =
   maximum . fmap cellWidth
@@ -612,7 +607,7 @@ slotWidth =
       CellPeers peerIds -> SlotWidth (sum (labelWidth <$> peerIds))
       _ -> 1
 
-    labelWidth pid = 2 + length (renderPeerId pid)
+    labelWidth pid = 2 + length (show pid)
 
     sortWidth = \case
       CellHere as -> sum (pointWidth <$> as)
@@ -773,7 +768,7 @@ renderSlotNo config width num =
 
 renderPeers :: [PeerId] -> Col
 renderPeers peers =
-  ColCat [ColAspect (pure (Candidate p)) (ColString ("  " ++ renderPeerId p)) | p <- peers]
+  ColCat [ColAspect (pure (Candidate p)) (ColString ("  " ++ show p)) | p <- peers]
 
 renderCell :: RenderConfig -> RenderCell -> Col
 renderCell config@RenderConfig {ellipsis} = \case

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/LinkedThreads.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/LinkedThreads.hs
@@ -21,8 +21,8 @@ import           Test.Consensus.PeerSimulator.Run (defaultSchedulerConfig)
 import           Test.Consensus.PeerSimulator.StateView
 import           Test.Consensus.PointSchedule
 import           Test.Consensus.PointSchedule.Peers (peersOnlyHonest)
-import           Test.Consensus.PointSchedule.SinglePeer (scheduleBlockPoint,
-                     scheduleHeaderPoint, scheduleTipPoint)
+import           Test.Consensus.PointSchedule.SinglePeer (scheduleHeaderPoint,
+                     scheduleTipPoint)
 import           Test.QuickCheck
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
@@ -67,8 +67,9 @@ prop_chainSyncKillsBlockFetch = do
       let (firstBlock, secondBlock) = case AF.toOldestFirst $ btTrunk gtBlockTree of
             b1 : b2 : _ -> (b1, b2)
             _           -> error "block tree must have two blocks"
-       in PointSchedule $ peersOnlyHonest $
+          psSchedule = peersOnlyHonest $
             [ (Time 0, scheduleTipPoint secondBlock),
-              (Time 0, scheduleHeaderPoint firstBlock),
-              (Time (timeout + 1), scheduleBlockPoint firstBlock)
+              (Time 0, scheduleHeaderPoint firstBlock)
             ]
+          psMinEndTime = Time $ timeout + 1
+       in PointSchedule {psSchedule, psMinEndTime}

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/LinkedThreads.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/LinkedThreads.hs
@@ -44,6 +44,7 @@ prop_chainSyncKillsBlockFetch = do
         pure $ gt $> schedule
     )
     defaultSchedulerConfig
+    -- No shrinking because the schedule is tiny and hand-crafted
     (\_ _ -> [])
     ( \_ stateView@StateView {svTipBlock} ->
         svTipBlock == Nothing

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/LinkedThreads.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/LinkedThreads.hs
@@ -72,4 +72,4 @@ prop_chainSyncKillsBlockFetch = do
               (Time 0, scheduleHeaderPoint firstBlock)
             ]
           psMinEndTime = Time $ timeout + 1
-       in PointSchedule {psSchedule, psMinEndTime}
+       in PointSchedule {psSchedule, psStartOrder = [], psMinEndTime}

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/LinkedThreads.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/LinkedThreads.hs
@@ -62,12 +62,12 @@ prop_chainSyncKillsBlockFetch = do
             _                                      -> False
     )
   where
-    dullSchedule :: GenesisTest blk () -> DiffTime -> PeersSchedule blk
+    dullSchedule :: GenesisTest blk () -> DiffTime -> PointSchedule blk
     dullSchedule GenesisTest {gtBlockTree} timeout =
       let (firstBlock, secondBlock) = case AF.toOldestFirst $ btTrunk gtBlockTree of
             b1 : b2 : _ -> (b1, b2)
             _           -> error "block tree must have two blocks"
-       in peersOnlyHonest $
+       in PointSchedule $ peersOnlyHonest $
             [ (Time 0, scheduleTipPoint secondBlock),
               (Time 0, scheduleHeaderPoint firstBlock),
               (Time (timeout + 1), scheduleBlockPoint firstBlock)

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
@@ -57,6 +57,7 @@ prop_rollback = do
 
     defaultSchedulerConfig
 
+    -- No shrinking because the schedule is tiny and hand-crafted
     (\_ _ -> [])
 
     (\_ -> not . hashOnTrunk . AF.headHash . svSelectedChain)
@@ -73,6 +74,7 @@ prop_cannotRollback =
 
     defaultSchedulerConfig
 
+    -- No shrinking because the schedule is tiny and hand-crafted
     (\_ _ -> [])
 
     (\_ -> hashOnTrunk . AF.headHash . svSelectedChain)

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
@@ -84,7 +84,7 @@ prop_cannotRollback =
 -- chain of the given block tree.
 --
 -- PRECONDITION: Block tree with at least one alternative chain.
-rollbackSchedule :: AF.HasHeader blk => Int -> BlockTree blk -> PeersSchedule blk
+rollbackSchedule :: AF.HasHeader blk => Int -> BlockTree blk -> PointSchedule blk
 rollbackSchedule n blockTree =
     let branch = case btBranches blockTree of
           [b] -> b
@@ -95,7 +95,7 @@ rollbackSchedule n blockTree =
           , banalSchedulePoints trunkSuffix
           , banalSchedulePoints (btbSuffix branch)
           ]
-    in peersOnlyHonest $ zip (map (Time . (/30)) [0..]) schedulePoints
+    in PointSchedule $ peersOnlyHonest $ zip (map (Time . (/30)) [0..]) schedulePoints
   where
     banalSchedulePoints :: AnchoredFragment blk -> [SchedulePoint blk]
     banalSchedulePoints = concatMap banalSchedulePoints' . toOldestFirst

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
@@ -95,7 +95,7 @@ rollbackSchedule n blockTree =
           , banalSchedulePoints trunkSuffix
           , banalSchedulePoints (btbSuffix branch)
           ]
-    in PointSchedule $ peersOnlyHonest $ zip (map (Time . (/30)) [0..]) schedulePoints
+    in mkPointSchedule $ peersOnlyHonest $ zip (map (Time . (/30)) [0..]) schedulePoints
   where
     banalSchedulePoints :: AnchoredFragment blk -> [SchedulePoint blk]
     banalSchedulePoints = concatMap banalSchedulePoints' . toOldestFirst

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
@@ -95,7 +95,11 @@ rollbackSchedule n blockTree =
           , banalSchedulePoints trunkSuffix
           , banalSchedulePoints (btbSuffix branch)
           ]
-    in mkPointSchedule $ peersOnlyHonest $ zip (map (Time . (/30)) [0..]) schedulePoints
+    in PointSchedule {
+         psSchedule = peersOnlyHonest $ zip (map (Time . (/30)) [0..]) schedulePoints,
+         psStartOrder = [],
+         psMinEndTime = Time 0
+       }
   where
     banalSchedulePoints :: AnchoredFragment blk -> [SchedulePoint blk]
     banalSchedulePoints = concatMap banalSchedulePoints' . toOldestFirst

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
@@ -70,4 +70,4 @@ prop_timeouts mustTimeout = do
             ]
           -- This keeps the test running long enough to pass the timeout by 'offset'.
           psMinEndTime = Time $ timeout + offset
-       in PointSchedule {psSchedule, psMinEndTime}
+       in PointSchedule {psSchedule, psStartOrder = [], psMinEndTime}

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
@@ -63,12 +63,11 @@ prop_timeouts mustTimeout = do
     dullSchedule _ (AF.Empty _) = error "requires a non-empty block tree"
     dullSchedule timeout (_ AF.:> tipBlock) =
       let offset :: DiffTime = if mustTimeout then 1 else -1
-       in PointSchedule $ peersOnlyHonest $ [
-            (Time 0, scheduleTipPoint tipBlock),
-            (Time 0, scheduleHeaderPoint tipBlock),
-            (Time 0, scheduleBlockPoint tipBlock),
-            -- This last point does not matter, it is only here to leave the
-            -- connection open (aka. keep the test running) long enough to
-            -- pass the timeout by 'offset'.
-            (Time (timeout + offset), scheduleTipPoint tipBlock)
+          psSchedule = peersOnlyHonest $ [
+              (Time 0, scheduleTipPoint tipBlock),
+              (Time 0, scheduleHeaderPoint tipBlock),
+              (Time 0, scheduleBlockPoint tipBlock)
             ]
+          -- This keeps the test running long enough to pass the timeout by 'offset'.
+          psMinEndTime = Time $ timeout + offset
+       in PointSchedule {psSchedule, psMinEndTime}

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
@@ -44,6 +44,9 @@ prop_timeouts mustTimeout = do
     -- Timeouts are enabled by default
     defaultSchedulerConfig
 
+    -- Here we can't shrink because we exploit the properties of the point schedule to wait
+    -- at the end of the test for the adversaries to get disconnected, by adding an extra point.
+    -- If this point gets removed by the shrinker, we lose that property and the test becomes useless.
     (\_ _ -> [])
 
     (\_ stateView ->

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
@@ -59,11 +59,11 @@ prop_timeouts mustTimeout = do
     )
 
   where
-    dullSchedule :: AF.HasHeader blk => DiffTime -> AF.AnchoredFragment blk -> PeersSchedule blk
+    dullSchedule :: AF.HasHeader blk => DiffTime -> AF.AnchoredFragment blk -> PointSchedule blk
     dullSchedule _ (AF.Empty _) = error "requires a non-empty block tree"
     dullSchedule timeout (_ AF.:> tipBlock) =
       let offset :: DiffTime = if mustTimeout then 1 else -1
-       in peersOnlyHonest $ [
+       in PointSchedule $ peersOnlyHonest $ [
             (Time 0, scheduleTipPoint tipBlock),
             (Time 0, scheduleHeaderPoint tipBlock),
             (Time 0, scheduleBlockPoint tipBlock),

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Trace.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Trace.hs
@@ -64,6 +64,8 @@ data TraceSchedulerEvent blk
     TraceBeginningOfTime
   | -- | Right after running the last tick of the schedule.
     TraceEndOfTime
+  | -- | An extra optional delay to keep the simulation running
+    TraceExtraDelay DiffTime
   | -- | When beginning a new tick. Contains the tick number (counting from
     -- @0@), the duration of the tick, the states, the current chain, the
     -- candidate fragment, and the jumping states.
@@ -195,6 +197,13 @@ traceSchedulerEventTestBlockWith setTickTime tracer0 _tracer = \case
       traceLinesWith tracer0
         [ "╶──────────────────────────────────────────────────────────────────────────────╴",
           "Finished running point schedule"
+        ]
+    TraceExtraDelay delay -> do
+      time <- getMonotonicTime
+      traceLinesWith tracer0
+        [ "┌──────────────────────────────────────────────────────────────────────────────┐",
+          "└─ " ++ prettyTime time,
+          "Waiting an extra delay to keep the simulation running for: " ++ prettyTime (Time delay)
         ]
     TraceNewTick number duration (Peer pid state) currentChain mCandidateFrag jumpingStates -> do
       time <- getMonotonicTime

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Trace.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Trace.hs
@@ -483,7 +483,7 @@ terseGDDEvent :: TraceGDDEvent PeerId TestBlock -> String
 terseGDDEvent = \case
   TraceGDDEvent {sgen = GenesisWindow sgen, curChain, bounds, candidates, candidateSuffixes, losingPeers, loeHead} ->
     unlines $ [
-      "GDG | Window: " ++ window sgen loeHead,
+      "GDD | Window: " ++ window sgen loeHead,
       "      Selection: " ++ terseHFragment curChain,
       "      Candidates:"
       ] ++

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
@@ -23,6 +23,7 @@
 module Test.Consensus.PointSchedule (
     BlockFetchTimeout (..)
   , CSJParams (..)
+  , DowntimeParams (..)
   , ForecastRange (..)
   , GenesisTest (..)
   , GenesisTestFull
@@ -30,6 +31,7 @@ module Test.Consensus.PointSchedule (
   , LoPBucketParams (..)
   , PeerSchedule
   , PeersSchedule
+  , PointsGeneratorParams (..)
   , RunGenesisTestResult (..)
   , enrichedWith
   , ensureScheduleDuration
@@ -43,16 +45,17 @@ module Test.Consensus.PointSchedule (
   , prettyPeersSchedule
   , stToGen
   , uniformPoints
-  , uniformPointsWithDowntime
   ) where
 
 import           Cardano.Slotting.Time (SlotLength)
+import           Control.Monad (replicateM)
 import           Control.Monad.Class.MonadTime.SI (Time (Time), addTime,
                      diffTime)
 import           Control.Monad.ST (ST)
 import           Data.Foldable (toList)
 import           Data.Functor (($>))
 import           Data.List (mapAccumL, partition, scanl')
+import qualified Data.Map.Strict as Map
 import           Data.Maybe (catMaybes, fromMaybe, mapMaybe)
 import           Data.Time (DiffTime)
 import           Data.Word (Word64)
@@ -76,7 +79,7 @@ import           Test.Consensus.PeerSimulator.StateView (StateView)
 import           Test.Consensus.PointSchedule.NodeState (NodeState (..),
                      genesisNodeState)
 import           Test.Consensus.PointSchedule.Peers (Peer (..), Peers (..),
-                     mkPeers, peersList)
+                     peers', peersList)
 import           Test.Consensus.PointSchedule.SinglePeer
                      (IsTrunk (IsBranch, IsTrunk), PeerScheduleParams (..),
                      SchedulePoint (..), defaultPeerScheduleParams, mergeOn,
@@ -96,6 +99,9 @@ prettyPeersSchedule ::
   PeersSchedule blk ->
   [String]
 prettyPeersSchedule peers =
+  [ "honest peers: " ++ show (Map.size (honestPeers peers))
+  , "adversaries: " ++ show (Map.size (adversarialPeers peers))
+  ] ++
   zipWith3
     (\number time peerState ->
       number ++ ": " ++ peerState ++ " @ " ++ time
@@ -191,7 +197,7 @@ longRangeAttack ::
 longRangeAttack BlockTree {btTrunk, btBranches = [branch]} g = do
   honest <- peerScheduleFromTipPoints g honParams [(IsTrunk, [AF.length btTrunk - 1])] btTrunk []
   adv <- peerScheduleFromTipPoints g advParams [(IsBranch, [AF.length (btbFull branch) - 1])] btTrunk [btbFull branch]
-  pure (mkPeers honest [adv])
+  pure (peers' [honest] [adv])
   where
     honParams = defaultPeerScheduleParams {pspHeaderDelayInterval = (0.3, 0.4)}
     advParams = defaultPeerScheduleParams {pspTipDelayInterval = (0, 0.1)}
@@ -199,22 +205,45 @@ longRangeAttack BlockTree {btTrunk, btBranches = [branch]} g = do
 longRangeAttack _ _ =
   error "longRangeAttack can only deal with single adversary"
 
--- | Generate a schedule in which the trunk and branches are served by one peer each, using
--- a single tip point, without specifically assigned delay intervals like in
--- 'newLongRangeAttack'.
---
--- Include rollbacks in a percentage of adversaries, in which case that peer uses two branchs.
---
+data PointsGeneratorParams = PointsGeneratorParams {
+  pgpExtraHonestPeers :: Int,
+  pgpDowntime         :: DowntimeParams
+}
+
+data DowntimeParams = NoDowntime | DowntimeWithSecurityParam SecurityParam
+
 uniformPoints ::
   (StatefulGen g m, AF.HasHeader blk) =>
+  PointsGeneratorParams ->
   BlockTree blk ->
   g ->
   m (PeersSchedule blk)
-uniformPoints BlockTree {btTrunk, btBranches} g = do
+uniformPoints PointsGeneratorParams {pgpExtraHonestPeers, pgpDowntime} = case pgpDowntime of
+  NoDowntime                  -> uniformPointsWithExtraHonestPeers pgpExtraHonestPeers
+  DowntimeWithSecurityParam k -> uniformPointsWithExtraHonestPeersAndDowntime pgpExtraHonestPeers k
+
+-- | Generate a schedule in which the trunk is served by @pgpExtraHonestPeers + 1@ peers,
+-- and extra branches are served by one peer each, using a single tip point,
+-- without specifically assigned delay intervals like in 'newLongRangeAttack'.
+--
+-- Include rollbacks in a percentage of adversaries, in which case that peer uses two branchs.
+--
+uniformPointsWithExtraHonestPeers ::
+  (StatefulGen g m, AF.HasHeader blk) =>
+  Int ->
+  BlockTree blk ->
+  g ->
+  m (PeersSchedule blk)
+uniformPointsWithExtraHonestPeers
+    extraHonestPeers
+    BlockTree {btTrunk, btBranches}
+    g
+  = do
   honestTip0 <- firstTip btTrunk
-  honest <- mkSchedule [(IsTrunk, [honestTip0 .. AF.length btTrunk - 1])] []
+  honests <- replicateM (extraHonestPeers + 1) $
+    mkSchedule [(IsTrunk, [honestTip0 .. AF.length btTrunk - 1])] []
   advs <- takeBranches btBranches
-  pure (mkPeers honest advs)
+  pure (peers' honests advs)
   where
     takeBranches = \case
         [] -> pure []
@@ -301,16 +330,16 @@ bumpTips tips =
       = (tn, (t0, p))
     step ts a = (ts, a)
 
-syncTips :: [(Time, SchedulePoint blk)] -> [[(Time, SchedulePoint blk)]] -> ([(Time, SchedulePoint blk)], [[(Time, SchedulePoint blk)]])
-syncTips honest advs =
-  (bump honest, bump <$> advs)
+syncTips :: [[(Time, SchedulePoint blk)]] -> [[(Time, SchedulePoint blk)]] -> ([[(Time, SchedulePoint blk)]], [[(Time, SchedulePoint blk)]])
+syncTips honests advs =
+  (bump <$> honests, bump <$> advs)
   where
     bump = bumpTips earliestTips
     earliestTips = chooseEarliest <$> zipPadN (tipTimes <$> scheds)
-    scheds = honest : advs
+    scheds = honests <> advs
     chooseEarliest times = minimum (fromMaybe (Time 0) <$> times)
 
--- | This is a variant of 'uniformPoints' that uses multiple tip points, used to simulate node downtimes.
+-- | This is a variant of 'uniformPointsWithExtraHonestPeers' that uses multiple tip points, used to simulate node downtimes.
 -- Ultimately, this should be replaced by a redesign of the peer schedule generator that is aware of node liveness
 -- intervals.
 --
@@ -320,23 +349,30 @@ syncTips honest advs =
 -- The second tip is the last block of each branch.
 --
 -- Includes rollbacks in some schedules.
-uniformPointsWithDowntime ::
+uniformPointsWithExtraHonestPeersAndDowntime ::
   (StatefulGen g m, AF.HasHeader blk) =>
+  Int ->
   SecurityParam ->
   BlockTree blk ->
   g ->
   m (PeersSchedule blk)
-uniformPointsWithDowntime (SecurityParam k) BlockTree {btTrunk, btBranches} g = do
+uniformPointsWithExtraHonestPeersAndDowntime
+    extraHonestPeers
+    (SecurityParam k)
+    BlockTree {btTrunk, btBranches}
+    g
+  = do
   let
     kSlot = withOrigin 0 (fromIntegral . unSlotNo) (AF.headSlot (AF.takeOldest (fromIntegral k) btTrunk))
     midSlot = (AF.length btTrunk) `div` 2
     lowerBound = max kSlot midSlot
   pauseSlot <- SlotNo . fromIntegral <$> Random.uniformRM (lowerBound, AF.length btTrunk - 1) g
   honestTip0 <- firstTip pauseSlot btTrunk
-  honest <- mkSchedule [(IsTrunk, [honestTip0, minusClamp (AF.length btTrunk) 1])] []
+  honests <- replicateM (extraHonestPeers + 1) $
+    mkSchedule [(IsTrunk, [honestTip0, minusClamp (AF.length btTrunk) 1])] []
   advs <- takeBranches pauseSlot btBranches
-  let (honest', advs') = syncTips honest advs
-  pure (mkPeers honest' advs')
+  let (honests', advs') = syncTips honests advs
+  pure (peers' honests' advs')
   where
     takeBranches pause = \case
         [] -> pure []
@@ -391,7 +427,6 @@ uniformPointsWithDowntime (SecurityParam k) BlockTree {btTrunk, btBranches} g = 
 
     rollbackProb = 0.2
 
-
 newtype ForecastRange = ForecastRange { unForecastRange :: Word64 }
   deriving (Show)
 
@@ -425,6 +460,13 @@ data GenesisTest blk schedule = GenesisTest
     gtLoPBucketParams    :: LoPBucketParams,
     gtCSJParams          :: CSJParams,
     gtSlotLength         :: SlotLength,
+    -- | The number of extra honest peers we want in the test.
+    -- It is stored here for convenience, and because it may affect schedule and block tree generation.
+    --
+    -- There will be at most one adversarial peer per alternative branch in the block tree
+    -- (exactly one per branch if no adversary does a rollback),
+    -- and `1 + gtExtraHonestPeers` honest peers.
+    gtExtraHonestPeers   :: Word,
     gtSchedule           :: schedule
   }
 
@@ -499,11 +541,9 @@ duplicateLastPoint d xs =
     in xs ++ [(addTime d t, p)]
 
 ensureScheduleDuration :: GenesisTest blk a -> PeersSchedule blk -> PeersSchedule blk
-ensureScheduleDuration gt Peers {honest, others} =
-  Peers {honest = extendHonest, others}
+ensureScheduleDuration gt peers =
+    duplicateLastPoint endingDelay <$> peers
   where
-    extendHonest = duplicateLastPoint endingDelay <$> honest
-
     endingDelay =
      let cst = gtChainSyncTimeouts gt
          bft = gtBlockFetchTimeouts gt
@@ -513,5 +553,4 @@ ensureScheduleDuration gt Peers {honest, others} =
            , busyTimeout bft
            , streamingTimeout bft
            ])
-
-    peerCount = 1 + length others
+    peerCount = length (peersList peers)

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Peers.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Peers.hs
@@ -15,13 +15,19 @@ module Test.Consensus.PointSchedule.Peers (
     Peer (..)
   , PeerId (..)
   , Peers (..)
+  , adversarialPeers'
+  , adversarialPeers''
+  , deletePeer
   , enumerateAdversaries
   , fromMap
   , fromMap'
   , getPeer
   , getPeerIds
-  , mkPeers
-  , mkPeers'
+  , honestPeers'
+  , honestPeers''
+  , isAdversarialPeerId
+  , isHonestPeerId
+  , peers'
   , peersFromPeerIdList
   , peersFromPeerIdList'
   , peersFromPeerList
@@ -33,8 +39,6 @@ module Test.Consensus.PointSchedule.Peers (
   ) where
 
 import           Data.Hashable (Hashable)
-import           Data.List.NonEmpty (NonEmpty ((:|)))
-import qualified Data.List.NonEmpty as NonEmpty
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           Data.String (IsString (fromString))
@@ -45,20 +49,25 @@ import           Ouroboros.Consensus.Util.Condense (Condense (..),
                      condenseListWithPadding)
 
 -- | Identifier used to index maps and specify which peer is active during a tick.
-data PeerId =
-  HonestPeer
-  |
-  PeerId String
+data PeerId
+  = HonestPeer Int
+  | AdversarialPeer Int
   deriving (Eq, Generic, Show, Ord, NoThunks)
 
 instance IsString PeerId where
-  fromString "honest" = HonestPeer
-  fromString i        = PeerId i
+  fromString s = case words s of
+    ["honest"]       -> HonestPeer 1
+    ["honest", n]    -> HonestPeer (read n)
+    ["adversary"]    -> AdversarialPeer 1
+    ["adversary", n] -> AdversarialPeer (read n)
+    _                -> error $ "fromString: invalid PeerId: " ++ s
 
 instance Condense PeerId where
   condense = \case
-    HonestPeer -> "honest"
-    PeerId name -> name
+    HonestPeer 1 -> "honest"
+    HonestPeer n -> "honest " ++ show n
+    AdversarialPeer 1 -> "adversary"
+    AdversarialPeer n -> "adversary " ++ show n
 
 instance CondenseList PeerId where
   condenseList = condenseListWithPadding PadRight
@@ -94,119 +103,158 @@ instance CondenseList a => CondenseList (Peer a) where
       (condenseList $ value <$> peers)
 
 -- | General-purpose functor for a set of peers.
---
--- REVIEW: There is a duplicate entry for the honest peer, here. We should
--- probably either have only the 'Map' or have the keys of the map be 'String'?
---
--- Alternatively, we could just have 'newtype PeerId = PeerId String' with an
--- alias for 'HonestPeer = PeerId "honest"'?
-data Peers a =
-  Peers {
-    honest :: Peer a,
-    others :: Map PeerId (Peer a)
+data Peers a = Peers
+  { honestPeers      :: Map Int a,
+    adversarialPeers :: Map Int a
   }
   deriving (Eq, Show)
 
+-- | Variant of 'honestPeers' that returns a map with 'PeerId's as keys.
+honestPeers' :: Peers a -> Map PeerId a
+honestPeers' = Map.mapKeysMonotonic HonestPeer . honestPeers
+
+-- | Variant of 'honestPeers' that returns a map with 'PeerId's as keys and
+-- values as 'Peer's.
+honestPeers'' :: Peers a -> Map PeerId (Peer a)
+honestPeers'' = Map.mapWithKey Peer . honestPeers'
+
+-- | Variant of 'adversarialPeers' that returns a map with 'PeerId's as keys.
+adversarialPeers' :: Peers a -> Map PeerId a
+adversarialPeers' peers = Map.mapKeysMonotonic AdversarialPeer $ adversarialPeers peers
+
+-- | Variant of 'adversarialPeers' that returns a map with 'PeerId's as keys and
+-- values as 'Peer's.
+adversarialPeers'' :: Peers a -> Map PeerId (Peer a)
+adversarialPeers'' = Map.mapWithKey Peer . adversarialPeers'
+
 instance Functor Peers where
-  fmap f Peers {honest, others} = Peers {honest = f <$> honest, others = fmap f <$> others}
+  fmap f Peers {honestPeers, adversarialPeers} =
+    Peers
+      { honestPeers = f <$> honestPeers,
+        adversarialPeers = f <$> adversarialPeers
+      }
 
 instance Foldable Peers where
-  foldMap f Peers {honest, others} = (f . value) honest <> foldMap (f . value) others
+  foldMap f Peers {honestPeers, adversarialPeers} =
+    foldMap f honestPeers <> foldMap f adversarialPeers
 
 -- | A set of peers with only one honest peer carrying the given value.
 peersOnlyHonest :: a -> Peers a
 peersOnlyHonest value =
-  Peers {
-    honest = Peer {name = HonestPeer, value},
-    others = Map.empty
+  Peers
+    { honestPeers = Map.singleton 1 value,
+      adversarialPeers = Map.empty
     }
 
 -- | Extract all 'PeerId's.
-getPeerIds :: Peers a -> NonEmpty PeerId
-getPeerIds peers = HonestPeer :| Map.keys (others peers)
+getPeerIds :: Peers a -> [PeerId]
+getPeerIds Peers {honestPeers, adversarialPeers} =
+  (HonestPeer <$> Map.keys honestPeers) ++ (AdversarialPeer <$> Map.keys adversarialPeers)
 
 getPeer :: PeerId -> Peers a -> Peer a
-getPeer pid peers
-  | HonestPeer <- pid
-  = honest peers
-  | otherwise
-  = others peers Map.! pid
+getPeer (HonestPeer n) Peers {honestPeers} = Peer (HonestPeer n) (honestPeers Map.! n)
+getPeer (AdversarialPeer n) Peers {adversarialPeers} = Peer (AdversarialPeer n) (adversarialPeers Map.! n)
 
 updatePeer :: (a -> (a, b)) -> PeerId -> Peers a -> (Peers a, b)
-updatePeer f pid Peers {honest, others}
-  | HonestPeer <- pid
-  , let (a, b) = f (value honest)
-  = (Peers {honest = a <$ honest, others}, b)
-  | otherwise
-  , let p = others Map.! pid
-        (a, b) = f (value p)
-  = (Peers {honest, others = Map.adjust (a <$) pid others}, b)
+updatePeer f (HonestPeer n) Peers {honestPeers, adversarialPeers} =
+  let (a, b) = f (honestPeers Map.! n)
+   in (Peers {honestPeers = Map.insert n a honestPeers, adversarialPeers}, b)
+updatePeer f (AdversarialPeer n) Peers {honestPeers, adversarialPeers} =
+  let (a, b) = f (adversarialPeers Map.! n)
+   in (Peers {honestPeers, adversarialPeers = Map.insert n a adversarialPeers}, b)
 
 -- | Convert 'Peers' to a list of 'Peer'.
-peersList :: Peers a -> NonEmpty (Peer a)
-peersList Peers {honest, others} =
-  honest :| Map.elems others
+peersList :: Peers a -> [Peer a]
+peersList Peers {honestPeers, adversarialPeers} =
+  Map.foldrWithKey
+    (\k v -> (Peer (HonestPeer k) v :))
+    ( Map.foldrWithKey
+        (\k v -> (Peer (AdversarialPeer k) v :))
+        []
+        adversarialPeers
+    )
+    honestPeers
 
 enumerateAdversaries :: [PeerId]
-enumerateAdversaries =
-  (\ n -> PeerId ("adversary " ++ show n)) <$> [1 :: Int ..]
+enumerateAdversaries = AdversarialPeer <$> [1 ..]
 
 -- | Construct 'Peers' from values, adding adversary names based on the default schema.
--- A single adversary gets the ID @adversary@, multiple get enumerated as @adversary N@.
-mkPeers :: a -> [a] -> Peers a
-mkPeers h as =
-  Peers (Peer HonestPeer h) (Map.fromList (mkPeer <$> advs as))
-  where
-    mkPeer (pid, a) = (pid, Peer pid a)
-    advs [a] = [("adversary", a)]
-    advs _   = zip enumerateAdversaries as
+peers' :: [a] -> [a] -> Peers a
+peers' hs as =
+  Peers
+    { honestPeers = Map.fromList $ zip [1 ..] hs,
+      adversarialPeers = Map.fromList $ zip [1 ..] as
+    }
 
--- | Make a 'Peers' structure from the honest value and the other peers. Fail if
--- one of the other peers is the 'HonestPeer'.
-mkPeers' :: a -> [Peer a] -> Peers a
-mkPeers' value prs =
-    Peers (Peer HonestPeer value) (Map.fromList $ dupAdvPeerId <$> prs)
+-- | Make a 'Peers' structure from individual 'Peer's.
+peersFromPeerList :: [Peer a] -> Peers a
+peersFromPeerList peers =
+  let (hs, as) = partitionPeers peers
+   in Peers
+        { honestPeers = Map.fromList hs,
+          adversarialPeers = Map.fromList as
+        }
   where
-    -- | Duplicate an adversarial peer id; fail if honest.
-    dupAdvPeerId :: Peer a -> (PeerId, Peer a)
-    dupAdvPeerId (Peer HonestPeer _) = error "cannot be the honest peer"
-    dupAdvPeerId peer@(Peer pid _)   = (pid, peer)
+    partitionPeers :: [Peer a] -> ([(Int, a)], [(Int, a)])
+    partitionPeers =
+      foldl
+        ( \(hs, as) (Peer pid v) -> case pid of
+            HonestPeer n      -> ((n, v) : hs, as)
+            AdversarialPeer n -> (hs, (n, v) : as)
+        )
+        ([], [])
 
--- | Make a 'Peers' structure from a non-empty list of peers. Fail if the honest
--- peer is not exactly once in the list.
-peersFromPeerList :: NonEmpty (Peer a) -> Peers a
-peersFromPeerList =
-    uncurry mkPeers' . extractHonestPeer . NonEmpty.toList
-  where
-    -- | Return the value associated with the honest peer and the list of peers
-    -- excluding the honest one.
-    extractHonestPeer :: [Peer a] -> (a, [Peer a])
-    extractHonestPeer [] = error "could not find honest peer"
-    extractHonestPeer (Peer HonestPeer value : peers) = (value, peers)
-    extractHonestPeer (peer : peers) = (peer :) <$> extractHonestPeer peers
-
--- | Make a 'Peers' structure from a non-empty list of peer ids and a default
--- value. Fails if the honest peer is not exactly once in the list.
-peersFromPeerIdList :: NonEmpty PeerId -> a -> Peers a
+-- | Make a 'Peers' structure from a list of peer ids and a default value.
+peersFromPeerIdList :: [PeerId] -> a -> Peers a
 peersFromPeerIdList = flip $ \val -> peersFromPeerList . fmap (flip Peer val)
 
 -- | Like 'peersFromPeerIdList' with @()@.
-peersFromPeerIdList' :: NonEmpty PeerId -> Peers ()
+peersFromPeerIdList' :: [PeerId] -> Peers ()
 peersFromPeerIdList' = flip peersFromPeerIdList ()
-
-toMap :: Peers a -> Map PeerId (Peer a)
-toMap Peers{honest, others} = Map.insert HonestPeer honest others
 
 -- | Same as 'toMap' but the map contains unwrapped values.
 toMap' :: Peers a -> Map PeerId a
-toMap' = fmap (\(Peer _ v) -> v) . toMap
+toMap' Peers {honestPeers, adversarialPeers} =
+  Map.union
+    (Map.mapKeysMonotonic HonestPeer honestPeers)
+    (Map.mapKeysMonotonic AdversarialPeer adversarialPeers)
 
-fromMap :: Map PeerId (Peer a) -> Peers a
-fromMap peers = Peers{
-    honest = peers Map.! HonestPeer,
-    others = Map.delete HonestPeer peers
-  }
+toMap :: Peers a -> Map PeerId (Peer a)
+toMap = Map.mapWithKey Peer . toMap'
 
 -- | Same as 'fromMap' but the map contains unwrapped values.
 fromMap' :: Map PeerId a -> Peers a
-fromMap' = fromMap . Map.mapWithKey Peer
+fromMap' peers =
+  let (honestPeers, adversarialPeers) =
+        Map.mapEitherWithKey
+          ( \case
+              HonestPeer _ -> Left
+              AdversarialPeer _ -> Right
+          )
+          peers
+   in Peers
+        { honestPeers = Map.mapKeysMonotonic unHonestPeer honestPeers,
+          adversarialPeers = Map.mapKeysMonotonic unAdversarialPeer adversarialPeers
+        }
+  where
+    unHonestPeer (HonestPeer n) = n
+    unHonestPeer _              = error "unHonestPeer: not a honest peer"
+    unAdversarialPeer (AdversarialPeer n) = n
+    unAdversarialPeer _ = error "unAdversarialPeer: not an adversarial peer"
+
+fromMap :: Map PeerId (Peer a) -> Peers a
+fromMap = fromMap' . Map.map value
+
+deletePeer :: PeerId -> Peers a -> Peers a
+deletePeer (HonestPeer n) Peers {honestPeers, adversarialPeers} =
+  Peers {honestPeers = Map.delete n honestPeers, adversarialPeers}
+deletePeer (AdversarialPeer n) Peers {honestPeers, adversarialPeers} =
+  Peers {honestPeers, adversarialPeers = Map.delete n adversarialPeers}
+
+isHonestPeerId :: PeerId -> Bool
+isHonestPeerId (HonestPeer _) = True
+isHonestPeerId _              = False
+
+isAdversarialPeerId :: PeerId -> Bool
+isAdversarialPeerId (AdversarialPeer _) = True
+isAdversarialPeerId _                   = False

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Peers.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Peers.hs
@@ -35,6 +35,7 @@ module Test.Consensus.PointSchedule.Peers (
   , peersOnlyHonest
   , toMap
   , toMap'
+  , unionWithKey
   , updatePeer
   ) where
 
@@ -203,6 +204,13 @@ peersFromPeerList peers =
             AdversarialPeer n -> (hs, (n, v) : as)
         )
         ([], [])
+
+unionWithKey :: (PeerId -> a -> a -> a) -> Peers a -> Peers a -> Peers a
+unionWithKey f peers1 peers2 =
+  Peers
+    { honestPeers = Map.unionWithKey (f . HonestPeer) (honestPeers peers1) (honestPeers peers2),
+      adversarialPeers = Map.unionWithKey (f . AdversarialPeer) (adversarialPeers peers1) (adversarialPeers peers2)
+    }
 
 -- | Make a 'Peers' structure from a list of peer ids and a default value.
 peersFromPeerIdList :: [PeerId] -> a -> Peers a

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Shrinking.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Shrinking.hs
@@ -41,7 +41,7 @@ shrinkPeerSchedules ::
   StateView TestBlock ->
   [GenesisTestFull TestBlock]
 shrinkPeerSchedules genesisTest@GenesisTest{gtBlockTree, gtSchedule} _stateView =
-  let PointSchedule {psSchedule} = gtSchedule
+  let PointSchedule {psSchedule, psStartOrder} = gtSchedule
       simulationDuration = duration gtSchedule
       trimmedBlockTree sch = trimBlockTree' sch gtBlockTree
       shrunkAdversarialPeers =
@@ -50,6 +50,7 @@ shrinkPeerSchedules genesisTest@GenesisTest{gtBlockTree, gtSchedule} _stateView 
             genesisTest
               { gtSchedule = PointSchedule
                   { psSchedule = shrunkSchedule
+                  , psStartOrder
                   , psMinEndTime = simulationDuration
                   }
               , gtBlockTree = trimmedBlockTree shrunkSchedule
@@ -61,6 +62,7 @@ shrinkPeerSchedules genesisTest@GenesisTest{gtBlockTree, gtSchedule} _stateView 
         <&> \shrunkSchedule -> genesisTest
           { gtSchedule = PointSchedule
             { psSchedule = shrunkSchedule
+            , psStartOrder
             , psMinEndTime = simulationDuration
             }
           }
@@ -81,6 +83,7 @@ shrinkByRemovingAdversaries genesisTest@GenesisTest{gtSchedule, gtBlockTree} _st
      in genesisTest
       { gtSchedule = PointSchedule
         { psSchedule = shrunkSchedule
+        , psStartOrder = psStartOrder gtSchedule
         , psMinEndTime = simulationDuration
         }
       , gtBlockTree = trimmedBlockTree

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Shrinking.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Shrinking.hs
@@ -5,17 +5,16 @@ module Test.Consensus.PointSchedule.Shrinking (
     -- | Exported only for testing (that is, checking the properties of the function)
     shrinkByRemovingAdversaries
   , shrinkHonestPeer
+  , shrinkHonestPeers
   , shrinkPeerSchedules
   ) where
 
 import           Control.Monad.Class.MonadTime.SI (DiffTime, Time, addTime,
                      diffTime)
 import           Data.Containers.ListUtils (nubOrd)
-import           Data.Function ((&))
 import           Data.Functor ((<&>))
-import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import           Data.Maybe (mapMaybe, maybeToList)
+import           Data.Maybe (mapMaybe)
 import           Ouroboros.Network.AnchoredFragment (AnchoredFragment,
                      AnchoredSeq (Empty), takeWhileOldest)
 import           Test.Consensus.BlockTree (BlockTree (..), BlockTreeBranch (..),
@@ -27,7 +26,6 @@ import           Test.Consensus.PointSchedule (GenesisTest (..),
 import           Test.Consensus.PointSchedule.Peers (Peers (..))
 import           Test.Consensus.PointSchedule.SinglePeer (SchedulePoint (..))
 import           Test.QuickCheck (shrinkList)
-import           Test.Util.PartialAccessors
 import           Test.Util.TestBlock (TestBlock, isAncestorOf,
                      isStrictAncestorOf)
 
@@ -42,7 +40,7 @@ shrinkPeerSchedules ::
 shrinkPeerSchedules genesisTest _stateView =
   let trimmedBlockTree sch = trimBlockTree' sch (gtBlockTree genesisTest)
       shrunkAdversarialPeers =
-        shrinkAdversarialPeers shrinkPeerSchedule (gtSchedule genesisTest)
+        shrinkAdversarialPeers shrinkAdversarialPeer (gtSchedule genesisTest)
           <&> \shrunkSchedule ->
             genesisTest
               { gtSchedule = shrunkSchedule,
@@ -69,8 +67,8 @@ shrinkByRemovingAdversaries genesisTest _stateView =
 
 -- | Shrink a 'PeerSchedule' by removing ticks from it. The other ticks are kept
 -- unchanged.
-shrinkPeerSchedule :: (PeerSchedule blk) -> [PeerSchedule blk]
-shrinkPeerSchedule = shrinkList (const [])
+shrinkAdversarialPeer :: (PeerSchedule blk) -> [PeerSchedule blk]
+shrinkAdversarialPeer = shrinkList (const [])
 
 -- | Shrink the 'others' field of a 'Peers' structure by attempting to remove
 -- peers or by shrinking their values using the given shrinking function.
@@ -82,37 +80,36 @@ shrinkAdversarialPeers shrink Peers {honestPeers, adversarialPeers} =
 
 -- | Shrinks honest peers by removing ticks. Because we are manipulating
 -- 'PeerSchedule' at this point, there is no proper notion of a tick. Instead,
--- we remove points from the honest 'PeerSchedule', and move all other points
--- sooner, including those on the other schedules. We check that this operation
--- neither changes the final state of the honest peer, nor removes points from
--- the other schedules.
+-- we remove points from the honest 'PeerSchedule', and move all other points sooner.
+--
+-- We check that this operation does not changes the final state of the honest peer,
+-- that is, it keeps the same final tip point, header point, and block point.
+--
+-- NOTE: This operation makes the honest peer to end its schedule sooner, which *may*
+-- trigger disconnections when the timeout for MsgAwaitReply is reached. In those cases,
+-- it is probably more pertinent to disable this timeout in tests than to disable shrinking.
 shrinkHonestPeers :: Peers (PeerSchedule blk) -> [Peers (PeerSchedule blk)]
-shrinkHonestPeers Peers {honestPeers, adversarialPeers} =
-  Map.toList honestPeers
-    & concatMap
-      ( \(n, schedule) ->
-          shrinkTheHonestPeer schedule (Map.delete n honestPeers) adversarialPeers
-            & map
-              ( \(schedule', otherHonestPeers', otherAdversarialPeers') ->
-                  Peers
-                    { honestPeers = Map.insert n schedule' otherHonestPeers',
-                      adversarialPeers = otherAdversarialPeers'
-                    }
-              )
-      )
+shrinkHonestPeers Peers {honestPeers, adversarialPeers} = do
+  (k, honestSch) <- Map.toList honestPeers
+  let (lastHonest, _) = last honestSch
+  shrunk <- shrinkHonestPeer honestSch
+  pure $ Peers
+    { honestPeers = Map.insert k shrunk honestPeers
+    , adversarialPeers = fmap (extendAdversary lastHonest) adversarialPeers
+    }
+  where
+    -- Add an extra point at the end of the adversarial schedule if the honest one
+    -- was longer than it. Preserves the total duration of the simulation, so that
+    -- timeouts/LoP disconnections can still happen.
+    extendAdversary tLast = \case
+      [] -> []
+      ps -> case last ps of
+        (t, p) | t < tLast -> ps ++ [(tLast, p)]
+        _                  -> ps
 
-shrinkTheHonestPeer ::
-  PeerSchedule blk ->
-  Map Int (PeerSchedule blk) ->
-  Map Int (PeerSchedule blk) ->
-  [(PeerSchedule blk, Map Int (PeerSchedule blk), Map Int (PeerSchedule blk))]
-shrinkTheHonestPeer theSchedule otherHonestPeers otherAdversarialPeers = do
-  (at, speedUpBy) <- splits
-  maybeToList $ do
-    theSchedule' <- speedUpTheSchedule at speedUpBy theSchedule
-    otherHonestPeers' <- mapM (speedUpOtherSchedule at speedUpBy) otherHonestPeers
-    otherAdversarialPeers' <- mapM (speedUpOtherSchedule at speedUpBy) otherAdversarialPeers
-    pure (theSchedule', otherHonestPeers', otherAdversarialPeers')
+shrinkHonestPeer :: PeerSchedule blk -> [PeerSchedule blk]
+shrinkHonestPeer sch =
+  mapMaybe (speedUpTheSchedule sch) splits
   where
     -- | A list of non-zero time intervals between successive points of the honest schedule
     splits :: [(Time, DiffTime)]
@@ -122,20 +119,7 @@ shrinkTheHonestPeer theSchedule otherHonestPeers otherAdversarialPeers = do
           then Nothing
           else Just (t1, diffTime t2 t1)
       )
-      (zip theSchedule (drop 1 theSchedule))
-
--- | For testing purposes only. Assumes there is exactly one honest peer and
--- shrinks it.
-shrinkHonestPeer :: PeersSchedule blk -> [PeersSchedule blk]
-shrinkHonestPeer Peers {honestPeers, adversarialPeers} =
-  shrinkTheHonestPeer (getHonestPeer honestPeers) Map.empty adversarialPeers
-    & map
-      ( \(schedule', _, otherAdversarialPeers') ->
-          Peers
-            { honestPeers = Map.singleton 1 schedule',
-              adversarialPeers = otherAdversarialPeers'
-            }
-      )
+      (zip sch (drop 1 sch))
 
 -- | Speeds up _the_ schedule (that is, the one that we are actually trying to
 -- speed up) after `at` time, by `speedUpBy`. This "speeding up" is done by
@@ -143,8 +127,8 @@ shrinkHonestPeer Peers {honestPeers, adversarialPeers} =
 -- they fall before `at`. We check that the operation doesn't change the final
 -- state of the peer, i.e. it doesn't remove all TP, HP, and BP in the sped up
 -- part.
-speedUpTheSchedule :: Time -> DiffTime -> PeerSchedule blk -> Maybe (PeerSchedule blk)
-speedUpTheSchedule at speedUpBy sch =
+speedUpTheSchedule :: PeerSchedule blk -> (Time, DiffTime) -> Maybe (PeerSchedule blk)
+speedUpTheSchedule sch (at, speedUpBy) =
   if stillValid then Just $ beforeSplit ++ spedUpSchedule else Nothing
   where
     (beforeSplit, afterSplit) = span ((< at) . fst) sch
@@ -159,21 +143,6 @@ speedUpTheSchedule at speedUpBy sch =
     hasTP = any (\case (_, ScheduleTipPoint    _) -> True; _ -> False)
     hasHP = any (\case (_, ScheduleHeaderPoint _) -> True; _ -> False)
     hasBP = any (\case (_, ScheduleBlockPoint  _) -> True; _ -> False)
-
--- | Speeds up the other schedules after `at` time, by `speedUpBy`. This
--- "speeding up" is done by removing `speedUpBy` to all points after `at`. We
--- check that the schedule had no points between `at` and `at + speedUpBy`. We
--- also keep the last point where it is, so that the end time stays the same.
-speedUpOtherSchedule :: Time -> DiffTime -> PeerSchedule blk -> Maybe (PeerSchedule blk)
-speedUpOtherSchedule at speedUpBy sch =
-  if losesPoint then Nothing else Just $ beforeSplit ++ spedUpSchedule ++ lastPoint
-  where
-    (beforeSplit, afterSplit) = span ((< at) . fst) sch
-    spedUpSchedule = map (\(t, p) -> (addTime (-speedUpBy) t, p)) $ take (length afterSplit - 1) afterSplit
-    losesPoint = any ((< (addTime speedUpBy at)) . fst) afterSplit
-    lastPoint = case afterSplit of
-      [] -> []
-      as -> [last as]
 
 -- | Remove blocks from the given block tree that are not necessary for the
 -- given peer schedules. If entire branches are unused, they are removed. If the

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Shrinking.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Shrinking.hs
@@ -2,8 +2,8 @@
 {-# LANGUAGE NamedFieldPuns #-}
 
 module Test.Consensus.PointSchedule.Shrinking (
-    shrinkByRemovingAdversaries
     -- | Exported only for testing (that is, checking the properties of the function)
+    shrinkByRemovingAdversaries
   , shrinkHonestPeer
   , shrinkPeerSchedules
   ) where
@@ -11,7 +11,9 @@ module Test.Consensus.PointSchedule.Shrinking (
 import           Control.Monad.Class.MonadTime.SI (DiffTime, Time, addTime,
                      diffTime)
 import           Data.Containers.ListUtils (nubOrd)
+import           Data.Function ((&))
 import           Data.Functor ((<&>))
+import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           Data.Maybe (mapMaybe, maybeToList)
 import           Ouroboros.Network.AnchoredFragment (AnchoredFragment,
@@ -22,9 +24,10 @@ import           Test.Consensus.PeerSimulator.StateView (StateView)
 import           Test.Consensus.PointSchedule (GenesisTest (..),
                      GenesisTestFull, PeerSchedule, PeersSchedule,
                      peerSchedulesBlocks)
-import           Test.Consensus.PointSchedule.Peers (Peer (..), Peers (..))
+import           Test.Consensus.PointSchedule.Peers (Peers (..))
 import           Test.Consensus.PointSchedule.SinglePeer (SchedulePoint (..))
 import           Test.QuickCheck (shrinkList)
+import           Test.Util.PartialAccessors
 import           Test.Util.TestBlock (TestBlock, isAncestorOf,
                      isStrictAncestorOf)
 
@@ -38,16 +41,19 @@ shrinkPeerSchedules ::
   [GenesisTestFull TestBlock]
 shrinkPeerSchedules genesisTest _stateView =
   let trimmedBlockTree sch = trimBlockTree' sch (gtBlockTree genesisTest)
-      shrunkOthers = shrinkOtherPeers shrinkPeerSchedule (gtSchedule genesisTest) <&>
-        \shrunkSchedule -> genesisTest
-          { gtSchedule = shrunkSchedule
-          , gtBlockTree = trimmedBlockTree shrunkSchedule
-          }
-      shrunkHonest = shrinkHonestPeer
-        (gtSchedule genesisTest)
-        -- No need to update the tree here, shrinking the honest peer never discards blocks
-        <&> \shrunkSchedule -> genesisTest {gtSchedule = shrunkSchedule}
-  in shrunkOthers ++ shrunkHonest
+      shrunkAdversarialPeers =
+        shrinkAdversarialPeers shrinkPeerSchedule (gtSchedule genesisTest)
+          <&> \shrunkSchedule ->
+            genesisTest
+              { gtSchedule = shrunkSchedule,
+                gtBlockTree = trimmedBlockTree shrunkSchedule
+              }
+      shrunkHonestPeers =
+        shrinkHonestPeers
+          (gtSchedule genesisTest)
+          -- No need to update the tree here, shrinking the honest peers never discards blocks
+          <&> \shrunkSchedule -> genesisTest {gtSchedule = shrunkSchedule}
+   in shrunkAdversarialPeers ++ shrunkHonestPeers
 
 -- | Shrink a 'Peers PeerSchedule' by removing adversaries. This does not affect
 -- the honest peer; and it does not remove ticks from the schedules of the
@@ -57,7 +63,7 @@ shrinkByRemovingAdversaries ::
   StateView TestBlock ->
   [GenesisTestFull TestBlock]
 shrinkByRemovingAdversaries genesisTest _stateView =
-  shrinkOtherPeers (const []) (gtSchedule genesisTest) <&> \shrunkSchedule ->
+  shrinkAdversarialPeers (const []) (gtSchedule genesisTest) <&> \shrunkSchedule ->
     let trimmedBlockTree = trimBlockTree' shrunkSchedule (gtBlockTree genesisTest)
      in (genesisTest{gtSchedule = shrunkSchedule, gtBlockTree = trimmedBlockTree})
 
@@ -68,25 +74,45 @@ shrinkPeerSchedule = shrinkList (const [])
 
 -- | Shrink the 'others' field of a 'Peers' structure by attempting to remove
 -- peers or by shrinking their values using the given shrinking function.
-shrinkOtherPeers :: (a -> [a]) -> Peers a -> [Peers a]
-shrinkOtherPeers shrink Peers{honest, others} =
-  map (Peers honest . Map.fromList) $
-    shrinkList (traverse (traverse shrink)) $ Map.toList others
+shrinkAdversarialPeers :: (a -> [a]) -> Peers a -> [Peers a]
+shrinkAdversarialPeers shrink Peers {honestPeers, adversarialPeers} =
+  map (Peers honestPeers . Map.fromList) $
+    shrinkList (traverse shrink) $
+      Map.toList adversarialPeers
 
--- | Shrinks an honest peer by removing ticks.
--- Because we are manipulating 'PeerSchedule' at that point, there is no proper
--- notion of a tick. Instead, we remove points of the honest 'PeerSchedule',
--- and move all other points sooner, including those on the adversarial schedule.
--- We check that this operation neither changes the final state of the honest peer,
--- nor that it removes points from the adversarial schedules.
-shrinkHonestPeer :: Peers (PeerSchedule blk) -> [Peers (PeerSchedule blk)]
-shrinkHonestPeer Peers{honest, others} = do
+-- | Shrinks honest peers by removing ticks. Because we are manipulating
+-- 'PeerSchedule' at this point, there is no proper notion of a tick. Instead,
+-- we remove points from the honest 'PeerSchedule', and move all other points
+-- sooner, including those on the other schedules. We check that this operation
+-- neither changes the final state of the honest peer, nor removes points from
+-- the other schedules.
+shrinkHonestPeers :: Peers (PeerSchedule blk) -> [Peers (PeerSchedule blk)]
+shrinkHonestPeers Peers {honestPeers, adversarialPeers} =
+  Map.toList honestPeers
+    & concatMap
+      ( \(n, schedule) ->
+          shrinkTheHonestPeer schedule (Map.delete n honestPeers) adversarialPeers
+            & map
+              ( \(schedule', otherHonestPeers', otherAdversarialPeers') ->
+                  Peers
+                    { honestPeers = Map.insert n schedule' otherHonestPeers',
+                      adversarialPeers = otherAdversarialPeers'
+                    }
+              )
+      )
+
+shrinkTheHonestPeer ::
+  PeerSchedule blk ->
+  Map Int (PeerSchedule blk) ->
+  Map Int (PeerSchedule blk) ->
+  [(PeerSchedule blk, Map Int (PeerSchedule blk), Map Int (PeerSchedule blk))]
+shrinkTheHonestPeer theSchedule otherHonestPeers otherAdversarialPeers = do
   (at, speedUpBy) <- splits
-  (honest', others') <- maybeToList $ do
-    honest' <- traverse (speedUpHonestSchedule at speedUpBy) honest
-    others' <- mapM (traverse (speedUpAdversarialSchedule at speedUpBy)) others
-    pure (honest', others')
-  pure $ Peers honest' others'
+  maybeToList $ do
+    theSchedule' <- speedUpTheSchedule at speedUpBy theSchedule
+    otherHonestPeers' <- mapM (speedUpOtherSchedule at speedUpBy) otherHonestPeers
+    otherAdversarialPeers' <- mapM (speedUpOtherSchedule at speedUpBy) otherAdversarialPeers
+    pure (theSchedule', otherHonestPeers', otherAdversarialPeers')
   where
     -- | A list of non-zero time intervals between successive points of the honest schedule
     splits :: [(Time, DiffTime)]
@@ -96,15 +122,29 @@ shrinkHonestPeer Peers{honest, others} = do
           then Nothing
           else Just (t1, diffTime t2 t1)
       )
-      (zip (value honest) (drop 1 $ value honest))
+      (zip theSchedule (drop 1 theSchedule))
 
--- | Speeds up an honest schedule after `at` time, by `speedUpBy`.
--- This “speeding up” is done by subtracting @speedUpBy@ to all points after @at@,
--- and removing those points if they fall before `at`. We check that the operation
--- doesn't change the final state of the peer, i.e. it doesn't remove all TP, HP, and BP
--- in the sped up part.
-speedUpHonestSchedule :: Time -> DiffTime -> PeerSchedule blk -> Maybe (PeerSchedule blk)
-speedUpHonestSchedule at speedUpBy sch =
+-- | For testing purposes only. Assumes there is exactly one honest peer and
+-- shrinks it.
+shrinkHonestPeer :: PeersSchedule blk -> [PeersSchedule blk]
+shrinkHonestPeer Peers {honestPeers, adversarialPeers} =
+  shrinkTheHonestPeer (getHonestPeer honestPeers) Map.empty adversarialPeers
+    & map
+      ( \(schedule', _, otherAdversarialPeers') ->
+          Peers
+            { honestPeers = Map.singleton 1 schedule',
+              adversarialPeers = otherAdversarialPeers'
+            }
+      )
+
+-- | Speeds up _the_ schedule (that is, the one that we are actually trying to
+-- speed up) after `at` time, by `speedUpBy`. This "speeding up" is done by
+-- removing `speedUpBy` to all points after `at`, and removing those points if
+-- they fall before `at`. We check that the operation doesn't change the final
+-- state of the peer, i.e. it doesn't remove all TP, HP, and BP in the sped up
+-- part.
+speedUpTheSchedule :: Time -> DiffTime -> PeerSchedule blk -> Maybe (PeerSchedule blk)
+speedUpTheSchedule at speedUpBy sch =
   if stillValid then Just $ beforeSplit ++ spedUpSchedule else Nothing
   where
     (beforeSplit, afterSplit) = span ((< at) . fst) sch
@@ -120,12 +160,12 @@ speedUpHonestSchedule at speedUpBy sch =
     hasHP = any (\case (_, ScheduleHeaderPoint _) -> True; _ -> False)
     hasBP = any (\case (_, ScheduleBlockPoint  _) -> True; _ -> False)
 
--- | Speeds up an adversarial schedule after `at` time, by `speedUpBy`.
--- This "speeding up" is done by removing `speedUpBy` to all points after `at`.
--- We check that the schedule had no points between `at` and `at + speedUpBy`.
--- We also keep the last point where it is, so that the end time stays the same.
-speedUpAdversarialSchedule :: Time -> DiffTime -> PeerSchedule blk -> Maybe (PeerSchedule blk)
-speedUpAdversarialSchedule at speedUpBy sch =
+-- | Speeds up the other schedules after `at` time, by `speedUpBy`. This
+-- "speeding up" is done by removing `speedUpBy` to all points after `at`. We
+-- check that the schedule had no points between `at` and `at + speedUpBy`. We
+-- also keep the last point where it is, so that the end time stays the same.
+speedUpOtherSchedule :: Time -> DiffTime -> PeerSchedule blk -> Maybe (PeerSchedule blk)
+speedUpOtherSchedule at speedUpBy sch =
   if losesPoint then Nothing else Just $ beforeSplit ++ spedUpSchedule ++ lastPoint
   where
     (beforeSplit, afterSplit) = span ((< at) . fst) sch

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Shrinking/Tests.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Shrinking/Tests.hs
@@ -11,7 +11,7 @@ import           Test.Consensus.Genesis.Setup (genChains)
 import           Test.Consensus.Genesis.Tests.Uniform (genUniformSchedulePoints)
 import           Test.Consensus.PointSchedule (PeerSchedule, PeersSchedule,
                      prettyPeersSchedule)
-import           Test.Consensus.PointSchedule.Peers (Peer (..), Peers (..))
+import           Test.Consensus.PointSchedule.Peers (Peers (..))
 import           Test.Consensus.PointSchedule.Shrinking (shrinkHonestPeer)
 import           Test.Consensus.PointSchedule.SinglePeer (SchedulePoint (..))
 import           Test.QuickCheck (Property, conjoin, counterexample)
@@ -45,7 +45,7 @@ lastM [a]    = Just a
 lastM (_:ps) = lastM ps
 
 samePeers :: PeersSchedule blk -> PeersSchedule blk -> Bool
-samePeers sch1 sch2 = (keys $ others sch1) == (keys $ others sch2)
+samePeers sch1 sch2 = (keys $ adversarialPeers sch1) == (keys $ adversarialPeers sch2)
 
 -- | Checks whether at least one peer schedule in the second given peers schedule
 -- is shorter than its corresponding one in the fist given peers schedule. “Shorter”
@@ -84,8 +84,8 @@ doesNotRemoveAdversarialPoints original shrunk =
   samePeers original shrunk
   && (and $ zipWith
     (\oldSch newSch -> fmap snd oldSch == fmap snd newSch)
-    (toList $ (fmap value) $ others original)
-    (toList $ (fmap value) $ others shrunk)
+    (toList $ adversarialPeers original)
+    (toList $ adversarialPeers shrunk)
   )
 
 checkShrinkProperty :: (PeersSchedule TestBlock -> PeersSchedule TestBlock -> Bool) -> Property

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Shrinking/Tests.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Shrinking/Tests.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE LambdaCase        #-}
+{-# LANGUAGE NamedFieldPuns    #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 -- | Test properties of the shrinking functions
@@ -40,24 +41,24 @@ lastM []     = Nothing
 lastM [a]    = Just a
 lastM (_:ps) = lastM ps
 
-samePeers :: PointSchedule blk -> PointSchedule blk -> Bool
+samePeers :: Peers (PeerSchedule blk) -> Peers (PeerSchedule blk) -> Bool
 samePeers sch1 sch2 =
-  (keys $ adversarialPeers $ unPointSchedule sch1)
-    == (keys $ adversarialPeers $ unPointSchedule sch2)
+  (keys $ adversarialPeers sch1)
+    == (keys $ adversarialPeers sch2)
 
 -- | Checks whether at least one peer schedule in the second given peers schedule
 -- is shorter than its corresponding one in the fist given peers schedule. “Shorter”
 -- here means that it executes in less time.
-isShorterThan :: PointSchedule blk -> PointSchedule blk -> Bool
+isShorterThan :: Peers (PeerSchedule blk) -> Peers (PeerSchedule blk) -> Bool
 isShorterThan original shrunk =
   samePeers original shrunk
   && (or $ zipWith
     (\oldSch newSch -> (fst <$> lastM newSch) < (fst <$> lastM oldSch))
-    (toList $ unPointSchedule original)
-    (toList $ unPointSchedule shrunk)
+    (toList original)
+    (toList shrunk)
   )
 
-doesNotChangeFinalState :: Eq blk => PointSchedule blk -> PointSchedule blk -> Bool
+doesNotChangeFinalState :: Eq blk => Peers (PeerSchedule blk) -> Peers (PeerSchedule blk) -> Bool
 doesNotChangeFinalState original shrunk =
   samePeers original shrunk
   && (and $ zipWith
@@ -66,8 +67,8 @@ doesNotChangeFinalState original shrunk =
       lastHP oldSch == lastHP newSch &&
       lastBP oldSch == lastBP newSch
     )
-    (toList $ unPointSchedule original)
-    (toList $ unPointSchedule shrunk)
+    (toList original)
+    (toList shrunk)
   )
   where
     lastTP :: PeerSchedule blk -> Maybe (SchedulePoint blk)
@@ -77,20 +78,20 @@ doesNotChangeFinalState original shrunk =
     lastBP :: PeerSchedule blk -> Maybe (SchedulePoint blk)
     lastBP sch = lastM $ mapMaybe (\case (_, p@(ScheduleBlockPoint  _)) -> Just p ; _ -> Nothing) sch
 
-checkShrinkProperty :: (PointSchedule TestBlock -> PointSchedule TestBlock -> Bool) -> Property
+checkShrinkProperty :: (Peers (PeerSchedule TestBlock) -> Peers (PeerSchedule TestBlock) -> Bool) -> Property
 checkShrinkProperty prop =
   forAllBlind
     (genChains (choose (1, 4)) >>= genUniformSchedulePoints)
-    (\schedule ->
+    (\sch@PointSchedule{psSchedule, psMinEndTime} ->
       conjoin $ map
       (\shrunk ->
           counterexample
           (  "Original schedule:\n"
-          ++ unlines (map ("    " ++) $ prettyPointSchedule schedule)
+          ++ unlines (map ("    " ++) $ prettyPointSchedule sch)
           ++ "\nShrunk schedule:\n"
-          ++ unlines (map ("    " ++) $ prettyPointSchedule shrunk)
+          ++ unlines (map ("    " ++) $ prettyPointSchedule $ PointSchedule shrunk psMinEndTime)
           )
-          (prop schedule shrunk)
+          (prop psSchedule shrunk)
       )
-      (shrinkHonestPeers schedule)
+      (shrinkHonestPeers psSchedule)
     )

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Shrinking/Tests.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Shrinking/Tests.hs
@@ -9,8 +9,8 @@ import           Data.Map (keys)
 import           Data.Maybe (mapMaybe)
 import           Test.Consensus.Genesis.Setup (genChains)
 import           Test.Consensus.Genesis.Tests.Uniform (genUniformSchedulePoints)
-import           Test.Consensus.PointSchedule (PeerSchedule, PeersSchedule,
-                     prettyPeersSchedule)
+import           Test.Consensus.PointSchedule (PeerSchedule, PointSchedule (..),
+                     prettyPointSchedule)
 import           Test.Consensus.PointSchedule.Peers (Peers (..))
 import           Test.Consensus.PointSchedule.Shrinking (shrinkHonestPeers)
 import           Test.Consensus.PointSchedule.SinglePeer (SchedulePoint (..))
@@ -40,22 +40,24 @@ lastM []     = Nothing
 lastM [a]    = Just a
 lastM (_:ps) = lastM ps
 
-samePeers :: PeersSchedule blk -> PeersSchedule blk -> Bool
-samePeers sch1 sch2 = (keys $ adversarialPeers sch1) == (keys $ adversarialPeers sch2)
+samePeers :: PointSchedule blk -> PointSchedule blk -> Bool
+samePeers sch1 sch2 =
+  (keys $ adversarialPeers $ unPointSchedule sch1)
+    == (keys $ adversarialPeers $ unPointSchedule sch2)
 
 -- | Checks whether at least one peer schedule in the second given peers schedule
 -- is shorter than its corresponding one in the fist given peers schedule. “Shorter”
 -- here means that it executes in less time.
-isShorterThan :: PeersSchedule blk -> PeersSchedule blk -> Bool
+isShorterThan :: PointSchedule blk -> PointSchedule blk -> Bool
 isShorterThan original shrunk =
   samePeers original shrunk
   && (or $ zipWith
     (\oldSch newSch -> (fst <$> lastM newSch) < (fst <$> lastM oldSch))
-    (toList original)
-    (toList shrunk)
+    (toList $ unPointSchedule original)
+    (toList $ unPointSchedule shrunk)
   )
 
-doesNotChangeFinalState :: Eq blk => PeersSchedule blk -> PeersSchedule blk -> Bool
+doesNotChangeFinalState :: Eq blk => PointSchedule blk -> PointSchedule blk -> Bool
 doesNotChangeFinalState original shrunk =
   samePeers original shrunk
   && (and $ zipWith
@@ -64,8 +66,8 @@ doesNotChangeFinalState original shrunk =
       lastHP oldSch == lastHP newSch &&
       lastBP oldSch == lastBP newSch
     )
-    (toList original)
-    (toList shrunk)
+    (toList $ unPointSchedule original)
+    (toList $ unPointSchedule shrunk)
   )
   where
     lastTP :: PeerSchedule blk -> Maybe (SchedulePoint blk)
@@ -75,7 +77,7 @@ doesNotChangeFinalState original shrunk =
     lastBP :: PeerSchedule blk -> Maybe (SchedulePoint blk)
     lastBP sch = lastM $ mapMaybe (\case (_, p@(ScheduleBlockPoint  _)) -> Just p ; _ -> Nothing) sch
 
-checkShrinkProperty :: (PeersSchedule TestBlock -> PeersSchedule TestBlock -> Bool) -> Property
+checkShrinkProperty :: (PointSchedule TestBlock -> PointSchedule TestBlock -> Bool) -> Property
 checkShrinkProperty prop =
   forAllBlind
     (genChains (choose (1, 4)) >>= genUniformSchedulePoints)
@@ -84,9 +86,9 @@ checkShrinkProperty prop =
       (\shrunk ->
           counterexample
           (  "Original schedule:\n"
-          ++ unlines (map ("    " ++) $ prettyPeersSchedule schedule)
+          ++ unlines (map ("    " ++) $ prettyPointSchedule schedule)
           ++ "\nShrunk schedule:\n"
-          ++ unlines (map ("    " ++) $ prettyPeersSchedule shrunk)
+          ++ unlines (map ("    " ++) $ prettyPointSchedule shrunk)
           )
           (prop schedule shrunk)
       )

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Shrinking/Tests.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Shrinking/Tests.hs
@@ -82,14 +82,14 @@ checkShrinkProperty :: (Peers (PeerSchedule TestBlock) -> Peers (PeerSchedule Te
 checkShrinkProperty prop =
   forAllBlind
     (genChains (choose (1, 4)) >>= genUniformSchedulePoints)
-    (\sch@PointSchedule{psSchedule, psMinEndTime} ->
+    (\sch@PointSchedule{psSchedule, psStartOrder, psMinEndTime} ->
       conjoin $ map
       (\shrunk ->
           counterexample
           (  "Original schedule:\n"
           ++ unlines (map ("    " ++) $ prettyPointSchedule sch)
           ++ "\nShrunk schedule:\n"
-          ++ unlines (map ("    " ++) $ prettyPointSchedule $ PointSchedule shrunk psMinEndTime)
+          ++ unlines (map ("    " ++) $ prettyPointSchedule $ PointSchedule {psSchedule = shrunk, psStartOrder, psMinEndTime})
           )
           (prop psSchedule shrunk)
       )

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Util/PartialAccessors.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Util/PartialAccessors.hs
@@ -1,0 +1,42 @@
+{-# LANGUAGE NamedFieldPuns #-}
+
+-- | Helpers to access particular parts of trees and schedules
+-- Those functions are partial, and are designed to only be used in tests.
+-- We know they won't fail there, because we generated the structures
+-- with the correct properties.
+module Test.Util.PartialAccessors (
+    getHonestPeer
+  , getOnlyBranch
+  , getOnlyBranchTip
+  , getTrunkTip
+  ) where
+
+import qualified Data.Map as Map
+import qualified Ouroboros.Network.AnchoredFragment as AF
+import           Ouroboros.Network.Block (HasHeader)
+import           Test.Consensus.BlockTree
+
+getOnlyBranch :: BlockTree blk -> BlockTreeBranch blk
+getOnlyBranch BlockTree {btBranches} = case btBranches of
+  [branch] -> branch
+  _        -> error "tree must have exactly one alternate branch"
+
+getTrunkTip :: HasHeader blk => BlockTree blk -> blk
+getTrunkTip tree = case btTrunk tree of
+  (AF.Empty _)       -> error "tree must have at least one block"
+  (_ AF.:> tipBlock) -> tipBlock
+
+getOnlyBranchTip :: HasHeader blk => BlockTree blk -> blk
+getOnlyBranchTip BlockTree {btBranches} = case btBranches of
+  [branch] -> case btbFull branch of
+    (AF.Empty _)       -> error "alternate branch must have at least one block"
+    (_ AF.:> tipBlock) -> tipBlock
+  _ -> error "tree must have exactly one alternate branch"
+
+getHonestPeer :: Map.Map Int a -> a
+getHonestPeer honests =
+  if Map.size honests /= 1
+    then error "there must be exactly one honest peer"
+    else case Map.lookup 1 honests of
+      Nothing -> error "the only honest peer must have id 1"
+      Just p  -> p

--- a/ouroboros-consensus/changelog.d/20240531_155125_alexander.esgen_milestone_13.md
+++ b/ouroboros-consensus/changelog.d/20240531_155125_alexander.esgen_milestone_13.md
@@ -1,0 +1,4 @@
+### Breaking
+
+- Internal refactorings in the CSJ and GDD.
+- Improvements to the LoE.

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -175,6 +175,7 @@ library
     Ouroboros.Consensus.MiniProtocol.LocalStateQuery.Server
     Ouroboros.Consensus.MiniProtocol.LocalTxMonitor.Server
     Ouroboros.Consensus.MiniProtocol.LocalTxSubmission.Server
+    Ouroboros.Consensus.Node.GsmState
     Ouroboros.Consensus.Node.InitStorage
     Ouroboros.Consensus.Node.NetworkProtocolVersion
     Ouroboros.Consensus.Node.ProtocolInfo
@@ -590,6 +591,7 @@ test-suite infra-test
   build-depends:
     QuickCheck,
     base,
+    io-classes,
     io-sim,
     mtl,
     ouroboros-consensus:{ouroboros-consensus, unstable-consensus-testlib},

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Genesis/Governor.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Genesis/Governor.hs
@@ -403,8 +403,10 @@ densityDisconnect (GenesisWindow sgen) (SecurityParam k) states candidateSuffixe
     firstSlotAfterGenesisWindow =
         succWithOrigin loeIntersectionSlot + SlotNo sgen
 
+    -- This is performance sensitive. We used to call @takeWhileOldest@ here,
+    -- which would reconstruct much of the original fragment.
     dropBeyondGenesisWindow =
-      AF.takeWhileOldest ((< firstSlotAfterGenesisWindow) . blockSlot)
+      AF.dropWhileNewest ((>= firstSlotAfterGenesisWindow) . blockSlot)
 
     clippedFrags =
       Map.map dropBeyondGenesisWindow candidateSuffixes

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Genesis/Governor.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Genesis/Governor.hs
@@ -37,11 +37,13 @@ module Ouroboros.Consensus.Genesis.Governor (
 
 import           Control.Monad (guard, when)
 import           Control.Tracer (Tracer, traceWith)
+import           Data.Bifunctor (second)
 import           Data.Containers.ListUtils (nubOrd)
 import           Data.Foldable (for_)
+import           Data.Functor.Compose (Compose (..))
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import           Data.Maybe (maybeToList)
+import           Data.Maybe (mapMaybe, maybeToList)
 import           Data.Word (Word64)
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config (TopLevelConfig, configLedger,
@@ -188,7 +190,7 @@ evaluateGDD cfg tracer stateView = do
 
         (loeFrag, candidateSuffixes) =
           sharedCandidatePrefix curChain candidates
-        candidates = csCandidate <$> states
+        candidates = Map.toList (csCandidate <$> states)
 
         msgen :: Maybe GenesisWindow
         -- This could also use 'runWithCachedSummary' if deemed desirable.
@@ -235,15 +237,17 @@ evaluateGDD cfg tracer stateView = do
 sharedCandidatePrefix ::
   GetHeader blk =>
   AnchoredFragment (Header blk) ->
-  Map peer (AnchoredFragment (Header blk)) ->
-  (AnchoredFragment (Header blk), Map peer (AnchoredFragment (Header blk)))
+  [(peer, AnchoredFragment (Header blk))] ->
+  (AnchoredFragment (Header blk), [(peer, AnchoredFragment (Header blk))])
 sharedCandidatePrefix curChain candidates =
-  stripCommonPrefix (AF.anchor curChain) immutableTipSuffixes
+  second getCompose $
+  stripCommonPrefix (AF.anchor curChain) $
+  Compose immutableTipSuffixes
   where
     immutableTip = AF.anchorPoint curChain
 
-    splitAfterImmutableTip frag =
-      snd <$> AF.splitAfterPoint frag immutableTip
+    splitAfterImmutableTip (peer, frag) =
+      (,) peer . snd <$> AF.splitAfterPoint frag immutableTip
 
     immutableTipSuffixes =
       -- If a ChainSync client's candidate forks off before the
@@ -252,7 +256,7 @@ sharedCandidatePrefix curChain candidates =
       -- 'InvalidIntersection' within that ChainSync client, so it's
       -- sound to pre-emptively discard their candidate from this
       -- 'Map' via 'mapMaybe'.
-      Map.mapMaybe splitAfterImmutableTip candidates
+      mapMaybe splitAfterImmutableTip candidates
 
 data DensityBounds blk =
   DensityBounds {
@@ -296,21 +300,20 @@ densityDisconnect ::
   => GenesisWindow
   -> SecurityParam
   -> Map peer (ChainSyncState blk)
-  -> Map peer (AnchoredFragment (Header blk))
+  -> [(peer, AnchoredFragment (Header blk))]
   -> AnchoredFragment (Header blk)
-  -> ([peer], Map peer (DensityBounds blk))
+  -> ([peer], [(peer, DensityBounds blk)])
 densityDisconnect (GenesisWindow sgen) (SecurityParam k) states candidateSuffixes loeFrag =
   (losingPeers, densityBounds)
   where
-    densityBounds = Map.fromList $ do
-      (peer, clippedFragment) <- Map.toList clippedFrags
+    densityBounds = do
+      (peer, candidateSuffix) <- candidateSuffixes
+      let clippedFragment = dropBeyondGenesisWindow candidateSuffix
       state <- maybeToList (states Map.!? peer)
       -- Skip peers that haven't sent any headers yet.
       -- They should be disconnected by timeouts instead.
       latestSlot <- maybeToList (csLatestSlot state)
-      let candidateSuffix = candidateSuffixes Map.! peer
-
-          idling = csIdling state
+      let idling = csIdling state
 
           -- Is there a block after the end of the Genesis window?
           hasBlockAfter =
@@ -347,7 +350,7 @@ densityDisconnect (GenesisWindow sgen) (SecurityParam k) states candidateSuffixe
 
       pure (peer, DensityBounds {clippedFragment, offersMoreThanK, lowerBound, upperBound, hasBlockAfter, latestSlot, idling})
 
-    losingPeers = nubOrd $ Map.toList densityBounds >>= \
+    losingPeers = nubOrd $ densityBounds >>= \
       (peer0 , DensityBounds { clippedFragment = frag0
                              , lowerBound = lb0
                              , upperBound = ub0
@@ -359,7 +362,7 @@ densityDisconnect (GenesisWindow sgen) (SecurityParam k) states candidateSuffixe
       -- from happening.
       if ub0 == 0 then pure peer0 else do
       (_peer1, DensityBounds {clippedFragment = frag1, offersMoreThanK, lowerBound = lb1 }) <-
-        Map.toList densityBounds
+        densityBounds
       -- Don't disconnect peer0 if it sent no headers after the intersection yet
       -- and it is not idling.
       --
@@ -408,9 +411,6 @@ densityDisconnect (GenesisWindow sgen) (SecurityParam k) states candidateSuffixe
     dropBeyondGenesisWindow =
       AF.dropWhileNewest ((>= firstSlotAfterGenesisWindow) . blockSlot)
 
-    clippedFrags =
-      Map.map dropBeyondGenesisWindow candidateSuffixes
-
 -- Note [Chain disagreement]
 -- ~~~~~~~~~~~~~~~~~~~~~~~~~
 --
@@ -436,10 +436,10 @@ densityDisconnect (GenesisWindow sgen) (SecurityParam k) states candidateSuffixe
 
 data TraceGDDEvent peer blk =
   TraceGDDEvent {
-    bounds            :: Map peer (DensityBounds blk),
+    bounds            :: [(peer, DensityBounds blk)],
     curChain          :: AnchoredFragment (Header blk),
-    candidates        :: Map peer (AnchoredFragment (Header blk)),
-    candidateSuffixes :: Map peer (AnchoredFragment (Header blk)),
+    candidates        :: [(peer, AnchoredFragment (Header blk))],
+    candidateSuffixes :: [(peer, AnchoredFragment (Header blk))],
     losingPeers       :: [peer],
     loeHead           :: AF.Anchor (Header blk),
     sgen              :: GenesisWindow

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Genesis/Governor.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Genesis/Governor.hs
@@ -6,6 +6,8 @@
 {-# LANGUAGE NamedFieldPuns       #-}
 {-# LANGUAGE RankNTypes           #-}
 {-# LANGUAGE ScopedTypeVariables  #-}
+{-# LANGUAGE StandaloneDeriving   #-}
+{-# LANGUAGE TypeOperators        #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 -- | Implementation of the GDD governor
@@ -26,9 +28,10 @@
 --
 module Ouroboros.Consensus.Genesis.Governor (
     DensityBounds (..)
+  , GDDStateView (..)
   , TraceGDDEvent (..)
   , densityDisconnect
-  , runGDDGovernor
+  , gddWatcher
   , sharedCandidatePrefix
   ) where
 
@@ -39,7 +42,6 @@ import           Data.Foldable (for_)
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           Data.Maybe (maybeToList)
-import           Data.Void
 import           Data.Word (Word64)
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config (TopLevelConfig, configLedger,
@@ -55,61 +57,100 @@ import           Ouroboros.Consensus.Ledger.SupportsProtocol
                      (LedgerSupportsProtocol)
 import           Ouroboros.Consensus.MiniProtocol.ChainSync.Client
                      (ChainSyncClientHandle (..), ChainSyncState (..))
-import           Ouroboros.Consensus.Storage.ChainDB.API (ChainDB,
-                     triggerChainSelectionAsync)
+import           Ouroboros.Consensus.Node.GsmState
+import           Ouroboros.Consensus.Storage.ChainDB.API (ChainDB)
 import qualified Ouroboros.Consensus.Storage.ChainDB.API as ChainDB
 import           Ouroboros.Consensus.Util (eitherToMaybe, whenJust)
 import           Ouroboros.Consensus.Util.AnchoredFragment (stripCommonPrefix)
 import           Ouroboros.Consensus.Util.IOLike
-import           Ouroboros.Consensus.Util.STM (blockUntilChanged)
+import           Ouroboros.Consensus.Util.STM (Watcher (..))
 import           Ouroboros.Network.AnchoredFragment (AnchoredFragment)
 import qualified Ouroboros.Network.AnchoredFragment as AF
 
--- | A never ending computation that evaluates the GDD rule whenever
--- the STM action @getTrigger@ yields a different result, writing the LoE
+-- | A 'Watcher' that evaluates the GDD rule whenever necessary, writing the LoE
 -- fragment to @varLoEFrag@, and then triggering ChainSel to reprocess all
 -- blocks that had previously been postponed by the LoE.
 --
 -- Evaluating the GDD rule might cause peers to be disconnected if they have
 -- sparser chains than the best chain.
---
--- The LoE fragment is the fragment anchored at the immutable tip and ending at
--- the LoE tip.
---
--- @getHandles@ is the callback to get the handles that allow to disconnect
--- from peers.
---
-runGDDGovernor ::
-  ( Monoid a,
-    Eq a,
-    HasHardForkHistory blk,
-    IOLike m,
-    LedgerSupportsProtocol blk,
-    Ord peer
-  ) =>
-  TopLevelConfig blk ->
-  Tracer m (TraceGDDEvent peer blk) ->
-  STM m (Map peer (ChainSyncClientHandle m blk)) ->
-  StrictTVar m (AnchoredFragment (Header blk)) ->
-  ChainDB m blk ->
-  STM m a ->
-  m Void
-runGDDGovernor cfg tracer getHandles varLoEFrag chainDb getTrigger =
-  spin mempty
+gddWatcher ::
+     forall m blk peer.
+     ( IOLike m
+     , Ord peer
+     , LedgerSupportsProtocol blk
+     , HasHardForkHistory blk
+     )
+  => TopLevelConfig blk
+  -> Tracer m (TraceGDDEvent peer blk)
+  -> ChainDB m blk
+  -> STM m GsmState
+  -> STM m (Map peer (ChainSyncClientHandle m blk))
+     -- ^ The ChainSync handles. We trigger the GDD whenever our 'GsmState'
+     -- changes, and when 'Syncing', whenever any of the candidate fragments
+     -- changes. Also, we use this to disconnect from peers with insufficient
+     -- densities.
+  -> StrictTVar m (AnchoredFragment (Header blk))
+     -- ^ The LoE fragment. It starts at a (recent) immutable tip and ends at
+     -- the common intersection of the candidate fragments.
+  -> Watcher m
+       (GsmState, GDDStateView m blk peer)
+       (Map peer (Maybe (WithOrigin SlotNo), Bool))
+gddWatcher cfg tracer chainDb getGsmState getHandles varLoEFrag =
+    Watcher {
+        wInitial = Nothing
+      , wReader  = (,) <$> getGsmState <*> getGDDStateView
+      , wFingerprint
+      , wNotify
+      }
   where
-    spin oldTrigger = do
-      (newTrigger, curChain, curLedger) <- atomically $ do
-        (_, newTrigger) <- blockUntilChanged id oldTrigger getTrigger
-        curChain <- ChainDB.getCurrentChain chainDb
-        curLedger <- ChainDB.getCurrentLedger chainDb
-        pure (newTrigger, curChain, curLedger)
-      loeFrag <- evaluateGDD cfg tracer getHandles curChain curLedger
-      oldLoEFrag <- atomically $ swapTVar varLoEFrag loeFrag
-      -- The chain selection only depends on the LoE tip, so there
-      -- is no point in retriggering it if the LoE tip hasn't changed.
-      when (AF.headHash oldLoEFrag /= AF.headHash loeFrag) $
-        triggerChainSelectionAsync chainDb
-      spin newTrigger
+    getGDDStateView :: STM m (GDDStateView m blk peer)
+    getGDDStateView = do
+        curChain          <- ChainDB.getCurrentChain chainDb
+        immutableLedgerSt <- ChainDB.getImmutableLedger chainDb
+        handles           <- getHandles
+        states            <- traverse (readTVar . cschState) handles
+        pure GDDStateView {
+            gddCtxCurChain          = curChain
+          , gddCtxImmutableLedgerSt = immutableLedgerSt
+          , gddCtxKillActions       = Map.map cschGDDKill handles
+          , gddCtxStates            = states
+          }
+
+    wFingerprint ::
+         (GsmState, GDDStateView m blk peer)
+      -> Map peer (Maybe (WithOrigin SlotNo), Bool)
+    wFingerprint (gsmState, GDDStateView{gddCtxStates}) = case gsmState of
+        -- When we are in 'PreSyncing' (HAA not satisfied) or are caught up, we
+        -- don't have to run the GDD on changes to the candidate fragments.
+        -- (Maybe we want to do it in 'PreSycing'?)
+        PreSyncing -> Map.empty
+        CaughtUp   -> Map.empty
+        -- When syncing, wake up regularly while headers are sent.
+        -- Watching csLatestSlot ensures that GDD is woken up when a peer is
+        -- sending headers even if they are after the forecast horizon. Note
+        -- that there can be some delay between the header being validated and
+        -- it becoming visible to GDD. It will be visible only when csLatestSlot
+        -- changes again or when csIdling changes, which is guaranteed to happen
+        -- eventually.
+        Syncing    ->
+          Map.map (\css -> (csLatestSlot css, csIdling css)) gddCtxStates
+
+    wNotify :: (GsmState, GDDStateView m blk peer) -> m ()
+    wNotify (_gsmState, stateView) = do
+        loeFrag <- evaluateGDD cfg tracer stateView
+        oldLoEFrag <- atomically $ swapTVar varLoEFrag loeFrag
+        -- The chain selection only depends on the LoE tip, so there
+        -- is no point in retriggering it if the LoE tip hasn't changed.
+        when (AF.headHash oldLoEFrag /= AF.headHash loeFrag) $
+          ChainDB.triggerChainSelectionAsync chainDb
+
+-- | Pure snapshot of the dynamic data the GDD operates on.
+data GDDStateView m blk peer = GDDStateView {
+    gddCtxCurChain          :: AnchoredFragment (Header blk)
+  , gddCtxImmutableLedgerSt :: ExtLedgerState blk
+  , gddCtxKillActions       :: Map peer (m ())
+  , gddCtxStates            :: Map peer (ChainSyncState blk)
+  }
 
 -- | Disconnect peers that lose density comparisons and recompute the LoE fragment.
 --
@@ -135,21 +176,21 @@ evaluateGDD ::
      )
   => TopLevelConfig blk
   -> Tracer m (TraceGDDEvent peer blk)
-  -> STM m (Map peer (ChainSyncClientHandle m blk))
-  -> AnchoredFragment (Header blk)
-  -> ExtLedgerState blk
+  -> GDDStateView m blk peer
   -> m (AnchoredFragment (Header blk))
-evaluateGDD cfg tracer getHandles curChain immutableLedgerSt = do
-    (states, candidates, candidateSuffixes, handles, loeFrag) <- atomically $ do
-      handles <- getHandles
-      states <- traverse (readTVar . cschState) handles
-      let
-        candidates = csCandidate <$> states
+evaluateGDD cfg tracer stateView = do
+    let GDDStateView {
+            gddCtxCurChain          = curChain
+          , gddCtxImmutableLedgerSt = immutableLedgerSt
+          , gddCtxKillActions       = killActions
+          , gddCtxStates            = states
+          } = stateView
+
         (loeFrag, candidateSuffixes) =
           sharedCandidatePrefix curChain candidates
-      pure (states, candidates, candidateSuffixes, handles, loeFrag)
+        candidates = csCandidate <$> states
 
-    let msgen :: Maybe GenesisWindow
+        msgen :: Maybe GenesisWindow
         -- This could also use 'runWithCachedSummary' if deemed desirable.
         msgen = eitherToMaybe $ runQuery qry summary
           where
@@ -180,7 +221,7 @@ evaluateGDD cfg tracer getHandles curChain immutableLedgerSt = do
 
       traceWith tracer TraceGDDEvent {sgen, curChain, bounds, candidates, candidateSuffixes, losingPeers, loeHead}
 
-      for_ losingPeers $ \peer -> cschGDDKill (handles Map.! peer)
+      for_ losingPeers $ \peer -> killActions Map.! peer
 
     pure loeFrag
 
@@ -223,6 +264,8 @@ data DensityBounds blk =
     latestSlot      :: WithOrigin SlotNo,
     idling          :: Bool
   }
+
+deriving stock instance (Show (Header blk), GetHeader blk) => Show (DensityBounds blk)
 
 -- | @densityDisconnect genWin k states candidateSuffixes loeFrag@
 -- yields the list of peers which are known to lose the density comparison with
@@ -399,3 +442,7 @@ data TraceGDDEvent peer blk =
     loeHead           :: AF.Anchor (Header blk),
     sgen              :: GenesisWindow
   }
+
+deriving stock instance
+  ( GetHeader blk, Show (Header blk), Show peer
+  ) => Show (TraceGDDEvent peer blk)

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Genesis/Governor.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Genesis/Governor.hs
@@ -34,7 +34,7 @@ module Ouroboros.Consensus.Genesis.Governor (
   , updateLoEFragUnconditional
   ) where
 
-import           Control.Monad (guard)
+import           Control.Monad (guard, when)
 import           Control.Tracer (Tracer, traceWith)
 import           Data.Containers.ListUtils (nubOrd)
 import           Data.Foldable (for_)
@@ -163,8 +163,11 @@ runGdd loEUpdater varLoEFrag chainDb getTrigger =
         curLedger <- ChainDB.getCurrentLedger chainDb
         pure (newTrigger, curChain, curLedger)
       loeFrag <- updateLoEFrag loEUpdater curChain curLedger
-      atomically $ writeTVar varLoEFrag loeFrag
-      triggerChainSelectionAsync chainDb
+      oldLoEFrag <- atomically $ swapTVar varLoEFrag loeFrag
+      -- The chain selection only depends on the LoE tip, so there
+      -- is no point in retriggering it if the LoE tip hasn't changed.
+      when (AF.headHash oldLoEFrag /= AF.headHash loeFrag) $
+        triggerChainSelectionAsync chainDb
       spin newTrigger
 
 data DensityBounds blk =

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ChainSync/Client.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ChainSync/Client.hs
@@ -233,8 +233,8 @@ viewChainSyncState ::
   STM m (Map peer (ChainSyncClientHandle m blk)) ->
   (ChainSyncState blk -> a) ->
   STM m (Map peer a)
-viewChainSyncState varHandles f =
-  Map.map f <$> (traverse (readTVar . cschState) =<< varHandles)
+viewChainSyncState readHandles f =
+  Map.map f <$> (traverse (readTVar . cschState) =<< readHandles)
 
 -- | Convenience function for reading the 'ChainSyncState' for a single peer
 -- from a nested set of TVars.

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ChainSync/Client.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ChainSync/Client.hs
@@ -74,6 +74,7 @@ module Ouroboros.Consensus.MiniProtocol.ChainSync.Client (
   ) where
 
 import           Control.Monad (join, void)
+import           Control.Monad.Class.MonadTimer (MonadTimer)
 import           Control.Monad.Except (runExcept, throwError)
 import           Control.Tracer
 import           Data.Kind (Type)
@@ -102,6 +103,7 @@ import           Ouroboros.Consensus.Ledger.SupportsProtocol
 import qualified Ouroboros.Consensus.MiniProtocol.ChainSync.Client.InFutureCheck as InFutureCheck
 import qualified Ouroboros.Consensus.MiniProtocol.ChainSync.Client.Jumping as Jumping
 import           Ouroboros.Consensus.MiniProtocol.ChainSync.Client.State
+import           Ouroboros.Consensus.Node.GsmState (GsmState (..))
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Storage.ChainDB (ChainDB,
@@ -113,6 +115,8 @@ import           Ouroboros.Consensus.Util.Assert (assertWithMsg)
 import           Ouroboros.Consensus.Util.EarlyExit (WithEarlyExit, exitEarly)
 import qualified Ouroboros.Consensus.Util.EarlyExit as EarlyExit
 import           Ouroboros.Consensus.Util.IOLike hiding (handle)
+import           Ouroboros.Consensus.Util.LeakyBucket
+                     (atomicallyWithMonotonicTime)
 import qualified Ouroboros.Consensus.Util.LeakyBucket as LeakyBucket
 import           Ouroboros.Consensus.Util.STM (Fingerprint, Watcher (..),
                      WithFingerprint (..), withWatcher)
@@ -313,16 +317,20 @@ deriving anyclass instance (
   NoThunks (Header blk)
   ) => NoThunks (ChainSyncStateView m blk)
 
-bracketChainSyncClient :: forall m peer blk a.
+bracketChainSyncClient ::
+  forall m peer blk a.
     ( IOLike m
     , Ord peer
     , LedgerSupportsProtocol blk
+    , MonadTimer m
     )
  => Tracer m (TraceChainSyncClientEvent blk)
  -> ChainDbView m blk
  -> StrictTVar m (Map peer (ChainSyncClientHandle m blk))
     -- ^ The kill handle and states for each peer, we need the whole map because we
     -- (de)register nodes (@peer@).
+ -> STM m GsmState
+    -- ^ A function giving the current GSM state; only used at startup.
  -> peer
  -> NodeToNodeVersion
  -> ChainSyncLoPBucketConfig
@@ -333,19 +341,21 @@ bracketChainSyncClient
     tracer
     ChainDbView { getIsInvalidBlock }
     varHandles
+    getGsmState
     peer
     version
     csBucketConfig
     csjConfig
     body
-  = mkChainSyncClientHandleState >>= \csHandleState ->
-    withCSJCallbacks csHandleState csjConfig $ \csjCallbacks ->
+  =
+    LeakyBucket.execAgainstBucket'
+  $ \lopBucket ->
+    mkChainSyncClientHandleState >>= \csHandleState ->
+    withCSJCallbacks lopBucket csHandleState csjConfig $ \csjCallbacks ->
         withWatcher
             "ChainSync.Client.rejectInvalidBlocks"
             (invalidBlockWatcher csHandleState)
-      $ LeakyBucket.execAgainstBucket lopBucketConfig
-      $ \lopBucket ->
-            body ChainSyncStateView {
+      $ body ChainSyncStateView {
               csvSetCandidate =
               modifyTVar csHandleState . \ c s -> s {csCandidate = c}
             , csvSetLatestSlot =
@@ -355,9 +365,9 @@ bracketChainSyncClient
               , idlingStop = atomically $ modifyTVar csHandleState $ \ s -> s {csIdling = False}
               }
             , csvLoPBucket = LoPBucket {
-                lbPause = LeakyBucket.setPaused lopBucket True
-              , lbResume = LeakyBucket.setPaused lopBucket False
-              , lbGrantToken = void $ LeakyBucket.fill lopBucket 1
+                lbPause = LeakyBucket.setPaused' lopBucket True
+              , lbResume = LeakyBucket.setPaused' lopBucket False
+              , lbGrantToken = void $ LeakyBucket.fill' lopBucket 1
               }
             , csvJumping = csjCallbacks
             }
@@ -370,34 +380,43 @@ bracketChainSyncClient
         }
 
     withCSJCallbacks ::
+      LeakyBucket.Handlers m ->
       StrictTVar m (ChainSyncState blk) ->
       CSJConfig ->
       (Jumping.Jumping m blk -> m a) ->
       m a
-    withCSJCallbacks cschState CSJDisabled f = do
+    withCSJCallbacks lopBucket cschState CSJDisabled f = do
       tid <- myThreadId
       cschJumpInfo <- newTVarIO Nothing
       cschJumping <- newTVarIO (Disengaged DisengagedDone)
       let handle = ChainSyncClientHandle {
               cschGDDKill = throwTo tid DensityTooLow
+            , cschGsmCallback = updateLopBucketConfig lopBucket
             , cschState
             , cschJumping
             , cschJumpInfo
             }
-          insertHandle = atomically $ modifyTVar varHandles $ Map.insert peer handle
+          insertHandle = atomicallyWithMonotonicTime $ \time -> do
+            initialGsmState <- getGsmState
+            updateLopBucketConfig lopBucket initialGsmState time
+            modifyTVar varHandles $ Map.insert peer handle
           deleteHandle = atomically $ modifyTVar varHandles $ Map.delete peer
       bracket_ insertHandle deleteHandle $ f Jumping.noJumping
 
-    withCSJCallbacks csHandleState (CSJEnabled csjEnabledConfig) f =
-      bracket (acquireContext csHandleState csjEnabledConfig) releaseContext $ \peerContext ->
+    withCSJCallbacks lopBucket csHandleState (CSJEnabled csjEnabledConfig) f =
+      bracket (acquireContext lopBucket csHandleState csjEnabledConfig) releaseContext $ \peerContext ->
         f $ Jumping.mkJumping peerContext
-    acquireContext cschState (CSJEnabledConfig jumpSize) = do
+
+    acquireContext lopBucket cschState (CSJEnabledConfig jumpSize) = do
         tid <- myThreadId
-        atomically $ do
+        atomicallyWithMonotonicTime $ \time -> do
+          initialGsmState <- getGsmState
+          updateLopBucketConfig lopBucket initialGsmState time
           cschJumpInfo <- newTVar Nothing
           context <- Jumping.makeContext varHandles jumpSize
           Jumping.registerClient context peer cschState $ \cschJumping -> ChainSyncClientHandle
             { cschGDDKill = throwTo tid DensityTooLow
+            , cschGsmCallback = updateLopBucketConfig lopBucket
             , cschState
             , cschJumping
             , cschJumpInfo
@@ -409,19 +428,33 @@ bracketChainSyncClient
         invalidBlockRejector
             tracer version getIsInvalidBlock (csCandidate <$> readTVar varState)
 
+    -- | Update the configuration of the bucket to match the given GSM state.
+    -- NOTE: The new level is currently the maximal capacity of the bucket;
+    -- maybe we want to change that later.
+    updateLopBucketConfig :: LeakyBucket.Handlers m -> GsmState -> Time -> STM m ()
+    updateLopBucketConfig lopBucket gsmState =
+      LeakyBucket.updateConfig lopBucket $ \_ ->
+        let config = lopBucketConfig gsmState in
+          (LeakyBucket.capacity config, config)
+
     -- | Wrapper around 'LeakyBucket.execAgainstBucket' that handles the
     -- disabled bucket by running the given action with dummy handlers.
-    lopBucketConfig :: LeakyBucket.Config m
-    lopBucketConfig =
-      case csBucketConfig of
-        ChainSyncLoPBucketDisabled -> LeakyBucket.dummyConfig
-        ChainSyncLoPBucketEnabled ChainSyncLoPBucketEnabledConfig {csbcCapacity, csbcRate} ->
+    lopBucketConfig :: GsmState -> LeakyBucket.Config m
+    lopBucketConfig gsmState =
+      case (gsmState, csBucketConfig) of
+        (Syncing, ChainSyncLoPBucketEnabled ChainSyncLoPBucketEnabledConfig {csbcCapacity, csbcRate}) ->
             LeakyBucket.Config
               { capacity = fromInteger $ csbcCapacity,
                 rate = csbcRate,
                 onEmpty = throwIO EmptyBucket,
                 fillOnOverflow = True
               }
+        -- NOTE: If we decide to slow the bucket down when “almost caught-up”,
+        -- we should add a state to the GSM and corresponding configuration
+        -- fields and a bucket config here.
+        (_, ChainSyncLoPBucketDisabled) -> LeakyBucket.dummyConfig
+        (PreSyncing, ChainSyncLoPBucketEnabled _) -> LeakyBucket.dummyConfig
+        (CaughtUp, ChainSyncLoPBucketEnabled _) -> LeakyBucket.dummyConfig
 
 -- Our task: after connecting to an upstream node, try to maintain an
 -- up-to-date header-only fragment representing their chain. We maintain

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ChainSync/Client.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ChainSync/Client.hs
@@ -64,10 +64,12 @@ module Ouroboros.Consensus.MiniProtocol.ChainSync.Client (
   , TraceChainSyncClientEvent (..)
     -- * State shared with other components
   , ChainSyncClientHandle (..)
+  , ChainSyncClientHandleCollection (..)
   , ChainSyncState (..)
   , ChainSyncStateView (..)
   , Jumping.noJumping
   , chainSyncStateFor
+  , newChainSyncClientHandleCollection
   , noIdling
   , noLoPBucket
   , viewChainSyncState
@@ -228,11 +230,11 @@ newtype Our a = Our { unOur :: a }
 -- data from 'ChainSyncState'.
 viewChainSyncState ::
   IOLike m =>
-  StrictTVar m (Map peer (ChainSyncClientHandle m blk)) ->
+  STM m (Map peer (ChainSyncClientHandle m blk)) ->
   (ChainSyncState blk -> a) ->
   STM m (Map peer a)
 viewChainSyncState varHandles f =
-  Map.map f <$> (traverse (readTVar . cschState) =<< readTVar varHandles)
+  Map.map f <$> (traverse (readTVar . cschState) =<< varHandles)
 
 -- | Convenience function for reading the 'ChainSyncState' for a single peer
 -- from a nested set of TVars.
@@ -326,7 +328,7 @@ bracketChainSyncClient ::
     )
  => Tracer m (TraceChainSyncClientEvent blk)
  -> ChainDbView m blk
- -> StrictTVar m (Map peer (ChainSyncClientHandle m blk))
+ -> ChainSyncClientHandleCollection peer m blk
     -- ^ The kill handle and states for each peer, we need the whole map because we
     -- (de)register nodes (@peer@).
  -> STM m GsmState
@@ -399,8 +401,8 @@ bracketChainSyncClient
           insertHandle = atomicallyWithMonotonicTime $ \time -> do
             initialGsmState <- getGsmState
             updateLopBucketConfig lopBucket initialGsmState time
-            modifyTVar varHandles $ Map.insert peer handle
-          deleteHandle = atomically $ modifyTVar varHandles $ Map.delete peer
+            cschcAddHandle varHandles peer handle
+          deleteHandle = atomically $ cschcRemoveHandle varHandles peer
       bracket_ insertHandle deleteHandle $ f Jumping.noJumping
 
     withCSJCallbacks lopBucket csHandleState (CSJEnabled csjEnabledConfig) f =

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ChainSync/Client/Jumping.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ChainSync/Client/Jumping.hs
@@ -156,8 +156,9 @@
 -- (j|k).
 --
 -- The BlockFetch logic can ask to change the dynamo if it is not serving blocks
--- fast enough. If there are other non-disengaged peers the dynamo is demoted to
--- a jumper (l) and a new dynamo is elected.
+-- fast enough. If there are other non-disengaged peers, the dynamo (and the
+-- objector if there is one) is demoted to a jumper (l+g) and a new dynamo is
+-- elected.
 --
 module Ouroboros.Consensus.MiniProtocol.ChainSync.Client.Jumping (
     Context
@@ -761,8 +762,9 @@ unregisterClient context = do
     Objector{} -> electNewObjector context'
     Dynamo{} -> void $ electNewDynamo context'
 
--- | Elects a new dynamo by demoting the given dynamo to a jumper, moving the
--- peer to the end of the queue of chain sync handles and electing a new dynamo.
+-- | Elects a new dynamo by demoting the given dynamo (and the objector if there
+-- is one) to a jumper, moving the peer to the end of the queue of chain sync
+-- handles and electing a new dynamo.
 --
 -- It does nothing if there is no other engaged peer to elect or if the given
 -- peer is not the dynamo.

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ChainSync/Client/Jumping.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ChainSync/Client/Jumping.hs
@@ -273,9 +273,9 @@ mkJumping peerContext = Jumping
 --
 -- Invariants:
 --
--- - If 'handlesCol is not empty, then there is exactly one dynamo in it.
--- - There is at most one objector in 'handlesCol.
--- - If there exist 'FoundIntersection' jumpers in 'handlesCol, then there
+-- - If 'handlesCol' is not empty, then there is exactly one dynamo in it.
+-- - There is at most one objector in 'handlesCol'.
+-- - If there exist 'FoundIntersection' jumpers in 'handlesCol', then there
 --   is an objector and the intersection of the objector with the dynamo is
 --   at least as old as the oldest intersection of the `FoundIntersection` jumpers
 --   with the dynamo.

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ChainSync/Client/State.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ChainSync/Client/State.hs
@@ -27,8 +27,9 @@ import           Ouroboros.Consensus.Block (HasHeader, Header, Point)
 import           Ouroboros.Consensus.HeaderStateHistory (HeaderStateHistory)
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
                      (LedgerSupportsProtocol)
-import           Ouroboros.Consensus.Util.IOLike (IOLike, NoThunks (..),
-                     StrictTVar)
+import           Ouroboros.Consensus.Node.GsmState (GsmState)
+import           Ouroboros.Consensus.Util.IOLike (IOLike, NoThunks (..), STM,
+                     StrictTVar, Time)
 import           Ouroboros.Network.AnchoredFragment (AnchoredFragment,
                      headPoint)
 
@@ -69,17 +70,21 @@ deriving anyclass instance (
 -- the GDD governor.
 data ChainSyncClientHandle m blk = ChainSyncClientHandle {
     -- | Disconnects from the peer when the GDD considers it adversarial
-    cschGDDKill  :: !(m ())
+    cschGDDKill     :: !(m ())
+
+    -- | Callback called by the GSM when the GSM state changes. They take the
+    -- current time and should execute rapidly. Used to enable/disable the LoP.
+  , cschGsmCallback :: !(GsmState -> Time -> STM m ())
 
     -- | Data shared between the client and external components like GDD.
-  , cschState    :: !(StrictTVar m (ChainSyncState blk))
+  , cschState       :: !(StrictTVar m (ChainSyncState blk))
 
     -- | The state of the peer with respect to ChainSync jumping.
-  , cschJumping  :: !(StrictTVar m (ChainSyncJumpingState m blk))
+  , cschJumping     :: !(StrictTVar m (ChainSyncJumpingState m blk))
 
     -- | ChainSync state needed to jump to the tip of the candidate fragment of
     -- the peer.
-  , cschJumpInfo :: !(StrictTVar m (Maybe (JumpInfo blk)))
+  , cschJumpInfo    :: !(StrictTVar m (Maybe (JumpInfo blk)))
   }
   deriving stock (Generic)
 

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Node/GsmState.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Node/GsmState.hs
@@ -1,0 +1,23 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric  #-}
+
+-- | This module contains the definition of a state in the Genesis State Machine
+-- (GSM). The GSM itself is defined in 'ouroboros-consensus-diffusion', but the
+-- ChainSync client relies on its state.
+module Ouroboros.Consensus.Node.GsmState (GsmState (..)) where
+
+import           GHC.Generics (Generic)
+import           NoThunks.Class (NoThunks)
+
+-- | Current state of the Genesis State Machine
+data GsmState =
+    PreSyncing
+    -- ^ We are syncing, and the Honest Availability Assumption is not
+    -- satisfied.
+  |
+    Syncing
+    -- ^ We are syncing, and the Honest Availability Assumption is satisfied.
+  |
+    CaughtUp
+    -- ^ We are caught-up.
+  deriving (Eq, Show, Read, Generic, NoThunks)

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/API.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/API.hs
@@ -884,7 +884,7 @@ data LoE a =
   LoEDisabled
   |
   -- | The LoE is enabled.
-  LoEEnabled a
+  LoEEnabled !a
   deriving (Eq, Show, Generic, NoThunks, Functor, Foldable, Traversable)
 
-type GetLoEFragment m blk = LoE (m (AnchoredFragment (Header blk)))
+type GetLoEFragment m blk = m (LoE (AnchoredFragment (Header blk)))

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/API.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/API.hs
@@ -63,12 +63,10 @@ module Ouroboros.Consensus.Storage.ChainDB.API (
     -- * Genesis
   , GetLoEFragment
   , LoE (..)
-  , LoELimit (..)
   ) where
 
 import           Control.Monad (void)
 import           Data.Typeable (Typeable)
-import           Data.Word (Word64)
 import           GHC.Generics (Generic)
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.HeaderStateHistory
@@ -864,35 +862,29 @@ instance (Typeable blk, StandardHash blk) => Exception (ChainDbError blk) where
     InvalidIteratorRange {} ->
       "An invalid range of blocks was requested"
 
--- | The Limit on Eagerness is a mechanism for keeping ChainSel from advancing
--- the current selection in the case of competing chains.
+-- | The Limit on Eagerness (LoE) is a mechanism for keeping ChainSel from
+-- advancing the current selection in the case of competing chains.
 --
--- The Limit on Eagerness prevents the selection of the node from extending
--- more than k blocks after the youngest block that is present on all candidate
--- fragments.
+-- The LoE tip is the youngest header that is present on all candidate
+-- fragments. Thus, after the LoE tip, peers either disagree on how the chain
+-- follows, or they do not offer more headers.
+--
+-- The LoE restrains the current selection of the node to be on the same chain
+-- as the LoE tip, and to not extend more than k blocks from it.
 --
 -- It requires a resolution mechanism to prevent indefinite stalling, which
 -- is implemented by the Genesis Density Disconnection governor, a component
--- that implements an 'UpdateLoEFrag' that disconnects from peers with forks
--- it considers inferior.
+-- that disconnects from peers with forks it considers inferior.
+-- See "Ouroboros.Consensus.Genesis.Governor" for details.
 --
--- This type indicates whether the feature is enabled, and contains a value
--- if it is.
+-- This type indicates whether LoE is enabled, and contains a value if it is.
 data LoE a =
   -- | The LoE is disabled, so ChainSel will not keep the selection from
   -- advancing.
   LoEDisabled
   |
-  -- | The LoE is enabled, using the security parameter @k@ as the limit.
-  -- When the selection's tip is @k@ blocks after the earliest intersection of
-  -- of all candidate fragments, ChainSel will not add new blocks to the
-  -- selection.
+  -- | The LoE is enabled.
   LoEEnabled a
   deriving (Eq, Show, Generic, NoThunks, Functor, Foldable, Traversable)
 
 type GetLoEFragment m blk = LoE (m (AnchoredFragment (Header blk)))
-
-data LoELimit =
-  LoELimit Word64
-  |
-  LoEUnlimited

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl.hs
@@ -37,7 +37,7 @@ module Ouroboros.Consensus.Storage.ChainDB.Impl (
 import           Control.Monad (when)
 import           Control.Monad.Trans.Class (lift)
 import           Control.Tracer
-import           Data.Functor ((<&>))
+import           Data.Functor (void, (<&>))
 import           Data.Functor.Identity (Identity)
 import qualified Data.Map.Strict as Map
 import           Data.Maybe.Strict (StrictMaybe (..))
@@ -148,6 +148,7 @@ openDBInternal args launchBgTasks = runWithTempRegistry $ do
       let initChainSelTracer = contramap TraceInitChainSelEvent tracer
 
       traceWith initChainSelTracer StartedInitChainSelection
+      initialLoE     <- Args.cdbsLoE cdbSpecificArgs
       chainAndLedger <- ChainSel.initialChainSelection
                           immutableDB
                           volatileDB
@@ -157,7 +158,7 @@ openDBInternal args launchBgTasks = runWithTempRegistry $ do
                           varInvalid
                           varFutureBlocks
                           (Args.cdbsCheckInFuture cdbSpecificArgs)
-                          (Args.cdbsLoE cdbSpecificArgs)
+                          (void initialLoE)
       traceWith initChainSelTracer InitialChainSelected
 
       let chain  = VF.validatedFragment chainAndLedger

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Args.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Args.hs
@@ -118,7 +118,7 @@ defaultSpecificArgs = ChainDbSpecificArgs {
     , cdbsTracer          = nullTracer
     , cdbsHasFSGsmDB      = noDefault
     , cdbsTopLevelConfig  = noDefault
-    , cdbsLoE             = LoEDisabled
+    , cdbsLoE             = pure LoEDisabled
     }
 
 -- | Default arguments

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Paths.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Paths.hs
@@ -71,7 +71,7 @@ maximalCandidates ::
      forall blk.
      (ChainHash blk -> Set (HeaderHash blk))
      -- ^ @filterByPredecessor@
-  -> LoELimit -- ^ Max length of any candidate
+  -> LoE Word64 -- ^ Max length of any candidate
   -> Point blk -- ^ @B@
   -> [NonEmpty (HeaderHash blk)]
      -- ^ Each element in the list is a list of hashes from which we can
@@ -86,7 +86,7 @@ maximalCandidates succsOf loeLimit b = mapMaybe (NE.nonEmpty . applyLoE) $ go (p
                , candidate <- go (BlockHash next)
                ]
     applyLoE
-      | LoELimit limit <- loeLimit
+      | LoEEnabled limit <- loeLimit
       = take (fromIntegral limit)
       | otherwise
       = id
@@ -105,7 +105,7 @@ extendWithSuccessors ::
      forall blk. HasHeader blk
   => (ChainHash blk -> Set (HeaderHash blk))
   -> LookupBlockInfo blk
-  -> LoELimit -- ^ Max extra length for any suffix
+  -> LoE Word64 -- ^ Max extra length for any suffix
   -> ChainDiff (HeaderFields blk)
   -> NonEmpty (ChainDiff (HeaderFields blk))
 extendWithSuccessors succsOf lookupBlockInfo loeLimit diff =

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Types.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Types.hs
@@ -268,7 +268,7 @@ data ChainDbEnv m blk = CDB
     -- The number of blocks from the future is bounded by the number of
     -- upstream peers multiplied by the max clock skew divided by the slot
     -- length.
-  , cdbLoE             :: LoE (m (AnchoredFragment (Header blk)))
+  , cdbLoE             :: m (LoE (AnchoredFragment (Header blk)))
     -- ^ Configure the Limit on Eagerness. If this is 'LoEEnabled', it contains
     -- an action that returns the LoE fragment, which indicates the latest rollback
     -- point, i.e. we are not allowed to select a chain from which we could not

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Util/LeakyBucket.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Util/LeakyBucket.hs
@@ -30,18 +30,30 @@ module Ouroboros.Consensus.Util.LeakyBucket (
     Config (..)
   , Handlers (..)
   , State (..)
+  , atomicallyWithMonotonicTime
   , diffTimeToSecondsRational
   , dummyConfig
   , evalAgainstBucket
   , execAgainstBucket
+  , execAgainstBucket'
+  , fill'
+  , microsecondsPerSecond
+  , picosecondsPerSecond
   , runAgainstBucket
   , secondsRationalToDiffTime
+  , setPaused'
+  , updateConfig'
   ) where
 
+import           Control.Monad (void, when)
+import qualified Control.Monad.Class.MonadSTM.Internal as TVar
+import           Control.Monad.Class.MonadTimer (MonadTimer, registerDelay)
+import           Control.Monad.Class.MonadTimer.SI (diffTimeToMicrosecondsAsInt)
 import           Data.Ratio ((%))
 import           Data.Time.Clock (diffTimeToPicoseconds)
 import           GHC.Generics (Generic)
-import           Ouroboros.Consensus.Util.IOLike
+import           Ouroboros.Consensus.Util.IOLike hiding (killThread)
+import           Ouroboros.Consensus.Util.STM (blockUntilChanged)
 import           Prelude hiding (init)
 
 -- | Configuration of a leaky bucket.
@@ -57,7 +69,7 @@ data Config m = Config
   }
   deriving (Generic)
 
-deriving instance NoThunks (m ()) => NoThunks (Config m)
+deriving instance (NoThunks (m ())) => NoThunks (Config m)
 
 -- | A configuration for a bucket that does nothing.
 dummyConfig :: (Applicative m) => Config m
@@ -70,118 +82,197 @@ dummyConfig =
     }
 
 -- | State of a leaky bucket, giving the level and the associated time.
-data State cfg = State
-  { level  :: !Rational,
-    time   :: !Time,
-    paused :: !Bool,
-    config :: !cfg
+data State m = State
+  { level            :: !Rational,
+    time             :: !Time,
+    paused           :: !Bool,
+    configGeneration :: !Int,
+    config           :: !(Config m)
   }
-  deriving (Eq, Show, Generic, NoThunks)
+  deriving (Generic)
 
--- | A bucket is simply a TVar of a state.
-type Bucket m = StrictTVar m (State (Config m))
+deriving instance (NoThunks (m ())) => NoThunks (State m)
+
+-- | A bucket is simply a TVar of a state. The state carries a 'Config' and an
+-- integer (a “generation”) to detect changes in the configuration.
+type Bucket m = StrictTVar m (State m)
 
 -- | Whether filling the bucket overflew.
 data FillResult = Overflew | DidNotOverflow
 
 -- | The handlers to a bucket: contains the API to interact with a running
--- bucket.
+-- bucket. All the endpoints are STM but require the current time; the easy way
+-- to provide this being 'atomicallyWithMonotonicTime'.
 data Handlers m = Handlers
   { -- | Refill the bucket by the given amount and returns whether the bucket
     -- overflew. The bucket may silently get filled to full capacity or not get
     -- filled depending on 'fillOnOverflow'.
-    fill         :: !(Rational -> m FillResult),
+    fill ::
+      !( Rational ->
+         Time ->
+         STM m FillResult
+       ),
     -- | Pause or resume the bucket. Pausing stops the bucket from leaking until
     -- it is resumed. It is still possible to fill it during that time. @setPaused
     -- True@ and @setPaused False@ are idempotent.
-    setPaused    :: !(Bool -> m ()),
-    -- | Dynamically update the configuration of the bucket.
-    updateConfig :: !((Config m -> Config m) -> m ())
+    setPaused ::
+      !( Bool ->
+         Time ->
+         STM m ()
+       ),
+    -- | Dynamically update the level and configuration of the bucket. Updating
+    -- the level matters if the capacity changes, in particular. If updating
+    -- leave the bucket empty, the action is triggered immediately.
+    updateConfig ::
+      !( ((Rational, Config m) -> (Rational, Config m)) ->
+         Time ->
+         STM m ()
+       )
   }
+
+-- | Variant of 'fill' already wrapped in 'atomicallyWithMonotonicTime'.
+fill' ::
+  ( MonadMonotonicTime m,
+    MonadSTM m
+  ) =>
+  Handlers m ->
+  Rational ->
+  m FillResult
+fill' h r = atomicallyWithMonotonicTime $ fill h r
+
+-- | Variant of 'setPaused' already wrapped in 'atomicallyWithMonotonicTime'.
+setPaused' ::
+  ( MonadMonotonicTime m,
+    MonadSTM m
+  ) =>
+  Handlers m ->
+  Bool ->
+  m ()
+setPaused' h p = atomicallyWithMonotonicTime $ setPaused h p
+
+-- | Variant of 'updateConfig' already wrapped in 'atomicallyWithMonotonicTime'.
+updateConfig' ::
+  ( MonadMonotonicTime m,
+    MonadSTM m
+  ) =>
+  Handlers m ->
+  ((Rational, Config m) -> (Rational, Config m)) ->
+  m ()
+updateConfig' h f = atomicallyWithMonotonicTime $ updateConfig h f
 
 -- | Create a bucket with the given configuration, then run the action against
 -- that bucket. Returns when the action terminates or the bucket empties. In the
 -- first case, return the value returned by the action. In the second case,
 -- return @Nothing@.
 execAgainstBucket ::
-  (MonadDelay m, MonadAsync m, MonadFork m, MonadMask m, NoThunks (m ())) =>
+  ( MonadDelay m,
+    MonadAsync m,
+    MonadFork m,
+    MonadMask m,
+    MonadTimer m,
+    NoThunks (m ())
+  ) =>
   Config m ->
   (Handlers m -> m a) ->
   m a
 execAgainstBucket config action = snd <$> runAgainstBucket config action
 
+-- | Variant of 'execAgainstBucket' that uses a dummy configuration. This only
+-- makes sense for actions that use 'updateConfig'.
+execAgainstBucket' ::
+  ( MonadDelay m,
+    MonadAsync m,
+    MonadFork m,
+    MonadMask m,
+    MonadTimer m,
+    NoThunks (m ())
+  ) =>
+  (Handlers m -> m a) ->
+  m a
+execAgainstBucket' action =
+  execAgainstBucket dummyConfig action
+
 -- | Same as 'execAgainstBucket' but returns the 'State' of the bucket when the
 -- action terminates. Exposed for testing purposes.
 evalAgainstBucket ::
-  (MonadDelay m, MonadAsync m, MonadFork m, MonadMask m, NoThunks (m ())) =>
+  (MonadDelay m, MonadAsync m, MonadFork m, MonadMask m, MonadTimer m, NoThunks (m ())
+  ) =>
   Config m ->
   (Handlers m -> m a) ->
-  m (State (Config m))
+  m (State m)
 evalAgainstBucket config action = fst <$> runAgainstBucket config action
 
 -- | Same as 'execAgainstBucket' but also returns the 'State' of the bucket when
 -- the action terminates. Exposed for testing purposes.
 runAgainstBucket ::
   forall m a.
-  (MonadDelay m, MonadAsync m, MonadFork m, MonadMask m, NoThunks (m ())) =>
+  ( MonadDelay m,
+    MonadAsync m,
+    MonadFork m,
+    MonadMask m,
+    MonadTimer m,
+    NoThunks (m ())
+  ) =>
   Config m ->
   (Handlers m -> m a) ->
-  m (State (Config m), a)
+  m (State m, a)
 runAgainstBucket config action = do
-  bucket <- init config
+  runThreadVar <- atomically newEmptyTMVar -- see note [Leaky bucket design].
   tid <- myThreadId
-  killThreadVar <- newTVarIO Nothing
-  finally
-    ( do
-        startThread killThreadVar bucket tid
-        result <-
-          action $
-            Handlers
-              { fill = (snd <$>) . snapshotFill bucket,
-                setPaused = setPaused bucket,
-                updateConfig = updateConfig killThreadVar bucket tid
-              }
-        state <- snapshot bucket
-        pure (state, result)
-    )
-    (stopThread killThreadVar)
+  bucket <- init config
+  withAsync (leak runThreadVar tid bucket) $ \_ -> do
+    atomicallyWithMonotonicTime $ maybeStartThread Nothing runThreadVar bucket
+    result <-
+      action $
+        Handlers
+          { fill = \r t -> (snd <$>) $ snapshotFill bucket r t,
+            setPaused = setPaused bucket,
+            updateConfig = updateConfig runThreadVar bucket
+          }
+    state <- atomicallyWithMonotonicTime $ snapshot bucket
+    pure (state, result)
   where
-    startThread ::
-      StrictTVar m (Maybe (m ())) ->
-      Bucket m ->
-      ThreadId m ->
-      m ()
-    startThread killThreadVar bucket tid =
-      readTVarIO killThreadVar >>= \case
-        Just _ -> error "LeakyBucket: startThread called when a thread is already running"
-        Nothing -> (atomically . writeTVar killThreadVar) =<< leak bucket tid
+    -- Start the thread (that is, write to its 'runThreadVar') if it is useful.
+    -- Takes a potential old value of the 'runThreadVar' as first argument,
+    -- which will be increased to help differentiate between restarts.
+    maybeStartThread :: Maybe Int -> StrictTMVar m Int -> Bucket m -> Time -> STM m ()
+    maybeStartThread oldRunThread runThreadVar bucket time = do
+      State {config = Config {rate}} <- snapshot bucket time
+      when (rate > 0) $ void $ tryPutTMVar runThreadVar $ maybe 0 (+ 1) oldRunThread
 
-    stopThread :: StrictTVar m (Maybe (m ())) -> m ()
-    stopThread killThreadVar =
-      readTVarIO killThreadVar >>= \case
-        Just killThread' -> killThread'
-        Nothing -> pure ()
-
-    setPaused :: Bucket m -> Bool -> m ()
-    setPaused bucket paused = do
-      newState <- snapshot bucket
-      atomically $ writeTVar bucket newState {paused}
+    setPaused :: Bucket m -> Bool -> Time -> STM m ()
+    setPaused bucket paused time = do
+      newState <- snapshot bucket time
+      writeTVar bucket newState {paused}
 
     updateConfig ::
-      StrictTVar m (Maybe (m ())) ->
+      StrictTMVar m Int ->
       Bucket m ->
-      ThreadId m ->
-      (Config m -> Config m) ->
-      m ()
-    updateConfig killThreadVar bucket tid = \f -> do
-      State {level, time, paused, config = oldConfig} <- snapshot bucket
-      let newConfig@Config {capacity = newCapacity, rate = newRate} = f oldConfig
-          newLevel = min newCapacity level
-      if
-        | newRate <= 0 -> stopThread killThreadVar
-        | newRate > rate oldConfig -> stopThread killThreadVar >> startThread killThreadVar bucket tid
-        | otherwise -> pure ()
-      atomically $ writeTVar bucket State {level = newLevel, time, paused, config = newConfig}
+      ((Rational, Config m) -> (Rational, Config m)) ->
+      Time ->
+      STM m ()
+    updateConfig runThreadVar bucket f time = do
+      State
+        { level = oldLevel,
+          paused,
+          configGeneration = oldConfigGeneration,
+          config = oldConfig
+        } <-
+        snapshot bucket time
+      let (newLevel, newConfig) = f (oldLevel, oldConfig)
+          Config {capacity = newCapacity} = newConfig
+          newLevel' = clamp (0, newCapacity) newLevel
+      writeTVar bucket $
+        State
+          { level = newLevel',
+            time,
+            paused,
+            configGeneration = oldConfigGeneration + 1,
+            config = newConfig
+          }
+      -- Ensure that 'runThreadVar' is empty, then maybe start the thread.
+      oldRunThread <- tryTakeTMVar runThreadVar
+      maybeStartThread oldRunThread runThreadVar bucket time
 
 -- | Initialise a bucket given a configuration. The bucket starts full at the
 -- time where one calls 'init'.
@@ -191,81 +282,163 @@ init ::
   m (Bucket m)
 init config@Config {capacity} = do
   time <- getMonotonicTime
-  newTVarIO $ State {time, level = capacity, paused = False, config}
+  newTVarIO $
+    State
+      { time,
+        level = capacity,
+        paused = False,
+        configGeneration = 0,
+        config = config
+      }
+
+-- Note [Leaky bucket design]
+-- ~~~~~~~~~~~~~~~~~~~~~~~~~~
+--
+-- The leaky bucket works by running the given action against a thread that
+-- makes the bucket leak. Since that would be extremely inefficient to actually
+-- remove tokens one by one from the token, the 'leak' thread instead looks at
+-- the current state of the bucket, computes how much time it would take for the
+-- bucket to empty, and then wait that amount of time. Once the wait is over, it
+-- recurses, looks at the new state of the bucket, etc. If tokens were given to
+-- the bucket via the action, the bucket is not empty and the loop continues.
+--
+-- This description assumes that two things hold:
+--
+--  - the bucket must be leaking (ie. rate is strictly positive),
+--  - the action can only increase the waiting time (eg. by giving tokens).
+--
+-- Neither of those properties hold in the general case. Indeed, it is possible
+-- for the bucket to have a zero rate or even a negative one (for a more
+-- traditional rate limiting bucket, for instance). Conversely, it is possible
+-- for the action to lower the waiting time by changing the bucket configuration
+-- to one where the rate is higher.
+--
+-- We fix both those issues with one mechanism, the “runThreadVar”. It is an
+-- MVar containing an integer that tells the thread whether it should be
+-- running. An empty MVar means that the thread should not be running, for
+-- instance if the rate is null. A full MVar (no matter what the integer is)
+-- means that the thread should be running. When recursing, the thread blocks
+-- until the MVar is full, and only then proceeds as described above.
+-- Additionally, while waiting for the bucket to empty, the thread monitors
+-- changes to the MVar, indicating either that the thread should stop running or
+-- that the configuration changed as that it might have to wait less long. The
+-- change in configuration is detected by changes in the integer.
+--
+-- Note that we call “start”/“stop” running the action of filling/emtpying the
+-- MVar. This is not to mistaken for the thread actually being spawned/killed.
 
 -- | Monadic action that calls 'threadDelay' until the bucket is empty, then
--- returns @()@. It receives the 'ThreadId' argument of the action's thread,
--- which it uses to throw exceptions at it; it returns a monadic action that can
--- be used to interrupt the thread from the outside.
+-- runs the 'onEmpty' action and terminates. See note [Leaky bucket design].
 leak ::
-  (MonadDelay m, MonadCatch m, MonadFork m, MonadAsync m) =>
-  Bucket m ->
+  ( MonadDelay m,
+    MonadCatch m,
+    MonadFork m,
+    MonadAsync m,
+    MonadTimer m
+  ) =>
+  -- | A variable indicating whether the thread should run (when it is filled)
+  -- or not (otherwise). The integer it carries only helps in differentiating
+  -- between starts and restarts. 'leak' does not modify this variable.
+  StrictTMVar m Int ->
+  -- | The 'ThreadId' of the action's thread, which is used to throw exceptions
+  -- at it.
   ThreadId m ->
-  m (Maybe (m ()))
-leak bucket actionThreadId = do
-  State {config = Config {rate}} <- snapshot bucket
-  if rate <= 0
-    then pure Nothing
-    else do
-      a <- async go
-      pure $ Just $! uninterruptibleCancel a
+  Bucket m ->
+  m ()
+leak runThreadVar actionThreadId bucket = go
   where
     go = do
-      State {level, config = Config {rate, onEmpty}} <- snapshot bucket
+      -- Block until we are allowed to run. Do not modify the TMVar.
+      oldRunThread <- atomically $ readTMVar runThreadVar
+      -- NOTE: It is tempting to group this @atomically@ and
+      -- @atomicallyWithMonotonicTime@ into one; however, because the former is
+      -- blocking, the latter could get a _very_ inaccurate time, which we
+      -- cannot afford.
+      State {level, configGeneration = oldConfigGeneration, config = Config {rate, onEmpty}} <-
+        atomicallyWithMonotonicTime $ snapshot bucket
       let timeToWait = secondsRationalToDiffTime (level / rate)
-      -- NOTE: It is possible that @timeToWait == 0@ while @level > 0@ when @level@
-      -- is so tiny that @level / rate@ rounds down to 0 picoseconds. In that case,
-      -- it is safe to assume that it is just zero.
-      if level <= 0 || timeToWait == 0
-        then handle (\(e :: SomeException) -> throwTo actionThreadId e) onEmpty
-        else threadDelay timeToWait >> go
+          timeToWaitMicroseconds = diffTimeToMicrosecondsAsInt timeToWait
+      -- NOTE: It is possible that @timeToWait <= 1µs@ while @level > 0@ when
+      -- @level@ is extremely small.
+      if level <= 0 || timeToWaitMicroseconds <= 0
+        then do
+          handle (\(e :: SomeException) -> throwTo actionThreadId e) onEmpty
+          -- We have run the action on empty, there is nothing left to do,
+          -- unless someone changes the configuration.
+          void $ atomically $ blockUntilChanged configGeneration oldConfigGeneration $ readTVar bucket
+          go
+        else do
+          -- Wait for the bucket to empty, or for the thread to be stopped or
+          -- restarted. Beware not to call 'registerDelay' with argument 0, that
+          -- is ensure that @timeToWaitMicroseconds > 0@.
+          varTimeout <- registerDelay timeToWaitMicroseconds
+          atomically $
+            (check =<< TVar.readTVar varTimeout)
+              `orElse`
+            (void $ blockUntilChanged id (Just oldRunThread) $ tryReadTMVar runThreadVar)
+          go
 
 -- | Take a snapshot of the bucket, that is compute its state at the current
 -- time.
 snapshot ::
-  (MonadSTM m, MonadMonotonicTime m) =>
+  ( MonadSTM m
+  ) =>
   Bucket m ->
-  m (State (Config m))
-snapshot bucket = fst <$> snapshotFill bucket 0
+  Time ->
+  STM m (State m)
+snapshot bucket newTime = fst <$> snapshotFill bucket 0 newTime
 
 -- | Same as 'snapshot' but also adds the given quantity to the resulting
 -- level and returns whether this action overflew the bucket.
 --
 -- REVIEW: What to do when 'toAdd' is negative?
---
--- REVIEW: Really, this should all be an STM transaction. Now there is the risk
--- that two snapshot-taking transactions interleave with the time measurement to
--- get a slightly imprecise state (which is not the worst because everything
--- should happen very fast). There is also the bigger risk that when we snapshot
--- and then do something (eg. in the 'setPaused' handler) we interleave with
--- something else. It cannot easily be an STM transaction, though, because we
--- need to measure the time, and @io-classes@'s STM does not allow running IO in
--- an STM.
 snapshotFill ::
-  (MonadSTM m, MonadMonotonicTime m) =>
+  ( MonadSTM m
+  ) =>
   Bucket m ->
   Rational ->
-  m (State (Config m), FillResult)
-snapshotFill bucket toAdd = do
-  newTime <- getMonotonicTime
-  atomically $ do
-    State {level, time, paused, config} <- readTVar bucket
-    let Config {rate, capacity, fillOnOverflow} = config
-        elapsed = diffTime newTime time
-        leaked = if paused then 0 else (diffTimeToSecondsRational elapsed * rate)
-        levelLeaked = max 0 (level - leaked)
-        levelFilled = min capacity (levelLeaked + toAdd)
-        overflew = levelLeaked + toAdd > capacity
-        newLevel = if not overflew || fillOnOverflow then levelFilled else levelLeaked
-        newState = State {time = newTime, level = newLevel, paused, config}
-    writeTVar bucket newState
-    pure (newState, if overflew then Overflew else DidNotOverflow)
+  Time ->
+  STM m (State m, FillResult)
+snapshotFill bucket toAdd newTime = do
+  State {level, time, paused, configGeneration, config = config} <- readTVar bucket
+  let Config {rate, capacity, fillOnOverflow} = config
+      elapsed = diffTime newTime time
+      leaked = if paused then 0 else (diffTimeToSecondsRational elapsed * rate)
+      levelLeaked = clamp (0, capacity) (level - leaked)
+      levelFilled = clamp (0, capacity) (levelLeaked + toAdd)
+      overflew = levelLeaked + toAdd > capacity
+      newLevel = if not overflew || fillOnOverflow then levelFilled else levelLeaked
+      newState = State {time = newTime, level = newLevel, paused, configGeneration, config}
+  writeTVar bucket newState
+  pure (newState, if overflew then Overflew else DidNotOverflow)
 
 -- | Convert a 'DiffTime' to a 'Rational' number of seconds. This is similar to
 -- 'diffTimeToSeconds' but with picoseconds precision.
 diffTimeToSecondsRational :: DiffTime -> Rational
-diffTimeToSecondsRational = (% 1_000_000_000_000) . diffTimeToPicoseconds
+diffTimeToSecondsRational = (% picosecondsPerSecond) . diffTimeToPicoseconds
 
 -- | Alias of 'realToFrac' to make code more readable and typing more explicit.
 secondsRationalToDiffTime :: Rational -> DiffTime
 secondsRationalToDiffTime = realToFrac
+
+-- | Helper around 'getMonotonicTime' and 'atomically'.
+atomicallyWithMonotonicTime ::
+  ( MonadMonotonicTime m,
+    MonadSTM m
+  ) =>
+  (Time -> STM m b) ->
+  m b
+atomicallyWithMonotonicTime f =
+  atomically . f =<< getMonotonicTime
+
+-- NOTE: Needed for GHC 8
+clamp :: Ord a => (a, a) -> a -> a
+clamp (low, high) x = min high (max low x)
+
+-- | Number of microseconds in a second (@10^6@).
+microsecondsPerSecond :: Integer
+microsecondsPerSecond = 1_000_000
+
+-- | Number of picoseconds in a second (@10^12@).
+picosecondsPerSecond :: Integer
+picosecondsPerSecond = 1_000_000_000_000

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/ChainDB.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/ChainDB.hs
@@ -129,6 +129,6 @@ fromMinimalChainDbArgs MinimalChainDbArgs {..} = ChainDbArgs {
         , cdbsRegistry        = mcdbRegistry
         , cdbsTracer          = nullTracer
         , cdbsTopLevelConfig  = mcdbTopLevelConfig
-        , cdbsLoE             = LoEDisabled
+        , cdbsLoE             = pure LoEDisabled
         }
     }

--- a/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/Util/LeakyBucket/Tests.hs
+++ b/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/Util/LeakyBucket/Tests.hs
@@ -12,19 +12,23 @@
 module Test.Ouroboros.Consensus.Util.LeakyBucket.Tests (tests) where
 
 import           Control.Monad (foldM, void)
+import           Control.Monad.Class.MonadTimer (MonadTimer)
 import           Control.Monad.IOSim (IOSim, runSimOrThrow)
 import           Data.Either (isLeft, isRight)
 import           Data.Functor ((<&>))
+import           Data.List (intersperse)
 import           Data.Ratio ((%))
 import           Data.Time.Clock (DiffTime, picosecondsToDiffTime)
 import           Ouroboros.Consensus.Util.IOLike (Exception (displayException),
                      MonadAsync, MonadCatch (try), MonadDelay, MonadFork,
-                     MonadMask, MonadThrow (throwIO), NoThunks, SomeException,
-                     Time (Time), addTime, fromException, threadDelay)
+                     MonadMask, MonadSTM, MonadThrow (throwIO), NoThunks,
+                     SomeException, Time (Time), addTime, fromException,
+                     threadDelay)
 import           Ouroboros.Consensus.Util.LeakyBucket
 import           Test.QuickCheck (Arbitrary (arbitrary), Gen, Property,
-                     classify, counterexample, forAll, frequency, ioProperty,
-                     listOf1, scale, suchThat, (===))
+                     classify, counterexample, forAllShrinkBlind, frequency,
+                     ioProperty, liftArbitrary2, listOf1, scale, shrinkList,
+                     suchThat)
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.QuickCheck (property, testProperty)
 import           Test.Util.TestEnv (adjustQuickCheckTests)
@@ -36,8 +40,8 @@ tests = testGroup "Ouroboros.Consensus.Util.LeakyBucket" [
   testProperty "play too long harmless" prop_playTooLongHarmless,
   testProperty "play with pause" prop_playWithPause,
   testProperty "play with pause too long" prop_playWithPauseTooLong,
-  testProperty "wait almost too long" (prop_noRefill (-1)),
-  testProperty "wait just too long" (prop_noRefill 1),
+  testProperty "wait almost too long" (prop_noRefill False),
+  testProperty "wait just too long" (prop_noRefill True),
   testProperty "propagates exceptions" prop_propagateExceptions,
   testProperty "propagates exceptions (IO)" prop_propagateExceptionsIO,
   testProperty "catch exception" prop_catchException,
@@ -80,6 +84,13 @@ data TestConfig = TestConfig
   }
   deriving (Eq, Show)
 
+data TestState = TestState
+  { testLevel  :: Rational,
+    testTime   :: Time,
+    testPaused :: Bool
+  }
+  deriving (Eq, Show)
+
 instance Arbitrary TestConfig where
   arbitrary =
     TestConfig
@@ -107,38 +118,59 @@ mkConfig TestConfig {testCapacity, testRate, testThrowOnEmpty} =
 
 -- | Make a configuration that fills on overflow and throws 'EmptyBucket' on
 -- empty bucket.
-configThrow :: MonadThrow m => Capacity -> Rate -> Config m
+configThrow :: Capacity -> Rate -> TestConfig
 configThrow (Capacity testCapacity) (Rate testRate) =
-  mkConfig TestConfig{testCapacity, testRate, testThrowOnEmpty = True}
+  TestConfig{testCapacity, testRate, testThrowOnEmpty = True}
 
 -- | A configuration with capacity and rate 1, that fills on overflow and throws
 -- 'EmptyBucket' on empty bucket.
-config11Throw :: MonadThrow m => Config m
+config11Throw :: TestConfig
 config11Throw = configThrow (Capacity 1) (Rate 1)
 
 -- | Make a configuration that fills on overflow and does nothing on empty
 -- bucket.
-configPure :: MonadThrow m => Capacity -> Rate -> Config m
+configPure :: Capacity -> Rate -> TestConfig
 configPure (Capacity testCapacity) (Rate testRate) =
-  mkConfig TestConfig{testCapacity, testRate, testThrowOnEmpty = False}
+  TestConfig{testCapacity, testRate, testThrowOnEmpty = False}
 
 -- | A configuration with capacity 1 and rate 1, that fills on overflow and does
 -- nothing on empty bucket.
-config11Pure :: MonadThrow m => Config m
+config11Pure :: TestConfig
 config11Pure = configPure (Capacity 1) (Rate 1)
 
--- | Strip the configuration from a 'State', so as to make it comparable,
--- showable, etc.
-stripConfig :: State cfg -> State ()
-stripConfig state = state{config=()}
+stateToTestState :: State m -> TestState
+stateToTestState State{level, time, paused} =
+  TestState{testLevel = level, testTime = time, testPaused = paused}
 
--- | 'evalAgainstBucket' followed by 'stripConfig'.
-stripEvalAgainstBucket ::
-  (MonadDelay m, MonadAsync m, MonadFork m, MonadMask m, NoThunks (m ())) =>
-  Config m ->
+-- | 'execAgainstBucket' except it takes a 'TestConfig'.
+testExecAgainstBucket ::
+  ( MonadDelay m,
+    MonadAsync m,
+    MonadFork m,
+    MonadMask m,
+    MonadTimer m,
+    NoThunks (m ())
+  ) =>
+  TestConfig ->
   (Handlers m -> m a) ->
-  m (State ())
-stripEvalAgainstBucket config action = stripConfig <$> evalAgainstBucket config action
+  m a
+testExecAgainstBucket testConfig action =
+  execAgainstBucket (mkConfig testConfig) action
+
+-- | 'evalAgainstBucket' except it takes a 'TestConfig' and returns a 'TestState'.
+testEvalAgainstBucket ::
+  ( MonadDelay m,
+    MonadAsync m,
+    MonadFork m,
+    MonadMask m,
+    MonadTimer m,
+    NoThunks (m ())
+  ) =>
+  TestConfig ->
+  (Handlers m -> m a) ->
+  m TestState
+testEvalAgainstBucket testConfig action =
+  stateToTestState <$> evalAgainstBucket (mkConfig testConfig) action
 
 -- | Alias for 'runSimOrThrow' by analogy to 'ioProperty'.
 ioSimProperty :: forall a. (forall s. IOSim s a) -> a
@@ -162,10 +194,6 @@ shouldEvaluateTo a v =
       | otherwise -> counterexample ("Expected " ++ show v ++ "; got " ++ show result) False
     Left (exn :: SomeException) -> counterexample ("Expected " ++ show v ++ "; got exception " ++ displayException exn) False
 
--- | Number of picoseconds in a second (@10^12@).
-picosecondsPerSecond :: Integer
-picosecondsPerSecond = 1_000_000_000_000
-
 --------------------------------------------------------------------------------
 -- Simple properties
 --------------------------------------------------------------------------------
@@ -175,20 +203,20 @@ picosecondsPerSecond = 1_000_000_000_000
 prop_playABit :: Property
 prop_playABit =
   ioSimProperty $
-    stripEvalAgainstBucket config11Throw (\handlers -> do
+    testEvalAgainstBucket config11Throw (\handlers -> do
       threadDelay 0.5
-      void $ fill handlers 67
+      void $ fill' handlers 67
       threadDelay 0.9
-    ) `shouldEvaluateTo` State{level = 1 % 10, time = Time 1.4, paused = False, config = ()}
+    ) `shouldEvaluateTo` TestState{testLevel = 1 % 10, testTime = Time 1.4, testPaused = False}
 
 -- | One test case similar to 'prop_playABit' but we wait a bit too long and
 -- should observe the triggering of the 'onEmpty' action.
 prop_playTooLong :: Property
 prop_playTooLong =
   ioSimProperty $
-    stripEvalAgainstBucket config11Throw (\handlers -> do
+    testEvalAgainstBucket config11Throw (\handlers -> do
       threadDelay 0.5
-      void $ fill handlers 67
+      void $ fill' handlers 67
       threadDelay 1.1
     ) `shouldThrow` EmptyBucket
 
@@ -197,31 +225,31 @@ prop_playTooLong =
 prop_playTooLongHarmless :: Property
 prop_playTooLongHarmless =
   ioSimProperty $
-    stripEvalAgainstBucket config11Pure (\handlers -> do
+    testEvalAgainstBucket config11Pure (\handlers -> do
       threadDelay 0.5
-      void $ fill handlers 67
+      void $ fill' handlers 67
       threadDelay 1.1
-    ) `shouldEvaluateTo` State{level = 0, time = Time 1.6, paused = False, config = ()}
+    ) `shouldEvaluateTo` TestState{testLevel = 0, testTime = Time 1.6, testPaused = False}
 
 prop_playWithPause :: Property
 prop_playWithPause =
   ioSimProperty $
-    stripEvalAgainstBucket config11Throw (\handlers -> do
+    testEvalAgainstBucket config11Throw (\handlers -> do
       threadDelay 0.5
-      setPaused handlers True
+      setPaused' handlers True
       threadDelay 1.5
-      setPaused handlers False
+      setPaused' handlers False
       threadDelay 0.4
-    ) `shouldEvaluateTo` State{level = 1 % 10, time = Time 2.4, paused = False, config = ()}
+    ) `shouldEvaluateTo` TestState{testLevel = 1 % 10, testTime = Time 2.4, testPaused = False}
 
 prop_playWithPauseTooLong :: Property
 prop_playWithPauseTooLong =
   ioSimProperty $
-    stripEvalAgainstBucket config11Throw (\handlers -> do
+    testEvalAgainstBucket config11Throw (\handlers -> do
       threadDelay 0.5
-      setPaused handlers True
+      setPaused' handlers True
       threadDelay 1.5
-      setPaused handlers False
+      setPaused' handlers False
       threadDelay 0.6
     ) `shouldThrow` EmptyBucket
 
@@ -230,24 +258,24 @@ prop_playWithPauseTooLong =
 -- state. If the offset is positive, we should get an exception. NOTE: Do not
 -- use an offset of @0@. NOTE: Considering the precision, we *need* IOSim for
 -- this test.
-prop_noRefill :: Integer -> Capacity -> Rate -> Property
-prop_noRefill offset capacity@(Capacity c) rate@(Rate r) = do
+prop_noRefill :: Bool -> Capacity -> Rate -> Property
+prop_noRefill tooLong capacity@(Capacity c) rate@(Rate r) = do
   -- NOTE: The @-1@ is to ensure that we do not test the situation where the
   -- bucket empties at the *exact* same time (curtesy of IOSim) as the action.
-  let ps = floor (c / r * fromInteger picosecondsPerSecond) + offset
+  let ps =
+        floor (c / r * fromInteger picosecondsPerSecond)
+          + (if tooLong then 1 else -1) * microsecondsPerSecond
       time = picosecondsToDiffTime ps
       level = c - (ps % picosecondsPerSecond) * r
-  if
-    | offset < 0 ->
+  if tooLong
+    then
       ioSimProperty $
-        stripEvalAgainstBucket (configThrow capacity rate) (\_ -> threadDelay time)
-        `shouldEvaluateTo` State{level, time = Time time, paused = False, config = ()}
-    | offset > 0 ->
+        testEvalAgainstBucket (configThrow capacity rate) (\_ -> threadDelay time)
+          `shouldThrow` EmptyBucket
+    else
       ioSimProperty $
-        stripEvalAgainstBucket (configThrow capacity rate) (\_ -> threadDelay time)
-        `shouldThrow` EmptyBucket
-    | otherwise ->
-      error "prop_noRefill: do not use an offset of 0"
+        testEvalAgainstBucket (configThrow capacity rate) (\_ -> threadDelay time)
+          `shouldEvaluateTo` TestState {testLevel = level, testTime = Time time, testPaused = False}
 
 --------------------------------------------------------------------------------
 -- Exception propagation
@@ -263,7 +291,7 @@ instance Exception NoPlumberException
 prop_propagateExceptions :: Property
 prop_propagateExceptions =
   ioSimProperty $
-    stripEvalAgainstBucket config11Throw (\_ -> throwIO NoPlumberException)
+    testEvalAgainstBucket config11Throw (\_ -> throwIO NoPlumberException)
       `shouldThrow`
     NoPlumberException
 
@@ -271,7 +299,7 @@ prop_propagateExceptions =
 prop_propagateExceptionsIO :: Property
 prop_propagateExceptionsIO =
   ioProperty $
-    stripEvalAgainstBucket config11Throw (\_ -> throwIO NoPlumberException)
+    testEvalAgainstBucket config11Throw (\_ -> throwIO NoPlumberException)
       `shouldThrow`
     NoPlumberException
 
@@ -280,7 +308,7 @@ prop_propagateExceptionsIO =
 prop_catchException :: Property
 prop_catchException =
   ioSimProperty $
-    execAgainstBucket config11Throw (\_ -> try $ threadDelay 1000)
+    testExecAgainstBucket config11Throw (\_ -> try $ threadDelay 1000)
       `shouldEvaluateTo`
     Left EmptyBucket
 
@@ -290,58 +318,90 @@ prop_catchException =
 
 -- | Abstract “actions” to be run. We can either wait by some time or refill the
 -- bucket by some value.
-data Action = ThreadDelay DiffTime | Fill Rational | SetPaused Bool
+data Action
+  = Wait DiffTime
+  | Fill Rational
+  | SetPaused Bool
+  | -- | Set the configuration, then wait the given time. Setting the
+    -- configuration without waiting can lead to poorly defined situations.
+    SetConfigWait TestConfig DiffTime
   deriving (Eq, Show)
 
 -- | Random generation of 'Action's. The scales and frequencies are taken such
 -- that we explore as many interesting cases as possible.
 genAction :: Gen Action
-genAction = frequency [
-  (1, ThreadDelay . picosecondsToDiffTime <$> scale (* fromInteger picosecondsPerSecond) (arbitrary `suchThat` (>= 0))),
-  (1, Fill <$> scale (* 1_000_000_000_000_000) (arbitrary `suchThat` (>= 0))),
-  (1, SetPaused <$> arbitrary)
-  ]
+genAction =
+  frequency
+    [ (1, Wait <$> genDelay),
+      (1, Fill <$> scale (* 1_000_000_000_000_000) (arbitrary `suchThat` (>= 0))),
+      (1, SetPaused <$> arbitrary),
+      (1, SetConfigWait <$> arbitrary <*> genDelay)
+    ]
+  where
+    genDelay = picosecondsToDiffTime <$> scale (* fromInteger picosecondsPerSecond) (arbitrary `suchThat` (>= 0))
 
 -- | How to run the 'Action's in a monad.
-applyActions :: MonadDelay m => Handlers m -> [Action] -> m ()
+applyActions :: (MonadDelay m, MonadThrow m, MonadSTM m) => Handlers m -> [Action] -> m ()
 applyActions handlers = mapM_ $ \case
-  ThreadDelay t -> threadDelay t
-  Fill t -> void $ fill handlers t
-  SetPaused p -> setPaused handlers p
+  Wait t -> threadDelay t
+  Fill t -> void $ fill' handlers t
+  SetPaused p -> setPaused' handlers p
+  SetConfigWait cfg t -> do
+    updateConfig' handlers $ (\(l, _) -> (l, mkConfig cfg))
+    threadDelay t
 
 -- | A model of what we expect the 'Action's to lead to, either an 'EmptyBucket'
 -- exception (if the bucket won the race) or a 'State' (otherwise).
-modelActions :: TestConfig -> [Action] -> Either EmptyBucket (State TestConfig)
-modelActions config =
-  foldM go $ State{level = testCapacity config, time = Time 0, paused = False, config}
+modelActions :: TestConfig -> [Action] -> Either EmptyBucket TestState
+modelActions testConfig =
+  (snd <$>) . foldM go (testConfig, TestState {testLevel = testCapacity testConfig, testTime = Time 0, testPaused = False})
   where
-    go :: State TestConfig -> Action -> Either EmptyBucket (State TestConfig)
-    go state@State{time, level, paused, config=TestConfig{testCapacity, testRate, testThrowOnEmpty}} = \case
+    go :: (TestConfig, TestState) -> Action -> Either EmptyBucket (TestConfig, TestState)
+    go (config@TestConfig {testCapacity, testRate, testThrowOnEmpty}, state@TestState {testTime, testLevel, testPaused}) = \case
       Fill t ->
-        Right state{level = min testCapacity (level + t)}
-      ThreadDelay t ->
-        let newTime = addTime t time
-            newLevel = if paused then level else max 0 (level - diffTimeToSecondsRational t * testRate)
+        Right (config, state {testLevel = clamp (0, testCapacity) (testLevel + t)})
+      Wait t ->
+        let newTime = addTime t testTime
+            newLevel =
+              if testPaused
+                then testLevel
+                else clamp (0, testCapacity) (testLevel - diffTimeToSecondsRational t * testRate)
          in if newLevel <= 0 && testThrowOnEmpty
               then Left EmptyBucket
-              else Right state{time = newTime, level = newLevel}
-      SetPaused p ->
-        Right state{paused = p}
+              else Right (config, state {testTime = newTime, testLevel = newLevel})
+      SetPaused newPaused ->
+        Right (config, state {testPaused = newPaused})
+      SetConfigWait newConfig@TestConfig {testCapacity = newTestCapacity} t ->
+        go (newConfig, state {testLevel = clamp (0, newTestCapacity) testLevel}) (Wait t)
 
 -- | A bunch of test cases where we generate a list of 'Action's ,run them via
 -- 'applyActions' and compare the result to that of 'modelActions'.
-prop_random :: TestConfig -> Property
-prop_random testConfig =
-  forAll (listOf1 genAction) $ \actions ->
-    let modelResult = modelActions testConfig actions
-        nbActions = length actions
-     in classify (isLeft modelResult) "bucket finished empty" $
-        classify (isRight modelResult) "bucket finished non-empty" $
-        classify (nbActions <= 10) "<= 10 actions" $
-        classify (10 < nbActions && nbActions <= 20) "11-20 actions" $
-        classify (20 < nbActions && nbActions <= 50) "21-50 actions" $
-        classify (50 < nbActions) "> 50 actions" $
-        runSimOrThrow (
-          try $ stripEvalAgainstBucket (mkConfig testConfig) $
-            flip applyActions actions
-        ) === (stripConfig <$> modelResult)
+prop_random :: Property
+prop_random =
+  forAllShrinkBlind
+    (liftArbitrary2 arbitrary (listOf1 genAction))
+    (traverse (shrinkList (const [])))
+    $ \(testConfig, actions) ->
+      let result =
+            runSimOrThrow
+              ( try $
+                  testEvalAgainstBucket testConfig $
+                    flip applyActions actions
+              )
+          modelResult = modelActions testConfig actions
+          nbActions = length actions
+       in classify (isLeft modelResult) "bucket finished empty" $
+          classify (isRight modelResult) "bucket finished non-empty" $
+          classify (nbActions <= 10) "<= 10 actions" $
+          classify (10 < nbActions && nbActions <= 20) "11-20 actions" $
+          classify (20 < nbActions && nbActions <= 50) "21-50 actions" $
+          classify (50 < nbActions) "> 50 actions" $
+          counterexample ("Config: " ++ show testConfig) $
+          counterexample ("Actions:\n" ++ (concat $ intersperse "\n" $ map ((" - " ++) . show) actions)) $
+          counterexample ("Result: " ++ show result) $
+          counterexample ("Model:  " ++ show modelResult) $
+          result == modelResult
+
+-- NOTE: Needed for GHC 8
+clamp :: Ord a => (a, a) -> a -> a
+clamp (low, high) x = min high (max low x)


### PR DESCRIPTION
This attack is only triggered if one replaces `FetchModeDeadline` by `FetchModeBulkSync` and reduces the `bfcMaxConcurrency*` constant to be lower or equal to the number of adversaries. (Typically, in the upcoming BlockFetch change, `bfcMaxConcurrencyBulkSync` will be 1.)