### PR TITLE
Only open Handles when performing a UTxO query

### DIFF
--- a/ouroboros-consensus-cardano/changelog.d/20250612_161519_javier.sagredo_only_vh_on_not_qfnotables.md
+++ b/ouroboros-consensus-cardano/changelog.d/20250612_161519_javier.sagredo_only_vh_on_not_qfnotables.md
@@ -1,0 +1,22 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+### Patch
+
+- Use new forker API from Consensus, which allows for opening forkers without tables.
+
+<!--
+### Non-Breaking
+
+- A bullet item for the Non-Breaking category.
+
+-->
+<!--
+### Breaking
+
+- A bullet item for the Breaking category.
+
+-->

--- a/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/QueryHF.hs
+++ b/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/QueryHF.hs
@@ -58,13 +58,13 @@ answerCardanoQueryHF ::
     Index xs blk ->
     ExtLedgerCfg blk ->
     BlockQuery blk footprint result ->
-    ReadOnlyForker' m (HardForkBlock xs) ->
+    ROForker' m (HardForkBlock xs) ->
     m result
   ) ->
   Index xs x ->
   ExtLedgerCfg x ->
   BlockQuery x footprint result ->
-  ReadOnlyForker' m (HardForkBlock xs) ->
+  ROForker' m (HardForkBlock xs) ->
   m result
 answerCardanoQueryHF f idx cfg q dlv =
   case sing :: Sing footprint of

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Query.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Query.hs
@@ -1141,7 +1141,7 @@ answerShelleyLookupQueries ::
   (TxIn (LedgerState blk) -> SL.TxIn) ->
   ExtLedgerCfg (ShelleyBlock proto era) ->
   BlockQuery (ShelleyBlock proto era) QFLookupTables result ->
-  ReadOnlyForker' m blk ->
+  ROForker' m blk ->
   m result
 answerShelleyLookupQueries injTables ejTxOut ejTxIn cfg q forker =
   case q of
@@ -1160,7 +1160,7 @@ answerShelleyLookupQueries injTables ejTxOut ejTxIn cfg q forker =
     m (SL.UTxO era)
   answerGetUtxOByTxIn txins = do
     LedgerTables (ValuesMK values) <-
-      LedgerDB.roforkerReadTables
+      LedgerDB.forkerReadTables
         forker
         (castLedgerTables $ injTables (LedgerTables $ KeysMK txins))
     pure $
@@ -1220,7 +1220,7 @@ answerShelleyTraversingQueries ::
   ) ->
   ExtLedgerCfg (ShelleyBlock proto era) ->
   BlockQuery (ShelleyBlock proto era) QFTraverseTables result ->
-  ReadOnlyForker' m blk ->
+  ROForker' m blk ->
   m result
 answerShelleyTraversingQueries ejTxOut ejTxIn filt cfg q forker = case q of
   GetUTxOByAddress{} -> loop (filt q) NoPreviousQuery emptyUtxo
@@ -1257,7 +1257,7 @@ answerShelleyTraversingQueries ejTxOut ejTxIn filt cfg q forker = case q of
   toMaxKey (LedgerTables (ValuesMK vs)) = fst $ Map.findMax vs
 
   loop queryPredicate !prev !acc = do
-    extValues <- LedgerDB.roforkerRangeReadTables forker prev
+    extValues <- LedgerDB.forkerRangeReadTables forker prev
     if ltcollapse $ ltmap (K2 . vnull) extValues
       then pure acc
       else

--- a/ouroboros-consensus-cardano/src/unstable-cardano-testlib/Test/ThreadNet/Infra/ShelleyBasedHardFork.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-testlib/Test/ThreadNet/Infra/ShelleyBasedHardFork.hs
@@ -336,13 +336,13 @@ answerShelleyBasedQueryHF ::
     Index xs blk ->
     ExtLedgerCfg blk ->
     BlockQuery blk footprint result ->
-    ReadOnlyForker' m (HardForkBlock xs) ->
+    ROForker' m (HardForkBlock xs) ->
     m result
   ) ->
   Index xs x ->
   ExtLedgerCfg x ->
   BlockQuery x footprint result ->
-  ReadOnlyForker' m (HardForkBlock xs) ->
+  ROForker' m (HardForkBlock xs) ->
   m result
 answerShelleyBasedQueryHF f idx cfgs q forker = case idx of
   IZ -> f idx cfgs q forker

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBSynthesizer/Forging.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBSynthesizer/Forging.hs
@@ -56,7 +56,7 @@ import Ouroboros.Consensus.Storage.ChainDB.API as ChainDB
   , blockProcessed
   , getCurrentChain
   , getPastLedger
-  , getReadOnlyForkerAtPoint
+  , getSimpleForkerAtPoint
   )
 import qualified Ouroboros.Consensus.Storage.ChainDB.API.Types.InvalidBlockPunishment as InvalidBlockPunishment
   ( noPunishment
@@ -85,7 +85,7 @@ initialForgeState = ForgeState 0 0 0 0
 -- | An action to generate transactions for a given block
 type GenTxs blk mk =
   SlotNo ->
-  IO (ReadOnlyForker IO (ExtLedgerState blk) blk) ->
+  IO (ROForker' IO blk) ->
   TickedLedgerState blk DiffMK ->
   IO [Validated (GenTx blk)]
 
@@ -210,8 +210,8 @@ runForge epochSize_ nextSlot opts chainDB blockForging cfg genTxs = do
         currentSlot
         ( either
             (error "Impossible: we are forging on top of a block that the ChainDB cannot create forkers on!")
-            id
-            <$> getReadOnlyForkerAtPoint chainDB reg (SpecificPoint bcPrevPoint)
+            upgradeSimpleForker
+            =<< getSimpleForkerAtPoint chainDB reg (SpecificPoint bcPrevPoint)
         )
         tickedLedgerState
 

--- a/ouroboros-consensus-diffusion/changelog.d/20250612_161535_javier.sagredo_only_vh_on_not_qfnotables.md
+++ b/ouroboros-consensus-diffusion/changelog.d/20250612_161535_javier.sagredo_only_vh_on_not_qfnotables.md
@@ -1,0 +1,22 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+### Patch
+
+- Use new forker API from Consensus, which allows for opening forkers without tables.
+
+<!--
+### Non-Breaking
+
+- A bullet item for the Non-Breaking category.
+
+-->
+<!--
+### Breaking
+
+- A bullet item for the Breaking category.
+
+-->

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToClient.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToClient.hs
@@ -145,7 +145,7 @@ mkHandlers NodeKernelArgs{cfg, tracers} NodeKernel{getChainDB, getMempool} =
           getMempool
     , hStateQueryServer =
         localStateQueryServer (ExtLedgerCfg cfg)
-          . ChainDB.getReadOnlyForkerAtPoint getChainDB
+          . ChainDB.getSimpleForkerAtPoint getChainDB
     , hTxMonitorServer =
         localTxMonitorServer
           getMempool

--- a/ouroboros-consensus/changelog.d/20250612_161526_javier.sagredo_only_vh_on_not_qfnotables.md
+++ b/ouroboros-consensus/changelog.d/20250612_161526_javier.sagredo_only_vh_on_not_qfnotables.md
@@ -1,0 +1,28 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Patch
+
+- A bullet item for the Patch category.
+
+-->
+<!--
+### Non-Breaking
+
+- A bullet item for the Non-Breaking category.
+
+-->
+### Breaking
+
+- Define new Forker API. Forkers are open as `SimpleForker`s which have no
+  tables and can later be promoted to open tables (`TablesReadForker`). In V1
+  this will hold the lock until the value handle is created on promotion. In V2
+  this change is transaparent.
+
+  Chain selection will use the `FullForker`, block forging will use
+  `TablesReadForker`, and queries will use `SimpleForker`s possibly promoting
+  them to `TablesReadForker` on the first UTxO-related query.

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Ledger/Query.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Ledger/Query.hs
@@ -135,7 +135,7 @@ class
     Index xs x ->
     ExtLedgerCfg x ->
     BlockQuery x QFLookupTables result ->
-    ReadOnlyForker' m (HardForkBlock xs) ->
+    ROForker' m (HardForkBlock xs) ->
     m result
 
   answerBlockQueryHFTraverse ::
@@ -144,7 +144,7 @@ class
     Index xs x ->
     ExtLedgerCfg x ->
     BlockQuery x QFTraverseTables result ->
-    ReadOnlyForker' m (HardForkBlock xs) ->
+    ROForker' m (HardForkBlock xs) ->
     m result
 
   -- | The @QFTraverseTables@ queries consist of some filter on the @TxOut@. This class
@@ -268,12 +268,12 @@ answerBlockQueryHelper ::
   (MonadSTM m, BlockSupportsHFLedgerQuery xs, CanHardFork xs) =>
   ( NP ExtLedgerCfg xs ->
     QueryIfCurrent xs footprint result ->
-    ReadOnlyForker' m (HardForkBlock xs) ->
+    ROForker' m (HardForkBlock xs) ->
     m (HardForkQueryResult xs result)
   ) ->
   ExtLedgerCfg (HardForkBlock xs) ->
   QueryIfCurrent xs footprint result ->
-  ReadOnlyForker' m (HardForkBlock xs) ->
+  ROForker' m (HardForkBlock xs) ->
   m (HardForkQueryResult xs result)
 answerBlockQueryHelper
   f
@@ -281,7 +281,8 @@ answerBlockQueryHelper
   qry
   forker = do
     hardForkState <-
-      hardForkLedgerStatePerEra . ledgerState <$> atomically (roforkerGetLedgerState forker)
+      hardForkLedgerStatePerEra . ledgerState
+        <$> atomically (forkerGetLedgerState forker)
     let ei = State.epochInfoLedger lcfg hardForkState
         cfgs = hmap ExtLedgerCfg $ distribTopLevelConfig ei cfg
     f cfgs qry forker
@@ -391,10 +392,10 @@ interpretQueryIfCurrentLookup ::
   (MonadSTM m, BlockSupportsHFLedgerQuery xs, CanHardFork xs) =>
   NP ExtLedgerCfg xs ->
   QueryIfCurrent xs QFLookupTables result ->
-  ReadOnlyForker' m (HardForkBlock xs) ->
+  ROForker' m (HardForkBlock xs) ->
   m (HardForkQueryResult xs result)
 interpretQueryIfCurrentLookup cfg q forker = do
-  st <- distribExtLedgerState <$> atomically (roforkerGetLedgerState forker)
+  st <- distribExtLedgerState <$> atomically (forkerGetLedgerState forker)
   go indices cfg q st
  where
   go ::
@@ -416,10 +417,10 @@ interpretQueryIfCurrentTraverse ::
   (MonadSTM m, BlockSupportsHFLedgerQuery xs, CanHardFork xs) =>
   NP ExtLedgerCfg xs ->
   QueryIfCurrent xs QFTraverseTables result ->
-  ReadOnlyForker' m (HardForkBlock xs) ->
+  ROForker' m (HardForkBlock xs) ->
   m (HardForkQueryResult xs result)
 interpretQueryIfCurrentTraverse cfg q forker = do
-  st <- distribExtLedgerState <$> atomically (roforkerGetLedgerState forker)
+  st <- distribExtLedgerState <$> atomically (forkerGetLedgerState forker)
   go indices cfg q st
  where
   go ::

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/API.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/API.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DeriveTraversable #-}
@@ -85,11 +86,7 @@ import Ouroboros.Consensus.Ledger.Abstract
 import Ouroboros.Consensus.Ledger.Extended
 import Ouroboros.Consensus.Storage.ChainDB.API.Types.InvalidBlockPunishment
 import Ouroboros.Consensus.Storage.Common
-import Ouroboros.Consensus.Storage.LedgerDB
-  ( GetForkerError
-  , ReadOnlyForker'
-  , Statistics
-  )
+import Ouroboros.Consensus.Storage.LedgerDB.Forker
 import Ouroboros.Consensus.Storage.Serialisation
 import Ouroboros.Consensus.Util.CallStack
 import Ouroboros.Consensus.Util.IOLike
@@ -208,10 +205,10 @@ data ChainDB m blk = ChainDB
   , getHeaderStateHistory :: STM m (HeaderStateHistory blk)
   -- ^ Get a 'HeaderStateHistory' populated with the 'HeaderState's of the
   -- last @k@ blocks of the current chain.
-  , getReadOnlyForkerAtPoint ::
+  , getSimpleForkerAtPoint ::
       ResourceRegistry m ->
       Target (Point blk) ->
-      m (Either GetForkerError (ReadOnlyForker' m blk))
+      m (Either GetForkerError (Forker' m blk NoTablesForker))
   -- ^ Acquire a read-only forker at a specific point if that point exists
   -- on the db.
   --

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl.hs
@@ -270,7 +270,7 @@ openDBInternal args launchBgTasks = runWithTempRegistry $ do
             , getImmutableLedger = getEnvSTM h Query.getImmutableLedger
             , getPastLedger = getEnvSTM1 h Query.getPastLedger
             , getHeaderStateHistory = getEnvSTM h Query.getHeaderStateHistory
-            , getReadOnlyForkerAtPoint = getEnv2 h Query.getReadOnlyForkerAtPoint
+            , getSimpleForkerAtPoint = getEnv2 h Query.getSimpleForkerAtPoint
             , getLedgerTablesAtFor = getEnv2 h Query.getLedgerTablesAtFor
             , getStatistics = getEnv h Query.getStatistics
             }

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Query.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Query.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE MultiWayIf #-}
@@ -19,7 +20,7 @@ module Ouroboros.Consensus.Storage.ChainDB.Impl.Query
   , getLedgerTablesAtFor
   , getMaxSlotNo
   , getPastLedger
-  , getReadOnlyForkerAtPoint
+  , getSimpleForkerAtPoint
   , getStatistics
   , getTipBlock
   , getTipHeader
@@ -252,13 +253,12 @@ getPastLedger ::
   STM m (Maybe (ExtLedgerState blk EmptyMK))
 getPastLedger CDB{..} = LedgerDB.getPastLedgerState cdbLedgerDB
 
-getReadOnlyForkerAtPoint ::
-  IOLike m =>
+getSimpleForkerAtPoint ::
   ChainDbEnv m blk ->
   ResourceRegistry m ->
   Target (Point blk) ->
-  m (Either LedgerDB.GetForkerError (LedgerDB.ReadOnlyForker' m blk))
-getReadOnlyForkerAtPoint CDB{..} = LedgerDB.getReadOnlyForker cdbLedgerDB
+  m (Either LedgerDB.GetForkerError (LedgerDB.Forker' m blk LedgerDB.NoTablesForker))
+getSimpleForkerAtPoint CDB{..} = LedgerDB.getForkerAtTarget cdbLedgerDB
 
 getLedgerTablesAtFor ::
   IOLike m =>

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/V1/Lock.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/V1/Lock.hs
@@ -17,6 +17,8 @@ module Ouroboros.Consensus.Storage.LedgerDB.V1.Lock
   , withReadLock
   , withWriteLock
   , writeLocked
+  , unsafeAcquireReadAccess
+  , unsafeReleaseReadAccess
   ) where
 
 import qualified Control.RAWLock as Lock
@@ -85,3 +87,9 @@ writeLocked = WriteLocked
 withWriteLock :: IOLike m => LedgerDBLock m -> WriteLocked m a -> m a
 withWriteLock (LedgerDBLock lock) m =
   Lock.withWriteAccess lock (\() -> (,()) <$> runWriteLocked m)
+
+unsafeAcquireReadAccess :: IOLike m => LedgerDBLock m -> STM m ()
+unsafeAcquireReadAccess (LedgerDBLock lock) = Lock.unsafeAcquireReadAccess lock
+
+unsafeReleaseReadAccess :: IOLike m => LedgerDBLock m -> STM m ()
+unsafeReleaseReadAccess (LedgerDBLock lock) = Lock.unsafeReleaseReadAccess lock

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/MiniProtocol/LocalStateQuery/Server.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/MiniProtocol/LocalStateQuery/Server.hs
@@ -202,7 +202,7 @@ mkServer rr k chain = do
   return $
     localStateQueryServer
       cfg
-      (LedgerDB.getReadOnlyForker lgrDB rr)
+      (LedgerDB.getForkerAtTarget lgrDB rr)
  where
   cfg = ExtLedgerCfg $ testCfg k
 


### PR DESCRIPTION
# Description

Expose a new Forker API, in which forkers are open as `SimpleForker`s which have no tables. They can be promoted to `TablesReadForker`s (for which they hold the necessary resources).

The main change is in the `LedgerDB.Forker` module, in which we define the new types of Forkers. These are then used in
- Chain selection will use a `FullForker` which can also commit changes.
- Block forging will use a `TablesReadForker`.
- Queries will use a `SimpleForker` that eventually can be upgraded to a `TablesReadForker` on the first UTxO query.
- Mempool will use a `TablesReadForker`.