### PR TITLE
Fix broken links that did not cause a `yarn build` failure

### DIFF
--- a/docs/website/contents/howtos/contributing/how_to_make_a_release.md
+++ b/docs/website/contents/howtos/contributing/how_to_make_a_release.md
@@ -297,7 +297,7 @@ B - the release of FOO-1.0.0 (tag: release-FOO-1.0.0)
 A - ...
 ```
 
-# Installing `scriv`
+## Installing `scriv`
 
 To manage the workflow described above, we will use the `scriv` tool slightly
 modified to support cabal files. If you use `nix` then you will find `scriv` in
@@ -320,7 +320,7 @@ pass in the flag `--break-system-packages`:
 pip install --break-system-packages scriv
 ```
 
-# Adding a changelog fragment
+## Adding a changelog fragment
 
 When a given branch contains a change that deserves a changelog entry, you
 should add a changelog
@@ -341,7 +341,7 @@ To create a changelog fragment you can follow these steps:
    guidelines][git-contributing-to-a-project].
 3. Add the file(s) to the branch.
 
-# Cutting a release
+## Cutting a release
 
 First, make sure `scriv` is [installed](#installing-scriv), along with the
 following Python3 packages (unless you use `scriv` in a `nix` shell):
@@ -396,7 +396,7 @@ git pull
 [contributing-to-a-project]: https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#Commit-Guidelines
 [chap]: https://github.com/IntersectMBO/cardano-haskell-packages
 
-# The first time we had to break this release process
+## The first time we had to break this release process
 
 On the first half of April 2023, we were asked to get a new Consensus release
 from current `master` in order for it to be integrated into the node. However
@@ -459,7 +459,7 @@ a new organization, and also migrate to a new repository.
 
 [solution]: https://github.com/IntersectMBO/cardano-haskell-packages/pull/207
 
-# The new organization
+## The new organization
 
 The consensus packages are now split as follows:
 

--- a/docs/website/contents/references/glossary.md
+++ b/docs/website/contents/references/glossary.md
@@ -1,4 +1,3 @@
-<!-- xrefcheck: ignore all -->
 # Glossary
 
 Notes on the use and maintenance of this glossary:
@@ -79,7 +78,7 @@ Wraps several other components and provides *chain selection* (ChainSel) functio
 
 This property states that there are at least $k$ blocks in $3k/f$ slots.
 
-Here $f$ refers to the [active slot coefficient](#active-slot-coefficient).
+Here $f$ refers to the [active slot coefficient](#active-slot-coefficient-f).
 
 The main Praos theorem also establishes a similarly-shaped bound on the probability of the immutable chain having less than `k` blocks in any contiguous run of `s` slots. The IOG researchers chose `s=3k/f` for Cardano. We started calling it `scg`, since `s` is a pretty common identifier.
 
@@ -196,7 +195,7 @@ When Ouroboros runs as intended, all short forks are short-lived.
 ## ;Forecasting
 
 Forecasting is the ability to validate headers that are ahead of a node's current selection.
-Because of [Common Prefix](#common-prefix) and [Chain Growth](#chain-growth), the latest `k+1` ledger states along the node's selection always provide sufficient information for the node to validate its peers' headers that are no more than `3k/f` after the peer's first header.
+Because of [Common Prefix](#common-prefix) and [Chain Growth](#chain-growth-property), the latest `k+1` ledger states along the node's selection always provide sufficient information for the node to validate its peers' headers that are no more than `3k/f` after the peer's first header.
 Since the node hasn't selected that header's block, it has to use forecasting in order to validate its descendant headers.
 
 ### ;Forecast horizon
@@ -289,7 +288,7 @@ All honest block-producing nodes that are fully synchronized to the state of the
 
  - active parties - honest caught-up parties plus the adversary.
 
-   [Genesis](#genesis) has two natural requirements which must be met throughout the system's lifetime:
+   [Genesis](miscellaneous/genesis_design.md) has two natural requirements which must be met throughout the system's lifetime:
 
     - The ratio `α` of honest caught-up parties over active parties is above `1/2`.
 


### PR DESCRIPTION
Docusaurus did not generate anchors for top-level headings, so they have been changed to second-level ones.

This PR fixes a couple of other broken links.