### PR TITLE
GDD: add separate trace event for disconnections

### DIFF
--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Trace.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Trace.hs
@@ -23,11 +23,12 @@ module Test.Consensus.PeerSimulator.Trace (
 import           Control.Tracer (Tracer (Tracer), contramap, traceWith)
 import           Data.Bifunctor (second)
 import           Data.List (intersperse)
+import qualified Data.List.NonEmpty as NE
 import           Data.Time.Clock (DiffTime, diffTimeToPicoseconds)
 import           Ouroboros.Consensus.Block (GenesisWindow (..), Header, Point,
                      WithOrigin (NotOrigin, Origin), succWithOrigin)
 import           Ouroboros.Consensus.Genesis.Governor (DensityBounds (..),
-                     TraceGDDEvent (..))
+                     GDDDebugInfo (..), TraceGDDEvent (..))
 import           Ouroboros.Consensus.MiniProtocol.ChainSync.Client
                      (TraceChainSyncClientEvent (..))
 import           Ouroboros.Consensus.MiniProtocol.ChainSync.Client.Jumping
@@ -490,7 +491,15 @@ showPeers = map (\ (peer, v) -> "        " ++ condense peer ++ ": " ++ v)
 -- * Other utilities
 terseGDDEvent :: TraceGDDEvent PeerId TestBlock -> String
 terseGDDEvent = \case
-  TraceGDDEvent {sgen = GenesisWindow sgen, curChain, bounds, candidates, candidateSuffixes, losingPeers, loeHead} ->
+  TraceGDDDisconnected peers -> "GDD | Disconnected " <> show (NE.toList peers)
+  TraceGDDDebug GDDDebugInfo {
+      sgen = GenesisWindow sgen
+    , curChain, bounds
+    , candidates
+    , candidateSuffixes
+    , losingPeers
+    , loeHead
+    } ->
     unlines $ [
       "GDD | Window: " ++ window sgen loeHead,
       "      Selection: " ++ terseHFragment curChain,

--- a/ouroboros-consensus/changelog.d/20240912_105038_alexander.esgen_gdd_disconnect_trace.md
+++ b/ouroboros-consensus/changelog.d/20240912_105038_alexander.esgen_gdd_disconnect_trace.md
@@ -1,0 +1,5 @@
+### Breaking
+
+- Made `TraceGDDEvent` into a sum type, added a new terse constructor for when
+  we disconnect from peers (this is supposed to get a high severity in the
+  tracing system).


### PR DESCRIPTION
It is desirable to have an explicit trace event for when the GDD decides to disconnect from someone. The already existing "debug info" already contained this information, but it should not be traced by default.