### PR TITLE
storage-test: move TestBlock to testlib

### DIFF
--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -380,6 +380,7 @@ library unstable-consensus-testlib
     Test.Ouroboros.Consensus.DiffusionPipelining
     Test.Ouroboros.Consensus.Protocol
     Test.Ouroboros.Consensus.QuickCheck.Extras
+    Test.Ouroboros.Storage.TestBlock
     Test.Util.BoolProps
     Test.Util.ChainDB
     Test.Util.ChainUpdates
@@ -449,6 +450,7 @@ library unstable-consensus-testlib
     fs-api ^>=0.3,
     fs-sim ^>=0.3,
     generics-sop,
+    hashable,
     io-classes,
     io-sim,
     mempack,
@@ -717,7 +719,6 @@ test-suite storage-test
     Test.Ouroboros.Storage.LedgerDB.V1.DbChangelog
     Test.Ouroboros.Storage.LedgerDB.V1.LMDB
     Test.Ouroboros.Storage.Orphans
-    Test.Ouroboros.Storage.TestBlock
     Test.Ouroboros.Storage.VolatileDB
     Test.Ouroboros.Storage.VolatileDB.Mock
     Test.Ouroboros.Storage.VolatileDB.Model
@@ -728,10 +729,8 @@ test-suite storage-test
     aeson,
     base,
     bifunctors,
-    binary,
     bytestring,
     cardano-binary,
-    cardano-crypto-class ^>=2.2,
     cardano-ledger-binary:testlib,
     cardano-ledger-core:{cardano-ledger-core, testlib},
     cardano-slotting:{cardano-slotting, testlib},
@@ -746,7 +745,6 @@ test-suite storage-test
     fs-api ^>=0.3,
     fs-sim ^>=0.3,
     generics-sop,
-    hashable,
     io-classes,
     io-sim,
     mempack,

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Storage/TestBlock.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Storage/TestBlock.hs
@@ -125,7 +125,6 @@ import qualified Ouroboros.Network.Mock.Chain as Chain
 import System.FS.API.Lazy
 import Test.Cardano.Slotting.Numeric ()
 import Test.Cardano.Slotting.TreeDiff ()
-import Test.Ouroboros.Storage.ChainDB.Model
 import Test.QuickCheck
 import Test.Util.Orphans.Arbitrary ()
 import Test.Util.Orphans.SignableRepresentation ()
@@ -934,8 +933,6 @@ deriving instance ToExpr TestBlockOtherHeaderEnvelopeError
 deriving instance ToExpr (HeaderEnvelopeError TestBlock)
 deriving instance ToExpr BftValidationErr
 deriving instance ToExpr (ExtValidationError TestBlock)
-
-instance ModelSupportsBlock TestBlock
 
 deriving anyclass instance ToExpr FsPath
 deriving anyclass instance ToExpr BlocksPerFile

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
@@ -344,6 +344,8 @@ deriving instance
   (TestConstraints blk, Show it, Show flr) =>
   Show (Success blk it flr)
 
+instance ModelSupportsBlock TestBlock
+
 -- | Short-hand
 type TestIterator m blk = WithEq (Iterator m blk (AllComponents blk))
 


### PR DESCRIPTION
This PR moves the `Test.Ouroboros.Storage.TestBlock` module form `storage-test` to `unstable-consensus-testlib` so that it could be used in a wider context. Specifically, I'd like to use it for Peras-related benchmarking in https://github.com/IntersectMBO/ouroboros-consensus/pull/1583