### PR TITLE
[Peras 3.5] Introduce `ObjectPool{Reader,Writer}` interfaces and implem of it for `PerasCert(DB)`

### DIFF
--- a/ouroboros-consensus/changelog.d/20260213_153410_thomas.bagrel_objectpool.md
+++ b/ouroboros-consensus/changelog.d/20260213_153410_thomas.bagrel_objectpool.md
@@ -1,0 +1,24 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+<!--
+### Patch
+
+- A bullet item for the Patch category.
+
+-->
+<!--
+
+
+- A bullet item for the Non-Breaking category.
+
+-->
+
+### Breaking
+
+- Add module `Ouroboros.Consensus.MiniProtocol.ObjectDiffusion.ObjectPool.API` defining `ObjectPool{Reader,Writer}` interfaces, through which ObjectDiffusion will access/store the objects to send/that have been received.
+- Add module `Ouroboros.Consensus.MiniProtocol.ObjectDiffusion.ObjectPool.PerasCert` containing implementation of `ObjectPool` interfaces for `PerasCert(DB)`.

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -191,6 +191,8 @@ library
     Ouroboros.Consensus.MiniProtocol.LocalStateQuery.Server
     Ouroboros.Consensus.MiniProtocol.LocalTxMonitor.Server
     Ouroboros.Consensus.MiniProtocol.LocalTxSubmission.Server
+    Ouroboros.Consensus.MiniProtocol.ObjectDiffusion.ObjectPool.API
+    Ouroboros.Consensus.MiniProtocol.ObjectDiffusion.ObjectPool.PerasCert
     Ouroboros.Consensus.Node.GsmState
     Ouroboros.Consensus.Node.InitStorage
     Ouroboros.Consensus.Node.NetworkProtocolVersion

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ObjectDiffusion/ObjectPool/API.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ObjectDiffusion/ObjectPool/API.hs
@@ -1,0 +1,129 @@
+-- | API for reading from and writing to object pools in the ObjectDiffusion
+-- miniprotocol.
+--
+-- The underlying object pool can be any database, such as a 'PerasCertDb' in
+-- Peras certificate diffusion.
+--
+-- 'ObjectPoolReader' is used on the outbound side of the protocol. Objects in
+-- the pool are ordered by a strictly increasing ticket number ('ticketNo'),
+-- which represents their time of arrival. Ticket numbers are local to each
+-- node, unlike object IDs, which are global. Object IDs are not used for
+-- ordering, since objects may arrive slightly out of order from peers.
+--
+-- To read from the pool, one requests objects with a ticket number strictly
+-- greater than the last known one. 'oprZeroTicketNo' provides an initial ticket
+-- number for the first request.
+--
+-- 'ObjectPoolWriter' is used on the inbound side of the protocol. It allows
+-- checking whether an object is already present (to avoid re-requesting it) and
+-- appending new objects. Ticket numbers are not part of the inbound interface,
+-- but are used internally: newly added objects always receive a ticket number
+-- strictly greater than those of older ones.
+--
+-- This API design is inspired by 'MempoolSnapshot' from the TX-submission
+-- miniprotocol, see:
+-- <https://ouroboros-consensus.cardano.intersectmbo.org/haddocks/ouroboros-consensus/Ouroboros-Consensus-Mempool-API.html#t:MempoolSnapshot>
+module Ouroboros.Consensus.MiniProtocol.ObjectDiffusion.ObjectPool.API
+  ( ObjectPoolReader (..)
+  , ObjectPoolWriter (..)
+
+    -- * Invariants
+  , prop_objectsAfterAreGreaterThanTicket
+  , prop_objectsAfterArePresentOnWriter
+  ) where
+
+import Control.Concurrent.Class.MonadSTM.Strict (MonadSTM (..), STM)
+import Data.Map (Map)
+import qualified Data.Map.Strict as Map
+import Data.Word (Word64)
+
+-- | Interface used by the outbound side of object diffusion as its source of
+-- objects to give to the remote side.
+data ObjectPoolReader objectId object ticketNo m
+  = ObjectPoolReader
+  { oprObjectId :: object -> objectId
+  -- ^ Return the id of the specified object
+  , oprZeroTicketNo :: ticketNo
+  -- ^ Ticket number before the first item in the pool.
+  , oprObjectsAfter :: ticketNo -> Word64 -> STM m (Maybe (m (Map ticketNo object)))
+  -- ^ Get the map of objects available in the pool with a 'ticketNo' greater
+  -- than the specified one, with the number of returned objects capped to the
+  -- specified limit.
+  -- Returns 'Nothing' if there are no such objects available atm in the pool,
+  -- or 'Just' a monadic action yielding the map of objects otherwise.
+  -- The monadic action is there to account for the fact that objects might be
+  -- stored on disk.
+  -- If the monadic action is executed immediately, the returned map will be
+  -- non-empty. But if the consumer delays executing the action too much,
+  -- it is possible that the objects get garbage-collected in the meantime, and
+  -- thus the returned map could be empty.
+  }
+
+-- | Interface used by the inbound side of object diffusion when receiving
+-- objects.
+data ObjectPoolWriter objectId object m
+  = ObjectPoolWriter
+  { opwObjectId :: object -> objectId
+  -- ^ Return the id of the specified object
+  , opwAddObjects :: [object] -> m ()
+  -- ^ Add a batch of objects to the objectPool.
+  , opwHasObject :: STM m (objectId -> Bool)
+  -- ^ Check if the object pool contains an object with the given id
+  }
+
+-- * Invariants
+
+-- | When retrieving objects after a given ticket number, all the objects in the
+-- returned map should have a strictly greater ticket number.
+prop_objectsAfterAreGreaterThanTicket ::
+  (Ord ticketNo, MonadSTM m) =>
+  ObjectPoolReader objectId object ticketNo m ->
+  ticketNo ->
+  Word64 ->
+  m Bool
+prop_objectsAfterAreGreaterThanTicket opr ticketNo limit = do
+  mObjects <- atomically $ oprObjectsAfter opr ticketNo limit
+  case mObjects of
+    Nothing ->
+      -- Vacuosly true if there are no objects available in the pool.
+      pure True
+    Just getObjects -> do
+      -- The returned map may be empty if the consumer delayed executing the
+      -- action and the objects got garbage-collected in the meantime. However,
+      -- any objects that are still present in the pool should have a ticket
+      -- number greater than the specified one.
+      objects <- getObjects
+      pure $
+        all
+          (> ticketNo)
+          (Map.keys objects)
+
+-- | Objects retrieved from an object pool reader must be present on the writer
+-- side at the the retrieval takes place.
+prop_objectsAfterArePresentOnWriter ::
+  MonadSTM m =>
+  ObjectPoolReader objectId object ticketNo m ->
+  ObjectPoolWriter objectId object m ->
+  ticketNo ->
+  Word64 ->
+  m Bool
+prop_objectsAfterArePresentOnWriter opr opw ticketNo limit = do
+  (mObjects, hasObject) <-
+    atomically $
+      (,)
+        <$> oprObjectsAfter opr ticketNo limit
+        <*> opwHasObject opw
+  case mObjects of
+    Nothing ->
+      -- Vacuosly true if there are no objects available in the pool.
+      pure True
+    Just getObjects -> do
+      -- The returned map may be empty if the consumer delayed executing the
+      -- action and the objects got garbage-collected in the meantime. However,
+      -- any objects that are still present in the pool should also be present
+      -- on the writer side.
+      objects <- getObjects
+      pure $
+        all
+          (hasObject . oprObjectId opr)
+          (Map.elems objects)

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ObjectDiffusion/ObjectPool/PerasCert.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ObjectDiffusion/ObjectPool/PerasCert.hs
@@ -1,0 +1,141 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE StandaloneDeriving #-}
+
+-- | Instantiate 'ObjectPoolReader' and 'ObjectPoolWriter' using Peras
+-- certificates from the 'PerasCertDB' (or the 'ChainDB' which is wrapping the
+-- 'PerasCertDB').
+module Ouroboros.Consensus.MiniProtocol.ObjectDiffusion.ObjectPool.PerasCert
+  ( makePerasCertPoolReaderFromCertDB
+  , makePerasCertPoolWriterFromCertDB
+  , makePerasCertPoolReaderFromChainDB
+  , makePerasCertPoolWriterFromChainDB
+  ) where
+
+import Data.Either (partitionEithers)
+import Data.Map (Map)
+import qualified Data.Map as Map
+import GHC.Exception (throw)
+import Ouroboros.Consensus.Block
+import Ouroboros.Consensus.BlockchainTime.WallClock.Types
+  ( SystemTime (..)
+  , WithArrivalTime (..)
+  )
+import Ouroboros.Consensus.MiniProtocol.ObjectDiffusion.ObjectPool.API
+import Ouroboros.Consensus.Storage.ChainDB.API (ChainDB)
+import qualified Ouroboros.Consensus.Storage.ChainDB.API as ChainDB
+import Ouroboros.Consensus.Storage.PerasCertDB.API
+  ( PerasCertDB
+  , PerasCertSnapshot
+  , PerasCertTicketNo
+  )
+import qualified Ouroboros.Consensus.Storage.PerasCertDB.API as PerasCertDB
+import Ouroboros.Consensus.Util.IOLike
+
+-- | TODO: replace by `Data.Map.take` as soon as we move to GHC 9.8
+takeAscMap :: Int -> Map k v -> Map k v
+takeAscMap n = Map.fromDistinctAscList . take n . Map.toAscList
+
+makePerasCertPoolReaderFromSnapshot ::
+  IOLike m =>
+  STM m (PerasCertSnapshot blk) ->
+  ObjectPoolReader PerasRoundNo (PerasCert blk) PerasCertTicketNo m
+makePerasCertPoolReaderFromSnapshot getCertSnapshot =
+  ObjectPoolReader
+    { oprObjectId = getPerasCertRound
+    , oprZeroTicketNo = PerasCertDB.zeroPerasCertTicketNo
+    , oprObjectsAfter = \lastKnown limit -> do
+        certSnapshot <- getCertSnapshot
+        let certsAfterLastKnown =
+              PerasCertDB.getCertsAfter certSnapshot lastKnown
+        let loadCertsAfterLastKnown =
+              pure $
+                fmap
+                  (vpcCert . forgetArrivalTime)
+                  (takeAscMap (fromIntegral limit) certsAfterLastKnown)
+        pure $
+          if Map.null certsAfterLastKnown
+            then Nothing
+            else Just loadCertsAfterLastKnown
+    }
+
+makePerasCertPoolReaderFromCertDB ::
+  IOLike m =>
+  PerasCertDB m blk ->
+  ObjectPoolReader PerasRoundNo (PerasCert blk) PerasCertTicketNo m
+makePerasCertPoolReaderFromCertDB perasCertDB =
+  makePerasCertPoolReaderFromSnapshot (PerasCertDB.getCertSnapshot perasCertDB)
+
+makePerasCertPoolWriterFromCertDB ::
+  (StandardHash blk, IOLike m) =>
+  SystemTime m ->
+  PerasCertDB m blk ->
+  ObjectPoolWriter PerasRoundNo (PerasCert blk) m
+makePerasCertPoolWriterFromCertDB systemTime perasCertDB =
+  ObjectPoolWriter
+    { opwObjectId = getPerasCertRound
+    , opwAddObjects = \certs -> do
+        addPerasCerts systemTime (PerasCertDB.addCert perasCertDB) certs
+    , opwHasObject = do
+        certSnapshot <- PerasCertDB.getCertSnapshot perasCertDB
+        pure $ PerasCertDB.containsCert certSnapshot
+    }
+
+makePerasCertPoolReaderFromChainDB ::
+  IOLike m =>
+  ChainDB m blk ->
+  ObjectPoolReader PerasRoundNo (PerasCert blk) PerasCertTicketNo m
+makePerasCertPoolReaderFromChainDB chainDB =
+  makePerasCertPoolReaderFromSnapshot (ChainDB.getPerasCertSnapshot chainDB)
+
+makePerasCertPoolWriterFromChainDB ::
+  (StandardHash blk, IOLike m) =>
+  SystemTime m ->
+  ChainDB m blk ->
+  ObjectPoolWriter PerasRoundNo (PerasCert blk) m
+makePerasCertPoolWriterFromChainDB systemTime chainDB =
+  ObjectPoolWriter
+    { opwObjectId = getPerasCertRound
+    , opwAddObjects = \certs -> do
+        addPerasCerts systemTime (ChainDB.addPerasCertAsync chainDB) certs
+    , opwHasObject = do
+        certSnapshot <- ChainDB.getPerasCertSnapshot chainDB
+        pure $ PerasCertDB.containsCert certSnapshot
+    }
+
+data PerasCertInboundException
+  = forall blk. PerasCertValidationError [PerasValidationErr blk]
+
+deriving instance Show PerasCertInboundException
+
+instance Exception PerasCertInboundException
+
+-- | Add a batch of Peras certs to a pool after validating them.
+addPerasCerts ::
+  (StandardHash blk, MonadSTM m) =>
+  SystemTime m ->
+  (WithArrivalTime (ValidatedPerasCert blk) -> m a) ->
+  [PerasCert blk] ->
+  m ()
+addPerasCerts systemTime addCert certs = do
+  now <- systemTimeCurrent systemTime
+  case validatePerasCerts certs of
+    -- All certs are valid => add them to the pool
+    ([], validatedCerts) ->
+      mapM_
+        (addCert . WithArrivalTime now)
+        validatedCerts
+    -- Some certs are invalid => reject the whole batch
+    (errs, _) ->
+      throw (PerasCertValidationError errs)
+
+-- | Validate a batch of Peras certs.
+validatePerasCerts ::
+  StandardHash blk =>
+  [PerasCert blk] ->
+  ([PerasValidationErr blk], [ValidatedPerasCert blk])
+validatePerasCerts certs = do
+  let perasParams = mkPerasParams
+  -- TODO pass down 'BlockConfig' when all the plumbing is in place
+  -- see https://github.com/tweag/cardano-peras/issues/73
+  -- see https://github.com/tweag/cardano-peras/issues/120
+  partitionEithers (validatePerasCert perasParams <$> certs)


### PR DESCRIPTION
This PR reintroduce a part of what [[Peras 4]](https://github.com/IntersectMBO/ouroboros-consensus/pull/1679) contains:

- Definition of the `ObjectPool{Reader,Writer}` interfaces that will be used by the (future) ObjectDiffusion mini-protocol to fetch/write objects when they are sent/received. (module `Ouroboros.Consensus.MiniProtocol.ObjectDiffusion.ObjectPool.API`)
- Implementation of these interfaces for `PerasCert(DB)` (module `Ouroboros.Consensus.MiniProtocol.ObjectDiffusion.ObjectPool.PerasCert`)

It's supposed to be code that already received approval from @dnadales in late november.

This is needed so that other PRs like https://github.com/IntersectMBO/ouroboros-consensus/pull/1768 can be merged without waiting on the rest of [[Peras 4]](https://github.com/IntersectMBO/ouroboros-consensus/pull/1679) (which itself waits on `ouroboros-network` [#5202](https://github.com/IntersectMBO/ouroboros-network/pull/5202)).