### PR TITLE
Add sanity checks for weird SnapshotPolicyArgs configurations

### DIFF
--- a/changelog.d/20260427_154243_georgy.lukyanov_snapshot_config_sanity_checks.md
+++ b/changelog.d/20260427_154243_georgy.lukyanov_snapshot_config_sanity_checks.md
@@ -1,0 +1,23 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+### Non-Breaking
+
+- Add sanity checks for `SnapshotPolicyArgs` configurations. The node now validates snapshot policy settings on startup and warns about suspicious configurations such as inverted delay ranges, negative delays, disabled or excessively large rate limits, zero on-disk snapshots, and snapshot intervals that do not divide the Cardano mainnet epoch length (breaking Mithril compatibility).
+
+<!--
+### Breaking
+
+- A bullet item for the Breaking category.
+
+-->
+<!--
+### Patch
+
+- A bullet item for the Patch category.
+
+-->

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Node.hs
@@ -527,6 +527,10 @@ runWith RunNodeArgs{..} encAddrNtN decAddrNtN LowLevelRunNodeArgs{..} =
 
           forM_ (sanityCheckConfig cfg) $ \issue ->
             traceWith (consensusSanityCheckTracer rnTraceConsensus) issue
+          let snapshotPolicyArgs =
+                lgrSnapshotPolicyArgs $ ChainDB.cdbLgrDbArgs llrnChainDbArgsDefaults
+          forM_ (sanityCheckSnapshotPolicyArgs snapshotPolicyArgs) $ \issue ->
+            traceWith (consensusSanityCheckTracer rnTraceConsensus) issue
 
           (chainDB, finalArgs) <-
             openChainDB

--- a/ouroboros-consensus.cabal
+++ b/ouroboros-consensus.cabal
@@ -822,6 +822,7 @@ test-suite storage-test
     Test.Ouroboros.Storage.ImmutableDB.StateMachine
     Test.Ouroboros.Storage.LedgerDB
     Test.Ouroboros.Storage.LedgerDB.Serialisation
+    Test.Ouroboros.Storage.LedgerDB.SnapshotPolicySanityCheck
     Test.Ouroboros.Storage.LedgerDB.Snapshots
     Test.Ouroboros.Storage.LedgerDB.StateMachine
     Test.Ouroboros.Storage.LedgerDB.StateMachine.TestBlock

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/Snapshots.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/Snapshots.hs
@@ -82,6 +82,8 @@ module Ouroboros.Consensus.Storage.LedgerDB.Snapshots
   , SnapshotFrequency (..)
   , SnapshotFrequencyArgs (..)
   , defaultSnapshotPolicy
+  , mithrilEpochSize
+  , sanityCheckSnapshotPolicyArgs
   , pattern DoDiskSnapshotChecksum
   , pattern NoDoDiskSnapshotChecksum
 
@@ -709,6 +711,59 @@ defaultSnapshotPolicy (SecurityParam k) args =
 
   -- Most relevant during syncing.
   defRateLimit = secondsToDiffTime $ 10 * 60
+
+-- | The Cardano mainnet epoch length in slots, used as the reference for the
+-- Mithril snapshot compatibility check in 'sanityCheckSnapshotPolicyArgs'.
+-- Mithril requires a ledger snapshot at each epoch boundary; for snapshots to
+-- land on every epoch boundary, 'sfaInterval' must divide this value evenly.
+mithrilEpochSize :: Word64
+mithrilEpochSize = 432000
+
+-- | Check a 'SnapshotPolicyArgs' for suspicious configurations and return a
+-- (possibly empty) list of 'SanityCheckIssue's describing any problems found.
+--
+-- Only 'Override' values are checked — 'UseDefault' values are known-good and
+-- are never flagged. Checks that are specific to 'SnapshotFrequency' are
+-- skipped entirely when 'spaFrequency' is 'DisableSnapshots'.
+sanityCheckSnapshotPolicyArgs :: SnapshotPolicyArgs -> [SanityCheckIssue]
+sanityCheckSnapshotPolicyArgs SnapshotPolicyArgs{spaFrequency, spaNum} =
+  catMaybes $
+    checkNumZero spaNum
+      : case spaFrequency of
+        DisableSnapshots -> []
+        SnapshotFrequency sfa -> checkFrequencyArgs sfa
+ where
+  checkNumZero (Override (NumOfDiskSnapshots 0)) = Just SnapshotNumZero
+  checkNumZero _ = Nothing
+
+  checkFrequencyArgs SnapshotFrequencyArgs{sfaDelaySnapshotRange, sfaRateLimit, sfaInterval} =
+    [ checkDelayRange sfaDelaySnapshotRange
+    , checkRateLimitDisabled sfaRateLimit
+    , checkRateLimitLarge sfaRateLimit
+    , checkMithrilDivisibility sfaInterval
+    ]
+
+  checkDelayRange UseDefault = Nothing
+  checkDelayRange (Override (SnapshotDelayRange mn mx))
+    | mn < 0 = Just (SnapshotDelayRangeNegativeMinimum mn)
+    | mn > mx = Just (SnapshotDelayRangeInverted mn mx)
+    | otherwise = Nothing
+
+  checkRateLimitDisabled UseDefault = Nothing
+  checkRateLimitDisabled (Override rl)
+    | rl <= 0 = Just SnapshotRateLimitDisabled
+    | otherwise = Nothing
+
+  checkRateLimitLarge UseDefault = Nothing
+  checkRateLimitLarge (Override rl)
+    | rl > 86400 = Just (SnapshotRateLimitSuspiciouslyLarge rl)
+    | otherwise = Nothing
+
+  checkMithrilDivisibility UseDefault = Nothing
+  checkMithrilDivisibility (Override interval)
+    | mithrilEpochSize `mod` unNonZero interval /= 0 =
+        Just (SnapshotIntervalNotDivisorOfEpoch (unNonZero interval))
+    | otherwise = Nothing
 
 {-------------------------------------------------------------------------------
   Tracing snapshot events

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/LedgerDB.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/LedgerDB.hs
@@ -6,6 +6,7 @@
 module Test.Ouroboros.Storage.LedgerDB (tests) where
 
 import qualified Test.Ouroboros.Storage.LedgerDB.Serialisation as Serialisation
+import qualified Test.Ouroboros.Storage.LedgerDB.SnapshotPolicySanityCheck as SnapshotPolicySanityCheck
 import qualified Test.Ouroboros.Storage.LedgerDB.Snapshots as Snapshots
 import qualified Test.Ouroboros.Storage.LedgerDB.StateMachine as StateMachine
 import qualified Test.Ouroboros.Storage.LedgerDB.V1.BackingStore as BackingStore
@@ -24,6 +25,7 @@ tests =
     , -- Independent of the LedgerDB implementation
       Serialisation.tests
     , Snapshots.tests
+    , SnapshotPolicySanityCheck.tests
     , -- Tests both V1 and V2
       StateMachine.tests
     ]

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/LedgerDB/SnapshotPolicySanityCheck.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/LedgerDB/SnapshotPolicySanityCheck.hs
@@ -1,0 +1,189 @@
+module Test.Ouroboros.Storage.LedgerDB.SnapshotPolicySanityCheck (tests) where
+
+import Cardano.Ledger.BaseTypes (unsafeNonZero)
+import Data.Time.Clock (DiffTime, secondsToDiffTime)
+import Data.Word (Word64)
+import Ouroboros.Consensus.Block.SupportsSanityCheck
+import Ouroboros.Consensus.Storage.LedgerDB.Snapshots
+import Ouroboros.Consensus.Util.Args (OverrideOrDefault (..))
+import Test.QuickCheck
+import Test.Tasty
+import Test.Tasty.QuickCheck (testProperty)
+
+tests :: TestTree
+tests =
+  testGroup
+    "SnapshotPolicySanityCheck"
+    [ testProperty "SnapshotNumZero fires iff spaNum overridden to 0" $
+        prop_num_zero_iff
+    , testProperty
+        "SnapshotDelayRangeInverted fires iff minimumDelay > maximumDelay (given minimumDelay >= 0)"
+        $ prop_delay_range_inverted_iff
+    , testProperty "SnapshotDelayRangeNegativeMinimum fires iff minimumDelay < 0" $
+        prop_delay_range_negative_minimum_iff
+    , testProperty "SnapshotRateLimitDisabled fires iff sfaRateLimit overridden to <= 0" $
+        prop_rate_limit_disabled_iff
+    , testProperty
+        "SnapshotRateLimitSuspiciouslyLarge fires iff sfaRateLimit overridden to > 86400s (given > 0)"
+        $ prop_rate_limit_large_iff
+    , testProperty "SnapshotIntervalNotDivisorOfEpoch fires iff 432000 mod interval /= 0" $
+        prop_mithril_divisibility_iff
+    , testProperty "no frequency issues emitted under DisableSnapshots" $
+        prop_disable_snapshots_no_frequency_issues
+    ]
+
+-------------------------------------------------------------------------------
+-- Properties
+-------------------------------------------------------------------------------
+
+-- | 'SnapshotNumZero' fires if and only if 'spaNum' is overridden to 0.
+-- Uses 'DisableSnapshots' so that no other checks interfere.
+prop_num_zero_iff :: Property
+prop_num_zero_iff =
+  forAll (arbitrary :: Gen Word) $ \n ->
+    let issues =
+          sanityCheckSnapshotPolicyArgs
+            SnapshotPolicyArgs{spaFrequency = DisableSnapshots, spaNum = Override (NumOfDiskSnapshots n)}
+     in (SnapshotNumZero `elem` issues) === (n == 0)
+
+-- | 'SnapshotDelayRangeInverted' fires if and only if @minimumDelay > maximumDelay@,
+-- when @minimumDelay >= 0@ (avoiding the 'SnapshotDelayRangeNegativeMinimum' case).
+prop_delay_range_inverted_iff :: Property
+prop_delay_range_inverted_iff =
+  forAll genNonNegativeDiffTime $ \mn ->
+    forAll genDiffTime $ \mx ->
+      let issues = sanityCheckSnapshotPolicyArgs (withDelayRange (SnapshotDelayRange mn mx))
+          fired = any isInverted issues
+       in fired === (mn > mx)
+ where
+  isInverted (SnapshotDelayRangeInverted _ _) = True
+  isInverted _ = False
+
+-- | 'SnapshotDelayRangeNegativeMinimum' fires if and only if @minimumDelay < 0@.
+prop_delay_range_negative_minimum_iff :: Property
+prop_delay_range_negative_minimum_iff =
+  forAll genDiffTime $ \mn ->
+    let issues = sanityCheckSnapshotPolicyArgs (withDelayRange (SnapshotDelayRange mn 0))
+        fired = any isNegativeMin issues
+     in fired === (mn < 0)
+ where
+  isNegativeMin (SnapshotDelayRangeNegativeMinimum _) = True
+  isNegativeMin _ = False
+
+-- | 'SnapshotRateLimitDisabled' fires if and only if 'sfaRateLimit' is overridden
+-- to a non-positive value.
+prop_rate_limit_disabled_iff :: Property
+prop_rate_limit_disabled_iff =
+  forAll genDiffTime $ \rl ->
+    let issues = sanityCheckSnapshotPolicyArgs (withRateLimit rl)
+     in (SnapshotRateLimitDisabled `elem` issues) === (rl <= 0)
+
+-- | 'SnapshotRateLimitSuspiciouslyLarge' fires if and only if 'sfaRateLimit' is
+-- overridden to a value greater than 86400s. We restrict to positive rate limits
+-- to avoid the 'SnapshotRateLimitDisabled' check interfering.
+prop_rate_limit_large_iff :: Property
+prop_rate_limit_large_iff =
+  forAll genPositiveDiffTime $ \rl ->
+    let issues = sanityCheckSnapshotPolicyArgs (withRateLimit rl)
+        fired = any isLarge issues
+     in fired === (rl > 86400)
+ where
+  isLarge (SnapshotRateLimitSuspiciouslyLarge _) = True
+  isLarge _ = False
+
+-- | 'SnapshotIntervalNotDivisorOfEpoch' fires if and only if
+-- @'mithrilEpochSize' \`mod\` interval /= 0@.
+prop_mithril_divisibility_iff :: Property
+prop_mithril_divisibility_iff =
+  forAll genNonZeroWord64 $ \n ->
+    let issues = sanityCheckSnapshotPolicyArgs (withInterval n)
+        fired = any isMithrilIssue issues
+     in fired === (mithrilEpochSize `mod` n /= 0)
+ where
+  isMithrilIssue (SnapshotIntervalNotDivisorOfEpoch _) = True
+  isMithrilIssue _ = False
+
+-- | With 'DisableSnapshots', no frequency-related issues are ever emitted,
+-- regardless of what 'spaNum' is set to.
+prop_disable_snapshots_no_frequency_issues :: Property
+prop_disable_snapshots_no_frequency_issues =
+  forAll (arbitrary :: Gen Word) $ \n ->
+    let issues =
+          sanityCheckSnapshotPolicyArgs
+            SnapshotPolicyArgs{spaFrequency = DisableSnapshots, spaNum = Override (NumOfDiskSnapshots n)}
+     in filter isFrequencyIssue issues === []
+ where
+  -- SnapshotNumZero is the only non-frequency issue that can appear here;
+  -- everything else would require a SnapshotFrequency.
+  isFrequencyIssue SnapshotNumZero = False
+  isFrequencyIssue InconsistentSecurityParam{} = False
+  isFrequencyIssue _ = True
+
+-------------------------------------------------------------------------------
+-- Generators
+-------------------------------------------------------------------------------
+
+-- | Generate an arbitrary 'DiffTime' (integer seconds, possibly negative).
+genDiffTime :: Gen DiffTime
+genDiffTime = secondsToDiffTime <$> arbitrary
+
+-- | Generate a non-negative 'DiffTime'.
+genNonNegativeDiffTime :: Gen DiffTime
+genNonNegativeDiffTime = secondsToDiffTime . abs <$> arbitrary
+
+-- | Generate a strictly positive 'DiffTime'.
+genPositiveDiffTime :: Gen DiffTime
+genPositiveDiffTime = secondsToDiffTime . getPositive <$> arbitrary
+
+-- | Generate a non-zero 'Word64'.
+genNonZeroWord64 :: Gen Word64
+genNonZeroWord64 = getPositive <$> arbitrary
+
+-------------------------------------------------------------------------------
+-- Helpers
+-------------------------------------------------------------------------------
+
+-- | Build a 'SnapshotPolicyArgs' with a specific 'SnapshotDelayRange' override.
+withDelayRange :: SnapshotDelayRange -> SnapshotPolicyArgs
+withDelayRange sdr =
+  SnapshotPolicyArgs
+    { spaFrequency =
+        SnapshotFrequency
+          SnapshotFrequencyArgs
+            { sfaInterval = UseDefault
+            , sfaOffset = UseDefault
+            , sfaRateLimit = UseDefault
+            , sfaDelaySnapshotRange = Override sdr
+            }
+    , spaNum = UseDefault
+    }
+
+-- | Build a 'SnapshotPolicyArgs' with a specific 'sfaRateLimit' override.
+withRateLimit :: DiffTime -> SnapshotPolicyArgs
+withRateLimit rl =
+  SnapshotPolicyArgs
+    { spaFrequency =
+        SnapshotFrequency
+          SnapshotFrequencyArgs
+            { sfaInterval = UseDefault
+            , sfaOffset = UseDefault
+            , sfaRateLimit = Override rl
+            , sfaDelaySnapshotRange = UseDefault
+            }
+    , spaNum = UseDefault
+    }
+
+-- | Build a 'SnapshotPolicyArgs' with a specific 'sfaInterval' override.
+withInterval :: Word64 -> SnapshotPolicyArgs
+withInterval n =
+  SnapshotPolicyArgs
+    { spaFrequency =
+        SnapshotFrequency
+          SnapshotFrequencyArgs
+            { sfaInterval = Override (unsafeNonZero n)
+            , sfaOffset = UseDefault
+            , sfaRateLimit = UseDefault
+            , sfaDelaySnapshotRange = UseDefault
+            }
+    , spaNum = UseDefault
+    }


### PR DESCRIPTION
As discussed in #1853, we want node operators to be warned if they configure their node in a way that is likely to be broken i.e. if they disable the snapshot rate limiting, or set the number of on-disk snapshots to 0, or set a snapshot interval that isn't a clean divisor of the epoch length (which is required for Mithril). This PR implements sanity checks similar to the existing ones for the `SnapshotPolicyArgs` and traces warnings to the user if these guidelines are ignored.