### PR TITLE
ChainDB q-s-m: fix test by maintaining LoE anchor invariant on VolDB wipe

### DIFF
--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/API.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/API.hs
@@ -888,4 +888,7 @@ data LoE a =
   LoEEnabled !a
   deriving (Eq, Show, Generic, NoThunks, Functor, Foldable, Traversable)
 
+-- | Get the current LoE fragment (if the LoE is enabled), see 'LoE' for more
+-- details. This fragment must be anchored in a (recent) point on the immutable
+-- chain, just like candidate fragments.
 type GetLoEFragment m blk = m (LoE (AnchoredFragment (Header blk)))

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/Model.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/Model.hs
@@ -1016,6 +1016,10 @@ wipeVolatileDB cfg m =
       , cps              = CPS.switchFork newChain (cps m)
       , currentLedger    = newLedger
       , invalid          = Map.empty
+        -- The LoE fragment must be anchored in an immutable point. Wiping the
+        -- VolDB can invalidate this when some immutable blocks have not yet
+        -- been persisted.
+      , loeFragment      = Fragment.Empty Fragment.AnchorGenesis <$ loeFragment m
       }
 
     -- Get the chain ending at the ImmutableDB by doing chain selection on the

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/Model.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/Model.hs
@@ -32,6 +32,7 @@ module Test.Ouroboros.Storage.ChainDB.Model (
   , getBlockComponentByPoint
   , getIsValid
   , getLedgerDB
+  , getLoEFragment
   , getMaxSlotNo
   , hasBlock
   , hasBlockByPoint
@@ -352,6 +353,9 @@ getLedgerDB cfg m@Model{..} =
           ledgerDbCfgSecParam = k
         , ledgerDbCfg         = ExtLedgerCfg cfg
         }
+
+getLoEFragment :: Model blk -> LoE (AnchoredFragment blk)
+getLoEFragment = loeFragment
 
 {-------------------------------------------------------------------------------
   Construction

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
@@ -1070,6 +1070,7 @@ precondition :: forall m blk. TestConstraints blk
 precondition Model {..} (At cmd) =
    forAll (iters cmd) (`member` RE.keys knownIters)   .&&
    forAll (flrs  cmd) (`member` RE.keys knownFollowers) .&&
+   loeHasImmutableAnchor .&&
    case cmd of
      -- Even though we ensure this in the generator, shrinking might change
      -- it.
@@ -1096,6 +1097,14 @@ precondition Model {..} (At cmd) =
     garbageCollectableIteratorNext :: IterRef blk m Symbolic -> Logic
     garbageCollectableIteratorNext it = Boolean $
       Model.garbageCollectableIteratorNext secParam dbModel (knownIters RE.! it)
+
+    loeHasImmutableAnchor :: Logic
+    loeHasImmutableAnchor = case Model.getLoEFragment dbModel of
+        LoEEnabled frag ->
+          Boolean $ Chain.pointOnChain (AF.anchorPoint frag) immChain
+        LoEDisabled     -> Top
+      where
+        immChain = Model.immutableChain secParam dbModel
 
     cfg :: TopLevelConfig blk
     cfg = unOpaque modelConfig


### PR DESCRIPTION
Follow-up to #1307 fixing a ChainDB q-s-m test failure (should have run more tests locally...)

The refactoring performed in #1307 is only valid when the invariant that the LoE fragment is anchored in an immutable point is actually true. However, it was violated in the ChainDB q-s-m test in an edge case: Wiping the VolatileDB can cause us to lose immutable blocks that have not yet been persisted in the ImmutableDB.

This PR properly documents the invariant, adds a preconditon to the ChainDB q-s-m test and modifies the semantics of `WipeVolatileDB` to reset the LoE fragment to uphold the invariant.

A seed for reproducing the test failure (or the preconditon failure when run on the second commit in this PR):

    cabal run storage-test -- -p 'ChainDB q-s-m' --quickcheck-replay="(SMGen 3849844548958586180 13048063761035159821,66)"
