### PR TITLE
Split NoThunks CI job in two to avoid hitting the GitHub Actions limit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,9 +142,13 @@ jobs:
       if: matrix.test-set == 'all'
       run: cabal test all -j --test-show-details=streaming
 
-    - name: Test (NoThunks-safe tests only)
+    - name: Test (NoThunks-safe tests only, part 1)
       if: matrix.test-set == 'no-thunks-safe'
-      run: cabal test ouroboros-consensus:consensus-test ouroboros-consensus:doctest ouroboros-consensus:infra-test ouroboros-consensus:storage-test ouroboros-consensus-cardano:byron-test ouroboros-consensus-cardano:shelley-test ouroboros-consensus-diffusion:infra-test ouroboros-consensus-diffusion:mock-test ouroboros-consensus-protocol:protocol-test -j --test-show-details=streaming
+      run: cabal test ouroboros-consensus:consensus-test ouroboros-consensus:doctest ouroboros-consensus:infra-test ouroboros-consensus:storage-test ouroboros-consensus-cardano:byron-test -j --test-show-details=streaming
+
+    - name: Test (NoThunks-safe tests only, part 2)
+      if: matrix.test-set == 'no-thunks-safe'
+      run: cabal test ouroboros-consensus-cardano:shelley-test ouroboros-consensus-diffusion:infra-test ouroboros-consensus-diffusion:mock-test ouroboros-consensus-protocol:protocol-test -j --test-show-details=streaming
 
     - name: Create baseline-benchmark
       if: github.event_name == 'push' && github.ref == 'refs/heads/main'


### PR DESCRIPTION
# Description

This PR splits the `no-thunks-safe` test set jobs into two separate jobs, since they're currently timing out during the nightly runs. I haven't timed each of the test suites to ensure that each of the halves of this particular split run in less than 6 hours each, but if this continues to fail, we can shuffle them around a little bit.

In future, if the NoThunks run is valuable, and we finally reach a point where the many small issues with our workflow pile up, we should use something more akin to `cardano-ledger`'s `workflow.yml` instead, but it's not worth making that change just for this.