### PR TITLE
Update Hackage index state

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -14,7 +14,7 @@ repository cardano-haskell-packages
 -- update either of these.
 index-state:
   -- Bump this if you need newer packages from Hackage
-  , hackage.haskell.org 2025-02-27T18:46:10Z
+  , hackage.haskell.org 2025-03-18T17:41:11Z
   -- Bump this if you need newer packages from CHaP
   , cardano-haskell-packages 2025-02-28T01:28:51Z
 

--- a/flake.lock
+++ b/flake.lock
@@ -237,15 +237,16 @@
     "hackageNix": {
       "flake": false,
       "locked": {
-        "lastModified": 1733877006,
-        "narHash": "sha256-rNpSFS/ziUQBPgo6iAbKgU00yRpeCngv215TW0D+kCo=",
+        "lastModified": 1742343895,
+        "narHash": "sha256-G60AWWVqGMWVrGMrHxE8l8XYJs9RcBXhlwzck7DLyig=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "583f569545854160b6bc5606374bf5006a9f6929",
+        "rev": "dc83d58b95ac0a90c84a505fb173cc32fa1e431d",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
+        "ref": "for-stackage",
         "repo": "hackage.nix",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -16,7 +16,7 @@
       inputs.hackage.follows = "hackageNix";
     };
     hackageNix = {
-      url = "github:input-output-hk/hackage.nix";
+      url = "github:input-output-hk/hackage.nix?ref=for-stackage";
       flake = false;
     };
     CHaP = {

--- a/nix/tools.nix
+++ b/nix/tools.nix
@@ -2,7 +2,7 @@ inputs: final: prev:
 
 let
   inherit (final) lib;
-  tool-index-state = "2024-07-04T00:00:00Z";
+  tool-index-state = "2025-03-18T17:41:11Z";
   tool = name: version: other:
     final.haskell-nix.tool final.hsPkgs.args.compiler-nix-name name ({
       version = version;


### PR DESCRIPTION
- bump the index state in `cabal.project`
- update hackage.nix, use the legacy `for-stackage` branch, as we still support GHC 8.10. See [this note](https://github.com/input-output-hk/hackage.nix/blob/58d6ddbb7cb41518a2f61a6b1f123308f6eece76/default.nix#L2) for more details.
- bump tool index state

This PR is needed to remove an s-r-p on `quickcheck-dynamic` in https://github.com/IntersectMBO/ouroboros-consensus/pull/1413