### PR TITLE
Calculate and compare CRC when writing and reading ledger snapshots

### DIFF
--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Run.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Run.hs
@@ -51,7 +51,7 @@ analyse ::
   => DBAnalyserConfig
   -> Args blk
   -> IO (Maybe AnalysisResult)
-analyse DBAnalyserConfig{analysis, confLimit, dbDir, selectDB, validation, verbose} args =
+analyse DBAnalyserConfig{analysis, confLimit, dbDir, selectDB, validation, verbose, diskSnapshotChecksumOnRead} args =
     withRegistry $ \registry -> do
       lock           <- newMVar ()
       chainDBTracer  <- mkTracer lock verbose
@@ -92,6 +92,7 @@ analyse DBAnalyserConfig{analysis, confLimit, dbDir, selectDB, validation, verbo
                 ledgerDbFS
                 (decodeDiskExtLedgerState $ configCodec cfg)
                 decode
+                diskSnapshotChecksumOnRead
                 (DiskSnapshot slot (Just "db-analyser"))
                 -- TODO @readSnapshot@ has type @ExceptT ReadIncrementalErr m
                 -- (ExtLedgerState blk)@ but it also throws exceptions! This makes

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Types.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Types.hs
@@ -1,20 +1,23 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 module Cardano.Tools.DBAnalyser.Types (module Cardano.Tools.DBAnalyser.Types) where
 
 import           Data.Word
 import           Ouroboros.Consensus.Block
+import           Ouroboros.Consensus.Util (Flag)
 
 data SelectDB =
     SelectImmutableDB (WithOrigin SlotNo)
 
 data DBAnalyserConfig = DBAnalyserConfig {
-    dbDir      :: FilePath
-  , verbose    :: Bool
-  , selectDB   :: SelectDB
-  , validation :: Maybe ValidateBlocks
-  , analysis   :: AnalysisName
-  , confLimit  :: Limit
+    dbDir                      :: FilePath
+  , verbose                    :: Bool
+  , selectDB                   :: SelectDB
+  , validation                 :: Maybe ValidateBlocks
+  , analysis                   :: AnalysisName
+  , confLimit                  :: Limit
+  , diskSnapshotChecksumOnRead :: Flag "DoDiskSnapshotChecksum"
   }
 
 data AnalysisName =
@@ -24,7 +27,7 @@ data AnalysisName =
   | ShowBlockTxsSize
   | ShowEBBs
   | OnlyValidation
-  | StoreLedgerStateAt SlotNo LedgerApplicationMode
+  | StoreLedgerStateAt SlotNo LedgerApplicationMode (Flag "DoDiskSnapshotChecksum")
   | CountBlocks
   | CheckNoThunksEvery Word64
   | TraceLedgerProcessing

--- a/ouroboros-consensus-cardano/test/tools-test/Main.hs
+++ b/ouroboros-consensus-cardano/test/tools-test/Main.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE PatternSynonyms #-}
+
 module Main (main) where
 
 import qualified Cardano.Tools.DBAnalyser.Block.Cardano as Cardano
@@ -8,6 +10,8 @@ import qualified Cardano.Tools.DBSynthesizer.Run as DBSynthesizer
 import           Cardano.Tools.DBSynthesizer.Types
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Cardano.Block
+import           Ouroboros.Consensus.Storage.LedgerDB.DiskPolicy
+                     (pattern NoDoDiskSnapshotChecksum)
 import qualified Test.Cardano.Tools.Headers
 import           Test.Tasty
 import           Test.Tasty.HUnit
@@ -62,12 +66,13 @@ testImmutaliserConfig =
 testAnalyserConfig :: DBAnalyserConfig
 testAnalyserConfig =
   DBAnalyserConfig {
-      dbDir       = chainDB
-    , verbose     = False
-    , selectDB    = SelectImmutableDB Origin
-    , validation  = Just ValidateAllBlocks
-    , analysis    = CountBlocks
-    , confLimit   = Unlimited
+      dbDir                      = chainDB
+    , verbose                    = False
+    , selectDB                   = SelectImmutableDB Origin
+    , validation                 = Just ValidateAllBlocks
+    , analysis                   = CountBlocks
+    , confLimit                  = Unlimited
+    , diskSnapshotChecksumOnRead = NoDoDiskSnapshotChecksum
     }
 
 testBlockArgs :: Cardano.Args (CardanoBlock StandardCrypto)

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Node.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MonadComprehensions #-}
 {-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE Rank2Types #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -51,6 +52,8 @@ module Ouroboros.Consensus.Node (
   , RunNodeArgs (..)
   , Tracers
   , Tracers' (..)
+  , pattern DoDiskSnapshotChecksum
+  , pattern NoDoDiskSnapshotChecksum
     -- * Internal helpers
   , mkNodeKernelArgs
   , nodeKernelArgsEnforceInvariants
@@ -107,7 +110,8 @@ import           Ouroboros.Consensus.Storage.ChainDB (ChainDB, ChainDbArgs,
 import qualified Ouroboros.Consensus.Storage.ChainDB as ChainDB
 import qualified Ouroboros.Consensus.Storage.ChainDB.Impl.Args as ChainDB
 import           Ouroboros.Consensus.Storage.LedgerDB.DiskPolicy
-                     (DiskPolicyArgs (..))
+                     (DiskPolicyArgs (..), pattern DoDiskSnapshotChecksum,
+                     pattern NoDoDiskSnapshotChecksum)
 import           Ouroboros.Consensus.Util.Args
 import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Consensus.Util.Orphans ()

--- a/ouroboros-consensus/changelog.d/20241128_084625_georgy.lukyanov_892_checksum_snaphot_file.md
+++ b/ouroboros-consensus/changelog.d/20241128_084625_georgy.lukyanov_892_checksum_snaphot_file.md
@@ -1,0 +1,14 @@
+### Breaking
+
+- When writing a ledger state snapshot to disk, calculate the state's CRC32 checksum and write it to a separate file, which is named the same as the snapshot file, plus the `.checksum` extension.
+- When reading a snapshot file in `readSnapshot`, calculate its checksum and compare it to the value in the corresponding `.checksum` file. Return an error if the checksum is different or invalid. Issue a warning if the checksum file does not exist, but still initialise the ledger DB.
+- To support the previous item, change the error type of the `readSnapshot` from `ReadIncrementalErr` to the extended `ReadSnaphotErr`.
+- Checksumming the snapshots is controlled via the `doChecksum :: Flag "DoDiskSnapshotChecksum"` parameter of `initFromSnapshot`. Ultimately, this parameter comes from the Node's configuration file via the `DiskPolicy` data type.
+- Extend the `DiskPolicyArgs` data type to enable the node to pass `Flag "DoDiskSnapshotChecksum"` to Consensus.
+
+### Non-breaking
+
+- Make `Ouroboros.Consensus.Util.CBOR.readIncremental` optionally compute the checksum of the data as it is read.
+- Introduce an explicit `Ord` instance for `DiskSnapshot` that compares the values on `dsNumber`.
+- Introduce a new utility newtype `Flag` to represent type-safe boolean flags. See ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Util.hs.
+- Use `Flag "DoDiskSnapshotChecksum"` to control the check of the snapshot checksum file in `takeSnapshot`, `readSnapshot` and `writeSnapshot`.

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE PatternSynonyms #-}
+
 -- | The Ledger DB is responsible for the following tasks:
 --
 -- - __Maintaining the in-memory ledger state at the tip__: When we try to
@@ -134,6 +136,8 @@ module Ouroboros.Consensus.Storage.LedgerDB (
   , SnapshotFailure (..)
   , diskSnapshotIsTemporary
   , listSnapshots
+  , pattern DoDiskSnapshotChecksum
+  , pattern NoDoDiskSnapshotChecksum
   , readSnapshot
     -- ** Write to disk
   , takeSnapshot
@@ -160,7 +164,9 @@ module Ouroboros.Consensus.Storage.LedgerDB (
 import           Ouroboros.Consensus.Storage.LedgerDB.DiskPolicy
                      (DiskPolicy (..), DiskPolicyArgs (..),
                      NumOfDiskSnapshots (..), SnapshotInterval (..),
-                     TimeSinceLast (..), defaultDiskPolicyArgs, mkDiskPolicy)
+                     TimeSinceLast (..), defaultDiskPolicyArgs, mkDiskPolicy,
+                     pattern DoDiskSnapshotChecksum,
+                     pattern NoDoDiskSnapshotChecksum)
 import           Ouroboros.Consensus.Storage.LedgerDB.Init (InitLog (..),
                      ReplayGoal (..), ReplayStart (..), TraceReplayEvent (..),
                      decorateReplayTracerWithGoal,

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/Snapshots.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/Snapshots.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
@@ -12,6 +14,7 @@
 module Ouroboros.Consensus.Storage.LedgerDB.Snapshots (
     DiskSnapshot (..)
     -- * Read from disk
+  , ReadSnapshotErr (..)
   , SnapshotFailure (..)
   , diskSnapshotIsTemporary
   , listSnapshots
@@ -34,13 +37,18 @@ import qualified Codec.CBOR.Write as CBOR
 import           Codec.Serialise.Decoding (Decoder)
 import qualified Codec.Serialise.Decoding as Dec
 import           Codec.Serialise.Encoding (Encoding)
-import           Control.Monad (forM, void)
-import           Control.Monad.Except (ExceptT (..))
+import           Control.Monad (forM, void, when)
+import           Control.Monad.Except (ExceptT (..), throwError, withExceptT)
 import           Control.Tracer
+import           Data.Bits
+import qualified Data.ByteString.Builder as BS
+import qualified Data.ByteString.Char8 as BSC
+import qualified Data.ByteString.Lazy as BSL
+import           Data.Char (ord)
 import           Data.Functor.Contravariant ((>$<))
 import qualified Data.List as List
 import           Data.Maybe (isJust, mapMaybe)
-import           Data.Ord (Down (..))
+import           Data.Ord (Down (..), comparing)
 import           Data.Set (Set)
 import qualified Data.Set as Set
 import           Data.Word
@@ -56,6 +64,7 @@ import           Ouroboros.Consensus.Util.Enclose
 import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Consensus.Util.Versioned
 import           System.FS.API.Lazy
+import           System.FS.CRC (CRC (..), hPutAllCRC)
 import           Text.Read (readMaybe)
 
 {-------------------------------------------------------------------------------
@@ -66,7 +75,7 @@ data SnapshotFailure blk =
     -- | We failed to deserialise the snapshot
     --
     -- This can happen due to data corruption in the ledger DB.
-    InitFailureRead ReadIncrementalErr
+    InitFailureRead ReadSnapshotErr
 
     -- | This snapshot is too recent (ahead of the tip of the chain)
   | InitFailureTooRecent (RealPoint blk)
@@ -82,7 +91,9 @@ data TraceSnapshotEvent blk
   | TookSnapshot DiskSnapshot (RealPoint blk) EnclosingTimed
     -- ^ A snapshot was written to disk.
   | DeletedSnapshot DiskSnapshot
-    -- ^ An old or invalid on-disk snapshot was deleted
+    -- ^ An old or invalid on-disk snapshot was deleted.
+  | SnapshotMissingChecksum DiskSnapshot
+    -- ^ The checksum file for a snapshot was missing and was not checked
   deriving (Generic, Eq, Show)
 
 -- | Take a snapshot of the /oldest ledger state/ in the ledger DB
@@ -108,9 +119,10 @@ takeSnapshot ::
      forall m blk. (MonadThrow m, MonadMonotonicTime m, IsLedger (LedgerState blk))
   => Tracer m (TraceSnapshotEvent blk)
   -> SomeHasFS m
+  -> Flag "DoDiskSnapshotChecksum"
   -> (ExtLedgerState blk -> Encoding)
   -> ExtLedgerState blk -> m (Maybe (DiskSnapshot, RealPoint blk))
-takeSnapshot tracer hasFS encLedger oldest =
+takeSnapshot tracer hasFS doChecksum encLedger oldest =
     case pointToWithOriginRealPoint (castPoint (getTip oldest)) of
       Origin ->
         return Nothing
@@ -122,7 +134,7 @@ takeSnapshot tracer hasFS encLedger oldest =
           return Nothing
         else do
           encloseTimedWith (TookSnapshot snapshot tip >$< tracer)
-              $ writeSnapshot hasFS encLedger snapshot oldest
+              $ writeSnapshot hasFS doChecksum encLedger snapshot oldest
           return $ Just (snapshot, tip)
 
 -- | Trim the number of on disk snapshots so that at most 'onDiskNumSnapshots'
@@ -149,6 +161,9 @@ trimSnapshots tracer hasFS DiskPolicy{..} = do
   Internal: reading from disk
 -------------------------------------------------------------------------------}
 
+-- | Name of a disk snapshot.
+--
+--   The snapshot itself might not yet exist on disk.
 data DiskSnapshot = DiskSnapshot {
       -- | Snapshots are numbered. We will try the snapshots with the highest
       -- number first.
@@ -169,7 +184,10 @@ data DiskSnapshot = DiskSnapshot {
       -- /not be trimmed/.
     , dsSuffix :: Maybe String
     }
-  deriving (Show, Eq, Ord, Generic)
+  deriving (Show, Eq, Generic)
+
+instance Ord DiskSnapshot where
+  compare = comparing dsNumber
 
 -- | Named snapshot are permanent, they will never be deleted when trimming.
 diskSnapshotIsPermanent :: DiskSnapshot -> Bool
@@ -180,39 +198,110 @@ diskSnapshotIsPermanent = isJust . dsSuffix
 diskSnapshotIsTemporary :: DiskSnapshot -> Bool
 diskSnapshotIsTemporary = not . diskSnapshotIsPermanent
 
--- | Read snapshot from disk
+data ReadSnapshotErr =
+    -- | Error while de-serialising data
+    ReadSnapshotFailed ReadIncrementalErr
+    -- | Checksum of read snapshot differs from the one tracked by
+    --   the corresponding '.checksum' file
+  | ReadSnapshotDataCorruption
+    -- | A '.checksum' file does not exist for a @'DiskSnapshot'@
+  | ReadSnapshotNoChecksumFile FsPath
+    -- | A '.checksum' file exists for a @'DiskSnapshot'@, but its contents is invalid
+  | ReadSnapshotInvalidChecksumFile FsPath
+  deriving (Eq, Show)
+
+-- | Read snapshot from disk.
+--
+--   Fail on data corruption, i.e. when the checksum of the read data differs
+--   from the one tracked by @'DiskSnapshot'@.
 readSnapshot ::
      forall m blk. IOLike m
   => SomeHasFS m
   -> (forall s. Decoder s (ExtLedgerState blk))
   -> (forall s. Decoder s (HeaderHash blk))
+  -> Flag "DoDiskSnapshotChecksum"
   -> DiskSnapshot
-  -> ExceptT ReadIncrementalErr m (ExtLedgerState blk)
-readSnapshot hasFS decLedger decHash =
-      ExceptT
-    . readIncremental hasFS decoder
-    . snapshotToPath
+  -> ExceptT ReadSnapshotErr m (ExtLedgerState blk)
+readSnapshot someHasFS decLedger decHash doChecksum snapshotName = do
+  (ledgerState, mbChecksumAsRead) <- withExceptT ReadSnapshotFailed . ExceptT $
+      readIncremental someHasFS (getFlag doChecksum) decoder (snapshotToPath snapshotName)
+  when (getFlag doChecksum) $ do
+    !snapshotCRC <- readCRC someHasFS (snapshotToChecksumPath snapshotName)
+    when (mbChecksumAsRead /= Just snapshotCRC) $
+      throwError ReadSnapshotDataCorruption
+  pure ledgerState
   where
     decoder :: Decoder s (ExtLedgerState blk)
     decoder = decodeSnapshotBackwardsCompatible (Proxy @blk) decLedger decHash
 
--- | Write snapshot to disk
+    readCRC ::
+      SomeHasFS m
+      -> FsPath
+      -> ExceptT ReadSnapshotErr m CRC
+    readCRC (SomeHasFS hasFS) crcPath = ExceptT $ do
+        crcExists <- doesFileExist hasFS crcPath
+        if not crcExists
+          then pure (Left $ ReadSnapshotNoChecksumFile crcPath)
+          else do
+            withFile hasFS crcPath ReadMode $ \h -> do
+              str <- BSL.toStrict <$> hGetAll hasFS h
+              if not (BSC.length str == 8 && BSC.all isHexDigit str)
+                then pure (Left $ ReadSnapshotInvalidChecksumFile crcPath)
+                else pure . Right . CRC $ fromIntegral (hexdigitsToInt str)
+        -- TODO: remove the functions in the where clause when we start depending on lsm-tree
+      where
+        isHexDigit :: Char -> Bool
+        isHexDigit c = (c >= '0' && c <= '9')
+                    || (c >= 'a' && c <= 'f') --lower case only
+
+        -- Precondition: BSC.all isHexDigit
+        hexdigitsToInt :: BSC.ByteString -> Word
+        hexdigitsToInt =
+            BSC.foldl' accumdigit 0
+          where
+            accumdigit :: Word -> Char -> Word
+            accumdigit !a !c =
+              (a `shiftL` 4) .|. hexdigitToWord c
+
+
+        -- Precondition: isHexDigit
+        hexdigitToWord :: Char -> Word
+        hexdigitToWord c
+          | let !dec = fromIntegral (ord c - ord '0')
+          , dec <= 9  = dec
+
+          | let !hex = fromIntegral (ord c - ord 'a' + 10)
+          , otherwise = hex
+
+-- | Write a ledger state snapshot to disk
+--
+--   This function writes two files:
+--   * the snapshot file itself, with the name generated by @'snapshotToPath'@
+--   * the checksum file, with the name generated by @'snapshotToChecksumPath'@
 writeSnapshot ::
      forall m blk. MonadThrow m
   => SomeHasFS m
+  -> Flag "DoDiskSnapshotChecksum"
   -> (ExtLedgerState blk -> Encoding)
   -> DiskSnapshot
   -> ExtLedgerState blk -> m ()
-writeSnapshot (SomeHasFS hasFS) encLedger ss cs = do
-    withFile hasFS (snapshotToPath ss) (WriteMode MustBeNew) $ \h ->
-      void $ hPut hasFS h $ CBOR.toBuilder (encode cs)
+writeSnapshot (SomeHasFS hasFS) doChecksum encLedger ss cs = do
+    crc <- withFile hasFS (snapshotToPath ss) (WriteMode MustBeNew) $ \h ->
+      snd <$> hPutAllCRC hasFS h (CBOR.toLazyByteString $ encode cs)
+    when (getFlag doChecksum) $
+      withFile hasFS (snapshotToChecksumPath ss) (WriteMode MustBeNew) $ \h ->
+        void $ hPutAll hasFS h . BS.toLazyByteString . BS.word32HexFixed $ getCRC crc
   where
     encode :: ExtLedgerState blk -> Encoding
     encode = encodeSnapshot encLedger
 
 -- | Delete snapshot from disk
-deleteSnapshot :: HasCallStack => SomeHasFS m -> DiskSnapshot -> m ()
-deleteSnapshot (SomeHasFS HasFS{..}) = removeFile . snapshotToPath
+deleteSnapshot :: Monad m => HasCallStack => SomeHasFS m -> DiskSnapshot -> m ()
+deleteSnapshot (SomeHasFS hasFS) snapshot = do
+  removeFile hasFS (snapshotToPath snapshot)
+  checksumFileExists <- doesFileExist hasFS (snapshotToChecksumPath snapshot)
+  when checksumFileExists $
+    removeFile hasFS (snapshotToChecksumPath snapshot)
 
 -- | List on-disk snapshots, highest number first.
 listSnapshots :: Monad m => SomeHasFS m -> m [DiskSnapshot]
@@ -220,7 +309,10 @@ listSnapshots (SomeHasFS HasFS{..}) =
     aux <$> listDirectory (mkFsPath [])
   where
     aux :: Set String -> [DiskSnapshot]
-    aux = List.sortOn (Down . dsNumber) . mapMaybe snapshotFromPath . Set.toList
+    aux = List.sortOn Down . mapMaybe snapshotFromPath . Set.toList
+
+snapshotToChecksumFileName :: DiskSnapshot -> String
+snapshotToChecksumFileName = (<> ".checksum") . snapshotToFileName
 
 snapshotToFileName :: DiskSnapshot -> String
 snapshotToFileName DiskSnapshot { dsNumber, dsSuffix } =
@@ -229,6 +321,9 @@ snapshotToFileName DiskSnapshot { dsNumber, dsSuffix } =
     suffix = case dsSuffix of
       Nothing -> ""
       Just s  -> "_" <> s
+
+snapshotToChecksumPath :: DiskSnapshot -> FsPath
+snapshotToChecksumPath = mkFsPath . (:[]) . snapshotToChecksumFileName
 
 snapshotToPath :: DiskSnapshot -> FsPath
 snapshotToPath = mkFsPath . (:[]) . snapshotToFileName

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Util.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Util.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
@@ -77,6 +78,8 @@ module Ouroboros.Consensus.Util (
   , electric
   , newFuse
   , withFuse
+    -- * Type-safe boolean flags
+  , Flag (..)
   ) where
 
 import           Cardano.Crypto.Hash (Hash, HashAlgorithm, hashFromBytes,
@@ -102,6 +105,7 @@ import           Data.Void
 import           Data.Word (Word64)
 import           GHC.Generics (Generic)
 import           GHC.Stack
+import           GHC.TypeLits (Symbol)
 import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Network.Protocol.LocalStateQuery.Codec (Some (..))
 import           Ouroboros.Network.Util.ShowProxy (ShowProxy (..))
@@ -450,3 +454,16 @@ withFuse (Fuse name m) (Electric io) = do
 newtype FuseBlownException = FuseBlownException Text
  deriving (Show)
  deriving anyclass (Exception)
+
+{-------------------------------------------------------------------------------
+  Type-safe boolean flags
+-------------------------------------------------------------------------------}
+
+-- | Type-safe boolean flags with type level tags
+--
+-- It is recommended to create pattern synonyms for the true and false values.
+--
+-- See 'Ouroboros.Consensus.Storage.LedgerDB.Snapshots.DiskSnapshotChecksum'
+-- for an example.
+newtype Flag (name :: Symbol) = Flag {getFlag :: Bool}
+    deriving (Eq, Show, Generic)

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/ChainDB.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/ChainDB.hs
@@ -111,7 +111,7 @@ fromMinimalChainDbArgs MinimalChainDbArgs {..} = ChainDbArgs {
         , volValidationPolicy = VolatileDB.ValidateAll
         }
     , cdbLgrDbArgs = LgrDbArgs {
-          lgrDiskPolicyArgs   = LedgerDB.DiskPolicyArgs LedgerDB.DefaultSnapshotInterval LedgerDB.DefaultNumOfDiskSnapshots
+          lgrDiskPolicyArgs   = LedgerDB.DiskPolicyArgs LedgerDB.DefaultSnapshotInterval LedgerDB.DefaultNumOfDiskSnapshots LedgerDB.DoDiskSnapshotChecksum
           -- Keep 2 ledger snapshots, and take a new snapshot at least every 2 *
           -- k seconds, where k is the security parameter.
         , lgrGenesis          = return mcdbInitLedger

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/Orphans/ToExpr.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/Orphans/ToExpr.hs
@@ -29,6 +29,7 @@ import           Ouroboros.Network.Mock.Chain
 import           Ouroboros.Network.Mock.ProducerState
 import           Ouroboros.Network.Point
 import           System.FS.API
+import           System.FS.CRC (CRC (..))
 import           Test.Cardano.Slotting.TreeDiff ()
 import           Test.Util.ToExpr ()
 
@@ -65,6 +66,7 @@ instance ( ToExpr (TipInfo blk)
          ) => ToExpr (AnnTip blk)
 
 instance ToExpr SecurityParam
+instance ToExpr CRC
 instance ToExpr DiskSnapshot
 
 instance ToExpr ChunkSize

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/LedgerDB/DiskPolicy.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/LedgerDB/DiskPolicy.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE TypeApplications #-}
 
 module Test.Ouroboros.Storage.LedgerDB.DiskPolicy (tests) where
@@ -13,7 +14,8 @@ import           Ouroboros.Consensus.Storage.LedgerDB (DiskPolicy (..),
                      NumOfDiskSnapshots (..), SnapshotInterval (..),
                      TimeSinceLast (..), mkDiskPolicy)
 import           Ouroboros.Consensus.Storage.LedgerDB.DiskPolicy
-                     (DiskPolicyArgs (DiskPolicyArgs))
+                     (DiskPolicyArgs (DiskPolicyArgs),
+                     pattern DoDiskSnapshotChecksum)
 import           Test.QuickCheck
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
@@ -49,7 +51,7 @@ toDiskPolicy :: TestSetup -> DiskPolicy
 toDiskPolicy ts = mkDiskPolicy (tsK ts) diskPolicyArgs
   where
     diskPolicyArgs =
-      DiskPolicyArgs (tsSnapshotInterval ts) DefaultNumOfDiskSnapshots
+      DiskPolicyArgs (tsSnapshotInterval ts) DefaultNumOfDiskSnapshots DoDiskSnapshotChecksum
 
 -- | The result of the represented call to 'onDiskShouldTakeSnapshot'
 shouldTakeSnapshot :: TestSetup -> Bool

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/LedgerDB/OrphanArbitrary.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/LedgerDB/OrphanArbitrary.hs
@@ -1,8 +1,12 @@
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GeneralisedNewtypeDeriving #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Test.Ouroboros.Storage.LedgerDB.OrphanArbitrary () where
 
 import           Ouroboros.Consensus.Config.SecurityParam (SecurityParam (..))
+import           Ouroboros.Consensus.Util (Flag (..))
 import           Test.QuickCheck
 
 {-------------------------------------------------------------------------------
@@ -12,3 +16,5 @@ import           Test.QuickCheck
 instance Arbitrary SecurityParam where
   arbitrary = SecurityParam <$> choose (0, 6)
   shrink (SecurityParam k) = SecurityParam <$> shrink k
+
+deriving newtype instance Arbitrary (Flag symbol)


### PR DESCRIPTION

Fixes https://github.com/IntersectMBO/ouroboros-consensus/issues/892

Integration into `cardano-node`: https://github.com/IntersectMBO/cardano-node/pull/6047. This uses the branch [geo2a/issue-892-checksum-snaphot-file-release-ouroboros-consensus-0.21.0.0-backport](https://github.com/IntersectMBO/ouroboros-consensus/tree/geo2a/issue-892-checksum-snaphot-file-release-ouroboros-consensus-0.21.0.0-backport) which is the backport of this PR onto the most resent release of the `ouroboros-consensus` package.

In this PR, we change the reading and writing disk snapshots of ledger state. When a snapshot is taken and written to disk, an additional file with the `.checksum` extension is written alongside it. The checksum file contains a string that represent the CRC32 checksum of the snapshot.

The checksum is calculated incrementally, alongside writing the snapshot to disk. When a snapshot is read from dist, the checksum is again calculated and compared to the tracked one. If the checksum is different, `readSnaphot` returns the `ReadSnapshotDataCorruption` error, indicating data corruption.

The checksum is calculated incrementally, alongside reading a writing the data. On write, we use the [`hPutAllCRC`](https://input-output-hk.github.io/fs-sim/fs-api/src/System.FS.CRC.html#hPutAllCRC) function from `fs-sim`, and on read we modify the [readIncremental](https://github.com/IntersectMBO/ouroboros-consensus/blob/892-checksum-snaphot-file/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Util/CBOR.hs#L191) function to compute the checksum as data is read.

To enable seamless integration into `cardano-node`, we make the check optional. When initialising the ledger state from a snapshot in `initLedgerDB`, we issue a warning in case the checksum file is missing for a snapshot, but do not fail as in case of invalid snapshots.

The `db-analyser` tool ignores the checksum files by default when reading the snapshots. We add `--disk-snapshot-checksum` flag to enabled the check. When writing a snapshot to disk, e.g. as a result of the `--store-ledger` analysis, `db-analyser` will always write
calculate the checksum and write it into the snapshot's `.checksum` file.

**Tests**

There state machine test in `Test.Ouroboros.Storage.LedgerDB.OnDisk` is relevant to this feature, and has caught a number of silly mistakes in the process of its implementation, for example forgetting to delete a checksum file when the snapshot is deleted.

The model in the test does not track checksums, and I do not think it can (or should) be augmented to do that. Howerver, the `Snap` and `Restore` events are now parameterised by the checksum flag, and the values for the flag are randomised when generating these events. This leads to testing the following properties:
- this feature is backwards-compatible, i.e. the `Restore` events will always lead to restoring from a snapshot, even if `Snap` events do not write checksum files (i.e. their flag is `NoDoDiskSnapshotChecksum` ~= `False`).
- If the interpretation of the `DoDiskSnapshotChecksum` flag changes in the code base and becomes strict, i.e. hard fail if the checksum file is missing, this test will discover that.

**Effects on Performance**:

Running `db-analyser` to read a ledger snapshot and store the snapshot of the state at the next slot shows a difference of 2 seconds on my machine. See a comment below for the logs.

To precisely evaluate the effects, we need a micro-benchmark of the reading and writing of snapshots with and without the checksum calculation.
