### PR TITLE
ChainSync client: allow to prevent historical `MsgRollBackward`/`MsgAwaitReply`

### DIFF
--- a/ouroboros-consensus-diffusion/changelog.d/20240722_170436_alexander.esgen_historical_rollbacks.md
+++ b/ouroboros-consensus-diffusion/changelog.d/20240722_170436_alexander.esgen_historical_rollbacks.md
@@ -1,0 +1,3 @@
+### Breaking
+
+- Adapted to ChainSync client changes due to new message historicity check.

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToNode.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToNode.hs
@@ -211,14 +211,15 @@ mkHandlers ::
   -> NodeKernel     m addrNTN addrNTC blk
   -> Handlers       m addrNTN           blk
 mkHandlers
-      NodeKernelArgs {chainSyncFutureCheck, keepAliveRng, miniProtocolParameters}
-      NodeKernel {getChainDB, getMempool, getTopLevelConfig, getTracers = tracers, getPeerSharingAPI} =
+      NodeKernelArgs {chainSyncFutureCheck, chainSyncHistoricityCheck, keepAliveRng, miniProtocolParameters}
+      NodeKernel {getChainDB, getMempool, getTopLevelConfig, getTracers = tracers, getPeerSharingAPI, getGsmState} =
     Handlers {
         hChainSyncClient = \peer _isBigLedgerpeer dynEnv ->
           CsClient.chainSyncClient
             CsClient.ConfigEnv {
                 CsClient.cfg                     = getTopLevelConfig
               , CsClient.someHeaderInFutureCheck = chainSyncFutureCheck
+              , CsClient.historicityCheck        = chainSyncHistoricityCheck (atomically getGsmState)
               , CsClient.chainDbView             =
                   CsClient.defaultChainDbView getChainDB
               , CsClient.mkPipelineDecision0     = pipelineDecisionLowHighMark

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Node/Genesis.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Node/Genesis.hs
@@ -24,6 +24,8 @@ import           Ouroboros.Consensus.MiniProtocol.ChainSync.Client
                      (CSJConfig (..), CSJEnabledConfig (..),
                      ChainSyncLoPBucketConfig (..),
                      ChainSyncLoPBucketEnabledConfig (..))
+import           Ouroboros.Consensus.MiniProtocol.ChainSync.Client.HistoricityCheck
+                     (HistoricityCutoff (..))
 import qualified Ouroboros.Consensus.Node.GsmState as GSM
 import           Ouroboros.Consensus.Storage.ChainDB (ChainDbArgs)
 import qualified Ouroboros.Consensus.Storage.ChainDB as ChainDB
@@ -45,6 +47,7 @@ data GenesisConfig = GenesisConfig {
     gcChainSyncLoPBucketConfig :: !ChainSyncLoPBucketConfig
   , gcCSJConfig                :: !CSJConfig
   , gcLoEAndGDDConfig          :: !(LoEAndGDDConfig ())
+  , gcHistoricityCutoff        :: !(Maybe HistoricityCutoff)
   }
 
 -- TODO justification/derivation from other parameters
@@ -58,6 +61,10 @@ enableGenesisConfigDefault = GenesisConfig {
           csjcJumpSize = 3 * 2160 * 20 -- mainnet forecast range
         }
     , gcLoEAndGDDConfig = LoEAndGDDEnabled ()
+      -- Duration in seconds of one Cardano mainnet Shelley stability window
+      -- (3k/f slots times one second per slot) plus one extra hour as a
+      -- safety margin.
+    , gcHistoricityCutoff = Just $ HistoricityCutoff $ 3 * 2160 * 20 + 3600
     }
 
 -- | Disable all Genesis components, yielding Praos behavior.
@@ -66,6 +73,7 @@ disableGenesisConfig = GenesisConfig {
       gcChainSyncLoPBucketConfig = ChainSyncLoPBucketDisabled
     , gcCSJConfig                = CSJDisabled
     , gcLoEAndGDDConfig          = LoEAndGDDDisabled
+    , gcHistoricityCutoff        = Nothing
     }
 
 -- | Genesis-related arguments needed by the NodeKernel initialization logic.

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
@@ -63,6 +63,8 @@ import qualified Ouroboros.Consensus.MiniProtocol.BlockFetch.ClientInterface as 
 import           Ouroboros.Consensus.MiniProtocol.ChainSync.Client
                      (ChainSyncClientHandle (..), ChainSyncState (..),
                      viewChainSyncState)
+import           Ouroboros.Consensus.MiniProtocol.ChainSync.Client.HistoricityCheck
+                     (HistoricityCheck)
 import           Ouroboros.Consensus.MiniProtocol.ChainSync.Client.InFutureCheck
                      (SomeHeaderInFutureCheck)
 import           Ouroboros.Consensus.Node.Genesis (GenesisNodeKernelArgs (..),
@@ -171,6 +173,9 @@ data NodeKernelArgs m addrNTN addrNTC blk = NodeKernelArgs {
     , chainDB                 :: ChainDB m blk
     , initChainDB             :: StorageConfig blk -> InitChainDB m blk -> m ()
     , chainSyncFutureCheck    :: SomeHeaderInFutureCheck m blk
+      -- | See 'HistoricityCheck' for details.
+    , chainSyncHistoricityCheck
+                              :: m GSM.GsmState -> HistoricityCheck m blk
     , blockFetchSize          :: Header blk -> SizeInBytes
     , mempoolCapacityOverride :: MempoolCapacityBytesOverride
     , miniProtocolParameters  :: MiniProtocolParameters

--- a/ouroboros-consensus-diffusion/src/unstable-diffusion-testlib/Test/ThreadNet/Network.hs
+++ b/ouroboros-consensus-diffusion/src/unstable-diffusion-testlib/Test/ThreadNet/Network.hs
@@ -71,6 +71,7 @@ import           Ouroboros.Consensus.Ledger.SupportsMempool
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
 import           Ouroboros.Consensus.Mempool
 import qualified Ouroboros.Consensus.MiniProtocol.ChainSync.Client as CSClient
+import qualified Ouroboros.Consensus.MiniProtocol.ChainSync.Client.HistoricityCheck as HistoricityCheck
 import qualified Ouroboros.Consensus.MiniProtocol.ChainSync.Client.InFutureCheck as InFutureCheck
 import qualified Ouroboros.Consensus.Network.NodeToNode as NTN
 import           Ouroboros.Consensus.Node.ExitPolicy
@@ -1003,6 +1004,7 @@ runThreadNetwork systemTime ThreadNetworkArgs
                   InFutureCheck.realHeaderInFutureCheck
                     InFuture.defaultClockSkew
                     (OracularClock.finiteSystemTime clock)
+            , chainSyncHistoricityCheck = \_getGsmState -> HistoricityCheck.noCheck
             , blockFetchSize          = estimateBlockSize
             , mempoolCapacityOverride = NoMempoolCapacityBytesOverride
             , keepAliveRng            = kaRng

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/ChainSync.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/ChainSync.hs
@@ -17,6 +17,7 @@ import           Data.Map.Strict (Map)
 import           Data.Proxy (Proxy (..))
 import           Network.TypedProtocol.Codec (AnyMessage)
 import           Ouroboros.Consensus.Block (Header, Point)
+import           Ouroboros.Consensus.BlockchainTime (RelativeTime (..))
 import           Ouroboros.Consensus.Config (TopLevelConfig (..))
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
                      (LedgerSupportsProtocol)
@@ -103,7 +104,9 @@ basicChainSyncClient
       { InFutureCheck.proxyArrival = Proxy
       , InFutureCheck.recordHeaderArrival = \_ -> pure ()
       , InFutureCheck.judgeHeaderArrival = \_ _ _ -> pure ()
-      , InFutureCheck.handleHeaderArrival = \_ -> pure Nothing
+      , InFutureCheck.handleHeaderArrival = \_ ->
+          -- We are not inspecting header slot time in the Genesis tests.
+          pure $ pure $ RelativeTime 0
       }
 
 -- | Create and run a ChainSync client using 'bracketChainSyncClient' and

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/ChainSync.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/ChainSync.hs
@@ -26,6 +26,7 @@ import           Ouroboros.Consensus.MiniProtocol.ChainSync.Client
                      ChainSyncLoPBucketConfig, ChainSyncStateView (..),
                      Consensus, bracketChainSyncClient, chainSyncClient)
 import qualified Ouroboros.Consensus.MiniProtocol.ChainSync.Client as CSClient
+import qualified Ouroboros.Consensus.MiniProtocol.ChainSync.Client.HistoricityCheck as HistoricityCheck
 import qualified Ouroboros.Consensus.MiniProtocol.ChainSync.Client.InFutureCheck as InFutureCheck
 import           Ouroboros.Consensus.Node.GsmState (GsmState (Syncing))
 import           Ouroboros.Consensus.Util (ShowProxy)
@@ -85,6 +86,10 @@ basicChainSyncClient
       , CSClient.cfg
       , CSClient.chainDbView
       , CSClient.someHeaderInFutureCheck = dummyHeaderInFutureCheck
+        -- Preventing historical MsgRollBack and MsgAwaitReply messages is
+        -- motivated by preventing additional load from CSJ-disengaged peers; we
+        -- do not care about this in these tests.
+      , CSClient.historicityCheck        = HistoricityCheck.noCheck
       }
     CSClient.DynamicEnv {
         CSClient.version             = maxBound

--- a/ouroboros-consensus/bench/ChainSync-client-bench/Main.hs
+++ b/ouroboros-consensus/bench/ChainSync-client-bench/Main.hs
@@ -22,6 +22,7 @@ import qualified Ouroboros.Consensus.HeaderStateHistory as HeaderStateHistory
 import qualified Ouroboros.Consensus.HeaderValidation as HV
 import qualified Ouroboros.Consensus.Ledger.Extended as Extended
 import qualified Ouroboros.Consensus.MiniProtocol.ChainSync.Client as CSClient
+import qualified Ouroboros.Consensus.MiniProtocol.ChainSync.Client.HistoricityCheck as HistoricityCheck
 import qualified Ouroboros.Consensus.MiniProtocol.ChainSync.Client.InFutureCheck as InFutureCheck
 import           Ouroboros.Consensus.MiniProtocol.ChainSync.Server
                      (chainSyncServerForFollower)
@@ -128,6 +129,7 @@ oneBenchRun
               , CSClient.cfg                     = topConfig
               , CSClient.tracer                  = nullTracer `asTypeOf` contramap show debugTracer
               , CSClient.someHeaderInFutureCheck = headerInFutureCheck
+              , CSClient.historicityCheck        = HistoricityCheck.noCheck
               , CSClient.mkPipelineDecision0     =
                     pipelineDecisionLowHighMark 10 20
               }

--- a/ouroboros-consensus/changelog.d/20240722_170344_alexander.esgen_historical_rollbacks.md
+++ b/ouroboros-consensus/changelog.d/20240722_170344_alexander.esgen_historical_rollbacks.md
@@ -1,0 +1,4 @@
+### Breaking
+
+- Added functionality to disallow historical `MsgRollBackward`s and
+  `MsgAwaitReply`s in the ChainSync client.

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -723,6 +723,7 @@ benchmark ChainSync-client-bench
     contra-tracer,
     ouroboros-consensus,
     ouroboros-network-api,
+    ouroboros-network-mock,
     ouroboros-network-protocols,
     time,
     typed-protocols-examples,

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -170,6 +170,7 @@ library
     Ouroboros.Consensus.MiniProtocol.BlockFetch.ClientInterface
     Ouroboros.Consensus.MiniProtocol.BlockFetch.Server
     Ouroboros.Consensus.MiniProtocol.ChainSync.Client
+    Ouroboros.Consensus.MiniProtocol.ChainSync.Client.HistoricityCheck
     Ouroboros.Consensus.MiniProtocol.ChainSync.Client.InFutureCheck
     Ouroboros.Consensus.MiniProtocol.ChainSync.Client.Jumping
     Ouroboros.Consensus.MiniProtocol.ChainSync.Client.State

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HeaderValidation.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HeaderValidation.hs
@@ -79,7 +79,6 @@ import           Ouroboros.Consensus.Ticked
 import           Ouroboros.Consensus.Util (whenJust)
 import           Ouroboros.Consensus.Util.Assert
 import qualified Ouroboros.Consensus.Util.CBOR as Util.CBOR
-import           Ouroboros.Network.AnchoredSeq (Anchorable (..))
 
 {-------------------------------------------------------------------------------
   Preliminary: annotated tip
@@ -159,11 +158,6 @@ data HeaderState blk = HeaderState {
     , headerStateChainDep :: !(ChainDepState (BlockProtocol blk))
     }
   deriving (Generic)
-
--- | Used by 'HeaderStateHistory' but defined here, where it is not an orphan.
-instance Anchorable (WithOrigin SlotNo) (HeaderState blk) (HeaderState blk) where
-  asAnchor = id
-  getAnchorMeasure _ = fmap annTipSlotNo . headerStateTip
 
 castHeaderState ::
      ( Coercible (ChainDepState (BlockProtocol blk ))

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ChainSync/Client.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ChainSync/Client.hs
@@ -1280,7 +1280,7 @@ knownIntersectionStateTop cfgEnv dynEnv intEnv =
                 -- where this wouldn't be true is if the original candidate
                 -- fragment provided by the dynamo contained headers that have
                 -- no corresponding header state.
-                rewoundHistory =
+                (rewoundHistory, _oldestRewound) =
                   fromMaybe (error "offerJump: cannot rewind history") mRewoundHistory
                 -- If the tip of jTheirFragment does not match the tip of
                 -- jTheirHeaderStateHistory, then the history needs rewinding.
@@ -1925,8 +1925,8 @@ attemptRollback ::
   ->       (AnchoredFragment (Header blk), HeaderStateHistory blk)
   -> Maybe (AnchoredFragment (Header blk), HeaderStateHistory blk)
 attemptRollback rollBackPoint (frag, state) = do
-    frag'  <- AF.rollback (castPoint rollBackPoint) frag
-    state' <- HeaderStateHistory.rewind rollBackPoint state
+    frag'                    <- AF.rollback (castPoint rollBackPoint) frag
+    (state', _oldestRewound) <- HeaderStateHistory.rewind rollBackPoint state
     return (frag', state')
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ChainSync/Client/HistoricityCheck.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ChainSync/Client/HistoricityCheck.hs
@@ -1,0 +1,168 @@
+{-# LANGUAGE DeriveAnyClass      #-}
+{-# LANGUAGE DerivingStrategies  #-}
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE LambdaCase          #-}
+{-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving  #-}
+{-# LANGUAGE TypeApplications    #-}
+
+module Ouroboros.Consensus.MiniProtocol.ChainSync.Client.HistoricityCheck (
+    -- * Interface
+    HistoricalChainSyncMessage (..)
+  , HistoricityCheck (..)
+  , HistoricityCutoff (..)
+  , HistoricityException (..)
+    -- * Real implementation
+  , mkCheck
+  , noCheck
+  ) where
+
+import           Control.Exception (Exception)
+import           Control.Monad (when)
+import           Control.Monad.Except (throwError)
+import           Data.Time.Clock (NominalDiffTime)
+import           Data.Typeable (eqT)
+import           Ouroboros.Consensus.Block
+import           Ouroboros.Consensus.BlockchainTime (RelativeTime,
+                     SystemTime (..), diffRelTime)
+import           Ouroboros.Consensus.HeaderStateHistory
+                     (HeaderStateWithTime (..))
+import           Ouroboros.Consensus.HeaderValidation (HasAnnTip,
+                     headerStatePoint)
+import           Ouroboros.Consensus.Node.GsmState (GsmState (..))
+
+{-------------------------------------------------------------------------------
+  Interface
+-------------------------------------------------------------------------------}
+
+-- | Interface for the ChainSync client for deciding whether @MsgRollBackward@s
+-- and @MsgAwaitReply@s are historical.
+data HistoricityCheck m blk = HistoricityCheck {
+    -- | Determine whether the received message is historical. Depending on the
+    -- first argument, the second argument is:
+    --
+    --  * 'HistoricalMsgRollBackward': The oldest state that was rolled back.
+    --    (Note that rollbacks of depth zero are hence never historical.).
+    --
+    --  * 'HistoricalMsgAwaitReply': The state corresponding to the tip of the
+    --    candidate fragment when @MsgAwaitReply@ was sent.
+    judgeMessageHistoricity ::
+         HistoricalChainSyncMessage
+      -> HeaderStateWithTime blk
+      -> m (Either HistoricityException ())
+  }
+
+-- | ChainSync historicity checks are performed for @MsgRollBackward@s and
+-- @MsgAwaitReply@s, see 'HistoricityCheck'.
+data HistoricalChainSyncMessage =
+    HistoricalMsgRollBackward
+  | HistoricalMsgAwaitReply
+  deriving stock (Show, Eq)
+
+data HistoricityException =
+  -- | We received a @MsgRollBackward@ or a @MsgAwaitReply@ while their
+  -- candidate chain was too old for it to plausibly have been sent by an honest
+  -- caught-up peer.
+  --
+  -- INVARIANT: @'historicityCutoff' < 'arrivalTime' `diffRelTime` 'slotTime'@
+  forall blk. HasHeader blk => HistoricityException {
+      historicalMessage :: HistoricalChainSyncMessage
+      -- | Depending on 'historicalMessage':
+      --
+      --  * 'HistoricalMsgRollBackward': The oldest header that was rewound.
+      --
+      --  * 'HistoricalMsgAwaitReply': The tip of the candidate fragment.
+    , historicalPoint   :: !(Point blk)
+      -- | The time corresponding to the slot of 'historicalPoint'.
+    , slotTime          :: !RelativeTime
+      -- | When the offending 'historicalMessage' was received.
+    , arrivalTime       :: !RelativeTime
+    , historicityCutoff :: !HistoricityCutoff
+    }
+  deriving anyclass (Exception)
+
+deriving stock instance Show HistoricityException
+
+instance Eq HistoricityException where
+  (==)
+    (HistoricityException l0 (l1 :: Point l) l2 l3 l4)
+    (HistoricityException r0 (r1 :: Point r) r2 r3 r4)
+    = case eqT @l @r of
+        Nothing   -> False
+        Just Refl -> (l0, l1, l2, l3, l4) == (r0, r1, r2, r3, r4)
+
+-- ^ The maximum age of a @MsgRollBackward@ or @MsgAwaitReply@ at arrival time,
+-- constraining the age of the oldest rewound header or the tip of the candidate
+-- fragment, respectively.
+--
+-- This should be set to at least the maximum duration (across all eras) of a
+-- stability window (the number of slots in which at least @k@ blocks are
+-- guaranteed to arise).
+--
+-- For example, on Cardano mainnet today, the Praos Chain Growth property
+-- implies that @3k/f@ (=129600) slots (=36 hours) will contain at least @k@
+-- (=2160) blocks. (Byron has a smaller stability window, namely @2k@ (=24 hours
+-- as the Byron slot length is 20s). Thus a peer rolling back a header that is
+-- older than 36 hours or signals that it doesn't have more headers is either
+-- violating the maximum rollback or else isn't a caught-up node. Either way, a
+-- syncing node should not be connected to that peer.
+newtype HistoricityCutoff = HistoricityCutoff {
+    getHistoricityCutoff :: NominalDiffTime
+  }
+  deriving stock (Show, Eq, Ord)
+
+{-------------------------------------------------------------------------------
+  Real implmementation
+-------------------------------------------------------------------------------}
+
+-- | Do not perform any historicity checks. This is useful when we only sync
+-- from trusted peers (Praos mode) or when the impact of historical messages is
+-- already mitigated by other means (for example indirectly by the Limit on
+-- Patience in the case of Genesis /without/ ChainSync Jumping).
+noCheck :: Applicative m => HistoricityCheck m blk
+noCheck = HistoricityCheck {
+      judgeMessageHistoricity = \_msg _hswt -> pure $ Right ()
+    }
+
+-- | Deny all rollbacks that rewind blocks older than
+-- 'HistoricityCutoff' upon arrival.
+mkCheck ::
+     forall m blk.
+     ( Monad m
+     , HasHeader blk
+     , HasAnnTip blk
+     )
+  => SystemTime m
+  -> m GsmState
+     -- ^ Get the current 'GsmState'.
+     --
+     -- This is used to disable the historicity check when we are caught up. The
+     -- rationale is extra resilience against disconnects between honest nodes
+     -- in disaster scenarios with very low chain density.
+  -> HistoricityCutoff
+  -> HistoricityCheck m blk
+mkCheck systemTime getCurrentGsmState cshc = HistoricityCheck {
+      judgeMessageHistoricity = \msg hswt -> getCurrentGsmState >>= \case
+          PreSyncing -> judgeRollback msg hswt
+          Syncing    -> judgeRollback msg hswt
+          CaughtUp   -> pure $ Right ()
+    }
+  where
+    HistoricityCutoff historicityCutoff = cshc
+
+    judgeRollback ::
+         HistoricalChainSyncMessage
+      -> HeaderStateWithTime blk
+      -> m (Either HistoricityException ())
+    judgeRollback msg (HeaderStateWithTime headerState slotTime) = do
+        arrivalTime <- systemTimeCurrent systemTime
+        let actualRollbackAge = arrivalTime `diffRelTime` slotTime
+        pure $ when (historicityCutoff < actualRollbackAge) $
+          throwError HistoricityException {
+              historicalMessage = msg
+            , historicalPoint   = headerStatePoint headerState
+            , slotTime
+            , arrivalTime
+            , historicityCutoff = cshc
+            }

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/API.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/API.hs
@@ -17,7 +17,6 @@ module Ouroboros.Consensus.Storage.ChainDB.API (
     ChainDB (..)
   , getCurrentLedger
   , getCurrentTip
-  , getHeaderStateHistory
   , getImmutableLedger
   , getPastLedger
   , getTipBlockNo
@@ -173,6 +172,10 @@ data ChainDB m blk = ChainDB {
 
       -- | Return the LedgerDB containing the last @k@ ledger states.
     , getLedgerDB        :: STM m (LedgerDB' blk)
+
+      -- | Get a 'HeaderStateHistory' populated with the 'HeaderState's and slot
+      -- times of the last @k@ blocks of the current chain.
+    , getHeaderStateHistory :: STM m (HeaderStateHistory blk)
 
       -- | Get block at the tip of the chain, if one exists
       --
@@ -374,20 +377,6 @@ getPastLedger ::
      (Monad (STM m), LedgerSupportsProtocol blk)
   => ChainDB m blk -> Point blk -> STM m (Maybe (ExtLedgerState blk))
 getPastLedger db pt = LedgerDB.ledgerDbPast pt <$> getLedgerDB db
-
--- | Get a 'HeaderStateHistory' populated with the 'HeaderState's of the
--- last @k@ blocks of the current chain.
-getHeaderStateHistory ::
-     Monad (STM m)
-  => ChainDB m blk -> STM m (HeaderStateHistory blk)
-getHeaderStateHistory = fmap toHeaderStateHistory . getLedgerDB
-  where
-    toHeaderStateHistory ::
-         LedgerDB' blk
-      -> HeaderStateHistory blk
-    toHeaderStateHistory =
-          HeaderStateHistory
-        . LedgerDB.ledgerDbBimap headerState headerState
 
 {-------------------------------------------------------------------------------
   Adding a block

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl.hs
@@ -208,6 +208,7 @@ openDBInternal args launchBgTasks = runWithTempRegistry $ do
             , chainSelAsync         = getEnv     h ChainSel.triggerChainSelectionAsync
             , getCurrentChain       = getEnvSTM  h Query.getCurrentChain
             , getLedgerDB           = getEnvSTM  h Query.getLedgerDB
+            , getHeaderStateHistory = getEnvSTM  h Query.getHeaderStateHistory
             , getTipBlock           = getEnv     h Query.getTipBlock
             , getTipHeader          = getEnv     h Query.getTipHeader
             , getTipPoint           = getEnvSTM  h Query.getTipPoint

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/MiniProtocol/ChainSync/Client.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/MiniProtocol/ChainSync/Client.hs
@@ -58,13 +58,13 @@ import           Control.Monad.Class.MonadTimer (MonadTimer)
 import           Control.Monad.IOSim (runSimOrThrow)
 import           Control.Tracer (contramap, contramapM, nullTracer)
 import           Data.DerivingVia (InstantiatedAt (InstantiatedAt))
-import           Data.List (intercalate)
+import           Data.List as List (foldl', intercalate)
 import qualified Data.Map.Merge.Strict as Map
 import qualified Data.Map.Strict as Map
-import           Data.Maybe (isJust)
+import           Data.Maybe (fromMaybe, isJust)
 import           Data.Semigroup (Max (Max), getMax)
 import qualified Data.Set as Set
-import           Data.Time (diffUTCTime)
+import           Data.Time (NominalDiffTime, diffUTCTime)
 import           Data.Typeable
 import           GHC.Generics (Generic)
 import           Network.TypedProtocol.Channel
@@ -88,6 +88,8 @@ import           Ouroboros.Consensus.MiniProtocol.ChainSync.Client
                      DynamicEnv (..), Our (..), Their (..),
                      TraceChainSyncClientEvent (..), bracketChainSyncClient,
                      chainSyncClient, chainSyncStateFor, viewChainSyncState)
+import           Ouroboros.Consensus.MiniProtocol.ChainSync.Client.HistoricityCheck
+                     (HistoricityCheck, HistoricityCutoff (..))
 import qualified Ouroboros.Consensus.MiniProtocol.ChainSync.Client.HistoricityCheck as HistoricityCheck
 import qualified Ouroboros.Consensus.MiniProtocol.ChainSync.Client.InFutureCheck as InFutureCheck
 import           Ouroboros.Consensus.Node.GsmState (GsmState (Syncing))
@@ -98,7 +100,7 @@ import           Ouroboros.Consensus.NodeId
 import           Ouroboros.Consensus.Protocol.BFT
 import           Ouroboros.Consensus.Storage.ChainDB.API
                      (InvalidBlockReason (ValidationError))
-import           Ouroboros.Consensus.Util (whenJust)
+import           Ouroboros.Consensus.Util (lastMaybe, whenJust)
 import           Ouroboros.Consensus.Util.Condense
 import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Consensus.Util.ResourceRegistry
@@ -343,11 +345,6 @@ runChainSync skew securityParam (ClientUpdates clientUpdates)
     let _ = clientSystemTime :: SystemTime m
 
     varCurrentLogicalTick <- uncheckedNewTVarM (Tick 0)
-    let clockUpdates :: Schedule NewMaxSlot
-        clockUpdates =
-            mkClockUpdates
-              (ClientUpdates clientUpdates)
-              (ServerUpdates serverUpdates)
 
     -- Set up the client
     varClientState  <- uncheckedNewTVarM Genesis
@@ -404,6 +401,15 @@ runChainSync skew securityParam (ClientUpdates clientUpdates)
             -- Note that this tests passes in the exact difference between the
             -- client's and server's clock as the tolerable clock skew.
 
+        historicityCheck :: HistoricityCheck m TestBlock
+        historicityCheck =
+            HistoricityCheck.mkCheck
+              clientSystemTime
+              -- The historicity check is disabled when we use 'CaughtUp' here,
+              -- so we use 'Syncing'.
+              (pure Syncing)
+              historicityCutoff
+
         lopBucketConfig :: ChainSyncLoPBucketConfig
         lopBucketConfig = ChainSyncLoPBucketDisabled
 
@@ -421,8 +427,7 @@ runChainSync skew securityParam (ClientUpdates clientUpdates)
                 , cfg                     = nodeCfg
                 , tracer                  = chainSyncTracer
                 , someHeaderInFutureCheck = headerInFutureCheck
-                  -- TODO this will be changed in the next commit
-                , historicityCheck        = HistoricityCheck.noCheck
+                , historicityCheck
                 , mkPipelineDecision0     =
                     pipelineDecisionLowHighMark 10 20
                 }
@@ -447,12 +452,7 @@ runChainSync skew securityParam (ClientUpdates clientUpdates)
         advanceWallClockForTick tick = do
             doTick clockUpdates tick $ \case
               [newMaxSlot] -> do
-                let target = case newMaxSlot of
-                      NewMaxClientSlot slot -> toOnset slot
-                      NewMaxServerSlot slot -> toSkewedOnset slot
-
-                      NewMaxClientAndServerSlot cslot sslot ->
-                        toOnset cslot `max` toSkewedOnset sslot
+                let target = clientTimeForNewMaxSlot newMaxSlot
                 now <- systemTimeCurrent clientSystemTime
                 threadDelay $ nominalDelay $ target `diffRelTime` now
 
@@ -596,6 +596,81 @@ runChainSync skew securityParam (ClientUpdates clientUpdates)
       let RelativeTime onset = toOnset slot
       in
       RelativeTime $ onset - unClockSkew skew
+
+    -- The target time (as reported by 'clientSystemTime') for the given
+    -- 'NewMaxSlot'.
+    clientTimeForNewMaxSlot :: NewMaxSlot -> RelativeTime
+    clientTimeForNewMaxSlot = \case
+        NewMaxClientSlot slot -> toOnset slot
+        NewMaxServerSlot slot -> toSkewedOnset slot
+
+        NewMaxClientAndServerSlot cslot sslot ->
+          toOnset cslot `max` toSkewedOnset sslot
+
+    clockUpdates :: Schedule NewMaxSlot
+    clockUpdates =
+        mkClockUpdates
+          (ClientUpdates clientUpdates)
+          (ServerUpdates serverUpdates)
+
+    -- Also see the module header for how ticks/time/clock skew are working in
+    -- this test.
+    clientTimeForTick :: Tick -> RelativeTime
+    clientTimeForTick = \tick -> case Map.lookupLE tick clientTimes of
+        Just (_, time) -> time
+        -- Before any clock updates, the client time is exactly @skew@ before
+        -- the onset of slot 0.
+        Nothing        -> RelativeTime (- unClockSkew skew)
+      where
+        clientTimes :: Map.Map Tick RelativeTime
+        clientTimes =
+            Map.foldlWithKey' f Map.empty (getSchedule clockUpdates)
+          where
+            f acc t [newMaxSlot] = case Map.lookupMax acc of
+                Just (_, time')
+                  | time' < time -> Map.insert t time acc
+                  | otherwise    -> acc
+                Nothing -> Map.singleton t time
+              where
+                time = clientTimeForNewMaxSlot newMaxSlot
+            f _   _ _            = error "bad clockUpdates"
+
+    -- For the historicity check, which constrains the age of @MsgRollBackward@
+    -- and @MsgAwaitReply@. This is calculated by considering the 'ChainUpdate'
+    -- which rewinds the oldest block relative to the client wallclock time in
+    -- the given tick, as well as the age of the last block sent up until a tick
+    -- (as a @MsgAwaitReply@ will be sent right after).
+    historicityCutoff :: HistoricityCutoff
+    historicityCutoff =
+          HistoricityCutoff
+        $ List.foldl' max 0
+        $ awaitReplyAges <> rollbackAges
+      where
+        rollbackAges :: [NominalDiffTime]
+        rollbackAges =
+          [ clientTime `diffRelTime` toSkewedOnset oldestRewound
+          | (tick, updates) <- Map.toList $ getSchedule serverUpdates
+          , let clientTime = clientTimeForTick tick
+          , SwitchFork rollbackPoint _blks <- updates
+          , -- Here, we make use of the fact that the blocks generated for this
+            -- test have dense slot numbers (ie there are no empty slots).
+            let oldestRewound =
+                  withOrigin firstSlot succ $ pointSlot rollbackPoint
+          ]
+
+        firstSlot = blockSlot $ firstBlock 0
+
+        awaitReplyAges :: [NominalDiffTime]
+        awaitReplyAges =
+          [ clientTimeForTick tick `diffRelTime` toSkewedOnset lastSlotBefore
+          | (tick, updates) <- Map.toList $ getSchedule serverUpdates
+          , let lastSlotBefore = fromMaybe 0 $ do
+                  lastUpdate <- lastMaybe updates
+                  lastBlk    <- case lastUpdate of
+                    AddBlock blk        -> pure blk
+                    SwitchFork _pt blks -> lastMaybe blks
+                  pure $ blockSlot lastBlk
+          ]
 
     doTick :: Schedule a -> Tick -> ([a] -> m ()) -> m ()
     doTick sched tick kont = whenJust (Map.lookup tick (getSchedule sched)) kont

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/MiniProtocol/ChainSync/Client.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/MiniProtocol/ChainSync/Client.hs
@@ -88,6 +88,7 @@ import           Ouroboros.Consensus.MiniProtocol.ChainSync.Client
                      DynamicEnv (..), Our (..), Their (..),
                      TraceChainSyncClientEvent (..), bracketChainSyncClient,
                      chainSyncClient, chainSyncStateFor, viewChainSyncState)
+import qualified Ouroboros.Consensus.MiniProtocol.ChainSync.Client.HistoricityCheck as HistoricityCheck
 import qualified Ouroboros.Consensus.MiniProtocol.ChainSync.Client.InFutureCheck as InFutureCheck
 import           Ouroboros.Consensus.Node.GsmState (GsmState (Syncing))
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion
@@ -420,6 +421,8 @@ runChainSync skew securityParam (ClientUpdates clientUpdates)
                 , cfg                     = nodeCfg
                 , tracer                  = chainSyncTracer
                 , someHeaderInFutureCheck = headerInFutureCheck
+                  -- TODO this will be changed in the next commit
+                , historicityCheck        = HistoricityCheck.noCheck
                 , mkPipelineDecision0     =
                     pipelineDecisionLowHighMark 10 20
                 }


### PR DESCRIPTION
This PR enables the ChainSync client to disconnect from peers who send *historical `MsgRollBackward` and `MsgAwaitReply` messages*, ie rollbacks that no honest caught-up peer would send as the corresponding blocks are already immutable for them, and `MsgAwaitReply`s that would indicate a chain whose tip is way behind the wall-clock.

This is relevant for the ChainSync Jumping (CSJ) optimization (part of Ouroboros Genesis): CSJ handles `MsgAwaitReply` and rollbacks to before a point that a peer previously acknowledged by "disengaging" that peer, ie running full ChainSync with them. This is the right thing to do when we are almost caught-up; however, during syncing the historical chain, this causes extra network load (albeit symmetrical) and CPU load.

We define a `MsgRollBackward`/`MsgAwaitReply` to be *historical* if the Genesis State Machine has not yet concluded that we are caught up and the wall-clock time of the slot of the oldest rewound header (if any) or the previous tip of the candidate fragment, respectively, is older than a configuration value, the *historicity cutoff*. In this PR, we set it to the duration of one mainnet stability window plus one hour as extra margin (so `36 h + 1 h = 37 h`). Future work might include getting this duration out of the HFC.

We also modify the existing ChainSync client test to test for false positives; false negatives can be tested by manually modifying the code (such as subtracting a constant from `historicityCutoff`, or introducing bugs in the actual implementation); we defer a standalone test for false negatives (similar to https://github.com/IntersectMBO/ouroboros-consensus/issues/526).

The PR is intended to be reviewed commit by commit.