### PR TITLE
ChainSel.ReprocessLoEBlocks: avoid transient chain switches

### DIFF
--- a/ouroboros-consensus/changelog.d/20250801_172359_alexander.esgen_chainsel_fix_transient_loe.md
+++ b/ouroboros-consensus/changelog.d/20250801_172359_alexander.esgen_chainsel_fix_transient_loe.md
@@ -1,0 +1,5 @@
+### Breaking
+
+- Changed `SelectionChangedInfo.newTipTrigger` (contained in tracing types) to
+  be a `Maybe` to accurately reflect Ouroboros Genesis-related (Limit on
+  Eagerness) triggered chain selection.

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/ChainSel.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/ChainSel.hs
@@ -583,7 +583,7 @@ chainSelectionForBlock cdb@CDB{..} blockCache hdr punish = electric $ withRegist
             chainSelection chainSelEnv rr chainDiffs' >>= \case
               Just validatedChainDiff ->
                 -- Switch to the new better chain.
-                switchTo cdb p validatedChainDiff
+                switchTo cdb (Just p) validatedChainDiff
               -- No valid candidate better than our chain.
               Nothing -> noChange
           -- No candidate better than our chain.
@@ -788,8 +788,10 @@ switchTo ::
   , HasCallStack
   ) =>
   ChainDbEnv m blk ->
-  -- | Which block we performed chain selection for.
-  RealPoint blk ->
+  -- | Which block we performed chain selection for (if any). This is 'Nothing'
+  -- when reprocessing blocks that were postponed due to the Limit on Eagerness
+  -- (cf 'ChainSelReprocessLoEBlocks').
+  Maybe (RealPoint blk) ->
   -- | Chain and ledger to switch to
   ValidatedChainDiff (Header blk) (Forker' m blk) ->
   m ()

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Types.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Types.hs
@@ -783,7 +783,7 @@ data SelectionChangedInfo blk = SelectionChangedInfo
   , newTipSlotInEpoch :: Word64
   -- ^ The slot in the epoch, i.e., the relative slot number, of the new
   -- tip.
-  , newTipTrigger :: RealPoint blk
+  , newTipTrigger :: Maybe (RealPoint blk)
   -- ^ The new tip of the current chain ('newTipPoint') is the result of
   -- performing chain selection for a /trigger/ block ('newTipTrigger').
   -- In most cases, we add a new block to the tip of the current chain, in
@@ -793,6 +793,10 @@ data SelectionChangedInfo blk = SelectionChangedInfo
   -- chain being A and having a disconnected C lying around, adding B will
   -- result in A -> B -> C as the new chain. The trigger B /= the new tip
   -- C.
+  --
+  -- Due to the Ouroboros Genesis (Limit on Eagerness), chain selection can also
+  -- be triggered without any particular trigger block, in which case this is
+  -- 'Nothing'.
   , newTipSelectView :: SelectView (BlockProtocol blk)
   -- ^ The 'SelectView' of the new tip. It is guaranteed that
   --

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
@@ -439,7 +439,6 @@ run cfg env@ChainDBEnv{varDB, ..} cmd =
   advanceAndAdd ChainDBState{chainDB} blk = do
     -- `blockProcessed` always returns 'Just'
     res <- addBlock chainDB InvalidBlockPunishment.noPunishment blk
-    ChainDB.triggerChainSelection chainDB
     return $ case res of
       FailedToAddBlock f -> error $ "advanceAndAdd: block not added - " ++ f
       SuccesfullyAddedBlock pt -> pt


### PR DESCRIPTION
Closes #1616 

The commits are intended to be reviewed individually.

 - The first seven commits are preparatory refactorings of the existing logic; they (intentionally) do not fix the bug, and actually might be of independent interest, breaking up the huge `chainSelectionForBlock` function.

   Using structural diffing via eg [difftastic](https://github.com/Wilfred/difftastic) might be useful while reviewing.

 - The last commit fixes the bug as described in #1616.