### PR TITLE
Use the memoized hash, instead of recomputing it from original bytes

### DIFF
--- a/ouroboros-consensus-protocol/changelog.d/20251223_180949_alexey.kuleshevich_use_memoized_block_header_hash.md
+++ b/ouroboros-consensus-protocol/changelog.d/20251223_180949_alexey.kuleshevich_use_memoized_block_header_hash.md
@@ -1,0 +1,25 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+<!--
+### Patch
+
+- A bullet item for the Patch category.
+
+-->
+### Non-Breaking
+
+- Optimize Block Header hash computation and as a result also remove redundant `Crypto` constraint on the `headerHash` function.
+- Add `HashAnnotated` instance for `Header`
+- Add `MemoHashIndex` type family instance for `HeaderRaw`
+
+<!--
+### Breaking
+
+- A bullet item for the Breaking category.
+
+-->


### PR DESCRIPTION
# Description

Prior implementation was suboptimal. We already provide memoized hash of the block header. With these changes not only memoized version of the hash will be used, but also it will not result in two redundant memcopies just for the sake of hash computation (MemoBytes uses `ShortByteString` underneath, so in order to compute the hash through CBOR it needs to be first converted to a lazy `ByteString` and then again converted to a strict `ByteString`, which can later be passed over FFI for hash computation)

Also note that:

- New code should be properly tested (even if it does not add new features).
- The fix for a regression should include a test that reproduces said regression.
