### PR TITLE
Remove stale `allow-newer` in cabal.project

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -14,9 +14,9 @@ repository cardano-haskell-packages
 -- update either of these.
 index-state:
   -- Bump this if you need newer packages from Hackage
-  , hackage.haskell.org 2024-08-26T10:41:44Z
+  , hackage.haskell.org 2024-08-27T14:57:57Z
   -- Bump this if you need newer packages from CHaP
-  , cardano-haskell-packages 2024-09-03T00:18:11Z
+  , cardano-haskell-packages 2024-10-03T15:13:19Z
 
 packages:
   ouroboros-consensus
@@ -44,15 +44,3 @@ package ouroboros-network
 if(os(windows))
   constraints:
     bitvec -simd
-
-if impl(ghc >= 9.10)
-  allow-newer:
-    -- All these cardano-ledger packages have been fixed on master but not
-    -- yet released to CHaP and according to the team will not be released
-    -- until after the Chang hardfork.
-    , cardano-ledger-alonzo:plutus-ledger-api
-    , cardano-ledger-alonzo-test:plutus-ledger-api
-    , cardano-ledger-babbage:plutus-ledger-api
-    , cardano-ledger-binary:plutus-ledger-api
-    , cardano-ledger-conway:plutus-ledger-api
-


### PR DESCRIPTION
These have been released to chap it seems, as the build succeeds locally.