### PR TITLE
`db-analyser` bugfixes

### DIFF
--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Analysis.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Analysis.hs
@@ -721,7 +721,7 @@ benchmarkLedgerOps mOutfile ledgerAppMode AnalysisEnv{db, registry, startFrom, c
 
     F.writeDataPoint outFileHandle outFormat slotDataPoint
 
-    LedgerDB.push intLedgerDB $ ExtLedgerState newLedger newHeader
+    LedgerDB.push intLedgerDB $ ExtLedgerState (prependDiffs tkLdgrSt newLedger) newHeader
     LedgerDB.tryFlush ledgerDB
    where
     rp = blockRealPoint blk


### PR DESCRIPTION
1. requesting to store a snapshot would store the snapshot before pushing the relevant block to the db.
2. In benchmark-ledger-ops, the differences from ticking would be ignored, which meant that running it through byron-shelley or shelley-allegra would fail catastrophically with `BadInputsUTxO` and `ValueNotConserved`.
