### PR TITLE
Full rework of the BlockFetch logic for bulk sync mode

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -47,3 +47,13 @@ if(os(windows))
 
 -- https://github.com/ulidtko/cabal-doctest/issues/85
 constraints: Cabal < 3.13
+
+source-repository-package
+  type: git
+  location: https://github.com/IntersectMBO/ouroboros-network
+  tag: bb0a7d0ff41e265a8ec47bc94377cb4d65e0b498
+  --sha256: sha256-P7m+nsjtogNQsdpXQnaH1kWxYibEWa0UC6iNGg0+bH4=
+  subdir:
+    ouroboros-network
+    ouroboros-network-api
+    ouroboros-network-protocols

--- a/ouroboros-consensus-diffusion/changelog.d/20240807_100458_alexander.esgen_milestone_1.md
+++ b/ouroboros-consensus-diffusion/changelog.d/20240807_100458_alexander.esgen_milestone_1.md
@@ -1,0 +1,3 @@
+### Breaking
+
+- Adapted to Genesis-related changes in `ouroboros-consensus` ([#1179](https://github.com/IntersectMBO/ouroboros-consensus/pull/1179)).

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Node.hs
@@ -321,7 +321,8 @@ nonImmutableDbPath (MultipleDbPaths _ vol) = vol
 --
 -- See 'stdLowLevelRunNodeArgsIO'.
 data StdRunNodeArgs m blk (p2p :: Diffusion.P2P) = StdRunNodeArgs
-  { srnBfcMaxConcurrencyDeadline    :: Maybe Word
+  { srnBfcMaxConcurrencyBulkSync    :: Maybe Word
+  , srnBfcMaxConcurrencyDeadline    :: Maybe Word
   , srnChainDbValidateOverride      :: Bool
     -- ^ If @True@, validate the ChainDB on init no matter what
   , srnDiskPolicyArgs               :: DiskPolicyArgs
@@ -985,6 +986,9 @@ stdLowLevelRunNodeArgsIO RunNodeArgs{ rnProtocolInfo
             maybe id
               (\mc bfc -> bfc { bfcMaxConcurrencyDeadline = mc })
               srnBfcMaxConcurrencyDeadline
+          . maybe id
+              (\mc bfc -> bfc { bfcMaxConcurrencyBulkSync = mc })
+              srnBfcMaxConcurrencyBulkSync
         modifyMempoolCapacityOverride =
             maybe id
               (\mc nka -> nka { mempoolCapacityOverride = mc })

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Node.hs
@@ -321,8 +321,7 @@ nonImmutableDbPath (MultipleDbPaths _ vol) = vol
 --
 -- See 'stdLowLevelRunNodeArgsIO'.
 data StdRunNodeArgs m blk (p2p :: Diffusion.P2P) = StdRunNodeArgs
-  { srnBfcMaxConcurrencyBulkSync    :: Maybe Word
-  , srnBfcMaxConcurrencyDeadline    :: Maybe Word
+  { srnBfcMaxConcurrencyDeadline    :: Maybe Word
   , srnChainDbValidateOverride      :: Bool
     -- ^ If @True@, validate the ChainDB on init no matter what
   , srnDiskPolicyArgs               :: DiskPolicyArgs
@@ -986,9 +985,6 @@ stdLowLevelRunNodeArgsIO RunNodeArgs{ rnProtocolInfo
             maybe id
               (\mc bfc -> bfc { bfcMaxConcurrencyDeadline = mc })
               srnBfcMaxConcurrencyDeadline
-          . maybe id
-              (\mc bfc -> bfc { bfcMaxConcurrencyBulkSync = mc })
-              srnBfcMaxConcurrencyBulkSync
         modifyMempoolCapacityOverride =
             maybe id
               (\mc nka -> nka { mempoolCapacityOverride = mc })

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Node/Genesis.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Node/Genesis.hs
@@ -66,26 +66,26 @@ data GenesisConfig = GenesisConfig
 
 -- | Genesis configuration flags and low-level args, as parsed from config file or CLI
 data GenesisConfigFlags = GenesisConfigFlags
-  { gcfEnableCSJ           :: Bool
-  , gcfEnableLoEAndGDD     :: Bool
-  , gcfEnableLoP           :: Bool
-  , gcfBulkSyncGracePeriod :: Maybe Integer
-  , gcfBucketCapacity      :: Maybe Integer
-  , gcfBucketRate          :: Maybe Integer
-  , gcfCSJJumpSize         :: Maybe Integer
-  , gcfGDDRateLimit        :: Maybe DiffTime
+  { gcfEnableCSJ             :: Bool
+  , gcfEnableLoEAndGDD       :: Bool
+  , gcfEnableLoP             :: Bool
+  , gcfBlockFetchGracePeriod :: Maybe Integer
+  , gcfBucketCapacity        :: Maybe Integer
+  , gcfBucketRate            :: Maybe Integer
+  , gcfCSJJumpSize           :: Maybe Integer
+  , gcfGDDRateLimit          :: Maybe DiffTime
   } deriving stock (Eq, Generic, Show)
 
 defaultGenesisConfigFlags :: GenesisConfigFlags
 defaultGenesisConfigFlags = GenesisConfigFlags
-  { gcfEnableCSJ            = True
-  , gcfEnableLoEAndGDD      = True
-  , gcfEnableLoP            = True
-  , gcfBulkSyncGracePeriod  = Nothing
-  , gcfBucketCapacity       = Nothing
-  , gcfBucketRate           = Nothing
-  , gcfCSJJumpSize          = Nothing
-  , gcfGDDRateLimit         = Nothing
+  { gcfEnableCSJ              = True
+  , gcfEnableLoEAndGDD        = True
+  , gcfEnableLoP              = True
+  , gcfBlockFetchGracePeriod  = Nothing
+  , gcfBucketCapacity         = Nothing
+  , gcfBucketRate             = Nothing
+  , gcfCSJJumpSize            = Nothing
+  , gcfGDDRateLimit           = Nothing
   }
 
 enableGenesisConfigDefault :: GenesisConfig
@@ -99,7 +99,7 @@ mkGenesisConfig :: Maybe GenesisConfigFlags -> GenesisConfig
 mkGenesisConfig Nothing = -- disable Genesis
   GenesisConfig
     { gcBlockFetchConfig = GenesisBlockFetchConfiguration
-        { gbfcBulkSyncGracePeriod = 0 -- no grace period when Genesis is disabled
+        { gbfcGracePeriod = 0 -- no grace period when Genesis is disabled
         }
     , gcChainSyncLoPBucketConfig = ChainSyncLoPBucketDisabled
     , gcCSJConfig                = CSJDisabled
@@ -109,7 +109,7 @@ mkGenesisConfig Nothing = -- disable Genesis
 mkGenesisConfig (Just GenesisConfigFlags{..}) =
   GenesisConfig
     { gcBlockFetchConfig = GenesisBlockFetchConfiguration
-        { gbfcBulkSyncGracePeriod
+        { gbfcGracePeriod
         }
     , gcChainSyncLoPBucketConfig = if gcfEnableLoP
         then ChainSyncLoPBucketEnabled ChainSyncLoPBucketEnabledConfig
@@ -134,7 +134,7 @@ mkGenesisConfig (Just GenesisConfigFlags{..}) =
     -- The minimum amount of time during which the Genesis BlockFetch logic will
     -- download blocks from a specific peer (even if it is not performing well
     -- during that period).
-    defaultBulkSyncGracePeriod = 10 -- seconds
+    defaultBlockFetchGracePeriod = 10 -- seconds
 
     -- LoP parameters. Empirically, it takes less than 1ms to validate a header,
     -- so leaking one token per 2ms is conservative. The capacity of 100_000
@@ -153,11 +153,11 @@ mkGenesisConfig (Just GenesisConfigFlags{..}) =
     -- Limiting the performance impact of the GDD.
     defaultGDDRateLimit        = 1.0 -- seconds
 
-    gbfcBulkSyncGracePeriod = fromInteger $ fromMaybe defaultBulkSyncGracePeriod gcfBulkSyncGracePeriod
-    csbcCapacity            = fromInteger $ fromMaybe defaultCapacity gcfBucketCapacity
-    csbcRate                = fromInteger $ fromMaybe defaultRate gcfBucketRate
-    csjcJumpSize            = fromInteger $ fromMaybe defaultCSJJumpSize gcfCSJJumpSize
-    lgpGDDRateLimit            = fromMaybe defaultGDDRateLimit gcfGDDRateLimit
+    gbfcGracePeriod = fromInteger $ fromMaybe defaultBlockFetchGracePeriod gcfBlockFetchGracePeriod
+    csbcCapacity    = fromInteger $ fromMaybe defaultCapacity gcfBucketCapacity
+    csbcRate        = fromInteger $ fromMaybe defaultRate gcfBucketRate
+    csjcJumpSize    = fromInteger $ fromMaybe defaultCSJJumpSize gcfCSJJumpSize
+    lgpGDDRateLimit = fromMaybe defaultGDDRateLimit gcfGDDRateLimit
 
 newtype LoEAndGDDParams = LoEAndGDDParams
   { -- | How often to evaluate GDD. 0 means as soon as possible.

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Node/Genesis.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Node/Genesis.hs
@@ -140,7 +140,12 @@ mkGenesisConfig (Just GenesisConfigFlags{..}) =
     defaultCapacity = 100_000 -- number of tokens
     defaultRate     = 500 -- tokens per second leaking, 1/2ms
 
-    defaultCSJJumpSize = 3 * 2160 * 20 -- mainnet forecast range
+    -- The larger Shelley forecast range (3 * 2160 * 20) works in more recent
+    -- ranges of slots, but causes syncing to block in Byron. A future
+    -- improvement would be to make this era-dynamic, such that we can use the
+    -- larger (and hence more efficient) larger CSJ jump size in Shelley-based
+    -- eras.
+    defaultCSJJumpSize = 2 * 2160 -- Byron forecast range
 
     gbfcBulkSyncGracePeriod = fromInteger $ fromMaybe defaultBulkSyncGracePeriod gcfBulkSyncGracePeriod
     csbcCapacity            = fromInteger $ fromMaybe defaultCapacity gcfBucketCapacity

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Node/Genesis.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Node/Genesis.hs
@@ -1,16 +1,21 @@
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DeriveTraversable #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Ouroboros.Consensus.Node.Genesis (
     -- * 'GenesisConfig'
     GenesisConfig (..)
+  , GenesisConfigFlags (..)
   , LoEAndGDDConfig (..)
+  , defaultGenesisConfigFlags
   , disableGenesisConfig
   , enableGenesisConfigDefault
+  , mkGenesisConfig
     -- * NodeKernel helpers
   , GenesisNodeKernelArgs (..)
   , mkGenesisNodeKernelArgs
@@ -18,7 +23,9 @@ module Ouroboros.Consensus.Node.Genesis (
   ) where
 
 import           Control.Monad (join)
+import           Data.Maybe (fromMaybe)
 import           Data.Traversable (for)
+import           GHC.Generics (Generic)
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.MiniProtocol.ChainSync.Client
                      (CSJConfig (..), CSJEnabledConfig (..),
@@ -34,47 +41,111 @@ import           Ouroboros.Consensus.Util.Args
 import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Network.AnchoredFragment (AnchoredFragment)
 import qualified Ouroboros.Network.AnchoredFragment as AF
+import           Ouroboros.Network.BlockFetch
+                     (GenesisBlockFetchConfiguration (..))
 
 -- | Whether to en-/disable the Limit on Eagerness and the Genesis Density
 -- Disconnector.
 data LoEAndGDDConfig a =
     LoEAndGDDEnabled !a
   | LoEAndGDDDisabled
-  deriving stock (Show, Functor, Foldable, Traversable)
+  deriving stock (Eq, Generic, Show, Functor, Foldable, Traversable)
 
 -- | Aggregating the various configs for Genesis-related subcomponents.
-data GenesisConfig = GenesisConfig {
-    gcChainSyncLoPBucketConfig :: !ChainSyncLoPBucketConfig
+--
+-- Usually, 'enableGenesisConfigDefault' or 'disableGenesisConfig' can be used.
+-- See the haddocks of the types of the individual fields for details.
+data GenesisConfig = GenesisConfig
+  { gcBlockFetchConfig         :: !GenesisBlockFetchConfiguration
+  , gcChainSyncLoPBucketConfig :: !ChainSyncLoPBucketConfig
   , gcCSJConfig                :: !CSJConfig
   , gcLoEAndGDDConfig          :: !(LoEAndGDDConfig ())
   , gcHistoricityCutoff        :: !(Maybe HistoricityCutoff)
+  } deriving stock (Eq, Generic, Show)
+
+-- | Genesis configuration flags and low-level args, as parsed from config file or CLI
+data GenesisConfigFlags = GenesisConfigFlags
+  { gcfEnableCSJ           :: Bool
+  , gcfEnableLoEAndGDD     :: Bool
+  , gcfEnableLoP           :: Bool
+  , gcfBulkSyncGracePeriod :: Maybe Integer
+  , gcfBucketCapacity      :: Maybe Integer
+  , gcfBucketRate          :: Maybe Integer
+  , gcfCSJJumpSize         :: Maybe Integer
+  } deriving stock (Eq, Generic, Show)
+
+defaultGenesisConfigFlags :: GenesisConfigFlags
+defaultGenesisConfigFlags = GenesisConfigFlags
+  { gcfEnableCSJ            = True
+  , gcfEnableLoEAndGDD      = True
+  , gcfEnableLoP            = True
+  , gcfBulkSyncGracePeriod  = Nothing
+  , gcfBucketCapacity       = Nothing
+  , gcfBucketRate           = Nothing
+  , gcfCSJJumpSize          = Nothing
   }
 
--- TODO justification/derivation from other parameters
 enableGenesisConfigDefault :: GenesisConfig
-enableGenesisConfigDefault = GenesisConfig {
-      gcChainSyncLoPBucketConfig = ChainSyncLoPBucketEnabled ChainSyncLoPBucketEnabledConfig {
-          csbcCapacity = 100_000 -- number of tokens
-        , csbcRate     = 500 -- tokens per second leaking, 1/2ms
-        }
-    , gcCSJConfig = CSJEnabled CSJEnabledConfig {
-          csjcJumpSize = 3 * 2160 * 20 -- mainnet forecast range
-        }
-    , gcLoEAndGDDConfig = LoEAndGDDEnabled ()
-      -- Duration in seconds of one Cardano mainnet Shelley stability window
-      -- (3k/f slots times one second per slot) plus one extra hour as a
-      -- safety margin.
-    , gcHistoricityCutoff = Just $ HistoricityCutoff $ 3 * 2160 * 20 + 3600
-    }
+enableGenesisConfigDefault = mkGenesisConfig $ Just defaultGenesisConfigFlags
 
 -- | Disable all Genesis components, yielding Praos behavior.
 disableGenesisConfig :: GenesisConfig
-disableGenesisConfig = GenesisConfig {
-      gcChainSyncLoPBucketConfig = ChainSyncLoPBucketDisabled
+disableGenesisConfig = mkGenesisConfig Nothing
+
+mkGenesisConfig :: Maybe GenesisConfigFlags -> GenesisConfig
+mkGenesisConfig Nothing = -- disable Genesis
+  GenesisConfig
+    { gcBlockFetchConfig = GenesisBlockFetchConfiguration
+        { gbfcBulkSyncGracePeriod = 0 -- no grace period when Genesis is disabled
+        }
+    , gcChainSyncLoPBucketConfig = ChainSyncLoPBucketDisabled
     , gcCSJConfig                = CSJDisabled
     , gcLoEAndGDDConfig          = LoEAndGDDDisabled
     , gcHistoricityCutoff        = Nothing
     }
+mkGenesisConfig (Just GenesisConfigFlags{..}) =
+  GenesisConfig
+    { gcBlockFetchConfig = GenesisBlockFetchConfiguration
+        { gbfcBulkSyncGracePeriod
+        }
+    , gcChainSyncLoPBucketConfig = if gcfEnableLoP
+        then ChainSyncLoPBucketEnabled ChainSyncLoPBucketEnabledConfig
+          { csbcCapacity
+          , csbcRate
+          }
+        else ChainSyncLoPBucketDisabled
+    , gcCSJConfig = if gcfEnableCSJ
+        then CSJEnabled CSJEnabledConfig
+          { csjcJumpSize
+          }
+        else CSJDisabled
+    , gcLoEAndGDDConfig = if gcfEnableLoEAndGDD
+        then LoEAndGDDEnabled ()
+        else LoEAndGDDDisabled
+    , -- Duration in seconds of one Cardano mainnet Shelley stability window
+      -- (3k/f slots times one second per slot) plus one extra hour as a
+      -- safety margin.
+      gcHistoricityCutoff = Just $ HistoricityCutoff $ 3 * 2160 * 20 + 3600
+    }
+  where
+    -- The minimum amount of time during which the Genesis BlockFetch logic will
+    -- download blocks from a specific peer (even if it is not performing well
+    -- during that period).
+    defaultBulkSyncGracePeriod = 10 -- seconds
+
+    -- LoP parameters. Empirically, it takes less than 1ms to validate a header,
+    -- so leaking one token per 2ms is conservative. The capacity of 100_000
+    -- tokens corresponds to 200s, which is definitely enough to handle long GC
+    -- pauses; we could even make this more conservative.
+    defaultCapacity = 100_000 -- number of tokens
+    defaultRate     = 500 -- tokens per second leaking, 1/2ms
+
+    defaultCSJJumpSize = 3 * 2160 * 20 -- mainnet forecast range
+
+    gbfcBulkSyncGracePeriod = fromInteger $ fromMaybe defaultBulkSyncGracePeriod gcfBulkSyncGracePeriod
+    csbcCapacity            = fromInteger $ fromMaybe defaultCapacity gcfBucketCapacity
+    csbcRate                = fromInteger $ fromMaybe defaultRate gcfBucketRate
+    csjcJumpSize            = fromInteger $ fromMaybe defaultCSJJumpSize gcfCSJJumpSize
 
 -- | Genesis-related arguments needed by the NodeKernel initialization logic.
 data GenesisNodeKernelArgs m blk = GenesisNodeKernelArgs {
@@ -124,9 +195,10 @@ setGetLoEFragment readGsmState readLoEFragment varGetLoEFragment =
   where
     getLoEFragment :: ChainDB.GetLoEFragment m blk
     getLoEFragment = atomically $ readGsmState >>= \case
-        -- When the Honest Availability Assumption cannot currently be guaranteed, we should not select
-        -- any blocks that would cause our immutable tip to advance, so we
-        -- return the most conservative LoE fragment.
+        -- When the Honest Availability Assumption cannot currently be
+        -- guaranteed, we should not select any blocks that would cause our
+        -- immutable tip to advance, so we return the most conservative LoE
+        -- fragment.
         GSM.PreSyncing ->
           pure $ ChainDB.LoEEnabled $ AF.Empty AF.AnchorGenesis
         -- When we are syncing, return the current LoE fragment.

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Node/Tracers.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Node/Tracers.hs
@@ -38,8 +38,10 @@ import           Ouroboros.Consensus.MiniProtocol.LocalTxSubmission.Server
                      (TraceLocalTxSubmissionServerEvent (..))
 import           Ouroboros.Consensus.Node.GSM (TraceGsmEvent)
 import           Ouroboros.Network.Block (Tip)
-import           Ouroboros.Network.BlockFetch (FetchDecision,
-                     TraceFetchClientState, TraceLabelPeer)
+import           Ouroboros.Network.BlockFetch (TraceFetchClientState,
+                     TraceLabelPeer)
+import           Ouroboros.Network.BlockFetch.Decision.Trace
+                     (TraceDecisionEvent)
 import           Ouroboros.Network.KeepAlive (TraceKeepAliveClient)
 import           Ouroboros.Network.TxSubmission.Inbound
                      (TraceTxSubmissionInbound)
@@ -54,7 +56,7 @@ data Tracers' remotePeer localPeer blk f = Tracers
   { chainSyncClientTracer         :: f (TraceLabelPeer remotePeer (TraceChainSyncClientEvent blk))
   , chainSyncServerHeaderTracer   :: f (TraceLabelPeer remotePeer (TraceChainSyncServerEvent blk))
   , chainSyncServerBlockTracer    :: f (TraceChainSyncServerEvent blk)
-  , blockFetchDecisionTracer      :: f [TraceLabelPeer remotePeer (FetchDecision [Point (Header blk)])]
+  , blockFetchDecisionTracer      :: f (TraceDecisionEvent remotePeer (Header blk))
   , blockFetchClientTracer        :: f (TraceLabelPeer remotePeer (TraceFetchClientState (Header blk)))
   , blockFetchServerTracer        :: f (TraceLabelPeer remotePeer (TraceBlockFetchServerEvent blk))
   , txInboundTracer               :: f (TraceLabelPeer remotePeer (TraceTxSubmissionInbound  (GenTxId blk) (GenTx blk)))

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Node/Tracers.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Node/Tracers.hs
@@ -32,6 +32,7 @@ import           Ouroboros.Consensus.MiniProtocol.BlockFetch.Server
                      (TraceBlockFetchServerEvent)
 import           Ouroboros.Consensus.MiniProtocol.ChainSync.Client
                      (TraceChainSyncClientEvent)
+import qualified Ouroboros.Consensus.MiniProtocol.ChainSync.Client.Jumping as CSJumping
 import           Ouroboros.Consensus.MiniProtocol.ChainSync.Server
                      (TraceChainSyncServerEvent)
 import           Ouroboros.Consensus.MiniProtocol.LocalTxSubmission.Server
@@ -71,6 +72,7 @@ data Tracers' remotePeer localPeer blk f = Tracers
   , consensusErrorTracer          :: f SomeException
   , gsmTracer                     :: f (TraceGsmEvent (Tip blk))
   , gddTracer                     :: f (TraceGDDEvent remotePeer blk)
+  , csjTracer                     :: f (CSJumping.TraceEvent remotePeer)
   }
 
 instance (forall a. Semigroup (f a))
@@ -94,6 +96,7 @@ instance (forall a. Semigroup (f a))
       , consensusErrorTracer          = f consensusErrorTracer
       , gsmTracer                     = f gsmTracer
       , gddTracer                     = f gddTracer
+      , csjTracer                     = f csjTracer
       }
     where
       f :: forall a. Semigroup a
@@ -125,6 +128,7 @@ nullTracers = Tracers
     , consensusErrorTracer          = nullTracer
     , gsmTracer                     = nullTracer
     , gddTracer                     = nullTracer
+    , csjTracer                     = nullTracer
     }
 
 showTracers :: ( Show blk
@@ -159,6 +163,7 @@ showTracers tr = Tracers
     , consensusErrorTracer          = showTracing tr
     , gsmTracer                     = showTracing tr
     , gddTracer                     = showTracing tr
+    , csjTracer                     = showTracing tr
     }
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
@@ -62,8 +62,9 @@ import           Ouroboros.Consensus.Ledger.SupportsProtocol
 import           Ouroboros.Consensus.Mempool
 import qualified Ouroboros.Consensus.MiniProtocol.BlockFetch.ClientInterface as BlockFetchClientInterface
 import           Ouroboros.Consensus.MiniProtocol.ChainSync.Client
-                     (ChainSyncClientHandle (..), ChainSyncState (..),
-                     viewChainSyncState)
+                     (ChainSyncClientHandle (..),
+                     ChainSyncClientHandleCollection (..), ChainSyncState (..),
+                     newChainSyncClientHandleCollection, viewChainSyncState)
 import           Ouroboros.Consensus.MiniProtocol.ChainSync.Client.HistoricityCheck
                      (HistoricityCheck)
 import           Ouroboros.Consensus.MiniProtocol.ChainSync.Client.InFutureCheck
@@ -143,7 +144,7 @@ data NodeKernel m addrNTN addrNTC blk = NodeKernel {
     , getGsmState             :: STM m GSM.GsmState
 
       -- | The kill handle and exposed state for each ChainSync client.
-    , getChainSyncHandles     :: StrictTVar m (Map (ConnectionId addrNTN) (ChainSyncClientHandle m blk))
+    , getChainSyncHandles     :: ChainSyncClientHandleCollection (ConnectionId addrNTN) m blk
 
       -- | Read the current peer sharing registry, used for interacting with
       -- the PeerSharing protocol
@@ -252,7 +253,7 @@ initNodeKernel args@NodeKernelArgs { registry, cfg, tracers
                   <&> \wd (_headers, lst) ->
                         GSM.getDurationUntilTooOld wd (getTipSlot lst)
               , GSM.equivalent                = (==) `on` (AF.headPoint . fst)
-              , GSM.getChainSyncStates        = fmap cschState <$> readTVar varChainSyncHandles
+              , GSM.getChainSyncStates        = fmap cschState <$> cschcMap varChainSyncHandles
               , GSM.getCurrentSelection       = do
                   headers        <- ChainDB.getCurrentChain  chainDB
                   extLedgerState <- ChainDB.getCurrentLedger chainDB
@@ -264,7 +265,7 @@ initNodeKernel args@NodeKernelArgs { registry, cfg, tracers
               , GSM.writeGsmState = \gsmState ->
                   atomicallyWithMonotonicTime $ \time -> do
                     writeTVar varGsmState gsmState
-                    handles <- readTVar varChainSyncHandles
+                    handles <- cschcMap varChainSyncHandles
                     traverse_ (($ time) . ($ gsmState) . cschOnGsmStateChanged) handles
               , GSM.isHaaSatisfied            = do
                   readTVar varOutboundConnectionsState <&> \case
@@ -299,7 +300,7 @@ initNodeKernel args@NodeKernelArgs { registry, cfg, tracers
             chainDB
             (readTVar varGsmState)
             -- TODO GDD should only consider (big) ledger peers
-            (readTVar varChainSyncHandles)
+            (cschcMap varChainSyncHandles)
             varLoEFragment
 
     void $ forkLinkedThread registry "NodeKernel.blockForging" $
@@ -356,7 +357,7 @@ data InternalState m addrNTN addrNTC blk = IS {
     , chainDB             :: ChainDB m blk
     , blockFetchInterface :: BlockFetchConsensusInterface (ConnectionId addrNTN) (Header blk) blk m
     , fetchClientRegistry :: FetchClientRegistry (ConnectionId addrNTN) (Header blk) blk m
-    , varChainSyncHandles :: StrictTVar m (Map (ConnectionId addrNTN) (ChainSyncClientHandle m blk))
+    , varChainSyncHandles :: ChainSyncClientHandleCollection (ConnectionId addrNTN) m blk
     , varGsmState         :: StrictTVar m GSM.GsmState
     , mempool             :: Mempool m blk
     , peerSharingRegistry :: PeerSharingRegistry addrNTN m
@@ -385,7 +386,7 @@ initInternalState NodeKernelArgs { tracers, chainDB, registry, cfg
         gsmMarkerFileView
       newTVarIO gsmState
 
-    varChainSyncHandles <- newTVarIO mempty
+    varChainSyncHandles <- atomically newChainSyncClientHandleCollection
     mempool       <- openMempool registry
                                  (chainDBLedgerInterface chainDB)
                                  (configLedger cfg)
@@ -395,7 +396,7 @@ initInternalState NodeKernelArgs { tracers, chainDB, registry, cfg
     fetchClientRegistry <- newFetchClientRegistry
 
     let getCandidates :: STM m (Map (ConnectionId addrNTN) (AnchoredFragment (Header blk)))
-        getCandidates = viewChainSyncState varChainSyncHandles csCandidate
+        getCandidates = viewChainSyncState (cschcMap varChainSyncHandles) csCandidate
 
     slotForgeTimeOracle <- BlockFetchClientInterface.initSlotForgeTimeOracle cfg chainDB
     let readFetchMode = BlockFetchClientInterface.readFetchModeDefault

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
@@ -402,6 +402,7 @@ initInternalState NodeKernelArgs { tracers, chainDB, registry, cfg
           (GSM.gsmStateToLedgerJudgement <$> readTVar varGsmState)
         blockFetchInterface :: BlockFetchConsensusInterface (ConnectionId addrNTN) (Header blk) blk m
         blockFetchInterface = BlockFetchClientInterface.mkBlockFetchConsensusInterface
+          (csjTracer tracers)
           (configBlock cfg)
           (BlockFetchClientInterface.defaultChainDbView chainDB)
           varChainSyncHandles

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
@@ -42,7 +42,6 @@ import           Data.Function (on)
 import           Data.Functor ((<&>))
 import           Data.Hashable (Hashable)
 import           Data.List.NonEmpty (NonEmpty)
-import           Data.Map.Strict (Map)
 import           Data.Maybe (isJust, mapMaybe)
 import           Data.Proxy
 import qualified Data.Text as Text
@@ -64,7 +63,7 @@ import qualified Ouroboros.Consensus.MiniProtocol.BlockFetch.ClientInterface as 
 import           Ouroboros.Consensus.MiniProtocol.ChainSync.Client
                      (ChainSyncClientHandle (..),
                      ChainSyncClientHandleCollection (..), ChainSyncState (..),
-                     newChainSyncClientHandleCollection, viewChainSyncState)
+                     newChainSyncClientHandleCollection)
 import           Ouroboros.Consensus.MiniProtocol.ChainSync.Client.HistoricityCheck
                      (HistoricityCheck)
 import           Ouroboros.Consensus.MiniProtocol.ChainSync.Client.InFutureCheck
@@ -395,9 +394,6 @@ initInternalState NodeKernelArgs { tracers, chainDB, registry, cfg
 
     fetchClientRegistry <- newFetchClientRegistry
 
-    let getCandidates :: STM m (Map (ConnectionId addrNTN) (AnchoredFragment (Header blk)))
-        getCandidates = viewChainSyncState (cschcMap varChainSyncHandles) csCandidate
-
     slotForgeTimeOracle <- BlockFetchClientInterface.initSlotForgeTimeOracle cfg chainDB
     let readFetchMode = BlockFetchClientInterface.readFetchModeDefault
           btime
@@ -408,7 +404,7 @@ initInternalState NodeKernelArgs { tracers, chainDB, registry, cfg
         blockFetchInterface = BlockFetchClientInterface.mkBlockFetchConsensusInterface
           (configBlock cfg)
           (BlockFetchClientInterface.defaultChainDbView chainDB)
-          getCandidates
+          varChainSyncHandles
           blockFetchSize
           slotForgeTimeOracle
           readFetchMode

--- a/ouroboros-consensus-diffusion/src/unstable-diffusion-testlib/Test/ThreadNet/Network.hs
+++ b/ouroboros-consensus-diffusion/src/unstable-diffusion-testlib/Test/ThreadNet/Network.hs
@@ -1013,8 +1013,7 @@ runThreadNetwork systemTime ThreadNetworkArgs
                   txSubmissionMaxUnacked      = 1000 -- TODO ?
                 }
             , blockFetchConfiguration = BlockFetchConfiguration {
-                  bfcMaxConcurrencyBulkSync = 1
-                , bfcMaxConcurrencyDeadline = 2
+                  bfcMaxConcurrencyDeadline = 2
                 , bfcMaxRequestsInflight    = 10
                 , bfcDecisionLoopInterval   = 0.0 -- Mock testsuite can use sub-second slot
                                                   -- interval which doesn't play nice with

--- a/ouroboros-consensus-diffusion/src/unstable-diffusion-testlib/Test/ThreadNet/Network.hs
+++ b/ouroboros-consensus-diffusion/src/unstable-diffusion-testlib/Test/ThreadNet/Network.hs
@@ -1015,9 +1015,9 @@ runThreadNetwork systemTime ThreadNetworkArgs
             , blockFetchConfiguration = BlockFetchConfiguration {
                   bfcMaxConcurrencyDeadline = 2
                 , bfcMaxRequestsInflight    = 10
-                , bfcDecisionLoopInterval   = 0.0 -- Mock testsuite can use sub-second slot
-                                                  -- interval which doesn't play nice with
-                                                  -- blockfetch descision interval.
+                , bfcDecisionLoopIntervalBulkSync = 0.0 -- Mock testsuite can use sub-second slot
+                , bfcDecisionLoopIntervalDeadline = 0.0 -- interval which doesn't play nice with
+                                                        -- blockfetch descision interval.
                 , bfcSalt                   = 0
                 , bfcGenesisBFConfig        = gcBlockFetchConfig enableGenesisConfigDefault
                 }

--- a/ouroboros-consensus-diffusion/src/unstable-diffusion-testlib/Test/ThreadNet/Network.hs
+++ b/ouroboros-consensus-diffusion/src/unstable-diffusion-testlib/Test/ThreadNet/Network.hs
@@ -1019,6 +1019,7 @@ runThreadNetwork systemTime ThreadNetworkArgs
                                                   -- interval which doesn't play nice with
                                                   -- blockfetch descision interval.
                 , bfcSalt                   = 0
+                , bfcGenesisBFConfig        = gcBlockFetchConfig enableGenesisConfigDefault
                 }
             , gsmArgs                 = GSM.GsmNodeKernelArgs {
                   gsmAntiThunderingHerd  = kaRng

--- a/ouroboros-consensus-diffusion/src/unstable-diffusion-testlib/Test/ThreadNet/Network.hs
+++ b/ouroboros-consensus-diffusion/src/unstable-diffusion-testlib/Test/ThreadNet/Network.hs
@@ -1034,7 +1034,7 @@ runThreadNetwork systemTime ThreadNetworkArgs
             , getUseBootstrapPeers = pure DontUseBootstrapPeers
             , publicPeerSelectionStateVar
             , genesisArgs          = GenesisNodeKernelArgs {
-                  gnkaGetLoEFragment = LoEAndGDDDisabled
+                  gnkaLoEAndGDDArgs = LoEAndGDDDisabled
                 }
             , getDiffusionPipeliningSupport = DiffusionPipeliningOn
             }

--- a/ouroboros-consensus-diffusion/src/unstable-diffusion-testlib/Test/ThreadNet/Network.hs
+++ b/ouroboros-consensus-diffusion/src/unstable-diffusion-testlib/Test/ThreadNet/Network.hs
@@ -1013,10 +1013,11 @@ runThreadNetwork systemTime ThreadNetworkArgs
                   txSubmissionMaxUnacked      = 1000 -- TODO ?
                 }
             , blockFetchConfiguration = BlockFetchConfiguration {
-                  bfcMaxConcurrencyDeadline = 2
+                  bfcMaxConcurrencyBulkSync = 1
+                , bfcMaxConcurrencyDeadline = 2
                 , bfcMaxRequestsInflight    = 10
-                , bfcDecisionLoopIntervalBulkSync = 0.0 -- Mock testsuite can use sub-second slot
-                , bfcDecisionLoopIntervalDeadline = 0.0 -- interval which doesn't play nice with
+                , bfcDecisionLoopIntervalPraos = 0.0 -- Mock testsuite can use sub-second slot
+                , bfcDecisionLoopIntervalGenesis = 0.0 -- interval which doesn't play nice with
                                                         -- blockfetch descision interval.
                 , bfcSalt                   = 0
                 , bfcGenesisBFConfig        = gcBlockFetchConfig enableGenesisConfigDefault

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup.hs
@@ -19,7 +19,7 @@ import           Control.Monad.IOSim (IOSim, runSimStrictShutdown)
 import           Control.Tracer (debugTracer, traceWith)
 import           Data.Maybe (mapMaybe)
 import           Ouroboros.Consensus.MiniProtocol.ChainSync.Client
-                     (ChainSyncClientException (DensityTooLow, EmptyBucket))
+                     (ChainSyncClientException (..))
 import           Ouroboros.Consensus.Util.Condense
 import           Ouroboros.Consensus.Util.IOLike (Exception, fromException)
 import           Ouroboros.Network.Driver.Limits
@@ -126,6 +126,7 @@ forAllGenesisTest generator schedulerConfig shrinker mkProperty =
       | Just DensityTooLow         <- e = true
       | Just (ExceededTimeLimit _) <- e = true
       | Just AsyncCancelled        <- e = true
+      | Just CandidateTooSparse{}  <- e = true
       | otherwise = counterexample
         ("Encountered unexpected exception: " ++ show exn)
         False

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup/GenChains.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup/GenChains.hs
@@ -188,6 +188,12 @@ chainSyncTimeouts =
     -- chains are finite, and therefore an honest peer can only serve it all,
     -- then send 'MsgAwaitReply' (therefore entering 'StMustReply'), and then
     -- stall forever, and it must not be killed for it.
+    --
+    -- Note that this allows the adversaries to stall us forever in that same
+    -- situation. However, that peer is only allowed to send 'MsgAwaitReply'
+    -- when they have served their tip, which leaves them fully vulnerable to
+    -- the Genesis Density Disconnection (GDD) logic. A bug related to this
+    -- disabled timeout is in fact either a bug in the GDD or in the tests.
     mustReplyTimeout :: Maybe DiffTime
     mustReplyTimeout = Nothing
 

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup/GenChains.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup/GenChains.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE NamedFieldPuns #-}
-{-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Test.Consensus.Genesis.Setup.GenChains (
@@ -132,10 +131,11 @@ genChainsWithExtraHonestPeers genNumExtraHonest genNumForks = do
     gtSlotLength,
     gtChainSyncTimeouts = chainSyncTimeouts gtSlotLength asc,
     gtBlockFetchTimeouts = blockFetchTimeouts,
-    gtLoPBucketParams = LoPBucketParams { lbpCapacity = 100_000, lbpRate = 1_000 },
-    -- ^ REVIEW: Do we want to generate those randomly? For now, the chosen
-    -- values carry no special meaning. Someone needs to think about what values
-    -- would make for interesting tests.
+    gtLoPBucketParams = LoPBucketParams { lbpCapacity = 50, lbpRate = 10 },
+    -- These values give little enough leeway (5s) so that some adversaries get disconnected
+    -- by the LoP during the stalling attack test. Maybe we should design a way to override
+    -- those values for individual tests?
+    -- Also, we might want to generate these randomly.
     gtCSJParams = CSJParams $ fromIntegral scg,
     gtBlockTree = List.foldl' (flip BT.addBranch') (BT.mkTrunk goodChain) $ zipWith (genAdversarialFragment goodBlocks) [1..] alternativeChainSchemas,
     gtExtraHonestPeers,

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/CSJ.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/CSJ.hs
@@ -6,12 +6,15 @@ module Test.Consensus.Genesis.Tests.CSJ (tests) where
 import           Data.List (nub)
 import qualified Data.Map.Strict as Map
 import           Data.Maybe (mapMaybe)
-import           Ouroboros.Consensus.Block (Header, blockSlot, succWithOrigin)
+import           Ouroboros.Consensus.Block (Header, blockSlot, succWithOrigin,
+                     unSlotNo)
 import           Ouroboros.Consensus.MiniProtocol.ChainSync.Client
                      (TraceChainSyncClientEvent (..))
 import           Ouroboros.Consensus.Util.Condense (PaddingDirection (..),
                      condenseListWithPadding)
 import qualified Ouroboros.Network.AnchoredFragment as AF
+import           Ouroboros.Network.Protocol.ChainSync.Codec
+                     (ChainSyncTimeout (mustReplyTimeout), idleTimeout)
 import           Test.Consensus.BlockTree (BlockTree (..))
 import           Test.Consensus.Genesis.Setup
 import           Test.Consensus.Genesis.Tests.Uniform (genUniformSchedulePoints)
@@ -28,10 +31,12 @@ import           Test.Tasty.QuickCheck
 import           Test.Util.Orphans.IOLike ()
 import           Test.Util.PartialAccessors
 import           Test.Util.TestBlock (TestBlock)
-import           Test.Util.TestEnv (adjustQuickCheckMaxSize)
+import           Test.Util.TestEnv (adjustQuickCheckMaxSize,
+                     adjustQuickCheckTests)
 
 tests :: TestTree
 tests =
+  adjustQuickCheckTests (* 10) $
   adjustQuickCheckMaxSize (`div` 5) $
     testGroup
       "CSJ"
@@ -49,6 +54,7 @@ tests =
 
 -- | A flag to indicate if properties are tested with adversarial peers
 data WithAdversariesFlag = NoAdversaries | WithAdversaries
+  deriving Eq
 
 -- | A flag to indicate if properties are tested using the same schedule for the
 -- honest peers, or if each peer should used its own schedule.
@@ -81,7 +87,7 @@ prop_CSJ adversariesFlag numHonestSchedules = do
                    NoAdversaries   -> pure 0
                    WithAdversaries -> choose (2, 4)
   forAllGenesisTest
-    ( case numHonestSchedules of
+    ( disableBoringTimeouts <$> case numHonestSchedules of
         OneScheduleForAllPeers ->
           genChains genForks
           `enrichedWith` genDuplicatedHonestSchedule
@@ -93,6 +99,13 @@ prop_CSJ adversariesFlag numHonestSchedules = do
       { scEnableCSJ = True
       , scEnableLoE = True
       , scEnableLoP = True
+      , scEnableChainSelStarvation = adversariesFlag == NoAdversaries
+      -- ^ NOTE: When there are adversaries and the ChainSel
+      -- starvation detection of BlockFetch is enabled, then our property does
+      -- not actually hold, because peer simulator-based tests have virtually
+      -- infinite CPU, and therefore ChainSel gets starved at every tick, which
+      -- makes us cycle the dynamos, which can lead to some extra headers being
+      -- downloaded.
       }
     )
     shrinkPeerSchedules
@@ -111,8 +124,16 @@ prop_CSJ adversariesFlag numHonestSchedules = do
                 _ -> Nothing
               )
               svTrace
+          -- We receive headers at most once from honest peer. The only
+          -- exception is when an honest peer gets to be the objector, until an
+          -- adversary dies, and then the dynamo. In that specific case, we
+          -- might re-download jumpSize blocks. TODO: If we ever choose to
+          -- promote objectors to dynamo to reuse their state, then we could
+          -- make this bound tighter.
           receivedHeadersAtMostOnceFromHonestPeers =
-            length (nub $ snd <$> headerHonestDownloadEvents) == length headerHonestDownloadEvents
+            length headerHonestDownloadEvents <=
+              length (nub $ snd <$> headerHonestDownloadEvents) +
+                (fromIntegral $ unSlotNo $ csjpJumpSize $ gtCSJParams gt)
         in
           tabulate ""
             [ if headerHonestDownloadEvents == []
@@ -152,3 +173,12 @@ prop_CSJ adversariesFlag numHonestSchedules = do
        in
         -- Sanity check: add @1 +@ after @>@ and watch the World burn.
         hdrSlot + jumpSize >= succWithOrigin tipSlot
+
+    disableBoringTimeouts gt =
+      gt
+        { gtChainSyncTimeouts =
+            (gtChainSyncTimeouts gt)
+              { mustReplyTimeout = Nothing,
+                idleTimeout = Nothing
+              }
+        }

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/DensityDisconnect.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/DensityDisconnect.hs
@@ -499,7 +499,8 @@ prop_densityDisconnectTriggersChainSel =
             (AF.Empty _)       -> Origin
             (_ AF.:> tipBlock) -> At tipBlock
           advTip = getOnlyBranchTip tree
-       in mkPointSchedule $ peers'
+       in PointSchedule {
+            psSchedule = peers'
             -- Eagerly serve the honest tree, but after the adversary has
             -- advertised its chain up to the intersection.
             [[(Time 0, scheduleTipPoint trunkTip),
@@ -514,4 +515,7 @@ prop_densityDisconnectTriggersChainSel =
               (Time 0, ScheduleBlockPoint intersect),
               (Time 1, scheduleHeaderPoint advTip),
               (Time 1, scheduleBlockPoint advTip)
-            ]]
+            ]],
+            psStartOrder = [],
+            psMinEndTime = Time 0
+          }

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LoE.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LoE.hs
@@ -26,16 +26,18 @@ import           Test.Tasty
 import           Test.Tasty.QuickCheck
 import           Test.Util.Orphans.IOLike ()
 import           Test.Util.PartialAccessors
-import           Test.Util.TestEnv (adjustQuickCheckTests)
+import           Test.Util.TestEnv (adjustQuickCheckMaxSize,
+                     adjustQuickCheckTests)
 
 tests :: TestTree
 tests =
+  adjustQuickCheckTests (* 10) $
   testGroup
     "LoE"
     [
-      adjustQuickCheckTests (`div` 5) $
+      adjustQuickCheckMaxSize (`div` 5) $
         testProperty "adversary does not hit timeouts" (prop_adversaryHitsTimeouts False),
-      adjustQuickCheckTests (`div` 5) $
+      adjustQuickCheckMaxSize (`div` 5) $
         testProperty "adversary hits timeouts" (prop_adversaryHitsTimeouts True)
     ]
 

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LoE.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LoE.hs
@@ -42,7 +42,14 @@ tests =
     ]
 
 -- | Tests that the selection advances in presence of the LoE when a peer is
--- killed by something that is not LoE-aware, eg. the timeouts.
+-- killed by something that is not LoE-aware, eg. the timeouts. This test
+-- features an honest peer behaving normally and an adversarial peer behaving
+-- such that it will get killed by timeouts. We check that, after the adversary
+-- gets disconnected, the LoE gets updated to stop taking it into account. There
+-- are two variants of the test: one with timeouts enabled, and one without. In
+-- the case where timeouts are disabled, we check that we do in fact remain
+-- stuck at the intersection between trunk and other chain.
+--
 -- NOTE: Same as 'LoP.prop_delayAttack' with timeouts instead of LoP.
 prop_adversaryHitsTimeouts :: Bool -> Property
 prop_adversaryHitsTimeouts timeoutsEnabled =

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LoE.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LoE.hs
@@ -115,4 +115,4 @@ prop_adversaryHitsTimeouts timeoutsEnabled =
             ]
           -- We want to wait more than the short wait timeout
           psMinEndTime = Time 11
-       in PointSchedule {psSchedule, psMinEndTime}
+       in PointSchedule {psSchedule, psStartOrder = [], psMinEndTime}

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LoP.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LoP.hs
@@ -59,6 +59,13 @@ tests =
         testProperty "delaying attack fails with LoP" (prop_delayAttack True)
     ]
 
+-- | Simple test in which we connect to only one peer, who advertises the tip of
+-- the block tree trunk and then does nothing. If the given boolean,
+-- @mustTimeout@, if @True@, then we wait just long enough for the LoP bucket to
+-- empty; we expect to observe an 'EmptyBucket' exception in the ChainSync
+-- client. If @mustTimeout@ is @False@, then we wait not quite as long, so the
+-- LoP bucket should not be empty at the end of the test and we should observe
+-- no exception in the ChainSync client.
 prop_wait :: Bool -> Property
 prop_wait mustTimeout =
   forAllGenesisTest
@@ -90,6 +97,13 @@ prop_wait mustTimeout =
             , psMinEndTime = Time $ timeout + offset
             }
 
+-- | Simple test in which we connect to only one peer, who advertises the tip of
+-- the block tree trunk, serves all of its headers, and then does nothing.
+-- Because the peer does not send its blocks, then the ChainSync client will end
+-- up stuck, waiting behind the forecast horizon. We expect that the LoP will
+-- then be disabled and that, therefore, one could wait forever in this state.
+-- We disable the timeouts and check that, indeed, the ChainSync client observes
+-- no exception.
 prop_waitBehindForecastHorizon :: Property
 prop_waitBehindForecastHorizon =
   forAllGenesisTest

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LoP.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LoP.hs
@@ -30,10 +30,12 @@ import           Test.Tasty
 import           Test.Tasty.QuickCheck
 import           Test.Util.Orphans.IOLike ()
 import           Test.Util.PartialAccessors
-import           Test.Util.TestEnv (adjustQuickCheckTests)
+import           Test.Util.TestEnv (adjustQuickCheckMaxSize,
+                     adjustQuickCheckTests)
 
 tests :: TestTree
 tests =
+  adjustQuickCheckTests (* 10) $
   testGroup
     "LoP"
     [ -- \| NOTE: Running the test that must _not_ timeout (@prop_smoke False@) takes
@@ -41,16 +43,18 @@ tests =
       -- does all the computation (serving the headers, validating them, serving the
       -- block, validating them) while the former does nothing, because it timeouts
       -- before reaching the last tick of the point schedule.
-      adjustQuickCheckTests (`div` 10) $
+      adjustQuickCheckMaxSize (`div` 5) $
         testProperty "wait just enough" (prop_wait False),
       testProperty "wait too much" (prop_wait True),
+      adjustQuickCheckMaxSize (`div` 5) $
       testProperty "wait behind forecast horizon" prop_waitBehindForecastHorizon,
-      adjustQuickCheckTests (`div` 5) $
+      adjustQuickCheckMaxSize (`div` 5) $
         testProperty "serve just fast enough" (prop_serve False),
+      adjustQuickCheckMaxSize (`div` 5) $
       testProperty "serve too slow" (prop_serve True),
-      adjustQuickCheckTests (`div` 5) $
+      adjustQuickCheckMaxSize (`div` 5) $
         testProperty "delaying attack succeeds without LoP" (prop_delayAttack False),
-      adjustQuickCheckTests (`div` 5) $
+      adjustQuickCheckMaxSize (`div` 5) $
         testProperty "delaying attack fails with LoP" (prop_delayAttack True)
     ]
 

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LoP.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LoP.hs
@@ -22,7 +22,8 @@ import           Test.Consensus.PeerSimulator.Run (SchedulerConfig (..),
                      defaultSchedulerConfig)
 import           Test.Consensus.PeerSimulator.StateView
 import           Test.Consensus.PointSchedule
-import           Test.Consensus.PointSchedule.Peers (peers', peersOnlyHonest)
+import           Test.Consensus.PointSchedule.Peers (peers', peersOnlyAdversary,
+                     peersOnlyHonest)
 import           Test.Consensus.PointSchedule.Shrinking (shrinkPeerSchedules)
 import           Test.Consensus.PointSchedule.SinglePeer (scheduleBlockPoint,
                      scheduleHeaderPoint, scheduleTipPoint)
@@ -82,7 +83,9 @@ prop_wait mustTimeout =
     dullSchedule timeout (_ AF.:> tipBlock) =
       let offset :: DiffTime = if mustTimeout then 1 else -1
        in PointSchedule
-            { psSchedule = peersOnlyHonest [(Time 0, scheduleTipPoint tipBlock)]
+            { psSchedule =
+                (if mustTimeout then peersOnlyAdversary else peersOnlyHonest)
+                [(Time 0, scheduleTipPoint tipBlock)]
             , psStartOrder = []
             , psMinEndTime = Time $ timeout + offset
             }
@@ -174,7 +177,7 @@ prop_serve mustTimeout =
     makeSchedule fragment@(_ AF.:> tipBlock) =
       PointSchedule {
         psSchedule =
-        peersOnlyHonest $
+        (if mustTimeout then peersOnlyAdversary else peersOnlyHonest) $
         (Time 0, scheduleTipPoint tipBlock)
           : ( flip concatMap (zip [1 ..] (AF.toOldestFirst fragment)) $ \(i, block) ->
                 [ (Time (secondsRationalToDiffTime (i * timeBetweenBlocks)), scheduleHeaderPoint block),

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LongRangeAttack.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LongRangeAttack.hs
@@ -34,6 +34,12 @@ tests =
     testProperty "one adversary" prop_longRangeAttack
   ]
 
+-- | This test case features a long-range attack with one adversary. The honest
+-- peer serves the block tree trunk, while the adversary serves its own chain,
+-- forking off the trunk by at least @k@ blocks, but less good than the trunk.
+-- The adversary serves the chain more rapidly than the honest peer. We check at
+-- the end that the selection is honest. This property does not hold with Praos,
+-- but should hold with Genesis.
 prop_longRangeAttack :: Property
 prop_longRangeAttack =
   -- NOTE: `shrinkPeerSchedules` only makes sense for tests that expect the

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
@@ -288,6 +288,7 @@ prop_leashingAttackTimeLimited =
           advs = fmap (takePointsUntil timeLimit) advs0
       pure $ PointSchedule
         { psSchedule = Peers honests advs
+        , psStartOrder = []
         , psMinEndTime = timeLimit
         }
 

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
@@ -421,6 +421,11 @@ prop_downtime = forAllGenesisTest
       , pgpDowntime = DowntimeWithSecurityParam (gtSecurityParam gt)
       }
 
+-- | Test that the block fetch leashing attack does not delay the immutable tip.
+-- This leashing attack consists in having adversarial peers that behave
+-- honestly when it comes to ChainSync but refuse to send blocks. A proper node
+-- under test should detect those behaviours as adversarial and find a way to
+-- make progress.
 prop_blockFetchLeashingAttack :: Property
 prop_blockFetchLeashingAttack =
   forAllGenesisTest
@@ -435,6 +440,9 @@ prop_blockFetchLeashingAttack =
   where
     genBlockFetchLeashingSchedule :: GenesisTest TestBlock () -> QC.Gen (PointSchedule TestBlock)
     genBlockFetchLeashingSchedule genesisTest = do
+      -- A schedule with several honest peers and no adversaries. We will then
+      -- keep one of those as honest and remove the block points from the
+      -- others, hence producing one honest peer and several adversaries.
       PointSchedule {psSchedule} <-
         stToGen $
           uniformPoints

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
@@ -237,15 +237,15 @@ prop_leashingAttackStalling =
       advs <- mapM dropRandomPoints $ adversarialPeers sch
       pure $ ps {psSchedule = sch {adversarialPeers = advs}}
 
-    dropRandomPoints :: [(Time, SchedulePoint blk)] -> QC.Gen [(Time, SchedulePoint blk)]
-    dropRandomPoints ps = do
+dropRandomPoints :: [(Time, SchedulePoint blk)] -> QC.Gen [(Time, SchedulePoint blk)]
+dropRandomPoints ps = do
       let lenps = length ps
           dropsMax = max 1 $ lenps - 1
       dropCount <- QC.choose (div dropsMax 2, dropsMax)
       let dedup = map NE.head . NE.group
       is <- fmap (dedup . sort) $ replicateM dropCount $ QC.choose (0, lenps - 1)
       pure $ dropElemsAt ps is
-
+  where
     dropElemsAt :: [a] -> [Int] -> [a]
     dropElemsAt xs is' =
       let is = Set.fromList is'
@@ -286,7 +286,8 @@ prop_leashingAttackTimeLimited =
             (gtLoPBucketParams genesisTest)
             (getHonestPeer honests)
             (Map.elems advs0)
-          advs = fmap (takePointsUntil timeLimit) advs0
+          advs1 = fmap (takePointsUntil timeLimit) advs0
+      advs <- mapM dropRandomPoints advs1
       pure $ PointSchedule
         { psSchedule = Peers honests advs
         , psStartOrder = []

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
@@ -23,6 +23,7 @@ import           Data.List (intercalate, sort, uncons)
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as Map
 import           Data.Maybe (fromMaybe, mapMaybe)
+import qualified Data.Set as Set
 import           Data.Word (Word64)
 import           GHC.Stack (HasCallStack)
 import           Ouroboros.Consensus.Block.Abstract (WithOrigin (NotOrigin))
@@ -239,10 +240,9 @@ prop_leashingAttackStalling =
       pure $ dropElemsAt ps is
 
     dropElemsAt :: [a] -> [Int] -> [a]
-    dropElemsAt xs [] = xs
-    dropElemsAt xs (i:is) =
-      let (ys, zs) = splitAt i xs
-       in ys ++ dropElemsAt (drop 1 zs) is
+    dropElemsAt xs is' =
+      let is = Set.fromList is'
+      in map fst $ filter (\(_, i) -> not $ i `Set.member` is) (zip xs [0..])
 
 -- | Test that the leashing attacks do not delay the immutable tip after. The
 -- immutable tip needs to be advanced enough when the honest peer has offered

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
@@ -213,6 +213,7 @@ prop_leashingAttackStalling =
       , scEnableLoE = True
       , scEnableLoP = True
       , scEnableCSJ = True
+      , scEnableBlockFetchTimeouts = False
       }
 
     shrinkPeerSchedules
@@ -234,7 +235,8 @@ prop_leashingAttackStalling =
     dropRandomPoints :: [(Time, SchedulePoint blk)] -> QC.Gen [(Time, SchedulePoint blk)]
     dropRandomPoints ps = do
       let lenps = length ps
-      dropCount <- QC.choose (0, max 1 $ div lenps 5)
+          dropsMax = max 1 $ lenps - 1
+      dropCount <- QC.choose (div dropsMax 2, dropsMax)
       let dedup = map NE.head . NE.group
       is <- fmap (dedup . sort) $ replicateM dropCount $ QC.choose (0, lenps - 1)
       pure $ dropElemsAt ps is

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
@@ -211,7 +211,7 @@ prop_leashingAttackStalling :: Property
 prop_leashingAttackStalling =
   forAllGenesisTest
 
-    (disableBoringTimeouts <$> genChains (QC.choose (1, 4)) `enrichedWith` genLeashingSchedule)
+    (genChains (QC.choose (1, 4)) `enrichedWith` genLeashingSchedule)
 
     defaultSchedulerConfig
       { scTrace = False
@@ -260,9 +260,7 @@ prop_leashingAttackTimeLimited :: Property
 prop_leashingAttackTimeLimited =
   forAllGenesisTest
 
-    (disableCanAwaitTimeout . disableBoringTimeouts <$>
-      genChains (QC.choose (1, 4)) `enrichedWith` genTimeLimitedSchedule
-    )
+    (genChains (QC.choose (1, 4)) `enrichedWith` genTimeLimitedSchedule)
 
     defaultSchedulerConfig
       { scTrace = False
@@ -336,15 +334,6 @@ prop_leashingAttackTimeLimited =
     fromTipPoint (t, ScheduleTipPoint bp) = Just (t, bp)
     fromTipPoint _                        = Nothing
 
-    disableCanAwaitTimeout :: GenesisTest blk schedule -> GenesisTest blk schedule
-    disableCanAwaitTimeout gt =
-      gt
-        { gtChainSyncTimeouts =
-            (gtChainSyncTimeouts gt)
-              { canAwaitTimeout = Nothing
-              }
-        }
-
 headCallStack :: HasCallStack => [a] -> a
 headCallStack = \case
   x:_ -> x
@@ -398,7 +387,7 @@ prop_loeStalling =
 prop_downtime :: Property
 prop_downtime = forAllGenesisTest
 
-    (disableBoringTimeouts <$> genChains (QC.choose (1, 4)) `enrichedWith` \ gt ->
+    (genChains (QC.choose (1, 4)) `enrichedWith` \ gt ->
       ensureScheduleDuration gt <$> stToGen (uniformPoints (pointsGeneratorParams gt) (gtBlockTree gt)))
 
     defaultSchedulerConfig
@@ -434,7 +423,7 @@ prop_downtime = forAllGenesisTest
 prop_blockFetchLeashingAttack :: Property
 prop_blockFetchLeashingAttack =
   forAllGenesisTest
-    (disableBoringTimeouts <$> genChains (pure 0) `enrichedWith` genBlockFetchLeashingSchedule)
+    (genChains (pure 0) `enrichedWith` genBlockFetchLeashingSchedule)
     defaultSchedulerConfig
       { scEnableLoE = True,
         scEnableLoP = True,
@@ -481,13 +470,3 @@ prop_blockFetchLeashingAttack =
 -- adversarial peer.
 addGracePeriodDelay :: Int -> Time -> Time
 addGracePeriodDelay adversaryCount = addTime (fromIntegral adversaryCount * 10)
-
-disableBoringTimeouts :: GenesisTest blk schedule -> GenesisTest blk schedule
-disableBoringTimeouts gt =
-    gt
-      { gtChainSyncTimeouts =
-          (gtChainSyncTimeouts gt)
-            { mustReplyTimeout = Nothing
-            , idleTimeout = Nothing
-            }
-      }

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/BlockFetch.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/BlockFetch.hs
@@ -6,8 +6,6 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
 
-{-# OPTIONS_GHC -Wno-missing-export-lists #-}
-
 -- | Functions that call to the BlockFetch API to start clients and servers
 module Test.Consensus.PeerSimulator.BlockFetch (
     blockFetchNoTimeouts
@@ -31,13 +29,16 @@ import           Ouroboros.Consensus.Config
 import qualified Ouroboros.Consensus.MiniProtocol.BlockFetch.ClientInterface as BlockFetchClientInterface
 import           Ouroboros.Consensus.MiniProtocol.ChainSync.Client
                      (ChainSyncClientHandleCollection)
+import           Ouroboros.Consensus.Node.Genesis (GenesisConfig (..),
+                     enableGenesisConfigDefault)
 import           Ouroboros.Consensus.Node.ProtocolInfo
                      (NumCoreNodes (NumCoreNodes))
 import           Ouroboros.Consensus.Storage.ChainDB.API
 import           Ouroboros.Consensus.Util (ShowProxy)
 import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Network.BlockFetch (BlockFetchConfiguration (..),
-                     FetchClientRegistry, FetchMode (..), blockFetchLogic,
+                     FetchClientRegistry, FetchMode (..),
+                     GenesisBlockFetchConfiguration (..), blockFetchLogic,
                      bracketFetchClient, bracketKeepAliveClient)
 import           Ouroboros.Network.BlockFetch.Client (blockFetchClient)
 import           Ouroboros.Network.Channel (Channel)
@@ -70,14 +71,15 @@ import           Test.Util.Time (dawnOfTime)
 
 startBlockFetchLogic ::
      forall m.
-     (IOLike m)
-  => ResourceRegistry m
+     (IOLike m, MonadTimer m)
+  => Bool -- ^ Whether to enable chain selection starvation
+  -> ResourceRegistry m
   -> Tracer m (TraceEvent TestBlock)
   -> ChainDB m TestBlock
   -> FetchClientRegistry PeerId (Header TestBlock) TestBlock m
   -> ChainSyncClientHandleCollection PeerId m TestBlock
   -> m ()
-startBlockFetchLogic registry tracer chainDb fetchClientRegistry csHandlesCol = do
+startBlockFetchLogic enableChainSelStarvation registry tracer chainDb fetchClientRegistry csHandlesCol = do
     let slotForgeTime :: BlockFetchClientInterface.SlotForgeTimeOracle m blk
         slotForgeTime _ = pure dawnOfTime
 
@@ -91,16 +93,17 @@ startBlockFetchLogic registry tracer chainDb fetchClientRegistry csHandlesCol = 
             -- do not serialize the blocks.
             (\_hdr -> 1000)
             slotForgeTime
-            -- Initially, we tried FetchModeBulkSync, but adversaries had the
-            -- opportunity to delay syncing by not responding to block requests.
-            -- The BlockFetch logic would then wait for the timeout to expire
-            -- before trying to download the block from another peer.
-            (pure FetchModeDeadline)
+            -- This is a syncing test, so we use 'FetchModeBulkSync'.
+            (pure FetchModeBulkSync)
             DiffusionPipeliningOn
 
         bfcGenesisBFConfig = if enableChainSelStarvation
           then GenesisBlockFetchConfiguration
-            { gbfcBulkSyncGracePeriod = 1000000 -- (more than 11 days)
+            { gbfcBulkSyncGracePeriod =
+                if enableChainSelStarvation then
+                  10  -- default value for cardano-node at the time of writing
+                else
+                  1000000  -- (more than 11 days)
             }
           else gcBlockFetchConfig enableGenesisConfigDefault
 
@@ -109,9 +112,10 @@ startBlockFetchLogic registry tracer chainDb fetchClientRegistry csHandlesCol = 
         blockFetchCfg = BlockFetchConfiguration
           { bfcMaxConcurrencyDeadline = 50 -- unused because of @pure FetchModeBulkSync@ above
           , bfcMaxRequestsInflight = 10
-          , bfcDecisionLoopInterval = 0
+          , bfcDecisionLoopIntervalBulkSync = 0
+          , bfcDecisionLoopIntervalDeadline = 0
           , bfcSalt = 0
-          , bfcBulkSyncGracePeriod
+          , bfcGenesisBFConfig
           }
 
     void $ forkLinkedThread registry "BlockFetchLogic" $

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/BlockFetch.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/BlockFetch.hs
@@ -37,10 +37,12 @@ import           Ouroboros.Consensus.Storage.ChainDB.API
 import           Ouroboros.Consensus.Util (ShowProxy)
 import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Network.BlockFetch (BlockFetchConfiguration (..),
-                     FetchClientRegistry, FetchMode (..),
-                     GenesisBlockFetchConfiguration (..), blockFetchLogic,
-                     bracketFetchClient, bracketKeepAliveClient)
+                     FetchClientRegistry, GenesisBlockFetchConfiguration (..),
+                     blockFetchLogic, bracketFetchClient,
+                     bracketKeepAliveClient)
 import           Ouroboros.Network.BlockFetch.Client (blockFetchClient)
+import           Ouroboros.Network.BlockFetch.ConsensusInterface
+                     (FetchMode (..))
 import           Ouroboros.Network.Channel (Channel)
 import           Ouroboros.Network.ControlMessage (ControlMessageSTM)
 import           Ouroboros.Network.Driver (runPeer)
@@ -93,13 +95,13 @@ startBlockFetchLogic enableChainSelStarvation registry tracer chainDb fetchClien
             -- do not serialize the blocks.
             (\_hdr -> 1000)
             slotForgeTime
-            -- This is a syncing test, so we use 'FetchModeBulkSync'.
-            (pure FetchModeBulkSync)
+            -- This is a syncing test, so we use 'FetchModeGenesis'.
+            (pure FetchModeGenesis)
             DiffusionPipeliningOn
 
         bfcGenesisBFConfig = if enableChainSelStarvation
           then GenesisBlockFetchConfiguration
-            { gbfcBulkSyncGracePeriod =
+            { gbfcGracePeriod =
                 if enableChainSelStarvation then
                   10  -- default value for cardano-node at the time of writing
                 else
@@ -110,10 +112,11 @@ startBlockFetchLogic enableChainSelStarvation registry tracer chainDb fetchClien
         -- Values taken from
         -- ouroboros-consensus-diffusion/src/unstable-diffusion-testlib/Test/ThreadNet/Network.hs
         blockFetchCfg = BlockFetchConfiguration
-          { bfcMaxConcurrencyDeadline = 50 -- unused because of @pure FetchModeBulkSync@ above
+          { bfcMaxConcurrencyBulkSync = 50
+          , bfcMaxConcurrencyDeadline = 50 -- unused because of @pure FetchModeBulkSync@ above
           , bfcMaxRequestsInflight = 10
-          , bfcDecisionLoopIntervalBulkSync = 0
-          , bfcDecisionLoopIntervalDeadline = 0
+          , bfcDecisionLoopIntervalPraos = 0
+          , bfcDecisionLoopIntervalGenesis = 0
           , bfcSalt = 0
           , bfcGenesisBFConfig
           }

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/BlockFetch.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/BlockFetch.hs
@@ -83,6 +83,7 @@ startBlockFetchLogic registry tracer chainDb fetchClientRegistry csHandlesCol = 
 
         blockFetchConsensusInterface =
           BlockFetchClientInterface.mkBlockFetchConsensusInterface
+            nullTracer -- FIXME
             (TestBlockConfig $ NumCoreNodes 0) -- Only needed when minting blocks
             (BlockFetchClientInterface.defaultChainDbView chainDb)
             csHandlesCol

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/BlockFetch.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/BlockFetch.hs
@@ -17,28 +17,25 @@ module Test.Consensus.PeerSimulator.BlockFetch (
   , startKeepAliveThread
   ) where
 
-import           Control.Exception (SomeException)
 import           Control.Monad (void)
 import           Control.Monad.Class.MonadTime
 import           Control.Monad.Class.MonadTimer.SI (MonadTimer)
 import           Control.ResourceRegistry
 import           Control.Tracer (Tracer, nullTracer, traceWith)
 import           Data.Functor.Contravariant ((>$<))
-import           Data.Map.Strict (Map)
 import           Network.TypedProtocol.Codec (ActiveState, AnyMessage,
                      StateToken, notActiveState)
 import           Ouroboros.Consensus.Block (HasHeader)
 import           Ouroboros.Consensus.Block.Abstract (Header, Point (..))
 import           Ouroboros.Consensus.Config
 import qualified Ouroboros.Consensus.MiniProtocol.BlockFetch.ClientInterface as BlockFetchClientInterface
+import           Ouroboros.Consensus.MiniProtocol.ChainSync.Client
+                     (ChainSyncClientHandleCollection)
 import           Ouroboros.Consensus.Node.ProtocolInfo
                      (NumCoreNodes (NumCoreNodes))
 import           Ouroboros.Consensus.Storage.ChainDB.API
 import           Ouroboros.Consensus.Util (ShowProxy)
-import           Ouroboros.Consensus.Util.IOLike (DiffTime,
-                     Exception (fromException), IOLike, STM, atomically, retry,
-                     try)
-import           Ouroboros.Network.AnchoredFragment (AnchoredFragment)
+import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Network.BlockFetch (BlockFetchConfiguration (..),
                      FetchClientRegistry, FetchMode (..), blockFetchLogic,
                      bracketFetchClient, bracketKeepAliveClient)
@@ -78,9 +75,9 @@ startBlockFetchLogic ::
   -> Tracer m (TraceEvent TestBlock)
   -> ChainDB m TestBlock
   -> FetchClientRegistry PeerId (Header TestBlock) TestBlock m
-  -> STM m (Map PeerId (AnchoredFragment (Header TestBlock)))
+  -> ChainSyncClientHandleCollection PeerId m TestBlock
   -> m ()
-startBlockFetchLogic registry tracer chainDb fetchClientRegistry getCandidates = do
+startBlockFetchLogic registry tracer chainDb fetchClientRegistry csHandlesCol = do
     let slotForgeTime :: BlockFetchClientInterface.SlotForgeTimeOracle m blk
         slotForgeTime _ = pure dawnOfTime
 
@@ -88,7 +85,7 @@ startBlockFetchLogic registry tracer chainDb fetchClientRegistry getCandidates =
           BlockFetchClientInterface.mkBlockFetchConsensusInterface
             (TestBlockConfig $ NumCoreNodes 0) -- Only needed when minting blocks
             (BlockFetchClientInterface.defaultChainDbView chainDb)
-            getCandidates
+            csHandlesCol
             -- The size of headers in bytes is irrelevant because our tests
             -- do not serialize the blocks.
             (\_hdr -> 1000)
@@ -103,17 +100,7 @@ startBlockFetchLogic registry tracer chainDb fetchClientRegistry getCandidates =
         -- Values taken from
         -- ouroboros-consensus-diffusion/src/unstable-diffusion-testlib/Test/ThreadNet/Network.hs
         blockFetchCfg = BlockFetchConfiguration
-          { -- We set a higher value here to allow downloading blocks from all
-            -- peers.
-            --
-            -- If the value is too low, block downloads from a peer may prevent
-            -- blocks from being downloaded from other peers. This can be
-            -- problematic, since the batch download of a simulated BlockFetch
-            -- server can last serveral ticks if the block pointer is not
-            -- advanced to allow completion of the batch.
-            --
-            bfcMaxConcurrencyBulkSync = 50
-          , bfcMaxConcurrencyDeadline = 50
+          { bfcMaxConcurrencyDeadline = 50 -- unused because of @pure FetchModeBulkSync@ above
           , bfcMaxRequestsInflight = 10
           , bfcDecisionLoopInterval = 0
           , bfcSalt = 0

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/BlockFetch.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/BlockFetch.hs
@@ -98,6 +98,12 @@ startBlockFetchLogic registry tracer chainDb fetchClientRegistry csHandlesCol = 
             (pure FetchModeDeadline)
             DiffusionPipeliningOn
 
+        bfcGenesisBFConfig = if enableChainSelStarvation
+          then GenesisBlockFetchConfiguration
+            { gbfcBulkSyncGracePeriod = 1000000 -- (more than 11 days)
+            }
+          else gcBlockFetchConfig enableGenesisConfigDefault
+
         -- Values taken from
         -- ouroboros-consensus-diffusion/src/unstable-diffusion-testlib/Test/ThreadNet/Network.hs
         blockFetchCfg = BlockFetchConfiguration
@@ -105,6 +111,7 @@ startBlockFetchLogic registry tracer chainDb fetchClientRegistry csHandlesCol = 
           , bfcMaxRequestsInflight = 10
           , bfcDecisionLoopInterval = 0
           , bfcSalt = 0
+          , bfcBulkSyncGracePeriod
           }
 
     void $ forkLinkedThread registry "BlockFetchLogic" $

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/CSJInvariants.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/CSJInvariants.hs
@@ -19,7 +19,7 @@ import           Data.Typeable (Typeable)
 import           Ouroboros.Consensus.Block (Point, StandardHash, castPoint)
 import qualified Ouroboros.Consensus.MiniProtocol.ChainSync.Client.State as CSState
 import           Ouroboros.Consensus.Util.IOLike (Exception, MonadSTM (STM),
-                     MonadThrow (throwIO), StrictTVar, readTVar)
+                     MonadThrow (throwIO), readTVar)
 import           Ouroboros.Consensus.Util.STM (Watcher (..))
 
 --------------------------------------------------------------------------------
@@ -109,10 +109,10 @@ readAndView ::
   forall m peer blk.
   ( MonadSTM m
   ) =>
-  StrictTVar m (Map peer (CSState.ChainSyncClientHandle m blk)) ->
+  STM m (Map peer (CSState.ChainSyncClientHandle m blk)) ->
   STM m (View peer blk)
-readAndView handles =
-  traverse (fmap idealiseState . readTVar . CSState.cschJumping) =<< readTVar handles
+readAndView readHandles =
+  traverse (fmap idealiseState . readTVar . CSState.cschJumping) =<< readHandles
   where
     -- Idealise the state of a ChainSync peer with respect to ChainSync jumping.
     -- In particular, we get rid of non-comparable information such as the TVars
@@ -170,7 +170,7 @@ watcher ::
     Typeable blk,
     StandardHash blk
   ) =>
-  StrictTVar m (Map peer (CSState.ChainSyncClientHandle m blk)) ->
+  STM m (Map peer (CSState.ChainSyncClientHandle m blk)) ->
   Watcher m (View peer blk) (View peer blk)
 watcher handles =
   Watcher

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/ChainSync.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/ChainSync.hs
@@ -13,7 +13,6 @@ module Test.Consensus.PeerSimulator.ChainSync (
 import           Control.Exception (SomeException)
 import           Control.Monad.Class.MonadTimer.SI (MonadTimer)
 import           Control.Tracer (Tracer (Tracer), nullTracer, traceWith)
-import           Data.Map.Strict (Map)
 import           Data.Proxy (Proxy (..))
 import           Network.TypedProtocol.Codec (AnyMessage)
 import           Ouroboros.Consensus.Block (Header, Point)
@@ -23,16 +22,17 @@ import           Ouroboros.Consensus.Config (DiffusionPipeliningSupport (..),
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
                      (LedgerSupportsProtocol)
 import           Ouroboros.Consensus.MiniProtocol.ChainSync.Client
-                     (CSJConfig (..), ChainDbView, ChainSyncClientHandle,
-                     ChainSyncLoPBucketConfig, ChainSyncStateView (..),
-                     Consensus, bracketChainSyncClient, chainSyncClient)
+                     (CSJConfig (..), ChainDbView,
+                     ChainSyncClientHandleCollection, ChainSyncLoPBucketConfig,
+                     ChainSyncStateView (..), Consensus, bracketChainSyncClient,
+                     chainSyncClient)
 import qualified Ouroboros.Consensus.MiniProtocol.ChainSync.Client as CSClient
 import qualified Ouroboros.Consensus.MiniProtocol.ChainSync.Client.HistoricityCheck as HistoricityCheck
 import qualified Ouroboros.Consensus.MiniProtocol.ChainSync.Client.InFutureCheck as InFutureCheck
 import           Ouroboros.Consensus.Node.GsmState (GsmState (Syncing))
 import           Ouroboros.Consensus.Util (ShowProxy)
 import           Ouroboros.Consensus.Util.IOLike (Exception (fromException),
-                     IOLike, MonadCatch (try), StrictTVar)
+                     IOLike, MonadCatch (try))
 import           Ouroboros.Network.Block (Tip)
 import           Ouroboros.Network.Channel (Channel)
 import           Ouroboros.Network.ControlMessage (ControlMessage (..))
@@ -134,7 +134,7 @@ runChainSyncClient ::
   -- ^ Configuration for ChainSync Jumping
   StateViewTracers blk m ->
   -- ^ Tracers used to record information for the future 'StateView'.
-  StrictTVar m (Map PeerId (ChainSyncClientHandle m blk)) ->
+  ChainSyncClientHandleCollection PeerId m blk ->
   -- ^ A TVar containing a map of states for each peer. This
   -- function will (via 'bracketChainSyncClient') register and de-register a
   -- TVar for the state of the peer.

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/NodeLifecycle.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/NodeLifecycle.hs
@@ -20,6 +20,8 @@ import           Data.Set (Set)
 import qualified Data.Set as Set
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config (TopLevelConfig (..))
+import           Ouroboros.Consensus.MiniProtocol.ChainSync.Client
+                     (ChainSyncClientHandleCollection (..))
 import           Ouroboros.Consensus.Storage.ChainDB.API
 import qualified Ouroboros.Consensus.Storage.ChainDB.API as ChainDB
 import qualified Ouroboros.Consensus.Storage.ChainDB.Impl as ChainDB
@@ -204,7 +206,7 @@ lifecycleStop resources LiveNode {lnStateViewTracers, lnCopyToImmDb, lnPeers} = 
   releaseAll lrRegistry
   -- Reset the resources in TVars that were allocated by the simulator
   atomically $ do
-    modifyTVar psrHandles (const mempty)
+    cschcRemoveAllHandles psrHandles
     case lrLoEVar of
       LoEEnabled var -> modifyTVar var (const (AF.Empty AF.AnchorGenesis))
       LoEDisabled    -> pure ()

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Run.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Run.hs
@@ -391,6 +391,7 @@ startNode schedulerConfig genesisTest interval = do
           lrConfig
           (mkGDDTracerTestBlock lrTracer)
           lnChainDb
+          1.0 -- Default config value in NodeKernel.hs at the time or writing
           (pure GSM.Syncing) -- TODO actually run GSM
           (cschcMap handles)
           var

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Run.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Run.hs
@@ -27,7 +27,9 @@ import           Ouroboros.Consensus.Ledger.SupportsProtocol
                      (LedgerSupportsProtocol)
 import           Ouroboros.Consensus.MiniProtocol.ChainSync.Client
                      (CSJConfig (..), CSJEnabledConfig (..), ChainDbView,
-                     ChainSyncClientHandle, ChainSyncLoPBucketConfig (..),
+                     ChainSyncClientHandle,
+                     ChainSyncClientHandleCollection (..),
+                     ChainSyncLoPBucketConfig (..),
                      ChainSyncLoPBucketEnabledConfig (..), viewChainSyncState)
 import qualified Ouroboros.Consensus.MiniProtocol.ChainSync.Client as CSClient
 import qualified Ouroboros.Consensus.Node.GsmState as GSM
@@ -147,7 +149,7 @@ startChainSyncConnectionThread ::
   ChainSyncLoPBucketConfig ->
   CSJConfig ->
   StateViewTracers blk m ->
-  StrictTVar m (Map PeerId (ChainSyncClientHandle m blk)) ->
+  ChainSyncClientHandleCollection PeerId m blk ->
   m (Thread m (), Thread m ())
 startChainSyncConnectionThread
   registry
@@ -230,7 +232,7 @@ smartDelay _ node duration = do
 dispatchTick :: forall m blk.
   IOLike m =>
   Tracer m (TraceSchedulerEvent blk) ->
-  StrictTVar m (Map PeerId (ChainSyncClientHandle m blk)) ->
+  STM m (Map PeerId (ChainSyncClientHandle m blk)) ->
   Map PeerId (PeerResources m blk) ->
   NodeLifecycle blk m ->
   LiveNode blk m ->
@@ -250,7 +252,7 @@ dispatchTick tracer varHandles peers lifecycle node (number, (duration, Peer pid
     traceNewTick = do
       currentChain <- atomically $ ChainDB.getCurrentChain (lnChainDb node)
       (csState, jumpingStates) <- atomically $ do
-         m <- readTVar varHandles
+         m <- varHandles
          csState <- traverse (readTVar . CSClient.cschState) (m Map.!? pid)
          jumpingStates <- forM (Map.toList m) $ \(peer, h) -> do
            st <- readTVar (CSClient.cschJumping h)
@@ -272,7 +274,7 @@ dispatchTick tracer varHandles peers lifecycle node (number, (duration, Peer pid
 runScheduler ::
   IOLike m =>
   Tracer m (TraceSchedulerEvent blk) ->
-  StrictTVar m (Map PeerId (ChainSyncClientHandle m blk)) ->
+  STM m (Map PeerId (ChainSyncClientHandle m blk)) ->
   PointSchedule blk ->
   Map PeerId (PeerResources m blk) ->
   NodeLifecycle blk m ->
@@ -314,7 +316,7 @@ mkStateTracer ::
   m (Tracer m ())
 mkStateTracer schedulerConfig GenesisTest {gtBlockTree} PeerSimulatorResources {psrHandles, psrPeers} chainDb
   | scTraceState schedulerConfig
-  , let getCandidates = viewChainSyncState psrHandles CSClient.csCandidate
+  , let getCandidates = viewChainSyncState (cschcMap psrHandles) CSClient.csCandidate
         getCurrentChain = ChainDB.getCurrentChain chainDb
         getPoints = traverse readTVar (srCurrentState . prShared <$> psrPeers)
   = peerSimStateDiagramSTMTracerDebug gtBlockTree getCurrentChain getCandidates getPoints
@@ -335,7 +337,7 @@ startNode ::
 startNode schedulerConfig genesisTest interval = do
   let
       handles = psrHandles lrPeerSim
-      getCandidates = viewChainSyncState handles CSClient.csCandidate
+      getCandidates = viewChainSyncState (cschcMap handles) CSClient.csCandidate
   fetchClientRegistry <- newFetchClientRegistry
   let chainDbView = CSClient.defaultChainDbView lnChainDb
       activePeers = Map.restrictKeys (psrPeers lrPeerSim) (lirActive liveResult)
@@ -384,10 +386,11 @@ startNode schedulerConfig genesisTest interval = do
           (mkGDDTracerTestBlock lrTracer)
           lnChainDb
           (pure GSM.Syncing) -- TODO actually run GSM
-          (readTVar handles)
+          (cschcMap handles)
           var
 
-  void $ forkLinkedWatcher lrRegistry "CSJ invariants watcher" $ CSJInvariants.watcher handles
+  void $ forkLinkedWatcher lrRegistry "CSJ invariants watcher" $
+    CSJInvariants.watcher (cschcMap handles)
   where
     LiveResources {lrRegistry, lrTracer, lrConfig, lrPeerSim, lrLoEVar} = resources
 
@@ -483,7 +486,7 @@ runPointSchedule schedulerConfig genesisTest tracer0 =
     lifecycle <- nodeLifecycle schedulerConfig genesisTest tracer registry peerSim
     (chainDb, stateViewTracers) <- runScheduler
       (Tracer $ traceWith tracer . TraceSchedulerEvent)
-      (psrHandles peerSim)
+      (cschcMap (psrHandles peerSim))
       gtSchedule
       (psrPeers peerSim)
       lifecycle

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Run.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Run.hs
@@ -336,9 +336,7 @@ startNode ::
   LiveInterval TestBlock m ->
   m ()
 startNode schedulerConfig genesisTest interval = do
-  let
-      handles = psrHandles lrPeerSim
-      getCandidates = viewChainSyncState (cschcMap handles) CSClient.csCandidate
+  let handles = psrHandles lrPeerSim
   fetchClientRegistry <- newFetchClientRegistry
   let chainDbView = CSClient.defaultChainDbView lnChainDb
       activePeers = Map.toList $ Map.restrictKeys (psrPeers lrPeerSim) (lirActive liveResult)
@@ -385,7 +383,7 @@ startNode schedulerConfig genesisTest interval = do
   -- The block fetch logic needs to be started after the block fetch clients
   -- otherwise, an internal assertion fails because getCandidates yields more
   -- peer fragments than registered clients.
-  BlockFetch.startBlockFetchLogic lrRegistry lrTracer lnChainDb fetchClientRegistry getCandidates
+  BlockFetch.startBlockFetchLogic lrRegistry lrTracer lnChainDb fetchClientRegistry handles
 
   for_ lrLoEVar $ \ var -> do
       forkLinkedWatcher lrRegistry "LoE updater background" $

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Run.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Run.hs
@@ -17,6 +17,7 @@ import           Control.ResourceRegistry
 import           Control.Tracer (Tracer (..), nullTracer, traceWith)
 import           Data.Coerce (coerce)
 import           Data.Foldable (for_)
+import           Data.List (sort)
 import qualified Data.List.NonEmpty as NonEmpty
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
@@ -340,8 +341,15 @@ startNode schedulerConfig genesisTest interval = do
       getCandidates = viewChainSyncState (cschcMap handles) CSClient.csCandidate
   fetchClientRegistry <- newFetchClientRegistry
   let chainDbView = CSClient.defaultChainDbView lnChainDb
-      activePeers = Map.restrictKeys (psrPeers lrPeerSim) (lirActive liveResult)
-  for_ activePeers $ \PeerResources {prShared, prChainSync, prBlockFetch} -> do
+      activePeers = Map.toList $ Map.restrictKeys (psrPeers lrPeerSim) (lirActive liveResult)
+      peersStartOrder = psStartOrder ++ sort [pid | (pid, _) <- activePeers, pid `notElem` psStartOrder]
+      activePeersOrdered = [
+          peerResources
+          | pid <- peersStartOrder
+          , (pid', peerResources) <- activePeers
+          , pid == pid'
+          ]
+  for_ activePeersOrdered $ \PeerResources {prShared, prChainSync, prBlockFetch} -> do
     let pid = srPeerId prShared
     forkLinkedThread lrRegistry ("Peer overview " ++ show pid) $
       -- The peerRegistry helps ensuring that if any thread fails, then
@@ -405,6 +413,7 @@ startNode schedulerConfig genesisTest interval = do
       , gtBlockFetchTimeouts
       , gtLoPBucketParams = LoPBucketParams { lbpCapacity, lbpRate }
       , gtCSJParams = CSJParams { csjpJumpSize }
+      , gtSchedule = PointSchedule {psStartOrder}
       } = genesisTest
 
     StateViewTracers{svtTraceTracer} = lnStateViewTracers

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/LinkedThreads.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/LinkedThreads.hs
@@ -72,4 +72,4 @@ prop_chainSyncKillsBlockFetch = do
               (Time 0, scheduleHeaderPoint firstBlock)
             ]
           psMinEndTime = Time $ timeout + 1
-       in PointSchedule {psSchedule, psMinEndTime}
+       in PointSchedule {psSchedule, psStartOrder = [], psMinEndTime}

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
@@ -95,7 +95,11 @@ rollbackSchedule n blockTree =
           , banalSchedulePoints trunkSuffix
           , banalSchedulePoints (btbSuffix branch)
           ]
-    in mkPointSchedule $ peersOnlyHonest $ zip (map (Time . (/30)) [0..]) schedulePoints
+    in PointSchedule {
+         psSchedule = peersOnlyHonest $ zip (map (Time . (/30)) [0..]) schedulePoints,
+         psStartOrder = [],
+         psMinEndTime = Time 0
+       }
   where
     banalSchedulePoints :: AnchoredFragment blk -> [SchedulePoint blk]
     banalSchedulePoints = concatMap banalSchedulePoints' . toOldestFirst

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
@@ -70,4 +70,4 @@ prop_timeouts mustTimeout = do
             ]
           -- This keeps the test running long enough to pass the timeout by 'offset'.
           psMinEndTime = Time $ timeout + offset
-       in PointSchedule {psSchedule, psMinEndTime}
+       in PointSchedule {psSchedule, psStartOrder = [], psMinEndTime}

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
@@ -18,7 +18,8 @@ import           Test.Consensus.Genesis.Setup
 import           Test.Consensus.PeerSimulator.Run (defaultSchedulerConfig)
 import           Test.Consensus.PeerSimulator.StateView
 import           Test.Consensus.PointSchedule
-import           Test.Consensus.PointSchedule.Peers (peersOnlyHonest)
+import           Test.Consensus.PointSchedule.Peers (peersOnlyAdversary,
+                     peersOnlyHonest)
 import           Test.Consensus.PointSchedule.SinglePeer (scheduleBlockPoint,
                      scheduleHeaderPoint, scheduleTipPoint)
 import           Test.QuickCheck
@@ -63,7 +64,7 @@ prop_timeouts mustTimeout = do
     dullSchedule _ (AF.Empty _) = error "requires a non-empty block tree"
     dullSchedule timeout (_ AF.:> tipBlock) =
       let offset :: DiffTime = if mustTimeout then 1 else -1
-          psSchedule = peersOnlyHonest $ [
+          psSchedule = (if mustTimeout then peersOnlyAdversary else peersOnlyHonest) $ [
               (Time 0, scheduleTipPoint tipBlock),
               (Time 0, scheduleHeaderPoint tipBlock),
               (Time 0, scheduleBlockPoint tipBlock)

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Trace.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Trace.hs
@@ -43,6 +43,7 @@ import qualified Ouroboros.Consensus.Storage.ChainDB.Impl as ChainDB
 import           Ouroboros.Consensus.Storage.ChainDB.Impl.Types
                      (TraceAddBlockEvent (..))
 import           Ouroboros.Consensus.Util.Condense (condense)
+import           Ouroboros.Consensus.Util.Enclose
 import           Ouroboros.Consensus.Util.IOLike (IOLike, MonadMonotonicTime,
                      Time (Time), atomically, getMonotonicTime, readTVarIO,
                      uncheckedNewTVarM, writeTVar)
@@ -376,10 +377,10 @@ traceChainDBEventTestBlockWith tracer = \case
         AddedReprocessLoEBlocksToQueue ->
           trace $ "Requested ChainSel run"
         _ -> pure ()
-    ChainDB.TraceChainSelStarvationEvent (ChainDB.ChainSelStarvationStarted time) ->
-      trace $ "ChainSel starvation started at " ++ prettyTime time
-    ChainDB.TraceChainSelStarvationEvent (ChainDB.ChainSelStarvationEnded time pt) ->
-      trace $ "ChainSel starvation ended at " ++ prettyTime time ++ " thanks to " ++ terseRealPoint pt
+    ChainDB.TraceChainSelStarvationEvent (ChainDB.ChainSelStarvation RisingEdge) ->
+      trace "ChainSel starvation started"
+    ChainDB.TraceChainSelStarvationEvent (ChainDB.ChainSelStarvation (FallingEdgeWith pt)) ->
+      trace $ "ChainSel starvation ended thanks to " ++ terseRealPoint pt
     _ -> pure ()
   where
     trace = traceUnitWith tracer "ChainDB"

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Trace.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Trace.hs
@@ -370,6 +370,10 @@ traceChainDBEventTestBlockWith tracer = \case
         AddedReprocessLoEBlocksToQueue ->
           trace $ "Requested ChainSel run"
         _ -> pure ()
+    ChainDB.TraceChainSelStarvationEvent (ChainDB.ChainSelStarvationStarted time) ->
+      trace $ "ChainSel starvation started at " ++ prettyTime time
+    ChainDB.TraceChainSelStarvationEvent (ChainDB.ChainSelStarvationEnded time pt) ->
+      trace $ "ChainSel starvation ended at " ++ prettyTime time ++ " thanks to " ++ terseRealPoint pt
     _ -> pure ()
   where
     trace = traceUnitWith tracer "ChainDB"

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Trace.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Trace.hs
@@ -25,6 +25,7 @@ import           Data.Bifunctor (second)
 import           Data.List (intersperse)
 import qualified Data.List.NonEmpty as NE
 import           Data.Time.Clock (DiffTime, diffTimeToPicoseconds)
+import           Network.TypedProtocol.Codec (AnyMessage (..))
 import           Ouroboros.Consensus.Block (GenesisWindow (..), Header, Point,
                      WithOrigin (NotOrigin, Origin), succWithOrigin)
 import           Ouroboros.Consensus.Genesis.Governor (DensityBounds (..),
@@ -49,6 +50,9 @@ import           Ouroboros.Network.AnchoredFragment (AnchoredFragment,
                      headPoint)
 import qualified Ouroboros.Network.AnchoredFragment as AF
 import           Ouroboros.Network.Block (SlotNo (SlotNo), Tip, castPoint)
+import           Ouroboros.Network.Driver.Simple (TraceSendRecv (..))
+import           Ouroboros.Network.Protocol.ChainSync.Type (ChainSync,
+                     Message (..))
 import           Test.Consensus.PointSchedule.NodeState (NodeState)
 import           Test.Consensus.PointSchedule.Peers (Peer (Peer), PeerId)
 import           Test.Util.TersePrinting (terseAnchor, terseBlock,
@@ -130,6 +134,7 @@ data TraceEvent blk
   | TraceChainSyncClientTerminationEvent PeerId TraceChainSyncClientTerminationEvent
   | TraceBlockFetchClientTerminationEvent PeerId TraceBlockFetchClientTerminationEvent
   | TraceGenesisDDEvent (TraceGDDEvent PeerId blk)
+  | TraceChainSyncSendRecvEvent PeerId String (TraceSendRecv (ChainSync (Header blk) (Point blk) (Tip blk)))
   | TraceOther String
 
 -- * 'TestBlock'-specific tracers for the peer simulator
@@ -182,6 +187,7 @@ traceEventTestBlockWith setTickTime tracer0 tracer = \case
     TraceChainSyncClientTerminationEvent peerId traceEvent -> traceChainSyncClientTerminationEventTestBlockWith peerId tracer traceEvent
     TraceBlockFetchClientTerminationEvent peerId traceEvent -> traceBlockFetchClientTerminationEventTestBlockWith peerId tracer traceEvent
     TraceGenesisDDEvent gddEvent -> traceWith tracer (terseGDDEvent gddEvent)
+    TraceChainSyncSendRecvEvent peerId peerType traceEvent -> traceChainSyncSendRecvEventTestBlockWith peerId peerType tracer traceEvent
     TraceOther msg -> traceWith tracer msg
 
 traceSchedulerEventTestBlockWith ::
@@ -463,6 +469,33 @@ traceBlockFetchClientTerminationEventTestBlockWith pid tracer = \case
       trace "Terminated because of time limit exceeded."
   where
     trace = traceUnitWith tracer ("BlockFetchClient " ++ condense pid)
+
+-- | Trace all the SendRecv events of the ChainSync mini-protocol.
+traceChainSyncSendRecvEventTestBlockWith ::
+  Applicative m =>
+  PeerId ->
+  String ->
+  Tracer m String ->
+  TraceSendRecv (ChainSync (Header TestBlock) (Point TestBlock) (Tip TestBlock)) ->
+  m ()
+traceChainSyncSendRecvEventTestBlockWith pid ptp tracer = \case
+    TraceSendMsg amsg -> traceMsg "send" amsg
+    TraceRecvMsg amsg -> traceMsg "recv" amsg
+  where
+    -- This can be very verbose and is only useful in rare situations, so it
+    -- does nothing by default.
+    -- trace = traceUnitWith tracer ("ChainSync " ++ condense pid) . ((ptp ++ " ") ++)
+    trace = (\_ _ _ -> const (pure ())) pid ptp tracer
+    traceMsg kd amsg = trace $ kd ++ " " ++ case amsg of
+      AnyMessage msg -> case msg of
+        MsgRequestNext -> "MsgRequestNext"
+        MsgAwaitReply -> "MsgAwaitReply"
+        MsgRollForward header tip -> "MsgRollForward " ++ terseHeader header ++ " " ++ terseTip tip
+        MsgRollBackward point tip -> "MsgRollBackward " ++ tersePoint point ++ " " ++ terseTip tip
+        MsgFindIntersect points -> "MsgFindIntersect [" ++ unwords (map tersePoint points) ++ "]"
+        MsgIntersectFound point tip -> "MsgIntersectFound " ++ tersePoint point ++ " " ++ terseTip tip
+        MsgIntersectNotFound tip -> "MsgIntersectNotFound " ++ terseTip tip
+        MsgDone -> "MsgDone"
 
 prettyDensityBounds :: [(PeerId, DensityBounds TestBlock)] -> [String]
 prettyDensityBounds bounds =

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Trace.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Trace.hs
@@ -191,7 +191,7 @@ traceSchedulerEventTestBlockWith ::
   Tracer m String ->
   TraceSchedulerEvent TestBlock ->
   m ()
-traceSchedulerEventTestBlockWith setTickTime tracer0 _tracer = \case
+traceSchedulerEventTestBlockWith setTickTime tracer0 tracer = \case
     TraceBeginningOfTime ->
       traceWith tracer0 "Running point schedule ..."
     TraceEndOfTime ->
@@ -222,13 +222,13 @@ traceSchedulerEventTestBlockWith setTickTime tracer0 _tracer = \case
           "  jumping states:\n" ++ traceJumpingStates jumpingStates
         ]
     TraceNodeShutdownStart immTip ->
-      traceWith tracer0 ("  Initiating node shutdown with immutable tip at slot " ++ condense immTip)
+      traceWith tracer ("  Initiating node shutdown with immutable tip at slot " ++ condense immTip)
     TraceNodeShutdownComplete ->
-      traceWith tracer0 "  Node shutdown complete"
+      traceWith tracer "  Node shutdown complete"
     TraceNodeStartupStart ->
-      traceWith tracer0 "  Initiating node startup"
+      traceWith tracer "  Initiating node startup"
     TraceNodeStartupComplete selection ->
-      traceWith tracer0 ("  Node startup complete with selection " ++ terseHFragment selection)
+      traceWith tracer ("  Node startup complete with selection " ++ terseHFragment selection)
 
   where
     traceJumpingStates :: [(PeerId, ChainSyncJumpingState m TestBlock)] -> String

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Trace.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Trace.hs
@@ -419,6 +419,8 @@ traceChainSyncClientEventTestBlockWith pid tracer = \case
       trace "Waiting for next instruction from the jumping governor"
     TraceJumpingInstructionIs instr ->
       trace $ "Received instruction: " ++ showInstr instr
+    TraceDrainingThePipe n ->
+      trace $ "Draining the pipe, remaining messages: " ++ show n
   where
     trace = traceUnitWith tracer ("ChainSyncClient " ++ condense pid)
 

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Trace.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Trace.hs
@@ -238,7 +238,7 @@ traceSchedulerEventTestBlockWith setTickTime tracer0 tracer = \case
     traceJumpingState = \case
       Dynamo initState lastJump ->
         let showInitState = case initState of
-              DynamoStarting ji -> terseJumpInfo ji
+              DynamoStarting ji -> "(DynamoStarting " ++ terseJumpInfo ji ++ ")"
               DynamoStarted     -> "DynamoStarted"
          in unwords ["Dynamo", showInitState, terseWithOrigin show lastJump]
       Objector initState goodJumpInfo badPoint -> unwords

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
@@ -55,6 +55,7 @@ import           Control.Monad.ST (ST)
 import           Data.Bifunctor (first)
 import           Data.Functor (($>))
 import           Data.List (mapAccumL, partition, scanl')
+import qualified Data.Map.Strict as Map
 import           Data.Maybe (catMaybes, fromMaybe, mapMaybe)
 import           Data.Time (DiffTime)
 import           Data.Word (Word64)
@@ -599,10 +600,12 @@ ensureScheduleDuration gt PointSchedule{psSchedule, psStartOrder, psMinEndTime} 
     endingDelay =
      let cst = gtChainSyncTimeouts gt
          bft = gtBlockFetchTimeouts gt
-      in 1 + fromIntegral peerCount * maximum (0 : catMaybes
+         bfGracePeriodDelay = fromIntegral adversaryCount * 10
+      in 1 + bfGracePeriodDelay + fromIntegral peerCount * maximum (0 : catMaybes
            [ canAwaitTimeout cst
            , intersectTimeout cst
            , busyTimeout bft
            , streamingTimeout bft
            ])
     peerCount = length (peersList psSchedule)
+    adversaryCount = Map.size (adversarialPeers psSchedule)

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Peers.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Peers.hs
@@ -32,6 +32,7 @@ module Test.Consensus.PointSchedule.Peers (
   , peersFromPeerIdList'
   , peersFromPeerList
   , peersList
+  , peersOnlyAdversary
   , peersOnlyHonest
   , toMap
   , toMap'
@@ -145,6 +146,13 @@ peersOnlyHonest value =
   Peers
     { honestPeers = Map.singleton 1 value,
       adversarialPeers = Map.empty
+    }
+
+peersOnlyAdversary :: a -> Peers a
+peersOnlyAdversary value =
+  Peers
+    { adversarialPeers = Map.singleton 1 value,
+      honestPeers = Map.empty
     }
 
 -- | Extract all 'PeerId's.

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Shrinking.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Shrinking.hs
@@ -41,7 +41,7 @@ shrinkPeerSchedules ::
   StateView TestBlock ->
   [GenesisTestFull TestBlock]
 shrinkPeerSchedules genesisTest@GenesisTest{gtBlockTree, gtSchedule} _stateView =
-  let PointSchedule {psSchedule} = gtSchedule
+  let PointSchedule {psSchedule, psStartOrder} = gtSchedule
       simulationDuration = duration gtSchedule
       trimmedBlockTree sch = trimBlockTree' sch gtBlockTree
       shrunkAdversarialPeers =
@@ -50,6 +50,7 @@ shrinkPeerSchedules genesisTest@GenesisTest{gtBlockTree, gtSchedule} _stateView 
             genesisTest
               { gtSchedule = PointSchedule
                   { psSchedule = shrunkSchedule
+                  , psStartOrder
                   , psMinEndTime = simulationDuration
                   }
               , gtBlockTree = trimmedBlockTree shrunkSchedule
@@ -61,6 +62,7 @@ shrinkPeerSchedules genesisTest@GenesisTest{gtBlockTree, gtSchedule} _stateView 
         <&> \shrunkSchedule -> genesisTest
           { gtSchedule = PointSchedule
             { psSchedule = shrunkSchedule
+            , psStartOrder
             , psMinEndTime = simulationDuration
             }
           }
@@ -81,6 +83,7 @@ shrinkByRemovingAdversaries genesisTest@GenesisTest{gtSchedule, gtBlockTree} _st
      in genesisTest
       { gtSchedule = PointSchedule
         { psSchedule = shrunkSchedule
+        , psStartOrder = psStartOrder gtSchedule
         , psMinEndTime = simulationDuration
         }
       , gtBlockTree = trimmedBlockTree

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Shrinking/Tests.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Shrinking/Tests.hs
@@ -82,14 +82,14 @@ checkShrinkProperty :: (Peers (PeerSchedule TestBlock) -> Peers (PeerSchedule Te
 checkShrinkProperty prop =
   forAllBlind
     (genChains (choose (1, 4)) >>= genUniformSchedulePoints)
-    (\sch@PointSchedule{psSchedule, psMinEndTime} ->
+    (\sch@PointSchedule{psSchedule, psStartOrder, psMinEndTime} ->
       conjoin $ map
       (\shrunk ->
           counterexample
           (  "Original schedule:\n"
           ++ unlines (map ("    " ++) $ prettyPointSchedule sch)
           ++ "\nShrunk schedule:\n"
-          ++ unlines (map ("    " ++) $ prettyPointSchedule $ PointSchedule shrunk psMinEndTime)
+          ++ unlines (map ("    " ++) $ prettyPointSchedule $ PointSchedule {psSchedule = shrunk, psStartOrder, psMinEndTime})
           )
           (prop psSchedule shrunk)
       )

--- a/ouroboros-consensus/changelog.d/20240807_095933_alexander.esgen_milestone_1.md
+++ b/ouroboros-consensus/changelog.d/20240807_095933_alexander.esgen_milestone_1.md
@@ -1,0 +1,11 @@
+### Breaking
+
+- Integrated new bulk sync BlockFetch logic.
+
+- CSJ: implemented rotation of dynamos.
+
+- ChainDB: let the BlockFetch client add blocks asynchronously
+
+- GDD: added rate limit
+
+- Tweaked certain edge cases in the GDD and ChainSync client ([#1179](https://github.com/IntersectMBO/ouroboros-consensus/pull/1179))

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -292,6 +292,7 @@ library
     io-classes ^>=1.5,
     measures,
     mtl,
+    multiset ^>=0.3,
     nothunks ^>=0.2,
     ouroboros-network-api ^>=0.11,
     ouroboros-network-mock ^>=0.1,

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Genesis/Governor.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Genesis/Governor.hs
@@ -365,11 +365,7 @@ densityDisconnect (GenesisWindow sgen) (SecurityParam k) states candidateSuffixe
                              , upperBound = ub0
                              , hasBlockAfter = hasBlockAfter0
                              , idling = idling0
-                             }) ->
-      -- If the density is 0, the peer should be disconnected. This affects
-      -- ChainSync jumping, where genesis windows with no headers prevent jumps
-      -- from happening.
-      if ub0 == 0 then pure peer0 else do
+                             }) -> do
       (_peer1, DensityBounds {clippedFragment = frag1, offersMoreThanK, lowerBound = lb1 }) <-
         densityBounds
       -- Don't disconnect peer0 if it sent no headers after the intersection yet
@@ -377,8 +373,6 @@ densityDisconnect (GenesisWindow sgen) (SecurityParam k) states candidateSuffixe
       --
       -- See Note [Chain disagreement]
       --
-      -- Note: hasBlockAfter0 is False if frag0 is empty and ub0>0.
-      -- But we leave it here as a reminder that we care about it.
       guard $ idling0 || not (AF.null frag0) || hasBlockAfter0
       -- ensure that the two peer fragments don't share any
       -- headers after the LoE

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Genesis/Governor.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Genesis/Governor.hs
@@ -43,7 +43,7 @@ import           Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NE
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import           Data.Maybe (mapMaybe, maybeToList)
+import           Data.Maybe (maybeToList)
 import           Data.Maybe.Strict (StrictMaybe)
 import           Data.Word (Word64)
 import           Ouroboros.Consensus.Block
@@ -255,16 +255,41 @@ sharedCandidatePrefix curChain candidates =
     immutableTip = AF.anchorPoint curChain
 
     splitAfterImmutableTip (peer, frag) =
-      (,) peer . snd <$> AF.splitAfterPoint frag immutableTip
+      case AF.splitAfterPoint frag immutableTip of
+        -- When there is no intersection, we assume the candidate fragment is
+        -- empty and anchored at the immutable tip.
+        -- See Note [CSJ truncates the candidate fragments].
+        Nothing          -> (peer, AF.takeOldest 0 curChain)
+        Just (_, suffix) -> (peer, suffix)
 
     immutableTipSuffixes =
-      -- If a ChainSync client's candidate forks off before the
-      -- immutable tip, then this transaction is currently winning an
-      -- innocuous race versus the thread that will fatally raise
-      -- 'InvalidIntersection' within that ChainSync client, so it's
-      -- sound to pre-emptively discard their candidate from this
-      -- 'Map' via 'mapMaybe'.
-      mapMaybe splitAfterImmutableTip candidates
+      map splitAfterImmutableTip candidates
+
+-- Note [CSJ truncates the candidate fragments]
+-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+--
+-- Before CSJ, only rollback could cause truncation of a candidate fragment.
+-- Truncation is a serious business to GDD because the LoE might have allowed
+-- the selection to advance, based on the tips of the candidate fragments.
+--
+-- Truncating a candidate fragment risks moving the LoE back, which could be
+-- earlier than the anchor of the latest selection. When rollbacks where the
+-- only mechanism to truncate, it was fine to ignore candidate fragments that
+-- don't intersect with the current selection. This could only happen if the
+-- peer is rolling back more than k blocks, which is dishonest behavior.
+--
+-- With CSJ, however, the candidate fragments can recede without a rollback.
+-- A former objector might be asked to jump back when it becomes a jumper again.
+-- The jump point might still be a descendent of the immutable tip. But by the
+-- time the jump is accepted, the immutable tip might have advanced, and the
+-- candidate fragment of the otherwise honest peer might be ignored by GDD.
+--
+-- Therefore, at the moment, when there is no intersection with the current
+-- selection, the GDD assumes that the candidate fragment is empty and anchored
+-- at the immutable tip. It is the job of the ChainSync client to update the
+-- candidate fragment so it intersects with the selection or to disconnect the
+-- peer if no such fragment can be established.
+--
 
 data DensityBounds blk =
   DensityBounds {

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/BlockFetch/ClientInterface.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/BlockFetch/ClientInterface.hs
@@ -14,6 +14,7 @@ module Ouroboros.Consensus.MiniProtocol.BlockFetch.ClientInterface (
   ) where
 
 import           Control.Monad
+import           Control.Tracer (Tracer)
 import           Data.Map.Strict (Map)
 import           Data.Time.Clock (UTCTime)
 import           GHC.Stack (HasCallStack)
@@ -29,7 +30,7 @@ import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
                      (LedgerSupportsProtocol)
 import qualified Ouroboros.Consensus.MiniProtocol.ChainSync.Client as CSClient
-import qualified Ouroboros.Consensus.MiniProtocol.ChainSync.Client.Jumping as Jumping
+import qualified Ouroboros.Consensus.MiniProtocol.ChainSync.Client.Jumping as CSJumping
 import           Ouroboros.Consensus.Storage.ChainDB.API (ChainDB)
 import qualified Ouroboros.Consensus.Storage.ChainDB.API as ChainDB
 import           Ouroboros.Consensus.Storage.ChainDB.API.Types.InvalidBlockPunishment
@@ -179,7 +180,8 @@ mkBlockFetchConsensusInterface ::
      , Ord peer
      , LedgerSupportsProtocol blk
      )
-  => BlockConfig blk
+  => Tracer m (CSJumping.TraceEvent peer)
+  -> BlockConfig blk
   -> ChainDbView m blk
   -> CSClient.ChainSyncClientHandleCollection peer m blk
   -> (Header blk -> SizeInBytes)
@@ -190,7 +192,7 @@ mkBlockFetchConsensusInterface ::
   -> DiffusionPipeliningSupport
   -> BlockFetchConsensusInterface peer (Header blk) blk m
 mkBlockFetchConsensusInterface
-  bcfg chainDB csHandlesCol blockFetchSize slotForgeTime readFetchMode pipelining =
+  csjTracer bcfg chainDB csHandlesCol blockFetchSize slotForgeTime readFetchMode pipelining =
     BlockFetchConsensusInterface {..}
   where
     getCandidates :: STM m (Map peer (AnchoredFragment (Header blk)))
@@ -343,5 +345,5 @@ mkBlockFetchConsensusInterface
 
     readChainSelStarvation = getChainSelStarvation chainDB
 
-    demoteCSJDynamo :: peer -> m ()
-    demoteCSJDynamo = void . atomically . Jumping.rotateDynamo csHandlesCol
+    demoteChainSyncJumpingDynamo :: peer -> m ()
+    demoteChainSyncJumpingDynamo = CSJumping.rotateDynamo csjTracer csHandlesCol

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/BlockFetch/ClientInterface.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/BlockFetch/ClientInterface.hs
@@ -31,7 +31,8 @@ import           Ouroboros.Consensus.Ledger.SupportsProtocol
                      (LedgerSupportsProtocol)
 import qualified Ouroboros.Consensus.MiniProtocol.ChainSync.Client as CSClient
 import qualified Ouroboros.Consensus.MiniProtocol.ChainSync.Client.Jumping as CSJumping
-import           Ouroboros.Consensus.Storage.ChainDB.API (ChainDB)
+import           Ouroboros.Consensus.Storage.ChainDB.API (AddBlockPromise,
+                     ChainDB)
 import qualified Ouroboros.Consensus.Storage.ChainDB.API as ChainDB
 import           Ouroboros.Consensus.Storage.ChainDB.API.Types.InvalidBlockPunishment
                      (InvalidBlockPunishment)
@@ -57,16 +58,16 @@ data ChainDbView m blk = ChainDbView {
      getCurrentChain           :: STM m (AnchoredFragment (Header blk))
    , getIsFetched              :: STM m (Point blk -> Bool)
    , getMaxSlotNo              :: STM m MaxSlotNo
-   , addBlockWaitWrittenToDisk :: InvalidBlockPunishment m -> blk -> m Bool
+   , addBlockAsync             :: InvalidBlockPunishment m -> blk -> m (AddBlockPromise m blk)
    , getChainSelStarvation     :: STM m ChainSelStarvation
    }
 
-defaultChainDbView :: IOLike m => ChainDB m blk -> ChainDbView m blk
+defaultChainDbView :: ChainDB m blk -> ChainDbView m blk
 defaultChainDbView chainDB = ChainDbView {
     getCurrentChain           = ChainDB.getCurrentChain chainDB
   , getIsFetched              = ChainDB.getIsFetched chainDB
   , getMaxSlotNo              = ChainDB.getMaxSlotNo chainDB
-  , addBlockWaitWrittenToDisk = ChainDB.addBlockWaitWrittenToDisk chainDB
+  , addBlockAsync             = ChainDB.addBlockAsync chainDB
   , getChainSelStarvation     = ChainDB.getChainSelStarvation chainDB
   }
 
@@ -217,8 +218,8 @@ mkBlockFetchConsensusInterface
       pipeliningPunishment <- InvalidBlockPunishment.mkForDiffusionPipelining
       pure $ mkAddFetchedBlock_ pipeliningPunishment pipelining
 
-    -- Waits until the block has been written to disk, but not until chain
-    -- selection has processed the block.
+    -- Hand over the block to the ChainDB, but don't wait until it has been
+    -- written to disk or processed.
     mkAddFetchedBlock_ ::
          (   BlockConfig blk
           -> Header blk
@@ -262,7 +263,7 @@ mkBlockFetchConsensusInterface
                DiffusionPipeliningOff -> disconnect
                DiffusionPipeliningOn  ->
                  pipeliningPunishment bcfg (getHeader blk) disconnect
-       addBlockWaitWrittenToDisk
+       addBlockAsync
          chainDB
          punishment
          blk

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ChainSync/Client.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ChainSync/Client.hs
@@ -118,7 +118,8 @@ import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Storage.ChainDB (ChainDB)
 import qualified Ouroboros.Consensus.Storage.ChainDB as ChainDB
 import           Ouroboros.Consensus.Util
-import           Ouroboros.Consensus.Util.AnchoredFragment (cross)
+import           Ouroboros.Consensus.Util.AnchoredFragment (cross,
+                     preferAnchoredCandidate)
 import           Ouroboros.Consensus.Util.Assert (assertWithMsg)
 import           Ouroboros.Consensus.Util.EarlyExit (WithEarlyExit, exitEarly)
 import qualified Ouroboros.Consensus.Util.EarlyExit as EarlyExit
@@ -1641,7 +1642,8 @@ checkKnownInvalid cfgEnv dynEnv intEnv hdr = case scrutinee of
 -- Finally, the client will block on the intersection a second time, if
 -- necessary, since it's possible for a ledger state to determine the slot's
 -- onset's timestamp without also determining the slot's 'LedgerView'. During
--- this pause, the LoP bucket is paused.
+-- this pause, the LoP bucket is paused. If we need to block and their fragment
+-- is not preferrable to ours, we disconnect.
 checkTime ::
   forall m blk arrival judgment.
      ( IOLike m
@@ -1750,9 +1752,42 @@ checkTime cfgEnv dynEnv intEnv =
                       )
                   $ getPastLedger mostRecentIntersection
                 case prj lst of
-                    Nothing         -> retry
+                    Nothing         -> do
+                        checkPreferTheirsOverOurs kis'
+                        retry
                     Just ledgerView ->
                         return $ return $ Intersects kis' ledgerView
+
+    -- Note [Candidate comparing beyond the forecast horizon]
+    -- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    --
+    -- When a header is beyond the forecast horizon and their fragment is not
+    -- preferrable to our selection (ourFrag), then we disconnect, as we will
+    -- never end up selecting it.
+    --
+    -- In the context of Genesis, one can think of the candidate losing a
+    -- density comparison against the selection. See the Genesis documentation
+    -- for why this check is necessary.
+    --
+    -- In particular, this means that we will disconnect from peers who offer us
+    -- a chain containing a slot gap larger than a forecast window.
+    checkPreferTheirsOverOurs :: KnownIntersectionState blk -> STM m ()
+    checkPreferTheirsOverOurs kis
+      | -- Precondition is fulfilled as ourFrag and theirFrag intersect by
+        -- construction.
+        preferAnchoredCandidate (configBlock cfg) ourFrag theirFrag
+      = pure ()
+      | otherwise
+      = throwSTM $ CandidateTooSparse
+            mostRecentIntersection
+            (ourTipFromChain ourFrag)
+            (theirTipFromChain theirFrag)
+      where
+        KnownIntersectionState {
+            mostRecentIntersection
+          , ourFrag
+          , theirFrag
+          } = kis
 
     -- Returns 'Nothing' if the ledger state cannot forecast the ledger view
     -- that far into the future.
@@ -1937,6 +1972,12 @@ ourTipFromChain ::
   => AnchoredFragment (Header blk)
   -> Our (Tip blk)
 ourTipFromChain = Our . AF.anchorToTip . AF.headAnchor
+
+theirTipFromChain ::
+     HasHeader (Header blk)
+  => AnchoredFragment (Header blk)
+  -> Their (Tip blk)
+theirTipFromChain = Their . AF.anchorToTip . AF.headAnchor
 
 -- | A type-legos auxillary function used in 'readLedgerState'.
 castM :: Monad m => m (WithEarlyExit m x) -> WithEarlyExit m x
@@ -2162,6 +2203,14 @@ data ChainSyncClientException =
         (ExtValidationError blk)
     -- ^ The upstream node's chain contained a block that we know is invalid.
   |
+    forall blk. BlockSupportsProtocol blk =>
+    CandidateTooSparse
+        (Point blk) -- ^ Intersection
+        (Our   (Tip blk))
+        (Their (Tip blk))
+    -- ^ The upstream node's chain was so sparse that it was worse than our
+    -- selection despite being blocked on the forecast horizon.
+  |
     InFutureHeaderExceedsClockSkew !InFutureCheck.HeaderArrivalException
     -- ^ A header arrived from the far future.
   |
@@ -2197,6 +2246,12 @@ instance Eq ChainSyncClientException where
       = (a, b, c) == (a', b', c')
 
     (==)
+        (CandidateTooSparse (a  :: Point blk ) b  c )
+        (CandidateTooSparse (a' :: Point blk') b' c')
+      | Just Refl <- eqT @blk @blk'
+      = (a, b, c) == (a', b', c')
+
+    (==)
         (InFutureHeaderExceedsClockSkew a )
         (InFutureHeaderExceedsClockSkew a')
       = a == a'
@@ -2219,6 +2274,7 @@ instance Eq ChainSyncClientException where
     HeaderError{}                    == _ = False
     InvalidIntersection{}            == _ = False
     InvalidBlock{}                   == _ = False
+    CandidateTooSparse{}             == _ = False
     InFutureHeaderExceedsClockSkew{} == _ = False
     HistoricityError{}               == _ = False
     EmptyBucket                      == _ = False

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ChainSync/Client.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ChainSync/Client.hs
@@ -63,10 +63,12 @@ module Ouroboros.Consensus.MiniProtocol.ChainSync.Client (
   , TraceChainSyncClientEvent (..)
     -- * State shared with other components
   , ChainSyncClientHandle (..)
+  , ChainSyncClientHandleCollection (..)
   , ChainSyncState (..)
   , ChainSyncStateView (..)
   , Jumping.noJumping
   , chainSyncStateFor
+  , newChainSyncClientHandleCollection
   , noIdling
   , noLoPBucket
   , viewChainSyncState
@@ -231,11 +233,11 @@ newtype Our a = Our { unOur :: a }
 -- data from 'ChainSyncState'.
 viewChainSyncState ::
   IOLike m =>
-  StrictTVar m (Map peer (ChainSyncClientHandle m blk)) ->
+  STM m (Map peer (ChainSyncClientHandle m blk)) ->
   (ChainSyncState blk -> a) ->
   STM m (Map peer a)
-viewChainSyncState varHandles f =
-  Map.map f <$> (traverse (readTVar . cschState) =<< readTVar varHandles)
+viewChainSyncState readHandles f =
+  Map.map f <$> (traverse (readTVar . cschState) =<< readHandles)
 
 -- | Convenience function for reading the 'ChainSyncState' for a single peer
 -- from a nested set of TVars.
@@ -329,7 +331,7 @@ bracketChainSyncClient ::
     )
  => Tracer m (TraceChainSyncClientEvent blk)
  -> ChainDbView m blk
- -> StrictTVar m (Map peer (ChainSyncClientHandle m blk))
+ -> ChainSyncClientHandleCollection peer m blk
     -- ^ The kill handle and states for each peer, we need the whole map because we
     -- (de)register nodes (@peer@).
  -> STM m GsmState
@@ -404,8 +406,8 @@ bracketChainSyncClient
           insertHandle = atomicallyWithMonotonicTime $ \time -> do
             initialGsmState <- getGsmState
             updateLopBucketConfig lopBucket initialGsmState time
-            modifyTVar varHandles $ Map.insert peer handle
-          deleteHandle = atomically $ modifyTVar varHandles $ Map.delete peer
+            cschcAddHandle varHandles peer handle
+          deleteHandle = atomically $ cschcRemoveHandle varHandles peer
       bracket_ insertHandle deleteHandle $ f Jumping.noJumping
 
     withCSJCallbacks lopBucket csHandleState (CSJEnabled csjEnabledConfig) f =

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ChainSync/Client.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ChainSync/Client.hs
@@ -167,7 +167,7 @@ data ChainSyncLoPBucketEnabledConfig = ChainSyncLoPBucketEnabledConfig {
     csbcCapacity :: Integer,
     -- | The rate of the bucket (think tokens per second).
     csbcRate     :: Rational
-  }
+  } deriving stock (Eq, Generic, Show)
 
 -- | Configuration of the leaky bucket.
 data ChainSyncLoPBucketConfig
@@ -178,6 +178,7 @@ data ChainSyncLoPBucketConfig
   |
     -- | Enable the leaky bucket.
     ChainSyncLoPBucketEnabled ChainSyncLoPBucketEnabledConfig
+  deriving stock (Eq, Generic, Show)
 
 -- | Configuration of ChainSync Jumping
 data CSJConfig
@@ -188,6 +189,7 @@ data CSJConfig
   |
     -- | Enable ChainSync Jumping
     CSJEnabled CSJEnabledConfig
+  deriving stock (Eq, Generic, Show)
 
 newtype CSJEnabledConfig = CSJEnabledConfig {
   -- | The _ideal_ size for ChainSync jumps. Note that the algorithm
@@ -207,7 +209,7 @@ newtype CSJEnabledConfig = CSJEnabledConfig {
   -- window has a higher change that dishonest peers can delay syncing by a
   -- small margin (around 2 minutes per dishonest peer with mainnet parameters).
   csjcJumpSize       :: SlotNo
-}
+} deriving stock (Eq, Generic, Show)
 
 defaultChainDbView ::
      (IOLike m, LedgerSupportsProtocol blk)

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ChainSync/Client.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ChainSync/Client.hs
@@ -917,7 +917,9 @@ chainSyncClient cfgEnv dynEnv =
                Nat n'
             -> s
             -> m (Consensus (ClientPipelinedStIdle n') blk m)
-          go n s = case n of
+          go n s = do
+            traceWith tracer $ TraceDrainingThePipe n
+            case n of
               Zero    -> continueWithState s m
               Succ n' -> return $ CollectResponse Nothing $ ClientStNext {
                   recvMsgRollForward  = \_hdr _tip -> go n' s
@@ -2334,12 +2336,8 @@ data TraceChainSyncClientEvent blk =
   |
     TraceJumpingInstructionIs (Jumping.Instruction blk)
     -- ^ ChainSync Jumping -- the ChainSync client got its next instruction.
-
-deriving instance
-  ( BlockSupportsProtocol blk
-  , Eq (Header blk)
-  )
-  => Eq (TraceChainSyncClientEvent blk)
+  |
+    forall n. TraceDrainingThePipe (Nat n)
 
 deriving instance
   ( BlockSupportsProtocol blk

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ChainSync/Client/Jumping.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ChainSync/Client/Jumping.hs
@@ -74,6 +74,13 @@
 -- when the client should pause, download headers, or ask about agreement with
 -- a given point (jumping). See the 'Jumping' type for more details.
 --
+-- CSJ depends on the ChainSync client to disconnect dynamos that have an empty
+-- genesis window after their intersection with the selection. This is necessary
+-- because otherwise there are no points to jump to, and CSJ could would get
+-- stuck when the dynamo blocks on the forecast horizon. See
+-- Note [Candidate comparing beyond the forecast horizon] in
+-- "Ouroboros.Consensus.MiniProtocol.ChainSync.Client".
+--
 -- Interactions with the BlockFetch logic
 -- --------------------------------------
 --

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ChainSync/Client/Jumping.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ChainSync/Client/Jumping.hs
@@ -163,11 +163,11 @@ module Ouroboros.Consensus.MiniProtocol.ChainSync.Client.Jumping (
 
 import           Cardano.Slotting.Slot (SlotNo (..), WithOrigin (..))
 import           Control.Monad (forM, forM_, when)
+import           Data.Foldable (toList)
 import           Data.List (sortOn)
-import           Data.Map.Strict (Map)
-import qualified Data.Map.Strict as Map
 import           Data.Maybe (catMaybes, fromMaybe)
 import           Data.Maybe.Strict (StrictMaybe (..))
+import qualified Data.Sequence.Strict as Seq
 import           GHC.Generics (Generic)
 import           Ouroboros.Consensus.Block (HasHeader (getHeaderFields), Header,
                      Point (..), castPoint, pointSlot, succWithOrigin)
@@ -175,6 +175,7 @@ import           Ouroboros.Consensus.Ledger.SupportsProtocol
                      (LedgerSupportsProtocol)
 import           Ouroboros.Consensus.MiniProtocol.ChainSync.Client.State
                      (ChainSyncClientHandle (..),
+                     ChainSyncClientHandleCollection (..),
                      ChainSyncJumpingJumperState (..),
                      ChainSyncJumpingState (..), ChainSyncState (..),
                      DisengagedInitState (..), DynamoInitState (..),
@@ -257,16 +258,16 @@ mkJumping peerContext = Jumping
 --
 -- Invariants:
 --
--- - If 'handlesVar' is not empty, then there is exactly one dynamo in it.
--- - There is at most one objector in 'handlesVar'.
--- - If there exist 'FoundIntersection' jumpers in 'handlesVar', then there
+-- - If 'handlesCol is not empty, then there is exactly one dynamo in it.
+-- - There is at most one objector in 'handlesCol.
+-- - If there exist 'FoundIntersection' jumpers in 'handlesCol, then there
 --   is an objector and the intersection of the objector with the dynamo is
 --   at least as old as the oldest intersection of the `FoundIntersection` jumpers
 --   with the dynamo.
 data ContextWith peerField handleField m peer blk = Context
   { peer       :: !peerField,
     handle     :: !handleField,
-    handlesVar :: !(StrictTVar m (Map peer (ChainSyncClientHandle m blk))),
+    handlesCol :: !(ChainSyncClientHandleCollection peer m blk),
     jumpSize   :: !SlotNo
   }
 
@@ -276,12 +277,12 @@ type Context = ContextWith () ()
 -- | A peer-specific context for ChainSync jumping. This is a 'ContextWith'
 -- pointing on the handler of the peer in question.
 --
--- Invariant: The binding from 'peer' to 'handle' is present in 'handlesVar'.
+-- Invariant: The binding from 'peer' to 'handle' is present in 'handlesCol'.
 type PeerContext m peer blk = ContextWith peer (ChainSyncClientHandle m blk) m peer blk
 
 makeContext ::
   MonadSTM m =>
-  StrictTVar m (Map peer (ChainSyncClientHandle m blk)) ->
+  ChainSyncClientHandleCollection peer m blk ->
   SlotNo ->
   -- ^ The size of jumps, in number of slots.
   STM m (Context m peer blk)
@@ -427,8 +428,8 @@ onRollForward context point =
     setJumps (Just jumpInfo) = do
         writeTVar (cschJumping (handle context)) $
           Dynamo DynamoStarted $ pointSlot $ AF.headPoint $ jTheirFragment jumpInfo
-        handles <- readTVar (handlesVar context)
-        forM_ (Map.elems handles) $ \h ->
+        handles <- cschcSeq (handlesCol context)
+        forM_ handles $ \(_, h) ->
           readTVar (cschJumping h) >>= \case
             Jumper nextJumpVar Happy{} -> writeTVar nextJumpVar (Just jumpInfo)
             _ -> pure ()
@@ -660,11 +661,11 @@ updateJumpInfo context jumpInfo =
 -- of the dynamo, or 'Nothing' if there is none.
 getDynamo ::
   (MonadSTM m) =>
-  StrictTVar m (Map peer (ChainSyncClientHandle m blk)) ->
+  ChainSyncClientHandleCollection peer m blk ->
   STM m (Maybe (ChainSyncClientHandle m blk))
-getDynamo handlesVar = do
-  handles <- Map.elems <$> readTVar handlesVar
-  findM (\handle -> isDynamo <$> readTVar (cschJumping handle)) handles
+getDynamo handlesCol = do
+  handles <- cschcSeq handlesCol
+  fmap snd <$> findM (\(_, handle) -> isDynamo <$> readTVar (cschJumping handle)) handles
   where
     isDynamo Dynamo{} = True
     isDynamo _        = False
@@ -705,8 +706,7 @@ newJumper jumpInfo jumperState = do
 -- that peer. If there is no dynamo, the peer starts as dynamo; otherwise, it
 -- starts as a jumper.
 registerClient ::
-  ( Ord peer,
-    LedgerSupportsProtocol blk,
+  ( LedgerSupportsProtocol blk,
     IOLike m
   ) =>
   Context m peer blk ->
@@ -716,7 +716,7 @@ registerClient ::
   (StrictTVar m (ChainSyncJumpingState m blk) -> ChainSyncClientHandle m blk) ->
   STM m (PeerContext m peer blk)
 registerClient context peer csState mkHandle = do
-  csjState <- getDynamo (handlesVar context) >>= \case
+  csjState <- getDynamo (handlesCol context) >>= \case
     Nothing -> do
       fragment <- csCandidate <$> readTVar csState
       pure $ Dynamo DynamoStarted $ pointSlot $ AF.anchorPoint fragment
@@ -725,7 +725,7 @@ registerClient context peer csState mkHandle = do
       newJumper mJustInfo (Happy FreshJumper Nothing)
   cschJumping <- newTVar csjState
   let handle = mkHandle cschJumping
-  modifyTVar (handlesVar context) $ Map.insert peer handle
+  cschcAddHandle (handlesCol context) peer handle
   pure $ context {peer, handle}
 
 -- | Unregister a client from a 'PeerContext'; this might trigger the election
@@ -738,7 +738,7 @@ unregisterClient ::
   PeerContext m peer blk ->
   STM m ()
 unregisterClient context = do
-  modifyTVar (handlesVar context) $ Map.delete (peer context)
+  cschcRemoveHandle (handlesCol context) (peer context)
   let context' = stripContext context
   readTVar (cschJumping (handle context)) >>= \case
     Disengaged{} -> pure ()
@@ -756,7 +756,7 @@ electNewDynamo ::
   Context m peer blk ->
   STM m ()
 electNewDynamo context = do
-  peerStates <- Map.toList <$> readTVar (handlesVar context)
+  peerStates <- cschcSeq (handlesCol context)
   mDynamo <- findNonDisengaged peerStates
   case mDynamo of
     Nothing -> pure ()
@@ -781,22 +781,20 @@ electNewDynamo context = do
     isDisengaged Disengaged{} = True
     isDisengaged _            = False
 
-findM :: Monad m => (a -> m Bool) -> [a] -> m (Maybe a)
-findM _ [] = pure Nothing
-findM p (x : xs) = p x >>= \case
-  True -> pure (Just x)
-  False -> findM p xs
+findM :: (Foldable f, Monad m) => (a -> m Bool) -> f a -> m (Maybe a)
+findM p =
+  foldr (\x mb -> p x >>= \case True -> pure (Just x); False -> mb) (pure Nothing)
 
 -- | Find the objector in a context, if there is one.
 findObjector ::
   (MonadSTM m) =>
   Context m peer blk ->
   STM m (Maybe (ObjectorInitState, JumpInfo blk, Point (Header blk), ChainSyncClientHandle m blk))
-findObjector context = do
-  readTVar (handlesVar context) >>= go . Map.toList
+findObjector context =
+  cschcSeq (handlesCol context) >>= go
   where
-    go [] = pure Nothing
-    go ((_, handle):xs) =
+    go Seq.Empty = pure Nothing
+    go ((_, handle) Seq.:<| xs) =
       readTVar (cschJumping handle) >>= \case
         Objector initState goodJump badPoint ->
           pure $ Just (initState, goodJump, badPoint, handle)
@@ -809,7 +807,7 @@ electNewObjector ::
   Context m peer blk ->
   STM m ()
 electNewObjector context = do
-  peerStates <- Map.toList <$> readTVar (handlesVar context)
+  peerStates <- toList <$> cschcSeq (handlesCol context)
   dissentingJumpers <- collectDissentingJumpers peerStates
   let sortedJumpers = sortOn (pointSlot . fst) dissentingJumpers
   case sortedJumpers of

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ChainSync/Client/Jumping.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ChainSync/Client/Jumping.hs
@@ -74,6 +74,13 @@
 -- when the client should pause, download headers, or ask about agreement with
 -- a given point (jumping). See the 'Jumping' type for more details.
 --
+-- Interactions with the BlockFetch logic
+-- --------------------------------------
+--
+-- When syncing, the BlockFetch logic will fetch blocks from the dynamo. If the
+-- dynamo is responding too slowly, the BlockFetch logic can ask to change the
+-- dynamo with a call to 'rotateDynamo'.
+--
 -- Interactions with the Limit on Patience
 -- ---------------------------------------
 --
@@ -100,15 +107,15 @@
 --
 -- >                j       ╔════════╗
 -- >            ╭────────── ║ Dynamo ║ ◀─────────╮
--- >            │           ╚════════╝           │f
--- >            ▼                  ▲             │
--- >    ┌────────────┐             │     k     ┌──────────┐
--- >    │ Disengaged │ ◀───────────│────────── │ Objector │
--- >    └────────────┘       ╭─────│────────── └──────────┘
--- >                         │     │             ▲    ▲ │
--- >                        g│     │e         b  │    │ │
--- >                         │     │       ╭─────╯   i│ │c
--- >                 ╭╌╌╌╌╌╌╌▼╌╌╌╌╌╌╌╌╌╌╌╌╌│╌╌╌╌╌╌╌╌╌╌│╌▼╌╌╌╮
+-- >            │        ╭──╚════════╝           │f
+-- >            ▼        │         ▲             │
+-- >    ┌────────────┐   │         │     k     ┌──────────┐
+-- >    │ Disengaged │ ◀─│─────────│────────── │ Objector │
+-- >    └────────────┘   │   ╭─────│────────── └──────────┘
+-- >                     │   │     │             ▲    ▲ │
+-- >                    l│  g│     │e         b  │    │ │
+-- >                     │   │     │       ╭─────╯   i│ │c
+-- >                 ╭╌╌╌▼╌╌╌▼╌╌╌╌╌╌╌╌╌╌╌╌╌│╌╌╌╌╌╌╌╌╌╌│╌▼╌╌╌╮
 -- >                 ┆ ╔═══════╗  a   ┌──────┐  d   ┌─────┐ |
 -- >                 ┆ ║ Happy ║ ───▶ │ LFI* │ ───▶ │ FI* │ |
 -- >                 ┆ ╚═══════╝ ◀─╮  └──────┘      └─────┘ |
@@ -147,6 +154,10 @@
 -- If dynamo or objector claim to have no more headers, they are disengaged
 -- (j|k).
 --
+-- The BlockFetch logic can ask to change the dynamo if it is not serving blocks
+-- fast enough. If there are other non-disengaged peers the dynamo is demoted to
+-- a jumper (l) and a new dynamo is elected.
+--
 module Ouroboros.Consensus.MiniProtocol.ChainSync.Client.Jumping (
     Context
   , ContextWith (..)
@@ -154,19 +165,23 @@ module Ouroboros.Consensus.MiniProtocol.ChainSync.Client.Jumping (
   , JumpInstruction (..)
   , JumpResult (..)
   , Jumping (..)
+  , getDynamo
   , makeContext
   , mkJumping
   , noJumping
   , registerClient
+  , rotateDynamo
   , unregisterClient
   ) where
 
 import           Cardano.Slotting.Slot (SlotNo (..), WithOrigin (..))
-import           Control.Monad (forM, forM_, when)
+import           Control.Monad (forM, forM_, void, when)
 import           Data.Foldable (toList)
 import           Data.List (sortOn)
+import qualified Data.Map as Map
 import           Data.Maybe (catMaybes, fromMaybe)
 import           Data.Maybe.Strict (StrictMaybe (..))
+import           Data.Sequence.Strict (StrictSeq)
 import qualified Data.Sequence.Strict as Seq
 import           GHC.Generics (Generic)
 import           Ouroboros.Consensus.Block (HasHeader (getHeaderFields), Header,
@@ -460,7 +475,7 @@ onRollBackward context slot =
     Dynamo _ lastJumpSlot
       | slot < lastJumpSlot -> do
           disengage (handle context)
-          electNewDynamo (stripContext context)
+          void $ electNewDynamo (stripContext context)
       | otherwise -> pure ()
 
 -- | This function is called when we receive a 'MsgAwaitReply' message.
@@ -478,7 +493,7 @@ onAwaitReply context =
   readTVar (cschJumping (handle context)) >>= \case
     Dynamo{} -> do
       disengage (handle context)
-      electNewDynamo (stripContext context)
+      void $ electNewDynamo (stripContext context)
     Objector{} -> do
       disengage (handle context)
       electNewObjector (stripContext context)
@@ -511,7 +526,7 @@ processJumpResult context jumpResult =
           updateChainSyncState (handle context) jumpInfo
         RejectedJump JumpToGoodPoint{} -> do
           startDisengaging (handle context)
-          electNewDynamo (stripContext context)
+          void $ electNewDynamo (stripContext context)
 
         -- Not interesting in the dynamo state
         AcceptedJump JumpTo{} -> pure ()
@@ -662,10 +677,10 @@ updateJumpInfo context jumpInfo =
 getDynamo ::
   (MonadSTM m) =>
   ChainSyncClientHandleCollection peer m blk ->
-  STM m (Maybe (ChainSyncClientHandle m blk))
+  STM m (Maybe (peer, ChainSyncClientHandle m blk))
 getDynamo handlesCol = do
   handles <- cschcSeq handlesCol
-  fmap snd <$> findM (\(_, handle) -> isDynamo <$> readTVar (cschJumping handle)) handles
+  findM (\(_, handle) -> isDynamo <$> readTVar (cschJumping handle)) handles
   where
     isDynamo Dynamo{} = True
     isDynamo _        = False
@@ -720,7 +735,7 @@ registerClient context peer csState mkHandle = do
     Nothing -> do
       fragment <- csCandidate <$> readTVar csState
       pure $ Dynamo DynamoStarted $ pointSlot $ AF.anchorPoint fragment
-    Just handle -> do
+    Just (_, handle) -> do
       mJustInfo <- readTVar (cschJumpInfo handle)
       newJumper mJustInfo (Happy FreshJumper Nothing)
   cschJumping <- newTVar csjState
@@ -744,7 +759,52 @@ unregisterClient context = do
     Disengaged{} -> pure ()
     Jumper{} -> pure ()
     Objector{} -> electNewObjector context'
-    Dynamo{} -> electNewDynamo context'
+    Dynamo{} -> void $ electNewDynamo context'
+
+-- | Elects a new dynamo by demoting the given dynamo to a jumper, moving the
+-- peer to the end of the queue of chain sync handles and electing a new dynamo.
+--
+-- It does nothing if there is no other engaged peer to elect or if the given
+-- peer is not the dynamo.
+--
+-- Yields the new dynamo, if there is one.
+rotateDynamo ::
+  ( Ord peer,
+    LedgerSupportsProtocol blk,
+    MonadSTM m
+  ) =>
+  ChainSyncClientHandleCollection peer m blk ->
+  peer ->
+  STM m (Maybe (peer, ChainSyncClientHandle m blk))
+rotateDynamo handlesCol peer = do
+  handles <- cschcMap handlesCol
+  case handles Map.!? peer of
+    Nothing ->
+      -- Do not re-elect a dynamo if the peer has been disconnected.
+      getDynamo handlesCol
+    Just oldDynHandle ->
+      readTVar (cschJumping oldDynHandle) >>= \case
+        Dynamo{} -> do
+          cschcRotateHandle handlesCol peer
+          peerStates <- cschcSeq handlesCol
+          mEngaged <- findNonDisengaged peerStates
+          case mEngaged of
+            Nothing ->
+              -- There are no engaged peers. This case cannot happen, as the
+              -- dynamo is always engaged.
+              error "rotateDynamo: no engaged peer found"
+            Just (newDynamoId, newDynHandle)
+              | newDynamoId == peer ->
+                -- The old dynamo is the only engaged peer left.
+                pure $ Just (newDynamoId, newDynHandle)
+              | otherwise -> do
+                newJumper Nothing (Happy FreshJumper Nothing)
+                  >>= writeTVar (cschJumping oldDynHandle)
+                promoteToDynamo peerStates newDynamoId newDynHandle
+                pure $ Just (newDynamoId, newDynHandle)
+        _ ->
+          -- Do not re-elect a dynamo if the peer is not the dynamo.
+          getDynamo handlesCol
 
 -- | Choose an unspecified new non-idling dynamo and demote all other peers to
 -- jumpers.
@@ -754,32 +814,53 @@ electNewDynamo ::
     LedgerSupportsProtocol blk
   ) =>
   Context m peer blk ->
-  STM m ()
+  STM m (Maybe (peer, ChainSyncClientHandle m blk))
 electNewDynamo context = do
   peerStates <- cschcSeq (handlesCol context)
   mDynamo <- findNonDisengaged peerStates
   case mDynamo of
-    Nothing -> pure ()
+    Nothing -> pure Nothing
     Just (dynId, dynamo) -> do
-      fragment <- csCandidate <$> readTVar (cschState dynamo)
-      mJumpInfo <- readTVar (cschJumpInfo dynamo)
-      -- If there is no jump info, the dynamo must be just starting and
-      -- there is no need to set the intersection of the ChainSync server.
-      let dynamoInitState = maybe DynamoStarted DynamoStarting mJumpInfo
-      writeTVar (cschJumping dynamo) $
-        Dynamo dynamoInitState $ pointSlot $ AF.headPoint fragment
-      -- Demote all other peers to jumpers
-      forM_ peerStates $ \(peer, st) ->
-        when (peer /= dynId) $ do
-          jumpingState <- readTVar (cschJumping st)
-          when (not (isDisengaged jumpingState)) $
-            newJumper mJumpInfo (Happy FreshJumper Nothing)
-              >>= writeTVar (cschJumping st)
-  where
-    findNonDisengaged =
-      findM $ \(_, st) -> not . isDisengaged <$> readTVar (cschJumping st)
-    isDisengaged Disengaged{} = True
-    isDisengaged _            = False
+      promoteToDynamo peerStates dynId dynamo
+      pure $ Just (dynId, dynamo)
+
+-- | Promote the given peer to dynamo and demote all other peers to jumpers.
+promoteToDynamo ::
+  ( MonadSTM m,
+    Eq peer,
+    LedgerSupportsProtocol blk
+  ) =>
+  StrictSeq (peer, ChainSyncClientHandle m blk) ->
+  peer ->
+  ChainSyncClientHandle m blk ->
+  STM m ()
+promoteToDynamo peerStates dynId dynamo = do
+  fragment <- csCandidate <$> readTVar (cschState dynamo)
+  mJumpInfo <- readTVar (cschJumpInfo dynamo)
+  -- If there is no jump info, the dynamo must be just starting and
+  -- there is no need to set the intersection of the ChainSync server.
+  let dynamoInitState = maybe DynamoStarted DynamoStarting mJumpInfo
+  writeTVar (cschJumping dynamo) $
+    Dynamo dynamoInitState $ pointSlot $ AF.headPoint fragment
+  -- Demote all other peers to jumpers
+  forM_ peerStates $ \(peer, st) ->
+    when (peer /= dynId) $ do
+      jumpingState <- readTVar (cschJumping st)
+      when (not (isDisengaged jumpingState)) $
+        newJumper mJumpInfo (Happy FreshJumper Nothing)
+          >>= writeTVar (cschJumping st)
+
+-- | Find a non-disengaged peer in the given sequence
+findNonDisengaged ::
+  (MonadSTM m) =>
+  StrictSeq (peer, ChainSyncClientHandle m blk) ->
+  STM m (Maybe (peer, ChainSyncClientHandle m blk))
+findNonDisengaged =
+  findM $ \(_, st) -> not . isDisengaged <$> readTVar (cschJumping st)
+
+isDisengaged :: ChainSyncJumpingState m blk -> Bool
+isDisengaged Disengaged{} = True
+isDisengaged _            = False
 
 findM :: (Foldable f, Monad m) => (a -> m Bool) -> f a -> m (Maybe a)
 findM p =

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ChainSync/Client/State.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ChainSync/Client/State.hs
@@ -9,6 +9,7 @@
 
 module Ouroboros.Consensus.MiniProtocol.ChainSync.Client.State (
     ChainSyncClientHandle (..)
+  , ChainSyncClientHandleCollection (..)
   , ChainSyncJumpingJumperState (..)
   , ChainSyncJumpingState (..)
   , ChainSyncState (..)
@@ -17,11 +18,16 @@ module Ouroboros.Consensus.MiniProtocol.ChainSync.Client.State (
   , JumpInfo (..)
   , JumperInitState (..)
   , ObjectorInitState (..)
+  , newChainSyncClientHandleCollection
   ) where
 
 import           Cardano.Slotting.Slot (SlotNo, WithOrigin)
 import           Data.Function (on)
+import           Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
 import           Data.Maybe.Strict (StrictMaybe (..))
+import           Data.Sequence.Strict (StrictSeq)
+import qualified Data.Sequence.Strict as Seq
 import           Data.Typeable (Proxy (..), typeRep)
 import           GHC.Generics (Generic)
 import           Ouroboros.Consensus.Block (HasHeader, Header, Point)
@@ -30,7 +36,7 @@ import           Ouroboros.Consensus.Ledger.SupportsProtocol
                      (LedgerSupportsProtocol)
 import           Ouroboros.Consensus.Node.GsmState (GsmState)
 import           Ouroboros.Consensus.Util.IOLike (IOLike, NoThunks (..), STM,
-                     StrictTVar, Time)
+                     StrictTVar, Time, modifyTVar, newTVar, readTVar)
 import           Ouroboros.Network.AnchoredFragment (AnchoredFragment,
                      headPoint)
 
@@ -95,6 +101,68 @@ deriving anyclass instance (
   LedgerSupportsProtocol blk,
   NoThunks (Header blk)
   ) => NoThunks (ChainSyncClientHandle m blk)
+
+-- | A collection of ChainSync client handles for the peers of this node.
+--
+-- Sometimes we want to see the collection as a Map, and sometimes as a sequence.
+-- The implementation keeps both views in sync.
+data ChainSyncClientHandleCollection peer m blk = ChainSyncClientHandleCollection {
+    -- | A map containing the handles for the peers in the collection
+    cschcMap :: !(STM m (Map peer (ChainSyncClientHandle m blk)))
+    -- | A sequence containing the handles for the peers in the collection
+  , cschcSeq :: !(STM m (StrictSeq (peer, ChainSyncClientHandle m blk)))
+    -- | Add the handle for the given peer to the collection
+    -- PRECONDITION: The peer is not already in the collection
+  , cschcAddHandle  :: !(peer -> ChainSyncClientHandle m blk -> STM m ())
+    -- | Remove the handle for the given peer from the collection
+  , cschcRemoveHandle :: !(peer -> STM m ())
+    -- | Moves the handle for the given peer to the end of the sequence
+  , cschcRotateHandle :: !(peer -> STM m ())
+    -- | Remove all the handles from the collection
+  , cschcRemoveAllHandles :: !(STM m ())
+  }
+  deriving stock (Generic)
+
+deriving anyclass instance (
+  IOLike m,
+  HasHeader blk,
+  LedgerSupportsProtocol blk,
+  NoThunks (STM m ()),
+  NoThunks (Header blk),
+  NoThunks (STM m (Map peer (ChainSyncClientHandle m blk))),
+  NoThunks (STM m (StrictSeq (peer, ChainSyncClientHandle m blk)))
+  ) => NoThunks (ChainSyncClientHandleCollection peer m blk)
+
+newChainSyncClientHandleCollection ::
+     ( Ord peer,
+       IOLike m,
+       LedgerSupportsProtocol blk,
+       NoThunks peer
+     )
+  => STM m (ChainSyncClientHandleCollection peer m blk)
+newChainSyncClientHandleCollection = do
+  handlesMap <- newTVar mempty
+  handlesSeq <- newTVar mempty
+
+  return ChainSyncClientHandleCollection {
+      cschcMap = readTVar handlesMap
+    , cschcSeq = readTVar handlesSeq
+    , cschcAddHandle = \peer handle -> do
+        modifyTVar handlesMap (Map.insert peer handle)
+        modifyTVar handlesSeq (Seq.|> (peer, handle))
+    , cschcRemoveHandle = \peer -> do
+        modifyTVar handlesMap (Map.delete peer)
+        modifyTVar handlesSeq $ \s ->
+          let (xs, ys) = Seq.spanl ((/= peer) . fst) s
+           in xs Seq.>< Seq.drop 1 ys
+    , cschcRotateHandle = \peer ->
+        modifyTVar handlesSeq $ \s ->
+          let (xs, ys) = Seq.spanl ((/= peer) . fst) s
+           in xs Seq.>< Seq.drop 1 ys Seq.>< Seq.take 1 ys
+    , cschcRemoveAllHandles = do
+        modifyTVar handlesMap (const mempty)
+        modifyTVar handlesSeq (const mempty)
+    }
 
 data DynamoInitState blk
   = -- | The dynamo has not yet started jumping and we first need to jump to the

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ChainSync/Client/State.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ChainSync/Client/State.hs
@@ -165,8 +165,11 @@ newChainSyncClientHandleCollection = do
     }
 
 data DynamoInitState blk
-  = -- | The dynamo has not yet started jumping and we first need to jump to the
-    -- given jump info to set the intersection of the ChainSync server.
+  = -- | The dynamo still has to set the intersection of the ChainSync server
+    -- before it can resume downloading headers. This is because
+    -- the message pipeline might be drained to do jumps, and this causes
+    -- the intersection on the ChainSync server to diverge from the tip of
+    -- the candidate fragment.
     DynamoStarting !(JumpInfo blk)
   | DynamoStarted
   deriving (Generic)
@@ -179,7 +182,10 @@ deriving anyclass instance
 
 data ObjectorInitState
   = -- | The objector still needs to set the intersection of the ChainSync
-    -- server before resuming retrieval of headers.
+    -- server before resuming retrieval of headers. This is mainly because
+    -- the message pipeline might be drained to do jumps, and this causes
+    -- the intersection on the ChainSync server to diverge from the tip of
+    -- the candidate fragment.
     Starting
   | Started
   deriving (Generic, Show, NoThunks)

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/API.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/API.hs
@@ -91,6 +91,8 @@ import qualified Ouroboros.Network.AnchoredFragment as AF
 import           Ouroboros.Network.Block (ChainUpdate, MaxSlotNo,
                      Serialised (..))
 import qualified Ouroboros.Network.Block as Network
+import           Ouroboros.Network.BlockFetch.ConsensusInterface
+                     (ChainSelStarvation (..))
 import           Ouroboros.Network.Mock.Chain (Chain (..))
 import qualified Ouroboros.Network.Mock.Chain as Chain
 import           System.FS.API.Types (FsError)
@@ -346,6 +348,10 @@ data ChainDB m blk = ChainDB {
       -- which rechecks the blocks in all candidate chains whenever a new
       -- invalid block is detected. These blocks are likely to be valid.
     , getIsInvalidBlock :: STM m (WithFingerprint (HeaderHash blk -> Maybe (ExtValidationError blk)))
+
+      -- | Whether ChainSel is currently starved, or when was last time it
+      -- stopped being starved.
+    , getChainSelStarvation :: STM m ChainSelStarvation
 
     , closeDB            :: m ()
 

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/API.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/API.hs
@@ -212,7 +212,9 @@ data ChainDB m blk = ChainDB {
     , getBlockComponent  :: forall b. BlockComponent blk b
                          -> RealPoint blk -> m (Maybe b)
 
-      -- | Return membership check function for recent blocks
+      -- | Return membership check function for recent blocks. This includes
+      -- blocks in the VolatileDB and blocks that are currently being processed
+      -- or are waiting in a queue to be processed.
       --
       -- This check is only reliable for blocks up to @k@ away from the tip.
       -- For blocks older than that the results should be regarded as
@@ -238,7 +240,8 @@ data ChainDB m blk = ChainDB {
       --   are part of a shorter fork.
     , getIsValid         :: STM m (RealPoint blk -> Maybe Bool)
 
-      -- | Get the highest slot number stored in the ChainDB.
+      -- | Get the highest slot number stored in the ChainDB (this includes
+      -- blocks that are waiting in the background queue to be processed).
       --
       -- Note that the corresponding block doesn't have to be part of the
       -- current chain, it could be part of some fork, or even be a

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Background.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Background.hs
@@ -541,6 +541,7 @@ addBlockRunner fuse cdb@CDB{..} = forever $ do
             ChainSelAddBlock BlockToAdd{blockToAdd} ->
               trace $ PoppedBlockFromQueue $ FallingEdgeWith $
                       blockRealPoint blockToAdd
-          chainSelSync cdb message)
+          chainSelSync cdb message
+          lift $ atomically $ processedChainSelMessage cdbChainSelQueue message)
   where
     starvationTracer = Tracer $ traceWith cdbTracer . TraceChainSelStarvationEvent

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Background.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Background.hs
@@ -522,7 +522,7 @@ addBlockRunner fuse cdb@CDB{..} = forever $ do
     -- exception (or it errored), notify the blocked thread
     withFuse fuse $
       bracketOnError
-        (lift $ getChainSelMessage cdbChainSelQueue)
+        (lift $ getChainSelMessage starvationTracer cdbChainSelStarvation cdbChainSelQueue)
         (\message -> lift $ atomically $ do
           case message of
             ChainSelReprocessLoEBlocks varProcessed ->
@@ -542,3 +542,5 @@ addBlockRunner fuse cdb@CDB{..} = forever $ do
               trace $ PoppedBlockFromQueue $ FallingEdgeWith $
                       blockRealPoint blockToAdd
           chainSelSync cdb message)
+  where
+    starvationTracer = Tracer $ traceWith cdbTracer . TraceChainSelStarvationEvent

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Query.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Query.hs
@@ -22,6 +22,7 @@ module Ouroboros.Consensus.Storage.ChainDB.Impl.Query (
   , getAnyBlockComponent
   , getAnyKnownBlock
   , getAnyKnownBlockComponent
+  , getChainSelStarvation
   ) where
 
 import qualified Data.Map.Strict as Map
@@ -50,6 +51,8 @@ import           Ouroboros.Consensus.Util.STM (WithFingerprint (..))
 import           Ouroboros.Network.AnchoredFragment (AnchoredFragment)
 import qualified Ouroboros.Network.AnchoredFragment as AF
 import           Ouroboros.Network.Block (MaxSlotNo, maxSlotNoFromWithOrigin)
+import           Ouroboros.Network.BlockFetch.ConsensusInterface
+                     (ChainSelStarvation (..))
 
 -- | Return the last @k@ headers.
 --
@@ -180,6 +183,12 @@ getIsInvalidBlock ::
   -> STM m (WithFingerprint (HeaderHash blk -> Maybe (ExtValidationError blk)))
 getIsInvalidBlock CDB{..} =
   fmap (fmap (fmap invalidBlockReason) . flip Map.lookup) <$> readTVar cdbInvalid
+
+getChainSelStarvation ::
+     forall m blk. IOLike m
+  => ChainDbEnv m blk
+  -> STM m ChainSelStarvation
+getChainSelStarvation CDB {..} = readTVar cdbChainSelStarvation
 
 getIsValid ::
      forall m blk. (IOLike m, HasHeader blk)

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Query.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Query.hs
@@ -164,18 +164,15 @@ getBlockComponent ::
 getBlockComponent CDB{..} = getAnyBlockComponent cdbImmutableDB cdbVolatileDB
 
 getIsFetched ::
-     forall m blk. IOLike m
+     forall m blk. (IOLike m, HasHeader blk)
   => ChainDbEnv m blk -> STM m (Point blk -> Bool)
-getIsFetched CDB{..} = basedOnHash <$> VolatileDB.getIsMember cdbVolatileDB
-  where
-    -- The volatile DB indexes by hash only, not by points. However, it should
-    -- not be possible to have two points with the same hash but different
-    -- slot numbers.
-    basedOnHash :: (HeaderHash blk -> Bool) -> Point blk -> Bool
-    basedOnHash f p =
-        case pointHash p of
-          BlockHash hash -> f hash
-          GenesisHash    -> False
+getIsFetched CDB{..} = do
+    checkQueue <- memberChainSelQueue cdbChainSelQueue
+    checkVolDb <- VolatileDB.getIsMember cdbVolatileDB
+    return $ \pt ->
+      case pointToWithOriginRealPoint pt of
+        Origin        -> False
+        NotOrigin pt' -> checkQueue pt' || checkVolDb (realPointHash pt')
 
 getIsInvalidBlock ::
      forall m blk. (IOLike m, HasHeader blk)
@@ -218,10 +215,13 @@ getMaxSlotNo CDB{..} = do
     -- contains block 9'. The ImmutableDB contains blocks 1-10. The max slot
     -- of the current chain will be 10 (being the anchor point of the empty
     -- current chain), while the max slot of the VolatileDB will be 9.
+    --
+    -- Moreover, we have to look in 'ChainSelQueue' too.
     curChainMaxSlotNo <- maxSlotNoFromWithOrigin . AF.headSlot
                      <$> readTVar cdbChain
-    volatileDbMaxSlotNo    <- VolatileDB.getMaxSlotNo cdbVolatileDB
-    return $ curChainMaxSlotNo `max` volatileDbMaxSlotNo
+    volatileDbMaxSlotNo <- VolatileDB.getMaxSlotNo cdbVolatileDB
+    queuedMaxSlotNo <- getMaxSlotNoChainSelQueue cdbChainSelQueue
+    return $ curChainMaxSlotNo `max` volatileDbMaxSlotNo `max` queuedMaxSlotNo
 
 {-------------------------------------------------------------------------------
   Unifying interface over the immutable DB and volatile DB, but independent

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Types.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Types.hs
@@ -64,6 +64,7 @@ module Ouroboros.Consensus.Storage.ChainDB.Impl.Types (
   ) where
 
 import           Cardano.Prelude (whenM)
+import           Control.Monad (when)
 import           Control.ResourceRegistry
 import           Control.Tracer
 import           Data.Foldable (traverse_)

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Types.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Types.hs
@@ -51,6 +51,7 @@ module Ouroboros.Consensus.Storage.ChainDB.Impl.Types (
     -- * Trace types
   , SelectionChangedInfo (..)
   , TraceAddBlockEvent (..)
+  , TraceChainSelStarvationEvent (..)
   , TraceCopyToImmutableDBEvent (..)
   , TraceEvent (..)
   , TraceFollowerEvent (..)
@@ -62,6 +63,7 @@ module Ouroboros.Consensus.Storage.ChainDB.Impl.Types (
   , TraceValidationEvent (..)
   ) where
 
+import           Cardano.Prelude (whenM)
 import           Control.ResourceRegistry
 import           Control.Tracer
 import           Data.Foldable (traverse_)
@@ -105,6 +107,8 @@ import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Consensus.Util.STM (WithFingerprint)
 import           Ouroboros.Network.AnchoredFragment (AnchoredFragment)
 import           Ouroboros.Network.Block (MaxSlotNo)
+import           Ouroboros.Network.BlockFetch.ConsensusInterface
+                     (ChainSelStarvation (..))
 
 -- | All the serialisation related constraints needed by the ChainDB.
 class ( ImmutableDbSerialiseConstraints blk
@@ -254,6 +258,9 @@ data ChainDbEnv m blk = CDB
     -- switch back to a chain containing it. The fragment is usually anchored at
     -- a recent immutable tip; if it does not, it will conservatively be treated
     -- as the empty fragment anchored in the current immutable tip.
+  , cdbChainSelStarvation :: !(StrictTVar m ChainSelStarvation)
+    -- ^ Information on the last starvation of ChainSel, whether ongoing or
+    -- ended recently.
   } deriving (Generic)
 
 -- | We include @blk@ in 'showTypeOf' because it helps resolving type families
@@ -483,9 +490,42 @@ addReprocessLoEBlocks tracer (ChainSelQueue queue) = do
   return $ ChainSelectionPromise waitUntilRan
 
 -- | Get the oldest message from the 'ChainSelQueue' queue. Can block when the
--- queue is empty.
-getChainSelMessage :: IOLike m => ChainSelQueue m blk -> m (ChainSelMessage m blk)
-getChainSelMessage (ChainSelQueue queue) = atomically $ readTBQueue queue
+-- queue is empty; in that case, reports the starvation (and its end) via the
+-- given tracer.
+getChainSelMessage
+  :: forall m blk. (HasHeader blk, IOLike m)
+  => Tracer m (TraceChainSelStarvationEvent blk)
+  -> StrictTVar m ChainSelStarvation
+  -> ChainSelQueue m blk
+  -> m (ChainSelMessage m blk)
+getChainSelMessage starvationTracer starvationVar (ChainSelQueue queue) =
+    atomically (tryReadTBQueue' queue) >>= \case
+      Just msg -> pure msg
+      Nothing  -> do
+        startStarvationMeasure
+        msg <- atomically $ readTBQueue queue
+        terminateStarvationMeasure msg
+        pure msg
+  where
+    startStarvationMeasure :: m ()
+    startStarvationMeasure = do
+      prevStarvation <- atomically $ swapTVar starvationVar ChainSelStarvationOngoing
+      when (prevStarvation /= ChainSelStarvationOngoing) $
+        traceWith starvationTracer . ChainSelStarvationStarted =<< getMonotonicTime
+
+    terminateStarvationMeasure :: ChainSelMessage m blk -> m ()
+    terminateStarvationMeasure = \case
+      ChainSelAddBlock BlockToAdd{blockToAdd=block} -> do
+        tf <- getMonotonicTime
+        let pt = blockRealPoint block
+        traceWith starvationTracer $ ChainSelStarvationEnded tf pt
+        atomically $ writeTVar starvationVar (ChainSelStarvationEndedAt tf)
+      ChainSelReprocessLoEBlocks{} -> pure ()
+
+-- TODO Can't use tryReadTBQueue from io-classes because it is broken for IOSim
+-- (but not for IO). https://github.com/input-output-hk/io-sim/issues/195
+tryReadTBQueue' :: MonadSTM m => TBQueue m a -> STM m (Maybe a)
+tryReadTBQueue' q = (Just <$> readTBQueue q) `orElse` pure Nothing
 
 -- | Flush the 'ChainSelQueue' queue and notify the waiting threads.
 --
@@ -519,6 +559,7 @@ data TraceEvent blk
   | TraceImmutableDBEvent       (ImmutableDB.TraceEvent       blk)
   | TraceVolatileDBEvent        (VolatileDB.TraceEvent        blk)
   | TraceLastShutdownUnclean
+  | TraceChainSelStarvationEvent(TraceChainSelStarvationEvent blk)
   deriving (Generic)
 
 
@@ -826,4 +867,17 @@ data TraceIteratorEvent blk
     -- back in the VolatileDB again because the ImmutableDB doesn't have the
     -- next block we're looking for.
   | SwitchBackToVolatileDB
+  deriving (Generic, Eq, Show)
+
+-- | Chain selection is /starved/ when the background thread runs out of work.
+-- This is the usual case and innocent while caught-up; but while syncing, it
+-- means that we are downloading blocks at a smaller rate than we can validate
+-- them, even though we generally expect to be CPU-bound.
+data TraceChainSelStarvationEvent blk
+    -- | A ChainSel starvation started at the given time.
+  = ChainSelStarvationStarted Time
+
+    -- | The last ChainSel starvation ended at the given time as a block wth the
+    -- given point has been received.
+  | ChainSelStarvationEnded Time (RealPoint blk)
   deriving (Generic, Eq, Show)

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Util/Orphans.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Util/Orphans.hs
@@ -23,6 +23,8 @@ import           Data.Bimap (Bimap)
 import qualified Data.Bimap as Bimap
 import           Data.IntPSQ (IntPSQ)
 import qualified Data.IntPSQ as PSQ
+import           Data.MultiSet (MultiSet)
+import qualified Data.MultiSet as MultiSet
 import           Data.SOP.BasicFunctors
 import           NoThunks.Class (InspectHeap (..), InspectHeapNamed (..),
                      NoThunks (..), OnlyCheckWhnfNamed (..), allNoThunks,
@@ -74,6 +76,10 @@ deriving via OnlyCheckWhnfNamed "Tracer" (Tracer m ev) instance NoThunks (Tracer
 instance NoThunks a => NoThunks (K a b) where
   showTypeOf _ = showTypeOf (Proxy @a)
   wNoThunks ctxt (K a) = wNoThunks ("K":ctxt) a
+
+instance NoThunks a => NoThunks (MultiSet a) where
+  showTypeOf _ = "MultiSet"
+  wNoThunks ctxt = wNoThunks ctxt . MultiSet.toMap
 
 {-------------------------------------------------------------------------------
   fs-api

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/MiniProtocol/BlockFetch/Client.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/MiniProtocol/BlockFetch/Client.hs
@@ -53,9 +53,9 @@ import           Ouroboros.Network.AnchoredFragment (AnchoredFragment)
 import qualified Ouroboros.Network.AnchoredFragment as AF
 import           Ouroboros.Network.BlockFetch (BlockFetchConfiguration (..),
                      BlockFetchConsensusInterface (..), FetchMode (..),
-                     blockFetchLogic, bracketFetchClient,
-                     bracketKeepAliveClient, bracketSyncWithFetchClient,
-                     newFetchClientRegistry)
+                     GenesisBlockFetchConfiguration (..), blockFetchLogic,
+                     bracketFetchClient, bracketKeepAliveClient,
+                     bracketSyncWithFetchClient, newFetchClientRegistry)
 import           Ouroboros.Network.BlockFetch.Client (blockFetchClient)
 import           Ouroboros.Network.ControlMessage (ControlMessage (..))
 import           Ouroboros.Network.Mock.Chain (Chain)
@@ -371,6 +371,8 @@ instance Arbitrary BlockFetchClientTestSetup where
             bfcBulkSyncGracePeriod = 10
         bfcMaxRequestsInflight <- chooseEnum (2, 10)
         bfcSalt                <- arbitrary
+        gbfcBulkSyncGracePeriod <- fromIntegral <$> chooseInteger (5, 60)
+        let bfcGenesisBFConfig = GenesisBlockFetchConfiguration {..}
         pure BlockFetchConfiguration {..}
       pure BlockFetchClientTestSetup {..}
     where

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/MiniProtocol/BlockFetch/Client.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/MiniProtocol/BlockFetch/Client.hs
@@ -96,7 +96,9 @@ prop_blockFetch bfcts@BlockFetchClientTestSetup{..} =
       ] <>
       [ Map.keysSet bfcoBlockFetchResults === Map.keysSet peerUpdates
       , counterexample ("Fetched blocks per peer: " <> condense bfcoFetchedBlocks) $
-        property $ all (> 0) bfcoFetchedBlocks
+        property $ case blockFetchMode of
+          FetchModeDeadline -> all (> 0) bfcoFetchedBlocks
+          FetchModeBulkSync -> any (> 0) bfcoFetchedBlocks
       ]
   where
     BlockFetchClientOutcome{..} = runSimOrThrow $ runBlockFetchTest bfcts
@@ -362,13 +364,12 @@ instance Arbitrary BlockFetchClientTestSetup where
       blockFetchMode <- elements [FetchModeBulkSync, FetchModeDeadline]
       blockFetchCfg  <- do
         let -- ensure that we can download blocks from all peers
-            bfcMaxConcurrencyBulkSync = fromIntegral numPeers
             bfcMaxConcurrencyDeadline = fromIntegral numPeers
             -- This is used to introduce a minimal delay between BlockFetch
             -- logic iterations in case the monitored state vars change too
             -- fast, which we don't have to worry about in this test.
-            bfcDecisionLoopInterval   = 0
-            bfcBulkSyncGracePeriod = 10
+            bfcDecisionLoopIntervalBulkSync = 0
+            bfcDecisionLoopIntervalDeadline = 0
         bfcMaxRequestsInflight <- chooseEnum (2, 10)
         bfcSalt                <- arbitrary
         gbfcBulkSyncGracePeriod <- fromIntegral <$> chooseInteger (5, 60)

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/MiniProtocol/BlockFetch/Client.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/MiniProtocol/BlockFetch/Client.hs
@@ -279,6 +279,7 @@ runBlockFetchTest BlockFetchClientTestSetup{..} = withRegistry \registry -> do
       -> BlockFetchConsensusInterface PeerId (Header TestBlock) TestBlock m
     mkTestBlockFetchConsensusInterface getCandidates chainDbView =
         (BlockFetchClientInterface.mkBlockFetchConsensusInterface @m @PeerId
+          nullTracer
           (TestBlockConfig numCoreNodes)
           chainDbView
           (error "ChainSyncClientHandleCollection not provided to mkBlockFetchConsensusInterface")

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/MiniProtocol/BlockFetch/Client.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/MiniProtocol/BlockFetch/Client.hs
@@ -8,6 +8,7 @@
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TupleSections #-}
+{-# LANGUAGE TypeApplications #-}
 
 -- | A test for the consensus-specific parts of the BlockFetch client.
 --
@@ -51,7 +52,7 @@ import           Ouroboros.Consensus.Util.STM (blockUntilJust,
 import           Ouroboros.Network.AnchoredFragment (AnchoredFragment)
 import qualified Ouroboros.Network.AnchoredFragment as AF
 import           Ouroboros.Network.BlockFetch (BlockFetchConfiguration (..),
-                     BlockFetchConsensusInterface, FetchMode (..),
+                     BlockFetchConsensusInterface (..), FetchMode (..),
                      blockFetchLogic, bracketFetchClient,
                      bracketKeepAliveClient, bracketSyncWithFetchClient,
                      newFetchClientRegistry)
@@ -254,10 +255,11 @@ runBlockFetchTest BlockFetchClientTestSetup{..} = withRegistry \registry -> do
 
         let -- Always return the empty chain such that the BlockFetch logic
             -- downloads all chains.
-            getCurrentChain           = pure $ AF.Empty AF.AnchorGenesis
-            getIsFetched              = ChainDB.getIsFetched chainDB
-            getMaxSlotNo              = ChainDB.getMaxSlotNo chainDB
-            addBlockWaitWrittenToDisk = ChainDB.addBlockWaitWrittenToDisk chainDB
+            getCurrentChain       = pure $ AF.Empty AF.AnchorGenesis
+            getIsFetched          = ChainDB.getIsFetched chainDB
+            getMaxSlotNo          = ChainDB.getMaxSlotNo chainDB
+            addBlockAsync         = ChainDB.addBlockAsync chainDB
+            getChainSelStarvation = ChainDB.getChainSelStarvation chainDB
         pure BlockFetchClientInterface.ChainDbView {..}
       where
         -- Needs to be larger than any chain length in this test, to ensure that
@@ -276,14 +278,17 @@ runBlockFetchTest BlockFetchClientTestSetup{..} = withRegistry \registry -> do
       -> BlockFetchClientInterface.ChainDbView m TestBlock
       -> BlockFetchConsensusInterface PeerId (Header TestBlock) TestBlock m
     mkTestBlockFetchConsensusInterface getCandidates chainDbView =
-        BlockFetchClientInterface.mkBlockFetchConsensusInterface
+        (BlockFetchClientInterface.mkBlockFetchConsensusInterface @m @PeerId
           (TestBlockConfig numCoreNodes)
           chainDbView
-          getCandidates
+          (error "ChainSyncClientHandleCollection not provided to mkBlockFetchConsensusInterface")
           (\_hdr -> 1000) -- header size, only used for peer prioritization
           slotForgeTime
           (pure blockFetchMode)
-          blockFetchPipelining
+          blockFetchPipelining)
+            { readCandidateChains          = getCandidates
+            , demoteChainSyncJumpingDynamo = const (pure ())
+            }
       where
         -- Bogus implementation; this is fine as this is only used for
         -- enriching tracing information ATM.
@@ -362,6 +367,7 @@ instance Arbitrary BlockFetchClientTestSetup where
             -- logic iterations in case the monitored state vars change too
             -- fast, which we don't have to worry about in this test.
             bfcDecisionLoopInterval   = 0
+            bfcBulkSyncGracePeriod = 10
         bfcMaxRequestsInflight <- chooseEnum (2, 10)
         bfcSalt                <- arbitrary
         pure BlockFetchConfiguration {..}

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/MiniProtocol/ChainSync/Client.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/MiniProtocol/ChainSync/Client.hs
@@ -81,12 +81,14 @@ import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Extended hiding (ledgerState)
 import           Ouroboros.Consensus.MiniProtocol.ChainSync.Client
                      (CSJConfig (..), ChainDbView (..),
-                     ChainSyncClientException, ChainSyncClientResult (..),
-                     ChainSyncLoPBucketConfig (..), ChainSyncState (..),
-                     ChainSyncStateView (..), ConfigEnv (..), Consensus,
-                     DynamicEnv (..), Our (..), Their (..),
-                     TraceChainSyncClientEvent (..), bracketChainSyncClient,
-                     chainSyncClient, chainSyncStateFor, viewChainSyncState)
+                     ChainSyncClientException,
+                     ChainSyncClientHandleCollection (..),
+                     ChainSyncClientResult (..), ChainSyncLoPBucketConfig (..),
+                     ChainSyncState (..), ChainSyncStateView (..),
+                     ConfigEnv (..), Consensus, DynamicEnv (..), Our (..),
+                     Their (..), TraceChainSyncClientEvent (..),
+                     bracketChainSyncClient, chainSyncClient, chainSyncStateFor,
+                     newChainSyncClientHandleCollection, viewChainSyncState)
 import           Ouroboros.Consensus.MiniProtocol.ChainSync.Client.HistoricityCheck
                      (HistoricityCheck, HistoricityCutoff (..))
 import qualified Ouroboros.Consensus.MiniProtocol.ChainSync.Client.HistoricityCheck as HistoricityCheck
@@ -353,7 +355,7 @@ runChainSync skew securityParam (ClientUpdates clientUpdates)
     -- separate map too, one that isn't emptied. We can use this map to look
     -- at the final state of each candidate.
     varFinalCandidates <- uncheckedNewTVarM Map.empty
-    varHandles     <- uncheckedNewTVarM Map.empty
+    cschCol            <- atomically newChainSyncClientHandleCollection
 
     (tracer, getTrace) <- do
           (tracer', getTrace) <- recordingTracerTVar
@@ -506,7 +508,7 @@ runChainSync skew securityParam (ClientUpdates clientUpdates)
               bracketChainSyncClient
                  chainSyncTracer
                  chainDbView
-                 varHandles
+                 cschCol
                  -- 'Syncing' only ever impacts the LoP, which is disabled in
                  -- this test, so any value would do.
                  (pure Syncing)
@@ -517,7 +519,7 @@ runChainSync skew securityParam (ClientUpdates clientUpdates)
                  diffusionPipelining
                  $ \csState -> do
                    atomically $ do
-                     handles <- readTVar varHandles
+                     handles <- cschcMap cschCol
                      modifyTVar varFinalCandidates $ Map.insert serverId (handles Map.! serverId)
                    (result, _) <-
                      runPipelinedPeer protocolTracer codecChainSyncId clientChannel $
@@ -538,7 +540,7 @@ runChainSync skew securityParam (ClientUpdates clientUpdates)
     let checkTipTime :: m ()
         checkTipTime = do
             now        <- systemTimeCurrent clientSystemTime
-            candidates <- atomically $ viewChainSyncState varHandles csCandidate
+            candidates <- atomically $ viewChainSyncState (cschcMap cschCol) csCandidate
             forM_ candidates $ \candidate -> do
               let p = castPoint $ AF.headPoint candidate :: Point TestBlock
               case pointSlot p of

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
@@ -1241,6 +1241,8 @@ deriving instance SOP.Generic         (ImmutableDB.TraceEvent blk)
 deriving instance SOP.HasDatatypeInfo (ImmutableDB.TraceEvent blk)
 deriving instance SOP.Generic         (VolatileDB.TraceEvent blk)
 deriving instance SOP.HasDatatypeInfo (VolatileDB.TraceEvent blk)
+deriving instance SOP.Generic         (TraceChainSelStarvationEvent blk)
+deriving instance SOP.HasDatatypeInfo (TraceChainSelStarvationEvent blk)
 
 data Tag =
     TagGetIsValidJust
@@ -1635,7 +1637,7 @@ traceEventName = \case
     TraceImmutableDBEvent       ev    -> "ImmutableDB."       <> constrName ev
     TraceVolatileDBEvent        ev    -> "VolatileDB."        <> constrName ev
     TraceLastShutdownUnclean          -> "LastShutdownUnclean"
-    TraceChainSelStarvationEvent _    -> "TraceChainSelStarvationEvent"
+    TraceChainSelStarvationEvent ev   -> "ChainSelStarvation." <> constrName ev
 
 mkArgs :: IOLike m
        => TopLevelConfig Blk

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
@@ -1635,6 +1635,7 @@ traceEventName = \case
     TraceImmutableDBEvent       ev    -> "ImmutableDB."       <> constrName ev
     TraceVolatileDBEvent        ev    -> "VolatileDB."        <> constrName ev
     TraceLastShutdownUnclean          -> "LastShutdownUnclean"
+    TraceChainSelStarvationEvent _    -> "TraceChainSelStarvationEvent"
 
 mkArgs :: IOLike m
        => TopLevelConfig Blk

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
@@ -1241,8 +1241,8 @@ deriving instance SOP.Generic         (ImmutableDB.TraceEvent blk)
 deriving instance SOP.HasDatatypeInfo (ImmutableDB.TraceEvent blk)
 deriving instance SOP.Generic         (VolatileDB.TraceEvent blk)
 deriving instance SOP.HasDatatypeInfo (VolatileDB.TraceEvent blk)
-deriving instance SOP.Generic         (TraceChainSelStarvationEvent blk)
-deriving instance SOP.HasDatatypeInfo (TraceChainSelStarvationEvent blk)
+deriving anyclass instance SOP.Generic         (TraceChainSelStarvationEvent blk)
+deriving anyclass instance SOP.HasDatatypeInfo (TraceChainSelStarvationEvent blk)
 
 data Tag =
     TagGetIsValidJust


### PR DESCRIPTION
Integrates a new implementation of the BulkSync mode, where blocks are downloaded from alternative peers as soon as the node has no more blocks to validate while there are longstanding requests in flight.

This PR depends on the new implementation of the BulkSync mode (https://github.com/IntersectMBO/ouroboros-network/pull/4919). `cabal.project` is made to point to a back-port of the BulkSync implementation on `ouroboros-network-0.16.1.1`.

### CSJ Changes

CSJ is involved because the new BulkSync mode requires to change the dynamo if it is also serving blocks, and it is not sending them promptly enough. The dynamo choice has an influence in the blocks that are chosen to be downloaded by BlockFetch.

For this sake, b93c379 gives the ability to order the ChainSync clients, so the dynamo role can be rotated among them whenever BlockFetch requests it.

b1c0bf8 provides the implementation of the rotation operation.

### BlockFetch tests

c4bfa37 allows to specify in tests in which order to start the peers, which has an effect on what peer is chosen as initial dynamo.

c594c09 in turn adds a new BlockFetch test to show that syncing isn't slowed down by peers that don't send blocks.

### Integration of BlockFetch changes

The collection of ChainSync client handles now needs to be passed between BlockFetch and ChainSync so dynamo rotations can be requested by BlockFetch.

The parameter `bfcMaxConcurrencyBulkSync` has been removed since blocks are not coordinated to be downloaded concurrently.

These changes are in 6926278.
 
### ChainSel changes

Now BlockFetch requires the ability to detect if ChainSel has run out of blocks to validate. This motivates 73187ba, which implements a mechanism to measure if ChainSel is waiting for more blocks (starves), and determines for how long.

The above change is not sufficient to measure starvation. The queue to send blocks for validation used to allow only for one block to sit in the queue. This would interfere with the ability to measure starvation since BlockFetch would block waiting for the queue to become empty, and the queue would quickly become empty after taking just 1 block. For download delays to be amortized, a larger queue capacity was needed. This is the reason why a fix similar to https://github.com/IntersectMBO/ouroboros-network/pull/2721 is part of 0d3fc28.

### Miscellaneous fixes

#### CSJ jump size adjustment

When syncing from mainnet, we discovered that CSJ wouldn't sync the blocks from the Byron era. This was because the jump size was set to the length of the genesis window of the Shelley era, which is much larger than Byron's. When the jump size is larger than the genesis window, the dynamo will block on the forecast horizon before offering a jump that allows the chain selection to advance. In this case, CSJ and chain selection will deadlock.

For this reason we set the default jump size to the size of Byron's genesis window in 028883a. This didn't show an impact on syncing time in our measures. Future work (as part of deploying Genesis) might involve allowing the jump size to vary between different eras.

#### GDD rate limit

GDD evaluation showed an overhead of 10% if run after every header arrives via ChainSync. Therefore, in b7fa122 we limited how often it could run, so multiple header arrivals could be handled by a single GDD evaluation.

#### Candidate fragment comparison in the ChainSync client

We stumbled upon a test case where the candidate fragments of the dynamo and an objector were no longer than the current selection (both peers were adversarial). This was problematic because BlockFetch would refuse to download blocks from these candidates, and ChainSync in turn would wait for the selection to advance in order to download more headers.

The fix in e27a73c is to have the ChainSync client disconnect a peer which is about to block on the forecast horizon if its candidate isn't better than the selection.

#### Candidate fragment truncations

At the moment, it is possible for a candidate fragment to be truncated by CSJ when a jumper jumps to a point that is not younger than the tip of its current candidate fragment. We encountered tests where the jump point could be so old that it would fall behind the immutable tip, and GDD would ignore the peer when computing the Limit on Eagerness. This in turn would cause the selection to advance into potentially adversarial chains.

The fix in dc5f6f7 is to have GDD never drop candidates. When the candidate does not intersect the current selection, the LoE is not advanced. This is a situation guaranteed to be unblocked by the ChainSync client since it will either disconnect the peer or bring the candidate to intersect with the current selection.