### PR TITLE
consensus: annotate headers with their slot's RelativeTime

### DIFF
--- a/ouroboros-consensus-diffusion/changelog.d/20241218_095040_nick.frisby_annotate_headers_with_time.md
+++ b/ouroboros-consensus-diffusion/changelog.d/20241218_095040_nick.frisby_annotate_headers_with_time.md
@@ -1,0 +1,22 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Patch
+
+- A bullet item for the Patch category.
+
+-->
+<!--
+### Non-Breaking
+
+- A bullet item for the Non-Breaking category.
+
+-->
+
+### Breaking
+
+- Use `HeaderWithTime` for the ChainSync candidates

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToNode.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToNode.hs
@@ -56,6 +56,7 @@ import qualified Network.Mux as Mux
 import           Network.TypedProtocol.Codec
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config (DiffusionPipeliningSupport (..))
+import           Ouroboros.Consensus.HeaderValidation (HeaderWithTime)
 import           Ouroboros.Consensus.Ledger.SupportsMempool
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
 import           Ouroboros.Consensus.MiniProtocol.BlockFetch.Server
@@ -152,7 +153,7 @@ data Handlers m addr blk = Handlers {
         :: NodeToNodeVersion
         -> ControlMessageSTM m
         -> FetchedMetricsTracer m
-        -> BlockFetchClient (Header blk) blk m ()
+        -> BlockFetchClient (HeaderWithTime blk) blk m ()
 
     , hBlockFetchServer
         :: ConnectionId addr

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Node/Genesis.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Node/Genesis.hs
@@ -26,8 +26,10 @@ module Ouroboros.Consensus.Node.Genesis (
 import           Control.Monad (join)
 import           Data.Maybe (fromMaybe)
 import           Data.Traversable (for)
+import           Data.Typeable (Typeable)
 import           GHC.Generics (Generic)
 import           Ouroboros.Consensus.Block
+import           Ouroboros.Consensus.HeaderValidation (HeaderWithTime (..))
 import           Ouroboros.Consensus.MiniProtocol.ChainSync.Client
                      (CSJConfig (..), CSJEnabledConfig (..),
                      ChainSyncLoPBucketConfig (..),
@@ -194,7 +196,7 @@ data LoEAndGDDNodeKernelArgs m blk = LoEAndGDDNodeKernelArgs {
 -- 'ChainDB.GetLoEFragment' that will be replaced via 'setGetLoEFragment') and a
 -- function to update the 'ChainDbArgs' accordingly.
 mkGenesisNodeKernelArgs ::
-     forall m blk. (IOLike m, GetHeader blk)
+     forall m blk. (IOLike m, GetHeader blk, Typeable blk)
   => GenesisConfig
   -> m ( GenesisNodeKernelArgs m blk
        , Complete ChainDbArgs m blk -> Complete ChainDbArgs m blk
@@ -222,9 +224,9 @@ mkGenesisNodeKernelArgs gcfg = do
 -- | Set 'gnkaGetLoEFragment' to the actual logic for determining the current
 -- LoE fragment.
 setGetLoEFragment ::
-     forall m blk. (IOLike m, GetHeader blk)
+     forall m blk. (IOLike m, GetHeader blk, Typeable blk)
   => STM m GSM.GsmState
-  -> STM m (AnchoredFragment (Header blk))
+  -> STM m (AnchoredFragment (HeaderWithTime blk))
      -- ^ The LoE fragment.
   -> StrictTVar m (ChainDB.GetLoEFragment m blk)
   -> m ()

--- a/ouroboros-consensus-diffusion/src/unstable-mock-testlib/Test/ThreadNet/Util/SimpleBlock.hs
+++ b/ouroboros-consensus-diffusion/src/unstable-mock-testlib/Test/ThreadNet/Util/SimpleBlock.hs
@@ -2,7 +2,7 @@
 
 module Test.ThreadNet.Util.SimpleBlock (prop_validSimpleBlock) where
 
-import           Data.Typeable
+import           Data.Typeable (Typeable)
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Mock.Ledger
 import           Ouroboros.Consensus.Util.Condense (condense)

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/NodeLifecycle.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/NodeLifecycle.hs
@@ -18,8 +18,10 @@ import           Control.Tracer (Tracer (..), traceWith)
 import           Data.Functor (void)
 import           Data.Set (Set)
 import qualified Data.Set as Set
+import           Data.Typeable (Typeable)
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config (TopLevelConfig (..))
+import           Ouroboros.Consensus.HeaderValidation (HeaderWithTime (..))
 import           Ouroboros.Consensus.MiniProtocol.ChainSync.Client
                      (ChainSyncClientHandleCollection (..))
 import           Ouroboros.Consensus.Storage.ChainDB.API
@@ -90,7 +92,7 @@ data LiveResources blk m = LiveResources {
   , lrCdb      :: NodeDBs (StrictTMVar m MockFS)
 
     -- | The LoE fragment must be reset for each live interval.
-  , lrLoEVar   :: LoE (StrictTVar m (AnchoredFragment (Header blk)))
+  , lrLoEVar   :: LoE (StrictTVar m (AnchoredFragment (HeaderWithTime blk)))
   }
 
 data LiveInterval blk m = LiveInterval {
@@ -190,7 +192,7 @@ lifecycleStart start liResources liResult = do
 -- | Shut down the node by killing all its threads after extracting the
 -- persistent state used to restart the node later.
 lifecycleStop ::
-  (IOLike m, GetHeader blk) =>
+  (IOLike m, GetHeader blk, Typeable blk) =>
   LiveResources blk m ->
   LiveNode blk m ->
   m (LiveIntervalResult blk)

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Trace.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Trace.hs
@@ -30,6 +30,7 @@ import           Ouroboros.Consensus.Block (GenesisWindow (..), Header, Point,
                      WithOrigin (NotOrigin, Origin), succWithOrigin)
 import           Ouroboros.Consensus.Genesis.Governor (DensityBounds (..),
                      GDDDebugInfo (..), TraceGDDEvent (..))
+import           Ouroboros.Consensus.HeaderValidation (HeaderWithTime (..))
 import           Ouroboros.Consensus.MiniProtocol.ChainSync.Client
                      (TraceChainSyncClientEvent (..))
 import           Ouroboros.Consensus.MiniProtocol.ChainSync.Client.Jumping
@@ -59,8 +60,9 @@ import           Ouroboros.Network.Protocol.ChainSync.Type (ChainSync,
 import           Test.Consensus.PointSchedule.NodeState (NodeState)
 import           Test.Consensus.PointSchedule.Peers (Peer (Peer), PeerId)
 import           Test.Util.TersePrinting (terseAnchor, terseBlock,
-                     terseFragment, terseHFragment, terseHeader, tersePoint,
-                     terseRealPoint, terseTip, terseWithOrigin)
+                     terseFragment, terseHFragment, terseHWTFragment,
+                     terseHeader, tersePoint, terseRealPoint, terseTip,
+                     terseWithOrigin)
 import           Test.Util.TestBlock (TestBlock)
 import           Text.Printf (printf)
 
@@ -555,7 +557,7 @@ prettyDensityBounds bounds =
         -- the density comparison should not be applied to two peers if they share any headers after the LoE fragment.
         lastPoint =
           "point: " ++
-          tersePoint (castPoint @(Header TestBlock) @TestBlock (AF.lastPoint clippedFragment)) ++
+          tersePoint (castPoint @(HeaderWithTime TestBlock) @TestBlock (AF.lastPoint clippedFragment)) ++
           ", "
 
         showLatestSlot = \case
@@ -582,14 +584,14 @@ terseGDDEvent = \case
     } ->
     unlines $ [
       "GDD | Window: " ++ window sgen loeHead,
-      "      Selection: " ++ terseHFragment curChain,
+      "      Selection: " ++ terseHWTFragment curChain,
       "      Candidates:"
       ] ++
       showPeers (second (tersePoint . castPoint . AF.headPoint) <$> candidates) ++
       [
       "      Candidate suffixes (bounds):"
       ] ++
-      showPeers (second (terseHFragment . clippedFragment) <$> bounds) ++
+      showPeers (second (terseHWTFragment . clippedFragment) <$> bounds) ++
       ["      Density bounds:"] ++
       prettyDensityBounds bounds ++
       ["      New candidate tips:"] ++

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Util/TersePrinting.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Util/TersePrinting.hs
@@ -8,6 +8,7 @@ module Test.Util.TersePrinting (
   , terseBlock
   , terseFragment
   , terseHFragment
+  , terseHWTFragment
   , terseHeader
   , terseMaybe
   , tersePoint
@@ -24,6 +25,7 @@ import           Ouroboros.Consensus.Block (Header,
                      Point (BlockPoint, GenesisPoint), RealPoint,
                      SlotNo (SlotNo), blockHash, blockNo, blockSlot,
                      realPointToPoint)
+import           Ouroboros.Consensus.HeaderValidation (HeaderWithTime (..))
 import           Ouroboros.Network.AnchoredFragment (Anchor, AnchoredFragment,
                      anchor, anchorToPoint, mapAnchoredFragment, toOldestFirst)
 import           Ouroboros.Network.Block (Tip (..))
@@ -117,6 +119,11 @@ terseFragment fragment =
 -- | Same as 'terseFragment' for fragments of headers.
 terseHFragment :: AnchoredFragment (Header TestBlock) -> String
 terseHFragment = terseFragment . mapAnchoredFragment (\(TestHeader block) -> block)
+
+-- | Same as 'terseFragment' for fragments of headers with time.
+--
+terseHWTFragment :: AnchoredFragment (HeaderWithTime TestBlock) -> String
+terseHWTFragment = terseHFragment . mapAnchoredFragment hwtHeader
 
 -- | Same as 'terseWithOrigin' for 'Maybe'.
 terseMaybe :: (a -> String) -> Maybe a -> String

--- a/ouroboros-consensus/bench/ChainSync-client-bench/Main.hs
+++ b/ouroboros-consensus/bench/ChainSync-client-bench/Main.hs
@@ -78,7 +78,7 @@ main = withStdTerminalHandles $ mainWith $ \n -> do
 
 {-# INLINE oneBenchRun #-}
 oneBenchRun ::
-     StrictTVar IO (AnchoredFragment H)
+     StrictTVar IO (AnchoredFragment (HV.HeaderWithTime B))
   -> StrictTVar IO (Tip B)
   -> ChainDB.Follower IO B (ChainDB.WithPoint B H)
   -> Int

--- a/ouroboros-consensus/changelog.d/20241218_095010_nick.frisby_annotate_headers_with_time.md
+++ b/ouroboros-consensus/changelog.d/20241218_095010_nick.frisby_annotate_headers_with_time.md
@@ -1,0 +1,27 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Patch
+
+- A bullet item for the Patch category.
+
+-->
+
+### Non-Breaking
+
+- Maintain a parallel selection with time annotations since the
+  `ConsensusBlockFetchInterface` uses the same type argument for ChainSync
+  candidates and the current selection.
+
+### Breaking
+
+- Define `HeaderWithTime`.
+
+- Use `HeaderWithTime` for the ChainSync candidates.
+
+- Remove `SlotForgeTimeOracle` and its use in the BlockFetch client interface,
+  as we no longer translate time in the BlockFetch client.

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -394,6 +394,7 @@ library unstable-consensus-testlib
     Test.Util.FileLock
     Test.Util.HardFork.Future
     Test.Util.HardFork.OracularClock
+    Test.Util.Header
     Test.Util.InvertedMap
     Test.Util.LedgerStateOnlyTables
     Test.Util.LogicalClock
@@ -439,6 +440,7 @@ library unstable-consensus-testlib
     cardano-ledger-binary:testlib,
     cardano-ledger-core,
     cardano-prelude,
+    cardano-slotting,
     cardano-slotting:testlib,
     cardano-strict-containers,
     cborg,

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Block/Abstract.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Block/Abstract.hs
@@ -18,6 +18,7 @@ module Ouroboros.Consensus.Block.Abstract (
   , blockPrevHash
     -- * Working with headers
   , GetHeader (..)
+  , GetHeader1 (..)
   , Header
   , blockIsEBB
   , blockToIsEBB
@@ -127,6 +128,7 @@ data family Header blk :: Type
 
 class HasHeader (Header blk) => GetHeader blk where
   getHeader          :: blk -> Header blk
+
   -- | Check whether the header is the header of the block.
   --
   -- For example, by checking whether the hash of the body stored in the
@@ -147,6 +149,11 @@ blockToIsEBB :: GetHeader blk => blk -> IsEBB
 blockToIsEBB = headerToIsEBB . getHeader
 
 type instance BlockProtocol (Header blk) = BlockProtocol blk
+
+class GetHeader1 t where
+  getHeader1 :: t blk -> Header blk
+
+instance GetHeader1 Header where getHeader1 = id
 
 {-------------------------------------------------------------------------------
   Some automatic instances for 'Header'

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Fragment/Diff.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Fragment/Diff.hs
@@ -21,6 +21,7 @@ module Ouroboros.Consensus.Fragment.Diff (
     -- * Application
   , apply
     -- * Manipulation
+  , Ouroboros.Consensus.Fragment.Diff.map
   , append
   , mapM
   , takeWhileOldest
@@ -165,6 +166,18 @@ takeWhileOldest ::
   -> ChainDiff b
 takeWhileOldest accept (ChainDiff nbRollback suffix) =
     ChainDiff nbRollback (AF.takeWhileOldest accept suffix)
+
+map ::
+     forall a b.
+     ( HasHeader b
+     , HeaderHash a ~ HeaderHash b
+     )
+  => (a -> b)
+  -> ChainDiff a
+  -> ChainDiff b
+map f (ChainDiff rollback suffix) =
+    ChainDiff rollback
+  $ AF.mapAnchoredFragment f suffix
 
 mapM ::
      forall a b m.

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ChainSync/Client/State.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ChainSync/Client/State.hs
@@ -28,10 +28,11 @@ import qualified Data.Map.Strict as Map
 import           Data.Maybe.Strict (StrictMaybe (..))
 import           Data.Sequence.Strict (StrictSeq)
 import qualified Data.Sequence.Strict as Seq
-import           Data.Typeable (Proxy (..), typeRep)
+import           Data.Typeable (Proxy (..), Typeable, typeRep)
 import           GHC.Generics (Generic)
 import           Ouroboros.Consensus.Block (HasHeader, Header, Point)
 import           Ouroboros.Consensus.HeaderStateHistory (HeaderStateHistory)
+import           Ouroboros.Consensus.HeaderValidation (HeaderWithTime (..))
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
                      (LedgerSupportsProtocol)
 import           Ouroboros.Consensus.Node.GsmState (GsmState)
@@ -45,8 +46,7 @@ import           Ouroboros.Network.AnchoredFragment (AnchoredFragment,
 data ChainSyncState blk = ChainSyncState {
 
     -- | The current candidate fragment.
-    csCandidate  :: !(AnchoredFragment (Header blk))
-
+    csCandidate  :: !(AnchoredFragment (HeaderWithTime blk))
     -- | Whether the last message sent by the peer was MsgAwaitReply.
     --
     -- This ChainSync client should ensure that its peer sets this flag while
@@ -257,12 +257,12 @@ deriving anyclass instance
 data JumpInfo blk = JumpInfo
   { jMostRecentIntersection  :: !(Point blk)
   , jOurFragment             :: !(AnchoredFragment (Header blk))
-  , jTheirFragment           :: !(AnchoredFragment (Header blk))
+  , jTheirFragment           :: !(AnchoredFragment (HeaderWithTime blk))
   , jTheirHeaderStateHistory :: !(HeaderStateHistory blk)
   }
   deriving (Generic)
 
-instance (HasHeader (Header blk)) => Eq (JumpInfo blk) where
+instance (HasHeader (Header blk), Typeable blk) => Eq (JumpInfo blk) where
   (==) = (==) `on` headPoint . jTheirFragment
 
 instance LedgerSupportsProtocol blk => NoThunks (JumpInfo blk) where

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/API.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/API.hs
@@ -67,7 +67,9 @@ import           Control.ResourceRegistry
 import           Data.Typeable (Typeable)
 import           GHC.Generics (Generic)
 import           Ouroboros.Consensus.Block
-import           Ouroboros.Consensus.HeaderStateHistory (HeaderStateHistory)
+import           Ouroboros.Consensus.HeaderStateHistory
+                     (HeaderStateHistory (..))
+import           Ouroboros.Consensus.HeaderValidation (HeaderWithTime (..))
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Storage.ChainDB.API.Types.InvalidBlockPunishment
@@ -172,6 +174,13 @@ data ChainDB m blk = ChainDB {
       -- fragment will move as the chain grows.
     , getCurrentChain    :: STM m (AnchoredFragment (Header blk))
 
+      -- | Exact same as 'getCurrentChain', except each header is annotated
+      -- with the 'RelativeTime' of the onset of its slot (translated according
+      -- to the chain it is on)
+      --
+      -- INVARIANT @'hwtHeader' <$> 'getCurrentChainWithTime' = 'getCurrentChain'@
+    , getCurrentChainWithTime
+                         :: STM m (AnchoredFragment (HeaderWithTime blk))
 
       -- | Get current ledger
     , getCurrentLedger :: STM m (ExtLedgerState blk EmptyMK)
@@ -911,4 +920,4 @@ data LoE a =
 -- | Get the current LoE fragment (if the LoE is enabled), see 'LoE' for more
 -- details. This fragment must be anchored in a (recent) point on the immutable
 -- chain, just like candidate fragments.
-type GetLoEFragment m blk = m (LoE (AnchoredFragment (Header blk)))
+type GetLoEFragment m blk = m (LoE (AnchoredFragment (HeaderWithTime blk)))

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Follower.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Follower.hs
@@ -272,7 +272,7 @@ instructionHelper registry varFollower chainType blockComponent fromMaybeSTM CDB
     trace = traceWith (contramap TraceFollowerEvent cdbTracer)
 
     getCurrentChainByType = do
-        curChain <- readTVar cdbChain
+        curChain <- icWithoutTime <$> readTVar cdbChain
         case chainType of
           SelectedChain  -> pure curChain
           TentativeChain -> readTVar cdbTentativeHeader <&> \case
@@ -434,7 +434,7 @@ forward registry varFollower blockComponent CDB{..} = \pts -> do
     -- that happen to have not yet been copied over to the ImmutableDB.
     join $ atomically $
       findFirstPointOnChain
-        <$> readTVar cdbChain
+        <$> (icWithoutTime <$> readTVar cdbChain)
         <*> readTVar varFollower
         <*> ImmutableDB.getTipSlot cdbImmutableDB
         <*> pure pts

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/Header.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/Header.hs
@@ -1,0 +1,50 @@
+{-# LANGUAGE FlexibleContexts #-}
+
+module Test.Util.Header (
+    -- * Enriching headers with a relative slot time
+    attachSlotTime
+  , attachSlotTimeToFragment
+  , dropTimeFromFragment
+  ) where
+
+import           Cardano.Slotting.EpochInfo.API (epochInfoSlotToRelativeTime)
+import           Data.Functor.Identity (runIdentity)
+import           Data.Typeable (Typeable)
+import           Ouroboros.Consensus.Block (Header, blockSlot)
+import           Ouroboros.Consensus.Config (TopLevelConfig)
+import           Ouroboros.Consensus.HardFork.Combinator.Abstract
+                     (ImmutableEraParams, immutableEpochInfo)
+import           Ouroboros.Consensus.HeaderValidation (HeaderWithTime (..))
+import           Ouroboros.Network.AnchoredFragment (AnchoredFragment)
+import qualified Ouroboros.Network.AnchoredFragment as AF
+
+{-------------------------------------------------------------------------------
+  Enriching headers with a relative slot time
+-------------------------------------------------------------------------------}
+
+dropTimeFromFragment :: (AF.HasHeader (Header blk))
+  => AnchoredFragment (HeaderWithTime blk)
+  -> AnchoredFragment (Header blk)
+dropTimeFromFragment  = AF.mapAnchoredFragment hwtHeader
+
+attachSlotTimeToFragment ::
+     ( AF.HasHeader (Header blk)
+     , Typeable blk
+     , ImmutableEraParams blk)
+  => TopLevelConfig blk
+  -> AnchoredFragment (Header blk)
+  -> AnchoredFragment (HeaderWithTime blk)
+attachSlotTimeToFragment cfg = AF.mapAnchoredFragment (attachSlotTime cfg)
+
+attachSlotTime ::
+     (AF.HasHeader (Header blk), ImmutableEraParams blk)
+  => TopLevelConfig blk
+  -> Header blk
+  -> HeaderWithTime blk
+attachSlotTime cfg hdr = HeaderWithTime {
+      hwtHeader           = hdr
+    , hwtSlotRelativeTime =
+        runIdentity $ epochInfoSlotToRelativeTime ei (blockSlot hdr)
+    }
+  where
+    ei = immutableEpochInfo cfg

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/TestBlock.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/TestBlock.hs
@@ -119,6 +119,8 @@ import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.Forecast
 import           Ouroboros.Consensus.HardFork.Abstract
+import           Ouroboros.Consensus.HardFork.Combinator.Abstract
+                     (ImmutableEraParams (immutableEraParams))
 import qualified Ouroboros.Consensus.HardFork.History as HardFork
 import           Ouroboros.Consensus.HeaderValidation
 import           Ouroboros.Consensus.Ledger.Abstract
@@ -312,7 +314,7 @@ newtype instance Header (TestBlockWith ptype) =
 
 instance Typeable ptype => ShowProxy (Header (TestBlockWith ptype)) where
 
-instance (Typeable ptype) => HasHeader (Header (TestBlockWith ptype)) where
+instance Typeable ptype => HasHeader (Header (TestBlockWith ptype)) where
   getHeaderFields (TestHeader TestBlockWith{..}) = HeaderFields {
         headerFieldHash    = tbHash
       , headerFieldSlot    = tbSlot
@@ -682,6 +684,9 @@ singleNodeTestConfigWith codecConfig storageConfig k genesisWindow = TopLevelCon
         },
       tblcForecastRange = SNothing
     }
+
+instance ImmutableEraParams (TestBlockWith ptype) where
+    immutableEraParams = tblcHardForkParams . topLevelConfigLedger
 
 {-------------------------------------------------------------------------------
   Test blocks without payload

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/MiniProtocol/ChainSync/Client.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/MiniProtocol/ChainSync/Client.hs
@@ -131,6 +131,7 @@ import           Test.Tasty
 import           Test.Tasty.QuickCheck
 import           Test.Util.ChainUpdates (ChainUpdate (..), UpdateBehavior (..),
                      genChainUpdates, toChainUpdates)
+import           Test.Util.Header (dropTimeFromFragment)
 import           Test.Util.LogicalClock (Tick (..))
 import           Test.Util.Orphans.Arbitrary ()
 import           Test.Util.Orphans.IOLike ()
@@ -592,7 +593,7 @@ runChainSync skew securityParam (ClientUpdates clientUpdates)
           finalClientChain
         , finalServerChain
         , mbResult
-        , syncedFragment   = AF.mapAnchoredFragment testHeader candidateFragment
+        , syncedFragment   = AF.mapAnchoredFragment testHeader (dropTimeFromFragment candidateFragment)
         , traceEvents
         }
   where

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/TestBlock.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/TestBlock.hs
@@ -89,6 +89,8 @@ import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.Forecast
 import           Ouroboros.Consensus.HardFork.Abstract
+import           Ouroboros.Consensus.HardFork.Combinator.Abstract
+                     (ImmutableEraParams (immutableEraParams))
 import qualified Ouroboros.Consensus.HardFork.History as HardFork
 import           Ouroboros.Consensus.HardFork.History.EraParams
                      (EraParams (eraGenesisWin))
@@ -722,6 +724,9 @@ mkTestConfig k ChunkSize { chunkCanContainEBB, numRegularBlocks } =
       , eraSafeZone   = HardFork.StandardSafeZone (unNonZero (maxRollbacks k) * 2)
       , eraGenesisWin = GenesisWindow (unNonZero (maxRollbacks k) * 2)
       }
+
+instance ImmutableEraParams TestBlock where
+    immutableEraParams = topLevelConfigLedger
 
 {-------------------------------------------------------------------------------
   NestedCtxt


### PR DESCRIPTION
Introduce a new `HeaderWithTime` data type, which annotates each received header with the relative time of its slot as calculated by the ChainSync client.

Partially addresses https://github.com/IntersectMBO/ouroboros-consensus/issues/1301