### PR TITLE
Add support for measures to LocalTxMonitor

### DIFF
--- a/ouroboros-consensus-cardano/changelog.d/20250213_115925_fraser.murray_localtxmonitor_measures.md
+++ b/ouroboros-consensus-cardano/changelog.d/20250213_115925_fraser.murray_localtxmonitor_measures.md
@@ -1,0 +1,4 @@
+### Non-Breaking
+
+- Add instances for `TxMeasureMetrics` to Cardano block types
+

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
@@ -766,9 +766,9 @@ getMempoolReader mempool = MempoolReader.TxSubmissionMempoolReader
         { mempoolTxIdsAfter = \idx ->
             [ ( txId (txForgetValidated tx)
               , idx'
-              , SizeInBytes $ unByteSize32 byteSize
+              , SizeInBytes $ unByteSize32 $ txMeasureByteSize msr
               )
-            | (tx, idx', byteSize) <- snapshotTxsAfter idx
+            | (tx, idx', msr) <- snapshotTxsAfter idx
             ]
         , mempoolLookupTx   = snapshotLookupTx
         , mempoolHasTx      = snapshotHasTx

--- a/ouroboros-consensus/changelog.d/20250213_115925_fraser.murray_localtxmonitor_measures.md
+++ b/ouroboros-consensus/changelog.d/20250213_115925_fraser.murray_localtxmonitor_measures.md
@@ -1,0 +1,4 @@
+### Breaking
+
+- Add `TxMeasureMetrics (TxMeasure blk)` constraint to `CanHardFork`
+

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Abstract/CanHardFork.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Abstract/CanHardFork.hs
@@ -35,6 +35,7 @@ class ( All SingleEraBlock xs
       , HasByteSize (HardForkTxMeasure xs)
       , NoThunks    (HardForkTxMeasure xs)
       , Show        (HardForkTxMeasure xs)
+      , TxMeasureMetrics (HardForkTxMeasure xs)
       ) => CanHardFork xs where
   -- | A measure that can accurately represent the 'TxMeasure' of any era.
   --

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/API.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/API.hs
@@ -320,13 +320,12 @@ data ForgeLedgerState blk =
 data MempoolSnapshot blk = MempoolSnapshot {
     -- | Get all transactions (oldest to newest) in the mempool snapshot along
     -- with their ticket number.
-    snapshotTxs         :: [(Validated (GenTx blk), TicketNo, ByteSize32)]
+    snapshotTxs         :: [(Validated (GenTx blk), TicketNo, TxMeasure blk)]
 
     -- | Get all transactions (oldest to newest) in the mempool snapshot,
     -- along with their ticket number, which are associated with a ticket
     -- number greater than the one provided.
-  , snapshotTxsAfter    ::
-      TicketNo -> [(Validated (GenTx blk), TicketNo, ByteSize32)]
+  , snapshotTxsAfter    :: TicketNo -> [(Validated (GenTx blk), TicketNo, TxMeasure blk)]
 
     -- | Get the greatest prefix (oldest to newest) that respects the given
     -- block capacity.

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Impl/Common.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Impl/Common.hs
@@ -431,12 +431,12 @@ snapshotFromIS is = MempoolSnapshot {
     }
  where
   implSnapshotGetTxs :: InternalState blk
-                     -> [(Validated (GenTx blk), TicketNo, ByteSize32)]
+                     -> [(Validated (GenTx blk), TicketNo, TxMeasure blk)]
   implSnapshotGetTxs = flip implSnapshotGetTxsAfter TxSeq.zeroTicketNo
 
   implSnapshotGetTxsAfter :: InternalState blk
                           -> TicketNo
-                          -> [(Validated (GenTx blk), TicketNo, ByteSize32)]
+                          -> [(Validated (GenTx blk), TicketNo, TxMeasure blk)]
   implSnapshotGetTxsAfter IS{isTxs} =
     TxSeq.toTuples . snd . TxSeq.splitAfterTicketNo isTxs
 

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/TxSeq.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/TxSeq.hs
@@ -38,8 +38,6 @@ import qualified Data.Measure as Measure
 import           Data.Word (Word64)
 import           GHC.Generics (Generic)
 import           NoThunks.Class (NoThunks)
-import           Ouroboros.Consensus.Ledger.SupportsMempool (ByteSize32,
-                     HasByteSize, txMeasureByteSize)
 
 {-------------------------------------------------------------------------------
   Mempool transaction sequence as a finger tree
@@ -256,13 +254,13 @@ toList :: TxSeq sz tx -> [TxTicket sz tx]
 toList (TxSeq ftree) = Foldable.toList ftree
 
 -- | Convert a 'TxSeq' to a list of pairs of transactions and their
--- associated 'TicketNo's and 'ByteSize32's.
-toTuples :: HasByteSize sz => TxSeq sz tx -> [(tx, TicketNo, ByteSize32)]
+-- associated 'TicketNo's and sizes.
+toTuples :: TxSeq sz tx -> [(tx, TicketNo, sz)]
 toTuples (TxSeq ftree) = fmap
     (\ticket ->
        ( txTicketTx ticket
        , txTicketNo ticket
-       , txMeasureByteSize (txTicketSize ticket)
+       , txTicketSize ticket
        )
     )
     (Foldable.toList ftree)

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/Mempool.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/Mempool.hs
@@ -308,7 +308,7 @@ prop_Mempool_TraceRemovedTxs setup =
       ]
 
 prjTx ::
-     (Validated (GenTx TestBlock), TicketNo, ByteSize32)
+     (Validated (GenTx TestBlock), TicketNo, TxMeasure TestBlock)
   -> Validated (GenTx TestBlock)
 prjTx (a, _b, _c) = a
 


### PR DESCRIPTION
# Description

This PR fixes #1178 and builds on #1175 by adding support for arbitrary measures to the `LocalTxMonitor` server in `ouroboros-consensus`. [Relevant changes to `ouroboros-network`](https://github.com/IntersectMBO/ouroboros-network/pull/4918) are required to build these changes, since the `LocalTxMonitor` protocol has been changed to add a new `GetMeasures` message.

Remaining work required before this can be merged: 

- [x] #1175 needs to be merged
- [x] corresponding `ouroboros-network` PR needs to be merged
- [x] version change needs to be implemented somewhere
- [x] clean up the commit history
- [x] ~~deal with `fromByteSize` being very likely to silently overflow the new numeric type~~