### PR TITLE
Use a script to check cabal files in GH actions

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -56,15 +56,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Cabal check
-      run: |
-        for x in $(find . -name '*.cabal' | grep -vE 'dist-newstyle|asserts\.cabal' | cut -c 3-); do
-          (
-            d=$(dirname $x)
-            echo "== $d =="
-            cd $d
-            cabal check
-          )
-        done
+      run: ./scripts/ci/check-cabal-files.sh
 
   check-release-badges:
 

--- a/scripts/ci/check-cabal-files.sh
+++ b/scripts/ci/check-cabal-files.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -Eeuo pipefail
+
 for x in $(find . -name '*.cabal' | grep -vE 'dist-newstyle|asserts\.cabal' | cut -c 3-); do
   (
     d=$(dirname $x)


### PR DESCRIPTION
# Description

I've noticed that the GH actions workflow step that runs  `cabal check` inlines the script we have in `./scropts`. This PR calls the script and also modifies it to exit on the first `cabal check` failure.