### PR TITLE
db-synthesizer: explain what "does not look like a ChainDB" means

### DIFF
--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBSynthesizer/Run.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBSynthesizer/Run.hs
@@ -183,4 +183,6 @@ preOpenChainDB mode db =
             OpenCreateForce | isChainDB ->
                 removePathForcibly db >> create
             _ ->
-                fail $ loc ++ " is non-empty and does not look like a ChainDB. Aborting."
+                fail $ loc ++ " is non-empty and does not look like a ChainDB"
+                    <> " (i.e. its entries are not exactly 'immutable'/'ledger'/'volatile')."
+                    <> " Aborting."


### PR DESCRIPTION
Motivation is to make the failure less confusing. We might also want to relax the `checkIsDB` predicate to be more lenient/less overeager in the future.