### PR TITLE
Conway: also enable mempool ref script size limit

### DIFF
--- a/ouroboros-consensus-cardano/changelog.d/20240627_125444_alexander.esgen_conway_mempool_refscript_limit.md
+++ b/ouroboros-consensus-cardano/changelog.d/20240627_125444_alexander.esgen_conway_mempool_refscript_limit.md
@@ -1,0 +1,4 @@
+### Non-Breaking
+
+- Also enabled total ref script size limit in the mempool in Conway (it
+  continues to be enabled in Babbage).

--- a/ouroboros-consensus/changelog.d/20240820_160936_alexander.esgen_conway_mempool_refscript_limit.md
+++ b/ouroboros-consensus/changelog.d/20240820_160936_alexander.esgen_conway_mempool_refscript_limit.md
@@ -1,0 +1,4 @@
+### Non-Breaking
+
+- Mempool: also changed to use the more conservative value of Ledger's
+  `maxRefScriptSizePerBlock`, ie 1MiB, that was decided on for Conway.

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Update.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Update.hs
@@ -185,10 +185,11 @@ pureTryAddTx cfg txSize wti tx is
     -- mempool, and...
   | let curSize = msNumBytes  $ isMempoolSize is
   , curSize < getMempoolCapacityBytes (isCapacity is)
-    -- ... if the mempool has less than 2.5 mebibytes of ref scripts.
-  , let maxTotalRefScriptSize = 5 * 512 * 1024 -- 2.5 Mebibytes
-        curTotalRefScriptSize = isTotalRefScriptSize is
-  , curTotalRefScriptSize Prelude.< maxTotalRefScriptSize
+    -- ... if the mempool will have at most 1 mebibyte of ref scripts.
+  , let curTotalRefScriptSize = isTotalRefScriptSize is
+        newTxRefScriptSize    = txRefScriptSize cfg (isLedgerState is) tx
+        maxTotalRefScriptSize = 1024 * 1024 -- 1MiB
+  , curTotalRefScriptSize + newTxRefScriptSize Prelude.<= maxTotalRefScriptSize
   =
   case eVtx of
       -- We only extended the ValidationResult with a single transaction


### PR DESCRIPTION
Also implementing https://github.com/IntersectMBO/ouroboros-consensus/pull/1166#discussion_r1655639209, but in a more fine-grained fashion

The insight here is that `txRefScriptSize` is implemented using `getBabbageTxDict` for Shelley-based blocks, see the usage sites of that function in `Ouroboros.Consensus.Mempool.Impl.Common` and `Ouroboros.Consensus.Mempool.Update`.