### PR TITLE
consensus: more carefully hide `HeaderWithTime` from traces

### DIFF
--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Trace.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Trace.hs
@@ -30,7 +30,6 @@ import           Ouroboros.Consensus.Block (GenesisWindow (..), Header, Point,
                      WithOrigin (NotOrigin, Origin), succWithOrigin)
 import           Ouroboros.Consensus.Genesis.Governor (DensityBounds (..),
                      GDDDebugInfo (..), TraceGDDEvent (..))
-import           Ouroboros.Consensus.HeaderValidation (HeaderWithTime (..))
 import           Ouroboros.Consensus.MiniProtocol.ChainSync.Client
                      (TraceChainSyncClientEvent (..))
 import           Ouroboros.Consensus.MiniProtocol.ChainSync.Client.Jumping
@@ -60,9 +59,8 @@ import           Ouroboros.Network.Protocol.ChainSync.Type (ChainSync,
 import           Test.Consensus.PointSchedule.NodeState (NodeState)
 import           Test.Consensus.PointSchedule.Peers (Peer (Peer), PeerId)
 import           Test.Util.TersePrinting (terseAnchor, terseBlock,
-                     terseFragment, terseHFragment, terseHWTFragment,
-                     terseHeader, tersePoint, terseRealPoint, terseTip,
-                     terseWithOrigin)
+                     terseFragment, terseHFragment, terseHeader, tersePoint,
+                     terseRealPoint, terseTip, terseWithOrigin)
 import           Test.Util.TestBlock (TestBlock)
 import           Text.Printf (printf)
 
@@ -557,7 +555,7 @@ prettyDensityBounds bounds =
         -- the density comparison should not be applied to two peers if they share any headers after the LoE fragment.
         lastPoint =
           "point: " ++
-          tersePoint (castPoint @(HeaderWithTime TestBlock) @TestBlock (AF.lastPoint clippedFragment)) ++
+          tersePoint (castPoint @(Header TestBlock) @TestBlock (AF.lastPoint clippedFragment)) ++
           ", "
 
         showLatestSlot = \case
@@ -584,14 +582,14 @@ terseGDDEvent = \case
     } ->
     unlines $ [
       "GDD | Window: " ++ window sgen loeHead,
-      "      Selection: " ++ terseHWTFragment curChain,
+      "      Selection: " ++ terseHFragment curChain,
       "      Candidates:"
       ] ++
       showPeers (second (tersePoint . castPoint . AF.headPoint) <$> candidates) ++
       [
       "      Candidate suffixes (bounds):"
       ] ++
-      showPeers (second (terseHWTFragment . clippedFragment) <$> bounds) ++
+      showPeers (second (terseHFragment . clippedFragment) <$> bounds) ++
       ["      Density bounds:"] ++
       prettyDensityBounds bounds ++
       ["      New candidate tips:"] ++

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Genesis/Governor.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Genesis/Governor.hs
@@ -234,7 +234,7 @@ evaluateGDD cfg tracer stateView = do
 
       traceWith tracer $ TraceGDDDebug $ GDDDebugInfo
         { sgen
-        , curChain
+        , curChain          = AF.mapAnchoredFragment hwtHeader curChain
         , bounds
         , candidates        = dropTimes candidates
         , candidateSuffixes = dropTimes candidateSuffixes
@@ -306,7 +306,7 @@ sharedCandidatePrefix curChain candidates =
 
 data DensityBounds blk =
   DensityBounds {
-    clippedFragment :: AnchoredFragment (HeaderWithTime blk),
+    clippedFragment :: AnchoredFragment (Header blk),
     offersMoreThanK :: Bool,
     lowerBound      :: Word64,
     upperBound      :: Word64,
@@ -395,7 +395,13 @@ densityDisconnect (GenesisWindow sgen) (SecurityParam k) states candidateSuffixe
           -- If not, it is not qualified to compete by density (yet).
           offersMoreThanK = totalBlockCount > unNonZero k
 
-      pure (peer, DensityBounds {clippedFragment, offersMoreThanK, lowerBound, upperBound, hasBlockAfter, latestSlot, idling})
+      pure (peer, DensityBounds { clippedFragment = AF.mapAnchoredFragment hwtHeader clippedFragment
+                                , offersMoreThanK
+                                , lowerBound
+                                , upperBound
+                                , hasBlockAfter
+                                , latestSlot
+                                , idling})
 
     losingPeers = nubOrd $ densityBounds >>= \
       (peer0 , DensityBounds { clippedFragment = frag0
@@ -473,7 +479,7 @@ densityDisconnect (GenesisWindow sgen) (SecurityParam k) states candidateSuffixe
 data GDDDebugInfo peer blk =
   GDDDebugInfo {
     bounds            :: [(peer, DensityBounds blk)],
-    curChain          :: AnchoredFragment (HeaderWithTime blk),
+    curChain          :: AnchoredFragment (Header blk),
     candidates        :: [(peer, AnchoredFragment (Header blk))],
     candidateSuffixes :: [(peer, AnchoredFragment (Header blk))],
     losingPeers       :: [peer],


### PR DESCRIPTION
This is a follow-up to #1288 that ensures 

- do not expose `HeaderWithTime` in `TraceGDDEvent` via `GDDDebugInfo`
- do not store the chain fragment with `HeaderWithTime` in `DensityBounds`

adding the "no changelog'' label, as the relevant changelog fragments are already included into "main"

Draft PR to for integration with the node: https://github.com/IntersectMBO/cardano-node/pull/6211