### PR TITLE
Require `cardano-ledger-shelley >=1.13.1`

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -16,7 +16,7 @@ index-state:
   -- Bump this if you need newer packages from Hackage
   , hackage.haskell.org 2024-07-23T00:03:37Z
   -- Bump this if you need newer packages from CHaP
-  , cardano-haskell-packages 2024-08-27T16:28:01Z
+  , cardano-haskell-packages 2024-09-03T00:18:11Z
 
 packages:
   ouroboros-consensus

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1724604182,
-        "narHash": "sha256-gQmj2hHwEvS29Gf+juG95T7Qt5LfzDJKzdPajcuHZgs=",
+        "lastModified": 1725366660,
+        "narHash": "sha256-TasR2Xcz8jkI9J/iP1DLSZ/F8pRl+I+G5MuVAd0iRfw=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "3a25be01c845e86092e514403882ac74141ac3da",
+        "rev": "33e6e90010b5635e1c732941efded22e8c4bde8d",
         "type": "github"
       },
       "original": {

--- a/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
+++ b/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
@@ -143,7 +143,7 @@ library
     cardano-ledger-conway ^>=1.16,
     cardano-ledger-core ^>=1.14,
     cardano-ledger-mary ^>=1.7,
-    cardano-ledger-shelley ^>=1.13,
+    cardano-ledger-shelley ^>=1.13.1,
     cardano-prelude,
     cardano-protocol-tpraos ^>=1.2,
     cardano-slotting,


### PR DESCRIPTION
We want to use the fixed Conway ledger snapshot deserialization logic for our tools, in particular for `db-analyser`. See https://github.com/IntersectMBO/cardano-haskell-packages/pull/885.