### PR TITLE
mempool-bench: move more pre-calculation into withResource

### DIFF
--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Capacity.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Capacity.hs
@@ -23,6 +23,7 @@ module Ouroboros.Consensus.Mempool.Capacity (
   , TxLimits (..)
   ) where
 
+import           Cardano.Prelude (NFData)
 import           Data.Measure (BoundedMeasure, Measure)
 import           Data.Word (Word32)
 import           NoThunks.Class
@@ -123,5 +124,5 @@ class BoundedMeasure (TxMeasure blk) => TxLimits blk where
 
 newtype ByteSize = ByteSize { unByteSize :: Word32 }
   deriving stock (Show)
-  deriving newtype (Eq, Ord)
+  deriving newtype (Eq, NFData, Ord)
   deriving newtype (BoundedMeasure, Measure)


### PR DESCRIPTION
PR https://github.com/IntersectMBO/ouroboros-consensus/pull/1175 makes a change that alters the cost of the size of the pre-generated txs. This PR pre-emptively removes that cost from the benchmarked section of code.