### PR TITLE
Add ^>= 1.14 bound to cardano-ledger-core in ouroboros-consensus

### DIFF
--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -279,7 +279,7 @@ library
     bytestring >=0.10 && <0.13,
     cardano-binary,
     cardano-crypto-class,
-    cardano-ledger-core,
+    cardano-ledger-core ^>=1.14,
     cardano-prelude,
     cardano-slotting,
     cardano-strict-containers,


### PR DESCRIPTION
Add ^>= 1.14 bound to cardano-ledger-core in ouroboros-consensus
