### PR TITLE
db-analyser: document pitfall of `--repro-mempool-and-forge 2` 

### DIFF
--- a/ouroboros-consensus-cardano/README.md
+++ b/ouroboros-consensus-cardano/README.md
@@ -166,6 +166,16 @@ Lastly the user can provide the analysis that should be run on the chain:
   - time spent in the mutator in microseconds
   - time spent in GC in microseconds
 
+  Currently, only NUM=1 or NUM=2 are supported. Note that with NUM=2, even for a
+  fully valid chain (like mainnet), you might get an error like this:
+
+  ```
+  Mempool rejected some of the on-chain txs: ... (OutsideValidityIntervalUTxO ...) ...
+  ```
+
+  Therefore, it is recommended to start with NUM=1, and only use NUM=2 when you
+  want to test the performance impact of a more filled mempool.
+
 * `--get-block-application-metrics NUM` computes different block application metrics every `NUM` blocks.
 It currently outputs block number, slot number, UTxO size in MB, and UTxO map size.
 In the [`scripts`](./scripts) directory we provide a `plot_utxo-growth.py` script that can be used to plot the these results.

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Analysis.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Analysis.hs
@@ -811,7 +811,10 @@ reproMempoolForge numBlks env = do
       -- add this block's transactions to the mempool
       do
         results <- Mempool.addTxs mempool $ LedgerSupportsMempool.extractTxs blk'
-        let rejs = [ rej | rej@Mempool.MempoolTxRejected{} <- results ]
+        let rejs =
+              [ (LedgerSupportsMempool.txId tx, rej)
+              | rej@(Mempool.MempoolTxRejected tx _) <- results
+              ]
         unless (null rejs) $ do
           fail $ "Mempool rejected some of the on-chain txs: " <> show rejs
 

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Analysis.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Analysis.hs
@@ -816,7 +816,14 @@ reproMempoolForge numBlks env = do
               | rej@(Mempool.MempoolTxRejected tx _) <- results
               ]
         unless (null rejs) $ do
-          fail $ "Mempool rejected some of the on-chain txs: " <> show rejs
+          fail $ unlines $
+               ["Mempool rejected some of the on-chain txs: " <> show rejs]
+            <> case howManyBlocks of
+                 ReproMempoolForgeOneBlk -> []
+                 ReproMempoolForgeTwoBlks ->
+                   [ "This might be expected, see the db-analyser README."
+                   , "Consider trying again with `--repro-mempool-and-forge 1`."
+                   ]
 
       let scrutinee = case howManyBlocks of
             ReproMempoolForgeOneBlk  -> Just blk'


### PR DESCRIPTION
This PR documents a deficiency of `--repro-mempool-and-forge 2`. This mode is used to simulate larger mempools compared to `--repro-mempool-and-forge 1` by inserting the contents of more than one block into the mempool. However, Cardano transactions have a validity interval, so but the transactions in the mempool are always validated against the same slot at any given point, which can lead to failures.

A concrete example occurs with the Cardano mainnet chain with `--analyse-from 100007913 --repro-mempool-and-forge 2 --num-blocks-to-process 3`, where the transaction with id `3cba8560cd6b2fee11d7813526cd2863e33db991796a2db5a052040cf572cf78` of block `9137142` will fail due to
```haskell
OutsideValidityIntervalUTxO
  ( ValidityInterval
    { invalidBefore    = SJust ( SlotNo 100008025 )
    , invalidHereafter = SJust ( SlotNo 100009025 )
    }
  )
  ( SlotNo 100008021 )
```
as block `9137140` is in slot `100008020`, and we increase the slot by one for validation: https://github.com/IntersectMBO/ouroboros-consensus/blob/126de8eb9669afb3220f57feb74da930f3b5dfa2/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Impl/Common.hs#L249

Follow-up work could include allowing to skip such transactions.

Also, we now print the tx id of rejected transactions prominently as the first entry.