### PR TITLE
ci.yml: enable NoThunks runs on PRs with the `nothunks` label

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,9 @@ jobs:
         exclude:
           - variant:
               ${{ (github.event_name == 'schedule' || inputs.nothunks) && 'default' || 'no-thunks' }}
+        include:
+          - variant:
+              ${{ contains(github.event.pull_request.labels.*.name, 'nothunks') && 'no-thunks' || null }}
     env:
       # Modify this value to "invalidate" the Cabal cache.
       CABAL_CACHE_VERSION: "2024-01-29"


### PR DESCRIPTION
# Description

Enables the NoThunks runs on pull requests that have the `nothunks` label, removing the need to manually fire NoThunks workflows for these PRs
