### PR TITLE
LedgerDB.V1: fix race between chain switch and forker acquisition

### DIFF
--- a/ouroboros-consensus/changelog.d/20251028_101139_alexander.esgen_ledgerdb_v1_race.md
+++ b/ouroboros-consensus/changelog.d/20251028_101139_alexander.esgen_ledgerdb_v1_race.md
@@ -1,0 +1,3 @@
+### Patch
+
+- Fix a race condition between chain switches and LedgerDB.V1 forker acquisition.


### PR DESCRIPTION
This fixes a small bug introduced in #1619, which does not affect Praos.

### Explanation

Before this PR, it was possible that, when opening a forker, we first would read the `DbChangelog`
https://github.com/IntersectMBO/ouroboros-consensus/blob/fd31cf8fd056d5ddee39c79400b3382d93bccb47/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/V1.hs#L762
then switch to a different chain in 
https://github.com/IntersectMBO/ouroboros-consensus/blob/fd31cf8fd056d5ddee39c79400b3382d93bccb47/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/ChainSel.hs#L915-L916
and only then read
https://github.com/IntersectMBO/ouroboros-consensus/blob/fd31cf8fd056d5ddee39c79400b3382d93bccb47/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/V1.hs#L763

With Praos, this doesn't matter, because `getVolatileSuffix` will always return the `k` most recent blocks/states, so there is no observable difference. However, with Peras, it can be the case that the length of the volatile suffix gets longer/shorter than before, leading to a mismatch in the length of the volatile headers and volatile `DbChangelog` states.

In practice, the only effect is that a user would erroneously not be able to acquire points in the LocalStateQuery mini-protocol that it should be able to acquire, or vice versa.

### Fix

The fix is to simply move these two things into the same `STM` transaction, as is already the case in all other places in LedgerDB.{V1,V2} that involve `ldbGetVolatileSuffix`.

A regression test would need to rely on IOSimPOR; therefore, I am deferring this until we have sth like https://github.com/IntersectMBO/ouroboros-consensus/issues/1494.