### PR TITLE
Propagate feature flags down to NodeKernelArgs

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -16,7 +16,7 @@ index-state:
   -- Bump this if you need newer packages from Hackage
   , hackage.haskell.org 2025-07-22T09:13:54Z
   -- Bump this if you need newer packages from CHaP
-  , cardano-haskell-packages 2025-08-21T09:41:03Z
+  , cardano-haskell-packages 2025-10-07T11:20:00Z
 
 packages:
   ouroboros-consensus

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1755770112,
-        "narHash": "sha256-BE9+swBBPBi9iRQNqsUNUjS02nyRF+OwfCkhIjted6I=",
+        "lastModified": 1759837865,
+        "narHash": "sha256-g8SMcVN1v51Muz6a+xJkB92mPx1jsg+sjHKvQ3Wj/jY=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "7af503772adf627cd23be5431440a0ffae74de52",
+        "rev": "9a46cacd941c108492cd4cee5d29735e8cd8ee65",
         "type": "github"
       },
       "original": {

--- a/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
+++ b/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
@@ -77,6 +77,7 @@ library
   build-depends:
     base >=4.14 && <4.22,
     bytestring >=0.10 && <0.13,
+    cardano-base,
     cardano-slotting,
     cborg ^>=0.2.2,
     containers >=0.5 && <0.8,

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Node.hs
@@ -60,6 +60,7 @@ module Ouroboros.Consensus.Node
   , openChainDB
   ) where
 
+import Cardano.Base.FeatureFlags (CardanoFeatureFlag)
 import qualified Cardano.Network.Diffusion as Cardano.Diffusion
 import Cardano.Network.Diffusion.Configuration (ChainSyncIdleTimeout (..))
 import qualified Cardano.Network.Diffusion.Policies as Cardano.Diffusion
@@ -84,6 +85,7 @@ import Data.Kind (Type)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Maybe (fromMaybe, isNothing)
+import Data.Set (Set)
 import Data.Time (NominalDiffTime)
 import Data.Typeable (Typeable)
 import Ouroboros.Consensus.Block
@@ -232,6 +234,8 @@ data RunNodeArgs m addrNTN addrNTC blk = RunNodeArgs
   -- ^ Network PeerSharing miniprotocol willingness flag
   , rnGetUseBootstrapPeers :: STM m UseBootstrapPeers
   , rnGenesisConfig :: GenesisConfig
+  , rnFeatureFlags :: Set CardanoFeatureFlag
+  -- ^ Enabled experimental features
   }
 
 -- | Arguments that usually only tests /directly/ specify.
@@ -319,6 +323,8 @@ data LowLevelRunNodeArgs m addrNTN addrNTC blk
   , llrnPublicPeerSelectionStateVar :: StrictSTM.StrictTVar m (PublicPeerSelectionState addrNTN)
   , llrnLdbFlavorArgs :: Complete LedgerDbFlavorArgs m
   -- ^ The flavor arguments
+  , llrnFeatureFlags :: Set CardanoFeatureFlag
+  -- ^ Enabled experimental features
   }
 
 data NodeDatabasePaths
@@ -570,6 +576,7 @@ runWith RunNodeArgs{..} encAddrNtN decAddrNtN LowLevelRunNodeArgs{..} =
                   gsmAntiThunderingHerd
                   keepAliveRng
                   cfg
+                  llrnFeatureFlags
                   rnTraceConsensus
                   btime
                   (InFutureCheck.realHeaderInFutureCheck llrnMaxClockSkew systemTime)
@@ -847,6 +854,7 @@ mkNodeKernelArgs ::
   StdGen ->
   StdGen ->
   TopLevelConfig blk ->
+  Set CardanoFeatureFlag ->
   Tracers m (ConnectionId addrNTN) (ConnectionId addrNTC) blk ->
   BlockchainTime m ->
   InFutureCheck.SomeHeaderInFutureCheck m blk ->
@@ -866,6 +874,7 @@ mkNodeKernelArgs
   gsmAntiThunderingHerd
   rng
   cfg
+  featureFlags
   tracers
   btime
   chainSyncFutureCheck
@@ -885,6 +894,7 @@ mkNodeKernelArgs
           { tracers
           , registry
           , cfg
+          , featureFlags
           , btime
           , chainDB
           , initChainDB = nodeInitChainDB
@@ -1003,6 +1013,7 @@ stdLowLevelRunNodeArgsIO
     { rnProtocolInfo
     , rnPeerSharing
     , rnGenesisConfig
+    , rnFeatureFlags
     }
   $(SafeWildCards.fields 'StdRunNodeArgs) = do
     llrnBfcSalt <- stdBfcSaltIO
@@ -1053,6 +1064,8 @@ stdLowLevelRunNodeArgsIO
             Diffusion.dcPublicPeerSelectionVar srnDiffusionConfiguration
         , llrnLdbFlavorArgs =
             srnLdbFlavorArgs
+        , llrnFeatureFlags =
+            rnFeatureFlags
         }
    where
     networkMagic :: NetworkMagic

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
@@ -27,6 +27,7 @@ module Ouroboros.Consensus.NodeKernel
   , toConsensusMode
   ) where
 
+import Cardano.Base.FeatureFlags (CardanoFeatureFlag)
 import Cardano.Network.ConsensusMode (ConsensusMode (..))
 import Cardano.Network.PeerSelection.Bootstrap (UseBootstrapPeers)
 import Cardano.Network.PeerSelection.LocalRootPeers
@@ -51,6 +52,7 @@ import Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NE
 import Data.Maybe (isJust, mapMaybe)
 import Data.Proxy
+import Data.Set (Set)
 import qualified Data.Text as Text
 import Data.Void (Void)
 import Ouroboros.Consensus.Block hiding (blockMatchesHeader)
@@ -195,6 +197,7 @@ data NodeKernelArgs m addrNTN addrNTC blk = NodeKernelArgs
   { tracers :: Tracers m (ConnectionId addrNTN) addrNTC blk
   , registry :: ResourceRegistry m
   , cfg :: TopLevelConfig blk
+  , featureFlags :: Set CardanoFeatureFlag
   , btime :: BlockchainTime m
   , chainDB :: ChainDB m blk
   , initChainDB :: StorageConfig blk -> InitChainDB m blk -> m ()

--- a/ouroboros-consensus-diffusion/src/unstable-diffusion-testlib/Test/ThreadNet/Network.hs
+++ b/ouroboros-consensus-diffusion/src/unstable-diffusion-testlib/Test/ThreadNet/Network.hs
@@ -1045,6 +1045,7 @@ runThreadNetwork
               { tracers
               , registry
               , cfg = pInfoConfig
+              , featureFlags = mempty
               , btime
               , chainDB
               , initChainDB = nodeInitChainDB


### PR DESCRIPTION
Brings in cardano-base and propagates a set of `CardanoFeatureFlag`s from the top-level `RunNodeArgs` down to the `NodeKernelArgs`.

This is currently needed by an upcoming PR to the GSM to distinguish whether having an established PerasCertDiffusion connection with a given peer is necessary or not when trying to decide if such peer is idling.