### PR TITLE
Leios: Build against backward-compatible block decoder

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -86,39 +86,39 @@ source-repository-package
     ntp-client
     cardano-client
 
--- Points to cardano-ledger/leios-prototype
+-- Points to cardano-ledger/ch1bo/backwards-compat-block-decoder
 source-repository-package
   type: git
   location: https://github.com/IntersectMBO/cardano-ledger.git
-  tag: 7e1fb14c916e58709aa36c4b4fe0265ba537e0f0
-  --sha256: sha256-nR60TiNlCaeutZNI083hdjM3HqglM9sGWqf6MFKaK1I=
+  tag: 22d32274ca2657f2966873b225aa9604852c4c77
+  --sha256: sha256-TnHTS2FDeUQoa3dIPSZwZ16svGw990arktNVx7z7aWY=
   subdir:
-    eras/allegra/impl
+    -- eras/allegra/impl
     eras/alonzo/impl
-    eras/alonzo/test-suite
-    eras/babbage/impl
-    eras/babbage/test-suite
+    -- eras/alonzo/test-suite
+    -- eras/babbage/impl
+    -- eras/babbage/test-suite
     eras/conway/impl
-    eras/conway/test-suite
-    eras/mary/impl
+    -- eras/conway/test-suite
+    -- eras/mary/impl
     eras/shelley/impl
-    eras/shelley/test-suite
-    eras/shelley-ma/test-suite
-    libs/cardano-ledger-api
+    -- eras/shelley/test-suite
+    -- eras/shelley-ma/test-suite
+    -- libs/cardano-ledger-api
     libs/cardano-ledger-core
-    libs/cardano-ledger-binary
-    libs/cardano-protocol-tpraos
-    libs/non-integral
-    libs/small-steps
-    libs/cardano-data
-    libs/set-algebra
-    libs/vector-map
-    eras/byron/chain/executable-spec
-    eras/byron/ledger/executable-spec
-    eras/byron/ledger/impl
-    eras/byron/ledger/impl/test
-    eras/byron/crypto
-    eras/byron/crypto/test
-    libs/cardano-ledger-test
-    libs/ledger-state
-    libs/constrained-generators
+    -- libs/cardano-ledger-binary
+    -- libs/cardano-protocol-tpraos
+    -- libs/non-integral
+    -- libs/small-steps
+    -- libs/cardano-data
+    -- libs/set-algebra
+    -- libs/vector-map
+    -- eras/byron/chain/executable-spec
+    -- eras/byron/ledger/executable-spec
+    -- eras/byron/ledger/impl
+    -- eras/byron/ledger/impl/test
+    -- eras/byron/crypto
+    -- eras/byron/crypto/test
+    -- libs/cardano-ledger-test
+    -- libs/ledger-state
+    -- libs/constrained-generators


### PR DESCRIPTION
Uses the decoder from https://github.com/IntersectMBO/cardano-ledger/pull/5721 

Not sure if we really need PRs for these dependency bumps?