### PR TITLE
kes-agent: allow using the `PraosCredentialsAgent` constructor

### DIFF
--- a/ouroboros-consensus-protocol/changelog.d/20251202_104021_georgy.lukyanov_enable_kes_agent.md
+++ b/ouroboros-consensus-protocol/changelog.d/20251202_104021_georgy.lukyanov_enable_kes_agent.md
@@ -1,0 +1,23 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+<!--
+### Patch
+
+- A bullet item for the Patch category.
+
+-->
+<!--
+### Non-Breaking
+
+- A bullet item for the Non-Breaking category.
+
+-->
+
+### Breaking
+
+- Allow `cardano-node` to integrate `kes-agent`: make the `PraosCredentialsAgent` constructor of `PraosCredentialsSource` usable by removing `Void`.

--- a/ouroboros-consensus-protocol/src/ouroboros-consensus-protocol/Ouroboros/Consensus/Protocol/Praos/Common.hs
+++ b/ouroboros-consensus-protocol/src/ouroboros-consensus-protocol/Ouroboros/Consensus/Protocol/Praos/Common.hs
@@ -42,7 +42,6 @@ import qualified Control.Tracer as Tracer
 import Data.Function (on)
 import Data.Map.Strict (Map)
 import Data.Ord (Down (Down))
-import Data.Void
 import Data.Word (Word64)
 import GHC.Generics (Generic)
 import NoThunks.Class
@@ -278,7 +277,7 @@ data PraosCredentialsSource c where
     OCert.OCert c -> KES.UnsoundPureSignKeyKES (KES c) -> PraosCredentialsSource c
   -- | Connect to a KES agent listening on a service socket at the given path.
   PraosCredentialsAgent ::
-    Agent.DSIGN (ACrypto c) ~ DSIGN => Void -> FilePath -> PraosCredentialsSource c
+    Agent.DSIGN (ACrypto c) ~ DSIGN => FilePath -> PraosCredentialsSource c
 
 instance (NoThunks (KES.UnsoundPureSignKeyKES (KES c)), Crypto c) => NoThunks (PraosCredentialsSource c) where
   wNoThunks ctxt = \case
@@ -287,7 +286,7 @@ instance (NoThunks (KES.UnsoundPureSignKeyKES (KES c)), Crypto c) => NoThunks (P
         [ noThunks ctxt oca
         , noThunks ctxt k
         ]
-    PraosCredentialsAgent _ fp -> noThunks ctxt fp
+    PraosCredentialsAgent fp -> noThunks ctxt fp
 
   showTypeOf _ = "PraosCredentialsSource"
 
@@ -308,7 +307,7 @@ instantiatePraosCredentials maxKESEvolutions _ (PraosCredentialsUnsound ocert sk
     sk
     startPeriod
     maxKESEvolutions
-instantiatePraosCredentials maxKESEvolutions tr (PraosCredentialsAgent _ path) = do
+instantiatePraosCredentials maxKESEvolutions tr (PraosCredentialsAgent path) = do
   HotKey.mkDynamicHotKey
     maxKESEvolutions
     (Just $ runKESAgentClient tr path)


### PR DESCRIPTION
This enables `cardano-node` to use `kes-agent`.