### PR TITLE
Add version `0.5` and its publishing date to the `utxo-db-api` doc

### DIFF
--- a/docs/tech-reports/utxo-db/utxo-db-api.tex
+++ b/docs/tech-reports/utxo-db/utxo-db-api.tex
@@ -14,6 +14,7 @@
 \usetikzlibrary{shapes.geometric}
 \usetikzlibrary{matrix}
 \usepackage{natbib}
+\usepackage{changelog}
 \usepackage{hyperref}
 \usepackage[capitalise,noabbrev,nameinlink]{cleveref}
 \hypersetup{
@@ -42,6 +43,11 @@
    }
 
 \maketitle
+
+\begin{changelog}[simple, sectioncmd=\section*]
+  \shortversion{author=Joris Dral, v=0.6, date=August 2023, changes={Editorial changes, final version}}
+  \shortversion{author={Duncan Coutts, Douglas Wilson}, v=0.5, date=November 2021, changes=Unfinished version}
+\end{changelog}
 
 \section{Purpose}
 

--- a/docs/tech-reports/utxo-db/utxo-db.tex
+++ b/docs/tech-reports/utxo-db/utxo-db.tex
@@ -12,6 +12,7 @@
 \usepackage{dcolumn}
 \usepackage{graphicx}
 \usepackage{natbib}
+\usepackage{changelog}
 \usepackage{hyperref}
 \usepackage[capitalise,noabbrev,nameinlink]{cleveref}
 \hypersetup{
@@ -33,6 +34,10 @@
    }
 
 \maketitle
+
+\begin{changelog}[simple, sectioncmd=\section*]
+  \shortversion{author={Duncan Coutts, Douglas Wilson}, v=1.0, date=April 2021, changes=Final version}
+\end{changelog}
 
 \section{Introduction}
 \label{introduction}
@@ -1124,7 +1129,7 @@ databases, including for example SQLite and PostgreSQL. There is also an
 existing Haskell implementation of a B+ tree on hackage%
 \footnote{\url{https://hackage.haskell.org/package/haskey}}.
 
-We do not expect to be able to meet the minimum performance targets (see 
+We do not expect to be able to meet the minimum performance targets (see
 \cref{performance-requirements}) with a B+ tree based solution. The ability to
 reuse an existing implementation is a clear benefit for development time. This
 could therefore be a useful interim solution, on route to the final delivery.


### PR DESCRIPTION
Soon, we'll publish a technical report that is related to lsm-tree, which refers
to version 0.5 of the "Storing the Cardano ledger state on disk: API design
concepts" document. Currently the latter only mentions version 0.6 on its title
page, but to reduce confusion with publishing dates, we'll also add version 0.5
to the list of published versions, with the appropriate date.

I'v added changelogs to the two `utxo-db` and `utxo-db-api` docs, to facilitate
the versioning information.

The changelogs look something like this:

![image](https://github.com/user-attachments/assets/f6132fea-d578-466d-a71a-028773a677c0)

![image](https://github.com/user-attachments/assets/44920a03-8423-4762-88cf-281d8aad4fd8)
