### PR TITLE
Remove unlawful and unused `Ord` instance for `DiskSnapshot`

### DIFF
--- a/ouroboros-consensus/changelog.d/20260212_125553_fraser.murray_remove_ord_disksnapshot.md
+++ b/ouroboros-consensus/changelog.d/20260212_125553_fraser.murray_remove_ord_disksnapshot.md
@@ -1,0 +1,21 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Patch
+
+- A bullet item for the Patch category.
+
+-->
+<!--
+### Non-Breaking
+
+- A bullet item for the Non-Breaking category.
+
+-->
+### Breaking
+
+- Removed unused `Ord` instance for `DiskSnapshot`

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/Snapshots.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/Snapshots.hs
@@ -161,9 +161,6 @@ data DiskSnapshot = DiskSnapshot
   }
   deriving (Show, Eq, Generic)
 
-instance Ord DiskSnapshot where
-  compare = comparing dsNumber
-
 data SnapshotFailure blk
   = -- | We failed to deserialise the snapshot
     --


### PR DESCRIPTION
The `Ord` instance for `DiskSnapshot` is currently unlawful, as `compare a b == EQ` and `a == b` should be equivalent, but the current `Ord` instance only compares `dsNumber`. This instance is not used anywhere in consensus, so this PR removes it.