### PR TITLE
A more precise type for Nary.inject

### DIFF
--- a/ouroboros-consensus-cardano/src/unstable-cardano-testlib/Test/Consensus/Cardano/Examples.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-testlib/Test/Consensus/Cardano/Examples.hs
@@ -96,7 +96,7 @@ combineEras = mconcat . hcollapse . hap eraInjections
       -> Examples (CardanoBlock Crypto)
     injExamples eraName idx =
           prefixExamples eraName
-        . inject exampleStartBounds idx
+        . inject (InjectionContext exampleStartBounds) idx
 
 {-------------------------------------------------------------------------------
   Inject instances

--- a/ouroboros-consensus-cardano/src/unstable-cardano-testlib/Test/Consensus/Cardano/Examples.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-testlib/Test/Consensus/Cardano/Examples.hs
@@ -96,7 +96,7 @@ combineEras = mconcat . hcollapse . hap eraInjections
       -> Examples (CardanoBlock Crypto)
     injExamples eraName idx =
           prefixExamples eraName
-        . inject (InjectionContext exampleStartBounds) idx
+        . inject (oracularInjectionIndex exampleStartBounds idx)
 
 {-------------------------------------------------------------------------------
   Inject instances
@@ -105,14 +105,16 @@ combineEras = mconcat . hcollapse . hap eraInjections
 -- | In reality, an era tag would be prepended, but we're testing that the
 -- encoder doesn't care what the bytes are.
 instance Inject Serialised where
-  inject _ _ (Serialised _) = Serialised "<CARDANO_BLOCK>"
+  inject _ (Serialised _) = Serialised "<CARDANO_BLOCK>"
 
 instance Inject SomeResult where
-  inject _ idx (SomeResult q r) =
-      SomeResult (QueryIfCurrent (injectQuery idx q)) (Right r)
+  inject iidx (SomeResult q r) =
+      SomeResult
+        (QueryIfCurrent (injectQuery (forgetInjectionIndex iidx) q))
+        (Right r)
 
 instance Inject Examples where
-  inject startBounds (idx :: Index xs x) Examples {..} = Examples {
+  inject (iidx :: InjectionIndex xs x) Examples {..} = Examples {
         exampleBlock            = inj (Proxy @I)                       exampleBlock
       , exampleSerialisedBlock  = inj (Proxy @Serialised)              exampleSerialisedBlock
       , exampleHeader           = inj (Proxy @Header)                  exampleHeader
@@ -137,7 +139,7 @@ instance Inject Examples where
            , Coercible b (f (HardForkBlock xs))
            )
         => Proxy f -> Labelled a -> Labelled b
-      inj p = fmap (fmap (inject' p startBounds idx))
+      inj p = map (fmap (inject' p iidx))
 
 {-------------------------------------------------------------------------------
   Setup

--- a/ouroboros-consensus/changelog.d/20250219_054827_nick.frisby_simplify_inject.md
+++ b/ouroboros-consensus/changelog.d/20250219_054827_nick.frisby_simplify_inject.md
@@ -1,0 +1,24 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Patch
+
+- A bullet item for the Patch category.
+
+-->
+<!--
+### Non-Breaking
+
+- A bullet item for the Non-Breaking category.
+
+-->
+
+### Breaking
+
+- Make the type of `Nary.inject` more precise.
+  The old type involves oracular data, so any required changes downstream are almost certainly limited to testing code.
+  (I'm therefore tempted to list this as Patch instead --- violating the [PVP](https://pvp.haskell.org/) --- but the risk-reward seems prohibitive.)


### PR DESCRIPTION
See the commit message of `consensus: a more precise type for Nary.inject`; the other commits are superficial.