### PR TITLE
Add bangs for avoiding retaining the `ProtocolInfo` and `LedgerDbArgs`

### DIFF
--- a/ouroboros-consensus-diffusion/changelog.d/20251024_123840_javier.sagredo_bangs.md
+++ b/ouroboros-consensus-diffusion/changelog.d/20251024_123840_javier.sagredo_bangs.md
@@ -1,0 +1,23 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+### Patch
+
+- Ensure the `ProtocolInfo` is garbage collected once we start Consensus.
+
+<!--
+### Non-Breaking
+
+- A bullet item for the Non-Breaking category.
+
+-->
+<!--
+### Breaking
+
+- A bullet item for the Breaking category.
+
+-->

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Node.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DuplicateRecordFields #-}
@@ -632,7 +633,7 @@ runWith RunNodeArgs{..} encAddrNtN decAddrNtN LowLevelRunNodeArgs{..} =
     } = rnProtocolInfo
 
   codecConfig :: CodecConfig blk
-  codecConfig = configCodec cfg
+  !codecConfig = configCodec cfg
 
   mkNodeToNodeApps ::
     NodeKernelArgs m addrNTN (ConnectionId addrNTC) blk ->

--- a/ouroboros-consensus/changelog.d/20251024_123836_javier.sagredo_bangs.md
+++ b/ouroboros-consensus/changelog.d/20251024_123836_javier.sagredo_bangs.md
@@ -1,0 +1,24 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+### Patch
+
+- Ensure the `LedgerDbArgs` are garbage collected once we start the LedgerDB.
+- Ensure the `ProtocolInfo` is garbage collected once we start Consensus.
+
+<!--
+### Non-Breaking
+
+- A bullet item for the Non-Breaking category.
+
+-->
+<!--
+### Breaking
+
+- A bullet item for the Breaking category.
+
+-->

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Node/ProtocolInfo.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Node/ProtocolInfo.hs
@@ -35,7 +35,7 @@ enumCoreNodes (NumCoreNodes numNodes) =
 
 -- | Data required to run the specified protocol.
 data ProtocolInfo b = ProtocolInfo
-  { pInfoConfig :: TopLevelConfig b
+  { pInfoConfig :: !(TopLevelConfig b)
   , pInfoInitLedger :: ExtLedgerState b ValuesMK
   -- ^ At genesis, this LedgerState must contain the UTxOs for the initial
   -- era (which for Cardano is Byron that has void tables).

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/Args.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/Args.hs
@@ -57,7 +57,7 @@ data LedgerDbArgs f m blk = LedgerDbArgs
   , lgrGenesis :: HKD f (m (ExtLedgerState blk ValuesMK))
   , lgrHasFS :: HKD f (SomeHasFS m)
   , lgrConfig :: LedgerDbCfgF f (ExtLedgerState blk)
-  , lgrTracer :: Tracer m (TraceEvent blk)
+  , lgrTracer :: !(Tracer m (TraceEvent blk))
   , lgrBackendArgs :: LedgerDbBackendArgs m blk
   , lgrRegistry :: HKD f (ResourceRegistry m)
   , lgrQueryBatchSize :: QueryBatchSize

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/V1.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/V1.hs
@@ -149,7 +149,8 @@ mkInitDb args bss getBlock snapManager getVolatileSuffix =
         pure $ implMkLedgerDb h snapManager
     }
  where
-  bsTracer = LedgerDBFlavorImplEvent . FlavorImplSpecificTraceV1 >$< lgrTracer
+  !bsTracer = LedgerDBFlavorImplEvent . FlavorImplSpecificTraceV1 >$< tr
+  !tr = lgrTracer
 
   LedgerDbArgs
     { lgrHasFS


### PR DESCRIPTION
# The backing store tracer

As `lgrTracer` was lazy, and also `>$<` is lazy, the `bsTracer` was a thunk that retained the `LedgerDbArgs` which contain the Genesis ledger state.

# The ProtocolInfo

As `pInfoConfig` is lazy, the `codecConfig` bind was remaining as a thunk and it was retaining the whole `ProtocolInfo` which contains the Genesis ledger state.