### PR TITLE
Bump ouroboros-network to match peras-staging/pr-5202

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -59,8 +59,8 @@ allow-newer:
 source-repository-package
    type: git
    location: https://github.com/IntersectMBO/ouroboros-network
-   tag: 8dfff7b8916f7a56b2a3773438d5e5530c780710
-   --sha256: sha256-wMDq19G1SW4+puuQUUjgaULSou4+r7wJj6evnWoW/Xk=
+   tag: peras-staging/pr-5202
+   --sha256: sha256-nTbjunQaqt6/syzSKw24Lne50083dI2SZFirG2/1T9U=
    subdir:
      ouroboros-network
      ouroboros-network-protocols

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Node.hs
@@ -740,7 +740,7 @@ runWith RunNodeArgs{..} encAddrNtN decAddrNtN LowLevelRunNodeArgs{..} =
                     version
                     llrnVersionDataNTN
                     ( \versionData ->
-                        NTN.initiator miniProtocolParams version versionData
+                        NTN.initiator llrnFeatureFlags miniProtocolParams version versionData
                         -- Initiator side won't start responder side of Peer
                         -- Sharing protocol so we give a dummy implementation
                         -- here.
@@ -755,7 +755,7 @@ runWith RunNodeArgs{..} encAddrNtN decAddrNtN LowLevelRunNodeArgs{..} =
                     version
                     llrnVersionDataNTN
                     ( \versionData ->
-                        NTN.initiatorAndResponder miniProtocolParams version versionData $
+                        NTN.initiatorAndResponder llrnFeatureFlags miniProtocolParams version versionData $
                           ntnApps blockVersion
                     )
                 | (version, blockVersion) <- Map.toList llrnNodeToNodeVersions


### PR DESCRIPTION
Bumps the external ouroboros-network source-repository-package to the updated peras-staging/pr-5202, which incorporates the changes from:

https://github.com/IntersectMBO/ouroboros-network/pull/5202

In addition, it tweak call sites of `nodeToNodeProtocols` to match its updated signature, passing down the enabled feature flags.