### PR TITLE
Nixify cabal-docspec check

### DIFF
--- a/nix/ci.nix
+++ b/nix/ci.nix
@@ -42,7 +42,7 @@ let
       haskell96 = mkHaskellJobsFor pkgs.hsPkgs;
     } // lib.optionalAttrs (buildSystem == "x86_64-linux") {
       formattingLinting = import ./formatting-linting.nix pkgs;
-      inherit (pkgs) consensus-pdfs agda-spec;
+      inherit (pkgs) cabal-docspec-check consensus-pdfs agda-spec;
 
       # also test newer GHCs, but only on Linux to reduce CI load
       haskell910 = mkHaskellJobsFor pkgs.hsPkgs.projectVariants.ghc910;


### PR DESCRIPTION
Currently, this check is only run on GHA on `main` (so it isn't run on PRs). This is fine as we currently only use it to render some images in the UTxO HD docs, but for Peras, we actually want to use it for checking the correctness of some API examples.

