### PR TITLE
Implement the Cached index using TVars

### DIFF
--- a/ouroboros-consensus/changelog.d/js-tvar-cache.md
+++ b/ouroboros-consensus/changelog.d/js-tvar-cache.md
@@ -1,0 +1,4 @@
+### Non-Breaking
+
+- Cached index is now based on `TVar`s instead of `MVar`s ensuring proper updates
+  to the current chunk cached information.


### PR DESCRIPTION
In the past some nodes have been crashing because of a misalingment in the data in the Cached Index. Ensuring that the changes are atomic via `stm` seems to solve the problem.

In terms of logic, this PR only moves the modifications into `atomically` blocks, the overall logic is the same.

Depends on #1196 
Closes #359 

