### PR TITLE
Revert "Constraint plutus to 1.37"

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -44,9 +44,3 @@ package ouroboros-network
 if(os(windows))
   constraints:
     bitvec -simd
-
-constraints:
-   -- There was a regression in 1.38 which was discarded for node 10.2. We don't
-   -- depend directly on plutus so we have to declare the bound here as a
-   -- constraint.
-   plutus ^>=1.37


### PR DESCRIPTION
This reverts commit e1a177e9b6d33cb18928b7335dd5ee25102f6a17.

We actually only need to constraint it in the `cardano-node-10.2-backports` branch
