### PR TITLE
Bump Cabal index states

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -14,9 +14,9 @@ repository cardano-haskell-packages
 -- update either of these.
 index-state:
   -- Bump this if you need newer packages from Hackage
-  , hackage.haskell.org 2025-12-03T15:53:31Z
+  , hackage.haskell.org 2026-01-12T19:29:50Z
   -- Bump this if you need newer packages from CHaP
-  , cardano-haskell-packages 2025-10-07T11:20:00Z
+  , cardano-haskell-packages 2026-01-08T17:40:53Z
 
 packages:
   ouroboros-consensus

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1761315163,
-        "narHash": "sha256-h+JPIMflNAOpY3XhZNcS5sUAOyO06499uWATj2j6P5Q=",
+        "lastModified": 1767896692,
+        "narHash": "sha256-nNfhSjopnCsPvqJ0mJULwJWMaAt+CICFPMRMkt3bPsU=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "131bcd51c4869b191e8c3afbb9f3fd326cd6e5e1",
+        "rev": "589f02eec59c9c11cf28e662ce452c3f7063e168",
         "type": "github"
       },
       "original": {
@@ -270,11 +270,11 @@
     "hackageNix": {
       "flake": false,
       "locked": {
-        "lastModified": 1764848834,
-        "narHash": "sha256-E/LzLZeiNkOB00WMERAk+GHHHcouxekCZVcwbpMTxnM=",
+        "lastModified": 1768299093,
+        "narHash": "sha256-CXR6BKipsxoyHwGkEW9aokXtUvSCbAJzLozdk30jNsU=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "6a3df2e0f103d9faa7ef52330ffcb01c9f87cbbe",
+        "rev": "e6daf968c1ba863c38577d1cecc8d416f696fe10",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Changes in the build plan:
```diff
-blockio-0.1.1.0 lib
+blockio-0.1.1.1 lib
-blockio-0.1.1.0 lib:sim
+blockio-0.1.1.1 lib:sim
-cardano-crypto-class-2.2.3.1 lib
+cardano-crypto-class-2.2.3.2 lib
-ouroboros-network-framework-0.19.1.0 lib
+ouroboros-network-framework-0.19.2.0 lib
-ouroboros-network-framework-0.19.1.0 lib:testlib
+ouroboros-network-framework-0.19.2.0 lib:testlib
-ouroboros-network-framework-0.19.1.0 exe:demo-connection-manager
+ouroboros-network-framework-0.19.2.0 exe:demo-connection-manager
-ouroboros-network-framework-0.19.1.0 exe:demo-ping-pong
+ouroboros-network-framework-0.19.2.0 exe:demo-ping-pong
-plutus-core-1.54.0.0 lib
+plutus-core-1.56.0.0 lib
-plutus-core-1.54.0.0 lib:flat
+plutus-core-1.56.0.0 lib:flat
-plutus-core-1.54.0.0 lib:index-envs
+plutus-core-1.56.0.0 lib:index-envs
-plutus-core-1.54.0.0 lib:plutus-core-execlib
+plutus-core-1.56.0.0 lib:plutus-core-execlib
-plutus-core-1.54.0.0 lib:plutus-core-testlib
+plutus-core-1.56.0.0 lib:plutus-core-testlib
-plutus-core-1.54.0.0 lib:plutus-ir
+plutus-core-1.56.0.0 lib:plutus-ir
-plutus-core-1.54.0.0 lib:plutus-ir-cert
+plutus-core-1.56.0.0 lib:plutus-ir-cert
-plutus-core-1.54.0.0 lib:satint
+plutus-core-1.56.0.0 lib:satint
-plutus-core-1.54.0.0 lib:untyped-plutus-core-testlib
+plutus-core-1.56.0.0 lib:untyped-plutus-core-testlib
-plutus-core-1.54.0.0 exe:cost-model-budgeting-bench
+plutus-core-1.56.0.0 exe:cost-model-budgeting-bench
-plutus-core-1.54.0.0 exe:plutus
+plutus-core-1.56.0.0 exe:plutus
-plutus-core-1.54.0.0 exe:print-cost-model
+plutus-core-1.56.0.0 exe:print-cost-model
-plutus-core-1.54.0.0 exe:traceToStacks
+plutus-core-1.56.0.0 exe:traceToStacks
-plutus-ledger-api-1.54.0.0 lib
+plutus-ledger-api-1.56.0.0 lib
-plutus-ledger-api-1.54.0.0 lib:plutus-ledger-api-testlib
+plutus-ledger-api-1.56.0.0 lib:plutus-ledger-api-testlib
-plutus-ledger-api-1.54.0.0 exe:analyse-script-events
+plutus-ledger-api-1.56.0.0 exe:analyse-script-events
-plutus-ledger-api-1.54.0.0 exe:dump-cost-model-parameters
+plutus-ledger-api-1.56.0.0 exe:dump-cost-model-parameters
-plutus-ledger-api-1.54.0.0 exe:test-onchain-evaluation
+plutus-ledger-api-1.56.0.0 exe:test-onchain-evaluation
-plutus-tx-1.54.0.0 lib
+plutus-tx-1.56.0.0 lib
-plutus-tx-1.54.0.0 lib:plutus-tx-testlib
+plutus-tx-1.56.0.0 lib:plutus-tx-testlib
```