### PR TITLE
flake.nix: add cuddle to dev shell

### DIFF
--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -16,6 +16,7 @@ hsPkgs.shellFor {
     pkgs.ghcid
     pkgs.xrefcheck
     pkgs.fourmolu
+    pkgs.cuddle
 
     # release management
     pkgs.scriv

--- a/nix/tools.nix
+++ b/nix/tools.nix
@@ -41,6 +41,15 @@ in
     compiler-nix-name = "ghc98";
   };
 
+  cuddle = tool "cuddle" "git" {
+    src = final.fetchFromGitHub {
+      owner = "input-output-hk";
+      repo = "cuddle";
+      rev = "43050522b2c3326dc2bcb95a3fde852bce5bc729";
+      hash = "sha256-S3GJBmvBmnbdb7tD2Fq9FNr9Z8iuT/eWwRpRxq9is10=";
+    };
+  };
+
   haskellBuildUtils = prev.haskellBuildUtils.override {
     inherit (final.hsPkgs.args) compiler-nix-name;
     index-state = tool-index-state;


### PR DESCRIPTION
This PR adds @jasagredo's experimental branch of `cuddle` to the dev shell of the Flake. Once a new release of `cuddle` is cut, we should pull it from CHaP rather than github.