### PR TITLE
Remove capacity override from the forging functions

### DIFF
--- a/ouroboros-consensus-cardano/changelog.d/20240710_104628_nick.frisby_remove_cap_override_forge.md
+++ b/ouroboros-consensus-cardano/changelog.d/20240710_104628_nick.frisby_remove_cap_override_forge.md
@@ -1,0 +1,22 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Patch
+
+- A bullet item for the Patch category.
+
+-->
+<!--
+### Non-Breaking
+
+- A bullet item for the Non-Breaking category.
+
+-->
+
+### Breaking
+
+- Remove the capacity override from forging functions.

--- a/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
+++ b/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
@@ -350,6 +350,7 @@ test-suite shelley-test
     constraints,
     containers,
     filepath,
+    measures,
     microlens,
     ouroboros-consensus:{ouroboros-consensus, unstable-consensus-testlib},
     ouroboros-consensus-cardano,

--- a/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/Node.hs
+++ b/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/Node.hs
@@ -100,7 +100,6 @@ import           Ouroboros.Consensus.HardFork.Combinator.Serialisation
 import qualified Ouroboros.Consensus.HardFork.History as History
 import           Ouroboros.Consensus.HeaderValidation
 import           Ouroboros.Consensus.Ledger.Extended
-import qualified Ouroboros.Consensus.Mempool as Mempool
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion
 import           Ouroboros.Consensus.Node.ProtocolInfo
 import           Ouroboros.Consensus.Node.Run
@@ -631,37 +630,30 @@ protocolInfoCardano paramsCardano
     genesisShelley = ledgerTransitionConfig ^. L.tcShelleyGenesisL
 
     ProtocolParamsByron {
-          byronGenesis                = genesisByron
-        , byronLeaderCredentials      = mCredsByron
-        , byronMaxTxCapacityOverrides = maxTxCapacityOverridesByron
+          byronGenesis           = genesisByron
+        , byronLeaderCredentials = mCredsByron
         } = paramsByron
     ProtocolParamsShelleyBased {
           shelleyBasedInitialNonce      = initialNonceShelley
         , shelleyBasedLeaderCredentials = credssShelleyBased
         } = paramsShelleyBased
     ProtocolParamsShelley {
-          shelleyProtVer                = protVerShelley
-        , shelleyMaxTxCapacityOverrides = maxTxCapacityOverridesShelley
+          shelleyProtVer = protVerShelley
         } = paramsShelley
     ProtocolParamsAllegra {
-          allegraProtVer                = protVerAllegra
-        , allegraMaxTxCapacityOverrides = maxTxCapacityOverridesAllegra
+          allegraProtVer = protVerAllegra
         } = paramsAllegra
     ProtocolParamsMary {
-          maryProtVer                = protVerMary
-        , maryMaxTxCapacityOverrides = maxTxCapacityOverridesMary
+          maryProtVer = protVerMary
         } = paramsMary
     ProtocolParamsAlonzo {
-          alonzoProtVer                = protVerAlonzo
-        , alonzoMaxTxCapacityOverrides = maxTxCapacityOverridesAlonzo
+          alonzoProtVer = protVerAlonzo
         } = paramsAlonzo
     ProtocolParamsBabbage {
-          babbageProtVer                = protVerBabbage
-        , babbageMaxTxCapacityOverrides = maxTxCapacityOverridesBabbage
+          babbageProtVer = protVerBabbage
         } = paramsBabbage
     ProtocolParamsConway {
-          conwayProtVer                = protVerConway
-        , conwayMaxTxCapacityOverrides = maxTxCapacityOverridesConway
+          conwayProtVer = protVerConway
         } = paramsConway
 
     transitionConfigShelley = transitionConfigAllegra ^. L.tcPreviousEraConfigL
@@ -1033,7 +1025,7 @@ protocolInfoCardano paramsCardano
     mBlockForgingByron :: Maybe (NonEmptyOptNP (BlockForging m) (CardanoEras c))
     mBlockForgingByron = do
         creds <- mCredsByron
-        return $ byronBlockForging maxTxCapacityOverridesByron creds `OptNP.at` IZ
+        return $ byronBlockForging creds `OptNP.at` IZ
 
     blockForgingShelleyBased ::
          ShelleyLeaderCredentials c
@@ -1058,28 +1050,26 @@ protocolInfoCardano paramsCardano
               Absolute.KESPeriod $ fromIntegral $ slot `div` praosSlotsPerKESPeriod
 
         let tpraos :: forall era.
-                 ShelleyEraWithCrypto c (TPraos c) era
-              => Mempool.TxOverrides (ShelleyBlock (TPraos c) era)
-              -> BlockForging m      (ShelleyBlock (TPraos c) era)
-            tpraos maxTxCapacityOverrides =
-              TPraos.shelleySharedBlockForging hotKey slotToPeriod credentials maxTxCapacityOverrides
+                 ShelleyEraWithCrypto c       (TPraos c) era
+              => BlockForging m (ShelleyBlock (TPraos c) era)
+            tpraos =
+              TPraos.shelleySharedBlockForging hotKey slotToPeriod credentials
 
         let praos :: forall era.
-                 ShelleyEraWithCrypto c (Praos c) era
-              => Mempool.TxOverrides (ShelleyBlock (Praos c) era)
-              -> BlockForging m      (ShelleyBlock (Praos c) era)
-            praos maxTxCapacityOverrides =
-              Praos.praosSharedBlockForging hotKey slotToPeriod credentials maxTxCapacityOverrides
+                 ShelleyEraWithCrypto c       (Praos c) era
+              => BlockForging m (ShelleyBlock (Praos c) era)
+            praos =
+              Praos.praosSharedBlockForging hotKey slotToPeriod credentials
 
         pure
           $ OptSkip    -- Byron
           $ OptNP.fromNonEmptyNP $
-            tpraos maxTxCapacityOverridesShelley :*
-            tpraos maxTxCapacityOverridesAllegra :*
-            tpraos maxTxCapacityOverridesMary    :*
-            tpraos maxTxCapacityOverridesAlonzo  :*
-            praos  maxTxCapacityOverridesBabbage :*
-            praos  maxTxCapacityOverridesConway  :*
+            tpraos :*
+            tpraos :*
+            tpraos :*
+            tpraos :*
+            praos  :*
+            praos  :*
             Nil
 
 protocolClientInfoCardano ::

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Forge.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Forge.hs
@@ -21,7 +21,6 @@ import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.SupportsMempool
 import           Ouroboros.Consensus.Mempool (TxLimits)
-import qualified Ouroboros.Consensus.Mempool as Mempool
 import           Ouroboros.Consensus.Protocol.Abstract (CanBeLeader, IsLeader)
 import           Ouroboros.Consensus.Protocol.Ledger.HotKey (HotKey)
 import           Ouroboros.Consensus.Shelley.Eras (EraCrypto)
@@ -45,8 +44,6 @@ forgeShelleyBlock ::
   => HotKey (EraCrypto era) m
   -> CanBeLeader proto
   -> TopLevelConfig (ShelleyBlock proto era)
-  -> Mempool.TxOverrides (ShelleyBlock proto era) -- ^ How to override max tx
-                                                  --   capacity defined by ledger
   -> BlockNo                                      -- ^ Current block number
   -> SlotNo                                       -- ^ Current slot number
   -> TickedLedgerState (ShelleyBlock proto era)   -- ^ Current ledger
@@ -57,7 +54,6 @@ forgeShelleyBlock
   hotKey
   cbl
   cfg
-  maxTxCapacityOverrides
   curNo
   curSlot
   tickedLedger
@@ -76,7 +72,7 @@ forgeShelleyBlock
         SL.toTxSeq @era
       . Seq.fromList
       . fmap extractTx
-      $ takeLargestPrefixThatFits maxTxCapacityOverrides tickedLedger txs
+      $ takeLargestPrefixThatFits tickedLedger txs
 
     extractTx :: Validated (GenTx (ShelleyBlock proto era)) -> Core.Tx era
     extractTx (ShelleyValidatedTx _txid vtx) = SL.extractTx vtx

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Node/Praos.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Node/Praos.hs
@@ -56,12 +56,11 @@ praosBlockForging ::
      , IOLike m
      )
   => PraosParams
-  -> Mempool.TxOverrides (ShelleyBlock (Praos c) era)
   -> ShelleyLeaderCredentials (EraCrypto era)
   -> m (BlockForging m (ShelleyBlock (Praos c) era))
-praosBlockForging praosParams maxTxCapacityOverrides credentials = do
+praosBlockForging praosParams credentials = do
     hotKey <- HotKey.mkHotKey @m @c initSignKey startPeriod praosMaxKESEvo
-    pure $ praosSharedBlockForging hotKey slotToPeriod credentials maxTxCapacityOverrides
+    pure $ praosSharedBlockForging hotKey slotToPeriod credentials
   where
     PraosParams {praosMaxKESEvo, praosSlotsPerKESPeriod} = praosParams
 
@@ -89,16 +88,14 @@ praosSharedBlockForging ::
   => HotKey.HotKey c m
   -> (SlotNo -> Absolute.KESPeriod)
   -> ShelleyLeaderCredentials c
-  -> Mempool.TxOverrides (ShelleyBlock (Praos c) era)
-  -> BlockForging m     (ShelleyBlock (Praos c) era)
+  -> BlockForging m (ShelleyBlock (Praos c) era)
 praosSharedBlockForging
   hotKey
   slotToPeriod
   ShelleyLeaderCredentials {
       shelleyLeaderCredentialsCanBeLeader = canBeLeader
     , shelleyLeaderCredentialsLabel = label
-    }
-  maxTxCapacityOverrides = do
+    } = do
     BlockForging
       { forgeLabel = label <> "_" <> T.pack (L.eraName @era),
         canBeLeader = canBeLeader,
@@ -114,7 +111,6 @@ praosSharedBlockForging
             hotKey
             canBeLeader
             cfg
-            maxTxCapacityOverrides
       }
 
 {-------------------------------------------------------------------------------
@@ -122,13 +118,11 @@ praosSharedBlockForging
 -------------------------------------------------------------------------------}
 
 data instance ProtocolParams (ShelleyBlock (Praos c) (BabbageEra c)) = ProtocolParamsBabbage {
-    babbageProtVer                :: SL.ProtVer
+    babbageProtVer :: SL.ProtVer
     -- ^ see 'Ouroboros.Consensus.Shelley.Node.TPraos.shelleyProtVer', mutatis mutandi
-  , babbageMaxTxCapacityOverrides :: Mempool.TxOverrides (ShelleyBlock (Praos c) (BabbageEra c))
   }
 
 data instance ProtocolParams (ShelleyBlock (Praos c) (ConwayEra c)) = ProtocolParamsConway {
-    conwayProtVer                :: SL.ProtVer
+    conwayProtVer :: SL.ProtVer
     -- ^ see 'Ouroboros.Consensus.Shelley.Node.TPraos.shelleyProtVer', mutatis mutandi
-  , conwayMaxTxCapacityOverrides :: Mempool.TxOverrides (ShelleyBlock (Praos c) (ConwayEra c))
   }

--- a/ouroboros-consensus-cardano/src/unstable-byron-testlib/Ouroboros/Consensus/ByronDual/Ledger.hs
+++ b/ouroboros-consensus-cardano/src/unstable-byron-testlib/Ouroboros/Consensus/ByronDual/Ledger.hs
@@ -43,7 +43,6 @@ import           Ouroboros.Consensus.ByronSpec.Ledger
 import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Dual
-import qualified Ouroboros.Consensus.Mempool as Mempool
 import           Ouroboros.Consensus.Protocol.PBFT
 import qualified Test.Cardano.Chain.Elaboration.Block as Spec.Test
 import qualified Test.Cardano.Chain.Elaboration.Keys as Spec.Test
@@ -223,7 +222,6 @@ forgeDualByronBlock cfg curBlockNo curSlotNo tickedLedger vtxs isLeader =
     main :: ByronBlock
     main = forgeByronBlock
              (dualTopLevelConfigMain cfg)
-             (Mempool.mkOverrides Mempool.noOverridesMeasure)
              curBlockNo
              curSlotNo
              (tickedDualLedgerStateMain tickedLedger)

--- a/ouroboros-consensus-cardano/src/unstable-byron-testlib/Ouroboros/Consensus/ByronDual/Node.hs
+++ b/ouroboros-consensus-cardano/src/unstable-byron-testlib/Ouroboros/Consensus/ByronDual/Node.hs
@@ -37,7 +37,6 @@ import           Ouroboros.Consensus.HeaderValidation
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Dual
 import           Ouroboros.Consensus.Ledger.Extended
-import qualified Ouroboros.Consensus.Mempool as Mempool
 import           Ouroboros.Consensus.Node.InitStorage
 import           Ouroboros.Consensus.Node.ProtocolInfo
 import           Ouroboros.Consensus.Node.Run
@@ -69,10 +68,7 @@ dualByronBlockForging creds = BlockForging {
     , forgeBlock       = return .....: forgeDualByronBlock
     }
   where
-    BlockForging {..} =
-      byronBlockForging
-        (Mempool.mkOverrides Mempool.noOverridesMeasure)
-        creds
+    BlockForging {..} = byronBlockForging creds
 
 {-------------------------------------------------------------------------------
   ProtocolInfo

--- a/ouroboros-consensus-cardano/src/unstable-byron-testlib/Test/Consensus/Byron/Examples.hs
+++ b/ouroboros-consensus-cardano/src/unstable-byron-testlib/Test/Consensus/Byron/Examples.hs
@@ -38,7 +38,6 @@ import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.HeaderValidation
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Extended
-import qualified Ouroboros.Consensus.Mempool as Mempool
 import           Ouroboros.Consensus.NodeId
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Protocol.PBFT
@@ -121,7 +120,6 @@ exampleBlock :: ByronBlock
 exampleBlock =
     forgeRegularBlock
       cfg
-      (Mempool.mkOverrides Mempool.noOverridesMeasure)
       (BlockNo 1)
       (SlotNo 1)
       (applyChainTick ledgerConfig (SlotNo 1) ledgerStateAfterEBB)

--- a/ouroboros-consensus-cardano/src/unstable-byron-testlib/Test/ThreadNet/Infra/Byron/ProtocolInfo.hs
+++ b/ouroboros-consensus-cardano/src/unstable-byron-testlib/Test/ThreadNet/Infra/Byron/ProtocolInfo.hs
@@ -24,7 +24,6 @@ import           Ouroboros.Consensus.Byron.Crypto.DSIGN (ByronDSIGN,
                      SignKeyDSIGN (..))
 import           Ouroboros.Consensus.Byron.Ledger (ByronBlock)
 import           Ouroboros.Consensus.Byron.Node
-import qualified Ouroboros.Consensus.Mempool as Mempool
 import           Ouroboros.Consensus.Node.ProtocolInfo (ProtocolInfo (..))
 import           Ouroboros.Consensus.NodeId (CoreNodeId (..))
 import           Ouroboros.Consensus.Protocol.PBFT
@@ -66,7 +65,6 @@ mkProtocolByron params coreNodeId genesisConfig genesisSecrets =
           , byronProtocolVersion        = theProposedProtocolVersion
           , byronSoftwareVersion        = theProposedSoftwareVersion
           , byronLeaderCredentials      = Just leaderCredentials
-          , byronMaxTxCapacityOverrides = Mempool.mkOverrides Mempool.noOverridesMeasure
           }
 
 mkLeaderCredentials ::

--- a/ouroboros-consensus-cardano/src/unstable-cardano-testlib/Test/Consensus/Cardano/ProtocolInfo.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-testlib/Test/Consensus/Cardano/ProtocolInfo.hs
@@ -35,8 +35,7 @@ import           Ouroboros.Consensus.Block.Forging (BlockForging)
 import           Ouroboros.Consensus.BlockchainTime (SlotLength)
 import           Ouroboros.Consensus.Byron.Node (ByronLeaderCredentials,
                      ProtocolParams (..), byronGenesis,
-                     byronMaxTxCapacityOverrides, byronPbftSignatureThreshold,
-                     byronSoftwareVersion)
+                     byronPbftSignatureThreshold, byronSoftwareVersion)
 import           Ouroboros.Consensus.Cardano.Block (CardanoBlock)
 import           Ouroboros.Consensus.Cardano.Node (CardanoHardForkConstraints,
                      CardanoHardForkTriggers (..), ProtocolParams (..),
@@ -44,7 +43,6 @@ import           Ouroboros.Consensus.Cardano.Node (CardanoHardForkConstraints,
                      protocolInfoCardano)
 import           Ouroboros.Consensus.Config (emptyCheckpointsMap)
 import           Ouroboros.Consensus.Config.SecurityParam (SecurityParam (..))
-import qualified Ouroboros.Consensus.Mempool as Mempool
 import           Ouroboros.Consensus.Node.ProtocolInfo (NumCoreNodes (..),
                      ProtocolInfo)
 import           Ouroboros.Consensus.NodeId (CoreNodeId (..))
@@ -279,35 +277,28 @@ mkTestProtocolInfo
             , byronProtocolVersion        = aByronProtocolVersion
             , byronSoftwareVersion        = softVerByron
             , byronLeaderCredentials      = Just leaderCredentialsByron
-            , byronMaxTxCapacityOverrides = Mempool.mkOverrides Mempool.noOverridesMeasure
             }
           ProtocolParamsShelleyBased {
               shelleyBasedInitialNonce      = initialNonce
             , shelleyBasedLeaderCredentials = [leaderCredentialsShelley]
             }
           ProtocolParamsShelley {
-              shelleyProtVer                = hfSpecProtVer Shelley hardForkSpec
-            , shelleyMaxTxCapacityOverrides = Mempool.mkOverrides Mempool.noOverridesMeasure
+              shelleyProtVer = hfSpecProtVer Shelley hardForkSpec
             }
           ProtocolParamsAllegra {
-              allegraProtVer                = hfSpecProtVer Allegra hardForkSpec
-            , allegraMaxTxCapacityOverrides = Mempool.mkOverrides Mempool.noOverridesMeasure
+              allegraProtVer = hfSpecProtVer Allegra hardForkSpec
             }
           ProtocolParamsMary {
-              maryProtVer                   = hfSpecProtVer Mary hardForkSpec
-            , maryMaxTxCapacityOverrides    = Mempool.mkOverrides Mempool.noOverridesMeasure
+              maryProtVer = hfSpecProtVer Mary hardForkSpec
             }
           ProtocolParamsAlonzo {
-              alonzoProtVer                 = hfSpecProtVer Alonzo hardForkSpec
-            , alonzoMaxTxCapacityOverrides  = Mempool.mkOverrides Mempool.noOverridesMeasure
+              alonzoProtVer = hfSpecProtVer Alonzo hardForkSpec
             }
           ProtocolParamsBabbage {
-              babbageProtVer                = hfSpecProtVer Babbage hardForkSpec
-            , babbageMaxTxCapacityOverrides = Mempool.mkOverrides Mempool.noOverridesMeasure
+              babbageProtVer = hfSpecProtVer Babbage hardForkSpec
             }
           ProtocolParamsConway {
-              conwayProtVer                 = hfSpecProtVer Conway hardForkSpec
-            , conwayMaxTxCapacityOverrides  = Mempool.mkOverrides Mempool.noOverridesMeasure
+              conwayProtVer = hfSpecProtVer Conway hardForkSpec
             }
           CardanoHardForkTriggers' {
               triggerHardForkShelley = hfSpecTransitionTrigger Shelley hardForkSpec

--- a/ouroboros-consensus-cardano/src/unstable-cardano-testlib/Test/ThreadNet/Infra/ShelleyBasedHardFork.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-testlib/Test/ThreadNet/Infra/ShelleyBasedHardFork.hs
@@ -50,7 +50,6 @@ import           Ouroboros.Consensus.Ledger.Basics (LedgerConfig)
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
                      (LedgerSupportsProtocol)
 import           Ouroboros.Consensus.Mempool (TxLimits)
-import qualified Ouroboros.Consensus.Mempool as Mempool
 import           Ouroboros.Consensus.Node
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion
 import           Ouroboros.Consensus.Protocol.TPraos
@@ -267,7 +266,6 @@ protocolInfoShelleyBasedHardFork protocolParamsShelleyBased
           protocolParamsShelleyBased
           (transCfg2 ^. L.tcPreviousEraConfigL)
           protVer1
-          (Mempool.mkOverrides Mempool.noOverridesMeasure)
 
     eraParams1 :: History.EraParams
     eraParams1 = shelleyEraParams genesis
@@ -292,7 +290,6 @@ protocolInfoShelleyBasedHardFork protocolParamsShelleyBased
             }
           transCfg2
           protVer2
-          (Mempool.mkOverrides Mempool.noOverridesMeasure)
 
     eraParams2 :: History.EraParams
     eraParams2 = shelleyEraParams genesis

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Node/Protocol/Byron.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Node/Protocol/Byron.hs
@@ -33,7 +33,6 @@ import qualified Data.ByteString.Lazy as LB
 import           Data.Text as Text (unpack)
 import           Ouroboros.Consensus.Cardano
 import qualified Ouroboros.Consensus.Cardano as Consensus
-import qualified Ouroboros.Consensus.Mempool as Mempool
 import           Prelude hiding (show, (.))
 
 
@@ -83,10 +82,7 @@ mkSomeConsensusProtocolByron NodeByronProtocolConfiguration {
           Update.SoftwareVersion
             npcByronApplicationName
             npcByronApplicationVersion,
-        byronLeaderCredentials =
-          optionalLeaderCredentials,
-        byronMaxTxCapacityOverrides =
-          Mempool.mkOverrides Mempool.noOverridesMeasure
+        byronLeaderCredentials = optionalLeaderCredentials
         }
 
 readGenesis :: GenesisFile

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Node/Protocol/Cardano.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Node/Protocol/Cardano.hs
@@ -37,7 +37,6 @@ import           Ouroboros.Consensus.Cardano.Condense ()
 import           Ouroboros.Consensus.Cardano.Node (CardanoProtocolParams)
 import           Ouroboros.Consensus.Config (emptyCheckpointsMap)
 import           Ouroboros.Consensus.HardFork.Combinator.Condense ()
-import qualified Ouroboros.Consensus.Mempool as Mempool
 import           Ouroboros.Consensus.Shelley.Crypto (StandardCrypto)
 
 
@@ -180,10 +179,7 @@ mkConsensusProtocolCardano NodeByronProtocolConfiguration {
             Byron.SoftwareVersion
               npcByronApplicationName
               npcByronApplicationVersion,
-          byronLeaderCredentials =
-            byronLeaderCredentials,
-          byronMaxTxCapacityOverrides =
-            Mempool.mkOverrides Mempool.noOverridesMeasure
+          byronLeaderCredentials = byronLeaderCredentials
         }
         Consensus.ProtocolParamsShelleyBased {
           shelleyBasedInitialNonce      = Shelley.genesisHashToPraosNonce
@@ -195,54 +191,40 @@ mkConsensusProtocolCardano NodeByronProtocolConfiguration {
           -- version that this node will declare that it understands, when it
           -- is in the Shelley era. That is, it is the version of protocol
           -- /after/ Shelley, i.e. Allegra.
-          shelleyProtVer =
-            ProtVer (natVersion @3) 0,
-          shelleyMaxTxCapacityOverrides =
-            Mempool.mkOverrides Mempool.noOverridesMeasure
+          shelleyProtVer = ProtVer (natVersion @3) 0
         }
         Consensus.ProtocolParamsAllegra {
           -- This is /not/ the Allegra protocol version. It is the protocol
           -- version that this node will declare that it understands, when it
           -- is in the Allegra era. That is, it is the version of protocol
           -- /after/ Allegra, i.e. Mary.
-          allegraProtVer =
-            ProtVer (natVersion @4) 0,
-          allegraMaxTxCapacityOverrides =
-            Mempool.mkOverrides Mempool.noOverridesMeasure
+          allegraProtVer = ProtVer (natVersion @4) 0
         }
         Consensus.ProtocolParamsMary {
           -- This is /not/ the Mary protocol version. It is the protocol
           -- version that this node will declare that it understands, when it
           -- is in the Mary era. That is, it is the version of protocol
           -- /after/ Mary, i.e. Alonzo.
-          maryProtVer = ProtVer (natVersion @5) 0,
-          maryMaxTxCapacityOverrides =
-            Mempool.mkOverrides Mempool.noOverridesMeasure
+          maryProtVer = ProtVer (natVersion @5) 0
         }
         Consensus.ProtocolParamsAlonzo {
           -- This is /not/ the Alonzo protocol version. It is the protocol
           -- version that this node will declare that it understands, when it
           -- is in the Alonzo era. That is, it is the version of protocol
           -- /after/ Alonzo, i.e. Babbage.
-          alonzoProtVer = ProtVer (natVersion @7) 0,
-          alonzoMaxTxCapacityOverrides =
-            Mempool.mkOverrides Mempool.noOverridesMeasure
+          alonzoProtVer = ProtVer (natVersion @7) 0
         }
         Consensus.ProtocolParamsBabbage {
           -- This is /not/ the Babbage protocol version. It is the protocol
           -- version that this node will declare that it understands, when it
           -- is in the Babbage era.
-          Consensus.babbageProtVer = ProtVer (natVersion @9) 0,
-          Consensus.babbageMaxTxCapacityOverrides =
-            Mempool.mkOverrides Mempool.noOverridesMeasure
+          Consensus.babbageProtVer = ProtVer (natVersion @9) 0
         }
         Consensus.ProtocolParamsConway {
           -- This is /not/ the Conway protocol version. It is the protocol
           -- version that this node will declare that it understands, when it
           -- is in the Conway era.
-          Consensus.conwayProtVer = ProtVer (natVersion @9) 0,
-          Consensus.conwayMaxTxCapacityOverrides =
-            Mempool.mkOverrides Mempool.noOverridesMeasure
+          Consensus.conwayProtVer = ProtVer (natVersion @9) 0
         }
         -- The 'CardanoHardForkTriggers' specify the parameters needed to
         -- transition between two eras. The comments below also apply for all

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Node/Protocol/Shelley.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Node/Protocol/Shelley.hs
@@ -44,7 +44,6 @@ import qualified Data.Aeson as Aeson (FromJSON (..), eitherDecodeStrict')
 import qualified Data.ByteString as BS
 import qualified Data.Text as T
 import qualified Ouroboros.Consensus.Cardano as Consensus
-import qualified Ouroboros.Consensus.Mempool as Mempool
 import           Ouroboros.Consensus.Protocol.Praos.Common
                      (PraosCanBeLeader (..))
 import           Ouroboros.Consensus.Shelley.Node (Nonce (..),
@@ -87,10 +86,7 @@ mkSomeConsensusProtocolShelley NodeShelleyProtocolConfiguration {
             leaderCredentials
       }
       Consensus.ProtocolParamsShelley {
-        shelleyProtVer =
-          ProtVer (natVersion @2) 0,
-        shelleyMaxTxCapacityOverrides =
-          Mempool.mkOverrides Mempool.noOverridesMeasure
+        shelleyProtVer = ProtVer (natVersion @2) 0
       }
 
 genesisHashToPraosNonce :: GenesisHash -> Nonce

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Block/Byron.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Block/Byron.hs
@@ -26,7 +26,6 @@ import           Ouroboros.Consensus.Byron.Ledger (ByronBlock)
 import qualified Ouroboros.Consensus.Byron.Ledger as Byron
 import           Ouroboros.Consensus.Byron.Node (PBftSignatureThreshold (..),
                      ProtocolParams (..), protocolInfoByron)
-import qualified Ouroboros.Consensus.Mempool as Mempool
 import           Ouroboros.Consensus.Node.ProtocolInfo
 import           Text.Builder (decimal)
 
@@ -114,5 +113,4 @@ mkByronProtocolInfo genesisConfig signatureThreshold =
       , byronProtocolVersion        = Update.ProtocolVersion 1 0 0
       , byronSoftwareVersion        = Update.SoftwareVersion (Update.ApplicationName "db-analyser") 2
       , byronLeaderCredentials      = Nothing
-      , byronMaxTxCapacityOverrides = Mempool.mkOverrides Mempool.noOverridesMeasure
       }

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Block/Cardano.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Block/Cardano.hs
@@ -70,7 +70,6 @@ import           Ouroboros.Consensus.HardFork.Combinator (HardForkBlock (..),
 import           Ouroboros.Consensus.HardFork.Combinator.State (currentState)
 import           Ouroboros.Consensus.HeaderValidation (HasAnnTip)
 import           Ouroboros.Consensus.Ledger.Abstract
-import qualified Ouroboros.Consensus.Mempool as Mempool
 import           Ouroboros.Consensus.Node.ProtocolInfo
 import           Ouroboros.Consensus.Shelley.HFEras ()
 import qualified Ouroboros.Consensus.Shelley.Ledger as Shelley.Ledger
@@ -376,7 +375,6 @@ mkCardanoProtocolInfo genesisByron signatureThreshold transitionConfig initialNo
           , byronProtocolVersion        = Byron.Update.ProtocolVersion 1 2 0
           , byronSoftwareVersion        = Byron.Update.SoftwareVersion (Byron.Update.ApplicationName "db-analyser") 2
           , byronLeaderCredentials      = Nothing
-          , byronMaxTxCapacityOverrides = Mempool.mkOverrides Mempool.noOverridesMeasure
           }
         ProtocolParamsShelleyBased {
             shelleyBasedInitialNonce      = initialNonce
@@ -386,28 +384,22 @@ mkCardanoProtocolInfo genesisByron signatureThreshold transitionConfig initialNo
             -- Note that this is /not/ the Shelley protocol version, see
             -- https://github.com/IntersectMBO/cardano-node/blob/daeae61a005776ee7b7514ce47de3933074234a8/cardano-node/src/Cardano/Node/Protocol/Cardano.hs#L167-L170
             -- and the succeeding comments.
-            shelleyProtVer                = ProtVer (SL.natVersion @3) 0
-          , shelleyMaxTxCapacityOverrides = Mempool.mkOverrides Mempool.noOverridesMeasure
+            shelleyProtVer = ProtVer (SL.natVersion @3) 0
           }
         ProtocolParamsAllegra {
-            allegraProtVer                = ProtVer (SL.natVersion @4) 0
-          , allegraMaxTxCapacityOverrides = Mempool.mkOverrides Mempool.noOverridesMeasure
+            allegraProtVer = ProtVer (SL.natVersion @4) 0
           }
         ProtocolParamsMary {
-            maryProtVer                   = ProtVer (SL.natVersion @5) 0
-          , maryMaxTxCapacityOverrides    = Mempool.mkOverrides Mempool.noOverridesMeasure
+            maryProtVer = ProtVer (SL.natVersion @5) 0
           }
         ProtocolParamsAlonzo {
-            alonzoProtVer                 = ProtVer (SL.natVersion @7) 0
-          , alonzoMaxTxCapacityOverrides  = Mempool.mkOverrides Mempool.noOverridesMeasure
+            alonzoProtVer = ProtVer (SL.natVersion @7) 0
           }
         ProtocolParamsBabbage {
-            babbageProtVer                 = ProtVer (SL.natVersion @9) 0
-          , babbageMaxTxCapacityOverrides  = Mempool.mkOverrides Mempool.noOverridesMeasure
+            babbageProtVer = ProtVer (SL.natVersion @9) 0
           }
         ProtocolParamsConway {
-            conwayProtVer                  = ProtVer (SL.natVersion @9) 0
-          , conwayMaxTxCapacityOverrides   = Mempool.mkOverrides Mempool.noOverridesMeasure
+            conwayProtVer = ProtVer (SL.natVersion @9) 0
           }
         triggers
         transitionConfig

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Block/Shelley.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Block/Shelley.hs
@@ -37,7 +37,6 @@ import           Data.Sequence.Strict (StrictSeq)
 import           Data.Word (Word64)
 import           Lens.Micro ((^.))
 import           Lens.Micro.Extras (view)
-import qualified Ouroboros.Consensus.Mempool as Mempool
 import           Ouroboros.Consensus.Node.ProtocolInfo
 import           Ouroboros.Consensus.Protocol.TPraos (TPraos)
 import           Ouroboros.Consensus.Shelley.Eras (StandardCrypto,
@@ -156,6 +155,5 @@ mkShelleyProtocolInfo genesis initialNonce =
         , shelleyBasedLeaderCredentials = []
         }
       ProtocolParamsShelley {
-          shelleyProtVer                = SL.ProtVer (CL.natVersion @2) 0
-        , shelleyMaxTxCapacityOverrides = Mempool.mkOverrides Mempool.noOverridesMeasure
+          shelleyProtVer = SL.ProtVer (CL.natVersion @2) 0
         }

--- a/ouroboros-consensus-cardano/src/unstable-shelley-testlib/Test/ThreadNet/Infra/Shelley.hs
+++ b/ouroboros-consensus-cardano/src/unstable-shelley-testlib/Test/ThreadNet/Infra/Shelley.hs
@@ -75,7 +75,6 @@ import           Lens.Micro
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Config.SecurityParam
-import qualified Ouroboros.Consensus.Mempool as Mempool
 import           Ouroboros.Consensus.Node.ProtocolInfo
 import           Ouroboros.Consensus.Protocol.Praos.Common
                      (PraosCanBeLeader (PraosCanBeLeader),
@@ -422,8 +421,7 @@ mkProtocolShelley genesis initialNonce protVer coreNode =
         , shelleyBasedLeaderCredentials = [mkLeaderCredentials coreNode]
         }
       ProtocolParamsShelley {
-          shelleyProtVer                = protVer
-        , shelleyMaxTxCapacityOverrides = Mempool.mkOverrides Mempool.noOverridesMeasure
+          shelleyProtVer = protVer
         }
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus-cardano/test/byron-test/Test/Consensus/Byron/Serialisation.hs
+++ b/ouroboros-consensus-cardano/test/byron-test/Test/Consensus/Byron/Serialisation.hs
@@ -20,7 +20,6 @@ import           Ouroboros.Consensus.Byron.Ledger hiding (byronProtocolVersion,
                      byronSoftwareVersion)
 import           Ouroboros.Consensus.Byron.Node
 import           Ouroboros.Consensus.Config
-import qualified Ouroboros.Consensus.Mempool as Mempool
 import           Ouroboros.Consensus.Node.ProtocolInfo
 import           Ouroboros.Consensus.Node.Serialisation ()
 import           Ouroboros.Consensus.Storage.Common (BinaryBlockInfo (..))
@@ -98,7 +97,6 @@ testCfg = pInfoConfig protocolInfo
         , byronProtocolVersion        = CC.Update.ProtocolVersion 1 0 0
         , byronSoftwareVersion        = CC.Update.SoftwareVersion (CC.Update.ApplicationName "Cardano Test") 2
         , byronLeaderCredentials      = Nothing
-        , byronMaxTxCapacityOverrides = Mempool.mkOverrides Mempool.noOverridesMeasure
         }
 
 -- | Matches the values used for the generators.

--- a/ouroboros-consensus-cardano/test/byron-test/Test/ThreadNet/Byron.hs
+++ b/ouroboros-consensus-cardano/test/byron-test/Test/ThreadNet/Byron.hs
@@ -47,7 +47,6 @@ import           Ouroboros.Consensus.Byron.Ledger.Conversions
 import           Ouroboros.Consensus.Byron.Node
 import           Ouroboros.Consensus.Byron.Protocol
 import           Ouroboros.Consensus.Config
-import qualified Ouroboros.Consensus.Mempool as TxLimits
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion
 import           Ouroboros.Consensus.Node.ProtocolInfo
 import           Ouroboros.Consensus.NodeId
@@ -1295,10 +1294,7 @@ mkRekeyUpd genesisConfig genesisSecrets cid pInfo blockForging eno newSK = do
     (_:_) ->
       let genSK = genesisSecretFor genesisConfig genesisSecrets cid
           creds' = updSignKey genSK bcfg cid (coerce eno) newSK
-          blockForging' =
-            byronBlockForging
-              (TxLimits.mkOverrides TxLimits.noOverridesMeasure)
-              creds'
+          blockForging' = byronBlockForging creds'
 
       in Just TestNodeInitialization
         { tniCrucialTxs = [dlgTx (blcDlgCert creds')]

--- a/ouroboros-consensus-cardano/test/shelley-test/Test/Consensus/Shelley/Coherence.hs
+++ b/ouroboros-consensus-cardano/test/shelley-test/Test/Consensus/Shelley/Coherence.hs
@@ -1,6 +1,7 @@
 module Test.Consensus.Shelley.Coherence (tests) where
 
 import           Cardano.Ledger.Alonzo.Scripts (ExUnits, pointWiseExUnits)
+import qualified Data.Measure as Measure
 import           Data.Word (Word32)
 import qualified Ouroboros.Consensus.Mempool.Capacity as MempoolCapacity
 import           Ouroboros.Consensus.Shelley.Ledger.Mempool (AlonzoMeasure (..),
@@ -11,15 +12,15 @@ import           Test.Tasty.QuickCheck
 
 tests :: TestTree
 tests = testGroup "Shelley coherences" [
-      testProperty "MempoolCapacity.<= uses pointWiseExUnits (<=)" leqCoherence
+      testProperty "Measure.<= uses pointWiseExUnits (<=)" leqCoherence
     ]
 
--- | 'MempoolCapacity.<=' and @'pointWiseExUnits' (<=)@ must agree
+-- | 'Measure.<=' and @'pointWiseExUnits' (<=)@ must agree
 leqCoherence :: Word32 -> ExUnits -> ExUnits -> Property
 leqCoherence w eu1 eu2 =
     actual === expected
   where
     inj eu = AlonzoMeasure (MempoolCapacity.ByteSize w) (fromExUnits eu)
 
-    actual   = inj eu1 MempoolCapacity.<= inj eu2
+    actual   = inj eu1 Measure.<= inj eu2
     expected = pointWiseExUnits (<=) eu1 eu2

--- a/ouroboros-consensus/changelog.d/20240710_104545_nick.frisby_remove_cap_override_forge.md
+++ b/ouroboros-consensus/changelog.d/20240710_104545_nick.frisby_remove_cap_override_forge.md
@@ -1,0 +1,22 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Patch
+
+- A bullet item for the Patch category.
+
+-->
+<!--
+### Non-Breaking
+
+- A bullet item for the Non-Breaking category.
+
+-->
+
+### Breaking
+
+- Remove the capacity override from forging functions.

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Block/Forging.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Block/Forging.hs
@@ -154,23 +154,16 @@ data BlockForging m blk = BlockForging {
 --
 -- Filters out all transactions that do not fit the maximum size of total
 -- transactions in a single block, which is determined by querying the ledger
--- state for the current limit and the given override. The result is the
--- pointwise minimum of the ledger-specific capacity and the result of the
--- override. In other words, the override can only reduce (parts of) the
--- 'MempoolCapacity.TxMeasure'.
+-- state for the current limit.
 takeLargestPrefixThatFits ::
      TxLimits blk
-  => MempoolCapacity.TxOverrides blk
-  -> TickedLedgerState blk
+  => TickedLedgerState blk
   -> [Validated (GenTx blk)]
   -> [Validated (GenTx blk)]
-takeLargestPrefixThatFits overrides ledger txs =
+takeLargestPrefixThatFits ledger txs =
     Measure.take (MempoolCapacity.txMeasure ledger) capacity txs
   where
-    capacity =
-      MempoolCapacity.applyOverrides
-        overrides
-        (MempoolCapacity.txsBlockCapacity ledger)
+    capacity = MempoolCapacity.txsBlockCapacity ledger
 
 data ShouldForge blk =
     -- | Before check whether we are a leader in this slot, we tried to update

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool.hs
@@ -27,12 +27,6 @@ module Ouroboros.Consensus.Mempool (
     -- ** Transaction size
   , ByteSize (..)
   , TxLimits (..)
-    -- ** Restricting more strongly than the ledger's limits
-  , TxOverrides
-  , applyOverrides
-  , getOverrides
-  , mkOverrides
-  , noOverridesMeasure
     -- * Mempool initialization
   , openMempool
   , openMempoolWithoutSyncThread
@@ -51,8 +45,7 @@ import           Ouroboros.Consensus.Mempool.API (ForgeLedgerState (..),
 import           Ouroboros.Consensus.Mempool.Capacity (ByteSize (..),
                      MempoolCapacityBytes (..),
                      MempoolCapacityBytesOverride (..), MempoolSize (..),
-                     TxLimits (..), TxOverrides (..), applyOverrides,
-                     computeMempoolCapacity, mkOverrides, noOverridesMeasure)
+                     TxLimits (..), computeMempoolCapacity)
 import           Ouroboros.Consensus.Mempool.Impl.Common (LedgerInterface (..),
                      TraceEventMempool (..), chainDBLedgerInterface)
 import           Ouroboros.Consensus.Mempool.Init (openMempool,


### PR DESCRIPTION
It's undesirable for a node to make blocks that aren't full. Moreover, this parameter was only ever set to "no override" in our codebase and in the `cardano-node` repo. So it seems good and harmless to remove this.

Note well that the capacity limit on the mempool is a separate parameter from the one removed by this PR.