### PR TITLE
Peras chain weight microbenchmark

### DIFF
--- a/docs/website/contents/for-developers/Benchmarks.md
+++ b/docs/website/contents/for-developers/Benchmarks.md
@@ -1,6 +1,11 @@
 # Consensus benchmarks
 
 We are in the process of adding component level microbenchmarks for Consensus.
+
+We check for regressions in performance on CI.
+
+## Mempool Benchmark
+
 We started with microbenchmarks for adding transactions to the mempool. The
 mempool benchmarks can be run using the following command.
 
@@ -8,4 +13,10 @@ mempool benchmarks can be run using the following command.
 cabal new-run ouroboros-consensus:mempool-bench
 ```
 
-We check for regressions in performance on CI. We might publish benchmark results in this site shortly.
+## ChainSync Client Benchmark
+
+To aid the refactoring of the ChainSync client, we added a benchmark for it in [PR#823](https://github.com/IntersectMBO/ouroboros-consensus/pull/823). The benchmark could be invoked as follows:
+
+```sh
+cabal new-run ouroboros-consensus:ChainSync-client-bench -- 10 10
+```

--- a/docs/website/contents/for-developers/Benchmarks.md
+++ b/docs/website/contents/for-developers/Benchmarks.md
@@ -20,3 +20,13 @@ To aid the refactoring of the ChainSync client, we added a benchmark for it in [
 ```sh
 cabal new-run ouroboros-consensus:ChainSync-client-bench -- 10 10
 ```
+
+## PerasCertDB Benchmark
+
+We have a microbenchmark for the boosted chain fragment weight calculation, which could be run as follows:
+
+```sh
+cabal run ouroboros-consensus:PerasCertDB-bench -- +RTS -T -A32m -RTS
+```
+
+We request GHC runtime system statistics with `-T` to get a memory usage estimate, and also request a large nursery with `-A32m` to minimise garbage collection. See `tasty-bench` [documentation](https://github.com/Bodigrim/tasty-bench?tab=readme-ov-file#troubleshooting) for more tips.

--- a/ouroboros-consensus/bench/PerasCertDB-bench/Main.hs
+++ b/ouroboros-consensus/bench/PerasCertDB-bench/Main.hs
@@ -1,0 +1,102 @@
+{-# LANGUAGE ImportQualifiedPost #-}
+{-# LANGUAGE LambdaCase #-}
+
+-- | This module contains benchmarks for Peras chain weight calculation as implemented by
+--   the by the 'Ouroboros.Consensus.Storage.PerasCertDB.API.boostedWeightForFragment'
+--   function.
+--
+--   We benchmark the calculation on a static sequence of chain fragments of increasing
+--   length, ranging from 0 to around 8640, with a sampling rate of 100. The chain fragments
+--   are instantiated with 'TestBlock', and every 5 blocks there is a booster block with
+--   weight 15. All parameters are set in 'benchmarkParams'.
+module Main (main) where
+
+import Data.List (iterate')
+import Data.Map.Strict qualified as Map
+import Numeric.Natural (Natural)
+import Ouroboros.Consensus.Block (PerasWeight (PerasWeight), SlotNo (..))
+import Ouroboros.Consensus.Storage.PerasCertDB.API
+  ( PerasWeightSnapshot (..)
+  , boostedWeightForFragment
+  )
+import Ouroboros.Network.AnchoredFragment qualified as AF
+import Test.Ouroboros.Storage.TestBlock (TestBlock (..), TestBody (..), TestHeader (..))
+import Test.Ouroboros.Storage.TestBlock qualified as TestBlock
+import Test.Tasty.Bench
+
+data BenchmarkParams = BenchmarkParams
+  { blockRate :: SlotNo
+  -- ^ How often the fragments will contain blocks, in slots
+  , fragmentLenghtSamplingRate :: Natural
+  -- ^ The rate of length increase for generate chain fragments
+  , fragmentMaxLenght :: Natural
+  -- ^ the maximum length of a fragment
+  , boostedBlockRate :: Natural
+  -- ^ How often boosted blocks occur, in blocks
+  , boostWeight :: PerasWeight
+  -- ^ The weight of the boost
+  }
+
+benchmarkParams :: BenchmarkParams
+benchmarkParams =
+  BenchmarkParams
+    { blockRate = 20
+    , fragmentLenghtSamplingRate = 100
+    , fragmentMaxLenght = 2160 + 3 * 2160
+    , boostedBlockRate = 5
+    , boostWeight = PerasWeight 15
+    }
+
+main :: IO ()
+main =
+  Test.Tasty.Bench.defaultMain $ map benchBoostedWeightForFragment inputs
+ where
+  -- NOTE: we do not use the 'env' combinator to set up the test data since
+  --       it requires 'NFData' for 'AF.AnchoredFragment'. While the necessary
+  --       instances could be provided, we do not think is necessary for this
+  --       benchmark, as the input data is rather small.
+  inputs :: [(Natural, (PerasWeightSnapshot TestBlock, AF.AnchoredFragment TestBlock))]
+  inputs =
+    getEveryN (fragmentLenghtSamplingRate benchmarkParams) $
+      take (fromIntegral $ fragmentMaxLenght benchmarkParams) $
+        zip [0 ..] $
+          zip (map uniformWeightSnapshot fragments) fragments
+
+benchBoostedWeightForFragment ::
+  (Natural, (PerasWeightSnapshot TestBlock, AF.AnchoredFragment TestBlock)) -> Benchmark
+benchBoostedWeightForFragment (i, (weightSnapshot, fragment)) =
+  bench ("boostedWeightForFragment of length " <> show i) $
+    whnf (boostedWeightForFragment weightSnapshot) fragment
+
+-- | An infinite list of chain fragments
+fragments :: [AF.AnchoredFragment TestBlock]
+fragments = iterate' addSuccessorBlock genesisFragment
+ where
+  genesisFragment :: AF.AnchoredFragment TestBlock
+  genesisFragment = AF.Empty AF.AnchorGenesis
+
+  addSuccessorBlock :: AF.AnchoredFragment TestBlock -> AF.AnchoredFragment TestBlock
+  addSuccessorBlock = \case
+    AF.Empty _ -> (AF.Empty AF.AnchorGenesis) AF.:> (TestBlock.firstBlock 0 dummyBody)
+    (xs AF.:> x) ->
+      let nextBlockSlot = blockRate benchmarkParams + (thSlotNo . testHeader $ x)
+       in (xs AF.:> x) AF.:> TestBlock.mkNextBlock x nextBlockSlot dummyBody
+
+  dummyBody :: TestBody
+  dummyBody = TestBody{tbForkNo = 0, tbIsValid = True}
+
+-- | Given a chain fragment, construct a weight snapshot where there's a boosted block every 90 slots
+uniformWeightSnapshot :: AF.AnchoredFragment TestBlock -> PerasWeightSnapshot TestBlock
+uniformWeightSnapshot fragment =
+  let pointsToBoost =
+        map snd
+          . getEveryN (boostedBlockRate benchmarkParams)
+          . zip [0 ..]
+          . map AF.blockPoint
+          . AF.toOldestFirst
+          $ fragment
+      weights = repeat (boostWeight benchmarkParams)
+   in PerasWeightSnapshot{getPerasWeightSnapshot = Map.fromList $ zip pointsToBoost weights}
+
+getEveryN :: Natural -> [(Natural, a)] -> [(Natural, a)]
+getEveryN n = filter (\(i, _) -> (i `mod` n) == 0)

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -383,6 +383,7 @@ library unstable-consensus-testlib
     Test.Ouroboros.Consensus.ChainGenerator.Some
     Test.Ouroboros.Consensus.DiffusionPipelining
     Test.Ouroboros.Consensus.Protocol
+    Test.Ouroboros.Storage.TestBlock
     Test.QuickCheck.Extras
     Test.Util.BoolProps
     Test.Util.ChainDB
@@ -453,6 +454,7 @@ library unstable-consensus-testlib
     fs-api ^>=0.3,
     fs-sim ^>=0.3,
     generics-sop,
+    hashable,
     io-classes,
     io-sim,
     mempack,
@@ -724,7 +726,6 @@ test-suite storage-test
     Test.Ouroboros.Storage.PerasCertDB
     Test.Ouroboros.Storage.PerasCertDB.Model
     Test.Ouroboros.Storage.PerasCertDB.StateMachine
-    Test.Ouroboros.Storage.TestBlock
     Test.Ouroboros.Storage.VolatileDB
     Test.Ouroboros.Storage.VolatileDB.Mock
     Test.Ouroboros.Storage.VolatileDB.Model
@@ -735,10 +736,8 @@ test-suite storage-test
     aeson,
     base,
     bifunctors,
-    binary,
     bytestring,
     cardano-binary,
-    cardano-crypto-class ^>=2.2,
     cardano-ledger-binary:testlib,
     cardano-ledger-core:{cardano-ledger-core, testlib},
     cardano-slotting:{cardano-slotting, testlib},
@@ -753,7 +752,6 @@ test-suite storage-test
     fs-api ^>=0.3,
     fs-sim ^>=0.3,
     generics-sop,
-    hashable,
     io-classes,
     io-sim,
     mempack,

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -837,6 +837,20 @@ benchmark ChainSync-client-bench
     unstable-consensus-testlib,
     with-utf8,
 
+benchmark PerasCertDB-bench
+  import: common-bench
+  type: exitcode-stdio-1.0
+  hs-source-dirs: bench/PerasCertDB-bench
+  main-is: Main.hs
+  other-modules:
+  build-depends:
+    base,
+    containers,
+    ouroboros-consensus,
+    ouroboros-network-api,
+    tasty-bench,
+    unstable-consensus-testlib,
+
 test-suite doctest
   import: common-test
   main-is: doctest.hs

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Storage/TestBlock.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Storage/TestBlock.hs
@@ -125,7 +125,6 @@ import qualified Ouroboros.Network.Mock.Chain as Chain
 import System.FS.API.Lazy
 import Test.Cardano.Slotting.Numeric ()
 import Test.Cardano.Slotting.TreeDiff ()
-import Test.Ouroboros.Storage.ChainDB.Model
 import Test.QuickCheck
 import Test.Util.Orphans.Arbitrary ()
 import Test.Util.Orphans.SignableRepresentation ()
@@ -934,8 +933,6 @@ deriving instance ToExpr TestBlockOtherHeaderEnvelopeError
 deriving instance ToExpr (HeaderEnvelopeError TestBlock)
 deriving instance ToExpr BftValidationErr
 deriving instance ToExpr (ExtValidationError TestBlock)
-
-instance ModelSupportsBlock TestBlock
 
 deriving anyclass instance ToExpr FsPath
 deriving anyclass instance ToExpr BlocksPerFile

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
@@ -345,6 +345,8 @@ deriving instance
   (TestConstraints blk, Show it, Show flr) =>
   Show (Success blk it flr)
 
+instance ModelSupportsBlock TestBlock
+
 -- | Short-hand
 type TestIterator m blk = WithEq (Iterator m blk (AllComponents blk))
 


### PR DESCRIPTION
Closes https://github.com/tweag/cardano-peras/issues/61

This PR contains a micro benchmark for Peras chain weight calculation as implemented by the by the `Ouroboros.Consensus.Storage.PerasCertDB.API.boostedWeightForFragment` function.