### PR TITLE
Use tasty-quickcheck-0.11

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -14,7 +14,7 @@ repository cardano-haskell-packages
 -- update either of these.
 index-state:
   -- Bump this if you need newer packages from Hackage
-  , hackage.haskell.org 2024-06-13T08:49:27Z
+  , hackage.haskell.org 2024-06-23T23:01:13Z
   -- Bump this if you need newer packages from CHaP
   , cardano-haskell-packages 2024-06-18T14:00:00Z
 

--- a/flake.lock
+++ b/flake.lock
@@ -258,11 +258,11 @@
     "hackageNix": {
       "flake": false,
       "locked": {
-        "lastModified": 1717374384,
-        "narHash": "sha256-YD87yUa2RkcR4Cno49rvHqshdwijQyni4stTKMt1HME=",
+        "lastModified": 1719189574,
+        "narHash": "sha256-/Dyn3dVaQpj+WDg84x9sWdqBfrE9z6BYx+JYohmiy1M=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "114e46a1de6c13d9dd2974aa076ea97d4557544f",
+        "rev": "1df2ba71243b5ccb7ddcabd3ca6263ebd326b6a2",
         "type": "github"
       },
       "original": {

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -419,7 +419,7 @@ library unstable-consensus-testlib
     tasty,
     tasty-golden,
     tasty-hunit,
-    tasty-quickcheck,
+    tasty-quickcheck >=0.11,
     template-haskell,
     text,
     time,


### PR DESCRIPTION
From the [changelog](https://hackage.haskell.org/package/tasty-quickcheck-0.11/changelog):

> Produce seeds that run a single failing tests instead of reproducing all the earlier successes ([#410](https://github.com/UnkindPartition/tasty/pull/410)).
> 
> Seeds are now pairs instead of single integers, e.g. `--quickcheck-replay="(SMGen 2909028190965759779 12330386376379709109,0)"`
> 
> Single integer seeds are still accepted as input, but they do run through earlier successes.
> 
> The `QuickCheckReplay` type used as a tasty option has three data constructors now. `QuickCheckReplayNone` is the default value and provides no seed. `QuickCheckReplayLegacy` takes an integer as before. The `QuickCheckReplay` data constructor takes the new seed form.

This is very useful both for slow tests, as well as for the WIP nightly tests.