### PR TITLE
Redefine `Header` with `MemoBytes`

### DIFF
--- a/ouroboros-consensus-protocol/changelog.d/20250918_191621_teodora.danciu.md
+++ b/ouroboros-consensus-protocol/changelog.d/20250918_191621_teodora.danciu.md
@@ -1,0 +1,3 @@
+### Non-Breaking
+
+- Added `SafeToHash` instance for `BHeader`


### PR DESCRIPTION
Since we removed the `era` type parameter in `MemoBytes` (in `cardano-ledger-core`),  we can use `MemoBytes` to define more types that need to be memoized - `Header` among them. 

This simplifies the definition of `Header` and also brings some instances for free.

Closes https://github.com/IntersectMBO/cardano-ledger/issues/4850


# Description

Please include a meaningful description of the PR and link the relevant issues
this PR might resolve.

Also note that:

- New code should be properly tested (even if it does not add new features).
- The fix for a regression should include a test that reproduces said regression.
