### PR TITLE
GDD: use new `AF.splitAtSlot`

### DIFF
--- a/ouroboros-consensus/changelog.d/20240829_095937_alexander.esgen_gdd_splitAtSlot.md
+++ b/ouroboros-consensus/changelog.d/20240829_095937_alexander.esgen_gdd_splitAtSlot.md
@@ -1,0 +1,3 @@
+### Patch
+
+- Used new `AF.splitAtSlot` function in GDD.

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Genesis/Governor.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Genesis/Governor.hs
@@ -302,7 +302,8 @@ densityDisconnect (GenesisWindow sgen) (SecurityParam k) states candidateSuffixe
   where
     densityBounds = do
       (peer, candidateSuffix) <- candidateSuffixes
-      let clippedFragment = dropBeyondGenesisWindow candidateSuffix
+      let (clippedFragment, _) =
+            AF.splitAtSlot firstSlotAfterGenesisWindow candidateSuffix
       state <- maybeToList (states Map.!? peer)
       -- Skip peers that haven't sent any headers yet.
       -- They should be disconnected by timeouts instead.
@@ -399,11 +400,6 @@ densityDisconnect (GenesisWindow sgen) (SecurityParam k) states candidateSuffixe
 
     firstSlotAfterGenesisWindow =
         succWithOrigin loeIntersectionSlot + SlotNo sgen
-
-    -- This is performance sensitive. We used to call @takeWhileOldest@ here,
-    -- which would reconstruct much of the original fragment.
-    dropBeyondGenesisWindow =
-      AF.dropWhileNewest ((>= firstSlotAfterGenesisWindow) . blockSlot)
 
 -- Note [Chain disagreement]
 -- ~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
With #1207 merged, we can use `AF.splitAtSlot` which was introduced for the use in the GDD by @facundominguez in https://github.com/IntersectMBO/ouroboros-network/pull/4884.