### PR TITLE
db-analyser: only print microsecond timestamps

### DIFF
--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Run.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Run.hs
@@ -34,6 +34,7 @@ import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Consensus.Util.Orphans ()
 import           Ouroboros.Consensus.Util.ResourceRegistry
 import           System.IO
+import           Text.Printf (printf)
 
 
 {-------------------------------------------------------------------------------
@@ -132,7 +133,7 @@ analyse DBAnalyserConfig{analysis, confLimit, dbDir, selectDB, validation, verbo
       return $ Tracer $ \ev -> withLock $ do
         traceTime <- getMonotonicTime
         let diff = diffTime traceTime startTime
-        hPutStrLn stderr $ concat ["[", show diff, "] ", show ev]
+        hPutStrLn stderr $ printf "[%.6fs] %s" (realToFrac diff :: Double) (show ev)
         hFlush stderr
       where
         withLock = bracket_ (takeMVar lock) (putMVar lock ())


### PR DESCRIPTION
This makes sure that all timestamps have equal "width" when printed.

I stared at a lot of db-analyser output in the last few days, and cases like this always make me sad:

```
[2077.592510521s] BlockNo 9604000   SlotNo 109592172    717bb9a86a1d55b27e7076e92c6bfec0d8fc15d24883e543f22fe188ac59ea1f
[2080.4654302s] BlockNo 9605000 SlotNo 109611771    f80d6eb569063580b82540be2e99852e8240c2380eaeda23e4ab704f361c100b
[2083.448678608s] BlockNo 9606000   SlotNo 109632028    640a32c3d0cfd637a56f4dd1aa930d9dd2d087ccc685209945c35ff25075a77a
```

With this tiny patch, we now always get nicely aligned output like this:

```
[1.129928s] BlockNo 10425662	SlotNo 126403322	9cffdd4dc33c0f63a037324c5e79e67577f6aa879a979e031d22ad556efeaf5a
[1.130118s] BlockNo 10425663	SlotNo 126403350	f74124363054ab15407b1cb4c3b015b6825022bcd3d8a45d7727e35dc87bcf2f
[1.130306s] BlockNo 10425664	SlotNo 126403378	17fcf0a85309428de5c28796215f1466c5f179eef62e8e0fc6649e8d5ba28c19
```