### PR TITLE
Expose more information on `EmptySlot` error

### DIFF
--- a/ouroboros-consensus/changelog.d/js-more-explanatory-error.md
+++ b/ouroboros-consensus/changelog.d/js-more-explanatory-error.md
@@ -1,0 +1,3 @@
+### Non-Breaking
+
+- The error `MissingBlock(EmptySlot)` now exposes more information when thrown.

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ImmutableDB/API.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ImmutableDB/API.hs
@@ -20,6 +20,7 @@ module Ouroboros.Consensus.Storage.ImmutableDB.API (
   , traverseIterator
     -- * Types
   , CompareTip (..)
+  , SecondaryOffset
   , Tip (..)
   , blockToTip
   , headerToTip
@@ -60,10 +61,13 @@ import           Data.Either (isRight)
 import           Data.Function (on)
 import           Data.List.NonEmpty (NonEmpty)
 import           Data.Typeable (Typeable)
+import           Data.Word (Word32)
 import           GHC.Generics (Generic)
+import           Data.Sequence.Strict (StrictSeq)
 import           NoThunks.Class (OnlyCheckWhnfNamed (..))
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Storage.Common
+import           Ouroboros.Consensus.Storage.ImmutableDB.Chunks.Internal
 import           Ouroboros.Consensus.Util.CallStack
 import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Consensus.Util.ResourceRegistry (ResourceRegistry)
@@ -74,6 +78,12 @@ import           System.FS.CRC (CRC)
 {-------------------------------------------------------------------------------
   API
 -------------------------------------------------------------------------------}
+
+-- | An offset in the secondary index file.
+--
+-- We need 4 bytes ('Word32') because the secondary index file can grow to
+-- +1MiB.
+type SecondaryOffset = Word32
 
 -- | API for the 'ImmutableDB'.
 --
@@ -399,7 +409,13 @@ throwUnexpectedFailure = throwIO . UnexpectedFailure
 -- 'Either', because it can be expected in some cases.
 data MissingBlock blk
     -- | There is no block in the slot of the given point.
-  = EmptySlot (RealPoint blk)
+  = EmptySlot
+       (RealPoint blk) -- ^ The requested point
+       ChunkNo         -- ^ The chunk we thought it was in
+       [RelativeSlot]  -- ^ What should be the relative slot in the chunk
+       (Maybe (StrictSeq SecondaryOffset))
+         -- ^ Which offsets are known if we are looking at the current (probably cached) chunk
+
     -- | The block and/or EBB in the slot of the given point have a different
     -- hash. We return the 'HeaderHash' for each block we found with the
     -- corresponding slot number.
@@ -411,7 +427,7 @@ data MissingBlock blk
 
 -- | Return the 'RealPoint' of the block that was missing.
 missingBlockPoint :: MissingBlock blk -> RealPoint blk
-missingBlockPoint (EmptySlot pt)      = pt
+missingBlockPoint (EmptySlot pt _ _ _)      = pt
 missingBlockPoint (WrongHash pt _)    = pt
 missingBlockPoint (NewerThanTip pt _) = pt
 

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ImmutableDB/API.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ImmutableDB/API.hs
@@ -60,10 +60,10 @@ import qualified Data.ByteString.Lazy as Lazy
 import           Data.Either (isRight)
 import           Data.Function (on)
 import           Data.List.NonEmpty (NonEmpty)
+import           Data.Sequence.Strict (StrictSeq)
 import           Data.Typeable (Typeable)
 import           Data.Word (Word32)
 import           GHC.Generics (Generic)
-import           Data.Sequence.Strict (StrictSeq)
 import           NoThunks.Class (OnlyCheckWhnfNamed (..))
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Storage.Common
@@ -427,9 +427,9 @@ data MissingBlock blk
 
 -- | Return the 'RealPoint' of the block that was missing.
 missingBlockPoint :: MissingBlock blk -> RealPoint blk
-missingBlockPoint (EmptySlot pt _ _ _)      = pt
-missingBlockPoint (WrongHash pt _)    = pt
-missingBlockPoint (NewerThanTip pt _) = pt
+missingBlockPoint (EmptySlot pt _ _ _) = pt
+missingBlockPoint (WrongHash pt _)     = pt
+missingBlockPoint (NewerThanTip pt _)  = pt
 
 {-------------------------------------------------------------------------------
   Wrappers that preserve 'HasCallStack'

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ImmutableDB/Impl.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ImmutableDB/Impl.hs
@@ -410,12 +410,12 @@ getHashForSlotImpl dbEnv slot =
       -- Primary index: test whether the slot contains a non-EBB, or an EBB as a
       -- fallback.
       (offset, isEBB) <- readOffset ifRegular >>= \case
-        Just offset -> pure (offset, IsNotEBB)
-        Nothing     -> case mIfBoundary of
+        (Just offset, _) -> pure (offset, IsNotEBB)
+        (Nothing, _)     -> case mIfBoundary of
           Nothing         -> exitEarly
           Just ifBoundary -> readOffset ifBoundary >>= \case
-            Just offset -> pure (offset, IsEBB)
-            Nothing     -> exitEarly
+            (Just offset, _) -> pure (offset, IsEBB)
+            (Nothing, _)     -> exitEarly
 
       -- Read hash from secondary index.
       (entry, _) <- lift $ Index.readEntry index chunk isEBB offset

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ImmutableDB/Impl/Index/Cache.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ImmutableDB/Impl/Index/Cache.hs
@@ -670,7 +670,7 @@ readOffsets cacheEnv chunk relSlots = do
     ci <- getChunkInfo cacheEnv chunk
     pure $ case ci of
       Left CurrentChunkInfo { currentChunkOffsets } ->
-        ( getOffsetFromSecondaryOffsets currentChunkOffsets <$> relSlots, Just currentChunkOffsets)
+        (getOffsetFromSecondaryOffsets currentChunkOffsets <$> relSlots, Just currentChunkOffsets)
       Right PastChunkInfo { pastChunkOffsets } ->
         (getOffsetFromPrimaryIndex pastChunkOffsets <$> relSlots, Nothing)
   where

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ImmutableDB/Impl/Index/Cache.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ImmutableDB/Impl/Index/Cache.hs
@@ -665,13 +665,14 @@ readOffsets ::
   => CacheEnv m blk h
   -> ChunkNo
   -> t RelativeSlot
-  -> m (t (Maybe SecondaryOffset))
-readOffsets cacheEnv chunk relSlots =
-    getChunkInfo cacheEnv chunk <&> \case
+  -> m (t (Maybe SecondaryOffset), Maybe (StrictSeq SecondaryOffset))
+readOffsets cacheEnv chunk relSlots = do
+    ci <- getChunkInfo cacheEnv chunk
+    pure $ case ci of
       Left CurrentChunkInfo { currentChunkOffsets } ->
-        getOffsetFromSecondaryOffsets currentChunkOffsets <$> relSlots
+        ( getOffsetFromSecondaryOffsets currentChunkOffsets <$> relSlots, Just currentChunkOffsets)
       Right PastChunkInfo { pastChunkOffsets } ->
-        getOffsetFromPrimaryIndex pastChunkOffsets <$> relSlots
+        (getOffsetFromPrimaryIndex pastChunkOffsets <$> relSlots, Nothing)
   where
     getOffsetFromSecondaryOffsets
       :: StrictSeq SecondaryOffset

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ImmutableDB/Impl/Index/Primary.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ImmutableDB/Impl/Index/Primary.hs
@@ -62,7 +62,8 @@ import           Foreign.Storable (sizeOf)
 import           GHC.Generics (Generic)
 import           Ouroboros.Consensus.Block (StandardHash)
 import           Ouroboros.Consensus.Storage.ImmutableDB.API
-                     (ImmutableDBError (..), UnexpectedFailure (..), SecondaryOffset)
+                     (ImmutableDBError (..), SecondaryOffset,
+                     UnexpectedFailure (..))
 import           Ouroboros.Consensus.Storage.ImmutableDB.Chunks
 import           Ouroboros.Consensus.Storage.ImmutableDB.Chunks.Internal
 import           Ouroboros.Consensus.Storage.ImmutableDB.Impl.Util

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ImmutableDB/Impl/Index/Primary.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ImmutableDB/Impl/Index/Primary.hs
@@ -62,7 +62,7 @@ import           Foreign.Storable (sizeOf)
 import           GHC.Generics (Generic)
 import           Ouroboros.Consensus.Block (StandardHash)
 import           Ouroboros.Consensus.Storage.ImmutableDB.API
-                     (ImmutableDBError (..), UnexpectedFailure (..))
+                     (ImmutableDBError (..), UnexpectedFailure (..), SecondaryOffset)
 import           Ouroboros.Consensus.Storage.ImmutableDB.Chunks
 import           Ouroboros.Consensus.Storage.ImmutableDB.Chunks.Internal
 import           Ouroboros.Consensus.Storage.ImmutableDB.Impl.Util
@@ -74,12 +74,6 @@ import           System.FS.API.Lazy hiding (allowExisting)
 {------------------------------------------------------------------------------
   SecondaryOffset
 ------------------------------------------------------------------------------}
-
--- | An offset in the secondary index file.
---
--- We need 4 bytes ('Word32') because the secondary index file can grow to
--- +1MiB.
-type SecondaryOffset = Word32
 
 getSecondaryOffset :: Get SecondaryOffset
 getSecondaryOffset = Get.getWord32be

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ImmutableDB/Impl/State.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ImmutableDB/Impl/State.hs
@@ -36,8 +36,6 @@ import           Ouroboros.Consensus.Storage.ImmutableDB.API
 import           Ouroboros.Consensus.Storage.ImmutableDB.Chunks
 import           Ouroboros.Consensus.Storage.ImmutableDB.Impl.Index (Index)
 import qualified Ouroboros.Consensus.Storage.ImmutableDB.Impl.Index as Index
-import           Ouroboros.Consensus.Storage.ImmutableDB.Impl.Index.Primary
-                     (SecondaryOffset)
 import           Ouroboros.Consensus.Storage.ImmutableDB.Impl.Index.Secondary
                      (BlockOffset (..))
 import           Ouroboros.Consensus.Storage.ImmutableDB.Impl.Types

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ImmutableDB/Impl/Validation.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ImmutableDB/Impl/Validation.hs
@@ -35,7 +35,7 @@ import           Ouroboros.Consensus.Storage.ImmutableDB.Impl.Index
                      (cachedIndex)
 import qualified Ouroboros.Consensus.Storage.ImmutableDB.Impl.Index as Index
 import           Ouroboros.Consensus.Storage.ImmutableDB.Impl.Index.Primary
-                     (PrimaryIndex, SecondaryOffset)
+                     (PrimaryIndex)
 import qualified Ouroboros.Consensus.Storage.ImmutableDB.Impl.Index.Primary as Primary
 import qualified Ouroboros.Consensus.Storage.ImmutableDB.Impl.Index.Secondary as Secondary
 import           Ouroboros.Consensus.Storage.ImmutableDB.Impl.Parser

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ImmutableDB/Model.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ImmutableDB/Model.hs
@@ -54,7 +54,8 @@ import           Ouroboros.Consensus.Storage.Common
 import           Ouroboros.Consensus.Storage.ImmutableDB.API hiding
                      (throwApiMisuse)
 import           Ouroboros.Consensus.Storage.ImmutableDB.Chunks
-import           Ouroboros.Consensus.Storage.ImmutableDB.Chunks.Internal (ChunkNo (..))
+import           Ouroboros.Consensus.Storage.ImmutableDB.Chunks.Internal
+                     (ChunkNo (..))
 import           Ouroboros.Consensus.Storage.ImmutableDB.Impl.Util (parseDBFile)
 import           Ouroboros.Consensus.Storage.Serialisation
 import           Ouroboros.Consensus.Util (lastMaybe, takeUntil)

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ImmutableDB/Model.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ImmutableDB/Model.hs
@@ -54,6 +54,7 @@ import           Ouroboros.Consensus.Storage.Common
 import           Ouroboros.Consensus.Storage.ImmutableDB.API hiding
                      (throwApiMisuse)
 import           Ouroboros.Consensus.Storage.ImmutableDB.Chunks
+import           Ouroboros.Consensus.Storage.ImmutableDB.Chunks.Internal (ChunkNo (..))
 import           Ouroboros.Consensus.Storage.ImmutableDB.Impl.Util (parseDBFile)
 import           Ouroboros.Consensus.Storage.Serialisation
 import           Ouroboros.Consensus.Util (lastMaybe, takeUntil)
@@ -208,7 +209,7 @@ lookupBlock pt@(RealPoint slot hash) dbm@DBModel { dbmSlots } =
         | NotOrigin slot > (tipSlotNo <$> dbmTip dbm)
         -> throwError $ NewerThanTip pt (tipToPoint (dbmTip dbm))
         | otherwise
-        -> throwError $ EmptySlot pt
+        -> throwError $ EmptySlot pt (ChunkNo 0) [] Nothing
 
 -- | Rolls back the chain so that the given 'Tip' is the new tip.
 --


### PR DESCRIPTION
This PR extends `EmptySlot` with some more information, such that in case the error is thrown, we can debug what happened. See `Ouroboros.Consensus.Storage.ImmutableDB.API.MissingBlock(EmptySlot)` for more context on what is exposed.
