### PR TITLE
fourmolu: use a single import group

### DIFF
--- a/fourmolu.yaml
+++ b/fourmolu.yaml
@@ -4,3 +4,4 @@ import-export-style: leading
 haddock-style: single-line
 single-constraint-parens: never
 single-deriving-parens: never
+import-grouping: single


### PR DESCRIPTION
This means that import groups are *not* preserved, just like with stylish-haskell in the past.

Concretely, something like
```haskell
import A

import B
```
will now no longer be a fixed point; rather, the blank line is removed.

I locally had "stray" import groups that arose due to eg deleting certain imports; it seems convenient to enforce their absence.

(Just FTR: Fourmolu also has ways to enforce import grouping based on [certain rules](https://fourmolu.github.io/config/import-grouping/); I personally don't care, but also wouldn't mind as long as it is fully automatic.)