### PR TITLE
Enforce LF line endings

### DIFF
--- a/nix/formatting.nix
+++ b/nix/formatting.nix
@@ -29,4 +29,5 @@ in
   stylish = checkFormatting pkgs.stylish-haskell ../scripts/ci/run-stylish.sh;
   cabal-gild = checkFormatting pkgs.cabal-gild ../scripts/ci/run-cabal-gild.sh;
   nixpkgs-fmt = checkFormatting pkgs.nixpkgs-fmt ../scripts/ci/run-nixpkgs-fmt.sh;
+  dos2unix = checkFormatting pkgs.dos2unix ../scripts/ci/run-dos2unix.sh;
 }

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -10,6 +10,7 @@ hsPkgs.shellFor {
     pkgs.fd
     pkgs.nixpkgs-fmt
     pkgs.stylish-haskell
+    pkgs.dos2unix
     pkgs.cabal-gild
     pkgs.cabal-hoogle
     pkgs.ghcid

--- a/scripts/ci/run-dos2unix.sh
+++ b/scripts/ci/run-dos2unix.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+fd -X dos2unix


### PR DESCRIPTION
To prevent files like the Agda files fixed in #1252 from entering the repo