### PR TITLE
Require `cardano-ledger-conway >=1.17.2`

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -16,7 +16,7 @@ index-state:
   -- Bump this if you need newer packages from Hackage
   , hackage.haskell.org 2024-10-22T14:26:27Z
   -- Bump this if you need newer packages from CHaP
-  , cardano-haskell-packages 2024-10-21T06:28:35Z
+  , cardano-haskell-packages 2024-10-30T11:23:17Z
 
 packages:
   ouroboros-consensus

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1729492933,
-        "narHash": "sha256-XuwElZKFRhXXuJtT7KUZcCb5QCr0cFQ60ukhPgX8N50=",
+        "lastModified": 1730295876,
+        "narHash": "sha256-ijnHTQ6eKIQ9FpEqDKt6c7vuFYN8aOBDhonp67utx2s=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "a36ff9eec592a38e9a23521079dbe41684ff9b51",
+        "rev": "25591f43ab943d5a070db5e8a2b9ff3a499d4d92",
         "type": "github"
       },
       "original": {

--- a/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
+++ b/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
@@ -140,7 +140,7 @@ library
     cardano-ledger-babbage ^>=1.10,
     cardano-ledger-binary ^>=1.4,
     cardano-ledger-byron ^>=1.0.1,
-    cardano-ledger-conway ^>=1.17,
+    cardano-ledger-conway ^>=1.17.2,
     cardano-ledger-core ^>=1.15,
     cardano-ledger-mary ^>=1.7,
     cardano-ledger-shelley ^>=1.14,


### PR DESCRIPTION
This ledger release is used in Node 10.1.1 and has important bug fixes; so bumping this here before the next regular major ledger update for e.g. db-analyser seems useful to avoid potential surprises.