### PR TITLE
Remove mock-test from the NoThunks CI nightly runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,7 @@ jobs:
 
     - name: Test (NoThunks-safe tests only, part 2)
       if: matrix.test-set == 'no-thunks-safe'
-      run: cabal test ouroboros-consensus-cardano:shelley-test ouroboros-consensus-diffusion:infra-test ouroboros-consensus-diffusion:mock-test ouroboros-consensus-protocol:protocol-test -j --test-show-details=streaming
+      run: cabal test ouroboros-consensus-cardano:shelley-test ouroboros-consensus-diffusion:infra-test ouroboros-consensus-protocol:protocol-test -j --test-show-details=streaming
 
     - name: Create baseline-benchmark
       if: github.event_name == 'push' && github.ref == 'refs/heads/main'


### PR DESCRIPTION
# Description

This PR removes the `mock-test` from the nightly CI NoThunks run in order to prevent the runs from being killed by the GitHub Actions runner due to taking too long.