### PR TITLE
Minimally re-implement additional logic on Babbage->Conway ledger state translation

### DIFF
--- a/ouroboros-consensus-cardano/changelog.d/20240905_151832_alexander.esgen_minimize_babbage_conway_hfc_tick_hack.md
+++ b/ouroboros-consensus-cardano/changelog.d/20240905_151832_alexander.esgen_minimize_babbage_conway_hfc_tick_hack.md
@@ -1,0 +1,3 @@
+### Patch
+
+- Minimize additional logic on ledger state translation from Babbage to Conway.


### PR DESCRIPTION
This PR reverts #366 and recovers the logic in a minimal fashion for backwards-compatibility (as the Conway HF already happened on mainnet).

The ledger state corresponding to the first mainnet Conway block is identical before and after this PR.