### PR TITLE
Update GHC and tools in Nix shell/GHA

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -95,8 +95,8 @@ jobs:
       uses: input-output-hk/actions/haskell@latest
       id: setup-haskell
       with:
-        cabal-version: "3.10.1.0"
-        ghc-version: "9.6.5"
+        cabal-version: "3.12.1.0"
+        ghc-version: "9.6.6"
 
     - name: Install base libraries
       uses: input-output-hk/actions/base@latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,16 +29,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ["8.10.7", "9.6.5", "9.8.2"]
+        ghc: ["8.10.7", "9.6.6", "9.8.2"]
         variant: [default, no-thunks]
         exclude:
           - variant:
               ${{ (github.event_name == 'schedule' || inputs.nothunks) && 'default' || 'no-thunks' }}
     env:
       # Modify this value to "invalidate" the Cabal cache.
-      CABAL_CACHE_VERSION: "2024-01-29"
+      CABAL_CACHE_VERSION: "2024-07-04"
 
-      CABAL: "3.10.3.0"
+      CABAL: "3.12.1.0"
 
     steps:
     - uses: actions/checkout@v4
@@ -186,7 +186,7 @@ jobs:
       if: |
         github.event_name == 'push'
         && github.ref == 'refs/heads/main'
-        && matrix.ghc=='9.6.5'
+        && matrix.ghc=='9.6.6'
       run: |
         # need for latex, dvisvgm and standalone
         sudo apt install texlive-latex-extra texlive-latex-base
@@ -201,7 +201,7 @@ jobs:
       if: |
         github.event_name == 'push'
         && github.ref == 'refs/heads/main'
-        && matrix.ghc=='9.6.5'
+        && matrix.ghc=='9.6.6'
       uses: actions/upload-artifact@v4
       with:
         name: haddocks

--- a/.github/workflows/hlint.yml
+++ b/.github/workflows/hlint.yml
@@ -29,7 +29,7 @@ jobs:
     - name: 'Set up HLint'
       uses: haskell-actions/hlint-setup@v2
       with:
-        version: 3.6.1
+        version: 3.8
 
     - name: 'Run HLint'
       uses: haskell-actions/hlint-run@v2

--- a/cabal.project
+++ b/cabal.project
@@ -30,6 +30,8 @@ packages:
 tests: true
 benchmarks: true
 
+multi-repl: True
+
 import: ./asserts.cabal
 
 -- We need to disable bitvec's SIMD for now, as it breaks during cross compilation.

--- a/flake.lock
+++ b/flake.lock
@@ -104,16 +104,16 @@
     "cabal-extras": {
       "flake": false,
       "locked": {
-        "lastModified": 1713098712,
-        "narHash": "sha256-+BakoEhy3h9scMo3cfPBByDOIeB7YZ2wAooOfMSgg2c=",
+        "lastModified": 1719942255,
+        "narHash": "sha256-UbNZASD2xUk1S/z7yJ+k41kl523MZQW5t2wtPwemUhM=",
         "owner": "phadej",
         "repo": "cabal-extras",
-        "rev": "f487e29cd7b0be52d73a7168eeff4ebc6ed55a6d",
+        "rev": "67a889582e7ef118f1c26b8f105abd2120f84fd0",
         "type": "github"
       },
       "original": {
         "owner": "phadej",
-        "ref": "cabal-docspec-0.0.0.20240414",
+        "ref": "cabal-docspec-0.0.0.20240703",
         "repo": "cabal-extras",
         "type": "github"
       }
@@ -188,11 +188,11 @@
     "gentle-introduction": {
       "flake": false,
       "locked": {
-        "lastModified": 1712341100,
-        "narHash": "sha256-epTiIoOeAZW5mS1vYwqh6g4DGEN3vSHDZ0fOvIngDPo=",
+        "lastModified": 1719935136,
+        "narHash": "sha256-CJQHzxMyyw62tzkBMbymLMLQSyaGsYZ2mAeS30GPFAw=",
         "owner": "phadej",
         "repo": "gentle-introduction",
-        "rev": "027e070551f4bc8059b1622f13b519d9c5e6ba50",
+        "rev": "407fe323ce0633afedabd92efdd968b8e22f3f1b",
         "type": "github"
       },
       "original": {
@@ -218,51 +218,14 @@
         "type": "github"
       }
     },
-    "ghc910X": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1714520650,
-        "narHash": "sha256-4uz6RA1hRr0RheGNDM49a/B3jszqNNU8iHIow4mSyso=",
-        "ref": "ghc-9.10",
-        "rev": "2c6375b9a804ac7fca1e82eb6fcfc8594c67c5f5",
-        "revCount": 62663,
-        "submodules": true,
-        "type": "git",
-        "url": "https://gitlab.haskell.org/ghc/ghc"
-      },
-      "original": {
-        "ref": "ghc-9.10",
-        "submodules": true,
-        "type": "git",
-        "url": "https://gitlab.haskell.org/ghc/ghc"
-      }
-    },
-    "ghc911": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1714817013,
-        "narHash": "sha256-m2je4UvWfkgepMeUIiXHMwE6W+iVfUY38VDGkMzjCcc=",
-        "ref": "refs/heads/master",
-        "rev": "fc24c5cf6c62ca9e3c8d236656e139676df65034",
-        "revCount": 62816,
-        "submodules": true,
-        "type": "git",
-        "url": "https://gitlab.haskell.org/ghc/ghc"
-      },
-      "original": {
-        "submodules": true,
-        "type": "git",
-        "url": "https://gitlab.haskell.org/ghc/ghc"
-      }
-    },
     "hackageNix": {
       "flake": false,
       "locked": {
-        "lastModified": 1719189574,
-        "narHash": "sha256-/Dyn3dVaQpj+WDg84x9sWdqBfrE9z6BYx+JYohmiy1M=",
+        "lastModified": 1720053473,
+        "narHash": "sha256-o8gX0asqHbAQbr2ajTHGAvbGxFxNEF2H3/g5cqEcC5w=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "1df2ba71243b5ccb7ddcabd3ca6263ebd326b6a2",
+        "rev": "7d44ab1317ea602c4f853067d3cd04e603ee1348",
         "type": "github"
       },
       "original": {
@@ -280,8 +243,6 @@
         "cardano-shell": "cardano-shell",
         "flake-compat": "flake-compat_2",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk",
-        "ghc910X": "ghc910X",
-        "ghc911": "ghc911",
         "hackage": [
           "hackageNix"
         ],
@@ -294,6 +255,7 @@
         "hls-2.6": "hls-2.6",
         "hls-2.7": "hls-2.7",
         "hls-2.8": "hls-2.8",
+        "hls-2.9": "hls-2.9",
         "hpc-coveralls": "hpc-coveralls",
         "hydra": "hydra",
         "iserv-proxy": "iserv-proxy",
@@ -313,11 +275,11 @@
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1718797200,
-        "narHash": "sha256-ueFxTuZrQ3ZT/Fj5sSeUWlqKa4+OkUU1xW0E+q/XTfw=",
+        "lastModified": 1720058742,
+        "narHash": "sha256-QcJiQDEvR6F653AhYBUA6Jukg7DGdkuBj/EsGDZCCLo=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "cb139fa956158397aa398186bb32dd26f7318784",
+        "rev": "cbd75e3669c44a383e7d80e35c8e96aa795336f3",
         "type": "github"
       },
       "original": {
@@ -475,6 +437,23 @@
       "original": {
         "owner": "haskell",
         "ref": "2.8.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.9": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1718469202,
+        "narHash": "sha256-THXSz+iwB1yQQsr/PY151+2GvtoJnTIB2pIQ4OzfjD4=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "40891bccb235ebacce020b598b083eab9dda80f1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.9.0.0",
         "repo": "haskell-language-server",
         "type": "github"
       }
@@ -825,11 +804,11 @@
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1718756571,
-        "narHash": "sha256-8rL8viTbuE9/yV1of6SWp2tHmhVMD2UmkOfmN5KDbKg=",
+        "lastModified": 1720052611,
+        "narHash": "sha256-XmmEd69FV7ysLmOF4sqwGombVErRYq9HGQqiZcc0m2I=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "027672fb6fd45828b0e623c8152572d4058429ad",
+        "rev": "a9cb6e2f089acd0abcef94013f559146be108a23",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -33,7 +33,7 @@
     };
     # for cabal-docspec
     cabal-extras = {
-      url = "github:phadej/cabal-extras/cabal-docspec-0.0.0.20240414";
+      url = "github:phadej/cabal-extras/cabal-docspec-0.0.0.20240703";
       flake = false;
     };
     gentle-introduction = {

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -14,7 +14,7 @@ let
   };
   hsPkgs = haskell-nix.cabalProject {
     src = ./..;
-    compiler-nix-name = "ghc965";
+    compiler-nix-name = "ghc966";
     flake.variants = {
       ghc810 = { compiler-nix-name = lib.mkForce "ghc8107"; };
       ghc98 = { compiler-nix-name = lib.mkForce "ghc982"; };

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -6,7 +6,6 @@ in
 hsPkgs.shellFor {
   nativeBuildInputs = [
     pkgs.cabal
-    pkgs.cabal-multi-repl
     pkgs.cabal-docspec
     pkgs.fd
     pkgs.nixpkgs-fmt
@@ -24,7 +23,7 @@ hsPkgs.shellFor {
   # version as used in hsPkgs.
   tools = {
     haskell-language-server = {
-      src = inputs.haskellNix.inputs."hls-2.8";
+      src = inputs.haskellNix.inputs."hls-2.9";
       configureArgs = "--disable-benchmarks --disable-tests";
     };
   };

--- a/nix/tools.nix
+++ b/nix/tools.nix
@@ -2,7 +2,7 @@ inputs: final: prev:
 
 let
   inherit (final) lib;
-  tool-index-state = "2024-05-31T00:00:00Z";
+  tool-index-state = "2024-07-04T00:00:00Z";
   tool = name: version: other:
     final.haskell-nix.tool final.hsPkgs.args.compiler-nix-name name ({
       version = version;
@@ -12,29 +12,7 @@ in
 {
   inherit tool-index-state;
 
-  cabal = tool "cabal" "latest" { };
-
-  cabal-multi-repl = (final.haskell-nix.cabalProject {
-    # cabal master commit containing https://github.com/haskell/cabal/pull/8726
-    src = final.fetchFromGitHub {
-      owner = "haskell";
-      repo = "cabal";
-      rev = "adc283a0f06c7d24aeed67e69aca3d71c04010b3";
-      hash = "sha256-3K9WVR/tINK3PyGlXpypSpp1pguHTnolDruHNE+VvE4=";
-    };
-    index-state = tool-index-state;
-    inherit (final.hsPkgs.args) compiler-nix-name;
-    cabalProject = ''
-      packages: Cabal-syntax Cabal cabal-install-solver cabal-install
-    '';
-    configureArgs = "--disable-benchmarks --disable-tests";
-    modules = [{
-      packages.cabal-install.components.exes.cabal.postInstall = ''
-        mv $out/bin/cabal $out/bin/cabal-multi-repl
-        wrapProgram $out/bin/cabal-multi-repl --add-flags --enable-multi-repl
-      '';
-    }];
-  }).cabal-install.components.exes.cabal;
+  cabal = tool "cabal" "3.12.1.0" { };
 
   cabal-docspec = tool "cabal-docspec" "git" {
     compiler-nix-name = "ghc98";
@@ -55,7 +33,7 @@ in
 
   stylish-haskell = tool "stylish-haskell" "0.14.6.0" { };
 
-  cabal-gild = tool "cabal-gild" "1.3.1.2" { };
+  cabal-gild = tool "cabal-gild" "1.5.0.1" { };
 
   haskellBuildUtils = prev.haskellBuildUtils.override {
     inherit (final.hsPkgs.args) compiler-nix-name;

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -61,7 +61,7 @@ common common-bench
   -- We use this option to avoid skewed results due to changes in cache-line
   -- alignment. See
   -- https://github.com/Bodigrim/tasty-bench#comparison-against-baseline
-  if impl(ghc >= 8.6)
+  if impl(ghc >=8.6)
     ghc-options: -fproc-alignment=64
 
 library

--- a/scripts/docs/haddocks.sh
+++ b/scripts/docs/haddocks.sh
@@ -25,7 +25,7 @@ GHC_VERSION=$(ghc --numeric-version)
 if ! command -v cabal-docspec &> /dev/null
 then
   # cabal-docspec. Download binary
-  curl -sL https://github.com/phadej/cabal-extras/releases/download/cabal-docspec-0.0.0.20240414/cabal-docspec-0.0.0.20240414-x86_64-linux.xz > cabal-docspec.xz
+  curl -sL https://github.com/phadej/cabal-extras/releases/download/cabal-docspec-0.0.0.20240703/cabal-docspec-0.0.0.20240703-x86_64-linux.xz > cabal-docspec.xz
   # this doesn't seem to exist in GH runners?
   mkdir -p "$HOME"/.local/bin
   xz -d < cabal-docspec.xz > "$HOME"/.local/bin/cabal-docspec


### PR DESCRIPTION
 - Update cabal-install to 3.12.1.0
 - Update GHC to 9.6.6
 - Update HLS to 2.9.0.0
 - Update cabal-gild to 1.5.0.0
 - Update cabal-docspec to 0.0.0.20240703
 - Update hlint to 2.8.0

Also, we enable the new [`multi-repl` feature](https://well-typed.com/blog/2023/03/cabal-multi-unit/) by default. For example, you can now easily spawn a single `ghcid` session for all of Consensus via

```
ghcid --target all
```

Also, this enables the (experimental) `multipleComponents` session loading mode of HLS, which is promising to increase robustness (locally, I haven't gotten spurious "overlapping instance" errors for example). See eg https://github.com/emacs-lsp/lsp-haskell/pull/184 or https://github.com/haskell/vscode-haskell/pull/1077 how to enable that in your editor. Also see https://well-typed.com/blog/2024/07/hls-multi/.