### PR TITLE
Improve Main.hs test-suite placeholder and update doctest instructions

### DIFF
--- a/ouroboros-consensus/test/doctest.hs
+++ b/ouroboros-consensus/test/doctest.hs
@@ -2,7 +2,11 @@ module Main (main) where
 
 main :: IO ()
 main = do
-  putStrLn "This test-suite exists only to add dependencies"
-  putStrLn "To run doctests: "
-  putStrLn "    cabal build all --enable-tests"
-  putStrLn "    cabal-docspec"
+  putStrLn "Test Suite Placeholder"
+  putStrLn "This test suite only exists to pull in the required dependencies."
+
+  putStrLn "\nTo run doctests:"
+  putStrLn "  cabal build all --enable-tests"
+  putStrLn "  cabal-docspec"
+
+  putStrLn "\n(No tests actually run from this file.)"


### PR DESCRIPTION
#This PR updates the Main.hs file used in the test-suite. The goal is simply to make the output clearer and more readable for anyone running doctests. Description

