### PR TITLE
Update `ouroboros-network` dependency

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -16,7 +16,7 @@ index-state:
   -- Bump this if you need newer packages from Hackage
   , hackage.haskell.org 2025-03-18T17:41:11Z
   -- Bump this if you need newer packages from CHaP
-  , cardano-haskell-packages 2025-03-22T21:55:03Z
+  , cardano-haskell-packages 2025-03-25T12:18:59Z
 
 packages:
   ouroboros-consensus

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1742682696,
-        "narHash": "sha256-HaC8SF2zDA0kQg8RMRhaYQ5Qjbm5Z5oOjKFM2yhXVbw=",
+        "lastModified": 1742907334,
+        "narHash": "sha256-VArjQZ+WtYWv/TyHsX5h9FZDGCVH5y137qODc9/CV2M=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "28afce651553604f9965d7ed1e77f9752082e7b9",
+        "rev": "aaa8c01190fff618871d75448d0c02e8d12b9244",
         "type": "github"
       },
       "original": {

--- a/ouroboros-consensus-diffusion/changelog.d/js-network-bump.md
+++ b/ouroboros-consensus-diffusion/changelog.d/js-network-bump.md
@@ -1,0 +1,3 @@
+### Non-breaking
+
+- Update to `ouroboros-network-0.20.1.0` to ensure consensus can be used on Windows.

--- a/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
+++ b/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
@@ -92,7 +92,7 @@ library
     mtl,
     network-mux ^>=0.7,
     ouroboros-consensus ^>=0.22,
-    ouroboros-network ^>=0.20,
+    ouroboros-network ^>=0.20.1,
     ouroboros-network-api ^>=0.13,
     ouroboros-network-framework ^>=0.17,
     ouroboros-network-protocols ^>=0.14,


### PR DESCRIPTION
# Description

`sigUSR1Handler` was ill-typed for Windows. With this we make sure the broken version (`0.20.0.0`) is not selected.
