### PR TITLE
Expose over-the-wire encoded transaction size

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -59,8 +59,8 @@ if impl(ghc >= 9.10)
 source-repository-package
   type: git
   location: https://github.com/IntersectMBO/ouroboros-network
-  tag: d900a38c55e02f5eed8c8d6d6a4671cd8c5acc6a
-  --sha256: sha256-VVccbWFmd9GlL2N/xNsKtXg2U2asGc4fIX1lLEo+Ar8=
+  tag: 388cc6906b83f41ac2da192b1fd89ab986b4af74
+  --sha256: sha256-LUwryrP5jK+/c4lDitJf/oKg/DqLgbIc68bn83FsHI0=
   subdir:
     cardano-client
     cardano-ping

--- a/ouroboros-consensus-cardano/changelog.d/20240808_125131_marcin.wojtowicz_tx_wire_size.md
+++ b/ouroboros-consensus-cardano/changelog.d/20240808_125131_marcin.wojtowicz_tx_wire_size.md
@@ -1,0 +1,22 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Patch
+
+- A bullet item for the Patch category.
+
+-->
+<!--
+### Non-Breaking
+
+- A bullet item for the Non-Breaking category.
+
+-->
+### Breaking
+
+- Implement wireTxSize of LedgerSupportsMempool instantiations for Byron and Shelley
+

--- a/ouroboros-consensus-cardano/src/byron/Ouroboros/Consensus/Byron/Ledger/Mempool.hs
+++ b/ouroboros-consensus-cardano/src/byron/Ouroboros/Consensus/Byron/Ledger/Mempool.hs
@@ -73,6 +73,7 @@ import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.SupportsMempool
 import           Ouroboros.Consensus.Util (ShowProxy (..))
 import           Ouroboros.Consensus.Util.Condense
+import           Ouroboros.Network.SizeInBytes as Network
 
 {-------------------------------------------------------------------------------
   Transactions

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Mempool.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Mempool.hs
@@ -39,7 +39,7 @@ module Ouroboros.Consensus.Shelley.Ledger.Mempool (
 import qualified Cardano.Crypto.Hash as Hash
 import qualified Cardano.Ledger.Allegra.Rules as AllegraEra
 import           Cardano.Ledger.Alonzo.Core (Tx, TxSeq, bodyTxL, eraProtVerLow,
-                     fromTxSeq, ppMaxBBSizeL, ppMaxBlockExUnitsL, sizeTxF)
+                     fromTxSeq, ppMaxBBSizeL, ppMaxBlockExUnitsL, sizeTxF, wireSizeTxF)
 import qualified Cardano.Ledger.Alonzo.Rules as AlonzoEra
 import           Cardano.Ledger.Alonzo.Scripts (ExUnits, ExUnits',
                      pointWiseExUnits, unWrapExUnits)
@@ -145,6 +145,8 @@ instance (ShelleyCompatible proto era, TxLimits (ShelleyBlock proto era))
   applyTx = applyShelleyTx
 
   reapplyTx = reapplyShelleyTx
+
+  wireTxSize (ShelleyTx _ tx) = fromIntegral $ tx ^. wireSizeTxF
 
   txForgetValidated (ShelleyValidatedTx txid vtx) = ShelleyTx txid (SL.extractTx vtx)
 

--- a/ouroboros-consensus-diffusion/changelog.d/20240808_125632_marcin.wojtowicz_tx_wire_size.md
+++ b/ouroboros-consensus-diffusion/changelog.d/20240808_125632_marcin.wojtowicz_tx_wire_size.md
@@ -1,0 +1,25 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Patch
+
+- A bullet item for the Patch category.
+
+-->
+
+### Non-Breaking
+
+- Pass wireTxSize binding to txSubmission{Inbound, Outbound} which
+  enables transaction submission handlers to conveniently work with
+  sizes of byte encoded transactions for network dissemination.
+
+<!--
+### Breaking
+
+- A bullet item for the Breaking category.
+
+-->

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToNode.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToNode.hs
@@ -748,6 +748,7 @@ mkApps kernel Tracers {..} mkCodecs ByteLimits {..} genChainSyncTimeout lopBucke
                    (getSharedTxStateVar kernel)
                    (mapTxSubmissionMempoolReader txForgetValidated
                    $ getMempoolReader (getMempool kernel))
+                   wireTxSize
                    them $ \api ->
                      runServer (newTxSubmissionServer api)
 

--- a/ouroboros-consensus/changelog.d/20240808_101916_marcin.wojtowicz_tx_wire_size.md
+++ b/ouroboros-consensus/changelog.d/20240808_101916_marcin.wojtowicz_tx_wire_size.md
@@ -1,0 +1,23 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Patch
+
+- A bullet item for the Patch category.
+
+-->
+<!--
+### Non-Breaking
+
+- A bullet item for the Non-Breaking category.
+
+-->
+### Breaking
+
+- Added txWireSize method to LedgerSupportsMempool to provide
+  a CBOR-encoded transaction size as it is when transmitted
+  over the network.

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Mempool.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Mempool.hs
@@ -109,6 +109,12 @@ instance CanHardFork xs => LedgerSupportsMempool (HardForkBlock xs) where
           (WrapValidatedGenTx vtx)
           tls
 
+  wireTxSize =
+        hcollapse
+      . hcmap proxySingle (K . wireTxSize)
+      . getOneEraGenTx
+      . getHardForkGenTx
+
   txForgetValidated =
         HardForkGenTx
       . OneEraGenTx

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Dual.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Dual.hs
@@ -609,6 +609,8 @@ instance Bridge m a => LedgerSupportsMempool (DualBlock m a) where
                                            tickedDualLedgerStateBridge
         }
 
+  wireTxSize    = wireTxSize . dualGenTxMain
+
   txForgetValidated vtx =
       DualGenTx {
           dualGenTxMain   = txForgetValidated vDualGenTxMain

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/SupportsMempool.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/SupportsMempool.hs
@@ -37,6 +37,7 @@ import           NoThunks.Class
 import           Ouroboros.Consensus.Block.Abstract
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ticked
+import           Ouroboros.Network.SizeInBytes as Network
 
 -- | Generalized transaction
 --
@@ -110,6 +111,10 @@ class ( UpdateLedger blk
             -> Validated (GenTx blk)
             -> TickedLedgerState blk
             -> Except (ApplyTxErr blk) (TickedLedgerState blk)
+
+  -- | Return the size of a serialised transaction as it is transmitted
+  -- across the network.
+  wireTxSize :: GenTx blk -> Network.SizeInBytes
 
   -- | Discard the evidence that transaction has been previously validated
   txForgetValidated :: Validated (GenTx blk) -> GenTx blk


### PR DESCRIPTION
# Description

This change introduces a new method wireSizeTx for the LedgerSupportsMempool class. It provides actual CBOR encoded transaction size as it is when transmitted over the network, which the difffusion layer could exploit.

Also note that:

- New code should be properly tested (even if it does not add new features).
- The fix for a regression should include a test that reproduces said regression.

IntersectMBO/cardano-ledger#4521
IntersectMBO/ouroboros-network#4926