### PR TITLE
Fix deadlock on acquiring a forker on a missing point

### DIFF
--- a/ouroboros-consensus/changelog.d/20251205_164754_javier.sagredo_fix_mempool_deadlock.md
+++ b/ouroboros-consensus/changelog.d/20251205_164754_javier.sagredo_fix_mempool_deadlock.md
@@ -1,0 +1,23 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+### Patch
+
+- Fix leaky read lock acquisition that could lead to whole node deadlock.
+
+<!--
+### Non-Breaking
+
+- A bullet item for the Non-Breaking category.
+
+-->
+<!--
+### Breaking
+
+- A bullet item for the Breaking category.
+
+-->


### PR DESCRIPTION
When using V1 LedgerDB (LMDB), on the unlikely event that two blocks arrive exactly in between the mempool being revalidated, the mempool would try to acquire a forker in the first block, which by that time is gone from the ChainDB. In that case, the logic did not release the read lock it had acquired temporarily to open a forker.

This change ensures that in such case, the read lock is properly released.

Closes https://github.com/IntersectMBO/ouroboros-consensus/issues/1787.
