### PR TITLE
Investigation: failing faster when validating txs with missing inputs

### DIFF
--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Run.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Run.hs
@@ -35,6 +35,7 @@ import qualified Ouroboros.Consensus.Storage.LedgerDB.Snapshots as LedgerDB
 import qualified Ouroboros.Consensus.Storage.LedgerDB.V1 as LedgerDB.V1
 import qualified Ouroboros.Consensus.Storage.LedgerDB.V1.Args as LedgerDB.V1
 import qualified Ouroboros.Consensus.Storage.LedgerDB.V1.BackingStore.Impl.LMDB as LMDB
+import qualified Ouroboros.Consensus.Storage.LedgerDB.V2 as LedgerDB.V2
 import qualified Ouroboros.Consensus.Storage.LedgerDB.V2.Args as LedgerDB.V2
 import           Ouroboros.Consensus.Util.Args
 import           Ouroboros.Consensus.Util.IOLike
@@ -68,8 +69,17 @@ openLedgerDB lgrDbArgs@LedgerDB.LedgerDbArgs{LedgerDB.lgrFlavorArgs=LedgerDB.Led
       emptyStream
       genesisPoint
   pure (ledgerDB, intLedgerDB)
-openLedgerDB LedgerDB.LedgerDbArgs{LedgerDB.lgrFlavorArgs=LedgerDB.LedgerDbFlavorArgsV2{}} =
-  error "not defined for v2, use v1 instead for now!"
+openLedgerDB lgrDbArgs@LedgerDB.LedgerDbArgs{LedgerDB.lgrFlavorArgs=LedgerDB.LedgerDbFlavorArgsV2 args} = do
+  (ledgerDB, _, intLedgerDB) <-
+    LedgerDB.openDBInternal
+      lgrDbArgs
+      (LedgerDB.V2.mkInitDb
+        lgrDbArgs
+        args
+        (\_ -> error "no replay"))
+      emptyStream
+      genesisPoint
+  pure (ledgerDB, intLedgerDB)
 
 emptyStream :: Applicative m => ImmutableDB.StreamAPI m blk a
 emptyStream = ImmutableDB.StreamAPI $ \_ k -> k $ Right $ pure ImmutableDB.NoMoreItems


### PR DESCRIPTION
In various common scenarios, the mempool will (re)apply a tx to a ledger state that does not contain all of the necessary inputs (usually because the tx has already been applied before). Therefore, it is desirable for tx (re) application to fail fast in these cases.

The purpose of this PR is just to summarize effort to look into improvements here. Ideally, no modification to Consensus would be necessary in the end; Ledger should be able to do everything on their side.

Specifically, this PR tries two things:

 - Try to use `reapplyTx` instead of `applyTx` when the tx is already in the mempool. The idea here is to avoid crypto work that will be unnecessary as tx validation will fail due to missing inputs eventually anyways.

   [This tx](https://adastat.net/blocks/3478fe87fd494cb7ecc35b4e1f800f7e5c54775eb6dcbeda8bb4df158e8b05c0) is a concrete example for a tx where this saves time.

 - Try to restrict the UTxO set before calling the ledger to the potentially needed inputs of the tx. That's exactly what UTxO HD does, so this PR branch is targeting #1267.

---

To test/benchmark this, this PR modifies the `--repro-mempool-and-forge` db-analyser pass. When processing a block, it adds all of its transactions to the mempool, and then individuall tries to add each tx again, measuring how long it takes until the mempool is rejected. The output data is stored in `readd-txs.csv`.

I ran `db-analyser` like this
```console
cabal run db-analyser -- --v2-in-mem --db /path/to/db --no-snapshot-checksum-on-read \
  --repro-mempool-and-forge 1 --analyse-from 133660855 --num-blocks-to-process 100000 \
  cardano --config /path/to/config.json
```
(takes ~30min) and used the mean of two runs.

Plots are created using a very ad-hoc [script](https://gist.github.com/amesgen/3286e36c300f7f715edf072e9d15e977).

Here, GHC mutator time is used, and `mut_{baseline,patched}` refer to versions against current `main` (ie without UTxO HD), and `mut_utxohd_{baseline,patched}` to versions in this branch. `_baseline` means that the mempool hasn't been patched to use `reapplyTx`, whereas `_patched` means exactly that.

<details><summary>Show plot :chart_with_upwards_trend:  </summary>

![plot](https://github.com/user-attachments/assets/368fee99-05f0-4314-84ba-791c9b02d9c2)

</details>

---

Thoughts:

 - The mempool patch definitely helps, both with and without UTxO HD, but only for certain txs.
 - UTxO HD seems is slower when comparing means/medians.
 - UTxO HD seems to significantly help for certain txs, visible both in "`mut_baseline` vs `mut_utxohd_baseline`" and "`mut_patched` vs `mut_utxohd_patched`". 
 - Eyeballing seems to indicate that there are significantly fewer big outliers with UTxO HD.

---


A next step would be to profile individual txs to understand why they are currently relatively "slow to fail". I did this already for a few txs (that's e.g. how I saw that the tx mentioned above is slow to fail due to crypto without the mempool patch) like this:

 - Create a ledger snapshot for the preceding block of the tx.
 - Run the `db-analyser` pass with `--num-blocks-to-process 1`, and make use of `{start,stop}ProfTimer` (see the code for an example).
 - Load the result into https://www.speedscope.app/ (requires `+RTS -pj`). 