### PR TITLE
reduce the frequency of client and server diverging before they reach startTick

### DIFF
--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/MiniProtocol/ChainSync/Client.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/MiniProtocol/ChainSync/Client.hs
@@ -766,7 +766,7 @@ instance Arbitrary ChainSyncClientSetup where
           , lastTick (getClientUpdates clientUpdates) - 1
           , lastTick (getServerUpdates serverUpdates) - 1
           ]
-    startTick <- choose (1, maxStartTick)
+    startTick <- chooseExponential 3 (1, maxStartTick)
     let trapBlocks =
           [ blockHash b
           | AddBlock b <- joinSchedule (getServerUpdates serverUpdates)
@@ -827,6 +827,13 @@ instance Arbitrary ChainSyncClientSetup where
     [ cscs { clientSlowBy = SlotLengthTenths y }
     | let SlotLengthTenths x = clientSlowBy
     , y <- shrink x
+    ]
+
+chooseExponential :: Enum a => Int -> (a, a) -> Gen a
+chooseExponential decayFactor (low, up) =
+  frequency
+    [ (decayFactor, pure low)
+    , (1, chooseExponential decayFactor (succ low, up))
     ]
 
 prettyChainSyncClientSetup :: ChainSyncClientSetup -> String


### PR DESCRIPTION
This PR changes the generator for `ChainSyncClientSetup` such that `startTick` is now heavily weighted to pick a lower value (closer to 1) rather than a linear range between 1 and `maxStartTick`. This causes fewer randomly-generated `ChainSyncClientSetup`s to produce test runs in which no headers are sent due to immediate divergence.

Before: 

```
ouroboros-consensus
  ChainSyncClient
    chainSync: OK (5.69s)                                                              
      +++ OK, passed 10000 tests:
      67.35% ForkTooDeep
      27.89% NoMoreIntersection
       0.25% RolledBackPastIntersection
      
      TickArrivalTimeStats (10000 in total):
      67.40% OnlyNotEarly_SomeEarly Zero Zero
      10.76% OnlyNotEarly_SomeEarly Zero Many
       6.72% OnlyNotEarly_SomeEarly One Many
       5.95% OnlyNotEarly_SomeEarly One One
       3.75% OnlyNotEarly_SomeEarly Many Zero
       2.89% OnlyNotEarly_SomeEarly One Zero
       1.38% OnlyNotEarly_SomeEarly Many Many
       1.07% OnlyNotEarly_SomeEarly Many One
       0.08% OnlyNotEarly_SomeEarly Zero One
```

After:
```
ouroboros-consensus
  ChainSyncClient
    chainSync: OK (8.51s)                                                              
      +++ OK, passed 10000 tests:
      84.58% NoMoreIntersection
      10.51% ForkTooDeep
       0.62% RolledBackPastIntersection
      
      TickArrivalTimeStats (10000 in total):
      19.50% OnlyNotEarly_SomeEarly One Many
      16.81% OnlyNotEarly_SomeEarly One Zero
      15.85% OnlyNotEarly_SomeEarly Zero Many
      13.83% OnlyNotEarly_SomeEarly One One
      13.25% OnlyNotEarly_SomeEarly Many Zero
      10.58% OnlyNotEarly_SomeEarly Zero Zero
       5.39% OnlyNotEarly_SomeEarly Many Many
       4.79% OnlyNotEarly_SomeEarly Many One

```

Note that the `NoMoreIntersection` case is now significantly more common than the `ForkTooDeep` case, rather than the inverse.

Closes #529