### PR TITLE
LedgerDB.StateMachine test: actually test rollbacks

### DIFF
--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/LedgerDB/StateMachine.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/LedgerDB/StateMachine.hs
@@ -567,6 +567,9 @@ instance RunModel Model (StateT Environment IO) where
     lift $ truncateSnapshots testInternals
   perform UnInit _ _ = error "Uninitialized model created a command different than Init"
 
+  monitoring _ (ValidateAndCommit n _) _ _ = tabulate "Rollback depths" [show n]
+  monitoring _ _ _ _ = id
+
   -- NOTE
   --
   -- In terms of postcondition, we only need to check that the immutable and

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/LedgerDB/StateMachine.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/LedgerDB/StateMachine.hs
@@ -365,7 +365,9 @@ instance StateModel Model where
     n <= min (BT.unNonZero $ maxRollbacks secParam) (fromIntegral $ AS.length chain)
       && case blks of
         [] -> True
-        (b : _) -> tbSlot b == 1 + withOrigin 0 id (getTipSlot (AS.headAnchor chain))
+        (b : _) -> tbSlot b == 1 + fromWithOrigin 0 (getTipSlot (AS.headAnchor chain'))
+         where
+          chain' = AS.dropNewest (fromIntegral n) chain
   precondition _ Init{} = False
   precondition _ _ = True
 

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/LedgerDB/StateMachine.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/LedgerDB/StateMachine.hs
@@ -553,7 +553,9 @@ instance RunModel Model (StateT Environment IO) where
         vr <- validateFork ldb rr (const $ pure ()) BlockCache.empty n (map getHeader blks)
         case vr of
           ValidateSuccessful forker -> do
-            atomically $ modifyTVar (dbChain chainDb) (reverse (map blockRealPoint blks) ++)
+            atomically $
+              modifyTVar (dbChain chainDb) $
+                (reverse (map blockRealPoint blks) ++) . drop (fromIntegral n)
             atomically (forkerCommit forker)
             forkerClose forker
           ValidateExceededRollBack{} -> error "Unexpected Rollback"


### PR DESCRIPTION
This PR fixes a bug in the LedgerDB state machine test that caused us to never generate non-trivial rollbacks, only chain extensions.

The first commit adds appropriate command labelling, demonstrating the problem:
```
Rollback depths (526356 in total):
100.0000% 0
```

The second commit fixes the bug causing this: The precondition is overzeleaos, so all generated `ValidateAndCommit` actions that have a positive rollback are rejected:
```
Actions rejected by precondition (584429 in total):
100.0000% ValidateAndCommit
```

The third commit fixes a trivial bug in the testing infrastructure where rollbacks were not accounted for.

With this PR, we now get a variety or rollback depths:

```
Rollback depths (898533 in total):
44.2447% 0
25.9243% 1
14.6631% 2
 7.9446% 3
 4.3239% 4
 2.1126% 5
 0.7868% 6
```
