### PR TITLE
Add support for new ledger state query GetDRepDelegations in NodeToClientV_23

### DIFF
--- a/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/Node.hs
+++ b/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/Node.hs
@@ -44,6 +44,7 @@ module Ouroboros.Consensus.Cardano.Node
   , pattern CardanoNodeToClientVersion16
   , pattern CardanoNodeToClientVersion17
   , pattern CardanoNodeToClientVersion18
+  , pattern CardanoNodeToClientVersion19
   , pattern CardanoNodeToNodeVersion1
   , pattern CardanoNodeToNodeVersion2
   ) where
@@ -422,6 +423,21 @@ pattern CardanoNodeToClientVersion18 =
         :* Nil
       )
 
+pattern CardanoNodeToClientVersion19 :: BlockNodeToClientVersion (CardanoBlock c)
+pattern CardanoNodeToClientVersion19 =
+  HardForkNodeToClientEnabled
+    HardForkSpecificNodeToClientVersion3
+    ( EraNodeToClientEnabled ByronNodeToClientVersion1
+        :* EraNodeToClientEnabled ShelleyNodeToClientVersion15
+        :* EraNodeToClientEnabled ShelleyNodeToClientVersion15
+        :* EraNodeToClientEnabled ShelleyNodeToClientVersion15
+        :* EraNodeToClientEnabled ShelleyNodeToClientVersion15
+        :* EraNodeToClientEnabled ShelleyNodeToClientVersion15
+        :* EraNodeToClientEnabled ShelleyNodeToClientVersion15
+        :* EraNodeToClientEnabled ShelleyNodeToClientVersion15
+        :* Nil
+      )
+
 instance
   CardanoHardForkConstraints c =>
   SupportedNetworkProtocolVersion (CardanoBlock c)
@@ -441,9 +457,10 @@ instance
       , (NodeToClientV_20, CardanoNodeToClientVersion16)
       , (NodeToClientV_21, CardanoNodeToClientVersion17)
       , (NodeToClientV_22, CardanoNodeToClientVersion18)
+      , (NodeToClientV_23, CardanoNodeToClientVersion19)
       ]
 
-  latestReleasedNodeVersion _prx = (Just NodeToNodeV_15, Just NodeToClientV_22)
+  latestReleasedNodeVersion _prx = (Just NodeToNodeV_15, Just NodeToClientV_23)
 
 {-------------------------------------------------------------------------------
   ProtocolInfo

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/NetworkProtocolVersion.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/NetworkProtocolVersion.hs
@@ -31,6 +31,8 @@ data ShelleyNodeToClientVersion
     ShelleyNodeToClientVersion13
   | -- | Support SRV in GetBigLedgerPeerSnapshot
     ShelleyNodeToClientVersion14
+    -- | New queries introduced: QueryDRepsDelegations
+  | ShelleyNodeToClientVersion15
   deriving (Show, Eq, Ord, Enum, Bounded)
 
 ledgerPeerSnapshotSupportsSRV :: ShelleyNodeToClientVersion -> LedgerPeerSnapshotSRVSupport
@@ -58,6 +60,7 @@ instance SupportedNetworkProtocolVersion (ShelleyBlock proto era) where
       , (NodeToClientV_20, ShelleyNodeToClientVersion12)
       , (NodeToClientV_21, ShelleyNodeToClientVersion13)
       , (NodeToClientV_22, ShelleyNodeToClientVersion14)
+      , (NodeToClientV_23, ShelleyNodeToClientVersion15)
       ]
 
   latestReleasedNodeVersion = latestReleasedNodeVersionDefault

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Query/Version.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Query/Version.hs
@@ -28,3 +28,4 @@ nodeToClientVersionToQueryVersion x = case x of
   NodeToClientV_20 -> QueryVersion3
   NodeToClientV_21 -> QueryVersion3
   NodeToClientV_22 -> QueryVersion3
+  NodeToClientV_23 -> QueryVersion3


### PR DESCRIPTION
# Description

The PR wires in a new ledger state query that was [recently added](https://github.com/IntersectMBO/cardano-ledger/pull/5176) but never got properly wired in. 

This PR requires IntersectMBO/ouroboros-network#5222 due to the nice dependency on the network version there 😬. 

Note that I do expect some help getting this merged. The repository is complex to build, and I kindly refuse to use Nix. So if anything goes wrong with CI, I would appreciate a little nudge from the maintainers to getting this through. It's been living on a fork of mine for a while, yet I can't properly make this available to end users in [Ogmios](https://github.com/cardanosolutions/ogmios) without "official" support for it in the node. 

Thanks.