### PR TITLE
ChainSel.ReprocessLoEBlocks: ensure trigger block is not on chain

### DIFF
--- a/ouroboros-consensus/changelog.d/20250721_172317_alexander.esgen_chaindb_loe_trigger_opt.md
+++ b/ouroboros-consensus/changelog.d/20250721_172317_alexander.esgen_chaindb_loe_trigger_opt.md
@@ -1,0 +1,4 @@
+### Patch
+
+- Changed ChainSel reprocessing of blocks postponed by the Limited of Eagerness
+  (Genesis), which in particular should be more efficient.


### PR DESCRIPTION
Before this PR, we triggered ChainSel for all successor blocks of the immutable tip, which in particular includes the oldest header on our selection (that is not yet immutable). This guarantees that we all consider all possible candidates reachable from our immutable tip, and we select the best out of all of these, subject to the Limit on Eagerness (LoE).

This is fine semantics-wise, but has a couple of weird (albeit currently non-crucial) consequences:

 1. We always trigger a `chainSelectionForBlock`, which will usually just conclude that there is no better chain (but it will still do work like loading the headers for the candidate from disk despite those usually being identical to those on the current selection).

 2. If we do switch to a longer chain (due to an no-longer-LoE-postponed block), then this is somewhat confusingly logged as a chain switch even if we just extended our chain.

 3. It is not true that all suffixes in the candidate `ChainDiff`s intersect as one might expect. This is fine in the current logic, as the precondition of `compareAnchoredFragments` is still fulfilled (namely due to the fact that all suffixes are non-empty), but we would like to require a stronger precondition (see https://github.com/IntersectMBO/ouroboros-consensus/pull/1594).

    For example, suppose that `k=2` and that our selection is

    ```
    A ] B :> C
    ```

    and the VolatileDB furthermore contains blocks `D` and `E` with `B :> D` and `C :> E`. Then, when we trigger ChainSel, we trigger it for `B` (the only successor of the immutable tip), and the ChainSel logic builds the following `ChainDiffs`:

     - `ChainDiff { getRollback = 1, getSuffix = B ] D }`
     - `ChainDiff { getRollback = 0, getSuffix = C ] E }`

    Note that the suffixes do not intersect.

---

This PR uses a slightly different approach for re-triggering ChainSel. Namely, we perform chain selection for all blocks that are successors of a point on our current selection, including the anchor, while ignoring blocks on our selection. This fixes all of the problems above:

 1. When there is no LoE-postponed block, we will not call `chainSelectionForBlock`.

 2. If we switch to an extension of our chain, this will be logged as such (`AddedToCurrentChain`) because we run `chainSelectionForBlock` for the immediate successor of our volatile tip.

 3. Because we perform separate `chainSelectionForBlock`s for different blocks extending a point `P` on our selection, all `ChainDiff` suffixes considered per `chainSelectionForBlock` do intersect, namely because they are anchored in `P`.

    In the example above, we would trigger separate chain selections for `D` and `E`, and only consider one `ChainDiff` in each case.

One side effect is that we will consider candidates in a potentially different order than before, which is acceptable while syncing via Genesis.
