### PR TITLE
Embrace using `threadDelay` with negative arguments

### DIFF
--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ChainSync/Client/InFutureCheck.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ChainSync/Client/InFutureCheck.hs
@@ -140,8 +140,7 @@ realHeaderInFutureCheck skew systemTime =
             now <- systemTimeCurrent systemTime
             let ageNow         = now `diffRelTime` onset
                 syntheticDelay = negate ageNow
-            when (0 < syntheticDelay) $ do   -- note https://github.com/input-output-hk/io-sim/issues/129
-                threadDelay $ nominalDelay syntheticDelay   -- TODO leap seconds?
+            threadDelay $ nominalDelay syntheticDelay   -- TODO leap seconds?
 
         pure $ do
           when tooEarly $ throwError FarFutureHeaderException {


### PR DESCRIPTION
https://github.com/input-output-hk/io-sim/issues/129 has been [fixed in `si-timers-1.4`](https://hackage.haskell.org/package/si-timers-1.5.0.0/changelog), and we already require `>=1.5`.