### PR TITLE
Move a couple of mempool operations to work on ledgerstates instead

### DIFF
--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Impl/Common.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Impl/Common.hs
@@ -305,7 +305,7 @@ validateNewTransaction cfg wti tx txsz origValues st is =
              , isTxKeys       = isTxKeys <> getTransactionKeySets tx
              , isTxValues     = ltliftA2 unionValues isTxValues origValues
              , isTxIds        = Set.insert (txId tx) isTxIds
-             , isLedgerState  = prependDiffs isLedgerState st'
+             , isLedgerState  = prependMempoolDiffs isLedgerState st'
              , isLastTicketNo = nextTicketNo
              }
         )
@@ -347,7 +347,7 @@ revalidateTxsFor capacityOverride cfg slot st values lastTicketNo txTickets =
       unwrap = (\(tx, (tk, tz)) -> TxTicket tx tk tz)
       ReapplyTxsResult err val st' =
         reapplyTxs ComputeDiffs cfg slot theTxs
-        $ applyDiffForKeysOnTables
+        $ applyMempoolDiffs
               values
               (Foldable.foldMap' (getTransactionKeySets . txForgetValidated . fst) theTxs)
               st
@@ -395,7 +395,7 @@ computeSnapshot capacityOverride cfg slot st values lastTicketNo txTickets =
       unwrap = (\(tx, (tk, tz)) -> TxTicket tx tk tz)
       ReapplyTxsResult _ val st' =
         reapplyTxs IgnoreDiffs cfg slot theTxs
-        $ applyDiffForKeysOnTables
+        $ applyMempoolDiffs
               values
               (Foldable.foldMap' (getTransactionKeySets . txForgetValidated . fst) theTxs)
               st

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Update.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Update.hs
@@ -24,7 +24,6 @@ import           Data.Void
 import           Ouroboros.Consensus.HeaderValidation
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.SupportsMempool
-import           Ouroboros.Consensus.Ledger.Tables.Utils
 import           Ouroboros.Consensus.Mempool.API
 import           Ouroboros.Consensus.Mempool.Capacity
 import           Ouroboros.Consensus.Mempool.Impl.Common
@@ -214,7 +213,7 @@ pureTryAddTx ::
   -> LedgerTables (LedgerState blk) ValuesMK
   -> TriedToAddTx blk
 pureTryAddTx cfg wti tx is values =
-  let st = applyDiffForKeysOnTables values (getTransactionKeySets tx) (isLedgerState is) in
+  let st = applyMempoolDiffs values (getTransactionKeySets tx) (isLedgerState is) in
   case runExcept $ txMeasure cfg st tx of
     Left err ->
       -- The transaction does not have a valid measure (eg its ExUnits is


### PR DESCRIPTION
# Description

10.2
![image](https://github.com/user-attachments/assets/fe19ceec-deaf-4de1-ad42-2ab660f0589b)


UTxO-HD before this:
![image](https://github.com/user-attachments/assets/b97d1fba-64f2-4bb3-a306-bb62b427824f)

UTxO-HD after this:
![image](https://github.com/user-attachments/assets/a001e330-907f-4ac6-9807-4cee1b3247ba)

The changes are in line with what is described in #1383. There are still some more operations that could be lifted to ledger states.
