### PR TITLE
Reintroduce `encodedSizeExpr` in `Header` instance

### DIFF
--- a/ouroboros-consensus-protocol/src/ouroboros-consensus-protocol/Ouroboros/Consensus/Protocol/Praos/Header.hs
+++ b/ouroboros-consensus-protocol/src/ouroboros-consensus-protocol/Ouroboros/Consensus/Protocol/Praos/Header.hs
@@ -42,6 +42,7 @@ import Cardano.Ledger.Binary
   , DecCBOR (decCBOR)
   , EncCBOR (..)
   , ToCBOR (..)
+  , encodedSigKESSizeExpr
   , serialize'
   , unCBORGroup
   )
@@ -224,7 +225,11 @@ instance Crypto crypto => DecCBOR (HeaderRaw crypto) where
 instance Crypto crypto => DecCBOR (Annotator (HeaderRaw crypto)) where
   decCBOR = pure <$> decCBOR
 
-instance Crypto c => EncCBOR (Header c)
+instance Crypto c => EncCBOR (Header c) where
+  encodedSizeExpr size proxy =
+    1
+      + encodedSizeExpr size (headerBody <$> proxy)
+      + encodedSigKESSizeExpr (KES.getSig . headerSig <$> proxy)
 
 deriving via
   Mem (HeaderRaw crypto)


### PR DESCRIPTION
# Description

In my previous [PR](https://github.com/IntersectMBO/ouroboros-consensus/pull/1687) , I [removed](https://github.com/IntersectMBO/ouroboros-consensus/pull/1687/files#diff-cc67072c8a9a8cae57404fc5f4ff58c83ef8c6238043df252402a83218ff1219L246) the implementation of `encodedSizeExpr` from the `Header` instance. 
On @lehins advice, I'm reintroducing it - even though it's not clear if it's actually used - it's better to remove it systematically if it turns out that's the case, rather than change it accidentally. 

