### PR TITLE
Remove mock-test from CI NoThunks runs and merge the two separated test runs back together

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,13 +142,9 @@ jobs:
       if: matrix.test-set == 'all'
       run: cabal test all -j --test-show-details=streaming
 
-    - name: Test (NoThunks-safe tests only, part 1)
+    - name: Test (NoThunks-safe tests only)
       if: matrix.test-set == 'no-thunks-safe'
-      run: cabal test ouroboros-consensus:consensus-test ouroboros-consensus:doctest ouroboros-consensus:infra-test ouroboros-consensus:storage-test ouroboros-consensus-cardano:byron-test -j --test-show-details=streaming
-
-    - name: Test (NoThunks-safe tests only, part 2)
-      if: matrix.test-set == 'no-thunks-safe'
-      run: cabal test ouroboros-consensus-cardano:shelley-test ouroboros-consensus-diffusion:infra-test ouroboros-consensus-diffusion:mock-test ouroboros-consensus-protocol:protocol-test -j --test-show-details=streaming
+      run: cabal test ouroboros-consensus:consensus-test ouroboros-consensus:doctest ouroboros-consensus:infra-test ouroboros-consensus:storage-test ouroboros-consensus-cardano:byron-test ouroboros-consensus-cardano:shelley-test ouroboros-consensus-diffusion:infra-test ouroboros-consensus-protocol:protocol-test -j --test-show-details=streaming
 
     - name: Create baseline-benchmark
       if: github.event_name == 'push' && github.ref == 'refs/heads/main'


### PR DESCRIPTION
# Description

This PR removes the `mock-test` from the nightly CI NoThunks run in order to prevent the runs from being killed by the GitHub Actions runner due to taking too long.