### PR TITLE
Ensure tables in InMemory snapshots are serialized with indefinite length encoding

### DIFF
--- a/ouroboros-consensus-cardano/changelog.d/20250723_135751_javier.sagredo_indef_cbor_enc_tables.md
+++ b/ouroboros-consensus-cardano/changelog.d/20250723_135751_javier.sagredo_indef_cbor_enc_tables.md
@@ -1,0 +1,24 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+### Patch
+
+- Ensure tables in InMemory snapshots use indefinite-length encoding. This was
+  already the case for the Cardano network as there are more than 23 UTxOs so
+  this change should have no effect on running nodes.
+
+<!--
+### Non-Breaking
+
+- A bullet item for the Non-Breaking category.
+
+-->
+<!--
+### Breaking
+
+- A bullet item for the Breaking category.
+
+-->

--- a/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/Ledger.hs
+++ b/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/Ledger.hs
@@ -213,7 +213,9 @@ instance
     encOne :: forall era. Era era => Proxy era -> Encoding
     encOne _ =
       toPlainEncoding (eraProtVerLow @era) $
-        encodeMap encodeMemPack (eliminateCardanoTxOut (const encodeMemPack)) tbs
+        Cardano.Ledger.Binary.Encoding.encodeMapLenIndef
+          <> Map.foldMapWithKey (\k v -> encodeMemPack k <> eliminateCardanoTxOut (const encodeMemPack) v) tbs
+          <> Cardano.Ledger.Binary.Encoding.encodeBreak
 
   decodeTablesWithHint ::
     forall s.


### PR DESCRIPTION
This was already the case, because for maps over 23 elements indefinite length is used, but this way we ensure this is true always.

It is necessary to allow writing non-native snapshots.


