### PR TITLE
Improvements to UTxO-HD: mempool snapshotting

### DIFF
--- a/ouroboros-consensus-cardano/src/byron/Ouroboros/Consensus/Byron/Ledger/Mempool.hs
+++ b/ouroboros-consensus-cardano/src/byron/Ouroboros/Consensus/Byron/Ledger/Mempool.hs
@@ -118,7 +118,7 @@ instance LedgerSupportsMempool ByronBlock where
     where
       validationMode = CC.ValidationMode CC.BlockValidation Utxo.TxValidation
 
-  reapplyTx cfg slot vtx st =
+  reapplyTx _ cfg slot vtx st =
       applyByronGenTx validationMode cfg slot (forgetValidatedByronTx vtx) st
     where
       validationMode = CC.ValidationMode CC.NoBlockValidation Utxo.TxValidationNoCrypto

--- a/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/CanHardFork.hs
+++ b/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/CanHardFork.hs
@@ -620,7 +620,6 @@ translateLedgerStateShelleyToAllegraWrapper =
                   avvmsAsDeletions = LedgerTables
                                    . DiffMK
                                    . Diff.fromMapDeletes
-                                   . Map.mapKeys ShelleyTxIn
                                    . Map.map SL.upgradeTxOut
                                    $ avvms
 
@@ -632,7 +631,6 @@ translateLedgerStateShelleyToAllegraWrapper =
                               . withLedgerTables ls
                               . LedgerTables
                               . ValuesMK
-                              . Map.mapKeys ShelleyTxIn
                               $ avvms
 
                   resultingState = unFlip . unComp

--- a/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/Ledger.hs
+++ b/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/Ledger.hs
@@ -52,7 +52,7 @@ import           Ouroboros.Consensus.Ledger.Tables
 import           Ouroboros.Consensus.Protocol.Praos (Praos)
 import           Ouroboros.Consensus.Protocol.TPraos (TPraos)
 import           Ouroboros.Consensus.Shelley.Ledger (IsShelleyBlock,
-                     ShelleyBlock, ShelleyBlockLedgerEra, ShelleyTxIn (..))
+                     ShelleyBlock, ShelleyBlockLedgerEra)
 import           Ouroboros.Consensus.Shelley.Protocol.Abstract (ProtoCrypto)
 import           Ouroboros.Consensus.TypeFamilyWrappers
 import           Ouroboros.Consensus.Util.IndexedMemPack
@@ -67,23 +67,23 @@ instance CardanoHardForkConstraints c
 
   injectCanonicalTxIn IZ       byronTxIn   = absurd byronTxIn
   injectCanonicalTxIn (IS idx) shelleyTxIn = case idx of
-      IZ                               -> CardanoTxIn $ getShelleyTxIn shelleyTxIn
-      IS IZ                            -> CardanoTxIn $ getShelleyTxIn shelleyTxIn
-      IS (IS IZ)                       -> CardanoTxIn $ getShelleyTxIn shelleyTxIn
-      IS (IS (IS IZ))                  -> CardanoTxIn $ getShelleyTxIn shelleyTxIn
-      IS (IS (IS (IS IZ)))             -> CardanoTxIn $ getShelleyTxIn shelleyTxIn
-      IS (IS (IS (IS (IS IZ))))        -> CardanoTxIn $ getShelleyTxIn shelleyTxIn
+      IZ                               -> CardanoTxIn shelleyTxIn
+      IS IZ                            -> CardanoTxIn shelleyTxIn
+      IS (IS IZ)                       -> CardanoTxIn shelleyTxIn
+      IS (IS (IS IZ))                  -> CardanoTxIn shelleyTxIn
+      IS (IS (IS (IS IZ)))             -> CardanoTxIn shelleyTxIn
+      IS (IS (IS (IS (IS IZ))))        -> CardanoTxIn shelleyTxIn
       IS (IS (IS (IS (IS (IS idx'))))) -> case idx' of {}
 
   ejectCanonicalTxIn IZ _                 =
       error "ejectCanonicalTxIn: Byron has no TxIns"
   ejectCanonicalTxIn (IS idx) cardanoTxIn = case idx of
-      IZ                               -> ShelleyTxIn $ getCardanoTxIn cardanoTxIn
-      IS IZ                            -> ShelleyTxIn $ getCardanoTxIn cardanoTxIn
-      IS (IS IZ)                       -> ShelleyTxIn $ getCardanoTxIn cardanoTxIn
-      IS (IS (IS IZ))                  -> ShelleyTxIn $ getCardanoTxIn cardanoTxIn
-      IS (IS (IS (IS IZ)))             -> ShelleyTxIn $ getCardanoTxIn cardanoTxIn
-      IS (IS (IS (IS (IS IZ))))        -> ShelleyTxIn $ getCardanoTxIn cardanoTxIn
+      IZ                               -> getCardanoTxIn cardanoTxIn
+      IS IZ                            -> getCardanoTxIn cardanoTxIn
+      IS (IS IZ)                       -> getCardanoTxIn cardanoTxIn
+      IS (IS (IS IZ))                  -> getCardanoTxIn cardanoTxIn
+      IS (IS (IS (IS IZ)))             -> getCardanoTxIn cardanoTxIn
+      IS (IS (IS (IS (IS IZ))))        -> getCardanoTxIn cardanoTxIn
       IS (IS (IS (IS (IS (IS idx'))))) -> case idx' of {}
 
 instance CardanoHardForkConstraints c => MemPack (CanonicalTxIn (CardanoEras c)) where

--- a/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/Ledger.hs
+++ b/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/Ledger.hs
@@ -33,13 +33,13 @@ module Ouroboros.Consensus.Cardano.Ledger (
   , eliminateCardanoTxOut
   ) where
 
-import qualified Data.SOP.Tails as Tails
 import qualified Cardano.Ledger.Shelley.API as SL
 import           Data.Maybe
 import           Data.MemPack
 import           Data.SOP.BasicFunctors
 import           Data.SOP.Index
 import           Data.SOP.Strict
+import qualified Data.SOP.Tails as Tails
 import qualified Data.SOP.Telescope as Telescope
 import           Data.Void
 import           GHC.Generics (Generic)

--- a/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/QueryHF.hs
+++ b/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/QueryHF.hs
@@ -104,13 +104,13 @@ instance CardanoHardForkConstraints c => BlockSupportsHFLedgerQuery (CardanoEras
       (\idx -> answerShelleyLookupQueries
                 (injectLedgerTables idx)
                 (ejectHardForkTxOut idx)
-                (getShelleyTxIn . ejectCanonicalTxIn idx)
+                (ejectCanonicalTxIn idx)
       )
   answerBlockQueryHFTraverse =
     answerCardanoQueryHF
       (\idx -> answerShelleyTraversingQueries
                 (ejectHardForkTxOut idx)
-                (getShelleyTxIn . ejectCanonicalTxIn idx)
+                (ejectCanonicalTxIn idx)
                 (queryLedgerGetTraversingFilter idx)
       )
 

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Mempool.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Mempool.hs
@@ -65,7 +65,6 @@ import           Control.Monad.Identity (Identity (..))
 import           Data.DerivingVia (InstantiatedAt (..))
 import           Data.Foldable (toList)
 import           Data.Measure (Measure)
-import qualified Data.Set as Set
 import           Data.Typeable (Typeable)
 import qualified Data.Validation as V
 import           GHC.Generics (Generic)
@@ -80,7 +79,6 @@ import           Ouroboros.Consensus.Shelley.Eras
 import           Ouroboros.Consensus.Shelley.Ledger.Block
 import           Ouroboros.Consensus.Shelley.Ledger.Ledger
                      (ShelleyLedgerConfig (shelleyLedgerGlobals),
-                     ShelleyTxIn (..),
                      Ticked (TickedShelleyLedgerState, tickedShelleyLedgerState),
                      getPParams)
 import           Ouroboros.Consensus.Util (ShowProxy (..))
@@ -155,7 +153,6 @@ instance (ShelleyCompatible proto era, TxLimits (ShelleyBlock proto era))
   getTransactionKeySets (ShelleyTx _ tx) =
         LedgerTables
       $ KeysMK
-      $ Set.map ShelleyTxIn
         (tx ^. (bodyTxL . SL.allInputsTxBodyF))
 
 mkShelleyTx :: forall era proto. ShelleyBasedEra era => Tx era -> GenTx (ShelleyBlock proto era)

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Mempool.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Mempool.hs
@@ -282,7 +282,7 @@ reapplyShelleyTx doDiffs cfg slot vgtx st0 = do
 
     pure $ (case doDiffs of
               ComputeDiffs -> calculateDifference st0
-              IgnoreDiffs -> attachEmptyDiffs
+              IgnoreDiffs  -> attachEmptyDiffs
            )
          $ unstowLedgerTables
          $ set theLedgerLens mempoolState' st1

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Query.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Query.hs
@@ -523,9 +523,9 @@ instance ( ShelleyCompatible proto era
       hst = headerState ext
       st  = shelleyLedgerState lst
 
-  answerBlockQueryLookup = answerShelleyLookupQueries id id getShelleyTxIn
+  answerBlockQueryLookup = answerShelleyLookupQueries id id id
 
-  answerBlockQueryTraverse = answerShelleyTraversingQueries id getShelleyTxIn shelleyQFTraverseTablesPredicate
+  answerBlockQueryTraverse = answerShelleyTraversingQueries id id shelleyQFTraverseTablesPredicate
 
 instance SameDepIndex2 (BlockQuery (ShelleyBlock proto era)) where
   sameDepIndex2 GetLedgerTip GetLedgerTip
@@ -1148,7 +1148,7 @@ answerShelleyLookupQueries injTables ejTxOut ejTxIn cfg q forker =
       LedgerTables (ValuesMK values) <-
         LedgerDB.roforkerReadTables
           forker
-          (castLedgerTables $ injTables (LedgerTables $ KeysMK $ Set.map ShelleyTxIn txins))
+          (castLedgerTables $ injTables (LedgerTables $ KeysMK txins))
       pure
         $ SL.UTxO
         $ Map.mapKeys ejTxIn

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/ShelleyHFC.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/ShelleyHFC.hs
@@ -44,6 +44,7 @@ import           Data.SOP.Functors (Flip (..))
 import           Data.SOP.Index (Index (..))
 import           Data.SOP.InPairs (RequiringBoth (..), ignoringBoth)
 import           Data.SOP.Strict
+import qualified Data.SOP.Tails as Tails
 import qualified Data.Text as T (pack)
 import           Data.Typeable
 import           Data.Void (Void)
@@ -407,6 +408,7 @@ instance SL.EraTxOut era => HasHardForkTxOut '[ShelleyBlock proto era] where
   ejectHardForkTxOut IZ txOut    = txOut
   ejectHardForkTxOut (IS idx') _ = case idx' of {}
   txOutEjections = fn (unZ . unK) :* Nil
+  txOutTranslations = Tails.mk1
 
 {-------------------------------------------------------------------------------
   Queries

--- a/ouroboros-consensus-cardano/src/unstable-byronspec/Ouroboros/Consensus/ByronSpec/Ledger/Mempool.hs
+++ b/ouroboros-consensus-cardano/src/unstable-byronspec/Ouroboros/Consensus/ByronSpec/Ledger/Mempool.hs
@@ -48,7 +48,7 @@ instance LedgerSupportsMempool ByronSpecBlock where
       $ GenTx.apply cfg (unByronSpecGenTx tx) st
 
   -- Byron spec doesn't have multiple validation modes
-  reapplyTx cfg slot vtx st =
+  reapplyTx _ cfg slot vtx st =
         attachEmptyDiffs . applyDiffs st . fst
     <$> applyTx cfg DoNotIntervene slot (forgetValidatedByronSpecGenTx vtx) st
 

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Run.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Run.hs
@@ -35,6 +35,7 @@ import qualified Ouroboros.Consensus.Storage.LedgerDB.Snapshots as LedgerDB
 import qualified Ouroboros.Consensus.Storage.LedgerDB.V1 as LedgerDB.V1
 import qualified Ouroboros.Consensus.Storage.LedgerDB.V1.Args as LedgerDB.V1
 import qualified Ouroboros.Consensus.Storage.LedgerDB.V1.BackingStore.Impl.LMDB as LMDB
+import qualified Ouroboros.Consensus.Storage.LedgerDB.V2 as LedgerDB.V2
 import qualified Ouroboros.Consensus.Storage.LedgerDB.V2.Args as LedgerDB.V2
 import           Ouroboros.Consensus.Util.Args
 import           Ouroboros.Consensus.Util.IOLike
@@ -69,8 +70,17 @@ openLedgerDB lgrDbArgs@LedgerDB.LedgerDbArgs{LedgerDB.lgrFlavorArgs=LedgerDB.Led
       emptyStream
       genesisPoint
   pure (ledgerDB, intLedgerDB)
-openLedgerDB LedgerDB.LedgerDbArgs{LedgerDB.lgrFlavorArgs=LedgerDB.LedgerDbFlavorArgsV2{}} =
-  error "not defined for v2, use v1 instead for now!"
+openLedgerDB lgrDbArgs@LedgerDB.LedgerDbArgs{LedgerDB.lgrFlavorArgs=LedgerDB.LedgerDbFlavorArgsV2 args} = do
+  (ledgerDB, _, intLedgerDB) <-
+    LedgerDB.openDBInternal
+      lgrDbArgs
+      (LedgerDB.V2.mkInitDb
+        lgrDbArgs
+        args
+        (\_ -> error "no replay"))
+      emptyStream
+      genesisPoint
+  pure (ledgerDB, intLedgerDB)
 
 emptyStream :: Applicative m => ImmutableDB.StreamAPI m blk a
 emptyStream = ImmutableDB.StreamAPI $ \_ k -> k $ Right $ pure ImmutableDB.NoMoreItems

--- a/ouroboros-consensus-cardano/src/unstable-shelley-testlib/Test/Consensus/Shelley/Examples.hs
+++ b/ouroboros-consensus-cardano/src/unstable-shelley-testlib/Test/Consensus/Shelley/Examples.hs
@@ -22,6 +22,7 @@ module Test.Consensus.Shelley.Examples (
 import qualified Cardano.Ledger.Block as SL
 import qualified Cardano.Ledger.Core as LC
 import           Cardano.Ledger.Crypto (Crypto)
+import qualified Cardano.Ledger.Shelley.API as SL
 import qualified Cardano.Protocol.TPraos.BHeader as SL
 import           Data.Coerce (coerce)
 import           Data.Foldable (toList)
@@ -88,7 +89,7 @@ mkLedgerTables tx =
     $ Map.fromList
     $ zip exampleTxIns exampleTxOuts
   where
-    exampleTxIns :: [ShelleyTxIn era]
+    exampleTxIns :: [SL.TxIn (EraCrypto era)]
     exampleTxIns  = case toList (tx ^. (LC.bodyTxL . LC.allInputsTxBodyF)) of
       [] -> error "No transaction inputs were provided to construct the ledger tables"
             -- We require at least one transaction input (and one
@@ -98,7 +99,7 @@ mkLedgerTables tx =
             --
             -- Also all transactions in Cardano have at least one input for
             -- automatic replay protection.
-      xs -> map ShelleyTxIn xs
+      xs -> xs
 
     exampleTxOuts :: [LC.TxOut era]
     exampleTxOuts = case toList (tx ^. (LC.bodyTxL . LC.outputsTxBodyL)) of

--- a/ouroboros-consensus-cardano/src/unstable-shelley-testlib/Test/Consensus/Shelley/Generators.hs
+++ b/ouroboros-consensus-cardano/src/unstable-shelley-testlib/Test/Consensus/Shelley/Generators.hs
@@ -18,7 +18,6 @@ import qualified Cardano.Ledger.Shelley.API as SL
 import qualified Cardano.Protocol.TPraos.API as SL
 import qualified Cardano.Protocol.TPraos.BHeader as SL
 import           Data.Coerce (coerce)
-import qualified Data.Map.Strict as Map
 import           Generic.Random (genericArbitraryU)
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.HeaderValidation
@@ -202,7 +201,7 @@ instance CanMock proto era
     <$> arbitrary
     <*> arbitrary
     <*> arbitrary
-    <*> (LedgerTables . ValuesMK . Map.mapKeys ShelleyTxIn <$> arbitrary)
+    <*> (LedgerTables . ValuesMK <$> arbitrary)
 
 instance CanMock proto era => Arbitrary (AnnTip (ShelleyBlock proto era)) where
   arbitrary = AnnTip

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator/A.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator/A.hs
@@ -356,7 +356,7 @@ instance LedgerSupportsMempool BlockA where
         InitiateAtoB -> do
           return (TickedLedgerStateA $ st { lgrA_transition = Just sno }, ValidatedGenTxA tx)
 
-  reapplyTx cfg slot tx st =
+  reapplyTx _ cfg slot tx st =
     attachAndApplyDiffs st . fst <$> applyTx cfg DoNotIntervene slot (forgetValidatedGenTxA tx) st
 
   txForgetValidated = forgetValidatedGenTxA

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator/B.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator/B.hs
@@ -291,7 +291,7 @@ type instance ApplyTxErr BlockB = Void
 
 instance LedgerSupportsMempool BlockB where
   applyTx   = \_ _ _wti tx -> case tx of {}
-  reapplyTx = \_ _ vtx -> case vtx of {}
+  reapplyTx = \_ _ _ vtx -> case vtx of {}
 
   txForgetValidated = \case {}
 

--- a/ouroboros-consensus/bench/mempool-bench/Bench/Consensus/Mempool/TestBlock.hs
+++ b/ouroboros-consensus/bench/mempool-bench/Bench/Consensus/Mempool/TestBlock.hs
@@ -210,7 +210,7 @@ instance Ledger.LedgerSupportsMempool TestBlock where
     except $ fmap ((, ValidatedGenTx (TestBlockGenTx tx)) . Ledger.trackingToDiffs)
            $ applyDirectlyToPayloadDependentState tickedSt tx
 
-  reapplyTx cfg slot (ValidatedGenTx genTx) tickedSt =
+  reapplyTx _ cfg slot (ValidatedGenTx genTx) tickedSt =
     Ledger.attachAndApplyDiffs tickedSt . fst <$> Ledger.applyTx cfg Ledger.DoNotIntervene slot genTx tickedSt
     -- FIXME: it is ok to use 'DoNotIntervene' here?
 

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Ledger.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Ledger.hs
@@ -62,6 +62,8 @@ import           Data.SOP.InPairs (InPairs (..))
 import qualified Data.SOP.InPairs as InPairs
 import qualified Data.SOP.Match as Match
 import           Data.SOP.Strict
+import           Data.SOP.Tails (Tails)
+import qualified Data.SOP.Tails as Tails
 import           Data.SOP.Telescope (Telescope (..))
 import qualified Data.SOP.Telescope as Telescope
 import           Data.Typeable
@@ -1113,6 +1115,14 @@ class ( Show (HardForkTxOut xs)
   txOutEjections      :: NP (K (NS WrapTxOut xs) -.-> WrapTxOut) xs
   default txOutEjections :: CanHardFork xs => NP (K (NS WrapTxOut xs) -.-> WrapTxOut) xs
   txOutEjections = composeTxOutTranslations $ ipTranslateTxOut hardForkEraTranslation
+
+  txOutTails :: Tails (InPairs.Fn2 WrapTxOut) xs
+  default txOutTails :: CanHardFork xs => Tails (InPairs.Fn2 WrapTxOut) xs
+  txOutTails =
+    Tails.inPairsToTails
+     $ InPairs.hmap
+      (\translator -> InPairs.Fn2 $ WrapTxOut . translateTxOutWith translator . unwrapTxOut)
+      (translateLedgerTables (hardForkEraTranslation @xs))
 
 instance (CanHardFork xs, HasHardForkTxOut xs)
       => CanUpgradeLedgerTables (LedgerState (HardForkBlock xs)) where

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Ledger.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Ledger.hs
@@ -1112,13 +1112,20 @@ class ( Show (HardForkTxOut xs)
   -- that we only compute it once, then it is cached for the duration of the
   -- program, as we will use it very often when converting from the
   -- HardForkBlock to the particular @blk@.
+  --
+  -- This particular method is useful when our HardForkBlock uses
+  -- DefaultHardForkTxOut, so that we can implement inject and project.
   txOutEjections      :: NP (K (NS WrapTxOut xs) -.-> WrapTxOut) xs
   default txOutEjections :: CanHardFork xs => NP (K (NS WrapTxOut xs) -.-> WrapTxOut) xs
   txOutEjections = composeTxOutTranslations $ ipTranslateTxOut hardForkEraTranslation
 
-  txOutTails :: Tails (InPairs.Fn2 WrapTxOut) xs
-  default txOutTails :: CanHardFork xs => Tails (InPairs.Fn2 WrapTxOut) xs
-  txOutTails =
+  -- | This method is a null-arity method in a typeclass to make it a CAF, such
+  -- that we only compute it once, then it is cached for the duration of the
+  -- program, as we will use it very often when converting from the
+  -- HardForkBlock to the particular @blk@.
+  txOutTranslations :: Tails (InPairs.Fn2 WrapTxOut) xs
+  default txOutTranslations :: CanHardFork xs => Tails (InPairs.Fn2 WrapTxOut) xs
+  txOutTranslations =
     Tails.inPairsToTails
      $ InPairs.hmap
       (\translator -> InPairs.Fn2 $ WrapTxOut . translateTxOutWith translator . unwrapTxOut)

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Dual.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Dual.hs
@@ -604,18 +604,20 @@ instance Bridge m a => LedgerSupportsMempool (DualBlock m a) where
         }, vtx)
 
 
-  reapplyTx DualLedgerConfig{..}
+  reapplyTx doDiffs DualLedgerConfig{..}
             slot
             tx@ValidatedDualGenTx{..}
             TickedDualLedgerState{..} = do
       (main', aux') <-
         agreeOnError DualGenTxErr (
             reapplyTx
+              doDiffs
               dualLedgerConfigMain
               slot
               vDualGenTxMain
               tickedDualLedgerStateMain
           , reapplyTx
+              doDiffs
               dualLedgerConfigAux
               slot
               vDualGenTxAux

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/SupportsMempool.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/SupportsMempool.hs
@@ -10,9 +10,9 @@
 module Ouroboros.Consensus.Ledger.SupportsMempool (
     ApplyTxErr
   , ByteSize32 (..)
+  , ComputeDiffs (..)
   , ConvertRawTxId (..)
   , GenTx
-  , ComputeDiffs (..)
   , GenTxId
   , HasByteSize (..)
   , HasTxId (..)

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Tables/Utils.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Tables/Utils.hs
@@ -38,6 +38,8 @@ module Ouroboros.Consensus.Ledger.Tables.Utils (
     -- ** Reduce
   , trackingToDiffs
   , trackingToValues
+    -- * Union values
+  , unionValues
     -- * Exposed for @cardano-api@
   , applyDiffsMK
   , restrictValuesMK
@@ -306,3 +308,15 @@ restrictValues' ::
      (SameUtxoTypes l l'', SameUtxoTypes l' l'', HasLedgerTables l, HasLedgerTables l', HasLedgerTables l'')
   => l ValuesMK -> l' KeysMK -> LedgerTables l'' ValuesMK
 restrictValues' l1 l2 = ltliftA2 restrictValuesMK (ltprj l1) (ltprj l2)
+
+---
+
+-- | For this first UTxO-HD iteration, there can't be two keys with
+-- different values on the tables, thus there will never be
+-- conflicting collisions.
+unionValues ::
+     Ord k
+  => ValuesMK k v
+  -> ValuesMK k v
+  -> ValuesMK k v
+unionValues (ValuesMK m1) (ValuesMK m2) = ValuesMK $ Map.union m1 m2

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Impl/Common.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Impl/Common.hs
@@ -22,9 +22,9 @@ module Ouroboros.Consensus.Mempool.Impl.Common (
   , chainDBLedgerInterface
     -- * Validation
   , RevalidateTxsResult (..)
+  , computeSnapshot
   , revalidateTxsFor
   , validateNewTransaction
-  , computeSnapshot
     -- * Tracing
   , TraceEventMempool (..)
     -- * Conversions

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Query.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Query.hs
@@ -3,7 +3,6 @@
 -- | Queries to the mempool
 module Ouroboros.Consensus.Mempool.Query (implGetSnapshotFor) where
 
-import qualified Data.Foldable as Foldable
 import           Ouroboros.Consensus.Block.Abstract
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.SupportsMempool
@@ -34,24 +33,23 @@ implGetSnapshotFor mpEnv slot ticked readUntickedTables = do
       -- have cached, then just return it.
       pure . snapshotFromIS $ is
     else do
-       let keys = Foldable.foldMap'
-                    getTransactionKeySets
-                    [ txForgetValidated . TxSeq.txTicketTx $ tx
-                    | tx <- TxSeq.toList $ isTxs is
-                    ]
-       values <- readUntickedTables keys
-       pure $ snapshotFromIS $
-         if pointHash (isTip is) == castHash (getTipHash ticked) && isSlotNo is == slot
-         then is
-         else newInternalState
-            $ revalidateTxsFor
-                capacityOverride
-                cfg
-                slot
-                ticked
-                values
-                (isLastTicketNo is)
-                (TxSeq.toList $ isTxs is)
+      values <-
+        if pointHash (isTip is) == castHash (getTipHash ticked)
+           -- We are looking for a snapshot at the same state ticked
+           -- to a different slot, so we can reuse the cached values
+        then pure (isTxValues is)
+           -- We are looking for a snapshot at a different state, so we
+           -- need to read the values from the ledgerdb.
+        else readUntickedTables (isTxKeys is)
+      pure
+        $ computeSnapshot
+            capacityOverride
+            cfg
+            slot
+            ticked
+            values
+            (isLastTicketNo is)
+            (TxSeq.toList $ isTxs is)
  where
     MempoolEnv { mpEnvStateVar         = istate
                , mpEnvLedgerCfg        = cfg

--- a/ouroboros-consensus/src/unstable-mempool-test-utils/Test/Consensus/Mempool/Mocked.hs
+++ b/ouroboros-consensus/src/unstable-mempool-test-utils/Test/Consensus/Mempool/Mocked.hs
@@ -19,7 +19,6 @@ import           Control.Concurrent.Class.MonadSTM.Strict (StrictTVar,
                      atomically, newTVarIO, readTVar, readTVarIO, writeTVar)
 import           Control.DeepSeq (NFData (rnf))
 import           Control.Tracer (Tracer)
-import           Data.Foldable (Foldable (foldMap'))
 import qualified Data.List.NonEmpty as NE
 import           Ouroboros.Consensus.Block (castPoint)
 import           Ouroboros.Consensus.HeaderValidation as Header
@@ -70,8 +69,7 @@ openMockedMempool capacityOverride tracer initialParams = do
     currentLedgerStateTVar <- newTVarIO (immpInitialState initialParams)
     let ledgerItf = Mempool.LedgerInterface {
           Mempool.getCurrentLedgerState = forgetLedgerTables <$> readTVar currentLedgerStateTVar
-        , Mempool.getLedgerTablesAtFor  = \pt txs -> do
-            let keys = foldMap' Ledger.getTransactionKeySets txs
+        , Mempool.getLedgerTablesAtFor  = \pt keys -> do
             st <- readTVarIO currentLedgerStateTVar
             if castPoint (getTip st) == pt
               then pure $ Just $ restrictValues' st keys

--- a/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Ledger/Block.hs
+++ b/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Ledger/Block.hs
@@ -543,7 +543,7 @@ instance MockProtocolSpecific c ext
      return ( trackingToDiffs $ calculateDifference st st''
              , ValidatedSimpleGenTx tx )
 
-  reapplyTx cfg slot vtx st = attachAndApplyDiffs st . fst
+  reapplyTx _ cfg slot vtx st = attachAndApplyDiffs st . fst
     <$> applyTx cfg DoNotIntervene slot (forgetValidatedSimpleGenTx vtx) st
 
   txForgetValidated = forgetValidatedSimpleGenTx

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/Mempool.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/Mempool.hs
@@ -41,7 +41,6 @@ import           Control.Monad.State (State, evalState, get, modify)
 import           Control.Tracer (Tracer (..))
 import           Data.Bifunctor (first, second)
 import           Data.Either (isRight)
-import qualified Data.Foldable as Foldable
 import qualified Data.List as List
 import qualified Data.List.NonEmpty as NE
 import           Data.Map.Strict (Map)
@@ -658,8 +657,7 @@ withTestMempool setup@TestSetup {..} prop =
       varCurrentLedgerState <- uncheckedNewTVarM testLedgerState
       let ledgerInterface = LedgerInterface
             { getCurrentLedgerState = forgetLedgerTables <$> readTVar varCurrentLedgerState
-            , getLedgerTablesAtFor = \pt txs -> do
-                let keys = Foldable.foldMap' getTransactionKeySets txs
+            , getLedgerTablesAtFor = \pt keys -> do
                 st <- atomically $ readTVar varCurrentLedgerState
                 if castPoint (getTip st) == pt
                   then pure $ Just $ restrictValues' st keys

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/Mempool/Fairness/TestBlock.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/Mempool/Fairness/TestBlock.hs
@@ -104,7 +104,7 @@ instance Ledger.LedgerSupportsMempool TestBlock where
     , ValidatedGenTx gtx
     )
 
-  reapplyTx _cfg _slot _gtx gst = pure
+  reapplyTx _ _cfg _slot _gtx gst = pure
     $ TestBlock.TickedTestLedger
     $ convertMapKind
     $ TestBlock.getTickedTestLedger

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/Mempool/StateMachine.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/Mempool/StateMachine.hs
@@ -535,8 +535,7 @@ newLedgerInterface initialLedger = do
   t <- newTVarIO $ MockedLedgerDB initialLedger Set.empty Set.empty
   pure (LedgerInterface {
       getCurrentLedgerState = forgetLedgerTables . ldbTip <$> readTVar t
-    , getLedgerTablesAtFor  = \pt txs -> do
-        let keys = Foldable.foldMap' getTransactionKeySets txs
+    , getLedgerTablesAtFor  = \pt keys -> do
         MockedLedgerDB ti oldReachableTips _ <- atomically $ readTVar t
         if pt == castPoint (getTip ti) -- if asking for tables at the tip of the
                                        -- ledger db

--- a/sop-extras/src/Data/SOP/Tails.hs
+++ b/sop-extras/src/Data/SOP/Tails.hs
@@ -20,19 +20,19 @@ module Data.SOP.Tails (
   , mk2
   , mk3
     -- * SOP-like operators
+  , extendWithTails
   , hcmap
   , hcpure
   , hmap
   , hpure
   , inPairsToTails
-  , extendWithTails
   ) where
 
-import           Data.SOP.Index
-import qualified Data.SOP.InPairs as InPairs
 import           Data.Kind (Type)
 import           Data.Proxy
 import           Data.SOP.Constraint
+import           Data.SOP.Index
+import qualified Data.SOP.InPairs as InPairs
 import           Data.SOP.Sing
 import           Data.SOP.Strict hiding (hcmap, hcpure, hmap, hpure)
 import qualified Data.SOP.Strict as SOP


### PR DESCRIPTION
This PR accumulates some improvements for UTxO-HD that result in benefits for mempool snapshotting, which is part of the critical path for block minting (and therefore block diffusion). Running in a full-block synthetic chain shows these times for 50 consecutive mempool snapshots:

- pre: at utxo-hd-main before this PR
- caf: pre + moving the Cardano tx out translations to a CAF
- no-diffs: caf + do not compute diffs when snapshotting the mempool
- no-shtxin: no-diffs + remove the `ShelleyTxIn` newtype

![plot](https://github.com/user-attachments/assets/aef9aa50-dcde-4c43-9b76-db3d50751d52)
