### PR TITLE
db-immutaliser: more info on volatile candidates 

### DIFF
--- a/ouroboros-consensus-cardano/README.md
+++ b/ouroboros-consensus-cardano/README.md
@@ -335,6 +335,8 @@ Additional flags:
    immutable tip in the graphviz DOT format to a file. The `dot` CLI tool can
    then be used to graphically render this tree.
 
+ - `--dry-run`: Do not actually append anything to the ImmutableDB.
+
 ## db-synthesizer
 
 ### About

--- a/ouroboros-consensus-cardano/README.md
+++ b/ouroboros-consensus-cardano/README.md
@@ -326,6 +326,15 @@ cabal run db-immutaliser -- \
 The `config.json` should be in the same format (Node configuration) as for eg
 db-analyser.
 
+Additional flags:
+
+ - `--verbose`: Print additional information on the blocks reachable from the
+   immutable tip, as well as all possible volatile candidates.
+
+ - `--dot-out /path/to/volatile.dot`: Write the block tree rooted at the
+   immutable tip in the graphviz DOT format to a file. The `dot` CLI tool can
+   then be used to graphically render this tree.
+
 ## db-synthesizer
 
 ### About

--- a/ouroboros-consensus-cardano/app/db-immutaliser.hs
+++ b/ouroboros-consensus-cardano/app/db-immutaliser.hs
@@ -45,4 +45,8 @@ optsParser =
         [ long "dot-out"
         , help "Write the volatile block tree to a file in DOT format"
         ]
-      pure Opts {dbDirs, configFile, verbose, dotOut}
+      dryRun <- switch $ mconcat
+        [ long "dry-run"
+        , help "Do not actually append anything to the ImmutableDB"
+        ]
+      pure Opts {dbDirs, configFile, verbose, dotOut, dryRun}

--- a/ouroboros-consensus-cardano/app/db-immutaliser.hs
+++ b/ouroboros-consensus-cardano/app/db-immutaliser.hs
@@ -37,4 +37,12 @@ optsParser =
         , help "Path to config file, in the same format as for the node or db-analyser"
         , metavar "PATH"
         ]
-      pure Opts {dbDirs, configFile}
+      verbose <- switch $ mconcat
+        [ long "verbose"
+        , help "Enable verbose logging"
+        ]
+      dotOut <- optional $ strOption $ mconcat
+        [ long "dot-out"
+        , help "Write the volatile block tree to a file in DOT format"
+        ]
+      pure Opts {dbDirs, configFile, verbose, dotOut}

--- a/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
+++ b/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
@@ -566,6 +566,7 @@ library unstable-cardano-tools
     containers >=0.5 && <0.8,
     contra-tracer,
     directory,
+    dot,
     filepath,
     fs-api ^>=0.3,
     githash,

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBImmutaliser/Run.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBImmutaliser/Run.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DeriveTraversable #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
@@ -20,13 +21,19 @@ module Cardano.Tools.DBImmutaliser.Run (
 import qualified Cardano.Tools.DBAnalyser.Block.Cardano as Cardano
 import           Cardano.Tools.DBAnalyser.HasAnalysis (mkProtocolInfo)
 import           Control.ResourceRegistry
-import           Control.Tracer (Tracer, stdoutTracer, traceWith)
+import           Control.Tracer (Tracer (..), stdoutTracer, traceWith)
 import           Data.Foldable (for_)
 import           Data.Functor.Contravariant ((>$<))
+import           Data.List (intercalate, sortOn)
 import           Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NE
-import           Data.Semigroup (Arg (..), ArgMax, Max (..))
+import           Data.Maybe (fromJust, listToMaybe)
+import           Data.Ord (Down (..))
+import           Data.Set (Set)
+import qualified Data.Set as Set
+import qualified Data.Text as T
 import           Data.Traversable (for)
+import qualified Dot
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
@@ -42,6 +49,7 @@ import           Ouroboros.Consensus.Storage.VolatileDB (VolatileDB,
                      VolatileDbArgs (..))
 import qualified Ouroboros.Consensus.Storage.VolatileDB.API as VolatileDB
 import qualified Ouroboros.Consensus.Storage.VolatileDB.Impl as VolatileDB
+import           Ouroboros.Consensus.Util
 import           Ouroboros.Consensus.Util.Args
 import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Network.Block (MaxSlotNo)
@@ -52,16 +60,25 @@ import           System.FS.IO (ioHasFS)
 data Opts = Opts {
     dbDirs     :: DBDirs FilePath
   , configFile :: FilePath
+  , verbose    :: Bool
+  , dotOut     :: Maybe FilePath
   }
 
 run :: Opts -> IO ()
-run Opts {dbDirs, configFile} = do
+run Opts {dbDirs, configFile, verbose, dotOut} = do
     let dbDirs' = SomeHasFS . ioHasFS . MountPoint <$> dbDirs
         args    = Cardano.CardanoBlockArgs configFile Nothing
     ProtocolInfo{pInfoConfig = cfg} <- mkProtocolInfo args
     withRegistry $ \registry ->
       withDBs cfg registry dbDirs' $
-        immutalise (configBlock cfg) (show >$< stdoutTracer)
+        immutalise (configBlock cfg) (tracer <> dotTracer)
+  where
+    tracer = prettyTrace verbose >$< stdoutTracer
+    dotTracer = Tracer $ \case
+      TraceAllCandidates candidates -> do
+        let dot = dotCandidates $ fst <$> candidates
+        whenJust dotOut $ flip Dot.encodeToFile dot
+      _ -> pure ()
 
 {-------------------------------------------------------------------------------
   Setup
@@ -115,31 +132,6 @@ withDBs cfg registry dbDirs f =
   Immutalise
 -------------------------------------------------------------------------------}
 
-data TraceImmutalisationEvent blk =
-    TraceStartImmutalisation
-      -- | Tip of the ImmutableDB.
-      (WithOrigin (Tip blk))
-      -- | 'MaxSlotNo' of the VolatileDB.
-      MaxSlotNo
-  | -- | No blocks in the VolatileDB extend the immutable tip.
-    TraceNoVolatileCandidate
-  | -- | Found a volatile candidate extending the immutable tip.
-    TraceFoundCandidate
-      -- | Hash of the candidate tip.
-      (HeaderHash blk)
-      -- | Blocks to be added to the ImmutableDB.
-      Int
-      -- | 'SelectView' of the candidate tip.
-      (SelectView (BlockProtocol blk))
-  | TraceCopiedtoImmutableDB
-      -- | New tip of the ImmutableDB.
-      (WithOrigin (Tip blk))
-
-deriving stock instance
-  ( ConsensusProtocol (BlockProtocol blk)
-  , StandardHash blk
-  ) => Show (TraceImmutalisationEvent blk)
-
 -- | Copy a specific chain from the given 'VolatileDB' to the 'ImmutableDB',
 -- such that other tools that only work with an 'ImmutableDB' can process the
 -- corresponding blocks.
@@ -170,24 +162,37 @@ immutalise bcfg tracer immDB volDB = do
     volMaxSlotNo <- atomically $ VolatileDB.getMaxSlotNo volDB
     traceWith tracer $ TraceStartImmutalisation immTip volMaxSlotNo
 
-    succsOf <- atomically $ VolatileDB.filterByPredecessor volDB
+    (succsOf, getBlockInfo) <- atomically $
+      (,) <$> VolatileDB.filterByPredecessor volDB <*> VolatileDB.getBlockInfo volDB
     let candidates =
           Paths.maximalCandidates succsOf Nothing (tipToPoint immTip)
+
+        -- All blocks that are reachable from the immutable tip. There might be
+        -- further blocks in the VolatileDB, but the public API currently does
+        -- not provide a way to observe them.
+        reachableBlocks :: [VolatileDB.BlockInfo blk]
+        reachableBlocks =
+            fmap (fromJust . getBlockInfo)
+          $ Set.toAscList $ foldMap (Set.fromList . NE.toList) candidates
+    traceWith tracer $ TraceReachableBlocks reachableBlocks
+
     candidatesAndTipHdrs <- for candidates $ \candidate -> do
       tipHdr <-
         VolatileDB.getKnownBlockComponent volDB GetHeader (NE.last candidate)
       pure (candidate, tipHdr)
-    let mBestCandidate ::
-             Maybe (ArgMax (SelectView (BlockProtocol blk)) (NonEmpty (HeaderHash blk)))
-        mBestCandidate = mconcat $ do
+    let sortedCandidates ::
+             [(NonEmpty (HeaderHash blk), SelectView (BlockProtocol blk))]
+        sortedCandidates = sortOn (Down . snd) $ do
           (candidate, tipHdr) <- candidatesAndTipHdrs
-          pure $ Just $ Max $ Arg (selectView bcfg tipHdr) candidate
+          pure (candidate, selectView bcfg tipHdr)
 
-    case mBestCandidate of
-      Nothing                       -> do
+    traceWith tracer $ TraceAllCandidates sortedCandidates
+
+    case sortedCandidates of
+      []                  -> do
         traceWith tracer TraceNoVolatileCandidate
-      Just (Max (Arg sv candidate)) -> do
-        traceWith tracer $ TraceFoundCandidate
+      (candidate, sv) : _ -> do
+        traceWith tracer $ TraceCandidateToImmutalise
           (NE.last candidate)
           (NE.length candidate)
           sv
@@ -199,3 +204,115 @@ immutalise bcfg tracer immDB volDB = do
 
         newImmTip <- atomically $ ImmutableDB.getTip immDB
         traceWith tracer $ TraceCopiedtoImmutableDB newImmTip
+
+{-------------------------------------------------------------------------------
+  Tracing
+-------------------------------------------------------------------------------}
+
+data TraceImmutalisationEvent blk =
+    TraceStartImmutalisation
+      -- | Tip of the ImmutableDB.
+      (WithOrigin (Tip blk))
+      -- | 'MaxSlotNo' of the VolatileDB.
+      MaxSlotNo
+  | TraceReachableBlocks
+      -- | The set of volatile blocks reachable from the immutable tip.
+      [VolatileDB.BlockInfo blk]
+  | -- | No blocks in the VolatileDB extend the immutable tip.
+    TraceNoVolatileCandidate
+  | -- | Found these volatile candidates extending the immutable tip.
+    TraceAllCandidates
+      -- | Each candidate is represented by its block hashes of the candidate
+      -- after the immutable tip, and the 'SelectView' of the candidate tip. The
+      -- candidates are sorted by this 'SelectView' in decreasing order.
+      [(NonEmpty (HeaderHash blk), SelectView (BlockProtocol blk))]
+  | -- | The volatile candidate to immutalise.
+    TraceCandidateToImmutalise
+      -- | Hash of the candidate tip.
+      (HeaderHash blk)
+      -- | Blocks to be added to the ImmutableDB.
+      Int
+      -- | 'SelectView' of the candidate tip.
+      (SelectView (BlockProtocol blk))
+  | TraceCopiedtoImmutableDB
+      -- | New tip of the ImmutableDB.
+      (WithOrigin (Tip blk))
+
+deriving stock instance
+  ( ConsensusProtocol (BlockProtocol blk)
+  , StandardHash blk
+  ) => Show (TraceImmutalisationEvent blk)
+
+prettyTrace ::
+     forall blk.
+     ( ConsensusProtocol (BlockProtocol blk)
+     , StandardHash blk
+     )
+  => Bool -- ^ verbose?
+  -> TraceImmutalisationEvent blk
+  -> String
+prettyTrace verbose = \case
+    TraceStartImmutalisation immTip volMaxSlot ->
+         "Start immutalisation: ImmutableDB tip at " <> show immTip
+      <> ", VolatileDB max slot at " <> show volMaxSlot
+    TraceReachableBlocks reachableBlocks ->
+         "Number of volatile blocks reachable from ImmutableDB tip: "
+      <> show (length reachableBlocks) <> " (VolatileDB might contain more blocks)"
+      <> if verbose then "\nAll hashes:\n" <> unlines (render <$> reachableBlocks) else ""
+      where
+        render :: VolatileDB.BlockInfo blk -> String
+        render bi = intercalate "\t" [show biHash, show biSlotNo, show biBlockNo]
+          where
+            VolatileDB.BlockInfo {
+                VolatileDB.biHash
+              , VolatileDB.biSlotNo
+              , VolatileDB.biBlockNo
+              } = bi
+    TraceNoVolatileCandidate ->
+         "No volatile candidate found for immutalisation"
+    TraceAllCandidates candidates -> unlines $
+         "Number of candidates: " <> show (length candidates)
+       : concat [selectViewInfo | verbose]
+      where
+        selectViewInfo =
+            "All candidates:"
+          : [ unlines
+                [ " - Length: " <> show (NE.length c)
+                , "   Tip hash: " <> show (NE.last c)
+                , "   " <> show sv
+                ]
+            | (c, sv) <- candidates
+            ]
+    TraceCandidateToImmutalise tipHash numBlocks sv ->
+         "Immutalising volatile candidate of length " <> show numBlocks
+      <> " with tip hash " <> show tipHash
+      <> if verbose then " and tip select view " <> show sv else ""
+    TraceCopiedtoImmutableDB newImmTip ->
+         "Copied to ImmutableDB, new tip is " <> show newImmTip
+
+-- | Construct a 'Dot.DotGraph' out of a list of candidates.
+dotCandidates :: forall hash. Show hash => [NonEmpty hash] -> Dot.DotGraph
+dotCandidates candidates =
+    Dot.DotGraph Dot.Strict Dot.Directed Nothing $ do
+      candidate <- fmap renderHash . NE.toList <$> candidates
+      (from, to) <- zip ("ImmTip" : candidate) candidate
+      let fromTo = Dot.ListTwo (toNode from) (toNode to) []
+      pure $ Dot.StatementEdge $ Dot.EdgeStatement fromTo []
+  where
+    toNode :: String -> Dot.EdgeElement
+    toNode l = Dot.EdgeNode $ Dot.NodeId (Dot.Id $ T.pack l) Nothing
+
+    -- Render a shortened hash like in git, i.e. the smallest prefix length
+    -- such that the hashes still are unique.
+    renderHash :: hash -> String
+    renderHash = take prefix . show
+      where
+        prefix = fromJust $ listToMaybe $
+            [ k
+            | k <- [4..]
+            , Set.size (Set.map (take k) allHashes) == Set.size allHashes
+            ]
+
+        allHashes :: Set String
+        allHashes =
+            foldMap (Set.fromList . fmap show . NE.toList) candidates

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBImmutaliser/Run.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBImmutaliser/Run.hs
@@ -140,8 +140,6 @@ deriving stock instance
   , StandardHash blk
   ) => Show (TraceImmutalisationEvent blk)
 
--- data ImmutalisationException =
-
 -- | Copy a specific chain from the given 'VolatileDB' to the 'ImmutableDB',
 -- such that other tools that only work with an 'ImmutableDB' can process the
 -- corresponding blocks.

--- a/ouroboros-consensus-cardano/test/tools-test/Main.hs
+++ b/ouroboros-consensus-cardano/test/tools-test/Main.hs
@@ -59,6 +59,7 @@ testImmutaliserConfig =
    , DBImmutaliser.configFile = nodeConfig
    , DBImmutaliser.verbose = False
    , DBImmutaliser.dotOut = Nothing
+   , DBImmutaliser.dryRun = False
    }
 
 testAnalyserConfig :: DBAnalyserConfig

--- a/ouroboros-consensus-cardano/test/tools-test/Main.hs
+++ b/ouroboros-consensus-cardano/test/tools-test/Main.hs
@@ -57,6 +57,8 @@ testImmutaliserConfig =
         , DBImmutaliser.volDBDir = chainDB <> "/volatile"
         }
    , DBImmutaliser.configFile = nodeConfig
+   , DBImmutaliser.verbose = False
+   , DBImmutaliser.dotOut = Nothing
    }
 
 testAnalyserConfig :: DBAnalyserConfig


### PR DESCRIPTION
Enrich db-immutaliser to print info about the candidates in a VolatileDB. This is useful when analyzing a VolatileDB with a priori unknown content (especially when it contains various forks).

Concretely, it will print all maximal candidates, as well as a block tree illustrating the fork relation.

An invocation looks like this (also see the updated README section):
```
db-immutaliser --immutable-db /path/to/immutable --volatile-db /path/to/volatile --config /path/to/config.json \ 
  --verbose --dot-out /path/to/block-tree.dot --dry-run
```

Here, `/path/to/out-imm` must be the path to an appropriate ImmutableDB (we are only processing volatile blocks that are reachable from the immutable tip) that will *not* be modified here due to `--dry-run` (new in this PR). In the simple case where no blocks are immutable yet (which can be the case for short-lived testnets), this can just be an empty directory.

The resulting block tree can be visually rendered as a graph, see the README, or https://github.com/IntersectMBO/ouroboros-consensus/pull/1482#issuecomment-2828083404 for an example.

---

A potential alternative is to put this into a separate tool, but that could also happen later.