### PR TITLE
Add some details on the expected file formats

### DIFF
--- a/ouroboros-consensus-cardano/app/DBSynthesizer/Parsers.hs
+++ b/ouroboros-consensus-cardano/app/DBSynthesizer/Parsers.hs
@@ -98,7 +98,8 @@ parseBulkFilePath =
   strOption
     ( long "bulk-credentials-file"
         <> metavar "FILE"
-        <> help "Path to the bulk credentials file (a JSON file containing an array of arrays containing 3 TextEnvelope objects for the opcert, VRF Signing key, KES signing key)"
+        <> help
+          "Path to the bulk credentials file (a JSON file containing an array of arrays containing 3 TextEnvelope objects for the opcert, VRF Signing key, KES signing key)"
         <> completer (bashCompleter "file")
     )
 


### PR DESCRIPTION
This tiny PR documents in a bit more details how the arguments to `db-synthesizer` program look like. In particular, it wasn't obvious what the "bulk credentials" structure was and I got it only after looking at the example. HTH.