### PR TITLE
db-analyser: add block size to --benchmark-ledger-ops and --show-block-header-size

### DIFF
--- a/ouroboros-consensus-cardano/changelog.d/20240906_081159_nick.frisby_db_analyser_add_blocksize.md
+++ b/ouroboros-consensus-cardano/changelog.d/20240906_081159_nick.frisby_db_analyser_add_blocksize.md
@@ -1,0 +1,22 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Patch
+
+- A bullet item for the Patch category.
+
+-->
+<!--
+### Non-Breaking
+
+- A bullet item for the Non-Breaking category.
+
+-->
+
+### Breaking
+
+- Added a `blockBytes` column to the output of --benchmark-ledger-ops and --show-header-size.

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Analysis/BenchmarkLedgerOps/FileWriting.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Analysis/BenchmarkLedgerOps/FileWriting.hs
@@ -112,5 +112,6 @@ dataPointCsvBuilder =
     , ("mut_headerApply"       , decimal . DP.mut_headerApply)
     , ("mut_blockTick"         , decimal . DP.mut_blockTick)
     , ("mut_blockApply"        , decimal . DP.mut_blockApply)
+    , ("blockBytes"            , decimal . DP.blockByteSize)
     , ("...era-specific stats" , Builder.intercalate csvSeparator . DP.unBlockStats . DP.blockStats)
     ]

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Analysis/BenchmarkLedgerOps/SlotDataPoint.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Analysis/BenchmarkLedgerOps/SlotDataPoint.hs
@@ -55,6 +55,7 @@ data SlotDataPoint =
       , mut_headerApply :: !Int64
       , mut_blockTick   :: !Int64
       , mut_blockApply  :: !Int64
+      , blockByteSize   :: !Word32
       -- | Free-form information about the block.
       , blockStats      :: !BlockStats
       } deriving (Generic, Show)


### PR DESCRIPTION
For example, the analysis in PR https://github.com/IntersectMBO/ouroboros-consensus/pull/1240 can be simplified via this PR.