### PR TITLE
Expose `querySupportedVersions`

### DIFF
--- a/ouroboros-consensus-cardano/changelog.d/js-query-version.md
+++ b/ouroboros-consensus-cardano/changelog.d/js-query-version.md
@@ -1,0 +1,4 @@
+### Breaking
+
+- Define `blockQueryIsSupportedOnVersion` for Byron and Shelley.
+  - For Shelley, this is just a relocation of the now gone `querySupportedVersion` function.

--- a/ouroboros-consensus-cardano/src/byron/Ouroboros/Consensus/Byron/Ledger/Ledger.hs
+++ b/ouroboros-consensus-cardano/src/byron/Ouroboros/Consensus/Byron/Ledger/Ledger.hs
@@ -200,6 +200,7 @@ data instance BlockQuery ByronBlock :: Type -> Type where
 instance BlockSupportsLedgerQuery ByronBlock where
   answerBlockQuery _cfg GetUpdateInterfaceState (ExtLedgerState ledgerState _) =
     CC.cvsUpdateState (byronLedgerState ledgerState)
+  blockQueryIsSupportedOnVersion GetUpdateInterfaceState = const True
 
 instance SameDepIndex (BlockQuery ByronBlock) where
   sameDepIndex GetUpdateInterfaceState GetUpdateInterfaceState = Just Refl

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Query.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Query.hs
@@ -23,7 +23,6 @@ module Ouroboros.Consensus.Shelley.Ledger.Query (
   , NonMyopicMemberRewards (..)
   , StakeSnapshot (..)
   , StakeSnapshots (..)
-  , querySupportedVersion
     -- * Serialisation
   , decodeShelleyQuery
   , decodeShelleyResult
@@ -509,6 +508,53 @@ instance
       hst = headerState ext
       st  = shelleyLedgerState lst
 
+  -- | Is the given query supported by the given 'ShelleyNodeToClientVersion'?
+  blockQueryIsSupportedOnVersion = \case
+    GetLedgerTip                               -> const True
+    GetEpochNo                                 -> const True
+    GetNonMyopicMemberRewards {}               -> const True
+    GetCurrentPParams                          -> const True
+    GetProposedPParamsUpdates                  -> (< v12)
+    GetStakeDistribution                       -> const True
+    GetUTxOByAddress {}                        -> const True
+    GetUTxOWhole                               -> const True
+    DebugEpochState                            -> const True
+    GetCBOR q                                  -> blockQueryIsSupportedOnVersion q
+    GetFilteredDelegationsAndRewardAccounts {} -> const True
+    GetGenesisConfig                           -> const True
+    DebugNewEpochState                         -> const True
+    DebugChainDepState                         -> const True
+    GetRewardProvenance                        -> const True
+    GetUTxOByTxIn {}                           -> const True
+    GetStakePools                              -> const True
+    GetStakePoolParams {}                      -> const True
+    GetRewardInfoPools                         -> const True
+    GetPoolState {}                            -> const True
+    GetStakeSnapshots {}                       -> const True
+    GetPoolDistr {}                            -> const True
+    GetStakeDelegDeposits {}                   -> const True
+    GetConstitution                            -> (>= v8)
+    GetGovState                                -> (>= v8)
+    GetDRepState {}                            -> (>= v8)
+    GetDRepStakeDistr {}                       -> (>= v8)
+    GetCommitteeMembersState {}                -> (>= v8)
+    GetFilteredVoteDelegatees {}               -> (>= v8)
+    GetAccountState {}                         -> (>= v8)
+    GetSPOStakeDistr {}                        -> (>= v8)
+    GetProposals {}                            -> (>= v9)
+    GetRatifyState {}                          -> (>= v9)
+    GetFuturePParams {}                        -> (>= v10)
+    GetBigLedgerPeerSnapshot                   -> (>= v11)
+    QueryStakePoolDefaultVote {}               -> (>= v12)
+    -- WARNING: when adding a new query, a new @ShelleyNodeToClientVersionX@
+    -- must be added. See #2830 for a template on how to do this.
+   where
+    v8  = ShelleyNodeToClientVersion8
+    v9  = ShelleyNodeToClientVersion9
+    v10 = ShelleyNodeToClientVersion10
+    v11 = ShelleyNodeToClientVersion11
+    v12 = ShelleyNodeToClientVersion12
+
 instance SameDepIndex (BlockQuery (ShelleyBlock proto era)) where
   sameDepIndex GetLedgerTip GetLedgerTip
     = Just Refl
@@ -702,54 +748,6 @@ instance ShelleyCompatible proto era => ShowQuery (BlockQuery (ShelleyBlock prot
       GetFuturePParams {}                        -> show
       GetBigLedgerPeerSnapshot                   -> show
       QueryStakePoolDefaultVote {}               -> show
-
--- | Is the given query supported by the given 'ShelleyNodeToClientVersion'?
-querySupportedVersion :: BlockQuery (ShelleyBlock proto era) result -> ShelleyNodeToClientVersion -> Bool
-querySupportedVersion = \case
-    GetLedgerTip                               -> const True
-    GetEpochNo                                 -> const True
-    GetNonMyopicMemberRewards {}               -> const True
-    GetCurrentPParams                          -> const True
-    GetProposedPParamsUpdates                  -> (< v12)
-    GetStakeDistribution                       -> const True
-    GetUTxOByAddress {}                        -> const True
-    GetUTxOWhole                               -> const True
-    DebugEpochState                            -> const True
-    GetCBOR q                                  -> querySupportedVersion q
-    GetFilteredDelegationsAndRewardAccounts {} -> const True
-    GetGenesisConfig                           -> const True
-    DebugNewEpochState                         -> const True
-    DebugChainDepState                         -> const True
-    GetRewardProvenance                        -> const True
-    GetUTxOByTxIn {}                           -> const True
-    GetStakePools                              -> const True
-    GetStakePoolParams {}                      -> const True
-    GetRewardInfoPools                         -> const True
-    GetPoolState {}                            -> const True
-    GetStakeSnapshots {}                       -> const True
-    GetPoolDistr {}                            -> const True
-    GetStakeDelegDeposits {}                   -> const True
-    GetConstitution                            -> (>= v8)
-    GetGovState                                -> (>= v8)
-    GetDRepState {}                            -> (>= v8)
-    GetDRepStakeDistr {}                       -> (>= v8)
-    GetCommitteeMembersState {}                -> (>= v8)
-    GetFilteredVoteDelegatees {}               -> (>= v8)
-    GetAccountState {}                         -> (>= v8)
-    GetSPOStakeDistr {}                        -> (>= v8)
-    GetProposals {}                            -> (>= v9)
-    GetRatifyState {}                          -> (>= v9)
-    GetFuturePParams {}                        -> (>= v10)
-    GetBigLedgerPeerSnapshot                   -> (>= v11)
-    QueryStakePoolDefaultVote {}               -> (>= v12)
-    -- WARNING: when adding a new query, a new @ShelleyNodeToClientVersionX@
-    -- must be added. See #2830 for a template on how to do this.
-  where
-    v8  = ShelleyNodeToClientVersion8
-    v9  = ShelleyNodeToClientVersion9
-    v10 = ShelleyNodeToClientVersion10
-    v11 = ShelleyNodeToClientVersion11
-    v12 = ShelleyNodeToClientVersion12
 
 {-------------------------------------------------------------------------------
   Auxiliary

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Node/Serialisation.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Node/Serialisation.hs
@@ -32,6 +32,7 @@ import           Ouroboros.Consensus.HardFork.Combinator.PartialConfig
 import           Ouroboros.Consensus.HardFork.History.EpochInfo
 import           Ouroboros.Consensus.HardFork.Simple
 import           Ouroboros.Consensus.HeaderValidation
+import           Ouroboros.Consensus.Ledger.Query
 import           Ouroboros.Consensus.Ledger.SupportsMempool (GenTxId)
 import           Ouroboros.Consensus.Node.Run
 import           Ouroboros.Consensus.Node.Serialisation
@@ -294,7 +295,7 @@ instance ShelleyBasedEra era => SerialiseNodeToClient (ShelleyBlock proto era) (
 instance ShelleyCompatible proto era
       => SerialiseNodeToClient (ShelleyBlock proto era) (SomeSecond BlockQuery (ShelleyBlock proto era)) where
   encodeNodeToClient _ version (SomeSecond q)
-    | querySupportedVersion q version
+    | blockQueryIsSupportedOnVersion q version
     = encodeShelleyQuery q
     | otherwise
     = throw $ ShelleyEncoderUnsupportedQuery (SomeSecond q) version

--- a/ouroboros-consensus-cardano/src/unstable-shelley-testlib/Test/Consensus/Shelley/Generators.hs
+++ b/ouroboros-consensus-cardano/src/unstable-shelley-testlib/Test/Consensus/Shelley/Generators.hs
@@ -278,5 +278,5 @@ instance CanMock proto era
       => Arbitrary (WithVersion ShelleyNodeToClientVersion (SomeSecond BlockQuery (ShelleyBlock proto era))) where
   arbitrary = do
       query@(SomeSecond q) <- arbitrary
-      version <- arbitrary `suchThat` querySupportedVersion q
+      version <- arbitrary `suchThat` blockQueryIsSupportedOnVersion q
       return $ WithVersion version query

--- a/ouroboros-consensus-diffusion/changelog.d/js-query-version.md
+++ b/ouroboros-consensus-diffusion/changelog.d/js-query-version.md
@@ -1,0 +1,1 @@
+<!-- empty, only two redundant constraints were removed -->

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToClient.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToClient.hs
@@ -180,7 +180,6 @@ type ClientCodecs blk  m =
 defaultCodecs :: forall m blk.
                  ( MonadST m
                  , SerialiseNodeToClientConstraints blk
-                 , ShowQuery (BlockQuery blk)
                  , StandardHash blk
                  , Serialise (HeaderHash blk)
                  )
@@ -241,7 +240,6 @@ defaultCodecs ccfg version networkVersion = Codecs {
 clientCodecs :: forall m blk.
                 ( MonadST m
                 , SerialiseNodeToClientConstraints blk
-                , ShowQuery (BlockQuery blk)
                 , StandardHash blk
                 , Serialise (HeaderHash blk)
                 )

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator/A.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator/A.hs
@@ -358,6 +358,7 @@ data instance BlockQuery BlockA result
 
 instance BlockSupportsLedgerQuery BlockA where
   answerBlockQuery _ qry = case qry of {}
+  blockQueryIsSupportedOnVersion qry _ = case qry of {}
 
 instance SameDepIndex (BlockQuery BlockA) where
   sameDepIndex qry _qry' = case qry of {}

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator/B.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator/B.hs
@@ -291,6 +291,7 @@ data instance BlockQuery BlockB result
 
 instance BlockSupportsLedgerQuery BlockB where
   answerBlockQuery _ qry = case qry of {}
+  blockQueryIsSupportedOnVersion qry _ = case qry of {}
 
 instance SameDepIndex (BlockQuery BlockB) where
   sameDepIndex qry _qry' = case qry of {}

--- a/ouroboros-consensus/changelog.d/js-query-version.md
+++ b/ouroboros-consensus/changelog.d/js-query-version.md
@@ -1,0 +1,4 @@
+### Breaking
+
+- Add method `blockQueryIsSupportedOnVersion` to `BlockSupportsLedgerQuery`.
+- Export new function `querySupportedVersions`.

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -117,6 +117,7 @@ library
     Ouroboros.Consensus.HardFork.Combinator.Ledger.Query
     Ouroboros.Consensus.HardFork.Combinator.Lifting
     Ouroboros.Consensus.HardFork.Combinator.Mempool
+    Ouroboros.Consensus.HardFork.Combinator.NetworkVersion
     Ouroboros.Consensus.HardFork.Combinator.Node
     Ouroboros.Consensus.HardFork.Combinator.Node.DiffusionPipelining
     Ouroboros.Consensus.HardFork.Combinator.Node.InitStorage

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/NetworkVersion.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/NetworkVersion.hs
@@ -1,0 +1,110 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+-- | Defines the different NTC and NTN versions for the HardFork Combinator.
+
+module Ouroboros.Consensus.HardFork.Combinator.NetworkVersion (
+    EraNodeToClientVersion (..)
+  , HardForkNodeToClientVersion (..)
+  , HardForkNodeToNodeVersion (..)
+  , HardForkSpecificNodeToClientVersion (..)
+  , HardForkSpecificNodeToNodeVersion (..)
+  , isHardForkNodeToClientEnabled
+  , isHardForkNodeToNodeEnabled
+  ) where
+
+import           Data.SOP.Constraint
+import           Data.SOP.Strict
+import           Ouroboros.Consensus.HardFork.Combinator.Basics
+import           Ouroboros.Consensus.Node.NetworkProtocolVersion
+import           Ouroboros.Consensus.TypeFamilyWrappers
+
+{-------------------------------------------------------------------------------
+  Versioning
+-------------------------------------------------------------------------------}
+
+-- | Versioning of the specific additions made by the HFC to the @NodeToNode@
+-- protocols, e.g., the era tag.
+data HardForkSpecificNodeToNodeVersion =
+    HardForkSpecificNodeToNodeVersion1
+  deriving (Eq, Ord, Show, Enum, Bounded)
+
+-- | Versioning of the specific additions made by the HFC to the @NodeToClient@
+-- protocols, e.g., the era tag or the hard-fork specific queries.
+data HardForkSpecificNodeToClientVersion =
+    -- | Include the Genesis window in 'EraParams'.
+    HardForkSpecificNodeToClientVersion3
+  deriving (Eq, Ord, Show, Enum, Bounded)
+
+data HardForkNodeToNodeVersion xs where
+  -- | Disable the HFC
+  --
+  -- This means that only the first era (@x@) is supported, and moreover, is
+  -- compatible with serialisation used if the HFC would not be present at all.
+  HardForkNodeToNodeDisabled ::
+       BlockNodeToNodeVersion x
+    -> HardForkNodeToNodeVersion (x ': xs)
+
+  -- | Enable the HFC
+  --
+  -- Serialised values will always include tags inserted by the HFC to
+  -- distinguish one era from another. We version the hard-fork specific parts
+  -- with 'HardForkSpecificNodeToNodeVersion'.
+  HardForkNodeToNodeEnabled ::
+       HardForkSpecificNodeToNodeVersion
+    -> NP WrapNodeToNodeVersion xs
+    -> HardForkNodeToNodeVersion xs
+
+data HardForkNodeToClientVersion xs where
+  -- | Disable the HFC
+  --
+  -- See 'HardForkNodeToNodeDisabled'
+  HardForkNodeToClientDisabled ::
+       BlockNodeToClientVersion x
+    -> HardForkNodeToClientVersion (x ': xs)
+
+  -- | Enable the HFC
+  --
+  -- See 'HardForkNodeToNodeEnabled'
+  HardForkNodeToClientEnabled ::
+       HardForkSpecificNodeToClientVersion
+    -> NP EraNodeToClientVersion xs
+    -> HardForkNodeToClientVersion xs
+
+data EraNodeToClientVersion blk =
+    EraNodeToClientEnabled !(BlockNodeToClientVersion blk)
+  | EraNodeToClientDisabled
+
+deriving instance Show (BlockNodeToClientVersion blk) => Show (EraNodeToClientVersion blk)
+
+deriving instance Eq (BlockNodeToClientVersion blk) => Eq (EraNodeToClientVersion blk)
+
+deriving instance (All HasNetworkProtocolVersion xs, All (Compose Show WrapNodeToNodeVersion) xs) => Show (HardForkNodeToNodeVersion xs)
+deriving instance (All HasNetworkProtocolVersion xs, All (Compose Show EraNodeToClientVersion) xs) => Show (HardForkNodeToClientVersion xs)
+
+deriving instance (All HasNetworkProtocolVersion xs, All (Compose Eq WrapNodeToNodeVersion) xs) => Eq (HardForkNodeToNodeVersion xs)
+deriving instance (All HasNetworkProtocolVersion xs, All (Compose Eq EraNodeToClientVersion) xs) => Eq (HardForkNodeToClientVersion xs)
+
+instance ( All (Compose Show WrapNodeToNodeVersion) xs
+         , All (Compose Eq WrapNodeToNodeVersion) xs
+         , All (Compose Show EraNodeToClientVersion) xs
+         , All (Compose Eq EraNodeToClientVersion) xs
+         , All HasNetworkProtocolVersion xs)
+    => HasNetworkProtocolVersion (HardForkBlock xs) where
+  type BlockNodeToNodeVersion   (HardForkBlock xs) = HardForkNodeToNodeVersion   xs
+  type BlockNodeToClientVersion (HardForkBlock xs) = HardForkNodeToClientVersion xs
+
+isHardForkNodeToNodeEnabled :: HardForkNodeToNodeVersion xs -> Bool
+isHardForkNodeToNodeEnabled HardForkNodeToNodeEnabled {} = True
+isHardForkNodeToNodeEnabled _                            = False
+
+isHardForkNodeToClientEnabled :: HardForkNodeToClientVersion xs -> Bool
+isHardForkNodeToClientEnabled HardForkNodeToClientEnabled {} = True
+isHardForkNodeToClientEnabled _                              = False

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Dual.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Dual.hs
@@ -528,6 +528,7 @@ instance (Typeable m, Typeable a)
 -- | Not used in the tests: no constructors
 instance Bridge m a => BlockSupportsLedgerQuery (DualBlock m a) where
   answerBlockQuery _ = \case {}
+  blockQueryIsSupportedOnVersion qry _ = case qry of {}
 
 instance SameDepIndex (BlockQuery (DualBlock m a)) where
   sameDepIndex = \case {}

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Node/Run.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Node/Run.hs
@@ -76,6 +76,8 @@ class ( Typeable blk
       , SerialiseNodeToClient blk (LedgerConfig blk)
       , SerialiseResult       blk (BlockQuery blk)
       , SerialiseNodeToClient blk (LedgerConfig blk)
+      , BlockSupportsLedgerQuery blk
+      , Show (BlockNodeToClientVersion blk)
       ) => SerialiseNodeToClientConstraints blk
 
 class ( LedgerSupportsProtocol           blk

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/Serialisation/Roundtrip.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/Serialisation/Roundtrip.hs
@@ -214,7 +214,6 @@ roundtrip_all
      , SerialiseNodeToClientConstraints blk
 
      , Show (BlockNodeToNodeVersion   blk)
-     , Show (BlockNodeToClientVersion blk)
 
      , StandardHash blk
      , GetHeader    blk
@@ -263,7 +262,6 @@ roundtrip_all_skipping
      , SerialiseNodeToClientConstraints blk
 
      , Show (BlockNodeToNodeVersion   blk)
-     , Show (BlockNodeToClientVersion blk)
 
      , StandardHash blk
      , GetHeader    blk
@@ -534,7 +532,6 @@ roundtrip_SerialiseNodeToNode ccfg =
 roundtrip_SerialiseNodeToClient
   :: forall blk.
      ( SerialiseNodeToClientConstraints blk
-     , Show (BlockNodeToClientVersion blk)
      , ArbitraryWithVersion (BlockNodeToClientVersion blk) blk
      , ArbitraryWithVersion (BlockNodeToClientVersion blk) (GenTx blk)
      , ArbitraryWithVersion (BlockNodeToClientVersion blk) (ApplyTxErr blk)

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/TestBlock.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/TestBlock.hs
@@ -650,6 +650,7 @@ data instance BlockQuery TestBlock result where
 instance BlockSupportsLedgerQuery TestBlock where
   answerBlockQuery _cfg QueryLedgerTip (ExtLedgerState TestLedger { lastAppliedPoint } _) =
     lastAppliedPoint
+  blockQueryIsSupportedOnVersion QueryLedgerTip = const True
 
 instance SameDepIndex (BlockQuery TestBlock) where
   sameDepIndex QueryLedgerTip QueryLedgerTip = Just Refl

--- a/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Ledger/Block.hs
+++ b/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Ledger/Block.hs
@@ -534,6 +534,7 @@ instance MockProtocolSpecific c ext => BlockSupportsLedgerQuery (SimpleBlock c e
         castPoint
       . ledgerTipPoint
       . ledgerState
+  blockQueryIsSupportedOnVersion QueryLedgerTip = const True
 
 instance SameDepIndex (BlockQuery (SimpleBlock c ext)) where
   sameDepIndex QueryLedgerTip QueryLedgerTip = Just Refl

--- a/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Node.hs
+++ b/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Node.hs
@@ -38,9 +38,6 @@ import           Ouroboros.Consensus.Util.RedundantConstraints
   RunNode instance for the mock ledger
 -------------------------------------------------------------------------------}
 
-instance HasNetworkProtocolVersion (SimpleBlock SimpleMockCrypto ext) where
-  -- Use defaults
-
 instance SupportedNetworkProtocolVersion (SimpleBlock SimpleMockCrypto ext) where
   supportedNodeToNodeVersions   _ = Map.singleton maxBound ()
   supportedNodeToClientVersions _ = Map.singleton maxBound ()

--- a/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Node/Serialisation.hs
+++ b/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Node/Serialisation.hs
@@ -23,6 +23,7 @@ import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.SupportsMempool
 import           Ouroboros.Consensus.Mock.Ledger
 import           Ouroboros.Consensus.Mock.Node.Abstract
+import           Ouroboros.Consensus.Node.NetworkProtocolVersion
 import           Ouroboros.Consensus.Node.Run
 import           Ouroboros.Consensus.Node.Serialisation
 import           Ouroboros.Consensus.Storage.Serialisation
@@ -66,6 +67,9 @@ instance DecodeDisk (MockBlock ext) (AnnTip (MockBlock ext)) where
   possible.
 -------------------------------------------------------------------------------}
 
+instance HasNetworkProtocolVersion (MockBlock ext) where
+  -- Use defaults
+
 instance Serialise ext => SerialiseNodeToNodeConstraints (MockBlock ext) where
   estimateBlockSize hdr =
       7 {- CBOR-in-CBOR -} + 1 {- encodeListLen 2 -} + hdrSize + bodySize
@@ -95,7 +99,7 @@ instance SerialiseNodeToNode (MockBlock ext) (GenTxId (MockBlock ext))
   possible.
 -------------------------------------------------------------------------------}
 
-instance (Serialise ext, Typeable ext, Serialise (MockLedgerConfig SimpleMockCrypto ext))
+instance (Serialise ext, Typeable ext, Serialise (MockLedgerConfig SimpleMockCrypto ext), MockProtocolSpecific SimpleMockCrypto ext)
       => SerialiseNodeToClientConstraints (MockBlock ext)
 
 instance Serialise ext => SerialiseNodeToClient (MockBlock ext) (MockBlock ext) where


### PR DESCRIPTION
This PR exposes a `querySupportedVersions` function that provides the list of versions in which a query is available, to be used by `cardano-api`
