### PR TITLE
Drop GHC 8.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ["8.10.7", "9.6.6", "9.10.1", "9.12"]
+        ghc: ["9.6.6", "9.10.1", "9.12"]
         variant: [default, no-thunks]
         test-set: [all, no-thunks-safe]
         exclude:
@@ -193,7 +193,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ["8.10.7", "9.6.6", "9.10.1"]
+        ghc: ["9.6.6", "9.10.1"]
 
     steps:
     - uses: actions/checkout@v4

--- a/nix/ci.nix
+++ b/nix/ci.nix
@@ -42,11 +42,6 @@ let
       formattingLinting = import ./formatting-linting.nix pkgs;
       inherit (pkgs) consensus-pdfs agda-spec;
 
-      # ensure we can still build on 8.10, can be removed soon
-      haskell810 = builtins.removeAttrs
-        (mkHaskellJobsFor pkgs.hsPkgs.projectVariants.ghc810)
-        [ "checks" "devShell" "devShellProfiled" ];
-
       # also already test GHC 9.10, but only on Linux to reduce CI load
       haskell910 = mkHaskellJobsFor pkgs.hsPkgs.projectVariants.ghc910;
     };

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -16,7 +16,6 @@ let
     src = ./..;
     compiler-nix-name = "ghc966";
     flake.variants = {
-      ghc810 = { compiler-nix-name = lib.mkForce "ghc8107"; };
       ghc910 = { compiler-nix-name = lib.mkForce "ghc9101"; };
     };
     inputMap = {

--- a/ouroboros-consensus-cardano/changelog.d/20250430_141707_alexander.esgen_drop_ghc810.md
+++ b/ouroboros-consensus-cardano/changelog.d/20250430_141707_alexander.esgen_drop_ghc810.md
@@ -1,0 +1,3 @@
+### Non-Breaking
+
+- Drop GHC 8.10 support.

--- a/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
+++ b/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
@@ -171,9 +171,6 @@ library
     validation,
     vector-map,
 
-  -- GHC 8.10.7 on aarch64-darwin cannot use text-2
-  build-depends: text >=1.2.5.0 && <2.2
-
 library unstable-byronspec
   import: common-lib
   visibility: public

--- a/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/Ledger.hs
+++ b/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/Ledger.hs
@@ -20,13 +20,6 @@
 -- TODO: can we un-orphan this module?
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-#if __GLASGOW_HASKELL__ <= 906
-{-# OPTIONS_GHC -Wno-incomplete-patterns
-                -Wno-incomplete-uni-patterns
-                -Wno-incomplete-record-updates
-                -Wno-overlapping-patterns #-}
-#endif
-
 module Ouroboros.Consensus.Cardano.Ledger (
     CardanoTxOut (..)
   , eliminateCardanoTxOut

--- a/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/Node.hs
+++ b/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/Node.hs
@@ -17,21 +17,6 @@
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 
--- Disable completeness checks on GHC versions pre-9.6, where this can be
--- exceptionally slow:
-#if __GLASGOW_HASKELL__ <= 906
-{-# OPTIONS_GHC -Wno-incomplete-patterns
-                -Wno-incomplete-uni-patterns
-                -Wno-incomplete-record-updates
-                -Wno-overlapping-patterns #-}
-#endif
-
--- TODO: this is required for ghc-8.10.7, because using NamedFieldPuns and
--- PatternSynonyms with record syntax results in warnings related to shadowing.
--- This can be removed once we drop ghc-8.10.7.
-
-{-# OPTIONS_GHC -Wno-name-shadowing #-}
-
 module Ouroboros.Consensus.Cardano.Node (
     CardanoHardForkConstraints
   , CardanoHardForkTrigger (..)
@@ -831,10 +816,10 @@ protocolInfoCardano paramsCardano
              ShelleyBasedEra era
           => WrapTransitionConfig (ShelleyBlock proto era)
           -> (Flip LedgerState ValuesMK -.-> Flip LedgerState ValuesMK) (ShelleyBlock proto era)
-        injectIntoTestState (WrapTransitionConfig cfg) = fn $ \(Flip st) ->
+        injectIntoTestState (WrapTransitionConfig tcfg) = fn $ \(Flip st) ->
           -- We need to unstow the injected values
           Flip $ unstowLedgerTables $ forgetLedgerTables $ st {
-            Shelley.shelleyLedgerState = L.injectIntoTestState cfg
+            Shelley.shelleyLedgerState = L.injectIntoTestState tcfg
               (Shelley.shelleyLedgerState $ stowLedgerTables st)
           }
 

--- a/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/QueryHF.hs
+++ b/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/QueryHF.hs
@@ -17,12 +17,6 @@
 {-# LANGUAGE UndecidableSuperClasses #-}
 
 {-# OPTIONS_GHC -Wno-orphans #-}
-#if __GLASGOW_HASKELL__ <= 906
-{-# OPTIONS_GHC -Wno-incomplete-patterns
-                -Wno-incomplete-uni-patterns
-                -Wno-incomplete-record-updates
-                -Wno-overlapping-patterns #-}
-#endif
 
 module Ouroboros.Consensus.Cardano.QueryHF () where
 

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Ledger.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Ledger.hs
@@ -21,12 +21,6 @@
 {-# LANGUAGE UndecidableInstances #-}
 
 {-# OPTIONS_GHC -Wno-orphans #-}
-#if __GLASGOW_HASKELL__ <= 906
-{-# OPTIONS_GHC -Wno-incomplete-patterns
-                -Wno-incomplete-uni-patterns
-                -Wno-incomplete-record-updates
-                -Wno-overlapping-patterns #-}
-#endif
 
 module Ouroboros.Consensus.Shelley.Ledger.Ledger (
     LedgerState (..)

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Query.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Query.hs
@@ -20,12 +20,6 @@
 {-# LANGUAGE UndecidableInstances #-}
 
 {-# OPTIONS_GHC -Wno-orphans #-}
-#if __GLASGOW_HASKELL__ <= 906
-{-# OPTIONS_GHC -Wno-incomplete-patterns
-                -Wno-incomplete-uni-patterns
-                -Wno-incomplete-record-updates
-                -Wno-overlapping-patterns #-}
-#endif
 
 module Ouroboros.Consensus.Shelley.Ledger.Query (
     BlockQuery (..)

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Protocol/Praos.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Protocol/Praos.hs
@@ -4,10 +4,6 @@
 {-# LANGUAGE TypeFamilies #-}
 
 {-# OPTIONS_GHC -Wno-orphans #-}
--- See https://gitlab.haskell.org/ghc/ghc/-/issues/14630. GHC currently warns
--- (erroneously) about name shadowing for record field selectors defined by
--- pattern synonyms. This can be deleted once GHC 8.10.7 is gone.
-{-# OPTIONS_GHC -Wno-name-shadowing #-}
 
 module Ouroboros.Consensus.Shelley.Protocol.Praos (PraosEnvelopeError (..)) where
 

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Analysis.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Analysis.hs
@@ -371,9 +371,7 @@ showEBBs AnalysisEnv { db, registry, startFrom, limit, tracer } = do
 storeLedgerStateAt ::
      forall blk .
      ( LedgerSupportsProtocol blk
-#if __GLASGOW_HASKELL__ > 810
      , HasAnalysis blk
-#endif
      )
   => SlotNo
   -> LedgerApplicationMode

--- a/ouroboros-consensus-diffusion/changelog.d/20250430_141654_alexander.esgen_drop_ghc810.md
+++ b/ouroboros-consensus-diffusion/changelog.d/20250430_141654_alexander.esgen_drop_ghc810.md
@@ -1,0 +1,3 @@
+### Non-Breaking
+
+- Drop GHC 8.10 support.

--- a/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
+++ b/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
@@ -107,9 +107,6 @@ library
     typed-protocols,
     typed-protocols-stateful,
 
-  -- GHC 8.10.7 on aarch64-darwin cannot use text-2
-  build-depends: text >=1.2.5.0 && <2.2
-
 library unstable-diffusion-testlib
   import: common-lib
   visibility: public

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup/Classifiers.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup/Classifiers.hs
@@ -21,7 +21,7 @@ import qualified Data.List.NonEmpty as NonEmpty
 import qualified Data.Map as Map
 import           Data.Maybe (mapMaybe)
 import           Data.Word (Word64)
-import           Ouroboros.Consensus.Block (ChainHash (BlockHash), HeaderHash,
+import           Ouroboros.Consensus.Block (ChainHash (..), HeaderHash,
                      blockSlot, succWithOrigin)
 import           Ouroboros.Consensus.Block.Abstract (SlotNo (SlotNo),
                      withOrigin)
@@ -269,6 +269,4 @@ simpleHash ::
   [Word64]
 simpleHash = \case
   BlockHash (TestHash h) -> reverse (NonEmpty.toList h)
-  -- not matching on @GenesisHash@ because 8.10 can't prove exhaustiveness of
-  -- TestHash with the equality constraint
-  _ -> []
+  GenesisHash            -> []

--- a/ouroboros-consensus/changelog.d/20250430_141645_alexander.esgen_drop_ghc810.md
+++ b/ouroboros-consensus/changelog.d/20250430_141645_alexander.esgen_drop_ghc810.md
@@ -1,0 +1,3 @@
+### Non-Breaking
+
+- Drop GHC 8.10 support.

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -61,8 +61,7 @@ common common-bench
   -- We use this option to avoid skewed results due to changes in cache-line
   -- alignment. See
   -- https://github.com/Bodigrim/tasty-bench#comparison-against-baseline
-  if impl(ghc >=8.6)
-    ghc-options: -fproc-alignment=64
+  ghc-options: -fproc-alignment=64
 
 library
   import: common-lib
@@ -356,10 +355,6 @@ library
     typed-protocols ^>=0.3,
     vector ^>=0.13,
 
-  if !impl(ghc >=9.4)
-    build-depends: data-array-byte
-  -- GHC 8.10.7 on aarch64-darwin cannot use text-2
-  build-depends: text >=1.2.5.0 && <2.2
   x-docspec-extra-packages:
     directory
     latex-svg-image

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Basics.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Basics.hs
@@ -1,9 +1,6 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
-#if __GLASGOW_HASKELL__ < 900
-{-# LANGUAGE DataKinds #-}
-#endif
 {-# LANGUAGE DeriveTraversable #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MultiParamTypeClasses #-}

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Dual.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Dual.hs
@@ -1,9 +1,5 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE ConstraintKinds #-}
-{-# LANGUAGE TypeOperators #-}
-#if __GLASGOW_HASKELL__ < 900
-{-# LANGUAGE DataKinds #-}
-#endif
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE EmptyCase #-}
@@ -20,6 +16,7 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE UndecidableSuperClasses #-}
 
@@ -1012,7 +1009,6 @@ instance (Ord (TxIn (LedgerState m)), MemPack (TxIn (LedgerState m)), MemPack (T
 
 instance (
     Bridge m a
-#if __GLASGOW_HASKELL__ >= 906
   , NoThunks (TxOut (LedgerState m))
   , NoThunks (TxIn (LedgerState m))
   , Show (TxOut (LedgerState m))
@@ -1020,7 +1016,6 @@ instance (
   , Eq (TxOut (LedgerState m))
   , Ord (TxIn (LedgerState m))
   , MemPack (TxIn (LedgerState m))
-#endif
   ) => HasLedgerTables (LedgerState (DualBlock m a)) where
   projectLedgerTables DualLedgerState{..} =
       castLedgerTables
@@ -1036,7 +1031,6 @@ instance (
 
 instance (
     Bridge m a
-#if __GLASGOW_HASKELL__ >= 906
   , NoThunks (TxOut (LedgerState m))
   , NoThunks (TxIn (LedgerState m))
   , Show (TxOut (LedgerState m))
@@ -1044,7 +1038,6 @@ instance (
   , Eq (TxOut (LedgerState m))
   , Ord (TxIn (LedgerState m))
   , MemPack (TxIn (LedgerState m))
-#endif
   )=> HasLedgerTables (Ticked (LedgerState (DualBlock m a))) where
   projectLedgerTables TickedDualLedgerState{..} =
       castLedgerTables

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Extended.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Extended.hs
@@ -35,9 +35,7 @@ import           Codec.CBOR.Decoding (Decoder, decodeListLenOf)
 import           Codec.CBOR.Encoding (Encoding, encodeListLen)
 import           Control.Monad.Except
 import           Data.Functor ((<&>))
-#if __GLASGOW_HASKELL__ >= 906
 import           Data.MemPack
-#endif
 import           Data.Proxy
 import           Data.Typeable
 import           GHC.Generics (Generic)
@@ -93,9 +91,7 @@ instance (
   , Typeable (HeaderHash blk)
   , Show (HeaderHash blk)
   , Ord (HeaderHash blk)
-#if __GLASGOW_HASKELL__ >= 906
   , Eq (HeaderHash blk)
-#endif
   ) => StandardHash (ExtLedgerState blk)
 
 instance IsLedger (LedgerState blk) => GetTip (ExtLedgerState blk) where
@@ -293,7 +289,6 @@ type instance TxOut (ExtLedgerState blk) = TxOut (LedgerState blk)
 
 instance (
     HasLedgerTables (LedgerState blk)
-#if __GLASGOW_HASKELL__ >= 906
   , NoThunks (TxOut (LedgerState blk))
   , NoThunks (TxIn (LedgerState blk))
   , Show (TxOut (LedgerState blk))
@@ -301,7 +296,6 @@ instance (
   , Eq (TxOut (LedgerState blk))
   , Ord (TxIn (LedgerState blk))
   , MemPack (TxIn (LedgerState blk))
-#endif
   ) => HasLedgerTables (ExtLedgerState blk) where
   projectLedgerTables (ExtLedgerState lstate _) =
       castLedgerTables (projectLedgerTables lstate)
@@ -321,7 +315,6 @@ instance LedgerTablesAreTrivial (Ticked (LedgerState blk))
 
 instance (
     HasLedgerTables (Ticked (LedgerState blk))
-#if __GLASGOW_HASKELL__ >= 906
   , NoThunks (TxOut (LedgerState blk))
   , NoThunks (TxIn (LedgerState blk))
   , Show (TxOut (LedgerState blk))
@@ -329,7 +322,6 @@ instance (
   , Eq (TxOut (LedgerState blk))
   , Ord (TxIn (LedgerState blk))
   , MemPack (TxIn (LedgerState blk))
-#endif
   ) => HasLedgerTables (Ticked (ExtLedgerState blk)) where
   projectLedgerTables (TickedExtLedgerState lstate _view _hstate) =
       castLedgerTables (projectLedgerTables lstate)

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Query.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Query.hs
@@ -128,9 +128,7 @@ class
      -- These instances are not needed for BlockSupportsLedgerQuery but we bundle them here
      -- so that we don't need to put them in 'SingleEraBlock' later on
      (
-#if __GLASGOW_HASKELL__ <= 902
        forall fp result. Show          (BlockQuery blk fp result),
-#endif
        forall fp.        ShowQuery     (BlockQuery blk fp)
      ,                   SameDepIndex2 (BlockQuery blk)
      )

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/LocalTxSubmission/Server.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/LocalTxSubmission/Server.hs
@@ -10,7 +10,7 @@ module Ouroboros.Consensus.MiniProtocol.LocalTxSubmission.Server (
   ) where
 
 import           Control.Tracer
-import           Data.SOP.BasicFunctors
+import           Data.Tuple (Solo (..))
 import           Ouroboros.Consensus.Ledger.SupportsMempool
 import           Ouroboros.Consensus.Mempool.API
 import           Ouroboros.Consensus.Util.IOLike
@@ -31,8 +31,7 @@ localTxSubmissionServer tracer mempool =
     server = LocalTxSubmissionServer {
       recvMsgSubmitTx = \tx -> do
         traceWith tracer $ TraceReceivedTx tx
-        -- Once we drop GHC 8.10, we could use @Solo@ from base.
-        I addTxRes <- addLocalTxs mempool (I tx)
+        MkSolo addTxRes <- addLocalTxs mempool (MkSolo tx)
         case addTxRes of
           MempoolTxAdded _tx             -> return (SubmitSuccess, server)
           MempoolTxRejected _tx addTxErr -> return (SubmitFail addTxErr, server)

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/V2.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/V2.hs
@@ -146,9 +146,6 @@ implMkLedgerDb ::
      , IsLedger l
      , l ~ ExtLedgerState blk
      , StandardHash l, HasLedgerTables l
-#if __GLASGOW_HASKELL__ < 908
-     , HeaderHash l ~ HeaderHash blk
-#endif
      , LedgerSupportsProtocol blk
      , LedgerDbSerialiseConstraints blk
      , HasHardForkHistory blk

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Util/AnchoredFragment.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Util/AnchoredFragment.hs
@@ -17,8 +17,9 @@ module Ouroboros.Consensus.Util.AnchoredFragment (
 
 import           Control.Monad.Except (throwError)
 import           Data.Foldable (toList)
+import qualified Data.Foldable1 as F1
 import           Data.Function (on)
-import qualified Data.List as L
+import qualified Data.List.NonEmpty as NE
 import           Data.Maybe (isJust)
 import           Data.Word (Word64)
 import           GHC.Stack
@@ -217,10 +218,9 @@ stripCommonPrefix sharedAnchor frags
       Just (cp, _, _, _) -> cp
       Nothing            -> error "unreachable"
 
-    commonPrefix
-      | null frags = AF.Empty sharedAnchor
-      -- TODO use Foldable1 once all our GHCs support it
-      | otherwise = L.foldl1' computeCommonPrefix (toList frags)
+    commonPrefix = case NE.nonEmpty $ toList frags of
+      Nothing      -> AF.Empty sharedAnchor
+      Just fragsNE -> F1.foldl1' computeCommonPrefix fragsNE
 
     splitAfterCommonPrefix frag =
       case AF.splitAfterPoint frag (AF.headPoint commonPrefix) of

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Util/LeakyBucket.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Util/LeakyBucket.hs
@@ -51,6 +51,7 @@ import           Control.Monad (forever, void, when)
 import qualified Control.Monad.Class.MonadSTM.Internal as TVar
 import           Control.Monad.Class.MonadTimer (MonadTimer, registerDelay)
 import           Control.Monad.Class.MonadTimer.SI (diffTimeToMicrosecondsAsInt)
+import           Data.Ord (clamp)
 import           Data.Ratio ((%))
 import           Data.Time.Clock (diffTimeToPicoseconds)
 import           GHC.Generics (Generic)
@@ -434,10 +435,6 @@ atomicallyWithMonotonicTime ::
   m b
 atomicallyWithMonotonicTime f =
   atomically . f =<< getMonotonicTime
-
--- NOTE: Needed for GHC 8
-clamp :: Ord a => (a, a) -> a -> a
-clamp (low, high) x = min high (max low x)
 
 -- | Number of microseconds in a second (@10^6@).
 microsecondsPerSecond :: Integer

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Consensus/ChainGenerator/Counting.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Consensus/ChainGenerator/Counting.hs
@@ -7,6 +7,7 @@
 {-# LANGUAGE Rank2Types #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE StandaloneKindSignatures #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 
@@ -155,11 +156,8 @@ uniformIndex n g = Count <$> R.uniformRM (0, getCount $ lastIndex n) g
 -----
 
 -- | A human-readable label for a 'Win'
-data Lbl lbl = Lbl   -- no explicit kind var so that type applications don't
-                     -- need to provide the kind
-                     --
-                     -- TODO as of GHC 9.0, use a standalone kind signature to
-                     -- declare k as /inferred/ instead of /specified/
+type Lbl :: forall {k}. k -> Type
+data Lbl lbl = Lbl
 instance (lbl TypeEq.~~ s) => IsLabel s (Lbl lbl) where fromLabel = Lbl
 
 -- | A type-level name for a window within some containing sequence

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/Orphans/ToExpr.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/Orphans/ToExpr.hs
@@ -6,9 +6,7 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE StandaloneDeriving #-}
-#if __GLASGOW_HASKELL__ <= 906
 {-# LANGUAGE TypeFamilies #-}
-#endif
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/Mempool/StateMachine.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/Mempool/StateMachine.hs
@@ -586,9 +586,7 @@ mkSUT cfg initialLedger = do
 semantics ::
      ( MonadSTM m
      , LedgerSupportsMempool blk
-#if __GLASGOW_HASKELL__  > 810
      , ValidateEnvelope blk
-#endif
      ) =>
      CT.Tracer m String
   -> Command blk Concrete
@@ -680,9 +678,7 @@ shrinker _ _ = []
 sm ::
   ( LedgerSupportsMempool blk
   , IOLike m
-#if __GLASGOW_HASKELL__  > 810
-     , ValidateEnvelope blk
-#endif
+  , ValidateEnvelope blk
   )
   => StateMachine (Model blk) (Command blk) m (Response blk)
   -> CT.Tracer m String
@@ -731,9 +727,7 @@ prop_mempoolSequential ::
   ( HasTxId (GenTx blk)
   , blk ~ TestBlock
   , LedgerSupportsMempool blk
-#if __GLASGOW_HASKELL__ > 900
   , LedgerSupportsProtocol blk
-#endif
   )
   => LedgerConfig blk
   -> TxMeasure blk
@@ -774,9 +768,7 @@ prop_mempoolParallel ::
   ( HasTxId (GenTx blk)
   , blk ~ TestBlock
   , LedgerSupportsMempool blk
-#if __GLASGOW_HASKELL__ > 900
   , LedgerSupportsProtocol blk
-#endif
   )
   => LedgerConfig blk
   -> TxMeasure blk

--- a/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/Util/LeakyBucket/Tests.hs
+++ b/ouroboros-consensus/test/infra-test/Test/Ouroboros/Consensus/Util/LeakyBucket/Tests.hs
@@ -16,6 +16,7 @@ import           Control.Monad.IOSim (IOSim, runSimOrThrow)
 import           Data.Either (isLeft, isRight)
 import           Data.Functor ((<&>))
 import           Data.List (intersperse)
+import           Data.Ord (clamp)
 import           Data.Ratio ((%))
 import           Data.Time.Clock (DiffTime, picosecondsToDiffTime)
 import           Ouroboros.Consensus.Util.IOLike (Exception (displayException),
@@ -401,6 +402,3 @@ prop_random =
           counterexample ("Model:  " ++ show modelResult) $
           result == modelResult
 
--- NOTE: Needed for GHC 8
-clamp :: Ord a => (a, a) -> a -> a
-clamp (low, high) x = min high (max low x)

--- a/scripts/ci/run-stylish.sh
+++ b/scripts/ci/run-stylish.sh
@@ -27,8 +27,6 @@ esac
 
 $fdcmd --full-path "$path" \
        --extension hs \
-       --exclude ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Dual.hs \
-       --exclude ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Extended.hs \
        --exec-batch stylish-haskell -c .stylish-haskell.yaml -i
 
 case "$(uname -s)" in


### PR DESCRIPTION
The node already uses 9.6, so we can finally drop 8.10 and get rid of a lot of cruft.

I tried to remove everything I could find by grepping for a few ad-hoc regexes; maybe there is more, but we can remove that as we go.

Follow-up work (like upgrading from `Haskell2010` to `GHC2021`) can happen in later PRs as it needs more discussion.