### PR TITLE
[Peras 26] Concrete certs and votes using BLS crypto

### DIFF
--- a/changelog.d/20260421_170000_agustin.mista_concrete_certs_and_votes.md
+++ b/changelog.d/20260421_170000_agustin.mista_concrete_certs_and_votes.md
@@ -1,0 +1,28 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+<!--
+### Breaking
+
+- A bullet item for the Breaking category.
+
+-->
+
+### Non-Breaking
+
+- Introduce `Ouroboros.Consensus.Util.Bitmap` providing `ByteString`-based compact bitmaps.
+- Define `PerasBLSCrypto` scheme with support for all the voting committee superclasses.
+- Define concrete `PerasVote` and `PerasCert` types using BLS signatures.
+- Define `PerasVoteCompatibleWithVotingCommittee` and `PerasCertCompatibleWithVotingCommittee` type classes with conversions between concrete Peras types and their abstract voting committee counterparts.
+- Instantiate `VotingCommitteeSupportsPeras` for both `WFALS` and `EveryoneVotes`.
+
+<!--
+### Patch
+
+- A bullet item for the Patch category.
+
+-->

--- a/ouroboros-consensus.cabal
+++ b/ouroboros-consensus.cabal
@@ -320,6 +320,7 @@ library
     Ouroboros.Consensus.Util.AnchoredSeq
     Ouroboros.Consensus.Util.Args
     Ouroboros.Consensus.Util.Assert
+    Ouroboros.Consensus.Util.Bitmap
     Ouroboros.Consensus.Util.CallStack
     Ouroboros.Consensus.Util.CBOR
     Ouroboros.Consensus.Util.Condense

--- a/ouroboros-consensus.cabal
+++ b/ouroboros-consensus.cabal
@@ -236,12 +236,12 @@ library
     Ouroboros.Consensus.Node.Run
     Ouroboros.Consensus.Node.Serialisation
     Ouroboros.Consensus.NodeId
-    Ouroboros.Consensus.Peras.Cert
     Ouroboros.Consensus.Peras.Cert.Inclusion
+    Ouroboros.Consensus.Peras.Cert.V1
     Ouroboros.Consensus.Peras.Params
     Ouroboros.Consensus.Peras.SelectView
-    Ouroboros.Consensus.Peras.Vote
     Ouroboros.Consensus.Peras.Vote.Aggregation
+    Ouroboros.Consensus.Peras.Vote.V1
     Ouroboros.Consensus.Peras.Voting.Rules
     Ouroboros.Consensus.Peras.Voting.View
     Ouroboros.Consensus.Peras.Weight

--- a/ouroboros-consensus.cabal
+++ b/ouroboros-consensus.cabal
@@ -680,6 +680,7 @@ test-suite consensus-test
     Test.Consensus.Peras.Util
     Test.Consensus.Peras.Voting.Rules
     Test.Consensus.Peras.WeightSnapshot
+    Test.Consensus.Util.Bitmap
     Test.Consensus.Util.MonadSTM.NormalForm
     Test.Consensus.Util.Pred
     Test.Consensus.Util.Versioned

--- a/ouroboros-consensus.cabal
+++ b/ouroboros-consensus.cabal
@@ -243,6 +243,7 @@ library
     Ouroboros.Consensus.Peras.SelectView
     Ouroboros.Consensus.Peras.Vote.Aggregation
     Ouroboros.Consensus.Peras.Vote.V1
+    Ouroboros.Consensus.Peras.Voting.Committee
     Ouroboros.Consensus.Peras.Voting.Rules
     Ouroboros.Consensus.Peras.Voting.View
     Ouroboros.Consensus.Peras.Weight

--- a/ouroboros-consensus.cabal
+++ b/ouroboros-consensus.cabal
@@ -238,6 +238,7 @@ library
     Ouroboros.Consensus.NodeId
     Ouroboros.Consensus.Peras.Cert.Inclusion
     Ouroboros.Consensus.Peras.Cert.V1
+    Ouroboros.Consensus.Peras.Crypto.BLS
     Ouroboros.Consensus.Peras.Params
     Ouroboros.Consensus.Peras.SelectView
     Ouroboros.Consensus.Peras.Vote.Aggregation

--- a/ouroboros-consensus.cabal
+++ b/ouroboros-consensus.cabal
@@ -677,6 +677,7 @@ test-suite consensus-test
     Test.Consensus.MiniProtocol.ObjectDiffusion.PerasVote.Smoke
     Test.Consensus.MiniProtocol.ObjectDiffusion.Smoke
     Test.Consensus.Peras.Cert.Inclusion
+    Test.Consensus.Peras.Util
     Test.Consensus.Peras.Voting.Rules
     Test.Consensus.Peras.WeightSnapshot
     Test.Consensus.Util.MonadSTM.NormalForm

--- a/ouroboros-consensus.cabal
+++ b/ouroboros-consensus.cabal
@@ -679,6 +679,7 @@ test-suite consensus-test
     Test.Consensus.Peras.Cert.Inclusion
     Test.Consensus.Peras.Serialisation
     Test.Consensus.Peras.Util
+    Test.Consensus.Peras.Voting.Committee
     Test.Consensus.Peras.Voting.Rules
     Test.Consensus.Peras.WeightSnapshot
     Test.Consensus.Util.Bitmap

--- a/ouroboros-consensus.cabal
+++ b/ouroboros-consensus.cabal
@@ -677,6 +677,7 @@ test-suite consensus-test
     Test.Consensus.MiniProtocol.ObjectDiffusion.PerasVote.Smoke
     Test.Consensus.MiniProtocol.ObjectDiffusion.Smoke
     Test.Consensus.Peras.Cert.Inclusion
+    Test.Consensus.Peras.Serialisation
     Test.Consensus.Peras.Util
     Test.Consensus.Peras.Voting.Rules
     Test.Consensus.Peras.WeightSnapshot

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Block/SupportsPeras.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Block/SupportsPeras.hs
@@ -14,6 +14,8 @@
 module Ouroboros.Consensus.Block.SupportsPeras
   ( PerasRoundNo (..)
   , onPerasRoundNo
+  , PerasBoostedBlock (..)
+  , PerasSeatIndex (..)
   , PerasVoteId (..)
   , PerasVoteTarget (..)
   , PerasVoterId (..)
@@ -59,10 +61,15 @@ import qualified Data.Map as Map
 import Data.Map.Strict (Map)
 import Data.Monoid (Sum (..))
 import Data.Proxy (Proxy (..))
-import Data.Word (Word64)
+import Data.Word (Word16, Word64)
 import GHC.Generics (Generic)
 import NoThunks.Class
 import Ouroboros.Consensus.Block.Abstract
+import Ouroboros.Consensus.Block.RealPoint
+  ( Bytes32RealPoint
+  , decodeBytes32RealPoint
+  , encodeBytes32RealPoint
+  )
 import Ouroboros.Consensus.BlockchainTime.WallClock.Types (WithArrivalTime (..))
 import Ouroboros.Consensus.Peras.Params
 import Ouroboros.Consensus.Util
@@ -91,6 +98,31 @@ onPerasRoundNo ::
   (Word64 -> Word64 -> Word64) ->
   (PerasRoundNo -> PerasRoundNo -> PerasRoundNo)
 onPerasRoundNo = coerce
+
+-- ** Boosted blocks
+
+-- | The slot number and 32-byte hash of the block being voted for
+newtype PerasBoostedBlock
+  = PerasBoostedBlock
+  { unPerasBoostedBlock :: Bytes32RealPoint
+  }
+  deriving stock (Eq, Show)
+
+instance FromCBOR PerasBoostedBlock where
+  fromCBOR = PerasBoostedBlock <$> decodeBytes32RealPoint
+
+instance ToCBOR PerasBoostedBlock where
+  toCBOR = encodeBytes32RealPoint . unPerasBoostedBlock
+
+-- ** Seat indices
+
+-- | Seat index in the voting committee used for Peras
+newtype PerasSeatIndex
+  = PerasSeatIndex
+  { unPerasSeatIndex :: Word16
+  }
+  deriving stock (Eq, Ord, Show)
+  deriving newtype (FromCBOR, ToCBOR, Enum, Bounded)
 
 -- ** Stake pool distributions
 

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Peras/Cert.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Peras/Cert.hs
@@ -1,3 +1,0 @@
-module Ouroboros.Consensus.Peras.Cert (module X) where
-
-import Ouroboros.Consensus.Peras.Cert.Inclusion as X

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Peras/Cert/V1.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Peras/Cert/V1.hs
@@ -1,0 +1,218 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+-- | Concrete Peras certificate types using BLS signatures.
+--
+-- NOTE: this module is meant to be imported qualified.
+--
+-- NOTE: the validation performed during serialization is minimal, and does not
+-- cover any of additional semantic and cryptographic checks that must be
+-- performed on the certificate later on.
+module Ouroboros.Consensus.Peras.Cert.V1
+  ( PerasCert (..)
+  , PerasCertVoters (..)
+  ) where
+
+import Cardano.Binary
+  ( FromCBOR (..)
+  , ToCBOR (..)
+  , decodeListLenOf
+  , encodeListLen
+  )
+import Control.Monad (when)
+import Control.Monad.Error.Class (MonadError (..))
+import Data.Containers.NonEmpty (HasNonEmpty (..))
+import qualified Data.List.NonEmpty as NonEmpty
+import qualified Data.Map.NonEmpty as NEMap
+import Data.Map.Strict (Map)
+import Data.Maybe (catMaybes)
+import Data.Word (Word16)
+import Ouroboros.Consensus.Block.SupportsPeras
+  ( PerasBoostedBlock
+  , PerasRoundNo
+  , PerasSeatIndex (..)
+  )
+import Ouroboros.Consensus.Committee.Crypto
+  ( CryptoSupportsAggregateVoteSigning (..)
+  )
+import Ouroboros.Consensus.Peras.Crypto.BLS
+  ( PerasBLSCrypto
+  , VRFOutput
+  )
+import Ouroboros.Consensus.Peras.Vote.V1 (PerasVoteEligibilityProof (..))
+import Ouroboros.Consensus.Util.Bitmap (Bitmap)
+import qualified Ouroboros.Consensus.Util.Bitmap as Bitmap
+
+-- | Concrete Peras certificates using BLS signatures
+data PerasCert
+  = PerasCert
+  { pcRoundNo :: !PerasRoundNo
+  -- ^ Election identifier
+  , pcBoostedBlock :: !PerasBoostedBlock
+  -- ^ Certificate message, i.e., the hash of the block being boosted
+  , pcVoters :: !PerasCertVoters
+  -- ^ Voters who contributed to this certificate
+  , pcSignature :: !(AggregateVoteSignature PerasBLSCrypto)
+  -- ^ Aggregate BLS signature on the hash of the election identifier and
+  -- the certificate message
+  }
+  deriving (Show, Eq)
+
+instance FromCBOR PerasCert where
+  fromCBOR = do
+    decodeListLenOf 4
+    pcRoundNo <- fromCBOR
+    pcBoostedBlock <- fromCBOR
+    pcVoters <- fromCBOR
+    pcSignature <- fromCBOR
+    pure
+      PerasCert
+        { pcRoundNo
+        , pcBoostedBlock
+        , pcVoters
+        , pcSignature
+        }
+
+instance ToCBOR PerasCert where
+  toCBOR cert =
+    encodeListLen 4
+      <> toCBOR (pcRoundNo cert)
+      <> toCBOR (pcBoostedBlock cert)
+      <> toCBOR (pcVoters cert)
+      <> toCBOR (pcSignature cert)
+
+-- | Voters contained in a certificate with their appropriate eligibility proof
+newtype PerasCertVoters
+  = PerasCertVoters
+  { unPerasCertVoters ::
+      NE (Map PerasSeatIndex PerasVoteEligibilityProof)
+  }
+  deriving (Eq, Show)
+
+instance FromCBOR PerasCertVoters where
+  fromCBOR = do
+    decodeListLenOf 2
+    votersBitmap <- fromCBOR
+    nonPersistentSigs <- fromCBOR
+
+    either fail pure
+      . fromCompactRepr
+      $ CompactPerasCertVoters
+        { votersBitmap
+        , nonPersistentSigs
+        }
+
+instance ToCBOR PerasCertVoters where
+  toCBOR voters =
+    encodeListLen 2
+      <> toCBOR votersBitmap
+      <> toCBOR nonPersistentSigs
+   where
+    CompactPerasCertVoters
+      { votersBitmap
+      , nonPersistentSigs
+      } =
+        toCompactRepr voters
+
+-- | Compact representation of the voters in a Peras certificate.
+--
+-- This compact representation consists of a bitmap of voter seat indices and a
+-- list of non-persistent eligibility proofs (VRF outputs). In this setup, the
+-- last @np@ indices in the bitmap that are flipped to 1 correspond to
+-- non-persistent voters, where @np@ is the length of the list of non-persistent
+-- eligibility proofs. The remaining flipped indices in the bitmap correspond
+-- to persistent voters.
+--
+-- @
+--   fromCompactRepr
+--      CompactPerasCertVoters {
+--        votersBitmap = <01101011>,
+--        nonPersistentSigs = [np1, np2, np3]
+--      }
+--   ==
+--   PerasCertVoters {
+--     1 => persistent
+--     2 => persistent
+--     4 => non-persistent(np1)
+--     6 => non-persistent(np2)
+--     7 => non-persistent(np3)
+--   }
+-- @
+data CompactPerasCertVoters
+  = CompactPerasCertVoters
+  { votersBitmap :: !(Bitmap Word16)
+  , nonPersistentSigs :: ![VRFOutput PerasBLSCrypto]
+  }
+  deriving (Eq, Show)
+
+-- | Decode 'PerasCertVoters' from their compact representation.
+--
+-- See 'CompactPerasCertVoters' for the encoding scheme used here.
+fromCompactRepr ::
+  CompactPerasCertVoters ->
+  Either String PerasCertVoters
+fromCompactRepr
+  CompactPerasCertVoters
+    { votersBitmap
+    , nonPersistentSigs
+    } = do
+    let voterSeatIndices =
+          PerasSeatIndex <$> Bitmap.toIndices votersBitmap
+
+    when (null voterSeatIndices) $
+      throwError "Invalid Peras certificate: empty voters bitmap"
+
+    when (length nonPersistentSigs > length voterSeatIndices) $
+      throwError $
+        unlines
+          [ "Invalid Peras certificate:"
+              <> " more non-persistent voter eligibility proofs were provided"
+              <> " than the number of voters in the certificate"
+          , " * number of voters: "
+              <> show (length voterSeatIndices)
+          , " * number of proofs: "
+              <> show (length nonPersistentSigs)
+          ]
+
+    let numPersistentVoters =
+          length voterSeatIndices - length nonPersistentSigs
+    let persistentProofs =
+          take numPersistentVoters (repeat PersistentPerasVoteEligibilityProof)
+    let nonPersistentProofs =
+          fmap NonPersistentPerasVoteEligibilityProof nonPersistentSigs
+    let voters =
+          NEMap.fromAscList
+            . NonEmpty.fromList
+            . zip voterSeatIndices
+            $ persistentProofs <> nonPersistentProofs
+
+    pure (PerasCertVoters voters)
+
+-- | Encode 'PerasCertVoters' into their compact representation.
+--
+-- See 'CompactPerasCertVoters' for the encoding scheme used here.
+toCompactRepr ::
+  PerasCertVoters ->
+  CompactPerasCertVoters
+toCompactRepr (PerasCertVoters voters) =
+  CompactPerasCertVoters
+    { votersBitmap
+    , nonPersistentSigs
+    }
+ where
+  logicalUpperBound =
+    unPerasSeatIndex (fst (NEMap.findMax voters))
+  votersByAscSeatIndex =
+    NonEmpty.toList (NEMap.toAscList voters)
+  votersSeatIndices =
+    fmap (unPerasSeatIndex . fst) votersByAscSeatIndex
+  votersBitmap =
+    Bitmap.fromIndices logicalUpperBound votersSeatIndices
+  nonPersistentSigs =
+    catMaybes (fmap getNonPersistentSig votersByAscSeatIndex)
+  getNonPersistentSig = \case
+    (_, PersistentPerasVoteEligibilityProof) -> Nothing
+    (_, NonPersistentPerasVoteEligibilityProof p) -> Just p

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Peras/Crypto/BLS.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Peras/Crypto/BLS.hs
@@ -1,0 +1,283 @@
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+-- | BLS-based crypto scheme used in Peras voting committees
+module Ouroboros.Consensus.Peras.Crypto.BLS
+  ( PerasBLSCrypto
+  , ElectionId
+  , VoteCandidate
+  , PerasPrivateKey (..)
+  , PerasPublicKey (..)
+  , VoteSignature (..)
+  , VRFElectionInput (..)
+  , VRFOutput (..)
+  , AggregateVoteVerificationKey
+  , AggregateVoteSignature
+
+    -- * For testing purposes
+  , PerasBLSCryptoAggregateVoteVerificationKey (..)
+  , PerasBLSCryptoAggregateVoteSignature (..)
+  ) where
+
+import Cardano.Binary (FromCBOR, ToCBOR (..))
+import Cardano.Crypto.DSIGN (BLS12381MinSigDSIGN, DSIGNAlgorithm (..))
+import Cardano.Crypto.Hash (Hash)
+import qualified Cardano.Crypto.Hash as Hash
+import Cardano.Ledger.BaseTypes (Nonce (..), SlotNo (..))
+import Cardano.Ledger.Binary (runByteBuilder)
+import Cardano.Ledger.Hashes (HASH)
+import qualified Data.ByteString.Builder as BS
+import qualified Data.ByteString.Builder.Extra as BS
+import qualified Data.ByteString.Short as BS
+import Ouroboros.Consensus.Block.RealPoint
+  ( bytes32RealPointHash
+  , bytes32RealPointSlot
+  )
+import Ouroboros.Consensus.Block.SupportsPeras
+  ( PerasBoostedBlock (..)
+  , PerasRoundNo (..)
+  )
+import Ouroboros.Consensus.Committee.Crypto
+  ( CryptoSupportsAggregateVoteSigning (..)
+  , CryptoSupportsBatchVRFVerification (..)
+  , CryptoSupportsVRF (..)
+  , CryptoSupportsVoteSigning (..)
+  , ElectionId
+  , PrivateKey
+  , PublicKey
+  , VRFPoolContext (..)
+  , VoteCandidate
+  )
+import Ouroboros.Consensus.Committee.Crypto.BLS (KeyRole (..))
+import qualified Ouroboros.Consensus.Committee.Crypto.BLS as BLS
+
+-- | BLS-based crypto scheme used in Peras voting committees
+data PerasBLSCrypto
+
+type instance ElectionId PerasBLSCrypto = PerasRoundNo
+type instance VoteCandidate PerasBLSCrypto = PerasBoostedBlock
+
+-- | Private key of a Peras committee member
+data PerasPrivateKey
+  = PerasPrivateKey
+  { perasVoteSignKey :: BLS.PrivateKey SIGN
+  , perasVRFSignKey :: BLS.PrivateKey VRF
+  }
+
+type instance PrivateKey PerasBLSCrypto = PerasPrivateKey
+
+-- | Public key of a Peras committee member
+data PerasPublicKey
+  = PerasPublicKey
+  { perasVoteVerKey :: BLS.PublicKey SIGN
+  , perasVRFVerKey :: BLS.PublicKey VRF
+  }
+
+type instance PublicKey PerasBLSCrypto = PerasPublicKey
+
+-- | Hash the message of a Peras vote
+--
+-- NOTE: this is inspired by the implementation used by the Praos VRF check in
+-- 'Ouroboros.Consensus.Protocol.Praos.VRF.mkInputVRF'.
+hashVoteSignature ::
+  ElectionId PerasBLSCrypto ->
+  VoteCandidate PerasBLSCrypto ->
+  Hash HASH (SigDSIGN BLS12381MinSigDSIGN)
+hashVoteSignature roundNo boostedBlock =
+  Hash.castHash
+    . Hash.hashWith id
+    . runByteBuilder (8 + 8 + 32)
+    $ roundNoBytes
+      <> boostedBlockSlotBytes
+      <> boostedBlockHashBytes
+ where
+  roundNoBytes =
+    BS.word64BE
+      . unPerasRoundNo
+      $ roundNo
+  boostedBlockSlotBytes =
+    BS.word64BE
+      . unSlotNo
+      . bytes32RealPointSlot
+      . unPerasBoostedBlock
+      $ boostedBlock
+  boostedBlockHashBytes =
+    BS.byteStringCopy
+      . BS.fromShort
+      . bytes32RealPointHash
+      . unPerasBoostedBlock
+      $ boostedBlock
+
+-- | Hash the input for the VRF used in Peras elections
+--
+-- NOTE: this is inspired by the implementation used by the Praos VRF check in
+-- 'Ouroboros.Consensus.Protocol.Praos.VRF.mkInputVRF'.
+hashVRFInput ::
+  ElectionId PerasBLSCrypto ->
+  Nonce ->
+  Hash HASH (SigDSIGN BLS12381MinSigDSIGN)
+hashVRFInput roundNo epochNonce =
+  Hash.castHash
+    . Hash.hashWith id
+    . runByteBuilder (8 + 32)
+    $ roundNoBytes <> epochNonceBytes
+ where
+  roundNoBytes =
+    BS.word64BE (unPerasRoundNo roundNo)
+  epochNonceBytes =
+    case epochNonce of
+      NeutralNonce -> mempty
+      Nonce h -> BS.byteStringCopy (Hash.hashToBytes h)
+
+-- * Crypto instances
+
+instance CryptoSupportsVoteSigning PerasBLSCrypto where
+  type VoteSigningKey PerasBLSCrypto = BLS.PrivateKey SIGN
+  type VoteVerificationKey PerasBLSCrypto = BLS.PublicKey SIGN
+
+  newtype VoteSignature PerasBLSCrypto
+    = PerasBLSCryptoVoteSignature
+    { unPerasBLSCryptoVoteSignature ::
+        BLS.Signature BLS.SIGN
+    }
+    deriving stock (Eq, Show)
+    deriving newtype (FromCBOR, ToCBOR)
+
+  getVoteSigningKey _ =
+    perasVoteSignKey
+  getVoteVerificationKey _ =
+    perasVoteVerKey
+
+  signVote sk roundNo boostedBlock =
+    PerasBLSCryptoVoteSignature
+      . BLS.signWithRole @SIGN sk
+      $ hashVoteSignature roundNo boostedBlock
+
+  verifyVoteSignature
+    pk
+    roundNo
+    boostedBlock
+    (PerasBLSCryptoVoteSignature sig) =
+      BLS.verifyWithRole @SIGN
+        pk
+        (hashVoteSignature roundNo boostedBlock)
+        sig
+
+instance CryptoSupportsVRF PerasBLSCrypto where
+  type VRFSigningKey PerasBLSCrypto = BLS.PrivateKey VRF
+  type VRFVerificationKey PerasBLSCrypto = BLS.PublicKey VRF
+
+  newtype VRFElectionInput PerasBLSCrypto
+    = PerasBLSCryptoVRFElectionInput
+    { unPerasBLSCryptoVRFElectionInput ::
+        Hash HASH (SigDSIGN BLS12381MinSigDSIGN)
+    }
+    deriving stock (Eq, Show)
+
+  newtype VRFOutput PerasBLSCrypto
+    = PerasBLSCryptoVRFOutput
+    { unPerasBLSCryptoVRFOutput ::
+        BLS.Signature VRF
+    }
+    deriving stock (Eq, Show)
+    deriving newtype (FromCBOR, ToCBOR)
+
+  getVRFSigningKey _ =
+    perasVRFSignKey
+
+  getVRFVerificationKey _ =
+    perasVRFVerKey
+
+  mkVRFElectionInput epochNonce roundNo =
+    PerasBLSCryptoVRFElectionInput $
+      hashVRFInput roundNo epochNonce
+
+  evalVRF context (PerasBLSCryptoVRFElectionInput input) =
+    case context of
+      VRFSignContext sk -> do
+        let sig = BLS.signWithRole @VRF (BLS.coercePrivateKey @VRF sk) input
+        pure $ PerasBLSCryptoVRFOutput sig
+      VRFVerifyContext pk (PerasBLSCryptoVRFOutput sig) -> do
+        BLS.verifyWithRole @VRF (BLS.coercePublicKey @VRF pk) input sig
+        pure $ PerasBLSCryptoVRFOutput sig
+
+  normalizeVRFOutput (PerasBLSCryptoVRFOutput sig) =
+    BLS.toNormalizedVRFOutput sig
+
+-- * Support for aggregate signatures and VRF outputs
+
+-- | Wrapper around the aggregate vote signatures.
+newtype PerasBLSCryptoAggregateVoteVerificationKey
+  = PerasBLSCryptoAggregateVoteVerificationKey
+  { unPerasBLSCryptoAggregateVoteVerificationKey ::
+      BLS.PublicKey SIGN
+  }
+  deriving stock (Eq, Show)
+
+-- | Wrapper around the aggregate vote verification keys.
+newtype PerasBLSCryptoAggregateVoteSignature
+  = PerasBLSCryptoAggregateVoteSignature
+  { unPerasBLSCryptoAggregateVoteSignature ::
+      BLS.Signature SIGN
+  }
+  deriving stock (Eq, Show)
+  deriving newtype (FromCBOR, ToCBOR)
+
+instance CryptoSupportsAggregateVoteSigning PerasBLSCrypto where
+  type
+    AggregateVoteVerificationKey PerasBLSCrypto =
+      PerasBLSCryptoAggregateVoteVerificationKey
+  type
+    AggregateVoteSignature PerasBLSCrypto =
+      PerasBLSCryptoAggregateVoteSignature
+
+  aggregateVoteVerificationKeys _ pks = do
+    aggPk <- BLS.aggregatePublicKeys @SIGN pks
+    pure (PerasBLSCryptoAggregateVoteVerificationKey aggPk)
+
+  aggregateVoteSignatures _ sigs = do
+    aggSig <-
+      BLS.aggregateSignatures @SIGN
+        . fmap unPerasBLSCryptoVoteSignature
+        $ sigs
+    pure (PerasBLSCryptoAggregateVoteSignature aggSig)
+
+  verifyAggregateVoteSignature
+    _
+    aggPk
+    roundNo
+    boostedBlock
+    aggSig = do
+      BLS.verifyWithRole @SIGN
+        (unPerasBLSCryptoAggregateVoteVerificationKey aggPk)
+        (hashVoteSignature roundNo boostedBlock)
+        (unPerasBLSCryptoAggregateVoteSignature aggSig)
+
+instance CryptoSupportsBatchVRFVerification PerasBLSCrypto where
+  -- NOTE: in contrast to vote signatures, we cannot aggregate multiple VRF
+  -- outputs into a single one when forging a certificate (because we need to
+  -- derive non-persistent seat numbers from each individual one). This means
+  -- that, at verification time, @sigs@ will always contain one VRF output per
+  -- non-persistent voter in the certificate, even when verifying a certificate
+  -- forged by someone else that we received over the network.
+  --
+  -- However, we still want to verify all the VRF outputs in a single batch for
+  -- efficiency reasons, and we can do that by first aggregating all the VRF
+  -- outputs in the list locally (using linearization to avoid swap-attacks),
+  -- and then verifying the resulting aggregate VRF output against the aggregate
+  -- VRF verification key.
+  batchVerifyVRFOutputs
+    pks
+    (PerasBLSCryptoVRFElectionInput input)
+    sigs = do
+      BLS.linearizeAndVerifyVRFs
+        pks
+        input
+        . fmap unPerasBLSCryptoVRFOutput
+        $ sigs

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Peras/Vote.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Peras/Vote.hs
@@ -1,3 +1,0 @@
-module Ouroboros.Consensus.Peras.Vote (module X) where
-
-import Ouroboros.Consensus.Peras.Vote.Aggregation as X

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Peras/Vote/V1.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Peras/Vote/V1.hs
@@ -1,0 +1,106 @@
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+-- | Concrete Peras vote types using BLS signatures.
+--
+-- NOTE: this module is meant to be imported qualified.
+module Ouroboros.Consensus.Peras.Vote.V1
+  ( PerasVote (..)
+  , PerasVoteEligibilityProof (..)
+  ) where
+
+import Cardano.Binary
+  ( FromCBOR (..)
+  , ToCBOR (..)
+  , decodeListLen
+  , decodeListLenOf
+  , encodeListLen
+  )
+import Data.Word (Word8)
+import Ouroboros.Consensus.Block.SupportsPeras
+  ( PerasBoostedBlock
+  , PerasRoundNo
+  , PerasSeatIndex
+  )
+import Ouroboros.Consensus.Committee.Crypto (CryptoSupportsVoteSigning (..))
+import Ouroboros.Consensus.Peras.Crypto.BLS
+  ( PerasBLSCrypto
+  , VRFOutput
+  )
+
+-- | Concrete Peras votes using BLS signatures
+data PerasVote
+  = PerasVote
+  { pvRoundNo :: !PerasRoundNo
+  -- ^ Election identifier
+  , pvBoostedBlock :: !PerasBoostedBlock
+  -- ^ Vote message, i.e., the hash of the block being voted for
+  , pvSeatIndex :: !PerasSeatIndex
+  -- ^ Seat index assigned to the committee member (identifies the voter)
+  , pvEligibilityProof :: !PerasVoteEligibilityProof
+  -- ^ Proof of eligibility for voting, depending on the type of membership to
+  -- the committee (persistent vs non-persistent)
+  , pvSignature :: !(VoteSignature PerasBLSCrypto)
+  -- ^ BLS signature on the hash of the election identifier and vote message
+  }
+  deriving (Show, Eq)
+
+instance FromCBOR PerasVote where
+  fromCBOR = do
+    decodeListLenOf 5
+    pvRoundNo <- fromCBOR
+    pvBoostedBlock <- fromCBOR
+    pvSeatIndex <- fromCBOR
+    pvEligibilityProof <- fromCBOR
+    pvSignature <- fromCBOR
+    pure
+      PerasVote
+        { pvRoundNo
+        , pvBoostedBlock
+        , pvSeatIndex
+        , pvEligibilityProof
+        , pvSignature
+        }
+
+instance ToCBOR PerasVote where
+  toCBOR vote =
+    encodeListLen 5
+      <> toCBOR (pvRoundNo vote)
+      <> toCBOR (pvBoostedBlock vote)
+      <> toCBOR (pvSeatIndex vote)
+      <> toCBOR (pvEligibilityProof vote)
+      <> toCBOR (pvSignature vote)
+
+-- | Proof of eligibility for voting for committee members
+data PerasVoteEligibilityProof
+  = -- | Persistent committee members require no additional proof of eligibility
+    PersistentPerasVoteEligibilityProof
+  | -- | Non-persistent committee members provide a VRF proof of eligibility
+    NonPersistentPerasVoteEligibilityProof !(VRFOutput PerasBLSCrypto)
+  deriving stock (Eq, Show)
+
+instance FromCBOR PerasVoteEligibilityProof where
+  fromCBOR = do
+    len <- decodeListLen
+    tag <- fromCBOR @Word8
+    case (len, tag) of
+      (1, 0) -> pure PersistentPerasVoteEligibilityProof
+      (2, 1) -> NonPersistentPerasVoteEligibilityProof <$> fromCBOR
+      _ ->
+        fail $
+          "Invalid PerasVoteEligibilityProof length/tag: "
+            <> show (len, tag)
+
+instance ToCBOR PerasVoteEligibilityProof where
+  toCBOR = \case
+    PersistentPerasVoteEligibilityProof ->
+      encodeListLen 1
+        <> toCBOR (0 :: Word8)
+    NonPersistentPerasVoteEligibilityProof vrfOutput ->
+      encodeListLen 2
+        <> toCBOR (1 :: Word8)
+        <> toCBOR vrfOutput

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Peras/Voting/Committee.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Peras/Voting/Committee.hs
@@ -1,0 +1,302 @@
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+
+-- | Support for using concrete votes and certificates with multiple voting
+-- committee implementations.
+module Ouroboros.Consensus.Peras.Voting.Committee
+  ( -- * Peras support for multiple voting committee implementations
+    PerasConversionError (..)
+  , PerasVoteCompatibleWithVotingCommittee (..)
+  , PerasCertCompatibleWithVotingCommittee (..)
+  ) where
+
+import Data.Containers.NonEmpty (HasNonEmpty (..))
+import qualified Data.List.NonEmpty as NonEmpty
+import Data.Map (Map)
+import qualified Data.Map as Map
+import qualified Data.Map.NonEmpty as NEMap
+import Data.Maybe (isJust)
+import Data.Word (Word16, Word64)
+import Ouroboros.Consensus.Block.SupportsPeras (PerasSeatIndex (..))
+import qualified Ouroboros.Consensus.Committee.Class as Committee
+import Ouroboros.Consensus.Committee.Crypto (CryptoSupportsVRF (..))
+import Ouroboros.Consensus.Committee.EveryoneVotes
+  ( Cert (..)
+  , EveryoneVotes
+  , Vote (..)
+  )
+import Ouroboros.Consensus.Committee.WFA (SeatIndex (..))
+import Ouroboros.Consensus.Committee.WFALS (Cert (..), Vote (..), WFALS)
+import qualified Ouroboros.Consensus.Peras.Cert.V1 as V1
+import Ouroboros.Consensus.Peras.Crypto.BLS (PerasBLSCrypto)
+import qualified Ouroboros.Consensus.Peras.Vote.V1 as V1
+
+-- * Peras support for multiple voting committee implementations
+
+-- | Errors that can occur when converting between Peras and committee types
+data PerasConversionError
+  = EveryoneVotesButFoundNonPersistentVoterInVote SeatIndex
+  | EveryoneVotesButFoundNonPersistentVotersInCert (NE [SeatIndex])
+  | SeatIndexOverflowError Word64
+  | CryptoError String
+  deriving stock (Eq, Show)
+
+-- | Conversion between (concrete) Peras votes and (abstract) committee votes.
+--
+-- NOTE: the functional dependency @vote -> crypto@ explicitly ties each
+-- concrete Peras vote type to a specific crypto scheme.
+class
+  PerasVoteCompatibleWithVotingCommittee vote crypto committee
+    | vote -> crypto
+  where
+  toPerasVote ::
+    Committee.Vote crypto committee ->
+    Either PerasConversionError vote
+  fromPerasVote ::
+    vote ->
+    Either PerasConversionError (Committee.Vote crypto committee)
+
+-- | Conversion between (concrete) Peras certificates and (abstract) committee
+-- certificates.
+--
+-- NOTE: the functional dependency @cert -> crypto@ explicitly ties each
+-- concrete Peras certificate type to a specific crypto scheme.
+class
+  PerasCertCompatibleWithVotingCommittee cert crypto committee
+    | cert -> crypto
+  where
+  toPerasCert ::
+    Committee.Cert crypto committee ->
+    Either PerasConversionError cert
+  fromPerasCert ::
+    cert ->
+    Either PerasConversionError (Committee.Cert crypto committee)
+
+-- 'V1.PerasVote's are compatible with 'WFALS' as long as we make sure to avoid
+-- overflowing their `Word16` seat index.
+instance
+  PerasVoteCompatibleWithVotingCommittee
+    V1.PerasVote
+    PerasBLSCrypto
+    WFALS
+  where
+  toPerasVote = \case
+    WFALSPersistentVote seatIndex electionId candidate sig -> do
+      perasSeatIndex <- toPerasSeatIndex seatIndex
+      pure $
+        V1.PerasVote
+          { V1.pvRoundNo = electionId
+          , V1.pvBoostedBlock = candidate
+          , V1.pvSeatIndex = perasSeatIndex
+          , V1.pvEligibilityProof = V1.PersistentPerasVoteEligibilityProof
+          , V1.pvSignature = sig
+          }
+    WFALSNonPersistentVote seatIndex electionId candidate vrfOutput sig -> do
+      perasSeatIndex <- toPerasSeatIndex seatIndex
+      let proof = V1.NonPersistentPerasVoteEligibilityProof vrfOutput
+      pure $
+        V1.PerasVote
+          { V1.pvRoundNo = electionId
+          , V1.pvBoostedBlock = candidate
+          , V1.pvSeatIndex = perasSeatIndex
+          , V1.pvEligibilityProof = proof
+          , V1.pvSignature = sig
+          }
+
+  fromPerasVote = \case
+    V1.PerasVote electionId candidate seatIndex proof sig -> do
+      let seatIndex' = fromPerasSeatIndex seatIndex
+      case proof of
+        V1.PersistentPerasVoteEligibilityProof ->
+          pure $
+            WFALSPersistentVote
+              seatIndex'
+              electionId
+              candidate
+              sig
+        V1.NonPersistentPerasVoteEligibilityProof vrfOutput ->
+          pure $
+            WFALSNonPersistentVote
+              seatIndex'
+              electionId
+              candidate
+              vrfOutput
+              sig
+
+-- 'V1.PerasCert's are compatible with 'WFALS' as long as we make sure to avoid
+-- overflowing the `Word16` seat index of each voter.
+instance
+  PerasCertCompatibleWithVotingCommittee
+    V1.PerasCert
+    PerasBLSCrypto
+    WFALS
+  where
+  toPerasCert = \case
+    WFALSCert electionId candidate voters sig -> do
+      voters' <- toPerasCertVoters voters
+      pure $
+        V1.PerasCert
+          { V1.pcRoundNo = electionId
+          , V1.pcBoostedBlock = candidate
+          , V1.pcVoters = voters'
+          , V1.pcSignature = sig
+          }
+
+  fromPerasCert = \case
+    V1.PerasCert electionId candidate voters sig -> do
+      let voters' = fromPerasCertVoters voters
+      pure $
+        WFALSCert
+          electionId
+          candidate
+          voters'
+          sig
+
+-- 'V1.PerasVote's are compatible with 'EveryoneVotes' as long as we make sure
+-- to only accept votes with persistent eligibility proofs (in addition to
+-- avoiding overflowing their `Word16` seat index).
+instance
+  PerasVoteCompatibleWithVotingCommittee
+    V1.PerasVote
+    PerasBLSCrypto
+    EveryoneVotes
+  where
+  toPerasVote = \case
+    EveryoneVotesVote seatIndex electionId candidate sig -> do
+      perasSeatIndex <- toPerasSeatIndex seatIndex
+      pure $
+        V1.PerasVote
+          { V1.pvRoundNo = electionId
+          , V1.pvBoostedBlock = candidate
+          , V1.pvSeatIndex = perasSeatIndex
+          , V1.pvEligibilityProof = V1.PersistentPerasVoteEligibilityProof
+          , V1.pvSignature = sig
+          }
+
+  fromPerasVote = \case
+    V1.PerasVote electionId candidate seatIndex proof sig -> do
+      let seatIndex' = fromPerasSeatIndex seatIndex
+      case proof of
+        V1.PersistentPerasVoteEligibilityProof ->
+          pure $
+            EveryoneVotesVote
+              seatIndex'
+              electionId
+              candidate
+              sig
+        V1.NonPersistentPerasVoteEligibilityProof _ ->
+          Left $
+            EveryoneVotesButFoundNonPersistentVoterInVote seatIndex'
+
+-- 'V1.PerasCert's are compatible with 'EveryoneVotes' as long as we make sure
+-- to only accept certificates containing only persistent eligibility proofs
+-- (in addition to avoiding overflowing the `Word16` seat index of each voter).
+instance
+  PerasCertCompatibleWithVotingCommittee
+    V1.PerasCert
+    PerasBLSCrypto
+    EveryoneVotes
+  where
+  toPerasCert = \case
+    EveryoneVotesCert electionId candidate voters sig -> do
+      voters' <-
+        toPerasCertVoters
+          . NEMap.fromSet (const Nothing)
+          $ voters
+      pure $
+        V1.PerasCert
+          { V1.pcRoundNo = electionId
+          , V1.pcBoostedBlock = candidate
+          , V1.pcVoters = voters'
+          , V1.pcSignature = sig
+          }
+
+  fromPerasCert = \case
+    V1.PerasCert electionId candidate voters sig -> do
+      let voters' = fromPerasCertVoters voters
+      case nonPersistentVoters voters' of
+        Nothing ->
+          pure $
+            EveryoneVotesCert
+              electionId
+              candidate
+              (NEMap.keysSet voters')
+              sig
+        Just nonPersistentSeatIndices ->
+          Left $
+            EveryoneVotesButFoundNonPersistentVotersInCert
+              nonPersistentSeatIndices
+   where
+    nonPersistentVoters voters' =
+      case Map.keys (NEMap.filter isJust voters') of
+        [] ->
+          Nothing
+        nonPersistentSeats ->
+          Just (NonEmpty.fromList nonPersistentSeats)
+
+-- * Helpers
+
+-- | Convert a Peras seat index to a committee seat index.
+fromPerasSeatIndex ::
+  PerasSeatIndex ->
+  SeatIndex
+fromPerasSeatIndex (PerasSeatIndex seatIndex) =
+  SeatIndex (fromIntegral @Word16 @Word64 seatIndex)
+
+-- | Convert a committee seat index to a Peras seat index
+--
+-- NOTE: this can fail if the seat index in the committee vote or certificate
+-- overflows the smaller 'Word16' type used by Peras votes and certificates.
+-- In practice, this should never happen unless there is a bug in the voting
+-- committee logic.
+toPerasSeatIndex ::
+  SeatIndex ->
+  Either PerasConversionError PerasSeatIndex
+toPerasSeatIndex (SeatIndex seatIndex)
+  | seatIndex <= fromIntegral @Word16 @Word64 maxBound =
+      Right (PerasSeatIndex (fromIntegral @Word64 @Word16 seatIndex))
+  | otherwise =
+      Left (SeatIndexOverflowError seatIndex)
+
+-- | Convert concrete Peras certificate voters to abstract committee voters
+fromPerasCertVoters ::
+  V1.PerasCertVoters ->
+  NE (Map SeatIndex (Maybe (VRFOutput PerasBLSCrypto)))
+fromPerasCertVoters voters =
+  NEMap.fromAscList
+    . NonEmpty.map
+      ( \(seatIndex, proof) ->
+          ( fromPerasSeatIndex seatIndex
+          , fromPerasVoteEligibilityProof proof
+          )
+      )
+    . NEMap.toAscList
+    . V1.unPerasCertVoters
+    $ voters
+ where
+  fromPerasVoteEligibilityProof = \case
+    V1.PersistentPerasVoteEligibilityProof -> Nothing
+    V1.NonPersistentPerasVoteEligibilityProof vrfOutput -> Just vrfOutput
+
+-- | Convert abstract committee voters to concrete Peras certificate voters
+toPerasCertVoters ::
+  NE (Map SeatIndex (Maybe (VRFOutput PerasBLSCrypto))) ->
+  Either PerasConversionError V1.PerasCertVoters
+toPerasCertVoters voters =
+  fmap V1.PerasCertVoters
+    . fmap NEMap.fromAscList
+    . traverse
+      ( \(seatIndex, proof) -> do
+          seatIndex' <- toPerasSeatIndex seatIndex
+          let proof' = toPerasVoteEligibilityProof proof
+          pure (seatIndex', proof')
+      )
+    . NEMap.toAscList
+    $ voters
+ where
+  toPerasVoteEligibilityProof = \case
+    Nothing -> V1.PersistentPerasVoteEligibilityProof
+    Just vrfOutput -> V1.NonPersistentPerasVoteEligibilityProof vrfOutput

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Util/Bitmap.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Util/Bitmap.hs
@@ -1,0 +1,144 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+-- | A compact bitmap representation using serialisation-ready ByteStrings.
+--
+-- Adapted from @Cardano.Leios.BitMapPV@ in the @leios-wfa-ls-demo@ package.
+--
+-- NOTE: this module is meant to be imported qualified.
+module Ouroboros.Consensus.Util.Bitmap
+  ( Bitmap
+  , fromIndices
+  , toIndices
+  , logicalUpperBound
+  , rawSerialise
+  , rawDeserialise
+  ) where
+
+import Cardano.Binary (FromCBOR (..), ToCBOR (..))
+import qualified Codec.CBOR.Decoding as CBOR
+import qualified Codec.CBOR.Encoding as CBOR
+import Control.Monad (forM_, when)
+import Data.Bits
+  ( countTrailingZeros
+  , popCount
+  , unsafeShiftL
+  , (.&.)
+  , (.|.)
+  )
+import Data.ByteString (ByteString)
+import qualified Data.ByteString as ByteString
+import qualified Data.ByteString.Internal as ByteString
+import Data.Word (Word8)
+import Foreign.Marshal.Utils (fillBytes)
+import Foreign.Storable (peekByteOff, pokeByteOff)
+
+-- | A compact bitmap representation over an index type.
+--
+-- NOTE: the logical upper bound is stored explicitly so serialisation
+-- round-trips exactly.
+data Bitmap a
+  = Bitmap
+      -- | Logical upper bound
+      !a
+      -- | Payload
+      !ByteString
+  deriving Eq
+
+instance Show a => Show (Bitmap a) where
+  show (Bitmap maxIx bs) =
+    "Bitmap{maxIx="
+      <> show maxIx
+      <> ",bytes="
+      <> show (ByteString.length bs)
+      <> ",set="
+      <> show (countSetBits bs)
+      <> "}"
+   where
+    countSetBits arr =
+      sum
+        [ popCount (ByteString.index arr i)
+        | i <- [0 .. ByteString.length arr - 1]
+        ]
+
+-- | Construct a 'Bitmap' from a list of indexes that should be set (flipped to
+-- 1) and a maximum index (inclusive logical upper bound).
+fromIndices :: Integral a => a -> [a] -> Bitmap a
+fromIndices maxIx flipped =
+  Bitmap maxIx $
+    ByteString.unsafeCreate nBytes $ \ptr -> do
+      fillBytes ptr 0 nBytes
+      forM_ flipped $ \ix -> do
+        let !i = fromIntegral ix :: Int
+        when (i >= 0 && i <= maxI) $ do
+          let !byteIx = i `quot` 8
+          let !bitIx = i `rem` 8
+          let !mask = bitMask bitIx
+          w <- peekByteOff ptr byteIx :: IO Word8
+          pokeByteOff ptr byteIx (w .|. mask)
+ where
+  !maxI = fromIntegral maxIx :: Int
+  !nBytes = (maxI `quot` 8) + 1
+
+  bitMask k = fromIntegral ((1 :: Int) `unsafeShiftL` k)
+
+-- | Retrieve all indexes that are set (flipped to 1) in the bitmap, in
+-- ascending order.
+toIndices :: Integral a => Bitmap a -> [a]
+toIndices (Bitmap maxIx bitmap) =
+  goBytes 0
+ where
+  !maxI = fromIntegral maxIx :: Int
+  !nBytes = ByteString.length bitmap
+
+  goBytes !byteIx
+    | byteIx >= nBytes = []
+    | otherwise =
+        let !w = ByteString.index bitmap byteIx
+         in goBits (byteIx * 8) w <> goBytes (byteIx + 1)
+
+  goBits !_ 0 = []
+  goBits !base !w =
+    let !bitIx = countTrailingZeros w
+        !i = base + bitIx
+        !w' = w .&. (w - 1)
+     in if i <= maxI
+          then fromIntegral i : goBits base w'
+          else []
+
+-- | Get the logical upper bound of a bitmap
+logicalUpperBound :: Bitmap a -> a
+logicalUpperBound (Bitmap a _) = a
+
+-- | Raw serialisation of the bitmap (just the underlying bytes, without the
+-- logical upper bound).
+rawSerialise :: Bitmap a -> ByteString
+rawSerialise (Bitmap _ bs) = bs
+
+-- | Raw deserialisation of a bitmap from a logical upper bound and a ByteString
+--
+-- Returns 'Nothing' if the byte string length does not match the expected size
+-- for the given upper bound.
+rawDeserialise :: Integral a => a -> ByteString -> Maybe (Bitmap a)
+rawDeserialise maxIx bs
+  | ByteString.length bs /= expectedBytes = Nothing
+  | otherwise = Just (Bitmap maxIx bs)
+ where
+  expectedBytes = (fromIntegral maxIx `quot` 8) + 1
+
+instance ToCBOR a => ToCBOR (Bitmap a) where
+  toCBOR (Bitmap maxIx bs) =
+    CBOR.encodeListLen 2
+      <> toCBOR maxIx
+      <> CBOR.encodeBytes bs
+
+instance (Integral a, FromCBOR a) => FromCBOR (Bitmap a) where
+  fromCBOR = do
+    CBOR.decodeListLenOf 2
+    maxIx <- fromCBOR
+    bs <- CBOR.decodeBytes
+    case rawDeserialise maxIx bs of
+      Nothing ->
+        fail "Bitmap: invalid bitmap data or size mismatch"
+      Just bitmap ->
+        pure bitmap

--- a/ouroboros-consensus/test/consensus-test/Main.hs
+++ b/ouroboros-consensus/test/consensus-test/Main.hs
@@ -25,6 +25,7 @@ import qualified Test.Consensus.MiniProtocol.ObjectDiffusion.Smoke (tests)
 import qualified Test.Consensus.Peras.Cert.Inclusion (tests)
 import qualified Test.Consensus.Peras.Voting.Rules (tests)
 import qualified Test.Consensus.Peras.WeightSnapshot (tests)
+import qualified Test.Consensus.Util.Bitmap (tests)
 import qualified Test.Consensus.Util.MonadSTM.NormalForm (tests)
 import qualified Test.Consensus.Util.Pred (tests)
 import qualified Test.Consensus.Util.Versioned (tests)
@@ -69,6 +70,7 @@ tests =
         , Test.Consensus.Peras.Voting.Rules.tests
         , Test.Consensus.Peras.WeightSnapshot.tests
         ]
+    , Test.Consensus.Util.Bitmap.tests
     , Test.Consensus.Util.MonadSTM.NormalForm.tests
     , Test.Consensus.Util.Versioned.tests
     , Test.Consensus.Util.Pred.tests

--- a/ouroboros-consensus/test/consensus-test/Main.hs
+++ b/ouroboros-consensus/test/consensus-test/Main.hs
@@ -23,6 +23,7 @@ import qualified Test.Consensus.MiniProtocol.ObjectDiffusion.PerasCert.Smoke (te
 import qualified Test.Consensus.MiniProtocol.ObjectDiffusion.PerasVote.Smoke (tests)
 import qualified Test.Consensus.MiniProtocol.ObjectDiffusion.Smoke (tests)
 import qualified Test.Consensus.Peras.Cert.Inclusion (tests)
+import qualified Test.Consensus.Peras.Serialisation (tests)
 import qualified Test.Consensus.Peras.Voting.Rules (tests)
 import qualified Test.Consensus.Peras.WeightSnapshot (tests)
 import qualified Test.Consensus.Util.Bitmap (tests)
@@ -69,6 +70,7 @@ tests =
         [ Test.Consensus.Peras.Cert.Inclusion.tests
         , Test.Consensus.Peras.Voting.Rules.tests
         , Test.Consensus.Peras.WeightSnapshot.tests
+        , Test.Consensus.Peras.Serialisation.tests
         ]
     , Test.Consensus.Util.Bitmap.tests
     , Test.Consensus.Util.MonadSTM.NormalForm.tests

--- a/ouroboros-consensus/test/consensus-test/Main.hs
+++ b/ouroboros-consensus/test/consensus-test/Main.hs
@@ -24,6 +24,7 @@ import qualified Test.Consensus.MiniProtocol.ObjectDiffusion.PerasVote.Smoke (te
 import qualified Test.Consensus.MiniProtocol.ObjectDiffusion.Smoke (tests)
 import qualified Test.Consensus.Peras.Cert.Inclusion (tests)
 import qualified Test.Consensus.Peras.Serialisation (tests)
+import qualified Test.Consensus.Peras.Voting.Committee (tests)
 import qualified Test.Consensus.Peras.Voting.Rules (tests)
 import qualified Test.Consensus.Peras.WeightSnapshot (tests)
 import qualified Test.Consensus.Util.Bitmap (tests)
@@ -68,6 +69,7 @@ tests =
     , testGroup
         "Peras"
         [ Test.Consensus.Peras.Cert.Inclusion.tests
+        , Test.Consensus.Peras.Voting.Committee.tests
         , Test.Consensus.Peras.Voting.Rules.tests
         , Test.Consensus.Peras.WeightSnapshot.tests
         , Test.Consensus.Peras.Serialisation.tests

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/Peras/Serialisation.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/Peras/Serialisation.hs
@@ -1,0 +1,82 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+-- | Serialisation roundtrip tests for Peras types
+module Test.Consensus.Peras.Serialisation
+  ( tests
+  ) where
+
+import Cardano.Binary (FromCBOR (..), ToCBOR (..), decodeFull, serialize)
+import qualified Data.ByteString.Lazy as LazyByteString
+import Test.Consensus.Peras.Util
+  ( genPerasCert
+  , genPerasVote
+  , mkBucket
+  , tabulatePerasCert
+  , tabulatePerasVote
+  )
+import Test.QuickCheck
+  ( Gen
+  , Property
+  , counterexample
+  , forAll
+  , tabulate
+  , (===)
+  )
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.QuickCheck (testProperty)
+import Test.Util.TestEnv (adjustQuickCheckTests)
+
+tests :: TestTree
+tests =
+  testGroup
+    "Serialization roundtrip for Peras types"
+    [ adjustQuickCheckTests (* 10) $
+        testProperty "Roundtrip for PerasVote" $
+          prop_roundtrip
+            -- Generate both persistent and non-persistent votes
+            (genPerasVote True)
+            tabulatePerasVote
+    , adjustQuickCheckTests (* 10) $
+        testProperty "Roundtrip for PerasCert" $
+          prop_roundtrip
+            -- Generate certs with both persistent and non-persistent votes
+            (genPerasCert True)
+            tabulatePerasCert
+    ]
+
+-- * Properties
+
+prop_roundtrip ::
+  forall a.
+  ( Eq a
+  , Show a
+  , ToCBOR a
+  , FromCBOR a
+  ) =>
+  Gen a ->
+  (a -> Property -> Property) ->
+  Property
+prop_roundtrip gen tabulateValue =
+  forAll gen $ \a -> do
+    let encoded = serialize a
+    let decoded = decodeFull encoded
+    tabulateValue a
+      . tabulateEncodedSize encoded
+      . counterexample
+        ( unlines
+            [ "Original value:"
+            , show a
+            , "Decoded value:"
+            , show decoded
+            ]
+        )
+      $ Right a === decoded
+
+-- * Tabulators
+
+tabulateEncodedSize :: LazyByteString.ByteString -> Property -> Property
+tabulateEncodedSize bytes =
+  tabulate
+    "Encoded size"
+    [mkBucket 1000 (fromIntegral (LazyByteString.length bytes)) " bytes"]

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/Peras/Util.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/Peras/Util.hs
@@ -1,0 +1,274 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+
+-- | Common utilities for writing tests for Peras types.
+module Test.Consensus.Peras.Util
+  ( -- * Predicates
+    perasVoteIsPersistent
+  , perasCertContainsOnlyPersistentVotes
+
+    -- * Generators
+  , genPerasVote
+  , genPerasCert
+
+    -- * Tabulators
+  , mkBucket
+  , tabulatePerasCert
+  , tabulatePerasVote
+  ) where
+
+import Cardano.Crypto.Hash (ByteString)
+import Cardano.Ledger.BaseTypes (SlotNo (..))
+import Control.Monad (forM)
+import qualified Data.ByteString as ByteString
+import Data.ByteString.Short (ShortByteString)
+import qualified Data.ByteString.Short as ShortByteString
+import qualified Data.ByteString.Short as ShortBytesString
+import qualified Data.List.NonEmpty as NonEmpty
+import qualified Data.Map.NonEmpty as NEMap
+import Data.Maybe (catMaybes, fromMaybe)
+import Data.Proxy (Proxy (..))
+import Data.String (IsString (..))
+import Data.Traversable (mapAccumM)
+import Data.Word (Word8)
+import GHC.Word (Word16)
+import Ouroboros.Consensus.Block (ConvertRawHash, HeaderHash)
+import Ouroboros.Consensus.Block.Abstract (ConvertRawHash (..))
+import Ouroboros.Consensus.Block.RealPoint (RealPoint (..), toBytes32RealPoint)
+import Ouroboros.Consensus.Block.SupportsPeras
+  ( PerasBoostedBlock (..)
+  , PerasRoundNo (..)
+  , PerasSeatIndex (..)
+  )
+import qualified Ouroboros.Consensus.Committee.Crypto.BLS as BLS
+import qualified Ouroboros.Consensus.Peras.Cert.V1 as V1
+import Ouroboros.Consensus.Peras.Crypto.BLS
+  ( PerasBLSCryptoAggregateVoteSignature (..)
+  , VRFOutput (..)
+  , VoteSignature (..)
+  )
+import qualified Ouroboros.Consensus.Peras.Vote.V1 as V1
+import Test.QuickCheck
+  ( Arbitrary (..)
+  , Gen
+  , Property
+  , choose
+  , frequency
+  , sized
+  , tabulate
+  , vectorOf
+  )
+
+-- * Predicates
+
+-- | Whether a Peras vote is a persistent one
+perasVoteIsPersistent :: V1.PerasVote -> Bool
+perasVoteIsPersistent vote
+  | V1.PersistentPerasVoteEligibilityProof{} <- V1.pvEligibilityProof vote = True
+  | otherwise = False
+
+-- | Whether a Peras certifcate only contains persistent votes
+perasCertContainsOnlyPersistentVotes :: V1.PerasCert -> Bool
+perasCertContainsOnlyPersistentVotes cert =
+  all
+    ( \case
+        V1.PersistentPerasVoteEligibilityProof -> True
+        V1.NonPersistentPerasVoteEligibilityProof{} -> False
+    )
+    ( NEMap.elems
+        . V1.unPerasCertVoters
+        . V1.pcVoters
+        $ cert
+    )
+
+-- * Generators
+
+genRoundNo :: Gen PerasRoundNo
+genRoundNo = PerasRoundNo <$> arbitrary
+
+data BlockWith32BytesHeaderHash
+type instance HeaderHash BlockWith32BytesHeaderHash = ShortByteString
+
+instance ConvertRawHash BlockWith32BytesHeaderHash where
+  type HashSize BlockWith32BytesHeaderHash = 32
+  toRawHash _ = ShortBytesString.fromShort
+  unsafeFromRawHash _ = ShortBytesString.toShort
+
+genBoostedBlock :: Gen PerasBoostedBlock
+genBoostedBlock = do
+  slotNo <- SlotNo <$> arbitrary
+  hash <- ShortByteString.pack <$> vectorOf 32 arbitrary
+  let bytes32realPoint =
+        toBytes32RealPoint @BlockWith32BytesHeaderHash $
+          RealPoint slotNo hash
+  pure (PerasBoostedBlock bytes32realPoint)
+
+genSeatIndex :: Gen PerasSeatIndex
+genSeatIndex = PerasSeatIndex <$> arbitrary
+
+genPrivateKey :: Proxy r -> Gen (BLS.PrivateKey r)
+genPrivateKey _ =
+  fromMaybe (error "genPrivateKey: invalid key bytes")
+    . BLS.rawDeserialisePrivateKey "ROUNDTRIP"
+    . ByteString.pack
+    <$> vectorOf 32 (arbitrary @Word8)
+
+genSignature ::
+  forall r.
+  BLS.HasBLSContext r =>
+  Proxy r ->
+  Gen (BLS.Signature r)
+genSignature _ = do
+  key <- genPrivateKey (Proxy @r)
+  msg <- fromString @ByteString <$> arbitrary
+  pure $ BLS.signWithRole key msg
+
+genVoteEligibilityProof :: Bool -> Gen V1.PerasVoteEligibilityProof
+genVoteEligibilityProof shouldGenNonPersistent = do
+  frequency
+    [
+      ( 4
+      , pure V1.PersistentPerasVoteEligibilityProof
+      )
+    ,
+      ( if shouldGenNonPersistent then 1 else 0
+      , V1.NonPersistentPerasVoteEligibilityProof
+          . PerasBLSCryptoVRFOutput
+          <$> genSignature (Proxy @BLS.VRF)
+      )
+    ]
+
+genVoters :: Bool -> Gen V1.PerasCertVoters
+genVoters shouldGenNonPersistent = do
+  numVoters <-
+    sized $ \size ->
+      fmap (+ 1) $
+        choose @Word16 (0, fromIntegral size * 10)
+  numPersistentVoters <-
+    case shouldGenNonPersistent of
+      True -> choose (0, numVoters)
+      False -> pure numVoters
+  persistentVoters <-
+    if numPersistentVoters == 0
+      then pure []
+      else forM [0 .. numPersistentVoters - 1] $ \i -> do
+        let proof = V1.PersistentPerasVoteEligibilityProof
+        pure (PerasSeatIndex i, proof)
+  nonPersistentVoters <-
+    if numPersistentVoters == numVoters
+      then pure []
+      else forM [numPersistentVoters .. numVoters - 1] $ \i -> do
+        proof <-
+          V1.NonPersistentPerasVoteEligibilityProof
+            . PerasBLSCryptoVRFOutput
+            <$> genSignature (Proxy @BLS.VRF)
+        pure (PerasSeatIndex i, proof)
+  voters <-
+    fmap (snd . fmap catMaybes)
+      . mapAccumM
+        ( \canDrop (i, proof) -> do
+            voter <-
+              frequency
+                [ (75, pure (Just (i, proof)))
+                , (if canDrop then 25 else 0, pure Nothing)
+                ]
+            pure
+              ( canDrop || voter == Nothing
+              , voter
+              )
+        )
+        False
+      $ persistentVoters <> nonPersistentVoters
+  pure $
+    V1.PerasCertVoters (NEMap.fromList (NonEmpty.fromList voters))
+
+genPerasVote :: Bool -> Gen V1.PerasVote
+genPerasVote shouldGenNonPersistent = do
+  pvRoundNo <- genRoundNo
+  pvBoostedBlock <- genBoostedBlock
+  pvSeatIndex <- genSeatIndex
+  pvEligibilityProof <- genVoteEligibilityProof shouldGenNonPersistent
+  pvSignature <-
+    PerasBLSCryptoVoteSignature
+      <$> genSignature (Proxy @BLS.SIGN)
+  pure
+    V1.PerasVote
+      { V1.pvRoundNo
+      , V1.pvBoostedBlock
+      , V1.pvSeatIndex
+      , V1.pvEligibilityProof
+      , V1.pvSignature
+      }
+
+genPerasCert :: Bool -> Gen V1.PerasCert
+genPerasCert shouldGenNonPersistent = do
+  pcRoundNo <- genRoundNo
+  pcBoostedBlock <- genBoostedBlock
+  pcVoters <- genVoters shouldGenNonPersistent
+  pcSignature <-
+    PerasBLSCryptoAggregateVoteSignature
+      <$> genSignature (Proxy @BLS.SIGN)
+  pure
+    V1.PerasCert
+      { V1.pcRoundNo
+      , V1.pcBoostedBlock
+      , V1.pcVoters
+      , V1.pcSignature
+      }
+
+-- * Tabulators
+
+mkBucket :: Int -> Int -> String -> String
+mkBucket bucketSize x suffix
+  | lower == upper = show lower <> suffix
+  | otherwise = show lower <> "-" <> show upper <> suffix
+ where
+  lower = (x `div` bucketSize) * bucketSize
+  upper = lower + bucketSize
+
+tabulatePerasCert :: V1.PerasCert -> Property -> Property
+tabulatePerasCert cert =
+  foldr (flip (.)) id $
+    [ tabulate
+        "Number of voters"
+        [mkBucket 100 numVoters " voters"]
+    , tabulate
+        "Proportion of persistent voters"
+        [mkBucket 10 persistentVotersRatio "%"]
+    ]
+ where
+  numVoters =
+    length
+      . V1.unPerasCertVoters
+      . V1.pcVoters
+      $ cert
+  numPersistentVoters =
+    length
+      . filter (== V1.PersistentPerasVoteEligibilityProof)
+      . NonEmpty.toList
+      . NEMap.elems
+      . V1.unPerasCertVoters
+      . V1.pcVoters
+      $ cert
+
+  persistentVotersRatio
+    | numVoters == 0 = 0
+    | otherwise = numPersistentVoters * 100 `div` numVoters
+
+tabulatePerasVote :: V1.PerasVote -> Property -> Property
+tabulatePerasVote vote =
+  foldr (flip (.)) id $
+    [ tabulate
+        "Voter type"
+        [voterType]
+    ]
+ where
+  voterType =
+    case V1.pvEligibilityProof vote of
+      V1.PersistentPerasVoteEligibilityProof -> "persistent"
+      V1.NonPersistentPerasVoteEligibilityProof _ -> "non-persistent"

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/Peras/Voting/Committee.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/Peras/Voting/Committee.hs
@@ -1,0 +1,207 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+-- | Test properties relating Peras and voting committee types.
+module Test.Consensus.Peras.Voting.Committee
+  ( tests
+  ) where
+
+import Data.Proxy (Proxy (..))
+import qualified Ouroboros.Consensus.Committee.Class as Committee
+import Ouroboros.Consensus.Committee.EveryoneVotes (EveryoneVotes)
+import Ouroboros.Consensus.Committee.WFALS (WFALS)
+import qualified Ouroboros.Consensus.Peras.Cert.V1 as V1
+import qualified Ouroboros.Consensus.Peras.Vote.V1 as V1
+import Ouroboros.Consensus.Peras.Voting.Committee
+  ( PerasCertCompatibleWithVotingCommittee (..)
+  , PerasVoteCompatibleWithVotingCommittee (..)
+  )
+import Test.Consensus.Peras.Util
+  ( genPerasCert
+  , genPerasVote
+  , perasCertContainsOnlyPersistentVotes
+  , perasVoteIsPersistent
+  , tabulatePerasCert
+  , tabulatePerasVote
+  )
+import Test.QuickCheck
+  ( Gen
+  , Property
+  , Testable (..)
+  , counterexample
+  , forAll
+  , frequency
+  , tabulate
+  , (===)
+  )
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.QuickCheck (testProperty)
+import Test.Util.TestEnv (adjustQuickCheckTests)
+
+tests :: TestTree
+tests =
+  testGroup
+    "Roundtrip for Peras types via abstract committee types"
+    [ adjustQuickCheckTests (* 10) $
+        testProperty "Roundtrip for PerasVote via WFALS" $
+          prop_roundtrip_vote
+            (Proxy @V1.PerasVote)
+            (Proxy @WFALS)
+            -- WFALS supports both persistent and non-persistent of votes
+            (const True)
+            -- Generate both persistent and non-persistent votes
+            (genPerasVote True)
+            tabulatePerasVote
+    , adjustQuickCheckTests (* 10) $
+        testProperty "Roundtrip for PerasVote via EveryoneVotes" $
+          prop_roundtrip_vote
+            (Proxy @V1.PerasVote)
+            (Proxy @EveryoneVotes)
+            -- EveryoneVotes only supports non-persistent votes
+            perasVoteIsPersistent
+            -- Generate both persistent and non-persistent votes to trigger
+            -- conversion errors in a reasonable amount of tests
+            (genPerasVote =<< frequency [(2, pure True), (1, pure False)])
+            tabulatePerasVote
+    , adjustQuickCheckTests (* 10) $
+        testProperty "Roundtrip for PerasCert via WFALS" $
+          prop_roundtrip_cert
+            (Proxy @V1.PerasCert)
+            (Proxy @WFALS)
+            -- WFALS supports certs with both persistent and non-persistent votes
+            (const True)
+            -- Generate certs with both persistent and non-persistent votes
+            (genPerasCert True)
+            tabulatePerasCert
+    , adjustQuickCheckTests (* 10) $
+        testProperty "Roundtrip for PerasCert via EveryoneVotes" $
+          prop_roundtrip_cert
+            (Proxy @V1.PerasCert)
+            (Proxy @EveryoneVotes)
+            -- EveryoneVotes only supports certs with persistent votes
+            perasCertContainsOnlyPersistentVotes
+            -- Only sometimes generate certs with non-persistent votes to
+            -- trigger conversion errors in a reasonable amount of tests
+            (genPerasCert =<< frequency [(2, pure False), (1, pure True)])
+            tabulatePerasCert
+    ]
+
+-- * Properties
+
+-- | Test that converting a concrete Peras vote to an committee vote and back
+-- again results in the original Peras vote.
+--
+-- NOTE: this takes a predicate to determine whether triggering an exception is
+-- a test failure or an expected outcome for the given voting committee scheme.
+prop_roundtrip_vote ::
+  forall vote crypto committee.
+  ( Show vote
+  , Eq vote
+  , PerasVoteCompatibleWithVotingCommittee vote crypto committee
+  ) =>
+  Proxy vote ->
+  Proxy committee ->
+  (vote -> Bool) ->
+  Gen vote ->
+  (vote -> Property -> Property) ->
+  Property
+prop_roundtrip_vote _ _ shouldPass gen tabulateValue =
+  forAll gen $ \vote -> do
+    tabulateValue vote $
+      case fromPerasVote vote of
+        Left err
+          | shouldPass vote ->
+              counterexample
+                ( unlines
+                    [ "fromPerasVote failed with:"
+                    , show err
+                    , "Original vote:"
+                    , show vote
+                    ]
+                )
+                False
+          | otherwise ->
+              tabulateOutcome "Fails as expected" $
+                property True
+        Right (committeeVote :: Committee.Vote crypto committee) ->
+          case toPerasVote committeeVote of
+            Left err ->
+              counterexample
+                ( unlines
+                    [ "toPerasVote failed with:"
+                    , show err
+                    ]
+                )
+                $ property False
+            Right vote' ->
+              tabulateOutcome "Roundtrips successfully"
+                . counterexample
+                  ( unlines
+                      [ "Original vote:"
+                      , show vote
+                      , "Roundtripped vote:"
+                      , show vote'
+                      ]
+                  )
+                $ vote === vote'
+
+-- | Test that converting a concrete Peras cert to an committee cert and back
+-- again results in the original Peras cert.
+--
+-- NOTE: this takes a predicate to determine whether triggering an exception is
+-- a test failure or an expected outcome for the given voting committee scheme.
+prop_roundtrip_cert ::
+  forall cert crypto committee.
+  ( Show cert
+  , Eq cert
+  , PerasCertCompatibleWithVotingCommittee cert crypto committee
+  ) =>
+  Proxy cert ->
+  Proxy committee ->
+  (cert -> Bool) ->
+  Gen cert ->
+  (cert -> Property -> Property) ->
+  Property
+prop_roundtrip_cert _ _ shouldPass gen tabulateValue =
+  forAll gen $ \cert -> do
+    tabulateValue cert $
+      case fromPerasCert cert of
+        Left err
+          | shouldPass cert ->
+              counterexample
+                ( unlines
+                    [ "fromPerasCert failed with:"
+                    , show err
+                    , "Original cert:"
+                    , show cert
+                    ]
+                )
+                $ property False
+          | otherwise ->
+              tabulateOutcome "Fails as expected" $
+                property True
+        Right (committeeCert :: Committee.Cert crypto committee) ->
+          case toPerasCert committeeCert of
+            Left err ->
+              counterexample
+                ( unlines
+                    [ "toPerasCert failed with:"
+                    , show err
+                    ]
+                )
+                False
+            Right cert' ->
+              tabulateOutcome "Roundtrips successfully"
+                . counterexample
+                  ( unlines
+                      [ "Original cert:"
+                      , show cert
+                      , "Roundtripped cert:"
+                      , show cert'
+                      ]
+                  )
+                $ cert === cert'
+
+tabulateOutcome :: String -> Property -> Property
+tabulateOutcome outcome = tabulate "Outcome" [outcome]

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/Util/Bitmap.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/Util/Bitmap.hs
@@ -1,0 +1,73 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+
+-- | Property-based tests for 'Bitmap'
+module Test.Consensus.Util.Bitmap (tests) where
+
+import Cardano.Binary (decodeFull, serialize)
+import qualified Data.Set as Set
+import qualified Ouroboros.Consensus.Util.Bitmap as Bitmap
+import Test.QuickCheck (Testable (..), counterexample, vectorOf)
+import Test.Tasty
+import Test.Tasty.QuickCheck
+  ( Gen
+  , Property
+  , choose
+  , forAll
+  , testProperty
+  , (===)
+  )
+import Test.Util.TestEnv (adjustQuickCheckTests)
+
+tests :: TestTree
+tests =
+  adjustQuickCheckTests (* 100) $
+    testGroup
+      "Bitmap"
+      [ testProperty
+          "prop_roundtrip_toIndices"
+          prop_roundtrip_toIndices
+      , testProperty
+          "prop_roundtrip_serialisation"
+          prop_roundtrip_serialisation
+      ]
+
+-- * Properties
+
+-- | Converting from indices to bitmap and back preserves the indices.
+prop_roundtrip_toIndices :: Property
+prop_roundtrip_toIndices =
+  forAll genMaxIndex $ \maxIndex ->
+    forAll genNumIndices $ \numIndices -> do
+      forAll (genIndices numIndices maxIndex) $ \indices -> do
+        let bitmap = Bitmap.fromIndices maxIndex indices
+        let indices' = Bitmap.toIndices bitmap
+        Set.fromList indices === Set.fromList indices'
+
+-- | Serialisation roundtrip preserves the bitmap.
+prop_roundtrip_serialisation :: Property
+prop_roundtrip_serialisation =
+  forAll genMaxIndex $ \maxIndex ->
+    forAll genNumIndices $ \numIndices -> do
+      forAll (genIndices numIndices maxIndex) $ \indices -> do
+        let bitmap = Bitmap.fromIndices maxIndex indices
+        let encoded = serialize bitmap
+        case decodeFull encoded of
+          Left err ->
+            counterexample ("Deserialization failed: " <> show err) $
+              property False
+          Right bitmap' ->
+            bitmap === bitmap'
+
+-- * Generators
+
+genMaxIndex :: Gen Int
+genMaxIndex =
+  choose (0, 10000)
+
+genNumIndices :: Gen Int
+genNumIndices =
+  choose (0, 100)
+
+genIndices :: Int -> Int -> Gen [Int]
+genIndices numIndices maxIndex =
+  vectorOf numIndices (choose (0, maxIndex))


### PR DESCRIPTION
This PR implements concrete Peras votes and certificates using BLS signatures, including all necessary cryptography infrastructure and integration with the existing voting committee abstractions.

- Added compact `ByteString`-based bitmap implementation to identify voters in a certificate
- Defined concrete `PerasVote` and `PerasCert` types using BLS signatures to carry validation and eligibility proofs
- Defined `PerasCrypto` scheme and implemented all the necessary crypto infrastructure to use it with both `WFALS` and `EveryoneVotes`
- Implemented `VotingCommitteeSupportsPeras` type class with conversions between concrete Peras types and the abstract `WFALS`/`EveryoneVotes` voting committee types
- Added property tests covering bitmap operations, serialization roundtrips, and conversion roundtrips (both total and partial)