### PR TITLE
Consolidate TxLimits

### DIFF
--- a/ouroboros-consensus-cardano/changelog.d/20240711_064942_nick.frisby_consolidate_txlimits.md
+++ b/ouroboros-consensus-cardano/changelog.d/20240711_064942_nick.frisby_consolidate_txlimits.md
@@ -1,0 +1,23 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+### Patch
+
+- Updates for the `TxLimits` mempool consolidation.
+
+### Non-Breaking
+
+- Do not check transaction sizes in the forging functions; simply include all
+  given transactions.
+
+- Remove the hotfix Babbage mempool checks.
+
+<!--
+### Breaking
+
+- A bullet item for the Breaking category.
+
+-->

--- a/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
+++ b/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
@@ -167,6 +167,7 @@ library
     strict-sop-core ^>=0.1,
     text,
     these ^>=1.2,
+    validation,
     vector-map,
 
   -- GHC 8.10.7 on aarch64-darwin cannot use text-2

--- a/ouroboros-consensus-cardano/src/byron/Ouroboros/Consensus/Byron/Ledger/Forge.hs
+++ b/ouroboros-consensus-cardano/src/byron/Ouroboros/Consensus/Byron/Ledger/Forge.hs
@@ -48,7 +48,7 @@ forgeByronBlock ::
   -> BlockNo                          -- ^ Current block number
   -> SlotNo                           -- ^ Current slot number
   -> TickedLedgerState ByronBlock     -- ^ Current ledger
-  -> [Validated (GenTx ByronBlock)]   -- ^ Txs to consider adding in the block
+  -> [Validated (GenTx ByronBlock)]   -- ^ Txs to include
   -> PBftIsLeader PBftByronCrypto     -- ^ Leader proof ('IsLeader')
   -> ByronBlock
 forgeByronBlock cfg = forgeRegularBlock (configBlock cfg)
@@ -123,7 +123,7 @@ forgeRegularBlock ::
   -> BlockNo                           -- ^ Current block number
   -> SlotNo                            -- ^ Current slot number
   -> TickedLedgerState ByronBlock      -- ^ Current ledger
-  -> [Validated (GenTx ByronBlock)]    -- ^ Txs to consider adding in the block
+  -> [Validated (GenTx ByronBlock)]    -- ^ Txs to include
   -> PBftIsLeader PBftByronCrypto      -- ^ Leader proof ('IsLeader')
   -> ByronBlock
 forgeRegularBlock cfg bno sno st txs isLeader =
@@ -141,7 +141,7 @@ forgeRegularBlock cfg bno sno st txs isLeader =
         foldr
           extendBlockPayloads
           initBlockPayloads
-          (takeLargestPrefixThatFits st txs)
+          txs
 
     txPayload :: CC.UTxO.TxPayload
     txPayload = CC.UTxO.mkTxPayload (bpTxs blockPayloads)

--- a/ouroboros-consensus-cardano/src/byron/Ouroboros/Consensus/Byron/Ledger/Mempool.hs
+++ b/ouroboros-consensus-cardano/src/byron/Ouroboros/Consensus/Byron/Ledger/Mempool.hs
@@ -143,8 +143,6 @@ instance LedgerSupportsMempool ByronBlock where
 
   txForgetValidated = forgetValidatedByronTx
 
-  txRefScriptSize _ _ _ = 0
-
 data instance TxId (GenTx ByronBlock)
   = ByronTxId             !Utxo.TxId
   | ByronDlgId            !Delegation.CertificateId

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Eras.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Eras.hs
@@ -5,7 +5,6 @@
 {-# LANGUAGE GADTs                   #-}
 {-# LANGUAGE LambdaCase              #-}
 {-# LANGUAGE MultiParamTypeClasses   #-}
-{-# LANGUAGE NumericUnderscores      #-}
 {-# LANGUAGE ScopedTypeVariables     #-}
 {-# LANGUAGE TypeApplications        #-}
 {-# LANGUAGE TypeFamilies            #-}
@@ -29,7 +28,6 @@ module Ouroboros.Consensus.Shelley.Eras (
   , StandardMary
   , StandardShelley
     -- * Shelley-based era
-  , BabbageTxDict (..)
   , ConwayEraGovDict (..)
   , ShelleyBasedEra (..)
   , WrapTx (..)
@@ -47,7 +45,6 @@ import           Cardano.Ledger.Alonzo (AlonzoEra)
 import qualified Cardano.Ledger.Alonzo.Rules as Alonzo
 import qualified Cardano.Ledger.Alonzo.Translation as Alonzo
 import qualified Cardano.Ledger.Alonzo.Tx as Alonzo
-import qualified Cardano.Ledger.Api as SL
 import qualified Cardano.Ledger.Api.Era as L
 import           Cardano.Ledger.Babbage (BabbageEra)
 import qualified Cardano.Ledger.Babbage.Rules as Babbage
@@ -60,8 +57,6 @@ import qualified Cardano.Ledger.Conway.Rules as Conway
 import qualified Cardano.Ledger.Conway.Rules as SL
                      (ConwayLedgerPredFailure (..))
 import qualified Cardano.Ledger.Conway.Translation as Conway
-import qualified Cardano.Ledger.Conway.Tx as SL
-import qualified Cardano.Ledger.Conway.UTxO as SL
 import           Cardano.Ledger.Core as Core
 import           Cardano.Ledger.Crypto (StandardCrypto)
 import           Cardano.Ledger.Keys (DSignable, Hash)
@@ -73,13 +68,11 @@ import           Cardano.Ledger.Shelley.Core as Core
 import qualified Cardano.Ledger.Shelley.LedgerState as SL
 import qualified Cardano.Ledger.Shelley.Rules as SL
 import qualified Cardano.Ledger.Shelley.Transition as SL
-import qualified Cardano.Ledger.Val as SL
 import qualified Cardano.Protocol.TPraos.API as SL
 import           Control.Monad.Except
 import           Control.State.Transition (PredicateFailure)
 import           Data.Data (Proxy (Proxy))
 import           Data.List.NonEmpty (NonEmpty ((:|)))
-import           Lens.Micro ((^.))
 import           NoThunks.Class (NoThunks)
 import           Ouroboros.Consensus.Ledger.SupportsMempool
                      (WhetherToIntervene (..))
@@ -169,16 +162,6 @@ class ( Core.EraSegWits era
   -- | Whether the era has an instance of 'CG.ConwayEraGov'
   getConwayEraGovDict :: proxy era -> Maybe (ConwayEraGovDict era)
 
-  getBabbageTxDict :: proxy era -> Maybe (BabbageTxDict era)
-
-data BabbageTxDict era where
-    BabbageTxDict ::
-         SL.BabbageEraTxBody era
-      => (Integer -> Integer -> SL.ApplyTxError era)
-         -- ^ Construct an arbitrary ledger error with two integers as its
-         -- payload.
-      -> BabbageTxDict era
-
 data ConwayEraGovDict era where
     ConwayEraGovDict :: CG.ConwayEraGov era => ConwayEraGovDict era
 
@@ -189,7 +172,7 @@ isBeforeConway _ =
 -- | The default implementation of 'applyShelleyBasedTx', a thin wrapper around
 -- 'SL.applyTx'
 defaultApplyShelleyBasedTx ::
-     forall era. ShelleyBasedEra era
+     ShelleyBasedEra era
   => SL.Globals
   -> SL.LedgerEnv era
   -> SL.LedgerState era
@@ -201,55 +184,11 @@ defaultApplyShelleyBasedTx ::
        , SL.Validated (Core.Tx era)
        )
 defaultApplyShelleyBasedTx globals ledgerEnv mempoolState _wti tx = do
-    refScriptPredicate
     SL.applyTx
       globals
       ledgerEnv
       mempoolState
       tx
-  where
-    refScriptPredicate = case getBabbageTxDict (Proxy @era) of
-      Nothing -> pure ()
-      Just (BabbageTxDict mkError)
-        -- The ledger rules of Conway (and later eras) already handle ref
-        -- scripts appropriately, so we only need to perform the checks below
-        -- for Babbage.
-        | not $ isBeforeConway (Proxy @era)
-        -> pure ()
-        -- Reject it if it has more than 100 kibibytes of ref script.
-        | refScriptsSize > totalRefScriptsSizeLimit
-        -> throwError $ mkError
-            -- As we are reusing an existing error message, we add a large
-            -- number to make users running into this are productively irritated
-            -- and post this error message somewhere where they can receive
-            -- help/context.
-            (toInteger refScriptsSize           + 1_000_000_000)
-            (toInteger totalRefScriptsSizeLimit + 1_000_000_000)
-        -- Reject it if it has more than 50 kibibytes of ref script and does not
-        -- satisfy an additional fee as calculated in the table below.
-        | refScriptsSize > freeOfChargeRefScriptsBytes
-        , actualFee < expectedFee
-        -> throwError $ mkError
-            -- See above for why we add a large constant.
-            (SL.unCoin actualFee   + 100_000_000)
-            (SL.unCoin expectedFee + 100_000_000)
-        | otherwise -> pure ()
-        where
-          totalRefScriptsSizeLimit :: Int
-          totalRefScriptsSizeLimit = 100 * 1024
-
-          freeOfChargeRefScriptsBytes :: Int
-          freeOfChargeRefScriptsBytes = 50 * 1024
-
-          actualFee = tx ^. SL.bodyTxL . SL.feeTxBodyL
-          expectedFee = minFee SL.<+> refScriptsFee
-            where
-              minFee = SL.getMinFeeTx (SL.ledgerPp ledgerEnv) tx 0
-              refScriptsFee = SL.tierRefScriptFee 1.2 25600 15 refScriptsSize
-
-          refScriptsSize = SL.txNonDistinctRefScriptsSize utxo tx
-
-          utxo = SL.utxosUtxo . SL.lsUTxOState $ mempoolState
 
 defaultGetConwayEraGovDict :: proxy era -> Maybe (ConwayEraGovDict era)
 defaultGetConwayEraGovDict _ = Nothing
@@ -260,15 +199,11 @@ instance (SL.PraosCrypto c, DSignable c (Hash c EraIndependentTxBody))
 
   getConwayEraGovDict = defaultGetConwayEraGovDict
 
-  getBabbageTxDict _ = Nothing
-
 instance (SL.PraosCrypto c, DSignable c (Hash c EraIndependentTxBody))
   => ShelleyBasedEra (AllegraEra c) where
   applyShelleyBasedTx = defaultApplyShelleyBasedTx
 
   getConwayEraGovDict = defaultGetConwayEraGovDict
-
-  getBabbageTxDict _ = Nothing
 
 instance (SL.PraosCrypto c, DSignable c (Hash c EraIndependentTxBody))
   => ShelleyBasedEra (MaryEra c) where
@@ -276,40 +211,21 @@ instance (SL.PraosCrypto c, DSignable c (Hash c EraIndependentTxBody))
 
   getConwayEraGovDict = defaultGetConwayEraGovDict
 
-  getBabbageTxDict _ = Nothing
-
 instance (SL.PraosCrypto c, DSignable c (Hash c EraIndependentTxBody))
   => ShelleyBasedEra (AlonzoEra c) where
   applyShelleyBasedTx = applyAlonzoBasedTx
 
   getConwayEraGovDict = defaultGetConwayEraGovDict
 
-  getBabbageTxDict _ = Nothing
-
 instance (Praos.PraosCrypto c) => ShelleyBasedEra (BabbageEra c) where
   applyShelleyBasedTx = applyAlonzoBasedTx
 
   getConwayEraGovDict = defaultGetConwayEraGovDict
 
-  getBabbageTxDict _ = Just $ BabbageTxDict $ \a b ->
-      SL.ApplyTxError
-    $ pure
-    $ SL.UtxowFailure
-    $ Babbage.UtxoFailure
-    $ Babbage.AlonzoInBabbageUtxoPredFailure
-    $ Alonzo.MaxTxSizeUTxO a b
-
 instance (Praos.PraosCrypto c) => ShelleyBasedEra (ConwayEra c) where
   applyShelleyBasedTx = applyAlonzoBasedTx
 
   getConwayEraGovDict _ = Just ConwayEraGovDict
-
-  getBabbageTxDict _ = Just $ BabbageTxDict $ \a b ->
-      SL.ApplyTxError
-    $ pure
-    $ Conway.ConwayUtxowFailure
-    $ Conway.UtxoFailure
-    $ Conway.MaxTxSizeUTxO a b
 
 applyAlonzoBasedTx :: forall era.
   ( ShelleyBasedEra era,

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Mempool.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Mempool.hs
@@ -149,12 +149,6 @@ instance ShelleyCompatible proto era
 
   txForgetValidated (ShelleyValidatedTx txid vtx) = ShelleyTx txid (SL.extractTx vtx)
 
-  txRefScriptSize _cfg st (ShelleyTx _ tx) = case getBabbageTxDict (Proxy @era) of
-      Nothing              -> 0
-      Just BabbageTxDict{} -> SL.txNonDistinctRefScriptsSize utxo tx
-    where
-      utxo = SL.getUTxO . tickedShelleyLedgerState $ st
-
 mkShelleyTx :: forall era proto. ShelleyBasedEra era => Tx era -> GenTx (ShelleyBlock proto era)
 mkShelleyTx tx = ShelleyTx (SL.txIdTxBody @era (tx ^. bodyTxL)) tx
 

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Node.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Node.hs
@@ -32,6 +32,7 @@ import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config
+import           Ouroboros.Consensus.Ledger.SupportsMempool (TxLimits)
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
                      (LedgerSupportsProtocol)
 import           Ouroboros.Consensus.Node.ProtocolInfo
@@ -107,8 +108,9 @@ instance ShelleyCompatible proto era => BlockSupportsMetrics (ShelleyBlock proto
 instance ConsensusProtocol proto => BlockSupportsSanityCheck (ShelleyBlock proto era) where
   configAllSecurityParams = pure . protocolSecurityParam . topLevelConfigProtocol
 
-instance
-  ( ShelleyCompatible proto era
-  , LedgerSupportsProtocol (ShelleyBlock proto era)
-  , BlockSupportsSanityCheck (ShelleyBlock proto era)
-  ) => RunNode (ShelleyBlock proto era)
+instance ( ShelleyCompatible                      proto era
+         , LedgerSupportsProtocol   (ShelleyBlock proto era)
+         , BlockSupportsSanityCheck (ShelleyBlock proto era)
+         , TxLimits                 (ShelleyBlock proto era)
+         )
+      => RunNode (ShelleyBlock proto era)

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Node/Common.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Node/Common.hs
@@ -28,7 +28,7 @@ import           Ouroboros.Consensus.Block (CannotForge, ForgeStateInfo,
                      ForgeStateUpdateError)
 import           Ouroboros.Consensus.Config (maxRollbacks)
 import           Ouroboros.Consensus.Config.SupportsNode
-import           Ouroboros.Consensus.Mempool (TxLimits)
+import           Ouroboros.Consensus.Ledger.SupportsMempool (TxLimits)
 import           Ouroboros.Consensus.Node.InitStorage
 import qualified Ouroboros.Consensus.Protocol.Ledger.HotKey as HotKey
 import           Ouroboros.Consensus.Protocol.Praos.Common

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Node/Praos.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Node/Praos.hs
@@ -24,7 +24,7 @@ import qualified Cardano.Protocol.TPraos.OCert as SL
 import qualified Data.Text as T
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config (configConsensus)
-import qualified Ouroboros.Consensus.Mempool as Mempool
+import qualified Ouroboros.Consensus.Ledger.SupportsMempool as Mempool
 import qualified Ouroboros.Consensus.Protocol.Ledger.HotKey as HotKey
 import           Ouroboros.Consensus.Protocol.Praos (Praos, PraosParams (..),
                      praosCheckCanForge)

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Node/TPraos.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Node/TPraos.hs
@@ -52,7 +52,7 @@ import qualified Ouroboros.Consensus.HardFork.History as History
 import           Ouroboros.Consensus.HeaderValidation
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Extended
-import           Ouroboros.Consensus.Mempool (TxLimits)
+import           Ouroboros.Consensus.Ledger.SupportsMempool (TxLimits)
 import           Ouroboros.Consensus.Node.ProtocolInfo
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Protocol.Ledger.HotKey (HotKey)
@@ -121,7 +121,7 @@ shelleySharedBlockForging ::
   => HotKey c m
   -> (SlotNo -> Absolute.KESPeriod)
   -> ShelleyLeaderCredentials c
-  -> BlockForging m     (ShelleyBlock (TPraos c) era)
+  -> BlockForging m (ShelleyBlock (TPraos c) era)
 shelleySharedBlockForging hotKey slotToPeriod credentials =
     BlockForging {
         forgeLabel       = label <> "_" <> T.pack (L.eraName @era)

--- a/ouroboros-consensus-cardano/src/unstable-byronspec/Ouroboros/Consensus/ByronSpec/Ledger/Mempool.hs
+++ b/ouroboros-consensus-cardano/src/unstable-byronspec/Ouroboros/Consensus/ByronSpec/Ledger/Mempool.hs
@@ -51,8 +51,12 @@ instance LedgerSupportsMempool ByronSpecBlock where
         fmap fst
       $ applyTx cfg DoNotIntervene slot (forgetValidatedByronSpecGenTx vtx) st
 
-  -- Dummy values, as these are not used in practice.
-  txsMaxBytes   = const maxBound
-  txInBlockSize = const 0
-
   txForgetValidated = forgetValidatedByronSpecGenTx
+
+instance TxLimits ByronSpecBlock where
+  type TxMeasure ByronSpecBlock = IgnoringOverflow ByteSize32
+
+  -- Dummy values, as these are not used in practice.
+  blockCapacityTxMeasure _cfg _st = IgnoringOverflow $ ByteSize32 1
+
+  txMeasure _cfg _st _tx = pure $ IgnoringOverflow $ ByteSize32 0

--- a/ouroboros-consensus-cardano/src/unstable-byronspec/Ouroboros/Consensus/ByronSpec/Ledger/Mempool.hs
+++ b/ouroboros-consensus-cardano/src/unstable-byronspec/Ouroboros/Consensus/ByronSpec/Ledger/Mempool.hs
@@ -56,5 +56,3 @@ instance LedgerSupportsMempool ByronSpecBlock where
   txInBlockSize = const 0
 
   txForgetValidated = forgetValidatedByronSpecGenTx
-
-  txRefScriptSize _cfg _tlst _tx = 0

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Analysis.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Analysis.hs
@@ -740,8 +740,11 @@ reproMempoolForge numBlks env = do
         Mempool.getCurrentLedgerState = ledgerState <$> IOLike.readTVar ref
       }
       lCfg
-      -- one megabyte should generously accomodate two blocks' worth of txs
-      (Mempool.MempoolCapacityBytesOverride $ Mempool.MempoolCapacityBytes $ 2^(20 :: Int))
+      -- one mebibyte should generously accomodate two blocks' worth of txs
+      ( Mempool.MempoolCapacityBytesOverride
+      $ LedgerSupportsMempool.ByteSize32
+      $ 1024*1024
+      )
       nullTracer
 
     void $ processAll db registry GetBlock startFrom limit Nothing (process howManyBlocks ref mempool)

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Analysis.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Analysis.hs
@@ -743,7 +743,6 @@ reproMempoolForge numBlks env = do
       -- one megabyte should generously accomodate two blocks' worth of txs
       (Mempool.MempoolCapacityBytesOverride $ Mempool.MempoolCapacityBytes $ 2^(20 :: Int))
       nullTracer
-      (SizeInBytes . LedgerSupportsMempool.txInBlockSize)
 
     void $ processAll db registry GetBlock startFrom limit Nothing (process howManyBlocks ref mempool)
     pure Nothing

--- a/ouroboros-consensus-cardano/test/cardano-test/Test/Consensus/Cardano/MiniProtocol/LocalTxSubmission/Server.hs
+++ b/ouroboros-consensus-cardano/test/cardano-test/Test/Consensus/Cardano/MiniProtocol/LocalTxSubmission/Server.hs
@@ -19,6 +19,7 @@ import qualified Ouroboros.Consensus.Config as Consensus
 import           Ouroboros.Consensus.HardFork.Combinator (getHardForkState,
                      hardForkLedgerStatePerEra)
 import           Ouroboros.Consensus.Ledger.Extended (ledgerState)
+import           Ouroboros.Consensus.Ledger.SupportsMempool (ByteSize32 (..))
 import qualified Ouroboros.Consensus.Ledger.SupportsMempool as Ledger
 import qualified Ouroboros.Consensus.Ledger.SupportsMempool as LedgerSupportsMempool
 import qualified Ouroboros.Consensus.Mempool.Capacity as Mempool
@@ -32,7 +33,6 @@ import           Ouroboros.Network.Protocol.LocalTxSubmission.Examples
                      (localTxSubmissionClient)
 import           Ouroboros.Network.Protocol.LocalTxSubmission.Server
                      (localTxSubmissionServerPeer)
-import           Ouroboros.Network.SizeInBytes
 import           Test.Consensus.Cardano.MiniProtocol.LocalTxSubmission.ByteStringTxParser
                      (deserialiseTx)
 import           Test.Consensus.Cardano.ProtocolInfo
@@ -73,7 +73,8 @@ tests =
 
           let
             -- We don't want the mempool to fill up during these tests.
-            capcityBytesOverride = Mempool.mkCapacityBytesOverride 100_000
+            capcityBytesOverride =
+              Mempool.mkCapacityBytesOverride (ByteSize32 100_000)
             -- Use 'show >$< stdoutTracer' for debugging.
             tracer               = nullTracer
             mempoolParams        = Mocked.MempoolAndModelParams {

--- a/ouroboros-consensus-cardano/test/cardano-test/Test/Consensus/Cardano/MiniProtocol/LocalTxSubmission/Server.hs
+++ b/ouroboros-consensus-cardano/test/cardano-test/Test/Consensus/Cardano/MiniProtocol/LocalTxSubmission/Server.hs
@@ -86,7 +86,6 @@ tests =
           mempool <- Mocked.openMockedMempool
                       capcityBytesOverride
                       tracer
-                      (SizeInBytes . LedgerSupportsMempool.txInBlockSize)
                       mempoolParams
 
           mempool `should_process` [ _137 ]

--- a/ouroboros-consensus-cardano/test/shelley-test/Test/Consensus/Shelley/Coherence.hs
+++ b/ouroboros-consensus-cardano/test/shelley-test/Test/Consensus/Shelley/Coherence.hs
@@ -3,9 +3,10 @@ module Test.Consensus.Shelley.Coherence (tests) where
 import           Cardano.Ledger.Alonzo.Scripts (ExUnits, pointWiseExUnits)
 import qualified Data.Measure as Measure
 import           Data.Word (Word32)
-import qualified Ouroboros.Consensus.Mempool.Capacity as MempoolCapacity
+import           Ouroboros.Consensus.Ledger.SupportsMempool (ByteSize32 (..),
+                     IgnoringOverflow (..))
 import           Ouroboros.Consensus.Shelley.Ledger.Mempool (AlonzoMeasure (..),
-                     fromExUnits)
+                     ConwayMeasure (..), fromExUnits)
 import           Test.Cardano.Ledger.Alonzo.Serialisation.Generators ()
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
@@ -16,11 +17,18 @@ tests = testGroup "Shelley coherences" [
     ]
 
 -- | 'Measure.<=' and @'pointWiseExUnits' (<=)@ must agree
-leqCoherence :: Word32 -> ExUnits -> ExUnits -> Property
-leqCoherence w eu1 eu2 =
+leqCoherence :: Word32 -> Word32 -> ExUnits -> ExUnits -> Property
+leqCoherence w1 w2 eu1 eu2 =
     actual === expected
   where
-    inj eu = AlonzoMeasure (MempoolCapacity.ByteSize w) (fromExUnits eu)
+    -- ConwayMeasure is the fullest TxMeasure and mainnet's
+    inj eu =
+        ConwayMeasure
+          (AlonzoMeasure
+             (IgnoringOverflow $ ByteSize32 w1)
+             (fromExUnits eu)
+          )
+          (IgnoringOverflow $ ByteSize32 w2)
 
     actual   = inj eu1 Measure.<= inj eu2
     expected = pointWiseExUnits (<=) eu1 eu2

--- a/ouroboros-consensus-diffusion/changelog.d/20240711_064938_nick.frisby_consolidate_txlimits.md
+++ b/ouroboros-consensus-diffusion/changelog.d/20240711_064938_nick.frisby_consolidate_txlimits.md
@@ -1,0 +1,23 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+
+### Patch
+
+- Updates for the `TxLimits` mempool consolidation.
+
+<!--
+### Non-Breaking
+
+- A bullet item for the Non-Breaking category.
+
+-->
+<!--
+### Breaking
+
+- A bullet item for the Breaking category.
+
+-->

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
@@ -380,7 +380,6 @@ initInternalState NodeKernelArgs { tracers, chainDB, registry, cfg
                                  (configLedger cfg)
                                  mempoolCapacityOverride
                                  (mempoolTracer tracers)
-                                 (SizeInBytes . txInBlockSize)
 
     fetchClientRegistry <- newFetchClientRegistry
 
@@ -733,8 +732,8 @@ getMempoolReader mempool = MempoolReader.TxSubmissionMempoolReader
                                       snapshotHasTx } =
       MempoolReader.MempoolSnapshot
         { mempoolTxIdsAfter = \idx ->
-            [ (txId (txForgetValidated tx), idx', getTxSize mempool (txForgetValidated tx))
-            | (tx, idx') <- snapshotTxsAfter idx
+            [ (txId (txForgetValidated tx), idx', sz)
+            | (tx, idx', sz) <- snapshotTxsAfter idx
             ]
         , mempoolLookupTx   = snapshotLookupTx
         , mempoolHasTx      = snapshotHasTx

--- a/ouroboros-consensus-diffusion/src/unstable-diffusion-testlib/Test/ThreadNet/Network.hs
+++ b/ouroboros-consensus-diffusion/src/unstable-diffusion-testlib/Test/ThreadNet/Network.hs
@@ -649,7 +649,8 @@ runThreadNetwork systemTime ThreadNetworkArgs
                 -- a new tx (e.g. added by TxSubmission) might render a crucial
                 -- transaction valid
                 mempChanged = do
-                  let getMemp = (map snd . snapshotTxs) <$> getSnapshot mempool
+                  let prjTno (_a, b, _c) = b :: TicketNo
+                      getMemp = (map prjTno . snapshotTxs) <$> getSnapshot mempool
                   (mempFp', _) <- atomically $ blockUntilChanged id mempFp getMemp
                   pure (slot, ledger, mempFp')
 

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE DerivingVia           #-}
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE LambdaCase            #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings     #-}
 {-# LANGUAGE RankNTypes            #-}
@@ -362,6 +363,8 @@ instance TxGen TestBlock where
 type TestBlock = HardForkBlock '[BlockA, BlockB]
 
 instance CanHardFork '[BlockA, BlockB] where
+  type HardForkTxMeasure '[BlockA, BlockB] = IgnoringOverflow ByteSize32
+
   hardForkEraTranslation = EraTranslation {
         translateLedgerState   = PCons ledgerState_AtoB   PNil
       , translateChainDepState = PCons chainDepState_AtoB PNil
@@ -369,6 +372,10 @@ instance CanHardFork '[BlockA, BlockB] where
       }
   hardForkChainSel  = Tails.mk2 CompareBlockNo
   hardForkInjectTxs = InPairs.mk2 injectTx_AtoB
+
+  hardForkInjTxMeasure = \case
+    (  Z (WrapTxMeasure x)) -> x
+    S (Z (WrapTxMeasure x)) -> x
 
 versionN2N :: BlockNodeToNodeVersion TestBlock
 versionN2N =

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator/A.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator/A.hs
@@ -331,8 +331,6 @@ instance LedgerSupportsMempool BlockA where
 
   txForgetValidated = forgetValidatedGenTxA
 
-  txRefScriptSize _cfg _tlst _tx = 0
-
 newtype instance TxId (GenTx BlockA) = TxIdA Int
   deriving stock   (Show, Eq, Ord, Generic)
   deriving newtype (NoThunks, Serialise)

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator/A.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator/A.hs
@@ -326,10 +326,12 @@ instance LedgerSupportsMempool BlockA where
 
   reapplyTx cfg slot = fmap fst .: (applyTx cfg DoNotIntervene slot . forgetValidatedGenTxA)
 
-  txsMaxBytes   _ = maxBound
-  txInBlockSize _ = 0
-
   txForgetValidated = forgetValidatedGenTxA
+
+instance TxLimits BlockA where
+  type TxMeasure BlockA = IgnoringOverflow ByteSize32
+  blockCapacityTxMeasure _cfg _st     = IgnoringOverflow $ ByteSize32 $ 100 * 1024   -- arbitrary
+  txMeasure              _cfg _st _tx = pure $ IgnoringOverflow $ ByteSize32 0
 
 newtype instance TxId (GenTx BlockA) = TxIdA Int
   deriving stock   (Show, Eq, Ord, Generic)

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator/B.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator/B.hs
@@ -267,8 +267,6 @@ instance LedgerSupportsMempool BlockB where
 
   txForgetValidated = \case {}
 
-  txRefScriptSize _cfg _tlst _tx = 0
-
 data instance TxId (GenTx BlockB)
   deriving stock    (Show, Eq, Ord, Generic)
   deriving anyclass (NoThunks, Serialise)

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator/B.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator/B.hs
@@ -262,10 +262,12 @@ instance LedgerSupportsMempool BlockB where
   applyTx   = \_ _ _wti tx -> case tx of {}
   reapplyTx = \_ _ vtx -> case vtx of {}
 
-  txsMaxBytes   _ = maxBound
-  txInBlockSize _ = 0
-
   txForgetValidated = \case {}
+
+instance TxLimits BlockB where
+  type TxMeasure BlockB = IgnoringOverflow ByteSize32
+  blockCapacityTxMeasure _cfg _st     = IgnoringOverflow $ ByteSize32 $ 100 * 1024   -- arbitrary
+  txMeasure              _cfg _st _tx = pure $ IgnoringOverflow $ ByteSize32 0
 
 data instance TxId (GenTx BlockB)
   deriving stock    (Show, Eq, Ord, Generic)

--- a/ouroboros-consensus/bench/mempool-bench/Bench/Consensus/Mempool/TestBlock.hs
+++ b/ouroboros-consensus/bench/mempool-bench/Bench/Consensus/Mempool/TestBlock.hs
@@ -153,8 +153,6 @@ instance Ledger.LedgerSupportsMempool TestBlock where
 
   txForgetValidated (ValidatedGenTx tx) = tx
 
-  txRefScriptSize _cfg _tlst _tx = 0
-
 newtype instance Ledger.TxId (Ledger.GenTx TestBlock) = TestBlockTxId Tx
   deriving stock (Generic)
   deriving newtype (Show, Ord, Eq)

--- a/ouroboros-consensus/bench/mempool-bench/Main.hs
+++ b/ouroboros-consensus/bench/mempool-bench/Main.hs
@@ -140,7 +140,6 @@ openMempoolWithCapacity capacity =
                                (Mempool.unByteSize capacity)
                              )
                              Tracer.nullTracer
-                             TestBlock.txSize
                              Mocked.MempoolAndModelParams {
                                  Mocked.immpInitialState = TestBlock.initialLedgerState
                                , Mocked.immpLedgerConfig = TestBlock.sampleLedgerConfig

--- a/ouroboros-consensus/changelog.d/20240711_064934_nick.frisby_consolidate_txlimits.md
+++ b/ouroboros-consensus/changelog.d/20240711_064934_nick.frisby_consolidate_txlimits.md
@@ -1,0 +1,38 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Patch
+
+- A bullet item for the Patch category.
+
+-->
+<!--
+### Non-Breaking
+
+- A bullet item for the Non-Breaking category.
+
+-->
+
+### Breaking
+
+- Consolidate `TxLimits` in the mempool.
+     - Remove `Mempool.`getTxSize`; the snapshot interface contains byte sizes
+       now.
+
+     - Transaction size, block capacity, and mempool capacity are
+       multi-dimensional vectors (`ExUnits`, etc), instead of merely bytes:
+       `TxMeasure`.
+
+     - A transaction cannot be added if it would push any component of the size
+       over that component of the mempool capacity.
+
+     - The mempool capacity override is still specified in terms of bytes, but
+       the magnitude is interpreted via division as a block count, rounded up.
+
+- Pass a correctly-sized prefix of the mempool to the forging functions,
+  instead of its entire contents. The mempool's finger tree is best way to find
+  that cutoff.

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -273,6 +273,7 @@ library
 
   build-depends:
     base >=4.14 && <4.21,
+    base-deriving-via,
     base16-bytestring,
     bimap >=0.4 && <0.6,
     binary >=0.8 && <0.11,
@@ -697,7 +698,6 @@ benchmark mempool-bench
     deepseq,
     nothunks,
     ouroboros-consensus,
-    ouroboros-network-api,
     serialise,
     tasty,
     tasty-bench,

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Abstract/CanHardFork.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Abstract/CanHardFork.hs
@@ -1,28 +1,48 @@
 {-# LANGUAGE DataKinds               #-}
 {-# LANGUAGE FlexibleContexts        #-}
 {-# LANGUAGE FlexibleInstances       #-}
+{-# LANGUAGE TypeFamilies            #-}
 {-# LANGUAGE UndecidableSuperClasses #-}
 
 module Ouroboros.Consensus.HardFork.Combinator.Abstract.CanHardFork (CanHardFork (..)) where
 
+import           Data.Measure (Measure)
 import           Data.SOP.Constraint
 import           Data.SOP.Functors (Product2)
 import           Data.SOP.InPairs (InPairs, RequiringBoth)
 import qualified Data.SOP.InPairs as InPairs
 import           Data.SOP.NonEmpty
+import qualified Data.SOP.Strict as SOP
 import           Data.SOP.Tails (Tails)
 import qualified Data.SOP.Tails as Tails
 import           Data.Typeable
+import           NoThunks.Class (NoThunks)
 import           Ouroboros.Consensus.HardFork.Combinator.Abstract.SingleEraBlock
 import           Ouroboros.Consensus.HardFork.Combinator.InjectTxs
 import           Ouroboros.Consensus.HardFork.Combinator.Protocol.ChainSel
 import           Ouroboros.Consensus.HardFork.Combinator.Translation
+import           Ouroboros.Consensus.Ledger.SupportsMempool
 import           Ouroboros.Consensus.TypeFamilyWrappers
+
 {-------------------------------------------------------------------------------
   CanHardFork
 -------------------------------------------------------------------------------}
 
-class (All SingleEraBlock xs, Typeable xs, IsNonEmpty xs) => CanHardFork xs where
+class ( All SingleEraBlock xs
+      , Typeable xs
+      , IsNonEmpty xs
+      , Measure     (HardForkTxMeasure xs)
+      , HasByteSize (HardForkTxMeasure xs)
+      , NoThunks    (HardForkTxMeasure xs)
+      , Show        (HardForkTxMeasure xs)
+      ) => CanHardFork xs where
+  -- | A measure that can accurately represent the 'TxMeasure' of any era.
+  --
+  -- Usually, this can simply be the union of the sets of components of each
+  -- individual era's 'TxMeasure'. (Which is too awkward of a type to express
+  -- in Haskell.)
+  type HardForkTxMeasure xs
+
   hardForkEraTranslation :: EraTranslation xs
   hardForkChainSel       :: Tails AcrossEraSelection xs
   hardForkInjectTxs      ::
@@ -33,7 +53,18 @@ class (All SingleEraBlock xs, Typeable xs, IsNonEmpty xs) => CanHardFork xs wher
       )
       xs
 
+  -- | This is ideally exact.
+  --
+  -- If that's not possible, the result must not be too small, since this is
+  -- relied upon to determine which prefix of the mempool's txs will fit in a
+  -- valid block.
+  hardForkInjTxMeasure :: SOP.NS WrapTxMeasure xs -> HardForkTxMeasure xs
+
 instance SingleEraBlock blk => CanHardFork '[blk] where
+  type HardForkTxMeasure '[blk] = TxMeasure blk
+
   hardForkEraTranslation = trivialEraTranslation
   hardForkChainSel       = Tails.mk1
   hardForkInjectTxs      = InPairs.mk1
+
+  hardForkInjTxMeasure (SOP.Z (WrapTxMeasure x)) = x

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Mempool.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Mempool.hs
@@ -5,7 +5,6 @@
 {-# LANGUAGE FlexibleContexts     #-}
 {-# LANGUAGE FlexibleInstances    #-}
 {-# LANGUAGE GADTs                #-}
-{-# LANGUAGE NamedFieldPuns       #-}
 {-# LANGUAGE RankNTypes           #-}
 {-# LANGUAGE RecordWildCards      #-}
 {-# LANGUAGE ScopedTypeVariables  #-}
@@ -124,40 +123,6 @@ instance CanHardFork xs => LedgerSupportsMempool (HardForkBlock xs) where
       . hcmap proxySingle (txForgetValidated . unwrapValidatedGenTx)
       . getOneEraValidatedGenTx
       . getHardForkValidatedGenTx
-
-  txRefScriptSize cfg st tx = case matchPolyTx injs tx' hardForkState of
-      Left {}       ->
-        -- This is ugly/adhoc, but fine, as in the mempool, we only call
-        -- txRefScriptSize after applyTx (which internall also calls
-        -- matchPolyTx), so this case is unreachable.
-        0
-      Right matched ->
-          hcollapse
-        $ hczipWith proxySingle
-            (\(WrapLedgerConfig eraCfg) (Pair eraTx (Comp eraSt)) ->
-               K $ txRefScriptSize eraCfg eraSt eraTx)
-            cfgs
-            (State.tip matched)
-    where
-      HardForkLedgerConfig {
-          hardForkLedgerConfigPerEra
-        , hardForkLedgerConfigShape
-        } = cfg
-      TickedHardForkLedgerState transition hardForkState = st
-      tx' = getOneEraGenTx . getHardForkGenTx $ tx
-
-      pcfgs = getPerEraLedgerConfig hardForkLedgerConfigPerEra
-      cfgs  = hcmap proxySingle (completeLedgerConfig'' ei) pcfgs
-      ei    = State.epochInfoPrecomputedTransitionInfo
-                hardForkLedgerConfigShape
-                transition
-                hardForkState
-
-      injs :: InPairs (InjectPolyTx GenTx) xs
-      injs =
-          InPairs.hmap
-            (\(Pair2 injTx _injValidatedTx) -> injTx)
-            (InPairs.requiringBoth cfgs hardForkInjectTxs)
 
 -- | A private type used only to clarify the parameterization of 'applyHelper'
 data ApplyHelperMode :: (Type -> Type) -> Type where

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Dual.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Dual.hs
@@ -624,12 +624,6 @@ instance Bridge m a => LedgerSupportsMempool (DualBlock m a) where
           , vDualGenTxBridge
           } = vtx
 
-  txRefScriptSize cfg st tx =
-      txRefScriptSize
-        (dualLedgerConfigMain cfg)
-        (tickedDualLedgerStateMain st)
-        (dualGenTxMain tx)
-
 -- We don't need a pair of IDs, as long as we can unique ID the transaction
 newtype instance TxId (GenTx (DualBlock m a)) = DualGenTxId {
       dualGenTxIdMain :: GenTxId m

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Dual.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Dual.hs
@@ -60,6 +60,7 @@ import           Cardano.Binary (enforceSize)
 import           Codec.CBOR.Decoding (Decoder)
 import           Codec.CBOR.Encoding (Encoding, encodeListLen)
 import           Codec.Serialise
+import           Control.Arrow ((+++))
 import           Control.Monad.Except
 import qualified Data.ByteString.Lazy as Lazy
 import qualified Data.ByteString.Short as Short
@@ -608,9 +609,6 @@ instance Bridge m a => LedgerSupportsMempool (DualBlock m a) where
                                            tickedDualLedgerStateBridge
         }
 
-  txsMaxBytes   = txsMaxBytes . tickedDualLedgerStateMain
-  txInBlockSize = txInBlockSize . dualGenTxMain
-
   txForgetValidated vtx =
       DualGenTx {
           dualGenTxMain   = txForgetValidated vDualGenTxMain
@@ -623,6 +621,18 @@ instance Bridge m a => LedgerSupportsMempool (DualBlock m a) where
           , vDualGenTxAux
           , vDualGenTxBridge
           } = vtx
+
+instance Bridge m a => TxLimits (DualBlock m a) where
+  type TxMeasure (DualBlock m a) = TxMeasure m
+
+  txMeasure DualLedgerConfig{..} TickedDualLedgerState{..} DualGenTx{..} = do
+      mapExcept (inj +++ id)
+    $ txMeasure dualLedgerConfigMain tickedDualLedgerStateMain dualGenTxMain
+    where
+      inj m = DualGenTxErr m (error "ByronSpec has no tx-too-big error")
+
+  blockCapacityTxMeasure DualLedgerConfig{..} TickedDualLedgerState{..} =
+      blockCapacityTxMeasure dualLedgerConfigMain tickedDualLedgerStateMain
 
 -- We don't need a pair of IDs, as long as we can unique ID the transaction
 newtype instance TxId (GenTx (DualBlock m a)) = DualGenTxId {

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/SupportsMempool.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/SupportsMempool.hs
@@ -1,28 +1,42 @@
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE TypeFamilies     #-}
+{-# LANGUAGE DataKinds                  #-}
+{-# LANGUAGE DerivingVia                #-}
+{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE FlexibleInstances          #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE TypeApplications           #-}
+{-# LANGUAGE TypeFamilies               #-}
 
 module Ouroboros.Consensus.Ledger.SupportsMempool (
     ApplyTxErr
+  , ByteSize32 (..)
   , ConvertRawTxId (..)
   , GenTx
   , GenTxId
+  , HasByteSize (..)
   , HasTxId (..)
   , HasTxs (..)
+  , IgnoringOverflow (..)
   , LedgerSupportsMempool (..)
   , TxId
+  , TxLimits (..)
   , Validated
   , WhetherToIntervene (..)
   ) where
 
+import           Control.DeepSeq (NFData)
 import           Control.Monad.Except
 import           Data.ByteString.Short (ShortByteString)
+import           Data.Coerce (coerce)
+import           Data.DerivingVia (InstantiatedAt (..))
 import           Data.Kind (Type)
+import           Data.Measure (Measure)
+import qualified Data.Measure
 import           Data.Word (Word32)
 import           GHC.Stack (HasCallStack)
+import           NoThunks.Class
 import           Ouroboros.Consensus.Block.Abstract
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ticked
-import           Ouroboros.Consensus.Util.IOLike
 
 -- | Generalized transaction
 --
@@ -59,6 +73,7 @@ data WhetherToIntervene
     deriving (Show)
 
 class ( UpdateLedger blk
+      , TxLimits blk
       , NoThunks (GenTx blk)
       , NoThunks (Validated (GenTx blk))
       , NoThunks (Ticked (LedgerState blk))
@@ -95,34 +110,6 @@ class ( UpdateLedger blk
             -> Validated (GenTx blk)
             -> TickedLedgerState blk
             -> Except (ApplyTxErr blk) (TickedLedgerState blk)
-
-  -- | The maximum number of bytes worth of transactions that can be put into
-  -- a block according to the currently adopted protocol parameters of the
-  -- ledger state.
-  --
-  -- This is (conservatively) computed by subtracting the header size and any
-  -- other fixed overheads from the maximum block size.
-  txsMaxBytes :: TickedLedgerState blk -> Word32
-
-  -- | Return the post-serialisation size in bytes of a 'GenTx' /when it is
-  -- embedded in a block/. This size might differ from the size of the
-  -- serialisation used to send and receive the transaction across the
-  -- network.
-  --
-  -- This size is used to compute how many transaction we can put in a block
-  -- when forging one.
-  --
-  -- For example, CBOR-in-CBOR could be used when sending the transaction
-  -- across the network, requiring a few extra bytes compared to the actual
-  -- in-block serialisation. Another example is the transaction of the
-  -- hard-fork combinator which will include an envelope indicating its era
-  -- when sent across the network. However, when embedded in the respective
-  -- era's block, there is no need for such envelope.
-  --
-  -- Can be implemented by serialising the 'GenTx', but, ideally, this is
-  -- implement more efficiently. E.g., by returning the length of the
-  -- annotation.
-  txInBlockSize :: GenTx blk -> Word32
 
   -- | Discard the evidence that transaction has been previously validated
   txForgetValidated :: Validated (GenTx blk) -> GenTx blk
@@ -166,3 +153,132 @@ type GenTxId blk = TxId (GenTx blk)
 class HasTxs blk where
   -- | Return the transactions part of the given block in no particular order.
   extractTxs :: blk -> [GenTx blk]
+
+{-------------------------------------------------------------------------------
+  Tx sizes
+-------------------------------------------------------------------------------}
+
+-- | Each block has its limits of how many transactions it can hold. That limit
+-- is compared against the sum of measurements taken of each of the
+-- transactions in that block.
+--
+-- How we measure the transaction depends of the era that this transaction
+-- belongs to (more specifically it depends on the block type to which this
+-- transaction will be added). For initial eras (like Byron and initial
+-- generations of Shelley based eras) this measure was simply a byte size
+-- (block could not be bigger then given size - in bytes - specified by the
+-- ledger state). In subsequent eras (starting with Alonzo) this measure was a
+-- bit more complex as it had to take other factors into account (like
+-- execution units). For details please see the individual instances for the
+-- TxLimits.
+class ( Measure     (TxMeasure blk)
+      , HasByteSize (TxMeasure blk)
+      , NoThunks    (TxMeasure blk)
+      , Show        (TxMeasure blk)
+      ) => TxLimits blk where
+  -- | The (possibly multi-dimensional) size of a transaction in a block.
+  type TxMeasure blk
+
+  -- | The various sizes (bytes, Plutus script ExUnits, etc) of a tx /when it's
+  -- in a block/
+  --
+  -- This size is used to compute how many transaction we can put in a block
+  -- when forging one.
+  --
+  -- The byte size component in particular might differ from the size of the
+  -- serialisation used to send and receive the transaction across the network.
+  -- For example, CBOR-in-CBOR could be used when sending the transaction
+  -- across the network, requiring a few extra bytes compared to the actual
+  -- in-block serialisation. Another example is the transaction of the
+  -- hard-fork combinator which will include an envelope indicating its era
+  -- when sent across the network. However, when embedded in the respective
+  -- era's block, there is no need for such envelope. An example from upstream
+  -- is that the Cardano ledger's "Segregated Witness" encoding scheme
+  -- contributes to the encoding overhead.
+  --
+  -- INVARIANT Assuming no hash collisions, the size should be the same in any
+  -- state in which the transaction is valid. For example, it's acceptable to
+  -- simply omit the size of ref scripts that could not be found, since their
+  -- absence implies the tx is invalid. In fact, that invalidity could be
+  -- reported by this function, but it need not be.
+  --
+  -- INVARIANT @Right x = txMeasure cfg st tx@ implies @x 'Measure.<='
+  -- 'blockCapacityTxMeasure cfg st'. Otherwise, the mempool could block
+  -- forever.
+  --
+  -- Returns an exception if and only if the transaction violates the per-tx
+  -- limits.
+  txMeasure ::
+       LedgerConfig blk
+       -- ^ used at least by HFC's composition logic
+    -> TickedLedgerState blk
+    -> GenTx blk
+    -> Except (ApplyTxErr blk) (TxMeasure blk)
+
+  -- | What is the allowed capacity for the txs in an individual block?
+  blockCapacityTxMeasure ::
+       LedgerConfig blk
+       -- ^ at least for symmetry with 'txMeasure'
+    -> TickedLedgerState blk
+    -> TxMeasure blk
+
+-- | We intentionally do not declare a 'Num' instance! We prefer @ByteSize32@
+-- to occur explicitly in the code where possible, for
+-- legibility/perspicuousness. We also do not need nor want subtraction.
+--
+-- This data type measures the size of a transaction, the sum of the sizes of
+-- txs in a block, the sum of the sizes of the txs in the mempool, etc. None of
+-- those will ever need to represent gigabytes, so 32 bits suffice. But 16 bits
+-- would not.
+--
+-- This is modular arithmetic, so uses need to be concerned with overflow. For
+-- example, see the related guard in
+-- 'Ouroboros.Consensus.Mempool.Update.pureTryAddTx'. One important element is
+-- anticipating the possibility of very large summands injected by the
+-- adversary.
+--
+-- There is a temptation to use 'Natural' here, since it can never overflow.
+-- However, some points in the interface do not easily handle 'Natural's, such
+-- as encoders. Thus 'Natural' would merely defer the overflow concern, and
+-- even risks instilling a false sense that overflow need not be considered at
+-- all.
+newtype ByteSize32 = ByteSize32 { unByteSize32 :: Word32 }
+  deriving stock    (Show)
+  deriving newtype  (Eq, Ord)
+  deriving newtype  (NFData)
+  deriving          (Monoid, Semigroup)
+                via (InstantiatedAt Measure (IgnoringOverflow ByteSize32))
+  deriving          (NoThunks)
+                via OnlyCheckWhnfNamed "ByteSize" ByteSize32
+
+-- | @'IgnoringOverflow' a@ has the same semantics as @a@, except it ignores
+-- the fact that @a@ can overflow.
+--
+-- For example, @'Measure' 'Word32'@ is not lawful, because overflow violates
+-- the /lattice-ordered monoid/ law. But @'Measure' (IgnoringOverflow
+-- 'Word32')@ is lawful, since it explicitly ignores that case.
+--
+-- WARNING: anywhere this type occurs is a very strong indicator that overflow
+-- will break assumptions, so overflow must therefore be guarded against.
+--
+-- TODO upstream this to the @measure@ package
+newtype IgnoringOverflow a = IgnoringOverflow { unIgnoringOverflow :: a }
+  deriving stock    (Show)
+  deriving newtype  (Eq, Ord)
+  deriving newtype  (NFData)
+  deriving newtype  (Monoid, Semigroup)
+  deriving newtype  (NoThunks)
+  deriving newtype  (HasByteSize)
+
+instance Measure (IgnoringOverflow ByteSize32) where
+  zero = coerce (0 :: Word32)
+  plus = coerce $ (+) @Word32
+  min  = coerce $ min @Word32
+  max  = coerce $ max @Word32
+
+class HasByteSize a where
+  -- | The byte size component (of 'TxMeasure')
+  txMeasureByteSize :: a -> ByteSize32
+
+instance HasByteSize ByteSize32 where
+  txMeasureByteSize = id

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/SupportsMempool.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/SupportsMempool.hs
@@ -127,8 +127,6 @@ class ( UpdateLedger blk
   -- | Discard the evidence that transaction has been previously validated
   txForgetValidated :: Validated (GenTx blk) -> GenTx blk
 
-  txRefScriptSize :: LedgerConfig blk -> TickedLedgerState blk -> GenTx blk -> Int
-
 -- | A generalized transaction, 'GenTx', identifier.
 data family TxId tx :: Type
 

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool.hs
@@ -19,14 +19,10 @@ module Ouroboros.Consensus.Mempool (
   , TicketNo
   , zeroTicketNo
     -- * Mempool capacity
-  , MempoolCapacityBytes (..)
   , MempoolCapacityBytesOverride (..)
   , computeMempoolCapacity
     -- ** Mempool Size
   , MempoolSize (..)
-    -- ** Transaction size
-  , ByteSize (..)
-  , TxLimits (..)
     -- * Mempool initialization
   , openMempool
   , openMempoolWithoutSyncThread
@@ -42,10 +38,9 @@ import           Ouroboros.Consensus.Mempool.API (ForgeLedgerState (..),
                      MempoolSnapshot (..), SizeInBytes, TicketNo, addLocalTxs,
                      addTxs, isMempoolTxAdded, isMempoolTxRejected,
                      mempoolTxAddedToMaybe, zeroTicketNo)
-import           Ouroboros.Consensus.Mempool.Capacity (ByteSize (..),
-                     MempoolCapacityBytes (..),
-                     MempoolCapacityBytesOverride (..), MempoolSize (..),
-                     TxLimits (..), computeMempoolCapacity)
+import           Ouroboros.Consensus.Mempool.Capacity
+                     (MempoolCapacityBytesOverride (..), MempoolSize (..),
+                     computeMempoolCapacity)
 import           Ouroboros.Consensus.Mempool.Impl.Common (LedgerInterface (..),
                      TraceEventMempool (..), chainDBLedgerInterface)
 import           Ouroboros.Consensus.Mempool.Init (openMempool,

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/API.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/API.hs
@@ -207,9 +207,6 @@ data Mempool m blk = Mempool {
       -- capacity, i.e., we won't admit new transactions until some have been
       -- removed because they have become invalid.
     , getCapacity    :: STM m Cap.MempoolCapacityBytes
-
-      -- | Return the post-serialisation size in bytes of a 'GenTx'.
-    , getTxSize      :: GenTx blk -> SizeInBytes
     }
 
 {-------------------------------------------------------------------------------
@@ -335,7 +332,8 @@ data MempoolSnapshot blk = MempoolSnapshot {
     -- | Get all transactions (oldest to newest) in the mempool snapshot,
     -- along with their ticket number, which are associated with a ticket
     -- number greater than the one provided.
-  , snapshotTxsAfter    :: TicketNo -> [(Validated (GenTx blk), TicketNo)]
+  , snapshotTxsAfter    ::
+      TicketNo -> [(Validated (GenTx blk), TicketNo, TxSizeInBytes)]
 
     -- | Get a specific transaction from the mempool snapshot by its ticket
     -- number, if it exists.

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Capacity.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Capacity.hs
@@ -1,8 +1,5 @@
-{-# LANGUAGE DerivingStrategies         #-}
-{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE DerivingVia                #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE ScopedTypeVariables        #-}
-{-# LANGUAGE TypeFamilies               #-}
 
 -- | Mempool capacity, size and transaction size datatypes.
 --
@@ -12,35 +9,23 @@
 -- > import qualified Ouroboros.Consensus.Mempool.Capacity as Capacity
 module Ouroboros.Consensus.Mempool.Capacity (
     -- * Mempool capacity
-    MempoolCapacityBytes (..)
-  , MempoolCapacityBytesOverride (..)
+    MempoolCapacityBytesOverride (..)
   , computeMempoolCapacity
   , mkCapacityBytesOverride
     -- * Mempool Size
   , MempoolSize (..)
-    -- * Transaction size
-  , ByteSize (..)
-  , TxLimits (..)
   ) where
 
-import           Cardano.Prelude (NFData)
+import           Data.DerivingVia (InstantiatedAt (..))
 import           Data.Measure (Measure)
+import           Data.Semigroup (stimes)
 import           Data.Word (Word32)
-import           NoThunks.Class
 import           Ouroboros.Consensus.Ledger.Basics
 import           Ouroboros.Consensus.Ledger.SupportsMempool
-import           Ouroboros.Consensus.Ticked (Ticked (..))
 
 {-------------------------------------------------------------------------------
   Mempool capacity in bytes
 -------------------------------------------------------------------------------}
-
--- | Represents the maximum number of bytes worth of transactions that a
--- 'Mempool' can contain.
-newtype MempoolCapacityBytes = MempoolCapacityBytes {
-      getMempoolCapacityBytes :: Word32
-    }
-  deriving (Eq, Show, NoThunks)
 
 -- | An override for the default 'MempoolCapacityBytes' which is 2x the
 -- maximum transaction capacity
@@ -48,27 +33,47 @@ data MempoolCapacityBytesOverride
   = NoMempoolCapacityBytesOverride
     -- ^ Use 2x the maximum transaction capacity of a block. This will change
     -- dynamically with the protocol parameters adopted in the current ledger.
-  | MempoolCapacityBytesOverride !MempoolCapacityBytes
-    -- ^ Use the following 'MempoolCapacityBytes'.
+  | MempoolCapacityBytesOverride !ByteSize32
+    -- ^ Use the least multiple of the block capacity that is no less than this
+    -- size.
   deriving (Eq, Show)
 
 -- | Create an override for the mempool capacity using the provided number of
 -- bytes.
-mkCapacityBytesOverride :: Word32 -> MempoolCapacityBytesOverride
-mkCapacityBytesOverride = MempoolCapacityBytesOverride . MempoolCapacityBytes
+mkCapacityBytesOverride :: ByteSize32 -> MempoolCapacityBytesOverride
+mkCapacityBytesOverride = MempoolCapacityBytesOverride
 
 -- | If no override is provided, calculate the default mempool capacity as 2x
 -- the current ledger's maximum transaction capacity of a block.
+--
+-- If an override is present, reinterpret it as a number of blocks (rounded
+-- up), and then simply multiply the ledger's capacity by that number.
 computeMempoolCapacity ::
      LedgerSupportsMempool blk
-  => TickedLedgerState blk
+  => LedgerConfig blk
+  -> TickedLedgerState blk
   -> MempoolCapacityBytesOverride
-  -> MempoolCapacityBytes
-computeMempoolCapacity st mc = case mc of
-    NoMempoolCapacityBytesOverride        -> noOverride
-    MempoolCapacityBytesOverride override -> override
+  -> TxMeasure blk
+computeMempoolCapacity cfg st override =
+    capacity
   where
-    noOverride = MempoolCapacityBytes (txsMaxBytes st * 2)
+    oneBlock                 = blockCapacityTxMeasure cfg st
+    ByteSize32 oneBlockBytes = txMeasureByteSize oneBlock
+
+    blockCount = case override of
+      NoMempoolCapacityBytesOverride              -> 2
+      MempoolCapacityBytesOverride (ByteSize32 x) ->
+        -- This calculation is happening at Word32. Thus overflow is silently
+        -- accepted. Adding one less than the denominator to the numerator
+        -- effectively rounds up instead of down.
+        max 1 $ (x + oneBlockBytes - 1) `div` oneBlockBytes
+
+    SemigroupViaMeasure capacity =
+      stimes blockCount (SemigroupViaMeasure oneBlock)
+
+newtype SemigroupViaMeasure a = SemigroupViaMeasure a
+  deriving (Eq, Measure)
+  deriving Semigroup via (InstantiatedAt Measure (SemigroupViaMeasure a))
 
 {-------------------------------------------------------------------------------
   Mempool size
@@ -78,51 +83,13 @@ computeMempoolCapacity st mc = case mc of
 data MempoolSize = MempoolSize
   { msNumTxs   :: !Word32
     -- ^ The number of transactions in the mempool.
-  , msNumBytes :: !Word32
+  , msNumBytes :: !ByteSize32
     -- ^ The summed byte size of all the transactions in the mempool.
   } deriving (Eq, Show)
 
 instance Semigroup MempoolSize where
-  MempoolSize xt xb <> MempoolSize yt yb = MempoolSize (xt + yt) (xb + yb)
+  MempoolSize xt xb <> MempoolSize yt yb = MempoolSize (xt + yt) (xb <> yb)
 
 instance Monoid MempoolSize where
-  mempty = MempoolSize { msNumTxs = 0, msNumBytes = 0 }
+  mempty  = MempoolSize { msNumTxs = 0, msNumBytes = ByteSize32 0 }
   mappend = (<>)
-
-{-------------------------------------------------------------------------------
-  Tx sizes
--------------------------------------------------------------------------------}
-
--- | Each block has its limits of how many transactions it can hold.
--- That limit is compared against the sum of measurements
--- taken of each of the transactions in that block.
---
--- How we measure the transaction depends of the era that this
--- transaction belongs to (more specifically it depends on the block
--- type to which this transaction will be added). For initial eras
--- (like Byron and initial generations of Shelley based eras) this
--- measure was simply a ByteSize (block could not be bigger then
--- given size - in bytes - specified by the ledger state). In future
--- eras (starting with Alonzo) this measure was a bit more complex
--- as it had to take other factors into account (like execution units).
--- For details please see the individual instances for the TxLimits.
-class Measure (TxMeasure blk) => TxLimits blk where
-  type TxMeasure blk
-
-  -- | What is the measure an individual tx?
-  txMeasure ::
-       TickedLedgerState blk
-    -> Validated (GenTx blk)
-    -> TxMeasure blk
-
-  -- | What is the allowed capacity for txs in an individual block?
-  txsBlockCapacity :: Ticked (LedgerState blk) -> TxMeasure blk
-
-{-------------------------------------------------------------------------------
-  ByteSize
--------------------------------------------------------------------------------}
-
-newtype ByteSize = ByteSize { unByteSize :: Word32 }
-  deriving stock (Show)
-  deriving newtype (Eq, NFData, Ord)
-  deriving newtype (Measure)

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Capacity.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Capacity.hs
@@ -24,7 +24,7 @@ module Ouroboros.Consensus.Mempool.Capacity (
   ) where
 
 import           Cardano.Prelude (NFData)
-import           Data.Measure (BoundedMeasure, Measure)
+import           Data.Measure (Measure)
 import           Data.Word (Word32)
 import           NoThunks.Class
 import           Ouroboros.Consensus.Ledger.Basics
@@ -106,7 +106,7 @@ instance Monoid MempoolSize where
 -- eras (starting with Alonzo) this measure was a bit more complex
 -- as it had to take other factors into account (like execution units).
 -- For details please see the individual instances for the TxLimits.
-class BoundedMeasure (TxMeasure blk) => TxLimits blk where
+class Measure (TxMeasure blk) => TxLimits blk where
   type TxMeasure blk
 
   -- | What is the measure an individual tx?
@@ -125,4 +125,4 @@ class BoundedMeasure (TxMeasure blk) => TxLimits blk where
 newtype ByteSize = ByteSize { unByteSize :: Word32 }
   deriving stock (Show)
   deriving newtype (Eq, NFData, Ord)
-  deriving newtype (BoundedMeasure, Measure)
+  deriving newtype (Measure)

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Impl/Common.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Impl/Common.hs
@@ -73,7 +73,7 @@ data InternalState blk = IS {
       -- the normal way: by becoming invalid w.r.t. the updated ledger state.
       -- We treat a Mempool /over/ capacity in the same way as a Mempool /at/
       -- capacity.
-      isTxs          :: !(TxSeq (Validated (GenTx blk)))
+      isTxs          :: !(TxSeq (TxMeasure blk) (Validated (GenTx blk)))
 
       -- | The cached IDs of transactions currently in the mempool.
       --
@@ -123,37 +123,42 @@ data InternalState blk = IS {
       -- transactions will be in the next block. So any changes caused by that
       -- block will take effect after applying it and will only affect the
       -- next block.
-    , isCapacity     :: !MempoolCapacityBytes
+    , isCapacity     :: !(TxMeasure blk)
     }
   deriving (Generic)
 
 deriving instance ( NoThunks (Validated (GenTx blk))
                   , NoThunks (GenTxId blk)
                   , NoThunks (Ticked (LedgerState blk))
+                  , NoThunks (TxMeasure blk)
                   , StandardHash blk
                   , Typeable blk
                   ) => NoThunks (InternalState blk)
 
 -- | \( O(1) \). Return the number of transactions in the internal state of
 -- the Mempool paired with their total size in bytes.
-isMempoolSize :: InternalState blk -> MempoolSize
-isMempoolSize = TxSeq.toMempoolSize . isTxs
+isMempoolSize :: TxLimits blk => InternalState blk -> MempoolSize
+isMempoolSize is = MempoolSize {
+    msNumTxs   = fromIntegral $ length $ isTxs is
+  , msNumBytes = txMeasureByteSize $ TxSeq.toSize $ isTxs is
+  }
 
 initInternalState ::
      LedgerSupportsMempool blk
   => MempoolCapacityBytesOverride
   -> TicketNo  -- ^ Used for 'isLastTicketNo'
+  -> LedgerConfig blk
   -> SlotNo
   -> TickedLedgerState blk
   -> InternalState blk
-initInternalState capacityOverride lastTicketNo slot st = IS {
+initInternalState capacityOverride lastTicketNo cfg slot st = IS {
       isTxs          = TxSeq.Empty
     , isTxIds        = Set.empty
     , isLedgerState  = st
     , isTip          = castHash (getTipHash st)
     , isSlotNo       = slot
     , isLastTicketNo = lastTicketNo
-    , isCapacity     = computeMempoolCapacity st capacityOverride
+    , isCapacity     = computeMempoolCapacity cfg st capacityOverride
     }
 
 {-------------------------------------------------------------------------------
@@ -203,7 +208,9 @@ initMempoolEnv :: ( IOLike m
 initMempoolEnv ledgerInterface cfg capacityOverride tracer = do
     st <- atomically $ getCurrentLedgerState ledgerInterface
     let (slot, st') = tickLedgerState cfg (ForgeInUnknownSlot st)
-    isVar <- newTVarIO $ initInternalState capacityOverride TxSeq.zeroTicketNo slot st'
+    isVar <-
+        newTVarIO
+      $ initInternalState capacityOverride TxSeq.zeroTicketNo cfg slot st'
     addTxRemoteFifo <- newMVar ()
     addTxAllFifo    <- newMVar ()
     return MempoolEnv
@@ -254,10 +261,10 @@ data ValidationResult invalidTx blk = ValidationResult {
 
       -- | Capacity of the Mempool. Corresponds to 'vrBeforeTip' and
       -- 'vrBeforeSlotNo', /not/ 'vrAfter'.
-    , vrBeforeCapacity :: MempoolCapacityBytes
+    , vrBeforeCapacity :: TxMeasure blk
 
       -- | The transactions that were found to be valid (oldest to newest)
-    , vrValid          :: TxSeq (Validated (GenTx blk))
+    , vrValid          :: TxSeq (TxMeasure blk) (Validated (GenTx blk))
 
       -- | The cached IDs of transactions that were found to be valid (oldest to
       -- newest)
@@ -297,7 +304,7 @@ data ValidationResult invalidTx blk = ValidationResult {
 -- signatures.
 extendVRPrevApplied :: (LedgerSupportsMempool blk, HasTxId (GenTx blk))
                     => LedgerConfig blk
-                    -> TxTicket (Validated (GenTx blk))
+                    -> TxTicket (TxMeasure blk) (Validated (GenTx blk))
                     -> ValidationResult (Validated (GenTx blk)) blk
                     -> ValidationResult (Validated (GenTx blk)) blk
 extendVRPrevApplied cfg txTicket vr =
@@ -323,39 +330,36 @@ extendVRNew :: (LedgerSupportsMempool blk, HasTxId (GenTx blk))
             -> WhetherToIntervene
             -> GenTx blk
             -> ValidationResult (GenTx blk) blk
-            -> ( Either (ApplyTxErr blk) (Validated (GenTx blk))
-               , ValidationResult (GenTx blk) blk
-               )
-extendVRNew cfg wti tx vr = assert (isNothing vrNewValid) $
-    case runExcept (applyTx cfg wti vrSlotNo tx vrAfter) of
-      Left err         ->
-        ( Left err
-        , vr { vrInvalid      = (tx, err) : vrInvalid
-             }
-        )
-      Right (st', vtx) ->
-        ( Right vtx
-        , vr { vrValid        = vrValid :> TxTicket vtx nextTicketNo sz
+            -> Either
+                 (ApplyTxErr blk)
+                 ( Validated        (GenTx blk)
+                 , ValidationResult (GenTx blk) blk
+                 )
+extendVRNew cfg wti tx vr =
+    assert (isNothing vrNewValid) $ runExcept m
+  where
+    ValidationResult {
+        vrValid
+      , vrValidTxIds
+      , vrAfter
+      , vrLastTicketNo
+      , vrNewValid
+      , vrSlotNo
+      } = vr
+
+    m = do
+      txsz <- txMeasure cfg vrAfter tx
+      (st', vtx) <- applyTx cfg wti vrSlotNo tx vrAfter
+      let nextTicketNo = succ vrLastTicketNo
+      pure
+        ( vtx
+        , vr { vrValid        = vrValid :> TxTicket vtx nextTicketNo txsz
              , vrValidTxIds   = Set.insert (txId tx) vrValidTxIds
              , vrNewValid     = Just vtx
              , vrAfter        = st'
              , vrLastTicketNo = nextTicketNo
              }
         )
-  where
-    ValidationResult {
-        vrValid
-      , vrValidTxIds
-      , vrAfter
-      , vrInvalid
-      , vrLastTicketNo
-      , vrNewValid
-      , vrSlotNo
-      } = vr
-
-    nextTicketNo = succ vrLastTicketNo
-
-    sz = txInBlockSize tx
 
 {-------------------------------------------------------------------------------
   Conversions
@@ -410,8 +414,8 @@ validationResultFromIS is = ValidationResult {
       } = is
 
 -- | Create a Mempool Snapshot from a given Internal State of the mempool.
-snapshotFromIS ::
-     HasTxId (GenTx blk)
+snapshotFromIS :: forall blk.
+     (HasTxId (GenTx blk), TxLimits blk)
   => InternalState blk
   -> MempoolSnapshot blk
 snapshotFromIS is = MempoolSnapshot {
@@ -422,34 +426,38 @@ snapshotFromIS is = MempoolSnapshot {
     , snapshotMempoolSize = implSnapshotGetMempoolSize is
     , snapshotSlotNo      = isSlotNo                   is
     , snapshotLedgerState = isLedgerState              is
+    , snapshotTake        = implSnapshotTake           is
     }
  where
   implSnapshotGetTxs :: InternalState blk
-                     -> [(Validated (GenTx blk), TicketNo)]
-  implSnapshotGetTxs is' =
-      map (\(a, b, _c) -> (a, b))
-    $ implSnapshotGetTxsAfter is' TxSeq.zeroTicketNo
+                     -> [(Validated (GenTx blk), TicketNo, ByteSize32)]
+  implSnapshotGetTxs = flip implSnapshotGetTxsAfter TxSeq.zeroTicketNo
 
   implSnapshotGetTxsAfter :: InternalState blk
                           -> TicketNo
-                          -> [(Validated (GenTx blk), TicketNo, TxSizeInBytes)]
+                          -> [(Validated (GenTx blk), TicketNo, ByteSize32)]
   implSnapshotGetTxsAfter IS{isTxs} =
     TxSeq.toTuples . snd . TxSeq.splitAfterTicketNo isTxs
+
+  implSnapshotTake :: InternalState blk
+                   -> TxMeasure blk
+                   -> [Validated (GenTx blk)]
+  implSnapshotTake IS{isTxs} =
+    map TxSeq.txTicketTx . TxSeq.toList . fst . TxSeq.splitAfterTxSize isTxs
 
   implSnapshotGetTx :: InternalState blk
                     -> TicketNo
                     -> Maybe (Validated (GenTx blk))
   implSnapshotGetTx IS{isTxs} = (isTxs `TxSeq.lookupByTicketNo`)
 
-  implSnapshotHasTx :: Ord (GenTxId blk)
-                    => InternalState blk
+  implSnapshotHasTx :: InternalState blk
                     -> GenTxId blk
                     -> Bool
   implSnapshotHasTx IS{isTxIds} = flip Set.member isTxIds
 
   implSnapshotGetMempoolSize :: InternalState blk
                              -> MempoolSize
-  implSnapshotGetMempoolSize = TxSeq.toMempoolSize . isTxs
+  implSnapshotGetMempoolSize = isMempoolSize
 
 {-------------------------------------------------------------------------------
   Validating txs or states
@@ -498,7 +506,7 @@ revalidateTxsFor ::
   -> TickedLedgerState blk
   -> TicketNo
      -- ^ 'isLastTicketNo' & 'vrLastTicketNo'
-  -> [TxTicket (Validated (GenTx blk))]
+  -> [TxTicket (TxMeasure blk) (Validated (GenTx blk))]
   -> ValidationResult (Validated (GenTx blk)) blk
 revalidateTxsFor capacityOverride cfg slot st lastTicketNo txTickets =
     repeatedly
@@ -506,7 +514,7 @@ revalidateTxsFor capacityOverride cfg slot st lastTicketNo txTickets =
       txTickets
       (validationResultFromIS is)
   where
-    is = initInternalState capacityOverride lastTicketNo slot st
+    is = initInternalState capacityOverride lastTicketNo cfg slot st
 
 {-------------------------------------------------------------------------------
   Tracing support for the mempool operations

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Impl/Common.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Impl/Common.hs
@@ -13,7 +13,6 @@ module Ouroboros.Consensus.Mempool.Impl.Common (
     -- * Internal state
     InternalState (..)
   , isMempoolSize
-  , isTotalRefScriptSize
     -- * Mempool environment
   , MempoolEnv (..)
   , initMempoolEnv
@@ -139,9 +138,6 @@ deriving instance ( NoThunks (Validated (GenTx blk))
 -- the Mempool paired with their total size in bytes.
 isMempoolSize :: InternalState blk -> MempoolSize
 isMempoolSize = TxSeq.toMempoolSize . isTxs
-
-isTotalRefScriptSize :: InternalState blk -> Int
-isTotalRefScriptSize = TxSeq.toRefScriptSize . isTxs
 
 initInternalState ::
      LedgerSupportsMempool blk
@@ -344,7 +340,6 @@ extendVRNew cfg txSize wti tx vr = assert (isNothing vrNewValid) $
       Right (st', vtx) ->
         ( Right vtx
         , vr { vrValid        = vrValid :> TxTicket vtx nextTicketNo (txSize tx)
-                                             (txRefScriptSize cfg vrAfter tx)
              , vrValidTxIds   = Set.insert (txId tx) vrValidTxIds
              , vrNewValid     = Just vtx
              , vrAfter        = st'

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/TxSeq.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/TxSeq.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE MultiParamTypeClasses      #-}
 {-# LANGUAGE NamedFieldPuns             #-}
 {-# LANGUAGE PatternSynonyms            #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
 {-# LANGUAGE ViewPatterns               #-}
 
 -- | Intended for qualified import.
@@ -21,21 +22,24 @@ module Ouroboros.Consensus.Mempool.TxSeq (
   , splitAfterTicketNo
   , splitAfterTxSize
   , toList
-  , toMempoolSize
+  , toSize
   , toTuples
   , zeroTicketNo
     -- * Reference implementations for testing
   , splitAfterTxSizeSpec
   ) where
 
+import           Control.Arrow ((***))
 import           Data.FingerTree.Strict (StrictFingerTree)
 import qualified Data.FingerTree.Strict as FingerTree
 import qualified Data.Foldable as Foldable
+import           Data.Measure (Measure)
+import qualified Data.Measure as Measure
 import           Data.Word (Word64)
 import           GHC.Generics (Generic)
 import           NoThunks.Class (NoThunks)
-import           Ouroboros.Consensus.Mempool.Capacity (MempoolSize (..))
-import           Ouroboros.Network.SizeInBytes
+import           Ouroboros.Consensus.Ledger.SupportsMempool (ByteSize32,
+                     HasByteSize, txMeasureByteSize)
 
 {-------------------------------------------------------------------------------
   Mempool transaction sequence as a finger tree
@@ -55,14 +59,13 @@ zeroTicketNo = TicketNo 0
 -- | We associate transactions in the mempool with their ticket number and
 -- size in bytes.
 --
-data TxTicket tx = TxTicket
-  { txTicketTx            :: !tx
+data TxTicket sz tx = TxTicket
+  { txTicketTx   :: !tx
     -- ^ The transaction associated with this ticket.
-  , txTicketNo            :: !TicketNo
+  , txTicketNo   :: !TicketNo
     -- ^ The ticket number.
-  , txTicketTxSizeInBytes :: !SizeInBytes
-    -- ^ The byte size of the transaction ('txTicketTx') associated with this
-    -- ticket.
+  , txTicketSize :: !sz
+    -- ^ The size of 'txTicketTx'.
   } deriving (Eq, Show, Generic, NoThunks)
 
 -- | The mempool is a sequence of transactions with their ticket numbers and
@@ -81,14 +84,15 @@ data TxTicket tx = TxTicket
 -- measure to allow not just normal sequence operations but also efficient
 -- splitting and indexing by the ticket number.
 --
-newtype TxSeq tx = TxSeq (StrictFingerTree TxSeqMeasure (TxTicket tx))
+newtype TxSeq sz tx =
+    TxSeq (StrictFingerTree (TxSeqMeasure sz) (TxTicket sz tx))
   deriving stock   (Show)
   deriving newtype (NoThunks)
 
-instance Foldable TxSeq where
+instance Measure sz => Foldable (TxSeq sz) where
   foldMap f (TxSeq txs) = Foldable.foldMap (f . txTicketTx) txs
   null      (TxSeq txs) = Foldable.null txs
-  length    (TxSeq txs) = mSize $ FingerTree.measure txs
+  length    (TxSeq txs) = mCount $ FingerTree.measure txs
 
 -- | The 'StrictFingerTree' relies on a \"measure\" for subsequences in the
 -- tree. A measure of the size of the subsequence allows for efficient
@@ -101,45 +105,57 @@ instance Foldable TxSeq where
 -- 'Measured' instance, and also a way to combine the measures, via a 'Monoid'
 -- instance.
 --
-data TxSeqMeasure = TxSeqMeasure {
-       mMinTicket     :: !TicketNo,
-       mMaxTicket     :: !TicketNo,
-       mSizeBytes     :: !SizeInBytes,
-       mSize          :: !Int
+data TxSeqMeasure sz = TxSeqMeasure {
+       mCount     :: !Int,
+       mMinTicket :: !TicketNo,
+       mMaxTicket :: !TicketNo,
+       mSize      :: !sz
      }
   deriving Show
 
-instance FingerTree.Measured TxSeqMeasure (TxTicket tx) where
-  measure (TxTicket _ tno tsz) = TxSeqMeasure tno tno tsz 1
+instance Measure sz => FingerTree.Measured (TxSeqMeasure sz) (TxTicket sz tx) where
+  measure ticket = TxSeqMeasure {
+      mCount = 1
+    , mMinTicket = txTicketNo
+    , mMaxTicket = txTicketNo
+    , mSize      = txTicketSize
+    }
+    where
+      TxTicket{txTicketNo, txTicketSize} = ticket
 
-instance Semigroup TxSeqMeasure where
+instance Measure sz => Semigroup (TxSeqMeasure sz) where
   vl <> vr = TxSeqMeasure
-               (mMinTicket vl `min` mMinTicket vr)
-               (mMaxTicket vl `max` mMaxTicket vr)
-               (mSizeBytes vl   +   mSizeBytes vr)
-               (mSize      vl   +   mSize      vr)
+               (mCount     vl +              mCount     vr)
+               (mMinTicket vl `min`          mMinTicket vr)
+               (mMaxTicket vl `max`          mMaxTicket vr)
+               (mSize      vl `Measure.plus` mSize      vr)
 
-instance Monoid TxSeqMeasure where
-  mempty  = TxSeqMeasure maxBound minBound 0 0
+instance Measure sz => Monoid (TxSeqMeasure sz) where
+  mempty  = TxSeqMeasure {
+        mCount     = 0
+      , mMinTicket = maxBound   -- note the inversion!
+      , mMaxTicket = minBound
+      , mSize      = Measure.zero
+      }
   mappend = (<>)
 
 -- | A helper function for the ':>' pattern.
 --
-viewBack :: TxSeq tx -> Maybe (TxSeq tx, TxTicket tx)
+viewBack :: Measure sz => TxSeq sz tx -> Maybe (TxSeq sz tx, TxTicket sz tx)
 viewBack (TxSeq txs) = case FingerTree.viewr txs of
                          FingerTree.EmptyR     -> Nothing
                          txs' FingerTree.:> tx -> Just (TxSeq txs', tx)
 
 -- | A helper function for the ':<' pattern.
 --
-viewFront :: TxSeq tx -> Maybe (TxTicket tx, TxSeq tx)
+viewFront :: Measure sz => TxSeq sz tx -> Maybe (TxTicket sz tx, TxSeq sz tx)
 viewFront (TxSeq txs) = case FingerTree.viewl txs of
                           FingerTree.EmptyL     -> Nothing
                           tx FingerTree.:< txs' -> Just (tx, TxSeq txs')
 
 -- | An empty mempool sequence.
 --
-pattern Empty :: TxSeq tx
+pattern Empty :: Measure sz => TxSeq sz tx
 pattern Empty <- (viewFront -> Nothing) where
   Empty = TxSeq FingerTree.empty
 
@@ -147,7 +163,7 @@ pattern Empty <- (viewFront -> Nothing) where
 --
 -- New txs are always added at the back.
 --
-pattern (:>) :: TxSeq tx -> TxTicket tx -> TxSeq tx
+pattern (:>) :: Measure sz => TxSeq sz tx -> TxTicket sz tx -> TxSeq sz tx
 pattern txs :> tx <- (viewBack -> Just (txs, tx)) where
   TxSeq txs :> tx = TxSeq (txs FingerTree.|> tx)  --TODO: assert ordered by ticket no
 
@@ -156,7 +172,7 @@ pattern txs :> tx <- (viewBack -> Just (txs, tx)) where
 -- Note that we never add txs at the front. We access txs from front to back
 -- when forwarding txs to other peers, or when adding txs to blocks.
 --
-pattern (:<) :: TxTicket tx -> TxSeq tx -> TxSeq tx
+pattern (:<) :: Measure sz => TxTicket sz tx -> TxSeq sz tx -> TxSeq sz tx
 pattern tx :< txs <- (viewFront -> Just (tx, txs))
 
 infixl 5 :>, :<
@@ -164,10 +180,9 @@ infixl 5 :>, :<
 {-# COMPLETE Empty, (:>) #-}
 {-# COMPLETE Empty, (:<) #-}
 
-
 -- | \( O(\log(n)) \). Look up a transaction in the sequence by its 'TicketNo'.
 --
-lookupByTicketNo :: TxSeq tx -> TicketNo -> Maybe tx
+lookupByTicketNo :: Measure sz => TxSeq sz tx -> TicketNo -> Maybe tx
 lookupByTicketNo (TxSeq txs) n =
     case FingerTree.search (\ml mr -> mMaxTicket ml >= n
                                    && mMinTicket mr >  n) txs of
@@ -179,19 +194,27 @@ lookupByTicketNo (TxSeq txs) n =
 -- less than or equal to the given ticket, and the second part has transactions
 -- with tickets strictly greater than the given ticket.
 --
-splitAfterTicketNo :: TxSeq tx -> TicketNo -> (TxSeq tx, TxSeq tx)
+splitAfterTicketNo ::
+     Measure sz
+  => TxSeq sz tx
+  -> TicketNo
+  -> (TxSeq sz tx, TxSeq sz tx)
 splitAfterTicketNo (TxSeq txs) n =
     case FingerTree.split (\m -> mMaxTicket m > n) txs of
       (l, r) -> (TxSeq l, TxSeq r)
 
--- | \( O(\log(n)) \). Split the sequence of transactions into two parts
--- based on the given 'SizeInBytes'. The first part has transactions whose
--- summed 'SizeInBytes' is less than or equal to the given 'SizeInBytes',
--- and the second part has the remaining transactions in the sequence.
+-- | \( O(\log(n)) \). Split the sequence of transactions into two parts based
+-- on the given @sz@. The first part has transactions whose summed @sz@ is less
+-- than or equal to the given @sz@, and the second part has the remaining
+-- transactions in the sequence.
 --
-splitAfterTxSize :: TxSeq tx -> SizeInBytes -> (TxSeq tx, TxSeq tx)
+splitAfterTxSize ::
+     Measure sz
+  => TxSeq sz tx
+  -> sz
+  -> (TxSeq sz tx, TxSeq sz tx)
 splitAfterTxSize (TxSeq txs) n =
-    case FingerTree.split (\m -> mSizeBytes m > n) txs of
+    case FingerTree.split (\m -> not $ mSize m Measure.<= n) txs of
       (l, r) -> (TxSeq l, TxSeq r)
 
 -- | \( O(n) \). Specification of 'splitAfterTxSize'.
@@ -200,51 +223,52 @@ splitAfterTxSize (TxSeq txs) n =
 --
 -- This function is used to verify whether 'splitAfterTxSize' behaves as
 -- expected.
-splitAfterTxSizeSpec :: TxSeq tx -> SizeInBytes -> (TxSeq tx, TxSeq tx)
+splitAfterTxSizeSpec :: forall sz tx.
+     Measure sz
+  => TxSeq sz tx
+  -> sz
+  -> (TxSeq sz tx, TxSeq sz tx)
 splitAfterTxSizeSpec txseq n =
-    mapTuple fromList $ go 0 [] (toList txseq)
+    (fromList *** fromList)
+  $ go Measure.zero []
+  $ toList txseq
   where
-    mapTuple :: (a -> b) -> (a, a) -> (b, b)
-    mapTuple f (x, y) = (f x, f y)
-
-    go :: SizeInBytes
-       -> [TxTicket tx]
-       -> [TxTicket tx]
-       -> ([TxTicket tx], [TxTicket tx])
-    go accByteSize accTickets = \case
+    go :: sz
+       -> [TxTicket sz tx]
+       -> [TxTicket sz tx]
+       -> ([TxTicket sz tx], [TxTicket sz tx])
+    go accSize accTickets = \case
       []
         -> (reverse accTickets, [])
       t:ts
-        | let accByteSize' = accByteSize + txTicketTxSizeInBytes t
-        , accByteSize' <= n
-        -> go accByteSize' (t:accTickets) ts
+        | let accSize' = accSize `Measure.plus` txTicketSize t
+        , accSize' Measure.<= n
+        -> go accSize' (t:accTickets) ts
         | otherwise
         -> (reverse accTickets, t:ts)
 
 -- | Given a list of 'TxTicket's, construct a 'TxSeq'.
-fromList :: [TxTicket tx] -> TxSeq tx
+fromList :: Measure sz => [TxTicket sz tx] -> TxSeq sz tx
 fromList = Foldable.foldl' (:>) Empty
 
 -- | Convert a 'TxSeq' to a list of 'TxTicket's.
-toList :: TxSeq tx -> [TxTicket tx]
+toList :: TxSeq sz tx -> [TxTicket sz tx]
 toList (TxSeq ftree) = Foldable.toList ftree
 
 -- | Convert a 'TxSeq' to a list of pairs of transactions and their
--- associated 'TicketNo's.
-toTuples :: TxSeq tx -> [(tx, TicketNo, TxSizeInBytes)]
+-- associated 'TicketNo's and 'ByteSize32's.
+toTuples :: HasByteSize sz => TxSeq sz tx -> [(tx, TicketNo, ByteSize32)]
 toTuples (TxSeq ftree) = fmap
     (\ticket ->
        ( txTicketTx ticket
        , txTicketNo ticket
-       , txTicketTxSizeInBytes ticket)
+       , txMeasureByteSize (txTicketSize ticket)
+       )
     )
     (Foldable.toList ftree)
 
--- | \( O(1) \). Return the 'MempoolSize' of the given 'TxSeq'.
-toMempoolSize :: TxSeq tx -> MempoolSize
-toMempoolSize (TxSeq ftree) = MempoolSize
-    { msNumTxs   = fromIntegral mSize
-    , msNumBytes = getSizeInBytes mSizeBytes
-    }
+-- | \( O(1) \). Return the total size of the given 'TxSeq'.
+toSize :: Measure sz => TxSeq sz tx -> sz
+toSize (TxSeq ftree) = mSize
   where
-    TxSeqMeasure { mSizeBytes, mSize } = FingerTree.measure ftree
+    TxSeqMeasure { mSize } = FingerTree.measure ftree

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/TxSeq.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/TxSeq.hs
@@ -231,9 +231,13 @@ toList (TxSeq ftree) = Foldable.toList ftree
 
 -- | Convert a 'TxSeq' to a list of pairs of transactions and their
 -- associated 'TicketNo's.
-toTuples :: TxSeq tx -> [(tx, TicketNo)]
+toTuples :: TxSeq tx -> [(tx, TicketNo, TxSizeInBytes)]
 toTuples (TxSeq ftree) = fmap
-    (\ticket -> (txTicketTx ticket, txTicketNo ticket))
+    (\ticket ->
+       ( txTicketTx ticket
+       , txTicketNo ticket
+       , txTicketTxSizeInBytes ticket)
+    )
     (Foldable.toList ftree)
 
 -- | \( O(1) \). Return the 'MempoolSize' of the given 'TxSeq'.

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/TypeFamilyWrappers.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/TypeFamilyWrappers.hs
@@ -22,6 +22,8 @@ module Ouroboros.Consensus.TypeFamilyWrappers (
   , WrapTentativeHeaderState (..)
   , WrapTentativeHeaderView (..)
   , WrapTipInfo (..)
+  , WrapTxMeasure (..)
+  , WrapValidatedGenTx (..)
     -- * Protocol based
   , WrapCanBeLeader (..)
   , WrapChainDepState (..)
@@ -31,7 +33,6 @@ module Ouroboros.Consensus.TypeFamilyWrappers (
   , WrapLedgerView (..)
   , WrapSelectView (..)
   , WrapValidateView (..)
-  , WrapValidatedGenTx (..)
   , WrapValidationErr (..)
     -- * Versioning
   , WrapNodeToClientVersion (..)
@@ -79,7 +80,8 @@ newtype WrapTipInfo               blk = WrapTipInfo               { unwrapTipInf
 -- :.: g)@ requires @'Data.Functor.Classes.Eq1' f)). The bespoke composition
 -- 'WrapValidatedGenTx' therefore serves much the same purpose as the other
 -- wrappers in this module.
-newtype WrapValidatedGenTx        blk = WrapValidatedGenTx        { unwrapValidatedGenTx        :: Validated         (GenTx blk)}
+newtype WrapValidatedGenTx blk = WrapValidatedGenTx { unwrapValidatedGenTx :: Validated (GenTx blk) }
+newtype WrapTxMeasure      blk = WrapTxMeasure      { unwrapTxMeasure      :: TxMeasure        blk  }
 
 {-------------------------------------------------------------------------------
   Consensus based

--- a/ouroboros-consensus/src/unstable-mempool-test-utils/Test/Consensus/Mempool/Mocked.hs
+++ b/ouroboros-consensus/src/unstable-mempool-test-utils/Test/Consensus/Mempool/Mocked.hs
@@ -58,10 +58,9 @@ openMockedMempool ::
      )
   => Mempool.MempoolCapacityBytesOverride
   -> Tracer IO (Mempool.TraceEventMempool blk)
-  -> (Ledger.GenTx blk -> Mempool.SizeInBytes)
   -> InitialMempoolAndModelParams blk
   -> IO (MockedMempool IO blk)
-openMockedMempool capacityOverride tracer txSizeImpl initialParams = do
+openMockedMempool capacityOverride tracer initialParams = do
     currentLedgerStateTVar <- newTVarIO (immpInitialState initialParams)
     let ledgerItf = Mempool.LedgerInterface {
             Mempool.getCurrentLedgerState = readTVar currentLedgerStateTVar
@@ -71,7 +70,6 @@ openMockedMempool capacityOverride tracer txSizeImpl initialParams = do
                    (immpLedgerConfig initialParams)
                    capacityOverride
                    tracer
-                   txSizeImpl
     pure MockedMempool {
         getLedgerInterface = ledgerItf
       , getLedgerStateTVar = currentLedgerStateTVar

--- a/ouroboros-consensus/src/unstable-mempool-test-utils/Test/Consensus/Mempool/Mocked.hs
+++ b/ouroboros-consensus/src/unstable-mempool-test-utils/Test/Consensus/Mempool/Mocked.hs
@@ -1,5 +1,6 @@
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE NamedFieldPuns   #-}
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 -- | Mempool with a mocked ledger interface
 module Test.Consensus.Mempool.Mocked (
@@ -96,11 +97,13 @@ removeTxs ::
   -> m ()
 removeTxs = Mempool.removeTxs . getMempool
 
-getTxs ::
+getTxs :: forall blk.
      (Ledger.LedgerSupportsMempool blk)
   => MockedMempool IO blk -> IO [Ledger.GenTx blk]
 getTxs mockedMempool = do
     snapshotTxs <- fmap Mempool.snapshotTxs $ atomically
                                             $ Mempool.getSnapshot
                                             $ getMempool mockedMempool
-    pure $ fmap (Ledger.txForgetValidated . fst) snapshotTxs
+    pure $ fmap prjTx snapshotTxs
+  where
+    prjTx (a, _b, _c) = Ledger.txForgetValidated a :: Ledger.GenTx blk

--- a/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Ledger/Block.hs
+++ b/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Ledger/Block.hs
@@ -59,6 +59,8 @@ module Ouroboros.Consensus.Mock.Ledger.Block (
   , decodeSimpleHeader
   , encodeSimpleHeader
   , simpleBlockBinaryBlockInfo
+    -- * For tests
+  , simpleBlockCapacity
   ) where
 
 import           Cardano.Binary (ToCBOR (..))
@@ -431,12 +433,20 @@ instance MockProtocolSpecific c ext
   reapplyTx _cfg slot vtx st =
       updateSimpleUTxO slot (forgetValidatedSimpleGenTx vtx) st
 
+  txForgetValidated = forgetValidatedSimpleGenTx
+
+instance TxLimits (SimpleBlock c ext) where
+  type TxMeasure (SimpleBlock c ext) = IgnoringOverflow ByteSize32
+
   -- Large value so that the Mempool tests never run out of capacity when they
   -- don't override it.
-  txsMaxBytes   = const 1000000000
-  txInBlockSize = txSize
+  --
+  -- But not 'maxbound'!, since the mempool sometimes holds multiple blocks worth.
+  blockCapacityTxMeasure _cfg _st = IgnoringOverflow simpleBlockCapacity
+  txMeasure              _cfg _st = pure . IgnoringOverflow . txSize
 
-  txForgetValidated = forgetValidatedSimpleGenTx
+simpleBlockCapacity :: ByteSize32
+simpleBlockCapacity = ByteSize32 512
 
 newtype instance TxId (GenTx (SimpleBlock c ext)) = SimpleGenTxId {
       unSimpleGenTxId :: Mock.TxId
@@ -480,8 +490,8 @@ mkSimpleGenTx tx = SimpleGenTx
     , simpleGenTxId = Hash.hashWithSerialiser toCBOR tx
     }
 
-txSize :: GenTx (SimpleBlock c ext) -> Word32
-txSize = fromIntegral . Lazy.length . serialise
+txSize :: GenTx (SimpleBlock c ext) -> ByteSize32
+txSize = ByteSize32 . fromIntegral . Lazy.length . serialise
 
 {-------------------------------------------------------------------------------
   Support for QueryLedger

--- a/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Ledger/Block.hs
+++ b/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Ledger/Block.hs
@@ -438,8 +438,6 @@ instance MockProtocolSpecific c ext
 
   txForgetValidated = forgetValidatedSimpleGenTx
 
-  txRefScriptSize _cfg _tlst _tx = 0
-
 newtype instance TxId (GenTx (SimpleBlock c ext)) = SimpleGenTxId {
       unSimpleGenTxId :: Mock.TxId
     }

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/Mempool.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/Mempool.hs
@@ -849,7 +849,7 @@ prop_TxSeq_lookupByTicketNo_complete xs =
     txseq :: TxSeq Int
     txseq =
         TxSeq.fromList
-      $ [ TxTicket x (TicketNo i) 0 0 | x <- xs | i <- [0..] ]
+      $ [ TxTicket x (TicketNo i) 0 | x <- xs | i <- [0..] ]
 
 -- | Only finds elements in the sequence
 prop_TxSeq_lookupByTicketNo_sound ::
@@ -877,7 +877,7 @@ prop_TxSeq_lookupByTicketNo_sound smalls small =
     txseq =
         List.foldl' (TxSeq.:>) TxSeq.Empty $ map mkTicket haystack
 
-    mkTicket x = TxTicket x (mkTicketNo x) 0 0
+    mkTicket x = TxTicket x (mkTicketNo x) 0
     mkTicketNo = TicketNo . toEnum
 
 -- | Test that the 'fst' of the result of 'splitAfterTxSize' only contains
@@ -952,7 +952,7 @@ instance Arbitrary TxSizeSplitTestSetup where
 -- | Convert a 'TxSizeSplitTestSetup' to a 'TxSeq'.
 txSizeSplitTestSetupToTxSeq :: TxSizeSplitTestSetup -> TxSeq Int
 txSizeSplitTestSetupToTxSeq TxSizeSplitTestSetup { tssTxSizes } =
-    TxSeq.fromList [TxTicket 0 (TicketNo 0) tssTxSize 0 | tssTxSize <- tssTxSizes]
+    TxSeq.fromList [TxTicket 0 (TicketNo 0) tssTxSize | tssTxSize <- tssTxSizes]
 
 {-------------------------------------------------------------------------------
   TicketNo Properties

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/Mempool.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/Mempool.hs
@@ -104,8 +104,9 @@ prop_Mempool_snapshotTxs_snapshotTxsAfter :: TestSetup -> Property
 prop_Mempool_snapshotTxs_snapshotTxsAfter setup =
     withTestMempool setup $ \TestMempool { mempool } -> do
       let Mempool { getSnapshot } = mempool
+          prj (tx, tn, _sz)       = (tx, tn)
       MempoolSnapshot { snapshotTxs, snapshotTxsAfter} <- atomically getSnapshot
-      return $ snapshotTxs === snapshotTxsAfter zeroTicketNo
+      return $ snapshotTxs === map prj (snapshotTxsAfter zeroTicketNo)
 
 -- | Test that all valid transactions added to a 'Mempool' can be retrieved
 -- afterward.
@@ -734,7 +735,6 @@ withTestMempool setup@TestSetup {..} prop =
           testLedgerConfig
           testMempoolCapOverride
           tracer
-          (SizeInBytes . txSize)
       result  <- addTxs mempool testInitialTxs
       -- the invalid transactions are reported in the same order they were
       -- added, so the first error is not the result of a cascade
@@ -844,7 +844,7 @@ prop_TxSeq_lookupByTicketNo_complete xs =
     and [ case TxSeq.lookupByTicketNo txseq tn of
             Just tx' -> tx == tx'
             Nothing  -> False
-        | (tx, tn) <- TxSeq.toTuples txseq ]
+        | (tx, tn, _sz) <- TxSeq.toTuples txseq ]
   where
     txseq :: TxSeq Int
     txseq =

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/Mempool.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/Mempool.hs
@@ -46,8 +46,9 @@ import           Data.List as List (foldl', isSuffixOf, nub, partition, sortOn)
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           Data.Maybe (mapMaybe)
+import           Data.Semigroup (stimes)
 import qualified Data.Set as Set
-import           Data.Word
+import           Data.Word (Word32)
 import           GHC.Stack (HasCallStack)
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.BlockchainTime
@@ -64,7 +65,6 @@ import           Ouroboros.Consensus.Util (repeatedly, repeatedlyM,
                      safeMaximumOn, (.:))
 import           Ouroboros.Consensus.Util.Condense (condense)
 import           Ouroboros.Consensus.Util.IOLike
-import           Ouroboros.Network.SizeInBytes
 import           Test.QuickCheck hiding (elements)
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.QuickCheck (testProperty)
@@ -95,6 +95,8 @@ tests = testGroup "Mempool"
   , testProperty "removeTxs [..] == forM [..] removeTxs"   prop_Mempool_semigroup_removeTxs
   ]
 
+type TheMeasure = IgnoringOverflow ByteSize32
+
 {-------------------------------------------------------------------------------
   Mempool Implementation Properties
 -------------------------------------------------------------------------------}
@@ -104,9 +106,8 @@ prop_Mempool_snapshotTxs_snapshotTxsAfter :: TestSetup -> Property
 prop_Mempool_snapshotTxs_snapshotTxsAfter setup =
     withTestMempool setup $ \TestMempool { mempool } -> do
       let Mempool { getSnapshot } = mempool
-          prj (tx, tn, _sz)       = (tx, tn)
       MempoolSnapshot { snapshotTxs, snapshotTxsAfter} <- atomically getSnapshot
-      return $ snapshotTxs === map prj (snapshotTxsAfter zeroTicketNo)
+      return $ snapshotTxs === snapshotTxsAfter zeroTicketNo
 
 -- | Test that all valid transactions added to a 'Mempool' can be retrieved
 -- afterward.
@@ -116,7 +117,7 @@ prop_Mempool_addTxs_getTxs setup =
       _ <- addTxs mempool (allTxs setup)
       MempoolSnapshot { snapshotTxs } <- atomically $ getSnapshot mempool
       return $ counterexample (ppTxs (txs setup)) $
-        validTxs setup `isSuffixOf` map (txForgetValidated . fst) snapshotTxs
+        validTxs setup `isSuffixOf` map (txForgetValidated . prjTx) snapshotTxs
 
 -- | Test that both adding the transactions one by one and adding them in one go
 -- produce the same result.
@@ -155,10 +156,10 @@ prop_Mempool_addTxs_result setup =
 prop_Mempool_InvalidTxsNeverAdded :: TestSetupWithTxs -> Property
 prop_Mempool_InvalidTxsNeverAdded setup =
     withTestMempool (testSetup setup) $ \TestMempool { mempool } -> do
-      txsInMempoolBefore <- map fst . snapshotTxs <$>
+      txsInMempoolBefore <- map prjTx . snapshotTxs <$>
         atomically (getSnapshot mempool)
       _ <- addTxs mempool (allTxs setup)
-      txsInMempoolAfter <- map fst . snapshotTxs <$>
+      txsInMempoolAfter <- map prjTx . snapshotTxs <$>
         atomically (getSnapshot mempool)
       return $ counterexample (ppTxs (txs setup)) $ conjoin
         -- Check for each transaction in the mempool (ignoring those already
@@ -178,7 +179,7 @@ prop_Mempool_removeTxs (TestSetupWithTxInMempool testSetup txToRemove) =
     withTestMempool testSetup $ \TestMempool { mempool } -> do
       let Mempool { removeTxs, getSnapshot } = mempool
       removeTxs [txId txToRemove]
-      txsInMempoolAfter <- map fst . snapshotTxs <$> atomically getSnapshot
+      txsInMempoolAfter <- map prjTx . snapshotTxs <$> atomically getSnapshot
       return $ counterexample
         ("Transactions in the mempool after removing (" <>
          show txToRemove <> "): " <> show txsInMempoolAfter)
@@ -203,8 +204,8 @@ prop_Mempool_semigroup_removeTxs (TestSetupWithTxsInMempool testSetup txsToRemov
         snapshotMempoolSize snapshot1 === snapshotMempoolSize snapshot2 .&&.
         snapshotSlotNo snapshot1 === snapshotSlotNo snapshot1
 
--- | Test that 'getCapacity' returns the 'MempoolCapacityBytes' value that the
--- mempool was initialized with.
+-- | Test that 'getCapacity' returns the greatest multiple of the block
+-- capacity that is not greater than the requested capacity.
 --
 -- Ignore the "100% empty Mempool" label in the test output, that is there
 -- because we reuse 'withTestMempool' and always start with an empty Mempool
@@ -212,11 +213,19 @@ prop_Mempool_semigroup_removeTxs (TestSetupWithTxsInMempool testSetup txsToRemov
 prop_Mempool_getCapacity :: MempoolCapTestSetup -> Property
 prop_Mempool_getCapacity mcts =
     withTestMempool testSetup $ \TestMempool{mempool} -> do
-      actualCapacity <- atomically $ getCapacity mempool
-      pure (actualCapacity === testCapacity)
+      IgnoringOverflow actualCapacity <- atomically $ getCapacity mempool
+      pure $ actualCapacity === expectedCapacity
   where
     MempoolCapacityBytesOverride testCapacity = testMempoolCapOverride testSetup
     MempoolCapTestSetup (TestSetupWithTxs testSetup _txsToAdd) = mcts
+
+    ByteSize32 dnom = simpleBlockCapacity
+
+    expectedCapacity =
+        (\n -> stimes n simpleBlockCapacity)
+      $ max 1
+        -- adding one less than the denom to the numer achieves rounding up
+      $ (unByteSize32 testCapacity + dnom - 1) `div` dnom
 
 -- | Test that all valid transactions added to a 'Mempool' via 'addTxs' are
 -- appropriately represented in the trace of events.
@@ -260,7 +269,7 @@ prop_Mempool_TraceRemovedTxs setup =
       MempoolSnapshot { snapshotTxs } <- atomically $ getSnapshot mempool
       -- We add all the transactions in the mempool to the ledger. Some of
       -- them will become invalid because all inputs have been spent.
-      let txsInMempool = map fst snapshotTxs
+      let txsInMempool = map prjTx snapshotTxs
       errs <- atomically $ addTxsToLedger (map txForgetValidated txsInMempool)
 
       -- Sync the mempool with the ledger. Now some of the transactions in the
@@ -290,6 +299,11 @@ prop_Mempool_TraceRemovedTxs setup =
       [ (tx, err)
       | (tx, Left err) <- fst $ validateTxs ledgerState txsInMempool
       ]
+
+prjTx ::
+     (Validated (GenTx TestBlock), TicketNo, ByteSize32)
+  -> Validated (GenTx TestBlock)
+prjTx (a, _b, _c) = a
 
 {-------------------------------------------------------------------------------
   TestSetup: how to set up a TestMempool
@@ -330,32 +344,30 @@ ppTestSetup :: TestSetup -> String
 ppTestSetup TestSetup { testInitialTxs
                       , testMempoolCapOverride
                       } = unlines $
-    ["Initial contents of the Mempool:"]  <>
-    (map ppTestTxWithHash testInitialTxs) <>
-    ["Mempool capacity override:"]        <>
+    ["Initial contents of the Mempool:"]     <>
+    (map ppTestTxWithHash testInitialTxs)    <>
+    ["Total size:"]                          <>
+    [show $ foldMap txSize $ testInitialTxs] <>
+    ["Mempool capacity override:"]           <>
     [show testMempoolCapOverride]
 
 ppTestTxWithHash :: TestTx -> String
 ppTestTxWithHash x = condense
   (hashWithSerialiser toCBOR (simpleGenTx x) :: Hash SHA256 Tx, x)
 
--- | Given some transactions, calculate the sum of their sizes in bytes.
-txSizesInBytes :: [TestTx] -> SizeInBytes
-txSizesInBytes = SizeInBytes . List.foldl' (\acc tx -> acc + txSize tx) 0
-
 -- | Generate a 'TestSetup' and return the ledger obtained by applying all of
 -- the initial transactions.
 --
 -- The generated 'testMempoolCap' will be:
--- > 'txSizesInBytes' 'testInitialTxs' + extraCapacity
-genTestSetupWithExtraCapacity :: Int -> Word32 -> Gen (TestSetup, LedgerState TestBlock)
+-- > foldMap 'txSize' 'testInitialTxs' + extraCapacity
+genTestSetupWithExtraCapacity :: Int -> ByteSize32 -> Gen (TestSetup, LedgerState TestBlock)
 genTestSetupWithExtraCapacity maxInitialTxs extraCapacity = do
     ledgerSize   <- choose (0, maxInitialTxs)
     nbInitialTxs <- choose (0, maxInitialTxs)
     (_txs1,  ledger1) <- genValidTxs ledgerSize testInitLedger
     ( txs2,  ledger2) <- genValidTxs nbInitialTxs ledger1
-    let initTxsSizeInBytes = txSizesInBytes txs2
-        mpCap = MempoolCapacityBytes (getSizeInBytes initTxsSizeInBytes + extraCapacity)
+    let initTxsSizeInBytes = foldMap txSize txs2
+        mpCap              = initTxsSizeInBytes <> extraCapacity
         testSetup = TestSetup
           { testLedgerState        = ledger1
           , testInitialTxs         = txs2
@@ -367,34 +379,38 @@ genTestSetupWithExtraCapacity maxInitialTxs extraCapacity = do
 -- the initial transactions. Generates setups with a fixed
 -- 'MempoolCapacityBytesOverride', no 'NoMempoolCapacityBytesOverride'.
 genTestSetup :: Int -> Gen (TestSetup, LedgerState TestBlock)
-genTestSetup maxInitialTxs = genTestSetupWithExtraCapacity maxInitialTxs 0
+genTestSetup maxInitialTxs =
+    genTestSetupWithExtraCapacity maxInitialTxs (ByteSize32 0)
 
 -- | Random 'MempoolCapacityBytesOverride'
 instance Arbitrary TestSetup where
   arbitrary = sized $ \n -> do
-    extraCapacity <- fromIntegral <$> choose (0, n)
+    extraCapacity <- (ByteSize32 . fromIntegral) <$> choose (0, n)
     testSetup <- fst <$> genTestSetupWithExtraCapacity n extraCapacity
     noOverride <- arbitrary
+    let initialSize = foldMap txSize $ testInitialTxs testSetup
+        defaultCap  = simpleBlockCapacity <> simpleBlockCapacity
     return $
-      if noOverride
+      if noOverride && initialSize <= defaultCap
       then testSetup { testMempoolCapOverride = NoMempoolCapacityBytesOverride }
       else testSetup
 
   shrink TestSetup { testLedgerState
                    , testInitialTxs
-                   , testMempoolCapOverride = MempoolCapacityBytesOverride
-                       (MempoolCapacityBytes mpCap)
+                   , testMempoolCapOverride =
+                       MempoolCapacityBytesOverride (ByteSize32 mpCap)
                    } =
     -- TODO we could shrink @testLedgerState@ too
     [ TestSetup { testLedgerState
                 , testInitialTxs = testInitialTxs'
-                , testMempoolCapOverride = MempoolCapacityBytesOverride
-                    (MempoolCapacityBytes mpCap')
+                , testMempoolCapOverride =
+                    MempoolCapacityBytesOverride mpCap'
                 }
-    | let extraCap = mpCap - getSizeInBytes (txSizesInBytes testInitialTxs)
+    | let ByteSize32 initial = foldMap txSize testInitialTxs
+          extraCap           = mpCap - initial
     , testInitialTxs' <- shrinkList (const []) testInitialTxs
     , isRight $ txsAreValid testLedgerState testInitialTxs'
-    , let mpCap' = getSizeInBytes (txSizesInBytes testInitialTxs') + extraCap
+    , let mpCap' = foldMap txSize testInitialTxs' <> ByteSize32 extraCap
     ]
 
   -- TODO shrink to an override, that's an easier test case
@@ -591,15 +607,19 @@ instance Arbitrary TestSetupWithTxs where
     (testSetup, ledger)  <- genTestSetup n
     (txs,      _ledger') <- genTxs nbTxs ledger
     testSetup' <- case testMempoolCapOverride testSetup of
-      NoMempoolCapacityBytesOverride -> return testSetup
-      MempoolCapacityBytesOverride (MempoolCapacityBytes mpCap) -> do
+      NoMempoolCapacityBytesOverride     -> return testSetup
+      MempoolCapacityBytesOverride mpCap -> do
         noOverride <- arbitrary
+        let initialSize = foldMap txSize $ testInitialTxs testSetup
+            defaultCap  = simpleBlockCapacity <> simpleBlockCapacity
+            newSize     =
+                 foldMap (txSize . fst) (filter snd txs)
+              <> maximum (ByteSize32 0 : map (txSize . fst) (filter (not . snd) txs))
         return testSetup {
               testMempoolCapOverride =
-                if noOverride
+                if noOverride && initialSize <> newSize <= defaultCap
                 then NoMempoolCapacityBytesOverride
-                else MempoolCapacityBytesOverride $ MempoolCapacityBytes $
-                       mpCap + getSizeInBytes (txSizesInBytes $ map fst txs)
+                else MempoolCapacityBytesOverride $ mpCap <> newSize
             }
     return TestSetupWithTxs { testSetup = testSetup', txs }
 
@@ -796,7 +816,7 @@ withTestMempool setup@TestSetup {..} prop =
           Right _ -> property True
           Left  e -> counterexample (mkErrMsg e) $ property False
       where
-        txs = map (txForgetValidated . fst) snapshotTxs
+        txs = map (txForgetValidated . prjTx) snapshotTxs
         mkErrMsg e =
           "At the end of the test, the Mempool contents were invalid: " <>
           show e
@@ -816,21 +836,24 @@ instance Arbitrary MempoolCapTestSetup where
     testSetupWithTxs@TestSetupWithTxs { testSetup, txs } <- arbitrary
     -- The Mempool should at least be capable of containing the transactions
     -- it already contains.
-    let currentSize      = sum (map txSize (testInitialTxs testSetup))
+    let currentSize      = foldMap txSize (testInitialTxs testSetup)
         capacityMinBound = currentSize
         validTxsToAdd    = [tx | (tx, True) <- txs]
         -- Use the current size + the sum of all the valid transactions to add
         -- as the upper bound.
-        capacityMaxBound = currentSize + sum (map txSize validTxsToAdd)
+        capacityMaxBound = currentSize <> foldMap txSize validTxsToAdd
     -- Note that we could pick @currentSize@, meaning that we can't add any
     -- more transactions to the Mempool
+
     capacity <- choose
-      ( capacityMinBound
-      , capacityMaxBound
+      ( unByteSize32 capacityMinBound
+      , unByteSize32 capacityMaxBound
       )
     let testSetup' = testSetup {
-            testMempoolCapOverride = MempoolCapacityBytesOverride $
-              MempoolCapacityBytes capacity
+            testMempoolCapOverride =
+                MempoolCapacityBytesOverride
+              $ ByteSize32
+              $ capacity
           }
     return $ MempoolCapTestSetup testSetupWithTxs { testSetup = testSetup' }
 
@@ -839,17 +862,19 @@ instance Arbitrary MempoolCapTestSetup where
 -------------------------------------------------------------------------------}
 
 -- | Finds elements in the sequence
-prop_TxSeq_lookupByTicketNo_complete :: [Int] -> Bool
+prop_TxSeq_lookupByTicketNo_complete :: [Int] -> Property
 prop_TxSeq_lookupByTicketNo_complete xs =
-    and [ case TxSeq.lookupByTicketNo txseq tn of
-            Just tx' -> tx == tx'
-            Nothing  -> False
-        | (tx, tn, _sz) <- TxSeq.toTuples txseq ]
+      counterexample (show txseq)
+    $ conjoin
+        [ case TxSeq.lookupByTicketNo txseq tn of
+            Just tx' -> tx === tx'
+            Nothing  -> property False
+        | (tx, tn, _byteSize) <- TxSeq.toTuples txseq ]
   where
-    txseq :: TxSeq Int
+    txseq :: TxSeq TheMeasure Int
     txseq =
         TxSeq.fromList
-      $ [ TxTicket x (TicketNo i) 0 | x <- xs | i <- [0..] ]
+      $ [ TxTicket x (TicketNo i) mempty | x <- xs | i <- [0..] ]
 
 -- | Only finds elements in the sequence
 prop_TxSeq_lookupByTicketNo_sound ::
@@ -873,16 +898,16 @@ prop_TxSeq_lookupByTicketNo_sound smalls small =
     needle = abs (getSmall small)
 
     -- the identity mapping over haystack
-    txseq :: TxSeq Int
+    txseq :: TxSeq TheMeasure Int
     txseq =
         List.foldl' (TxSeq.:>) TxSeq.Empty $ map mkTicket haystack
 
-    mkTicket x = TxTicket x (mkTicketNo x) 0
+    mkTicket x = TxTicket x (mkTicketNo x) mempty
     mkTicketNo = TicketNo . toEnum
 
 -- | Test that the 'fst' of the result of 'splitAfterTxSize' only contains
 -- 'TxTicket's whose summed up transaction sizes are less than or equal to
--- that of the 'SizeInBytes' which the 'TxSeq' was split on.
+-- that of the byte size which the 'TxSeq' was split on.
 prop_TxSeq_splitAfterTxSize :: TxSizeSplitTestSetup -> Property
 prop_TxSeq_splitAfterTxSize tss =
       property $ txSizeSum (TxSeq.toList before) <= tssTxSizeToSplitOn
@@ -891,11 +916,11 @@ prop_TxSeq_splitAfterTxSize tss =
 
     (before, _after) = splitAfterTxSize txseq tssTxSizeToSplitOn
 
-    txseq :: TxSeq Int
+    txseq :: TxSeq TheMeasure Int
     txseq = txSizeSplitTestSetupToTxSeq tss
 
-    txSizeSum :: [TxTicket tx] -> SizeInBytes
-    txSizeSum = sum . map txTicketTxSizeInBytes
+    txSizeSum :: [TxTicket TheMeasure tx] -> TheMeasure
+    txSizeSum = foldMap txTicketSize
 
 
 -- | Test that the results of 'splitAfterTxSizeSpec', a specification of
@@ -912,7 +937,7 @@ prop_TxSeq_splitAfterTxSizeSpec tss =
 
     (specBefore, specAfter) = splitAfterTxSizeSpec txseq tssTxSizeToSplitOn
 
-    txseq :: TxSeq Int
+    txseq :: TxSeq TheMeasure Int
     txseq = txSizeSplitTestSetupToTxSeq tss
 
 {-------------------------------------------------------------------------------
@@ -920,14 +945,14 @@ prop_TxSeq_splitAfterTxSizeSpec tss =
 -------------------------------------------------------------------------------}
 
 data TxSizeSplitTestSetup = TxSizeSplitTestSetup
-  { tssTxSizes         :: ![SizeInBytes]
-  , tssTxSizeToSplitOn :: !SizeInBytes
+  { tssTxSizes         :: ![TheMeasure]
+  , tssTxSizeToSplitOn :: !TheMeasure
   } deriving Show
 
 instance Arbitrary TxSizeSplitTestSetup where
   arbitrary = do
-    let txSizeMaxBound = 10 * 1024 * 1024 -- 10MB transaction max bound
-    txSizes <- listOf $ choose (1, txSizeMaxBound)
+    let txSizeMaxBound = 10 * 1024 * 1024 -- 10 mebibyte transaction max bound
+    txSizes <- listOf $ choose (1, txSizeMaxBound :: Word32)
     let totalTxsSize = sum txSizes
     txSizeToSplitOn <- frequency
       [ (1, pure 0)
@@ -936,23 +961,28 @@ instance Arbitrary TxSizeSplitTestSetup where
       , (1, choose (totalTxsSize + 1, totalTxsSize + 1000))
       ]
     pure TxSizeSplitTestSetup
-      { tssTxSizes = map SizeInBytes txSizes
-      , tssTxSizeToSplitOn = SizeInBytes txSizeToSplitOn
+      { tssTxSizes         = map (IgnoringOverflow . ByteSize32) txSizes
+      , tssTxSizeToSplitOn = IgnoringOverflow $ ByteSize32 txSizeToSplitOn
       }
 
   shrink TxSizeSplitTestSetup { tssTxSizes, tssTxSizeToSplitOn } =
     [ TxSizeSplitTestSetup
-        { tssTxSizes         = tssTxSizes'
-        , tssTxSizeToSplitOn = tssTxSizeToSplitOn'
+        { tssTxSizes         = map (IgnoringOverflow . ByteSize32) tssTxSizes'
+        , tssTxSizeToSplitOn = IgnoringOverflow $ ByteSize32 tssTxSizeToSplitOn'
         }
-    | tssTxSizes' <- shrinkList (const []) tssTxSizes
-    , tssTxSizeToSplitOn' <- shrinkIntegral tssTxSizeToSplitOn
+    | tssTxSizes' <- shrinkList (const []) [ y | IgnoringOverflow (ByteSize32 y) <- tssTxSizes ]
+    , tssTxSizeToSplitOn' <- shrinkIntegral x
     ]
+    where
+      IgnoringOverflow (ByteSize32 x) = tssTxSizeToSplitOn
 
 -- | Convert a 'TxSizeSplitTestSetup' to a 'TxSeq'.
-txSizeSplitTestSetupToTxSeq :: TxSizeSplitTestSetup -> TxSeq Int
+txSizeSplitTestSetupToTxSeq :: TxSizeSplitTestSetup -> TxSeq TheMeasure Int
 txSizeSplitTestSetupToTxSeq TxSizeSplitTestSetup { tssTxSizes } =
-    TxSeq.fromList [TxTicket 0 (TicketNo 0) tssTxSize | tssTxSize <- tssTxSizes]
+    TxSeq.fromList [ TxTicket 1 (TicketNo i) tssTxSize
+                   | tssTxSize <- tssTxSizes
+                   | i <- [0 ..]
+                   ]
 
 {-------------------------------------------------------------------------------
   TicketNo Properties
@@ -979,7 +1009,7 @@ prop_Mempool_idx_consistency :: Actions -> Property
 prop_Mempool_idx_consistency (Actions actions) =
     withTestMempool emptyTestSetup $ \testMempool@TestMempool { mempool } ->
       fmap conjoin $ forM actions $ \action -> do
-        txsInMempool      <- map fst . snapshotTxs <$>
+        txsInMempool      <- map prjTx . snapshotTxs <$>
                              atomically (getSnapshot mempool)
         actionProp        <- executeAction testMempool action
         currentAssignment <- currentTicketAssignment mempool
@@ -1010,7 +1040,10 @@ prop_Mempool_idx_consistency (Actions actions) =
       { testLedgerState        = testInitLedger
       , testInitialTxs         = []
       , testMempoolCapOverride =
-          MempoolCapacityBytesOverride $ MempoolCapacityBytes maxBound
+            MempoolCapacityBytesOverride
+          $ ByteSize32
+          $ 1024*1024*1024
+            -- There's no way this test will need more than a gibibyte.
       }
 
     lastOfMempoolRemoved txsInMempool = \case
@@ -1109,7 +1142,7 @@ currentTicketAssignment Mempool { syncWithLedger } = do
     MempoolSnapshot { snapshotTxs } <- syncWithLedger
     return $ Map.fromList
       [ (ticketNo, txId (txForgetValidated tx))
-      | (tx, ticketNo) <- snapshotTxs
+      | (tx, ticketNo, _byteSize) <- snapshotTxs
       ]
 
 instance Arbitrary Actions where

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/Mempool/Fairness.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/Mempool/Fairness.hs
@@ -93,7 +93,6 @@ testTxSizeFairness TestParams { mempoolMaxCapacity, smallTxSize, largeTxSize, nr
                    (testBlockLedgerConfigFrom eraParams)
                    (Mempool.mkCapacityBytesOverride mempoolMaxCapacity)
                    Tracer.nullTracer
-                   (SizeInBytes . genTxSize)
 
     ----------------------------------------------------------------------------
     --  Add and collect transactions

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/Mempool/Fairness.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/Mempool/Fairness.hs
@@ -20,15 +20,14 @@ import qualified Control.Tracer as Tracer
 import           Data.Foldable (asum)
 import qualified Data.List as List
 import           Data.Void (Void, vacuous)
-import           Data.Word (Word32)
 import           Ouroboros.Consensus.Config.SecurityParam as Consensus
 import qualified Ouroboros.Consensus.HardFork.History as HardFork
+import           Ouroboros.Consensus.Ledger.SupportsMempool (ByteSize32 (..))
 import qualified Ouroboros.Consensus.Ledger.SupportsMempool as Mempool
 import           Ouroboros.Consensus.Mempool (Mempool)
 import qualified Ouroboros.Consensus.Mempool as Mempool
 import qualified Ouroboros.Consensus.Mempool.Capacity as Mempool
 import           Ouroboros.Consensus.Util.IOLike (STM, atomically, retry)
-import           Ouroboros.Network.SizeInBytes
 import           System.Random (randomIO)
 import           Test.Consensus.Mempool.Fairness.TestBlock
 import           Test.Tasty (TestTree, testGroup)
@@ -39,11 +38,11 @@ import           Test.Util.TestBlock (testBlockLedgerConfigFrom,
 tests :: TestTree
 tests = testGroup "Mempool fairness"
                   [ testCase "There is no substantial bias in added transaction sizes" $
-                              testTxSizeFairness TestParams { mempoolMaxCapacity =   100
-                                                            , smallTxSize        =     1
-                                                            , largeTxSize        =    10
+                              testTxSizeFairness TestParams { mempoolMaxCapacity = ByteSize32 100
+                                                            , smallTxSize        = ByteSize32   1
+                                                            , largeTxSize        = ByteSize32  10
                                                             , nrOftxsToCollect   = 1_000
-                                                            , toleranceThreshold =     0.2 -- Somewhat arbitrarily chosen.
+                                                            , toleranceThreshold = 0.2 -- Somewhat arbitrarily chosen.
                                                             }
                   ]
 
@@ -145,10 +144,10 @@ runConcurrently = Async.runConcurrently . asum . fmap Async.Concurrently
 --   added before the mempool is saturated.
 --
 data TestParams = TestParams {
-    mempoolMaxCapacity :: Word32
-  , smallTxSize        :: Word32
+    mempoolMaxCapacity :: ByteSize32
+  , smallTxSize        :: ByteSize32
     -- ^ Size of what we consider to be a small transaction.
-  , largeTxSize        :: Word32
+  , largeTxSize        :: ByteSize32
     -- ^ Size of what we consider to be a large transaction.
   , nrOftxsToCollect   :: Int
     -- ^ How many added transactions we count.
@@ -168,7 +167,7 @@ data TestParams = TestParams {
 adders ::
      TestMempool
      -- ^ Mempool to which transactions will be added
-  -> Word32
+  -> ByteSize32
      -- ^ Transaction size
   -> IO a
 adders mempool fixedTxSize = vacuous $ runConcurrently $ fmap adder [0..2]
@@ -215,5 +214,7 @@ getTxsInSnapshot :: Mempool IO TestBlock -> STM IO [Mempool.GenTx TestBlock]
 getTxsInSnapshot mempool = fmap txsInSnapshot
                          $ Mempool.getSnapshot mempool
   where
-    txsInSnapshot = fmap (Mempool.txForgetValidated . fst)
+    txsInSnapshot = fmap prjTx
                   . Mempool.snapshotTxs
+
+    prjTx (a, _b, _c) = Mempool.txForgetValidated a :: Mempool.GenTx TestBlock

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/Mempool/Fairness/TestBlock.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/Mempool/Fairness/TestBlock.hs
@@ -100,8 +100,6 @@ instance Ledger.LedgerSupportsMempool TestBlock where
 
   txForgetValidated (ValidatedGenTx tx) = tx
 
-  txRefScriptSize _cfg _tlst _tx = 0
-
 {-------------------------------------------------------------------------------
   Ledger support
 -------------------------------------------------------------------------------}

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/Mempool/Fairness/TestBlock.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/Mempool/Fairness/TestBlock.hs
@@ -9,14 +9,12 @@
 module Test.Consensus.Mempool.Fairness.TestBlock (
     TestBlock
   , Tx
-  , genTxSize
   , mkGenTx
   , txSize
   , unGenTx
   ) where
 
 import           Control.DeepSeq (NFData)
-import           Data.Word (Word32)
 import           GHC.Generics (Generic)
 import           NoThunks.Class (NoThunks)
 import qualified Ouroboros.Consensus.Block as Block
@@ -36,7 +34,7 @@ type TestBlock = TestBlockWith Tx
 -- We do need to keep track of the transaction id.
 --
 -- All transactions will be accepted by the mempool.
-data Tx = Tx { txNumber :: Int, txSize ::  Word32 }
+data Tx = Tx { txNumber :: Int, txSize :: Ledger.ByteSize32 }
   deriving stock (Eq, Ord, Generic, Show)
   deriving anyclass (NoThunks, NFData)
 
@@ -80,10 +78,7 @@ newtype instance Ledger.TxId (Ledger.GenTx TestBlock) = TestBlockTxId Tx
 instance Ledger.HasTxId (Ledger.GenTx TestBlock) where
   txId (TestBlockGenTx tx) = TestBlockTxId tx
 
-genTxSize :: Ledger.GenTx TestBlock -> Word32
-genTxSize = txSize . unGenTx
-
-mkGenTx :: Int -> Word32 -> Ledger.GenTx TestBlock
+mkGenTx :: Int -> Ledger.ByteSize32 -> Ledger.GenTx TestBlock
 mkGenTx anId aSize = TestBlockGenTx $ Tx { txNumber = anId, txSize = aSize }
 
 instance Ledger.LedgerSupportsMempool TestBlock where
@@ -91,14 +86,17 @@ instance Ledger.LedgerSupportsMempool TestBlock where
 
   reapplyTx _cfg _slot _gtx gst = pure gst
 
-  txsMaxBytes _ = error "The tests should override this value"
-                  -- The tests should be in control of the mempool capacity,
-                  -- since the judgement on whether the mempool is fair depends
-                  -- on this parameter.
-
-  txInBlockSize = txSize . unGenTx
-
   txForgetValidated (ValidatedGenTx tx) = tx
+
+instance Ledger.TxLimits TestBlock where
+  type TxMeasure TestBlock = Ledger.IgnoringOverflow Ledger.ByteSize32
+
+  blockCapacityTxMeasure _cfg _st =
+    -- The tests will override this value. By using 1, @computeMempoolCapacity@
+    -- can be exactly what each test requests.
+    Ledger.IgnoringOverflow $ Ledger.ByteSize32 1
+
+  txMeasure _cfg _st = pure . Ledger.IgnoringOverflow . txSize . unGenTx
 
 {-------------------------------------------------------------------------------
   Ledger support


### PR DESCRIPTION
Closes https://github.com/IntersectMBO/ouroboros-consensus/issues/1177.

Beyond that Issue, this PR also changes the mempool's definition of full. The mempool will accepte transactions until the tx chosen to next enter the mempool would cause any component of the capacity vector (byte size, exunit steps, exunit mems, ref script byte size) to exceed its limit. The default capacity is chosen as twice the capacity of a block. Such a capacity can admit more txs than could fit into two back-to-back blocks, but no single component (eg ExUnits) of the mempool's contents' size could exceed what could fit in two blocks.

The mempool capacity has two consequences.

- It implements _latency hiding_: txs can cover the network a little in advance, so that two blocks on a chain whose slots are very close together could still both be full (if there are enough submitted txs).
- It bounds the potential burst of CPU load necessary to fill an empty mempool, which otherwise could be a DoS vector.

Also closes #1168 by superseding the "ad-hoc" mempool reference scripts capacity limit.

This PR also moves the logic for choosing which prefix of the mempool to put in the block out of the forging functions and into the NodeKernel forging thread --- the mempool snapshot is the perfect place to do that, since tx measurements (each using the correct ledger state) are already determined.