### PR TITLE
Use a single protocol version across all eras

### DIFF
--- a/ouroboros-consensus-cardano/changelog.d/20240823_131440_damian.nadales_324_simplify_protver_arguments.md
+++ b/ouroboros-consensus-cardano/changelog.d/20240823_131440_damian.nadales_324_simplify_protver_arguments.md
@@ -1,0 +1,5 @@
+### Breaking
+
+- ProtocolParams (CardanoBlock c) was monomorphized to `CardanoProtocolParams`
+- Remove `cardanoProtocolParamsPerEra` from `CardanoProtocolParams` in favour of a single `cardanoProtocolVersion`.
+  This patch intentionally removes the flexibility the n-ary product of versions per-era gave us, in favour of a simpler interface, as the current one has caused a lot of confusion and led to several mistakes in the past.

--- a/ouroboros-consensus-cardano/src/byron/Ouroboros/Consensus/Byron/Node.hs
+++ b/ouroboros-consensus-cardano/src/byron/Ouroboros/Consensus/Byron/Node.hs
@@ -18,7 +18,7 @@ module Ouroboros.Consensus.Byron.Node (
   , mkByronLeaderCredentials
   , mkPBftCanBeLeader
     -- * ProtocolInfo
-  , ProtocolParams (..)
+  , ProtocolParamsByron (..)
   , defaultPBftSignatureThreshold
   , mkByronConfig
   , protocolClientInfoByron
@@ -152,7 +152,7 @@ mkPBftCanBeLeader (ByronLeaderCredentials sk cert nid _) = PBftCanBeLeader {
     }
 
 blockForgingByron :: Monad m
-                  => ProtocolParams ByronBlock
+                  => ProtocolParamsByron
                   -> [BlockForging m ByronBlock]
 blockForgingByron ProtocolParamsByron { byronLeaderCredentials = mLeaderCreds
                                       } =
@@ -169,7 +169,7 @@ defaultPBftSignatureThreshold :: PBftSignatureThreshold
 defaultPBftSignatureThreshold = PBftSignatureThreshold 0.22
 
 -- | Parameters needed to run Byron
-data instance ProtocolParams ByronBlock = ProtocolParamsByron {
+data ProtocolParamsByron = ProtocolParamsByron {
       byronGenesis                :: Genesis.Config
     , byronPbftSignatureThreshold :: Maybe PBftSignatureThreshold
     , byronProtocolVersion        :: Update.ProtocolVersion
@@ -177,7 +177,7 @@ data instance ProtocolParams ByronBlock = ProtocolParamsByron {
     , byronLeaderCredentials      :: Maybe ByronLeaderCredentials
     }
 
-protocolInfoByron :: ProtocolParams ByronBlock
+protocolInfoByron :: ProtocolParamsByron
                   -> ProtocolInfo ByronBlock
 protocolInfoByron ProtocolParamsByron {
                       byronGenesis                = genesisConfig

--- a/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano.hs
+++ b/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano.hs
@@ -9,7 +9,6 @@ module Ouroboros.Consensus.Cardano (
   , ProtocolShelley
     -- * Abstract over the various protocols
   , CardanoHardForkTriggers (..)
-  , ProtocolParams (..)
   , module X
   ) where
 

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Node.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Node.hs
@@ -14,7 +14,6 @@
 
 module Ouroboros.Consensus.Shelley.Node (
     MaxMajorProtVer (..)
-  , ProtocolParams (..)
   , ProtocolParamsShelleyBased (..)
   , SL.Nonce (..)
   , SL.ProtVer (..)
@@ -44,7 +43,6 @@ import           Ouroboros.Consensus.Shelley.Ledger
 import           Ouroboros.Consensus.Shelley.Ledger.Inspect ()
 import           Ouroboros.Consensus.Shelley.Ledger.NetworkProtocolVersion ()
 import           Ouroboros.Consensus.Shelley.Node.DiffusionPipelining ()
-import           Ouroboros.Consensus.Shelley.Node.Praos
 import           Ouroboros.Consensus.Shelley.Node.Serialisation ()
 import           Ouroboros.Consensus.Shelley.Node.TPraos
 import           Ouroboros.Consensus.Shelley.Protocol.Abstract (pHeaderIssuer)

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Node/Praos.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Node/Praos.hs
@@ -16,26 +16,21 @@ module Ouroboros.Consensus.Shelley.Node.Praos (
     -- * BlockForging
     praosBlockForging
   , praosSharedBlockForging
-    -- * ProtocolInfo
-  , ProtocolParams (..)
   ) where
 
 import qualified Cardano.Ledger.Api.Era as L
-import qualified Cardano.Ledger.Shelley.API as SL
 import qualified Cardano.Protocol.TPraos.OCert as Absolute
 import qualified Cardano.Protocol.TPraos.OCert as SL
 import qualified Data.Text as T
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config (configConsensus)
 import qualified Ouroboros.Consensus.Mempool as Mempool
-import           Ouroboros.Consensus.Node.ProtocolInfo
 import qualified Ouroboros.Consensus.Protocol.Ledger.HotKey as HotKey
 import           Ouroboros.Consensus.Protocol.Praos (Praos, PraosParams (..),
                      praosCheckCanForge)
 import           Ouroboros.Consensus.Protocol.Praos.Common
                      (PraosCanBeLeader (praosCanBeLeaderOpCert))
-import           Ouroboros.Consensus.Shelley.Eras (BabbageEra, ConwayEra,
-                     EraCrypto)
+import           Ouroboros.Consensus.Shelley.Eras (EraCrypto)
 import           Ouroboros.Consensus.Shelley.Ledger (ShelleyBlock,
                      ShelleyCompatible, forgeShelleyBlock)
 import           Ouroboros.Consensus.Shelley.Node.Common (ShelleyEraWithCrypto,
@@ -112,17 +107,3 @@ praosSharedBlockForging
             canBeLeader
             cfg
       }
-
-{-------------------------------------------------------------------------------
-  ProtocolInfo
--------------------------------------------------------------------------------}
-
-data instance ProtocolParams (ShelleyBlock (Praos c) (BabbageEra c)) = ProtocolParamsBabbage {
-    babbageProtVer :: SL.ProtVer
-    -- ^ see 'Ouroboros.Consensus.Shelley.Node.TPraos.shelleyProtVer', mutatis mutandi
-  }
-
-data instance ProtocolParams (ShelleyBlock (Praos c) (ConwayEra c)) = ProtocolParamsConway {
-    conwayProtVer :: SL.ProtVer
-    -- ^ see 'Ouroboros.Consensus.Shelley.Node.TPraos.shelleyProtVer', mutatis mutandi
-  }

--- a/ouroboros-consensus-cardano/src/unstable-byron-testlib/Test/ThreadNet/Infra/Byron/ProtocolInfo.hs
+++ b/ouroboros-consensus-cardano/src/unstable-byron-testlib/Test/ThreadNet/Infra/Byron/ProtocolInfo.hs
@@ -58,7 +58,7 @@ mkProtocolByron params coreNodeId genesisConfig genesisSecrets =
     blockForging :: [BlockForging m ByronBlock]
     blockForging = blockForgingByron protocolParams
 
-    protocolParams :: ProtocolParams ByronBlock
+    protocolParams :: ProtocolParamsByron
     protocolParams = ProtocolParamsByron {
             byronGenesis                = genesisConfig
           , byronPbftSignatureThreshold = Just $ pbftSignatureThreshold

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Api/Protocol/Types.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Api/Protocol/Types.hs
@@ -20,7 +20,6 @@ module Cardano.Api.Protocol.Types (
 import           Cardano.Chain.Slotting (EpochSlots)
 import           Data.Bifunctor (bimap)
 import           Ouroboros.Consensus.Block.Forging (BlockForging)
-import qualified Ouroboros.Consensus.Byron.Ledger.Block as Consensus
 import           Ouroboros.Consensus.Cardano
 import           Ouroboros.Consensus.Cardano.Block
 import           Ouroboros.Consensus.Cardano.ByronHFC (ByronBlockHFC)
@@ -58,7 +57,7 @@ class RunNode blk => ProtocolClient blk where
 
 -- | Run PBFT against the Byron ledger
 instance IOLike m => Protocol m ByronBlockHFC where
-  data ProtocolInfoArgs m ByronBlockHFC = ProtocolInfoArgsByron (ProtocolParams Consensus.ByronBlock)
+  data ProtocolInfoArgs m ByronBlockHFC = ProtocolInfoArgsByron ProtocolParamsByron
   protocolInfo (ProtocolInfoArgsByron params) = ( inject $ protocolInfoByron params
                                                 , pure . map inject $ blockForgingByron params
                                                 )
@@ -92,9 +91,9 @@ instance ( IOLike m
   data ProtocolInfoArgs m (ShelleyBlockHFC (Consensus.TPraos StandardCrypto) StandardShelley) = ProtocolInfoArgsShelley
     (ShelleyGenesis StandardCrypto)
     (ProtocolParamsShelleyBased StandardCrypto)
-    (ProtocolParams (Consensus.ShelleyBlock (Consensus.TPraos StandardCrypto) (ShelleyEra StandardCrypto)))
-  protocolInfo (ProtocolInfoArgsShelley genesis paramsShelleyBased' paramsShelley') =
-    bimap inject (fmap $ map inject) $ protocolInfoShelley genesis paramsShelleyBased' paramsShelley'
+    ProtVer
+  protocolInfo (ProtocolInfoArgsShelley genesis shelleyBasedProtocolParams' protVer) =
+    bimap inject (fmap $ map inject) $ protocolInfoShelley genesis shelleyBasedProtocolParams' protVer
 
 instance Consensus.LedgerSupportsProtocol
           (Consensus.ShelleyBlock

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Node/Protocol/Cardano.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Node/Protocol/Cardano.hs
@@ -20,8 +20,8 @@ module Cardano.Node.Protocol.Cardano (
 import           Cardano.Api.Any
 import           Cardano.Api.Protocol.Types
 import qualified Cardano.Chain.Update as Byron
-import qualified Cardano.Ledger.Api.Transition as L
-import           Cardano.Ledger.BaseTypes (natVersion)
+import qualified Cardano.Ledger.Api.Era as L
+import qualified Cardano.Ledger.Api.Transition as SL
 import qualified Cardano.Node.Protocol.Alonzo as Alonzo
 import qualified Cardano.Node.Protocol.Byron as Byron
 import qualified Cardano.Node.Protocol.Conway as Conway
@@ -34,7 +34,7 @@ import           Ouroboros.Consensus.Cardano
 import qualified Ouroboros.Consensus.Cardano as Consensus
 import qualified Ouroboros.Consensus.Cardano.CanHardFork as Consensus
 import           Ouroboros.Consensus.Cardano.Condense ()
-import           Ouroboros.Consensus.Cardano.Node (CardanoProtocolParams)
+import           Ouroboros.Consensus.Cardano.Node (CardanoProtocolParams (..))
 import           Ouroboros.Consensus.Config (emptyCheckpointsMap)
 import           Ouroboros.Consensus.HardFork.Combinator.Condense ()
 import           Ouroboros.Consensus.Shelley.Crypto (StandardCrypto)
@@ -151,7 +151,7 @@ mkConsensusProtocolCardano NodeByronProtocolConfiguration {
         Shelley.readLeaderCredentials files
 
     let transitionLedgerConfig =
-          L.mkLatestTransitionConfig shelleyGenesis alonzoGenesis conwayGenesis
+          SL.mkLatestTransitionConfig shelleyGenesis alonzoGenesis conwayGenesis
 
     --TODO: all these protocol versions below are confusing and unnecessary.
     -- It could and should all be automated and these config entries eliminated.
@@ -185,46 +185,6 @@ mkConsensusProtocolCardano NodeByronProtocolConfiguration {
           shelleyBasedInitialNonce      = Shelley.genesisHashToPraosNonce
                                             shelleyGenesisHash,
           shelleyBasedLeaderCredentials = shelleyLeaderCredentials
-        }
-        Consensus.ProtocolParamsShelley {
-          -- This is /not/ the Shelley protocol version. It is the protocol
-          -- version that this node will declare that it understands, when it
-          -- is in the Shelley era. That is, it is the version of protocol
-          -- /after/ Shelley, i.e. Allegra.
-          shelleyProtVer = ProtVer (natVersion @3) 0
-        }
-        Consensus.ProtocolParamsAllegra {
-          -- This is /not/ the Allegra protocol version. It is the protocol
-          -- version that this node will declare that it understands, when it
-          -- is in the Allegra era. That is, it is the version of protocol
-          -- /after/ Allegra, i.e. Mary.
-          allegraProtVer = ProtVer (natVersion @4) 0
-        }
-        Consensus.ProtocolParamsMary {
-          -- This is /not/ the Mary protocol version. It is the protocol
-          -- version that this node will declare that it understands, when it
-          -- is in the Mary era. That is, it is the version of protocol
-          -- /after/ Mary, i.e. Alonzo.
-          maryProtVer = ProtVer (natVersion @5) 0
-        }
-        Consensus.ProtocolParamsAlonzo {
-          -- This is /not/ the Alonzo protocol version. It is the protocol
-          -- version that this node will declare that it understands, when it
-          -- is in the Alonzo era. That is, it is the version of protocol
-          -- /after/ Alonzo, i.e. Babbage.
-          alonzoProtVer = ProtVer (natVersion @7) 0
-        }
-        Consensus.ProtocolParamsBabbage {
-          -- This is /not/ the Babbage protocol version. It is the protocol
-          -- version that this node will declare that it understands, when it
-          -- is in the Babbage era.
-          Consensus.babbageProtVer = ProtVer (natVersion @9) 0
-        }
-        Consensus.ProtocolParamsConway {
-          -- This is /not/ the Conway protocol version. It is the protocol
-          -- version that this node will declare that it understands, when it
-          -- is in the Conway era.
-          Consensus.conwayProtVer = ProtVer (natVersion @9) 0
         }
         -- The 'CardanoHardForkTriggers' specify the parameters needed to
         -- transition between two eras. The comments below also apply for all
@@ -292,6 +252,7 @@ mkConsensusProtocolCardano NodeByronProtocolConfiguration {
         }
         transitionLedgerConfig
         emptyCheckpointsMap
+        (ProtVer (L.eraProtVerHigh @(L.LatestKnownEra StandardCrypto)) 0)
 
 ------------------------------------------------------------------------------
 -- Errors

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Node/Protocol/Shelley.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Node/Protocol/Shelley.hs
@@ -47,8 +47,8 @@ import qualified Ouroboros.Consensus.Cardano as Consensus
 import           Ouroboros.Consensus.Protocol.Praos.Common
                      (PraosCanBeLeader (..))
 import           Ouroboros.Consensus.Shelley.Node (Nonce (..),
-                     ProtocolParams (..), ProtocolParamsShelleyBased (..),
-                     ShelleyGenesis (..), ShelleyLeaderCredentials (..))
+                     ProtocolParamsShelleyBased (..), ShelleyGenesis (..),
+                     ShelleyLeaderCredentials (..))
 import           Prelude (String, id)
 
 
@@ -85,9 +85,7 @@ mkSomeConsensusProtocolShelley NodeShelleyProtocolConfiguration {
         shelleyBasedLeaderCredentials =
             leaderCredentials
       }
-      Consensus.ProtocolParamsShelley {
-        shelleyProtVer = ProtVer (natVersion @2) 0
-      }
+      (ProtVer (natVersion @2) 0)
 
 genesisHashToPraosNonce :: GenesisHash -> Nonce
 genesisHashToPraosNonce (GenesisHash h) = Nonce (Crypto.castHash h)

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Block/Byron.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Block/Byron.hs
@@ -25,7 +25,7 @@ import qualified Data.ByteString.Lazy as BL
 import           Ouroboros.Consensus.Byron.Ledger (ByronBlock)
 import qualified Ouroboros.Consensus.Byron.Ledger as Byron
 import           Ouroboros.Consensus.Byron.Node (PBftSignatureThreshold (..),
-                     ProtocolParams (..), protocolInfoByron)
+                     ProtocolParamsByron (..), protocolInfoByron)
 import           Ouroboros.Consensus.Node.ProtocolInfo
 import           Text.Builder (decimal)
 

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Block/Shelley.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Block/Shelley.hs
@@ -47,8 +47,8 @@ import           Ouroboros.Consensus.Shelley.Ledger (ShelleyCompatible,
 import           Ouroboros.Consensus.Shelley.Ledger.Block (ShelleyBlock)
 import qualified Ouroboros.Consensus.Shelley.Ledger.Block as Shelley
 import           Ouroboros.Consensus.Shelley.Node (Nonce (..),
-                     ProtocolParams (..), ProtocolParamsShelleyBased (..),
-                     ShelleyGenesis, protocolInfoShelley)
+                     ProtocolParamsShelleyBased (..), ShelleyGenesis,
+                     protocolInfoShelley)
 import           Text.Builder (decimal)
 
 -- | Usable for each Shelley-based era
@@ -154,6 +154,4 @@ mkShelleyProtocolInfo genesis initialNonce =
           shelleyBasedInitialNonce      = initialNonce
         , shelleyBasedLeaderCredentials = []
         }
-      ProtocolParamsShelley {
-          shelleyProtVer = SL.ProtVer (CL.natVersion @2) 0
-        }
+      (SL.ProtVer (CL.natVersion @2) 0)

--- a/ouroboros-consensus-cardano/src/unstable-shelley-testlib/Test/ThreadNet/Infra/Shelley.hs
+++ b/ouroboros-consensus-cardano/src/unstable-shelley-testlib/Test/ThreadNet/Infra/Shelley.hs
@@ -420,10 +420,7 @@ mkProtocolShelley genesis initialNonce protVer coreNode =
           shelleyBasedInitialNonce      = initialNonce
         , shelleyBasedLeaderCredentials = [mkLeaderCredentials coreNode]
         }
-      ProtocolParamsShelley {
-          shelleyProtVer = protVer
-        }
-
+      protVer
 {-------------------------------------------------------------------------------
   Necessary transactions for updating the 'DecentralizationParam'
 -------------------------------------------------------------------------------}

--- a/ouroboros-consensus-cardano/test/cardano-test/Test/Consensus/Cardano/MiniProtocol/LocalTxSubmission/Server.hs
+++ b/ouroboros-consensus-cardano/test/cardano-test/Test/Consensus/Cardano/MiniProtocol/LocalTxSubmission/Server.hs
@@ -37,7 +37,7 @@ import           Test.Consensus.Cardano.MiniProtocol.LocalTxSubmission.ByteStrin
 import           Test.Consensus.Cardano.ProtocolInfo
                      (ByronSlotLengthInSeconds (..), Era (..),
                      ShelleySlotLengthInSeconds (..), hardForkInto,
-                     mkSimpleTestProtocolInfo)
+                     mkSimpleTestProtocolInfo, protocolVersionZero)
 import qualified Test.Consensus.Mempool.Mocked as Mocked
 import           Test.Consensus.Mempool.Mocked (MockedMempool)
 import           Test.Tasty (TestTree, testGroup)
@@ -58,6 +58,7 @@ tests =
                         (Consensus.SecurityParam 10)
                         (ByronSlotLengthInSeconds 1)
                         (ShelleySlotLengthInSeconds 1)
+                        protocolVersionZero
                         (hardForkInto era)
 
             eraIndex = index_NS

--- a/ouroboros-consensus-cardano/test/cardano-test/Test/Consensus/Cardano/SupportsSanityCheck.hs
+++ b/ouroboros-consensus-cardano/test/cardano-test/Test/Consensus/Cardano/SupportsSanityCheck.hs
@@ -52,6 +52,7 @@ genSimpleTestProtocolInfo = do
       (securityParam setup)
       (byronSlotLength setup)
       (shelleySlotLength setup)
+      protocolVersionZero
       (hardForkSpec setup)
 
 data SimpleTestProtocolInfoSetup = SimpleTestProtocolInfoSetup

--- a/ouroboros-consensus-cardano/test/cardano-test/Test/ThreadNet/Cardano.hs
+++ b/ouroboros-consensus-cardano/test/cardano-test/Test/ThreadNet/Cardano.hs
@@ -478,31 +478,22 @@ mkProtocolCardanoAndHardForkTxs
                                           -- window so that the forks induced by
                                           -- the network partition are as deep
                                           -- as possible.
+        (SL.ProtVer conwayMajorVersion  0) -- During the tests, we
+                                           -- want to hard fork all
+                                           -- the way to Conway, so we
+                                           -- need to signal that we
+                                           -- support that era. This
+                                           -- version will have to be
+                                           -- changed if this test has
+                                           -- to hard fork to eras
+                                           -- beyond Conway.
         HardForkSpec {
-            shelleyHardForkSpec =
-              ( SL.ProtVer shelleyMajorVersion 0
-              , TriggerHardForkAtVersion $ SL.getVersion shelleyMajorVersion
-              )
-          , allegraHardForkSpec =
-              ( SL.ProtVer allegraMajorVersion 0
-              , TriggerHardForkAtVersion $ SL.getVersion allegraMajorVersion
-              )
-          , maryHardForkSpec =
-              ( SL.ProtVer maryMajorVersion    0
-              , TriggerHardForkAtVersion $ SL.getVersion maryMajorVersion
-              )
-          , alonzoHardForkSpec =
-              ( SL.ProtVer alonzoMajorVersion  0
-              , TriggerHardForkAtVersion $ SL.getVersion alonzoMajorVersion
-              )
-          , babbageHardForkSpec =
-              ( SL.ProtVer babbageMajorVersion  0
-              , TriggerHardForkAtVersion $ SL.getVersion babbageMajorVersion
-              )
-          , conwayHardForkSpec =
-              ( SL.ProtVer conwayMajorVersion  0
-              , TriggerHardForkAtVersion $ SL.getVersion conwayMajorVersion
-              )
+            shelleyHardForkSpec = TriggerHardForkAtVersion $ SL.getVersion shelleyMajorVersion
+          , allegraHardForkSpec = TriggerHardForkAtVersion $ SL.getVersion allegraMajorVersion
+          , maryHardForkSpec    = TriggerHardForkAtVersion $ SL.getVersion maryMajorVersion
+          , alonzoHardForkSpec  = TriggerHardForkAtVersion $ SL.getVersion alonzoMajorVersion
+          , babbageHardForkSpec = TriggerHardForkAtVersion $ SL.getVersion babbageMajorVersion
+          , conwayHardForkSpec  = TriggerHardForkAtVersion $ SL.getVersion conwayMajorVersion
         }
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus-protocol/changelog.d/20240823_131313_damian.nadales_324_simplify_protver_arguments.md
+++ b/ouroboros-consensus-protocol/changelog.d/20240823_131313_damian.nadales_324_simplify_protver_arguments.md
@@ -1,0 +1,3 @@
+<!--
+This PR just improved documentation.
+-->

--- a/ouroboros-consensus-protocol/src/ouroboros-consensus-protocol/Ouroboros/Consensus/Protocol/Praos/Common.hs
+++ b/ouroboros-consensus-protocol/src/ouroboros-consensus-protocol/Ouroboros/Consensus/Protocol/Praos/Common.hs
@@ -18,7 +18,8 @@ module Ouroboros.Consensus.Protocol.Praos.Common (
   ) where
 
 import qualified Cardano.Crypto.VRF as VRF
-import           Cardano.Ledger.BaseTypes (Nonce, Version)
+import           Cardano.Ledger.BaseTypes (Nonce)
+import qualified Cardano.Ledger.BaseTypes as SL
 import           Cardano.Ledger.Crypto (Crypto, VRF)
 import           Cardano.Ledger.Keys (KeyHash, KeyRole (BlockIssuer))
 import qualified Cardano.Ledger.Shelley.API as SL
@@ -35,10 +36,26 @@ import           Ouroboros.Consensus.Protocol.Abstract
 
 -- | The maximum major protocol version.
 --
--- Must be at least the current major protocol version. For Cardano mainnet, the
--- Shelley era has major protocol verison __2__.
+-- This refers to the largest __ledger__ version that this node supports.
+--
+-- Once the ledger protocol version (as reported by the ledger state)
+-- exceeds this version we will consider all blocks invalid. This is
+-- called the "obsolete node check" (see the 'ObsoleteNode' error
+-- constructor).
+--
+-- Major ledger protocol versions are used to trigger both intra and
+-- inter era hard forks, which can potentially change the set of
+-- ledger rules that are applied.
+--
+-- Minor ledger protocol versions were intended to signal soft forks
+-- but they're currently unused, and they're irrelevant for the
+-- consensus logic.
+--
+-- For Cardano mainnet, the Shelley era has major protocol version
+-- __2__.  For more details, see [this
+-- table](https://github.com/cardano-foundation/CIPs/blob/master/CIP-0059/feature-table.md)
 newtype MaxMajorProtVer = MaxMajorProtVer
-  { getMaxMajorProtVer :: Version
+  { getMaxMajorProtVer :: SL.Version
   }
   deriving (Eq, Show, Generic)
   deriving newtype NoThunks

--- a/ouroboros-consensus/changelog.d/20240823_130814_damian.nadales_324_simplify_protver_arguments.md
+++ b/ouroboros-consensus/changelog.d/20240823_130814_damian.nadales_324_simplify_protver_arguments.md
@@ -1,0 +1,4 @@
+### Breaking
+
+- Remove `PerEraProtocolParams` newtype.
+- Remove `ProtocolParams` data family.

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/AcrossEras.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/AcrossEras.hs
@@ -25,7 +25,6 @@ module Ouroboros.Consensus.HardFork.Combinator.AcrossEras (
   , PerEraCodecConfig (..)
   , PerEraConsensusConfig (..)
   , PerEraLedgerConfig (..)
-  , PerEraProtocolParams (..)
   , PerEraStorageConfig (..)
     -- * Values for /some/ eras
   , SomeErasCanBeLeader (..)
@@ -88,7 +87,6 @@ import           Ouroboros.Consensus.HardFork.Combinator.Info
 import           Ouroboros.Consensus.HardFork.Combinator.Lifting
 import           Ouroboros.Consensus.HardFork.Combinator.PartialConfig
 import           Ouroboros.Consensus.Ledger.SupportsMempool
-import           Ouroboros.Consensus.Node.ProtocolInfo
 import           Ouroboros.Consensus.TypeFamilyWrappers
 import           Ouroboros.Consensus.Util (allEqual)
 import           Ouroboros.Consensus.Util.Assert
@@ -104,8 +102,6 @@ newtype PerEraCodecConfig      xs = PerEraCodecConfig      { getPerEraCodecConfi
 newtype PerEraConsensusConfig  xs = PerEraConsensusConfig  { getPerEraConsensusConfig  :: NP WrapPartialConsensusConfig xs }
 newtype PerEraLedgerConfig     xs = PerEraLedgerConfig     { getPerEraLedgerConfig     :: NP WrapPartialLedgerConfig    xs }
 newtype PerEraStorageConfig    xs = PerEraStorageConfig    { getPerEraStorageConfig    :: NP StorageConfig              xs }
-
-newtype PerEraProtocolParams   xs = PerEraProtocolParams   { getPerEraProtocolParams   :: NP ProtocolParams             xs }
 
 {-------------------------------------------------------------------------------
   Values for /some/ eras

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Node/ProtocolInfo.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Node/ProtocolInfo.hs
@@ -7,11 +7,8 @@ module Ouroboros.Consensus.Node.ProtocolInfo (
   , ProtocolClientInfo (..)
   , ProtocolInfo (..)
   , enumCoreNodes
-    -- * Protocol parameters
-  , ProtocolParams
   ) where
 
-import           Data.Kind (Type)
 import           Data.Word
 import           NoThunks.Class (NoThunks)
 import           Ouroboros.Consensus.Block
@@ -45,9 +42,3 @@ data ProtocolInfo b = ProtocolInfo {
 data ProtocolClientInfo b = ProtocolClientInfo {
        pClientInfoCodecConfig :: CodecConfig b
      }
-
-{-------------------------------------------------------------------------------
-  Protocol parameters
--------------------------------------------------------------------------------}
-
-data family ProtocolParams blk :: Type


### PR DESCRIPTION
While giving us flexibility, using different protocol versions for all eras increased the level of complexity and led to several errors in the past. This PR removes this flexibility by using a single protocol version, which determines the maximum protocol version Consensus supports. 

See #324 for more background.

Closes #324.
Closes #276. 

TODOs:

- [x] Format the code.
- [x] Fix ThreadNet test failure.
- [x] Improve documentation.
- [x] Address all the `FIXME`s.