### PR TITLE
NodeKernel: expose getBlockchainTime

### DIFF
--- a/ouroboros-consensus-diffusion/changelog.d/mkarg-expose-btime.md
+++ b/ouroboros-consensus-diffusion/changelog.d/mkarg-expose-btime.md
@@ -1,0 +1,3 @@
+### Non-Breaking
+
+- Expose blockchain time as `getBlockchainTime :: BlockchainTime m` in the `NodeKernel`.

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
@@ -166,6 +166,7 @@ data NodeKernel m addrNTN addrNTC blk = NodeKernel {
                              :: StrictTVar m OutboundConnectionsState
     , getDiffusionPipeliningSupport
                              :: DiffusionPipeliningSupport
+    , getBlockchainTime      :: BlockchainTime m
     }
 
 -- | Arguments required when initializing a node
@@ -208,6 +209,7 @@ initNodeKernel ::
 initNodeKernel args@NodeKernelArgs { registry, cfg, tracers
                                    , chainDB, initChainDB
                                    , blockFetchConfiguration
+                                   , btime
                                    , gsmArgs
                                    , peerSharingRng
                                    , publicPeerSelectionStateVar
@@ -333,6 +335,7 @@ initNodeKernel args@NodeKernelArgs { registry, cfg, tracers
       , getOutboundConnectionsState
                                 = varOutboundConnectionsState
       , getDiffusionPipeliningSupport
+      , getBlockchainTime       = btime
       }
   where
     blockForgingController :: InternalState m remotePeer localPeer blk


### PR DESCRIPTION
# Description

This PR exposes the blockchain time in the node kernel.

This tiny change is a requirement for the "periodic metrics tracer" feature (cf. https://github.com/IntersectMBO/cardano-node/pull/6076), which has already shown promising performance improvements in benchmarks.
