### PR TITLE
Mempool test: generate txs larger than the entire mempool 

### DIFF
--- a/ouroboros-consensus/changelog.d/20240827_160651_alexander.esgen_test_empty_mempool_nonblocking.md
+++ b/ouroboros-consensus/changelog.d/20240827_160651_alexander.esgen_test_empty_mempool_nonblocking.md
@@ -1,0 +1,3 @@
+### Non-Breaking
+
+- Added a `Serialise ByteSize32` instance.

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -544,6 +544,7 @@ test-suite consensus-test
     base-deriving-via,
     cardano-binary,
     cardano-crypto-class,
+    cardano-crypto-tests,
     cardano-slotting:{cardano-slotting, testlib},
     cborg,
     containers,

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/SupportsMempool.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/SupportsMempool.hs
@@ -23,6 +23,7 @@ module Ouroboros.Consensus.Ledger.SupportsMempool (
   , WhetherToIntervene (..)
   ) where
 
+import           Codec.Serialise (Serialise)
 import           Control.DeepSeq (NFData)
 import           Control.Monad.Except
 import           Data.ByteString.Short (ShortByteString)
@@ -246,6 +247,7 @@ newtype ByteSize32 = ByteSize32 { unByteSize32 :: Word32 }
   deriving stock    (Show)
   deriving newtype  (Eq, Ord)
   deriving newtype  (NFData)
+  deriving newtype  (Serialise)
   deriving          (Monoid, Semigroup)
                 via (InstantiatedAt Measure (IgnoringOverflow ByteSize32))
   deriving          (NoThunks)

--- a/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Node/BFT.hs
+++ b/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Node/BFT.hs
@@ -38,7 +38,7 @@ protocolInfoBft numCoreNodes nid securityParam eraParams =
                   | n <- enumCoreNodes numCoreNodes
                   ]
               }
-          , topLevelConfigLedger      = SimpleLedgerConfig () eraParams
+          , topLevelConfigLedger      = SimpleLedgerConfig () eraParams defaultMockConfig
           , topLevelConfigBlock       = SimpleBlockConfig
           , topLevelConfigCodec       = SimpleCodecConfig
           , topLevelConfigStorage     = SimpleStorageConfig securityParam

--- a/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Node/PBFT.hs
+++ b/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Node/PBFT.hs
@@ -37,7 +37,7 @@ protocolInfoMockPBFT params eraParams =
             topLevelConfigProtocol = PBftConfig {
                 pbftParams = params
               }
-          , topLevelConfigLedger      = SimpleLedgerConfig ledgerView eraParams
+          , topLevelConfigLedger      = SimpleLedgerConfig ledgerView eraParams defaultMockConfig
           , topLevelConfigBlock       = SimpleBlockConfig
           , topLevelConfigCodec       = SimpleCodecConfig
           , topLevelConfigStorage     = SimpleStorageConfig (pbftSecurityParam params)

--- a/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Node/Praos.hs
+++ b/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Node/Praos.hs
@@ -48,7 +48,7 @@ protocolInfoPraos numCoreNodes nid params eraParams eta0 evolvingStakeDist =
               , praosEvolvingStake = evolvingStakeDist
               , praosVerKeys       = verKeys
               }
-          , topLevelConfigLedger      = SimpleLedgerConfig addrDist eraParams
+          , topLevelConfigLedger      = SimpleLedgerConfig addrDist eraParams defaultMockConfig
           , topLevelConfigBlock       = SimpleBlockConfig
           , topLevelConfigCodec       = SimpleCodecConfig
           , topLevelConfigStorage     = SimpleStorageConfig (praosSecurityParam params)

--- a/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Node/PraosRule.hs
+++ b/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Node/PraosRule.hs
@@ -50,7 +50,7 @@ protocolInfoPraosRule numCoreNodes
                 }
             , wlsConfigNodeId   = nid
             }
-        , topLevelConfigLedger      = SimpleLedgerConfig () eraParams
+        , topLevelConfigLedger      = SimpleLedgerConfig () eraParams defaultMockConfig
         , topLevelConfigBlock       = SimpleBlockConfig
         , topLevelConfigCodec       = SimpleCodecConfig
         , topLevelConfigStorage     = SimpleStorageConfig (praosSecurityParam params)


### PR DESCRIPTION
Closes #1226

In addition to the previously valid/invalid txs (purely based on the UTxO ledger rules), we add an optional per-tx limit to the mock block.

As a second step, we generate very large txs that are larger than an entire mempool, in order to test that we do *not* block when adding them (just like the other txs), which is important as explained in #1226.

---

One way to validate this PR is to introduce a bug that would cause us to block on such transactions, and observe that the test now indeed catches that.

For example, retrying when the per-tx limited is not satisfied (this is basically what happened in #1168 and was fixed by #1225) via
```diff
diff --git a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Update.hs b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Update.hs
index 372ea15c29..31abe25fbf 100644
--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Update.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Update.hs
@@ -170,25 +170,8 @@ pureTryAddTx ::
   -> TryAddTx blk
 pureTryAddTx cfg wti tx is =
   case runExcept $ txMeasure cfg (isLedgerState is) tx of
-    Left err ->
-      -- The transaction does not have a valid measure (eg its ExUnits is
-      -- greater than what this ledger state allows for a single transaction).
-      --
-      -- It might seem simpler to remove the failure case from 'txMeasure' and
-      -- simply fully validate the tx before determining whether it'd fit in
-      -- the mempool; that way we could reject invalid txs ASAP. However, for a
-      -- valid tx, we'd pay that validation cost every time the node's
-      -- selection changed, even if the tx wouldn't fit. So it'd very much be
-      -- as if the mempool were effectively over capacity! What's worse, each
-      -- attempt would not be using 'extendVRPrevApplied'.
-      TryAddTx
-        Nothing
-        (MempoolTxRejected tx err)
-        (TraceMempoolRejectedTx
-         tx
-         err
-         (isMempoolSize is)
-        )
+    Left _err ->
+      NotEnoughSpaceLeft
     Right txsz
       -- Check for overflow
       --
```
or here
```diff
diff --git a/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Ledger/Block.hs b/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Ledger/Block.hs
index 743e11bc61..e01d8cfe5a 100644
--- a/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Ledger/Block.hs
+++ b/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Ledger/Block.hs
@@ -452,10 +452,7 @@ instance TxLimits (SimpleBlock c ext) where
   -- But not 'maxbound'!, since the mempool sometimes holds multiple blocks worth.
   blockCapacityTxMeasure _cfg _st = IgnoringOverflow simpleBlockCapacity
 
-  txMeasure cfg _st =
-        fmap IgnoringOverflow
-      . checkTxSize (simpleLedgerMockConfig cfg)
-      . simpleGenTx
+  txMeasure _cfg _st = pure . IgnoringOverflow . txSize . simpleGenTx
 
 simpleBlockCapacity :: ByteSize32
 simpleBlockCapacity = ByteSize32 512
```
will cause many test failures with `FailureDeadlock [Labelled (ThreadId []) (Just "main")]'` via `io-sim`'s nice deadlock detection.

---

Stacked on top of #1175 to avoid boring rebase work