### PR TITLE
Keep around benchmark artifacts for 10 days in GHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,7 @@ jobs:
       with:
         name: benchmark-exes-${{ runner.os }}-${{ matrix.ghc }}
         path: mempool-bench
-        retention-days: 1
+        retention-days: 10
 
     # NB: build the haddocks at the end to avoid unecessary recompilations.
     # We build the haddocks only for one GHC version.


### PR DESCRIPTION
A lifetime of only a single day is prohibitive. If the benchmark jobs are run 24 hours after the build+test jobs, then the benchmark jobs will fail because the artifact will have been deleted by then. A stop-gap solution is to rerun all jobs, but that's not very nice UX. In this commit, we change retention days to 10.