### PR TITLE
Bugfix for Byron deserialization of Ledger Tables

### DIFF
--- a/ouroboros-consensus-cardano/changelog.d/byron-bugfix.md
+++ b/ouroboros-consensus-cardano/changelog.d/byron-bugfix.md
@@ -1,0 +1,3 @@
+### Patch
+
+- Fix LedgerTables deserialization for Byron snapshots.

--- a/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/Ledger.hs
+++ b/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/Ledger.hs
@@ -220,7 +220,8 @@ instance
         ( Fn $
             const $
               Comp $
-                K . LedgerTables @(LedgerState (HardForkBlock (CardanoEras c))) . ValuesMK <$> pure Map.empty
+                K . LedgerTables @(LedgerState (HardForkBlock (CardanoEras c))) . ValuesMK
+                  <$> (Codec.CBOR.Decoding.decodeMapLen >> pure Map.empty)
         )
           :* (Fn $ Comp . fmap K . getOne ShelleyTxOut . unFlip . currentState)
           :* (Fn $ Comp . fmap K . getOne AllegraTxOut . unFlip . currentState)


### PR DESCRIPTION
# Description

We were encoding a map length of `0`, but were not decoding it.
