### PR TITLE
Nix/Hydra/GHA: add GHC 9.10, drop GHC 9.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ["8.10.7", "9.6.6", "9.8.2", "9.10.1"]
+        ghc: ["8.10.7", "9.6.6", "9.10.1"]
         variant: [default, no-thunks]
         test-set: [all, no-thunks-safe]
         exclude:

--- a/cabal.project
+++ b/cabal.project
@@ -16,7 +16,7 @@ index-state:
   -- Bump this if you need newer packages from Hackage
   , hackage.haskell.org 2024-07-23T00:03:37Z
   -- Bump this if you need newer packages from CHaP
-  , cardano-haskell-packages 2024-07-24T06:25:44Z
+  , cardano-haskell-packages 2024-08-15T10:40:33Z
 
 packages:
   ouroboros-consensus

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1721797546,
-        "narHash": "sha256-GIJByqrkGA1gzGwIXYhMcX4AVDbyE3jAG7aeXwPZ5ko=",
+        "lastModified": 1723719216,
+        "narHash": "sha256-0RCMUZu1YthjOJUT6JHCfwxLZVobhTzx17nK7U745/I=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "029f74fa36d47aa8e4a8eece7a39d925be877331",
+        "rev": "e4cfce4c4612111b0b51567cb4445a7740303f0e",
         "type": "github"
       },
       "original": {
@@ -36,17 +36,17 @@
     "blst": {
       "flake": false,
       "locked": {
-        "lastModified": 1656163412,
-        "narHash": "sha256-xero1aTe2v4IhWIJaEDUsVDOfE77dOV5zKeHWntHogY=",
+        "lastModified": 1691598027,
+        "narHash": "sha256-oqljy+ZXJAXEB/fJtmB8rlAr4UXM+Z2OkDa20gpILNA=",
         "owner": "supranational",
         "repo": "blst",
-        "rev": "03b5124029979755c752eec45f3c29674b558446",
+        "rev": "3dd0f804b1819e5d03fb22ca2e6fac105932043a",
         "type": "github"
       },
       "original": {
         "owner": "supranational",
+        "ref": "v0.3.11",
         "repo": "blst",
-        "rev": "03b5124029979755c752eec45f3c29674b558446",
         "type": "github"
       }
     },
@@ -137,11 +137,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1688025799,
-        "narHash": "sha256-ktpB4dRtnksm9F5WawoIkEneh1nrEvuxb5lJFt1iOyw=",
+        "lastModified": 1717312683,
+        "narHash": "sha256-FrlieJH50AuvagamEvWMIE6D2OAnERuDboFDYAED/dE=",
         "owner": "nix-community",
         "repo": "flake-compat",
-        "rev": "8bf105319d44f6b9f0d764efa4fdef9f1cc9ba1c",
+        "rev": "38fd3954cf65ce6faf3d0d45cd26059e059f07ea",
         "type": "github"
       },
       "original": {
@@ -172,11 +172,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1701680307,
-        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
         "type": "github"
       },
       "original": {
@@ -221,11 +221,11 @@
     "hackageNix": {
       "flake": false,
       "locked": {
-        "lastModified": 1721780860,
-        "narHash": "sha256-V/HseJgvtK+dzlfSVQBiFyBFnl5FiofpaGG2ugHMkTs=",
+        "lastModified": 1723681836,
+        "narHash": "sha256-xM2vL6GdCRnBvxUbQrDjTfCbFKrtX+b/Uy0Eg3Z+XHg=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "e5ef290773ed5e732f26eec104a1ceeb1d68040f",
+        "rev": "227179361e9c1b2738aebab640fdf91e8846590b",
         "type": "github"
       },
       "original": {
@@ -270,16 +270,17 @@
         "nixpkgs-2211": "nixpkgs-2211",
         "nixpkgs-2305": "nixpkgs-2305",
         "nixpkgs-2311": "nixpkgs-2311",
+        "nixpkgs-2405": "nixpkgs-2405",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "old-ghc-nix": "old-ghc-nix",
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1720058742,
-        "narHash": "sha256-QcJiQDEvR6F653AhYBUA6Jukg7DGdkuBj/EsGDZCCLo=",
+        "lastModified": 1723683036,
+        "narHash": "sha256-pT74TrE+bCaeXhYLYJrZVocwopwwua4qOwN7waUdUpU=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "cbd75e3669c44a383e7d80e35c8e96aa795336f3",
+        "rev": "88aeace47b5e43cb4df5f96e754179293c06f47c",
         "type": "github"
       },
       "original": {
@@ -507,11 +508,11 @@
         "sodium": "sodium"
       },
       "locked": {
-        "lastModified": 1702362799,
-        "narHash": "sha256-cU8cZXNuo5GRwrSvWqdaqoW5tJ2HWwDEOvWwIVPDPmo=",
+        "lastModified": 1721825987,
+        "narHash": "sha256-PPcma4tjozwXJAWf+YtHUQUulmxwulVlwSQzKItx/n8=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "b426fb9e0b109a9d1dd2e1476f9e0bd8bb715142",
+        "rev": "eb61f2c14e1f610ec59117ad40f8690cddbf80cb",
         "type": "github"
       },
       "original": {
@@ -672,11 +673,11 @@
     },
     "nixpkgs-2305": {
       "locked": {
-        "lastModified": 1701362232,
-        "narHash": "sha256-GVdzxL0lhEadqs3hfRLuj+L1OJFGiL/L7gCcelgBlsw=",
+        "lastModified": 1705033721,
+        "narHash": "sha256-K5eJHmL1/kev6WuqyqqbS1cdNnSidIZ3jeqJ7GbrYnQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d2332963662edffacfddfad59ff4f709dde80ffe",
+        "rev": "a1982c92d8980a0114372973cbdfe0a307f1bdea",
         "type": "github"
       },
       "original": {
@@ -688,16 +689,32 @@
     },
     "nixpkgs-2311": {
       "locked": {
-        "lastModified": 1701386440,
-        "narHash": "sha256-xI0uQ9E7JbmEy/v8kR9ZQan6389rHug+zOtZeZFiDJk=",
+        "lastModified": 1719957072,
+        "narHash": "sha256-gvFhEf5nszouwLAkT9nWsDzocUTqLWHuL++dvNjMp9I=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "293822e55ec1872f715a66d0eda9e592dc14419f",
+        "rev": "7144d6241f02d171d25fba3edeaf15e0f2592105",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "ref": "nixpkgs-23.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2405": {
+      "locked": {
+        "lastModified": 1720122915,
+        "narHash": "sha256-Nby8WWxj0elBu1xuRaUcRjPi/rU3xVbkAt2kj4QwX2U=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "835cf2d3f37989c5db6585a28de967a667a75fb1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-24.05-darwin",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -720,17 +737,17 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1694822471,
-        "narHash": "sha256-6fSDCj++lZVMZlyqOe9SIOL8tYSBz1bI8acwovRwoX8=",
+        "lastModified": 1720181791,
+        "narHash": "sha256-i4vJL12/AdyuQuviMMd1Hk2tsGt02hDNhA0Zj1m16N8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "47585496bcb13fb72e4a90daeea2f434e2501998",
+        "rev": "4284c2b73c8bce4b46a6adf23e16d9e2ec8da4bb",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
-        "rev": "47585496bcb13fb72e4a90daeea2f434e2501998",
         "type": "github"
       }
     },
@@ -804,11 +821,11 @@
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1720052611,
-        "narHash": "sha256-XmmEd69FV7ysLmOF4sqwGombVErRYq9HGQqiZcc0m2I=",
+        "lastModified": 1723594352,
+        "narHash": "sha256-cQVhF1M1et3/XNE1sclwH39prxIDMUojTdnW61t3YrM=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "a9cb6e2f089acd0abcef94013f559146be108a23",
+        "rev": "c077da02c56031a78adc4bf0cf2b182effc895ed",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -73,8 +73,8 @@
           default = ghc96;
           ghc96 = hydraJobs.native.haskell96.devShell;
           ghc96-profiled = hydraJobs.native.haskell96.devShellProfiled;
-          ghc98 = hydraJobs.native.haskell98.devShell;
-          ghc98-profiled = hydraJobs.native.haskell98.devShellProfiled;
+          ghc910 = hydraJobs.native.haskell910.devShell;
+          ghc910-profiled = hydraJobs.native.haskell910.devShellProfiled;
 
           website = pkgs.mkShell {
             packages = [ pkgs.nodejs pkgs.yarn ];

--- a/nix/ci.nix
+++ b/nix/ci.nix
@@ -47,8 +47,8 @@ let
         (mkHaskellJobsFor pkgs.hsPkgs.projectVariants.ghc810)
         [ "checks" "devShell" "devShellProfiled" ];
 
-      # also already test GHC 9.8, but only on Linux to reduce CI load
-      haskell98 = mkHaskellJobsFor pkgs.hsPkgs.projectVariants.ghc98;
+      # also already test GHC 9.10, but only on Linux to reduce CI load
+      haskell910 = mkHaskellJobsFor pkgs.hsPkgs.projectVariants.ghc910;
     };
   } // lib.optionalAttrs (buildSystem == "x86_64-linux") {
     windows = {

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -17,7 +17,7 @@ let
     compiler-nix-name = "ghc966";
     flake.variants = {
       ghc810 = { compiler-nix-name = lib.mkForce "ghc8107"; };
-      ghc98 = { compiler-nix-name = lib.mkForce "ghc982"; };
+      ghc910 = { compiler-nix-name = lib.mkForce "ghc9101"; };
     };
     inputMap = {
       "https://chap.intersectmbo.org/" = inputs.CHaP;


### PR DESCRIPTION
Also drop GHC 9.8 as it is broken due to shipping a buggy `stm` version, see https://github.com/input-output-hk/io-sim/pull/166.