### PR TITLE
Add traceMarkerIO events for snapshots and genesis

### DIFF
--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Background.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Background.hs
@@ -42,7 +42,7 @@ module Ouroboros.Consensus.Storage.ChainDB.Impl.Background
   ) where
 
 import Control.Exception (assert)
-import Control.Monad (forM_, forever, void)
+import Control.Monad (forM_, forever, void, when)
 import Control.Monad.Trans.Class (lift)
 import Control.ResourceRegistry
 import Control.Tracer
@@ -369,6 +369,7 @@ ledgerDbTaskWatcher CDB{..} (LedgerDbTasksTrigger varSt) =
                   cdbLedgerDB
                   ((,now) <$> prevSnapTime)
                   blocksSinceLast
+              when (ntBlocksSinceLastSnap == 0) $ traceMarkerIO "Took snapshot"
               atomically $ modifyTVar varSt $ \st ->
                 st
                   { ldbtsBlocksSinceLastSnapshot =

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/API.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/API.hs
@@ -552,6 +552,7 @@ initialize
       traceWith (TraceReplayStartEvent >$< replayTracer) ReplayFromGenesis
       let replayTracer'' = decorateReplayTracerWithStart (Point Origin) replayTracer'
       initDb <- initFromGenesis
+      traceMarkerIO "Genesis loaded"
       eDB <-
         runExceptT $
           replayStartingWith
@@ -597,6 +598,7 @@ initialize
           traceWith snapTracer . InvalidSnapshot s $ err
           tryNewestFirst (acc . InitFailure s err) ss
         Right (initDb, pt) -> do
+          traceMarkerIO "Snapshot loaded"
           let pt' = realPointToPoint pt
           traceWith (TraceReplayStartEvent >$< replayTracer) (ReplayFromSnapshot s (ReplayStart pt'))
           let replayTracer'' = decorateReplayTracerWithStart pt' replayTracer'


### PR DESCRIPTION
Useful for general debugging and profiling.
