### PR TITLE
Simplify `CardanoHardForkTriggers`

### DIFF
--- a/ouroboros-consensus-cardano/changelog.d/20241014_170244_alexander.esgen_cardano_hf_trigger.md
+++ b/ouroboros-consensus-cardano/changelog.d/20241014_170244_alexander.esgen_cardano_hf_trigger.md
@@ -1,0 +1,16 @@
+### Breaking
+
+- Changed `CardanoHardTriggers` to contain `CardanoHardForkTrigger`s which are a
+  simpler version of the previous `TriggerHardForkAt`. In particular, this will
+  affect call sites of `protocolInfoCardano`.
+
+  Migration notes:
+
+    - Change `TriggerHardForkAtEpoch` to `CardanoTriggerHardForkAtEpoch`.
+    - Change `TriggerHardForkAtVersion` to `CardanoTriggerHardForkAtDefaultVersion`.
+
+      This constructor does not take a version argument, but rather defaults to
+      the corresponding first ledger protocol version. We are not aware of any
+      use case that requires a different value, but if there is, it is still
+      possible to manually modify the returned `LedgerConfig`s of
+      `protocolInfoCardano` directly.

--- a/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano.hs
+++ b/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano.hs
@@ -8,6 +8,7 @@ module Ouroboros.Consensus.Cardano (
   , ProtocolCardano
   , ProtocolShelley
     -- * Abstract over the various protocols
+  , CardanoHardForkTrigger (..)
   , CardanoHardForkTriggers (..)
   , module X
   ) where

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Node/Protocol/Cardano.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Node/Protocol/Cardano.hs
@@ -32,7 +32,6 @@ import           Control.Monad.Trans.Except (ExceptT)
 import           Control.Monad.Trans.Except.Extra (firstExceptT)
 import           Ouroboros.Consensus.Cardano
 import qualified Ouroboros.Consensus.Cardano as Consensus
-import qualified Ouroboros.Consensus.Cardano.CanHardFork as Consensus
 import           Ouroboros.Consensus.Cardano.Condense ()
 import           Ouroboros.Consensus.Cardano.Node (CardanoProtocolParams (..))
 import           Ouroboros.Consensus.Config (emptyCheckpointsMap)
@@ -108,17 +107,11 @@ mkConsensusProtocolCardano NodeByronProtocolConfiguration {
                             -- not-yet-ready eras in released node versions without mainnet nodes
                             -- prematurely advertising that they could hard fork into the new era.
                              npcTestShelleyHardForkAtEpoch,
-                             npcTestShelleyHardForkAtVersion,
                              npcTestAllegraHardForkAtEpoch,
-                             npcTestAllegraHardForkAtVersion,
                              npcTestMaryHardForkAtEpoch,
-                             npcTestMaryHardForkAtVersion,
                              npcTestAlonzoHardForkAtEpoch,
-                             npcTestAlonzoHardForkAtVersion,
                              npcTestBabbageHardForkAtEpoch,
-                             npcTestBabbageHardForkAtVersion,
-                             npcTestConwayHardForkAtEpoch,
-                             npcTestConwayHardForkAtVersion
+                             npcTestConwayHardForkAtEpoch
                            }
                            files = do
     byronGenesis <-
@@ -213,42 +206,36 @@ mkConsensusProtocolCardano NodeByronProtocolConfiguration {
               -- But we also provide an override to allow for simpler test setups
               -- such as triggering at the 0 -> 1 transition .
               --
-              Nothing -> Consensus.TriggerHardForkAtVersion
-                            (maybe 2 fromIntegral npcTestShelleyHardForkAtVersion)
+              Nothing      -> Consensus.CardanoTriggerHardForkAtDefaultVersion
 
               -- Alternatively, for testing we can transition at a specific epoch.
               --
-              Just epochNo -> Consensus.TriggerHardForkAtEpoch epochNo
+              Just epochNo -> Consensus.CardanoTriggerHardForkAtEpoch epochNo
           -- Shelley to Allegra hard fork parameters
         , triggerHardForkAllegra =
             case npcTestAllegraHardForkAtEpoch of
-              Nothing -> Consensus.TriggerHardForkAtVersion
-                            (maybe 3 fromIntegral npcTestAllegraHardForkAtVersion)
-              Just epochNo -> Consensus.TriggerHardForkAtEpoch epochNo
+              Nothing      -> Consensus.CardanoTriggerHardForkAtDefaultVersion
+              Just epochNo -> Consensus.CardanoTriggerHardForkAtEpoch epochNo
           -- Allegra to Mary hard fork parameters
         , triggerHardForkMary =
             case npcTestMaryHardForkAtEpoch of
-              Nothing -> Consensus.TriggerHardForkAtVersion
-                            (maybe 4 fromIntegral npcTestMaryHardForkAtVersion)
-              Just epochNo -> Consensus.TriggerHardForkAtEpoch epochNo
+              Nothing      -> Consensus.CardanoTriggerHardForkAtDefaultVersion
+              Just epochNo -> Consensus.CardanoTriggerHardForkAtEpoch epochNo
           -- Mary to Alonzo hard fork parameters
         , triggerHardForkAlonzo =
             case npcTestAlonzoHardForkAtEpoch of
-              Nothing -> Consensus.TriggerHardForkAtVersion
-                            (maybe 5 fromIntegral npcTestAlonzoHardForkAtVersion)
-              Just epochNo -> Consensus.TriggerHardForkAtEpoch epochNo
+              Nothing      -> Consensus.CardanoTriggerHardForkAtDefaultVersion
+              Just epochNo -> Consensus.CardanoTriggerHardForkAtEpoch epochNo
           -- Alonzo to Babbage hard fork parameters
         , triggerHardForkBabbage =
             case npcTestBabbageHardForkAtEpoch of
-                Nothing -> Consensus.TriggerHardForkAtVersion
-                            (maybe 7 fromIntegral npcTestBabbageHardForkAtVersion)
-                Just epochNo -> Consensus.TriggerHardForkAtEpoch epochNo
+                Nothing      -> Consensus.CardanoTriggerHardForkAtDefaultVersion
+                Just epochNo -> Consensus.CardanoTriggerHardForkAtEpoch epochNo
           -- Babbage to Conway hard fork parameters
         , triggerHardForkConway =
             case npcTestConwayHardForkAtEpoch of
-                Nothing -> Consensus.TriggerHardForkAtVersion
-                            (maybe 9 fromIntegral npcTestConwayHardForkAtVersion)
-                Just epochNo -> Consensus.TriggerHardForkAtEpoch epochNo
+                Nothing      -> Consensus.CardanoTriggerHardForkAtDefaultVersion
+                Just epochNo -> Consensus.CardanoTriggerHardForkAtEpoch epochNo
         }
         transitionLedgerConfig
         emptyCheckpointsMap

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Node/Types.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Node/Types.hs
@@ -201,31 +201,12 @@ data NodeHardForkProtocolConfiguration =
      , npcTestShelleyHardForkAtEpoch        :: Maybe EpochNo
 
        -- | For testing purposes we support specifying that the hard fork
-       -- happens at a given major protocol version. For example this can be
-       -- used to cause the Shelley hard fork to occur at the transition from
-       -- protocol version 0 to version 1 (rather than the default of from 1 to
-       -- 2) which can make the test setup simpler.
-       --
-       -- Obviously if this is used, all the nodes in the test cluster must be
-       -- configured the same, or they will disagree.
-       --
-     , npcTestShelleyHardForkAtVersion      :: Maybe Word
-
-       -- | For testing purposes we support specifying that the hard fork
        -- happens at an exact epoch number (ie the first epoch of the new era).
        --
        -- Obviously if this is used, all the nodes in the test cluster must be
        -- configured the same, or they will disagree.
        --
      , npcTestAllegraHardForkAtEpoch        :: Maybe EpochNo
-
-       -- | For testing purposes we support specifying that the hard fork
-       -- happens at a given major protocol version.
-       --
-       -- Obviously if this is used, all the nodes in the test cluster must be
-       -- configured the same, or they will disagree.
-       --
-     , npcTestAllegraHardForkAtVersion      :: Maybe Word
 
        -- | For testing purposes we support specifying that the hard fork
        -- happens at an exact epoch number (ie the first epoch of the new era).
@@ -236,15 +217,6 @@ data NodeHardForkProtocolConfiguration =
      , npcTestMaryHardForkAtEpoch           :: Maybe EpochNo
 
        -- | For testing purposes we support specifying that the hard fork
-       -- happens at a given major protocol version.
-       --
-       -- Obviously if this is used, all the nodes in the test cluster must be
-       -- configured the same, or they will disagree.
-       --
-       --
-     , npcTestMaryHardForkAtVersion         :: Maybe Word
-
-       -- | For testing purposes we support specifying that the hard fork
        -- happens at an exact epoch number (ie the first epoch of the new era).
        --
        -- Obviously if this is used, all the nodes in the test cluster must be
@@ -252,33 +224,9 @@ data NodeHardForkProtocolConfiguration =
        --
      , npcTestAlonzoHardForkAtEpoch         :: Maybe EpochNo
 
-       -- | For testing purposes we support specifying that the hard fork
-       -- happens at a given major protocol version.
-       --
-       -- Obviously if this is used, all the nodes in the test cluster must be
-       -- configured the same, or they will disagree.
-       --
-     , npcTestAlonzoHardForkAtVersion       :: Maybe Word
-
      , npcTestBabbageHardForkAtEpoch        :: Maybe EpochNo
 
-       -- | For testing purposes we support specifying that the hard fork
-       -- happens at a given major protocol version.
-       --
-       -- Obviously if this is used, all the nodes in the test cluster must be
-       -- configured the same, or they will disagree.
-       --
-     , npcTestBabbageHardForkAtVersion      :: Maybe Word
-
      , npcTestConwayHardForkAtEpoch         :: Maybe EpochNo
-
-       -- | For testing purposes we support specifying that the hard fork
-       -- happens at a given major protocol version.
-       --
-       -- Obviously if this is used, all the nodes in the test cluster must be
-       -- configured the same, or they will disagree.
-       --
-     , npcTestConwayHardForkAtVersion       :: Maybe Word
      }
   deriving (Eq, Show)
 

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBSynthesizer/Orphans.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBSynthesizer/Orphans.hs
@@ -55,17 +55,11 @@ instance FromJSON NodeHardForkProtocolConfiguration where
           <$> v .:? "TestEnableDevelopmentHardForkEras"
                 .!= False
           <*> v .:? "TestShelleyHardForkAtEpoch"
-          <*> v .:? "TestShelleyHardForkAtVersion"
           <*> v .:? "TestAllegraHardForkAtEpoch"
-          <*> v .:? "TestAllegraHardForkAtVersion"
           <*> v .:? "TestMaryHardForkAtEpoch"
-          <*> v .:? "TestMaryHardForkAtVersion"
           <*> v .:? "TestAlonzoHardForkAtEpoch"
-          <*> v .:? "TestAlonzoHardForkAtVersion"
           <*> v .:? "TestBabbageHardForkAtEpoch"
-          <*> v .:? "TestBabbageHardForkAtVersion"
           <*> v .:? "TestConwayHardForkAtEpoch"
-          <*> v .:? "TestConwayHardForkAtVersion"
 
 instance FromJSON NodeByronProtocolConfiguration where
     parseJSON = withObject "NodeByronProtocolConfiguration" $ \v ->

--- a/ouroboros-consensus-cardano/test/cardano-test/Test/Consensus/Cardano/SupportsSanityCheck.hs
+++ b/ouroboros-consensus-cardano/test/cardano-test/Test/Consensus/Cardano/SupportsSanityCheck.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE NamedFieldPuns #-}
 module Test.Consensus.Cardano.SupportsSanityCheck (tests) where
 
+import           Ouroboros.Consensus.Cardano (CardanoHardForkTriggers)
 import           Ouroboros.Consensus.Cardano.Block
 import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.HardFork.Combinator.Basics
@@ -53,14 +54,14 @@ genSimpleTestProtocolInfo = do
       (byronSlotLength setup)
       (shelleySlotLength setup)
       protocolVersionZero
-      (hardForkSpec setup)
+      (hardForkTriggers setup)
 
 data SimpleTestProtocolInfoSetup = SimpleTestProtocolInfoSetup
   { decentralizationParam :: Shelley.DecentralizationParam
   , securityParam         :: SecurityParam
   , byronSlotLength       :: ByronSlotLengthInSeconds
   , shelleySlotLength     :: ShelleySlotLengthInSeconds
-  , hardForkSpec          :: HardForkSpec
+  , hardForkTriggers      :: CardanoHardForkTriggers
   }
 
 instance Arbitrary SimpleTestProtocolInfoSetup where
@@ -70,7 +71,7 @@ instance Arbitrary SimpleTestProtocolInfoSetup where
       <*> genSecurityParam
       <*> genByronSlotLength
       <*> genShelleySlotLength
-      <*> genHardForkSpec
+      <*> genHardForkTriggers
     where
       genSecurityParam =
         SecurityParam <$> Gen.choose (8, 12)
@@ -78,5 +79,5 @@ instance Arbitrary SimpleTestProtocolInfoSetup where
         ByronSlotLengthInSeconds <$> Gen.choose (1, 4)
       genShelleySlotLength =
         ShelleySlotLengthInSeconds <$> Gen.choose (1, 4)
-      genHardForkSpec =
+      genHardForkTriggers =
         hardForkInto <$> Gen.chooseEnum (Byron, Conway)


### PR DESCRIPTION
Closes #1281 

Instead of letting the user provide several `TriggerHardFork`s, only let them provide `CardanoHardForkTrigger`s, a restricted version that should make `protocolInfoCardano` more straightforward and less error-prone.

```haskell
data CardanoHardForkTrigger blk =
    -- | Trigger the hard fork when the ledger protocol version is updated to
    -- the default for that era (@'L.eraProtVerLow' \@('ShelleyBlockLedgerEra'
    -- blk)@). Also see 'TriggerHardForkAtVersion'.
    CardanoTriggerHardForkAtDefaultVersion
  |
    -- | Trigger the hard fork at the given epoch. For testing only. Also see
    -- 'TriggerHardForkAtEpoch'.
    CardanoTriggerHardForkAtEpoch EpochNo
```

It is (intentionally) no longer possible to directly (though still manually, also see the changelog entry) to use a non-default version trigger. However, this feature was used in the Cardano ThreadNet test (as Byron had an intra-era HF), which we resolve by modifying the initial Byron protocol version (see the corresponding Haddocks).

In the node, this will result in the removal of the (unused) `TestXxxHardForkAtVersion` config fields.