### PR TITLE
db-truncater: make `--truncate-after-slot` more lenient again

### DIFF
--- a/ouroboros-consensus-cardano/app/DBTruncater/Parsers.hs
+++ b/ouroboros-consensus-cardano/app/DBTruncater/Parsers.hs
@@ -32,7 +32,7 @@ slotNoOption =
     mods = mconcat
       [ long "truncate-after-slot"
       , metavar "SLOT_NUMBER"
-      , help "The slot number of the intended new tip of the chain after truncation"
+      , help "Remove all blocks with a higher slot number"
       ]
 
 blockNoOption :: Parser BlockNo

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBTruncater/Types.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBTruncater/Types.hs
@@ -13,10 +13,8 @@ data DBTruncaterConfig = DBTruncaterConfig {
 
 -- | Where to truncate the ImmutableDB.
 data TruncateAfter
-    -- | Truncate after the given slot number, such that the new tip has this
-    -- exact slot number. Fail if this is not possible, ie no block has this
-    -- slot number. If there are two blocks with the same slot number (due to
-    -- EBBs), the tip will be the non-EBB.
+    -- | Truncate after the given slot number, deleting all blocks with a higher
+    -- slot number.
   = TruncateAfterSlot SlotNo
     -- | Truncate after the given block number (such that the new tip has this
     -- block number).


### PR DESCRIPTION
Closes #1202

This PR reverts the behavioral change of #1143, specifically 5747d3c76f3a2a73635f010f568cef1c4724b32f. Concretely, `--truncate-after-slot slotNo` will now remove all blocks with a slot number higher than `slotNo` in the ImmutableDB, but does not require that a block with exactly that slot number exists. This is convenient eg for truncating all blocks after an epoch without having to find out the exact slot of the last block in the epoch just before.

At the same time, the run time is still much faster than before #1143: We iteratively check all slot numbers descending from the given one, and truncate to the first point that is in the ImmutableDB. As realistic ImmutableDBs are only somewhat sparse (active slot coefficient is `f = 1/20`), this should be very fast (ie still constant time in the length of the chain if we consider the slot distance between any two adjacent blocks to be bounded). In addition, we explicitly check whether the given argument is beyond the tip of the ImmutableDB, and immediately exit (successfully) in that case.