### PR TITLE
Add support for new ledger state query GetDRepDelegations in NodeToClientV_23

### DIFF
--- a/ouroboros-consensus-cardano/changelog.d/20260204_093251_javier.sagredo_GetDRepDelegations.md
+++ b/ouroboros-consensus-cardano/changelog.d/20260204_093251_javier.sagredo_GetDRepDelegations.md
@@ -1,0 +1,24 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+<!--
+### Patch
+
+- A bullet item for the Patch category.
+
+-->
+
+### Non-Breaking
+
+- Add new `QueryDRepsDelegations` query.
+
+<!--
+### Breaking
+
+- A bullet item for the Breaking category.
+
+-->

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/NetworkProtocolVersion.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/NetworkProtocolVersion.hs
@@ -34,6 +34,7 @@ data ShelleyNodeToClientVersion
     -- when removing support of ShelleyNodeToClientVersion14
     ShelleyNodeToClientVersion14
   | -- | Support retrieving all ledger peers by GetLedgerPeerSnapshot
+    -- New queries introduced: QueryDRepDelegations
     ShelleyNodeToClientVersion15
   deriving (Show, Eq, Ord, Enum, Bounded)
 

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Query.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Query.hs
@@ -380,6 +380,13 @@ data instance BlockQuery (ShelleyBlock proto era) fp result where
     BlockQuery (ShelleyBlock proto era) QFNoTables SL.PoolDistr
   GetMaxMajorProtocolVersion ::
     BlockQuery (ShelleyBlock proto era) QFNoTables MaxMajorProtVer
+  GetDRepDelegations ::
+    (CG.ConwayEraGov era, CG.ConwayEraCertState era) =>
+    Set SL.DRep ->
+    BlockQuery
+      (ShelleyBlock proto era)
+      QFNoTables
+      (Map SL.DRep (Set (SL.Credential SL.Staking)))
 
 {-# DEPRECATED GetLedgerPeerSnapshot' "Use GetLedgerPeerSnapshot instead" #-}
 
@@ -566,6 +573,8 @@ instance
           . configConsensus
           . getExtLedgerCfg
           $ cfg
+      GetDRepDelegations dreps ->
+        SL.queryDRepDelegations st dreps
    where
     lcfg = configLedger $ getExtLedgerCfg cfg
     globals = shelleyLedgerGlobals lcfg
@@ -626,6 +635,7 @@ instance
     GetPoolDistr2{} -> (>= v13)
     GetStakeDistribution2{} -> (>= v13)
     GetMaxMajorProtocolVersion -> (>= v13)
+    GetDRepDelegations{} -> (>= v15)
    where
     -- WARNING: when adding a new query, a new @ShelleyNodeToClientVersionX@
     -- must be added. See #2830 for a template on how to do this.
@@ -796,6 +806,12 @@ instance SameDepIndex2 (BlockQuery (ShelleyBlock proto era)) where
   sameDepIndex2 GetStakeDistribution2{} _ = Nothing
   sameDepIndex2 GetMaxMajorProtocolVersion{} GetMaxMajorProtocolVersion{} = Just Refl
   sameDepIndex2 GetMaxMajorProtocolVersion{} _ = Nothing
+  sameDepIndex2 (GetDRepDelegations dreps) (GetDRepDelegations dreps')
+    | dreps == dreps' =
+        Just Refl
+    | otherwise =
+        Nothing
+  sameDepIndex2 GetDRepDelegations{} _ = Nothing
 
 deriving instance Eq (BlockQuery (ShelleyBlock proto era) fp result)
 deriving instance Show (BlockQuery (ShelleyBlock proto era) fp result)
@@ -841,6 +857,7 @@ instance ShelleyCompatible proto era => ShowQuery (BlockQuery (ShelleyBlock prot
     GetPoolDistr2{} -> show
     GetStakeDistribution2{} -> show
     GetMaxMajorProtocolVersion{} -> show
+    GetDRepDelegations{} -> show
 
 {-------------------------------------------------------------------------------
   Auxiliary
@@ -972,6 +989,8 @@ encodeShelleyQuery query = case query of
     CBOR.encodeListLen 1 <> CBOR.encodeWord8 37
   GetMaxMajorProtocolVersion ->
     CBOR.encodeListLen 1 <> CBOR.encodeWord8 38
+  GetDRepDelegations dreps ->
+    CBOR.encodeListLen 2 <> CBOR.encodeWord8 39 <> LC.toEraCBOR @era dreps
 
 decodeShelleyQuery ::
   forall era proto.
@@ -1054,6 +1073,7 @@ decodeShelleyQuery = do
     (2, 36) -> SomeBlockQuery . GetPoolDistr2 <$> fromCBOR
     (1, 37) -> return $ SomeBlockQuery GetStakeDistribution2
     (1, 38) -> return $ SomeBlockQuery GetMaxMajorProtocolVersion
+    (2, 39) -> requireCG $ SomeBlockQuery . GetDRepDelegations <$> LC.fromEraCBOR @era
     _ -> failmsg "invalid"
 
 encodeShelleyResult ::
@@ -1103,6 +1123,7 @@ encodeShelleyResult v query = case query of
   GetPoolDistr2{} -> LC.toEraCBOR @era
   GetStakeDistribution2{} -> LC.toEraCBOR @era
   GetMaxMajorProtocolVersion -> toCBOR
+  GetDRepDelegations{} -> LC.toEraCBOR @era
 
 decodeShelleyResult ::
   forall proto era fp result.
@@ -1151,6 +1172,7 @@ decodeShelleyResult v query = case query of
   GetPoolDistr2{} -> LC.fromEraCBOR @era
   GetStakeDistribution2 -> LC.fromEraCBOR @era
   GetMaxMajorProtocolVersion -> fromCBOR
+  GetDRepDelegations{} -> LC.fromEraCBOR @era
 
 currentPParamsEnDecoding ::
   forall era s.


### PR DESCRIPTION
# Description

The PR wires in a new ledger state query that was [recently added](https://github.com/IntersectMBO/cardano-ledger/pull/5176) but never got properly wired in. 

This PR requires IntersectMBO/ouroboros-network#5222 due to the nice dependency on the network version there 😬. 

Note that I do expect some help getting this merged. The repository is complex to build, and I kindly refuse to use Nix. So if anything goes wrong with CI, I would appreciate a little nudge from the maintainers to getting this through. It's been living on a fork of mine for a while, yet I can't properly make this available to end users in [Ogmios](https://github.com/cardanosolutions/ogmios) without "official" support for it in the node. 

Thanks.
