### PR TITLE
nix: added formatting.all

### DIFF
--- a/nix/formatting.nix
+++ b/nix/formatting.nix
@@ -24,10 +24,17 @@ let
       echo $EXIT_CODE > $out
     fi
   '';
+  formatting = {
+    stylish = checkFormatting pkgs.stylish-haskell ../scripts/ci/run-stylish.sh;
+    cabal-gild = checkFormatting pkgs.cabal-gild ../scripts/ci/run-cabal-gild.sh;
+    nixpkgs-fmt = checkFormatting pkgs.nixpkgs-fmt ../scripts/ci/run-nixpkgs-fmt.sh;
+    dos2unix = checkFormatting pkgs.dos2unix ../scripts/ci/run-dos2unix.sh;
+  };
 in
-{
-  stylish = checkFormatting pkgs.stylish-haskell ../scripts/ci/run-stylish.sh;
-  cabal-gild = checkFormatting pkgs.cabal-gild ../scripts/ci/run-cabal-gild.sh;
-  nixpkgs-fmt = checkFormatting pkgs.nixpkgs-fmt ../scripts/ci/run-nixpkgs-fmt.sh;
-  dos2unix = checkFormatting pkgs.dos2unix ../scripts/ci/run-dos2unix.sh;
+formatting // {
+  all = pkgs.releaseTools.aggregate {
+    name = "consensus-formatting";
+    meta.description = "Run all formatters";
+    constituents = lib.collect lib.isDerivation formatting;
+  };
 }


### PR DESCRIPTION
One can run:
```
nix build .\#hydraJobs.x86_64-linux.native.formatting.all
```
to check all formatters.
