### PR TITLE
Conway: add ref scripts size to `TxMeasure`

### DIFF
--- a/ouroboros-consensus-cardano/changelog.d/20240701_131358_alexander.esgen_conway_txmeasure.md
+++ b/ouroboros-consensus-cardano/changelog.d/20240701_131358_alexander.esgen_conway_txmeasure.md
@@ -1,0 +1,3 @@
+### Breaking
+
+- Added `TickedLedgerState` argument to `txMeasure`.

--- a/ouroboros-consensus-cardano/changelog.d/20240701_132131_alexander.esgen_conway_txmeasure.md
+++ b/ouroboros-consensus-cardano/changelog.d/20240701_132131_alexander.esgen_conway_txmeasure.md
@@ -1,0 +1,4 @@
+### Breaking
+
+- Introduced `ConwayMeasure`, a Conway-specific `TxMeasure` adding the total
+  reference scripts size as a new dimension on top of `AlonzoMeasure`.

--- a/ouroboros-consensus-cardano/src/byron/Ouroboros/Consensus/Byron/Ledger/Mempool.hs
+++ b/ouroboros-consensus-cardano/src/byron/Ouroboros/Consensus/Byron/Ledger/Mempool.hs
@@ -81,7 +81,7 @@ import           Ouroboros.Consensus.Util.Condense
 
 instance TxLimits ByronBlock where
   type TxMeasure ByronBlock = ByteSize
-  txMeasure        = ByteSize . txInBlockSize . txForgetValidated
+  txMeasure _st    = ByteSize . txInBlockSize . txForgetValidated
   txsBlockCapacity = ByteSize . txsMaxBytes
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Mempool.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Mempool.hs
@@ -295,17 +295,17 @@ theLedgerLens f x =
 
 instance ShelleyCompatible p (ShelleyEra c) => Mempool.TxLimits (ShelleyBlock p (ShelleyEra c)) where
   type TxMeasure (ShelleyBlock p (ShelleyEra c)) = Mempool.ByteSize
-  txMeasure        = Mempool.ByteSize . txInBlockSize . txForgetValidated
+  txMeasure _st    = Mempool.ByteSize . txInBlockSize . txForgetValidated
   txsBlockCapacity = Mempool.ByteSize . txsMaxBytes
 
 instance ShelleyCompatible p (AllegraEra c) => Mempool.TxLimits (ShelleyBlock p (AllegraEra c)) where
   type TxMeasure (ShelleyBlock p (AllegraEra c)) = Mempool.ByteSize
-  txMeasure        = Mempool.ByteSize . txInBlockSize . txForgetValidated
+  txMeasure _st    = Mempool.ByteSize . txInBlockSize . txForgetValidated
   txsBlockCapacity = Mempool.ByteSize . txsMaxBytes
 
 instance ShelleyCompatible p (MaryEra c) => Mempool.TxLimits (ShelleyBlock p (MaryEra c)) where
   type TxMeasure (ShelleyBlock p (MaryEra c)) = Mempool.ByteSize
-  txMeasure        = Mempool.ByteSize . txInBlockSize . txForgetValidated
+  txMeasure _st    = Mempool.ByteSize . txInBlockSize . txForgetValidated
   txsBlockCapacity = Mempool.ByteSize . txsMaxBytes
 
 instance ( ShelleyCompatible p (AlonzoEra c)
@@ -313,7 +313,7 @@ instance ( ShelleyCompatible p (AlonzoEra c)
 
   type TxMeasure (ShelleyBlock p (AlonzoEra c)) = AlonzoMeasure
 
-  txMeasure (ShelleyValidatedTx _txid vtx) =
+  txMeasure _st (ShelleyValidatedTx _txid vtx) =
     AlonzoMeasure {
         byteSize = Mempool.ByteSize $ txInBlockSize (mkShelleyTx @(AlonzoEra c) @p (SL.extractTx vtx))
       , exUnits  = fromExUnits $ totExUnits (SL.extractTx vtx)
@@ -342,7 +342,7 @@ instance ( ShelleyCompatible p (BabbageEra c)
 
   type TxMeasure (ShelleyBlock p (BabbageEra c)) = AlonzoMeasure
 
-  txMeasure (ShelleyValidatedTx _txid vtx) =
+  txMeasure _st (ShelleyValidatedTx _txid vtx) =
     AlonzoMeasure {
         byteSize = Mempool.ByteSize $ txInBlockSize (mkShelleyTx @(BabbageEra c) @p (SL.extractTx vtx))
       , exUnits  = fromExUnits $ totExUnits (SL.extractTx vtx)
@@ -361,7 +361,7 @@ instance ( ShelleyCompatible p (ConwayEra c)
 
   type TxMeasure (ShelleyBlock p (ConwayEra c)) = AlonzoMeasure
 
-  txMeasure (ShelleyValidatedTx _txid vtx) =
+  txMeasure _st (ShelleyValidatedTx _txid vtx) =
     AlonzoMeasure {
         byteSize = Mempool.ByteSize $ txInBlockSize (mkShelleyTx @(ConwayEra c) @p (SL.extractTx vtx))
       , exUnits  = fromExUnits $ totExUnits (SL.extractTx vtx)

--- a/ouroboros-consensus/changelog.d/20240701_133021_alexander.esgen_conway_txmeasure.md
+++ b/ouroboros-consensus/changelog.d/20240701_133021_alexander.esgen_conway_txmeasure.md
@@ -1,0 +1,3 @@
+### Breaking
+
+- Added `TickedLedgerState` argument to `txMeasure`.

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Block/Forging.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Block/Forging.hs
@@ -165,7 +165,7 @@ takeLargestPrefixThatFits ::
   -> [Validated (GenTx blk)]
   -> [Validated (GenTx blk)]
 takeLargestPrefixThatFits overrides ledger txs =
-    Measure.take MempoolCapacity.txMeasure capacity txs
+    Measure.take (MempoolCapacity.txMeasure ledger) capacity txs
   where
     capacity =
       MempoolCapacity.applyOverrides

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Capacity.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Capacity.hs
@@ -120,7 +120,10 @@ class BoundedMeasure (TxMeasure blk) => TxLimits blk where
   type TxMeasure blk
 
   -- | What is the measure an individual tx?
-  txMeasure        :: Validated (GenTx blk)    -> TxMeasure blk
+  txMeasure ::
+       TickedLedgerState blk
+    -> Validated (GenTx blk)
+    -> TxMeasure blk
 
   -- | What is the allowed capacity for txs in an individual block?
   txsBlockCapacity :: Ticked (LedgerState blk) -> TxMeasure blk


### PR DESCRIPTION
Making sure that we never forge blocks that violate the new max ref scripts size limit per block that is enforced at the ledger level starting in Conway: https://github.com/IntersectMBO/cardano-ledger/pull/4450

Also see #1168 for restoring a similar limit for the size of the total mempool in Conway.