### PR TITLE
Trace forkSyncStateOnTipPointChange

### DIFF
--- a/ouroboros-consensus/changelog.d/20241011_091242_karl.fb.knutsson_sync_tracing.md
+++ b/ouroboros-consensus/changelog.d/20241011_091242_karl.fb.knutsson_sync_tracing.md
@@ -1,0 +1,4 @@
+### Breaking
+
+- Add TraceMempoolSynced to TraceEventMempool for tracing mempool sync time.
+

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Impl/Common.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Impl/Common.hs
@@ -56,6 +56,7 @@ import qualified Ouroboros.Consensus.Mempool.TxSeq as TxSeq
 import           Ouroboros.Consensus.Storage.ChainDB (ChainDB)
 import qualified Ouroboros.Consensus.Storage.ChainDB.API as ChainDB
 import           Ouroboros.Consensus.Util (repeatedly)
+import           Ouroboros.Consensus.Util.Enclose (EnclosingTimed)
 import           Ouroboros.Consensus.Util.IOLike hiding (newMVar)
 
 {-------------------------------------------------------------------------------
@@ -556,6 +557,10 @@ data TraceEventMempool blk
       -- transactions.
       MempoolSize
       -- ^ The current size of the Mempool.
+   | TraceMempoolSynced
+      -- ^ Emitted when the mempool is adjusted after the tip has changed.
+      EnclosingTimed
+      -- ^ How long the sync operation took.
 
 deriving instance ( Eq (GenTx blk)
                   , Eq (Validated (GenTx blk))


### PR DESCRIPTION
# Description

Trace when forkSyncStateOnTipPointChange completes an iteration.
This provides insight into how much time is spent syncing the mempool after a new block has been adopted.