### PR TITLE
Run documentation job in GHC 9.10.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,7 +179,7 @@ jobs:
       if: |
         github.event_name == 'push'
         && github.ref == 'refs/heads/main'
-        && matrix.ghc=='9.12.2'
+        && matrix.ghc=='9.10.3'
       run: |
         # need for latex, dvisvgm and standalone
         sudo apt install texlive-latex-extra texlive-latex-base
@@ -194,7 +194,7 @@ jobs:
       if: |
         github.event_name == 'push'
         && github.ref == 'refs/heads/main'
-        && matrix.ghc=='9.12.2'
+        && matrix.ghc=='9.10.3'
       uses: actions/upload-artifact@v6
       with:
         name: haddocks


### PR DESCRIPTION
Actually, the GHC bug is present in GHC 9.12.2 too. It is backported to 9.10.3 and 9.12.3 (unreleased), so we have to stick with 9.10.3 for now.

See the issue: https://gitlab.haskell.org/ghc/ghc/-/issues/25739
And the fix: https://gitlab.haskell.org/ghc/ghc/-/merge_requests/13993