### PR TITLE
LedgerDB.V2: make sure to actually close handles

### DIFF
--- a/ouroboros-consensus-cardano/app/snapshot-converter.hs
+++ b/ouroboros-consensus-cardano/app/snapshot-converter.hs
@@ -198,7 +198,7 @@ load config@Config{inpath = pathToDiskSnapshot -> Just (fs@(SomeHasFS hasFS), pa
       pure (forgetLedgerTables st, projectLedgerTables st)
     Mem -> do
       checkSnapshotFileStructure Mem path fs
-      (ls, _) <- withExceptT SnapshotError $ V2.loadSnapshot rr ccfg fs ds
+      (ls, _) <- withExceptT SnapshotError $ V2.loadSnapshot nullTracer rr ccfg fs ds
       let h = V2.currentHandle ls
       (V2.state h,) <$> Trans.lift (V2.readAll (V2.tables h))
     LMDB -> do
@@ -237,7 +237,7 @@ store config@Config{outpath = pathToDiskSnapshot -> Just (fs@(SomeHasFS hasFS), 
       withFile hasFS (path <.> "checksum") (WriteMode MustBeNew) $ \h ->
         Monad.void $ hPutAll hasFS h . BS.toLazyByteString . BS.word32HexFixed $ getCRC crc
     Mem -> do
-      lseq <- V2.empty state tbs $ V2.newInMemoryLedgerTablesHandle fs
+      lseq <- V2.empty state tbs $ V2.newInMemoryLedgerTablesHandle nullTracer fs
       let h = V2.currentHandle lseq
       Monad.void $ V2.takeSnapshot ccfg nullTracer fs suffix h
     LMDB -> do

--- a/ouroboros-consensus/changelog.d/20250519_193751_alexander.esgen_v2_ledgerseq_close.md
+++ b/ouroboros-consensus/changelog.d/20250519_193751_alexander.esgen_v2_ledgerseq_close.md
@@ -1,0 +1,5 @@
+### Patch
+
+- Changed the V2 LedgerDB `LedgerTablesHandle`s to actually be closed in all
+  cases. With the current (only) backend (in-memory), this doesn't matter, but
+  on-disk backends (like LSM trees) need this.

--- a/ouroboros-consensus/changelog.d/20250528_135650_alexander.esgen_v2_ledgerseq_close.md
+++ b/ouroboros-consensus/changelog.d/20250528_135650_alexander.esgen_v2_ledgerseq_close.md
@@ -1,0 +1,3 @@
+### Breaking
+
+- LedgerDB: added new trace events (enabling new tests).

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/API.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/API.hs
@@ -302,6 +302,9 @@ data TestInternals m l blk = TestInternals
   , reapplyThenPushNOW :: blk -> m ()
   , truncateSnapshots :: m ()
   , closeLedgerDB :: m ()
+  , getNumLedgerTablesHandles :: m Word64
+  -- ^ Get the number of referenced 'LedgerTablesHandle's for V2. For V1, this
+  -- always returns 0.
   }
   deriving NoThunks via OnlyCheckWhnfNamed "TestInternals" (TestInternals m l blk)
 

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/V1.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/V1.hs
@@ -353,6 +353,7 @@ mkInternals h =
     , wipeLedgerDB = getEnv h $ void . destroySnapshots . snapshotsFs . ldbHasFS
     , closeLedgerDB = getEnv h $ bsClose . ldbBackingStore
     , truncateSnapshots = getEnv h $ void . implIntTruncateSnapshots . ldbHasFS
+    , getNumLedgerTablesHandles = pure 0
     }
 
 -- | Testing only! Truncate all snapshots in the DB.

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/V2.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/V2.hs
@@ -128,12 +128,15 @@ mkInitDb args flavArgs getBlock =
 
   bss = case flavArgs of V2Args bss0 -> bss0
 
+  v2Tracer :: Tracer m V2.FlavorImplSpecificTrace
+  v2Tracer = LedgerDBFlavorImplEvent . FlavorImplSpecificTraceV2 >$< lgrTracer
+
   emptyF ::
     ExtLedgerState blk ValuesMK ->
     m (LedgerSeq' m blk)
   emptyF st =
     empty' st $ case bss of
-      InMemoryHandleArgs -> InMemory.newInMemoryLedgerTablesHandle lgrHasFS
+      InMemoryHandleArgs -> InMemory.newInMemoryLedgerTablesHandle v2Tracer lgrHasFS
       LSMHandleArgs x -> absurd x
 
   loadSnapshot ::
@@ -142,7 +145,7 @@ mkInitDb args flavArgs getBlock =
     DiskSnapshot ->
     m (Either (SnapshotFailure blk) (LedgerSeq' m blk, RealPoint blk))
   loadSnapshot ccfg fs ds = case bss of
-    InMemoryHandleArgs -> runExceptT $ InMemory.loadSnapshot lgrRegistry ccfg fs ds
+    InMemoryHandleArgs -> runExceptT $ InMemory.loadSnapshot v2Tracer lgrRegistry ccfg fs ds
     LSMHandleArgs x -> absurd x
 
 implMkLedgerDb ::

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/V2.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/V2.hs
@@ -85,12 +85,12 @@ mkInitDb args flavArgs getBlock =
     , closeDb = closeLedgerSeq
     , initReapplyBlock = \a b c -> do
         (x, y) <- reapplyThenPush lgrRegistry a b c
-        closeLedgerSeq x
+        x
         pure y
     , currentTip = ledgerState . current
     , pruneDb = \lseq -> do
-        let (LedgerSeq rel, dbPrunedToImmDBTip) = pruneToImmTipOnly lseq
-        mapM_ (close . tables) (AS.toOldestFirst rel)
+        let (rel, dbPrunedToImmDBTip) = pruneToImmTipOnly lseq
+        rel
         pure dbPrunedToImmDBTip
     , mkLedgerDb = \lseq -> do
         varDB <- newTVarIO lseq

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/V2.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/V2.hs
@@ -231,6 +231,10 @@ mkInternals bss h =
         let LDBHandle tvar = h
          in atomically (writeTVar tvar LedgerDBClosed)
     , truncateSnapshots = getEnv h $ implIntTruncateSnapshots . ldbHasFS
+    , getNumLedgerTablesHandles = getEnv h $ \env -> do
+        l <- readTVarIO (ldbSeq env)
+        -- We always have a state at the anchor.
+        pure $ 1 + maxRollback l
     }
  where
   takeSnapshot ::

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/V2/Args.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/V2/Args.hs
@@ -26,6 +26,9 @@ data HandleArgs
   deriving (Generic, NoThunks)
 
 data FlavorImplSpecificTrace
-  = FlavorImplSpecificTraceInMemory
-  | FlavorImplSpecificTraceOnDisk
+  = -- | Created a new 'LedgerTablesHandle', potentially by duplicating an
+    -- existing one.
+    TraceLedgerTablesHandleCreate
+  | -- | Closed a 'LedgerTablesHandle'.
+    TraceLedgerTablesHandleClose
   deriving (Show, Eq)

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/V2/InMemory.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/V2/InMemory.hs
@@ -96,7 +96,11 @@ newInMemoryLedgerTablesHandle tracer someFS@(SomeHasFS hasFS) l = do
   pure
     LedgerTablesHandle
       { close = do
-          atomically $ writeTVar tv LedgerTablesHandleClosed
+          -- Temporarily a no-op until
+          -- https://github.com/IntersectMBO/ouroboros-consensus/issues/1551 has
+          -- been fixed.
+
+          -- atomically $ writeTVar tv LedgerTablesHandleClosed
           traceWith tracer V2.TraceLedgerTablesHandleClose
       , duplicate = do
           hs <- readTVarIO tv

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/LedgerDB/StateMachine.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/LedgerDB/StateMachine.hs
@@ -132,7 +132,7 @@ initialEnvironment fsOps getLmdbDir mkTestArguments cdb = do
   pure $
     Environment
       undefined
-      (TestInternals undefined undefined undefined undefined undefined (pure ()))
+      (TestInternals undefined undefined undefined undefined undefined (pure ()) (pure 0))
       cdb
       (flip mkTestArguments lmdbDir)
       sfs


### PR DESCRIPTION
Closes #1515 

The first three commits add a regression test by enrichting the existing LedgerDB state machine test, making sure that
```
  total number of all opened handles
- total number of closed handles
= states on the LedgerSeq in the end
```
The fourth commit then fixes the bug, causing the regression test to succeed.

Note that this bug fix reveals another bug #1551 (causing the `mock-test` failure for `LeaderSchedule.simple convergence`), which we silence by temporarily making the closing of an in-memory handle a no-op (as it is not *necessary* anyways, the GC will still collect the in-memory ledger state).