### PR TITLE
Add a benchmark about LeiosDemoDb

### DIFF
--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Forge.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Forge.hs
@@ -15,10 +15,7 @@ import qualified Cardano.Protocol.TPraos.BHeader as SL
 import Control.Exception
 import qualified Data.ByteString as BL
 import qualified Data.Sequence.Strict as Seq
-import qualified Debug.Trace as Debug
-import LeiosDemoDb
-  ( LeiosDbHandle (leiosDbQueryCertificateByPoint, leiosDbQueryCompletedEbByPoint)
-  )
+import LeiosDemoDb (LeiosDbHandle (leiosDbQueryCertificateByPoint, leiosDbQueryCompletedEbByPoint))
 import LeiosDemoTypes
   ( EbHash (ebHashBytes)
   , ForgedLeiosEb (point)
@@ -106,9 +103,7 @@ forgeShelleyBlock
                   Nothing -> return (SL.BodyInline rbTxs', False) -- This happens when EBs have been downloaded but voting hasn't completed
                   Just cert ->
                     return $
-                      Debug.trace
-                        (show ("certifying", cert, annEbPoint))
-                        (SL.BodyCertificate (toLedgerCert cert) (Just ebClosure), True)
+                      (SL.BodyCertificate (toLedgerCert cert) (Just ebClosure), True)
     hdr <-
       mkHeader @_ @(ProtoCrypto proto) -- FIXME(bladyjoker): EB announcement in header
         hotKey

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/ImmDBServer/Diffusion.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/ImmDBServer/Diffusion.hs
@@ -158,10 +158,8 @@ run immDBDir sockAddr cfg getSlotDelay leiosDbFile leiosSchedule = withRegistry 
           False -> die $ "The Leios database must already exist: " <> show leiosDbFile
           True -> pure ()
         leiosDb <- LeiosDemoDb.newLeiosDBSQLite leiosDbFile
-        leiosWriteLock <- MVar.newMVar ()
         fmap LeiosLogic.MkSomeLeiosFetchContext $
           LeiosLogic.newLeiosFetchContext
-            leiosWriteLock
             leiosDb
   ImmutableDB.withDB
     (ImmutableDB.openDB (immDBArgs registry) runWithTempRegistry)

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToNode.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToNode.hs
@@ -402,14 +402,13 @@ mkHandlers
                 (Node.leiosKernelTracer tracers)
                 (leiosPeerTracer peer)
                 ((== Terminate) <$> controlMessageSTM)
-                (getLeiosWriteLock, getLeiosOutstanding, getLeiosReady)
+                (getLeiosOutstanding, getLeiosReady)
                 leiosDB
                 (Leios.MkPeerId peer)
                 reqVar
       , hLeiosFetchServer = \_version peer -> Effect $ do
           leiosFetchContext <-
             Leios.newLeiosFetchContext
-              getLeiosWriteLock
               leiosDB
           pure $
             leiosFetchServerPeer
@@ -429,7 +428,6 @@ mkHandlers
       , getLeiosPeersVars
       , getLeiosOutstanding
       , getLeiosReady
-      , getLeiosWriteLock
       } = nodeKernel
 
     leiosPeerTracer peer = TraceLabelPeer peer `contramap` Node.leiosPeerTracer tracers

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
@@ -230,13 +230,6 @@ data NodeKernel m addrNTN addrNTC blk = NodeKernel
   -- LeiosNotify clients, LeiosFetch clients, and the LeiosCopier
   -- 'MVar.tryPutMVar' whenever they make a change that might unblock a new
   -- fetch decision.
-  , getLeiosWriteLock :: MVar m ()
-  -- ^ Must be held before writing to the database
-  --
-  -- Preferable to dealing with SQLite's BUSY errors.
-  --
-  -- INVARIANT: never acquire 'MVar' while holding this lock.
-  -- TODO: can we move this "behind the curtain" of transactional interactions with the LeiosDb?
   }
 
 -- | Arguments required when initializing a node
@@ -306,7 +299,6 @@ initNodeKernel
           , peerSharingRegistry
           , varChainSyncHandles
           , varGsmState
-          , leiosWriteLock
           } = st
 
     varOutboundConnectionsState <- newTVarIO UntrustedState
@@ -418,18 +410,10 @@ initNodeKernel
       leiosPeersVars <- MVar.readMVar getLeiosPeersVars
       offerings <- mapM (MVar.readMVar . Leios.offerings) leiosPeersVars
       newDecisions <- MVar.modifyMVar getLeiosOutstanding $ \outstanding -> do
-        -- FIXME: Avoid needing this global mutex.
-        --
-        -- It is currently needed as the 'leiosDB' handle is shared across
-        -- threads and 'BEGIN' queries would be interleaved over the same
-        -- connection.
-        traceWith tracer $ MkTraceLeiosKernel "wait for write lock"
-        filteredOutstanding <- MVar.withMVar leiosWriteLock $ \() -> do
-          traceWith tracer $ MkTraceLeiosKernel "with write lock"
-          -- Filter outstanding work against DB before running fetch iteration.
-          -- This removes EBs and TXs we already have (e.g., from forging or other peers).
+        -- Filter outstanding work against DB before running fetch iteration.
+        -- This removes EBs and TXs we already have (e.g., from forging or other peers).
+        filteredOutstanding <-
           Leios.filterMissingWork leiosDB outstanding
-
         traceWith tracer $ MkTraceLeiosKernel "leiosFetchLogic: filtered"
         let (!outstanding', newDecisions) =
               Leios.leiosFetchLogicIteration
@@ -474,7 +458,6 @@ initNodeKernel
         , getLeiosPeersVars
         , getLeiosOutstanding
         , getLeiosReady
-        , getLeiosWriteLock = leiosWriteLock
         }
    where
     blockForgingController ::
@@ -521,7 +504,6 @@ data InternalState m addrNTN addrNTC blk = IS
   , mempool :: Mempool m blk
   , peerSharingRegistry :: PeerSharingRegistry addrNTN m
   , leiosDB :: LeiosDbHandle m
-  , leiosWriteLock :: MVar m ()
   }
 
 initInternalState ::
@@ -588,7 +570,6 @@ initInternalState
             getDiffusionPipeliningSupport
 
     peerSharingRegistry <- newPeerSharingRegistry
-    leiosWriteLock <- MVar.newMVar ()
 
     return IS{..}
    where
@@ -868,7 +849,7 @@ forkBlockForging IS{..} blockForging =
 
       -- Store generated EB so it can be diffused
       for_ mayForgedEb $ \(eb :: ForgedLeiosEb) -> do
-        lift $ MVar.withMVar leiosWriteLock $ \() -> do
+        lift $ do
           leiosDbInsertEbPoint leiosDB eb.point (Leios.leiosEbBytesSize eb.body)
           leiosDbInsertEbBody leiosDB eb.point eb.body
           void $ leiosDbInsertTxs leiosDB eb.txClosure

--- a/ouroboros-consensus/bench/leios-db-bench/Main.hs
+++ b/ouroboros-consensus/bench/leios-db-bench/Main.hs
@@ -16,7 +16,7 @@
 --   10 'leiosDbBatchRetrieveTxs' calls cycling through the pre-populated EBs.
 --
 -- All data is deterministic (no QuickCheck generators), so runs are stable and
--- comparable before\/after lock-removal refactors.
+-- comparable across refactors.
 --
 -- Usage:
 --
@@ -29,8 +29,8 @@ import Cardano.Slotting.Slot (SlotNo (..))
 import Control.Concurrent.Async (async, mapConcurrently_, wait)
 import Control.Monad (forM, forM_, replicateM_, when)
 import Control.Monad.Class.MonadTime.SI (diffTime, getMonotonicTime)
-import Data.Bits (shiftR, (.&.))
 import qualified Data.ByteString as BS
+import qualified Data.ByteString.Char8 as BS8
 import Data.IORef (IORef, atomicModifyIORef', newIORef)
 import Data.Time.Clock (DiffTime)
 import qualified Data.Vector as V
@@ -208,7 +208,11 @@ insertOneEb :: LeiosDbHandle IO -> Int -> IO ()
 insertOneEb db ebIdx = do
   let point = genPoint ebIdx
       eb = genEb ebIdx
-      txs = [(genTxHash ebIdx txIdx, fixedTxBytes) | txIdx <- [0 .. txsPerEb - 1]]
+      txs =
+        [ (h, genTx h)
+        | txIdx <- [0 .. txsPerEb - 1]
+        , let h = genTxHash ebIdx txIdx
+        ]
   leiosDbInsertEbPoint db point (leiosEbBytesSize eb)
   leiosDbInsertEbBody db point eb
   _ <- leiosDbInsertTxs db txs
@@ -216,33 +220,15 @@ insertOneEb db ebIdx = do
 
 -- * Deterministic data generation
 
--- | 'EbHash' from a 32-bit index: 4 index bytes followed by 28 zeros.
-genEbHash :: Int -> EbHash
-genEbHash i =
-  MkEbHash $
-    BS.pack
-      [ fromIntegral (i .&. 0xFF)
-      , fromIntegral ((i `shiftR` 8) .&. 0xFF)
-      , fromIntegral ((i `shiftR` 16) .&. 0xFF)
-      , fromIntegral ((i `shiftR` 24) .&. 0xFF)
-      ]
-      <> BS.replicate 28 0
-
--- | 'TxHash' from an EB index + TX offset: 4 bytes followed by 28 ones.
-genTxHash :: Int -> Int -> TxHash
-genTxHash ebIdx txIdx =
-  MkTxHash $
-    BS.pack
-      [ fromIntegral (ebIdx .&. 0xFF)
-      , fromIntegral ((ebIdx `shiftR` 8) .&. 0xFF)
-      , fromIntegral (txIdx .&. 0xFF)
-      , fromIntegral ((txIdx `shiftR` 8) .&. 0xFF)
-      ]
-      <> BS.replicate 28 1
-
 -- | 'LeiosPoint' from an index (SlotNo = index).
 genPoint :: Int -> LeiosPoint
 genPoint i = MkLeiosPoint (SlotNo $ fromIntegral i) (genEbHash i)
+
+-- | 'EbHash' from an index: \"ebHash:<index>\" padded to 32 bytes with zeros.
+genEbHash :: Int -> EbHash
+genEbHash i =
+  let tag = BS8.pack ("ebHash:" <> show i)
+   in MkEbHash $ BS.take 32 (tag <> BS.replicate 32 0)
 
 -- | 'LeiosEb' with 'txsPerEb' transactions (200 bytes each).
 genEb :: Int -> LeiosEb
@@ -251,6 +237,16 @@ genEb ebIdx =
     V.fromList
       [(genTxHash ebIdx txIdx, 200 :: BytesSize) | txIdx <- [0 .. txsPerEb - 1]]
 
--- | Fixed TX payload: 16 KiB zeros (realistic worst-case size).
-fixedTxBytes :: BS.ByteString
-fixedTxBytes = BS.replicate 16_384 0
+-- | 'TxHash' from an EB index + TX offset: \"txHash:<ebIdx>:<txIdx>\" padded
+-- to 32 bytes with zeros.
+--
+-- NOTE: This is taking an EB index as it always generates the worst case of
+-- fully disjunct transaction closures between EBs.
+genTxHash :: Int -> Int -> TxHash
+genTxHash ebIdx txIdx =
+  let tag = BS8.pack ("txHash:" <> show ebIdx <> ":" <> show txIdx)
+   in MkTxHash $ BS.take 32 (tag <> BS.replicate 32 0)
+
+-- | Generate a TX payload: the TX hash bytes padded with zeros to 16 KiB.
+genTx :: TxHash -> BS.ByteString
+genTx (MkTxHash h) = h <> BS.replicate (16_384 - BS.length h) 0

--- a/ouroboros-consensus/bench/leios-db-bench/Main.hs
+++ b/ouroboros-consensus/bench/leios-db-bench/Main.hs
@@ -6,14 +6,15 @@
 --
 -- The following three roles run concurrently against the same SQLite handle:
 --
--- * __Active reader__ (fetch logic loop): 10 rounds of
+-- * __Fetch logic__ (1 thread): 10 rounds of
 --   'leiosDbFilterMissingEbBodies' + 'leiosDbFilterMissingTxs'.
 --
--- * __Writers__ (2 threads): each inserts 20 fresh EBs via
---   'leiosDbInsertEbPoint' → 'leiosDbInsertEbBody' → 'leiosDbInsertTxs'.
+-- * __Fetch clients__ (configurable, default 2 threads): each inserts 20 fresh
+--   EBs via 'leiosDbInsertEbPoint' → 'leiosDbInsertEbBody' → 'leiosDbInsertTxs'.
 --
--- * __Serving readers__ (8 threads): each does 30 'leiosDbLookupEbBody' +
---   10 'leiosDbBatchRetrieveTxs' calls cycling through the pre-populated EBs.
+-- * __Fetch servers__ (configurable, default 8 threads): each does 30
+--   'leiosDbLookupEbBody' + 10 'leiosDbBatchRetrieveTxs' calls cycling through
+--   the pre-populated EBs.
 --
 -- All data is deterministic (no QuickCheck generators), so runs are stable and
 -- comparable across refactors.
@@ -61,9 +62,9 @@ main = do
       , "  Total TXs         : " <> show (numPrePopulatedEbs * txsPerEb)
       , ""
       , "Concurrent workload per iteration:"
-      , "  Active reader (×1): 10 rounds of filterMissingEbBodies (200+200) + filterMissingTxs (500+500)"
-      , "  Writers       (×2): 20 insertEbPoint/insertEbBody/insertTxs each"
-      , "  Readers       (×" <> show numServingThreads <> "): 30 lookupEbBody + 10 batchRetrieveTxs each"
+      , "  Fetch logic   (×1): 10 rounds of filterMissingEbBodies (200+200) + filterMissingTxs (500+500)"
+      , "  Fetch clients (×" <> show numFetchClients <> "): 20 insertEbPoint/insertEbBody/insertTxs each"
+      , "  Fetch servers (×" <> show numFetchServers <> "): 30 lookupEbBody + 10 batchRetrieveTxs each"
       , ""
       , "Runs: 1 warmup + " <> show numRuns <> " timed"
       , ""
@@ -83,9 +84,13 @@ numPrePopulatedEbs = 500
 txsPerEb :: Int
 txsPerEb = 200
 
--- | Number of serving-reader threads (represents downstream peers).
-numServingThreads :: Int
-numServingThreads = 8
+-- | Number of fetch client threads (writers that insert fresh EBs).
+numFetchClients :: Int
+numFetchClients = 2
+
+-- | Number of fetch server threads (readers serving downstream peers).
+numFetchServers :: Int
+numFetchServers = 8
 
 -- | Timed repetitions (plus one warmup).
 numRuns :: Int
@@ -94,52 +99,47 @@ numRuns = 5
 -- * The benchmark
 
 -- | All three production roles running concurrently against one DB handle.
---
--- Per iteration:
---
--- * Active reader (1 thread): 10 rounds of @filterMissingEbBodies@ on
---   200 present + 200 absent points, and @filterMissingTxs@ on 500 present +
---   500 absent hashes.
---
--- * Writers (2 threads): each inserts 20 fresh EBs with full TX payloads.
---   Indices are unique per iteration via 'beWriterIdx'.
---
--- * Serving readers (8 threads): each does 30 @lookupEbBody@ + 10
---   @batchRetrieveTxs@ (sampled offsets) cycling through pre-populated EBs.
 benchConcurrentAll :: BenchEnv -> IO ()
 benchConcurrentAll BenchEnv{beDb = db, bePoints = points, beWriterIdx = writerIdxRef} = do
-  -- Allocate 40 fresh EB indices for the writers in this iteration.
-  startIdx <- atomicModifyIORef' writerIdxRef (\n -> (n + 40, n))
-  let writerRange1 = [startIdx .. startIdx + 19]
-      writerRange2 = [startIdx + 20 .. startIdx + 39]
-      -- Active reader mirrors filterMissingWork from LeiosDemoLogic
-      activeReader =
-        replicateM_ 10 $ do
-          let existingPoints = take 200 points
-              -- Points beyond the pre-populated range — guaranteed missing
-              missingPoints = [genPoint i | i <- [10_000 .. 10_199]]
-          _ <- leiosDbFilterMissingEbBodies db (existingPoints ++ missingPoints)
-          let existingHashes = [genTxHash 0 i | i <- [0 .. 499]]
-              missingHashes = [genTxHash 10_000 i | i <- [0 .. 499]]
-          _ <- leiosDbFilterMissingTxs db (existingHashes ++ missingHashes)
-          pure ()
-      -- Writers insert fresh EBs (unique per call)
-      writer range = forM_ range (insertOneEb db)
-      -- Serving readers mirror msgLeiosBlockRequest / msgLeiosBlockTxsRequest
-      sampleOffsets = [0, 10 .. txsPerEb - 1]
-      servingOps i = do
-        let ebPoints = take 30 $ drop (i * 30) (cycle points)
-            txPoints = take 10 $ drop (i * 10) (cycle points)
-        forM_ ebPoints $ \p -> leiosDbLookupEbBody db p.pointEbHash
-        forM_ txPoints $ \p -> leiosDbBatchRetrieveTxs db p.pointEbHash sampleOffsets
-  -- Start active reader and writers; serving readers are the "main" work.
-  ar <- async activeReader
-  w1 <- async (writer writerRange1)
-  w2 <- async (writer writerRange2)
-  mapConcurrently_ servingOps [0 .. numServingThreads - 1]
-  wait ar
-  wait w1
-  wait w2
+  startIdx <- atomicModifyIORef' writerIdxRef (\n -> (n + numFetchClients * ebsPerClient, n))
+  fl <- async (fetchLogic db points)
+  clients <- forM (clientRanges startIdx) $ \range -> async (fetchClient db range)
+  mapConcurrently_ (fetchServer db points) [0 .. numFetchServers - 1]
+  wait fl
+  forM_ clients wait
+ where
+  ebsPerClient = 20
+  clientRanges startIdx =
+    [ [startIdx + i * ebsPerClient .. startIdx + (i + 1) * ebsPerClient - 1]
+    | i <- [0 .. numFetchClients - 1]
+    ]
+
+-- | Mirrors the fetch logic loop: filters for missing EB bodies and TXs.
+fetchLogic :: LeiosDbHandle IO -> [LeiosPoint] -> IO ()
+fetchLogic db points =
+  replicateM_ 10 $ do
+    _ <- leiosDbFilterMissingEbBodies db (existingPoints ++ missingPoints)
+    _ <- leiosDbFilterMissingTxs db (existingHashes ++ missingHashes)
+    pure ()
+ where
+  existingPoints = take 200 points
+  missingPoints = [genPoint i | i <- [10_000 .. 10_199]]
+  existingHashes = [genTxHash 0 i | i <- [0 .. 499]]
+  missingHashes = [genTxHash 10_000 i | i <- [0 .. 499]]
+
+-- | Mirrors a fetch client: inserts fresh EBs with full TX payloads.
+fetchClient :: LeiosDbHandle IO -> [Int] -> IO ()
+fetchClient db range = forM_ range (insertOneEb db)
+
+-- | Mirrors a fetch server: looks up EB bodies and retrieves TX batches.
+fetchServer :: LeiosDbHandle IO -> [LeiosPoint] -> Int -> IO ()
+fetchServer db points i = do
+  forM_ ebPoints $ \p -> leiosDbLookupEbBody db p.pointEbHash
+  forM_ txPoints $ \p -> leiosDbBatchRetrieveTxs db p.pointEbHash sampleOffsets
+ where
+  sampleOffsets = [0, 10 .. txsPerEb - 1]
+  ebPoints = take 30 $ drop (i * 30) (cycle points)
+  txPoints = take 10 $ drop (i * 10) (cycle points)
 
 -- * Benchmark environment
 
@@ -225,9 +225,9 @@ genPoint i = MkLeiosPoint (SlotNo $ fromIntegral i) (genEbHash i)
 
 -- | 'EbHash' from an index: \"ebHash:<index>\" padded to 32 bytes with zeros.
 genEbHash :: Int -> EbHash
-genEbHash i =
-  let tag = BS8.pack ("ebHash:" <> show i)
-   in MkEbHash $ BS.take 32 (tag <> BS.replicate 32 0)
+genEbHash i = MkEbHash $ BS.take 32 (tag <> BS.replicate 32 0)
+ where
+  tag = BS8.pack ("ebHash:" <> show i)
 
 -- | 'LeiosEb' with 'txsPerEb' transactions (200 bytes each).
 genEb :: Int -> LeiosEb
@@ -242,9 +242,9 @@ genEb ebIdx =
 -- NOTE: This is taking an EB index as it always generates the worst case of
 -- fully disjunct transaction closures between EBs.
 genTxHash :: Int -> Int -> TxHash
-genTxHash ebIdx txIdx =
-  let tag = BS8.pack ("txHash:" <> show ebIdx <> ":" <> show txIdx)
-   in MkTxHash $ BS.take 32 (tag <> BS.replicate 32 0)
+genTxHash ebIdx txIdx = MkTxHash $ BS.take 32 (tag <> BS.replicate 32 0)
+ where
+  tag = BS8.pack ("txHash:" <> show ebIdx <> ":" <> show txIdx)
 
 -- | Generate a TX payload: the TX hash bytes padded with zeros to 16 KiB.
 genTx :: TxHash -> BS.ByteString

--- a/ouroboros-consensus/bench/leios-db-bench/Main.hs
+++ b/ouroboros-consensus/bench/leios-db-bench/Main.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedRecordDot #-}
 

--- a/ouroboros-consensus/bench/leios-db-bench/Main.hs
+++ b/ouroboros-consensus/bench/leios-db-bench/Main.hs
@@ -47,7 +47,7 @@ import LeiosDemoTypes
   , leiosEbBytesSize
   )
 import System.IO (hFlush, stdout)
-import System.IO.Temp (createTempDirectory, getCanonicalTemporaryDirectory)
+import System.IO.Temp (withSystemTempDirectory)
 
 main :: IO ()
 main = do
@@ -68,9 +68,10 @@ main = do
       , "Runs: 1 warmup + " <> show numRuns <> " timed"
       , ""
       ]
-  env <- setupBenchEnv
-  runBench (benchConcurrentAll env)
-  leiosDbClose env.beDb
+  withSystemTempDirectory "leios-db-bench" $ \tmpDir -> do
+    env <- setupBenchEnv tmpDir
+    runBench (benchConcurrentAll env)
+    leiosDbClose env.beDb
 
 -- * Configuration
 
@@ -153,10 +154,8 @@ data BenchEnv = BenchEnv
 
 -- | Create a fresh SQLite DB and insert 'numPrePopulatedEbs' complete EBs.
 -- This setup cost is not included in the timed measurements.
-setupBenchEnv :: IO BenchEnv
-setupBenchEnv = do
-  sysTmp <- getCanonicalTemporaryDirectory
-  tmpDir <- createTempDirectory sysTmp "leios-db-bench"
+setupBenchEnv :: FilePath -> IO BenchEnv
+setupBenchEnv tmpDir = do
   db <- newLeiosDBSQLite (tmpDir <> "/bench.db")
   putStr "Inserting EBs: " >> hFlush stdout
   forM_ [0 .. numPrePopulatedEbs - 1] $ \i -> do

--- a/ouroboros-consensus/bench/leios-db-bench/Main.hs
+++ b/ouroboros-consensus/bench/leios-db-bench/Main.hs
@@ -1,0 +1,257 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+
+-- | Concurrent benchmark for 'LeiosDemoDb' mirroring production access patterns.
+--
+-- The following three roles run concurrently against the same SQLite handle:
+--
+-- * __Active reader__ (fetch logic loop): 10 rounds of
+--   'leiosDbFilterMissingEbBodies' + 'leiosDbFilterMissingTxs'.
+--
+-- * __Writers__ (2 threads): each inserts 20 fresh EBs via
+--   'leiosDbInsertEbPoint' → 'leiosDbInsertEbBody' → 'leiosDbInsertTxs'.
+--
+-- * __Serving readers__ (8 threads): each does 30 'leiosDbLookupEbBody' +
+--   10 'leiosDbBatchRetrieveTxs' calls cycling through the pre-populated EBs.
+--
+-- All data is deterministic (no QuickCheck generators), so runs are stable and
+-- comparable before\/after lock-removal refactors.
+--
+-- Usage:
+--
+-- @
+-- cabal bench leios-db-bench --benchmark-options='+RTS -N4 -RTS'
+-- @
+module Main (main) where
+
+import Cardano.Slotting.Slot (SlotNo (..))
+import Control.Concurrent.Async (async, mapConcurrently_, wait)
+import Control.Monad (forM, forM_, replicateM_, when)
+import Control.Monad.Class.MonadTime.SI (diffTime, getMonotonicTime)
+import Data.Bits (shiftR, (.&.))
+import qualified Data.ByteString as BS
+import Data.IORef (IORef, atomicModifyIORef', newIORef)
+import Data.Time.Clock (DiffTime)
+import qualified Data.Vector as V
+import LeiosDemoDb
+  ( LeiosDbHandle (..)
+  , newLeiosDBSQLite
+  )
+import LeiosDemoTypes
+  ( BytesSize
+  , EbHash (..)
+  , LeiosEb (..)
+  , LeiosPoint (..)
+  , TxHash (..)
+  , leiosEbBytesSize
+  )
+import System.IO (hFlush, stdout)
+import System.IO.Temp (createTempDirectory, getCanonicalTemporaryDirectory)
+
+main :: IO ()
+main = do
+  putStr $
+    unlines
+      [ "LeiosDemoDb concurrent benchmark"
+      , ""
+      , "Database setup:"
+      , "  EBs pre-populated : " <> show numPrePopulatedEbs
+      , "  TXs per EB        : " <> show txsPerEb
+      , "  Total TXs         : " <> show (numPrePopulatedEbs * txsPerEb)
+      , ""
+      , "Concurrent workload per iteration:"
+      , "  Active reader (×1): 10 rounds of filterMissingEbBodies (200+200) + filterMissingTxs (500+500)"
+      , "  Writers       (×2): 20 insertEbPoint/insertEbBody/insertTxs each"
+      , "  Readers       (×" <> show numServingThreads <> "): 30 lookupEbBody + 10 batchRetrieveTxs each"
+      , ""
+      , "Runs: 1 warmup + " <> show numRuns <> " timed"
+      , ""
+      ]
+  env <- setupBenchEnv
+  runBench (benchConcurrentAll env)
+  leiosDbClose env.beDb
+
+-- * Configuration
+
+-- | Number of EBs pre-inserted into the DB during setup (not timed).
+numPrePopulatedEbs :: Int
+numPrePopulatedEbs = 500
+
+-- | TXs per EB (mid-range; Leios spec allows up to 2000).
+txsPerEb :: Int
+txsPerEb = 200
+
+-- | Number of serving-reader threads (represents downstream peers).
+numServingThreads :: Int
+numServingThreads = 8
+
+-- | Timed repetitions (plus one warmup).
+numRuns :: Int
+numRuns = 5
+
+-- * The benchmark
+
+-- | All three production roles running concurrently against one DB handle.
+--
+-- Per iteration:
+--
+-- * Active reader (1 thread): 10 rounds of @filterMissingEbBodies@ on
+--   200 present + 200 absent points, and @filterMissingTxs@ on 500 present +
+--   500 absent hashes.
+--
+-- * Writers (2 threads): each inserts 20 fresh EBs with full TX payloads.
+--   Indices are unique per iteration via 'beWriterIdx'.
+--
+-- * Serving readers (8 threads): each does 30 @lookupEbBody@ + 10
+--   @batchRetrieveTxs@ (sampled offsets) cycling through pre-populated EBs.
+benchConcurrentAll :: BenchEnv -> IO ()
+benchConcurrentAll BenchEnv{beDb = db, bePoints = points, beWriterIdx = writerIdxRef} = do
+  -- Allocate 40 fresh EB indices for the writers in this iteration.
+  startIdx <- atomicModifyIORef' writerIdxRef (\n -> (n + 40, n))
+  let writerRange1 = [startIdx .. startIdx + 19]
+      writerRange2 = [startIdx + 20 .. startIdx + 39]
+      -- Active reader mirrors filterMissingWork from LeiosDemoLogic
+      activeReader =
+        replicateM_ 10 $ do
+          let existingPoints = take 200 points
+              -- Points beyond the pre-populated range — guaranteed missing
+              missingPoints = [genPoint i | i <- [10_000 .. 10_199]]
+          _ <- leiosDbFilterMissingEbBodies db (existingPoints ++ missingPoints)
+          let existingHashes = [genTxHash 0 i | i <- [0 .. 499]]
+              missingHashes = [genTxHash 10_000 i | i <- [0 .. 499]]
+          _ <- leiosDbFilterMissingTxs db (existingHashes ++ missingHashes)
+          pure ()
+      -- Writers insert fresh EBs (unique per call)
+      writer range = forM_ range (insertOneEb db)
+      -- Serving readers mirror msgLeiosBlockRequest / msgLeiosBlockTxsRequest
+      sampleOffsets = [0, 10 .. txsPerEb - 1]
+      servingOps i = do
+        let ebPoints = take 30 $ drop (i * 30) (cycle points)
+            txPoints = take 10 $ drop (i * 10) (cycle points)
+        forM_ ebPoints $ \p -> leiosDbLookupEbBody db p.pointEbHash
+        forM_ txPoints $ \p -> leiosDbBatchRetrieveTxs db p.pointEbHash sampleOffsets
+  -- Start active reader and writers; serving readers are the "main" work.
+  ar <- async activeReader
+  w1 <- async (writer writerRange1)
+  w2 <- async (writer writerRange2)
+  mapConcurrently_ servingOps [0 .. numServingThreads - 1]
+  wait ar
+  wait w1
+  wait w2
+
+-- * Benchmark environment
+
+data BenchEnv = BenchEnv
+  { beDb :: !(LeiosDbHandle IO)
+  , bePoints :: ![LeiosPoint]
+  -- ^ Pre-computed list of all 'numPrePopulatedEbs' points.
+  , beWriterIdx :: !(IORef Int)
+  -- ^ Monotonically increasing counter so each benchmark iteration allocates
+  -- a fresh range of EB indices for writers (avoids duplicate-key errors).
+  }
+
+-- | Create a fresh SQLite DB and insert 'numPrePopulatedEbs' complete EBs.
+-- This setup cost is not included in the timed measurements.
+setupBenchEnv :: IO BenchEnv
+setupBenchEnv = do
+  sysTmp <- getCanonicalTemporaryDirectory
+  tmpDir <- createTempDirectory sysTmp "leios-db-bench"
+  db <- newLeiosDBSQLite (tmpDir <> "/bench.db")
+  putStr "Inserting EBs: " >> hFlush stdout
+  forM_ [0 .. numPrePopulatedEbs - 1] $ \i -> do
+    insertOneEb db i
+    when (i `mod` (numPrePopulatedEbs `div` 10) == numPrePopulatedEbs `div` 10 - 1) $
+      putStr (show (i + 1) <> " ") >> hFlush stdout
+  putStrLn "done"
+  let points = [genPoint i | i <- [0 .. numPrePopulatedEbs - 1]]
+  writerIdx <- newIORef numPrePopulatedEbs
+  pure $ BenchEnv db points writerIdx
+
+-- * Timing
+
+-- | Warm up once, then time 'numRuns' repetitions, printing each result and a
+-- final min\/avg\/max summary.
+runBench :: IO () -> IO ()
+runBench action = do
+  action -- warmup (not printed)
+  times <- forM [1 .. numRuns] $ \i -> do
+    t <- snd <$> timed action
+    putStrLn $ "  run " <> show i <> "/" <> show numRuns <> ": " <> showTime t
+    pure t
+  let avg = sum times / fromIntegral (length times)
+      minT = minimum times
+      maxT = maximum times
+  putStrLn $
+    "  => min=" <> showTime minT <> "  avg=" <> showTime avg <> "  max=" <> showTime maxT
+
+timed :: IO a -> IO (a, DiffTime)
+timed action = do
+  t0 <- getMonotonicTime
+  !result <- action
+  t1 <- getMonotonicTime
+  pure (result, diffTime t1 t0)
+
+showTime :: DiffTime -> String
+showTime t
+  | t < 1e-6 = show (round (s * 1_000_000_000 :: Double) :: Int) <> " ns"
+  | t < 1e-3 = show (round (s * 1_000_000 :: Double) :: Int) <> " μs"
+  | t < 1 = show (round (s * 1_000 :: Double) :: Int) <> " ms"
+  | otherwise = show s <> " s"
+ where
+  s = realToFrac t :: Double
+
+-- * DB helpers
+
+-- | Insert one complete EB (point + body + all TXs) by index.
+insertOneEb :: LeiosDbHandle IO -> Int -> IO ()
+insertOneEb db ebIdx = do
+  let point = genPoint ebIdx
+      eb = genEb ebIdx
+      txs = [(genTxHash ebIdx txIdx, fixedTxBytes) | txIdx <- [0 .. txsPerEb - 1]]
+  leiosDbInsertEbPoint db point (leiosEbBytesSize eb)
+  leiosDbInsertEbBody db point eb
+  _ <- leiosDbInsertTxs db txs
+  pure ()
+
+-- * Deterministic data generation
+
+-- | 'EbHash' from a 32-bit index: 4 index bytes followed by 28 zeros.
+genEbHash :: Int -> EbHash
+genEbHash i =
+  MkEbHash $
+    BS.pack
+      [ fromIntegral (i .&. 0xFF)
+      , fromIntegral ((i `shiftR` 8) .&. 0xFF)
+      , fromIntegral ((i `shiftR` 16) .&. 0xFF)
+      , fromIntegral ((i `shiftR` 24) .&. 0xFF)
+      ]
+      <> BS.replicate 28 0
+
+-- | 'TxHash' from an EB index + TX offset: 4 bytes followed by 28 ones.
+genTxHash :: Int -> Int -> TxHash
+genTxHash ebIdx txIdx =
+  MkTxHash $
+    BS.pack
+      [ fromIntegral (ebIdx .&. 0xFF)
+      , fromIntegral ((ebIdx `shiftR` 8) .&. 0xFF)
+      , fromIntegral (txIdx .&. 0xFF)
+      , fromIntegral ((txIdx `shiftR` 8) .&. 0xFF)
+      ]
+      <> BS.replicate 28 1
+
+-- | 'LeiosPoint' from an index (SlotNo = index).
+genPoint :: Int -> LeiosPoint
+genPoint i = MkLeiosPoint (SlotNo $ fromIntegral i) (genEbHash i)
+
+-- | 'LeiosEb' with 'txsPerEb' transactions (200 bytes each).
+genEb :: Int -> LeiosEb
+genEb ebIdx =
+  MkLeiosEb $
+    V.fromList
+      [(genTxHash ebIdx txIdx, 200 :: BytesSize) | txIdx <- [0 .. txsPerEb - 1]]
+
+-- | Fixed TX payload: 16 KiB zeros (realistic worst-case size).
+fixedTxBytes :: BS.ByteString
+fixedTxBytes = BS.replicate 16_384 0

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -852,16 +852,16 @@ benchmark leios-db-bench
   type: exitcode-stdio-1.0
   hs-source-dirs: bench/leios-db-bench
   main-is: Main.hs
-  ghc-options: "-with-rtsopts=-N4"
+  ghc-options: -with-rtsopts=-N4
   build-depends:
     async,
     base,
     bytestring,
     cardano-slotting,
-    si-timers,
-    time,
     ouroboros-consensus,
+    si-timers,
     temporary,
+    time,
     vector,
 
 test-suite doctest

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -847,6 +847,23 @@ benchmark ChainSync-client-bench
     unstable-consensus-testlib,
     with-utf8,
 
+benchmark leios-db-bench
+  import: common-bench
+  type: exitcode-stdio-1.0
+  hs-source-dirs: bench/leios-db-bench
+  main-is: Main.hs
+  ghc-options: "-with-rtsopts=-N4"
+  build-depends:
+    async,
+    base,
+    bytestring,
+    cardano-slotting,
+    si-timers,
+    time,
+    ouroboros-consensus,
+    temporary,
+    vector,
+
 test-suite doctest
   import: common-test
   main-is: doctest.hs

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic.hs
@@ -75,20 +75,18 @@ data LeiosFetchContext m = MkLeiosFetchContext
   { leiosDb :: !(LeiosDbHandle m)
   , leiosEbBuffer :: !(MV.MVector (PrimState m) (TxHash, BytesSize))
   , leiosEbTxsBuffer :: !(MV.MVector (PrimState m) LeiosTx)
-  , leiosWriteLock :: !(MVar m ())
   }
 
 newLeiosFetchContext ::
   PrimMonad m =>
-  MVar m () ->
   LeiosDbHandle m ->
   m (LeiosFetchContext m)
-newLeiosFetchContext leiosWriteLock leiosDb = do
+newLeiosFetchContext leiosDb = do
   -- each LeiosFetch server calls this when it initializes
   leiosEbBuffer <- MV.new maxTxsPerEb
   leiosEbTxsBuffer <- MV.new maxTxsPerEb
   pure
-    MkLeiosFetchContext{leiosDb, leiosEbBuffer, leiosEbTxsBuffer, leiosWriteLock}
+    MkLeiosFetchContext{leiosDb, leiosEbBuffer, leiosEbTxsBuffer}
 
 -----
 
@@ -116,16 +114,15 @@ msgLeiosBlockRequest ::
   LeiosPoint ->
   m LeiosEb
 msgLeiosBlockRequest tracer leiosContext MkLeiosPoint{pointEbHash} = do
-  let MkLeiosFetchContext{leiosDb = db, leiosEbBuffer = buf, leiosWriteLock} = leiosContext
-  n <- MVar.withMVar leiosWriteLock $ \() -> do
-    traceException tracer TraceLeiosPeerDbException $ do
-      -- get the EB items using new db
-      items <- leiosDbLookupEbBody db pointEbHash
-      let loop !i [] = pure i
-          loop !i ((txHash, txBytesSize) : rest) = do
-            MV.write buf i (txHash, txBytesSize)
-            loop (i + 1) rest
-      loop 0 items
+  let MkLeiosFetchContext{leiosDb = db, leiosEbBuffer = buf} = leiosContext
+  n <- traceException tracer TraceLeiosPeerDbException $ do
+    -- get the EB items using new db
+    items <- leiosDbLookupEbBody db pointEbHash
+    let loop !i [] = pure i
+        loop !i ((txHash, txBytesSize) : rest) = do
+          MV.write buf i (txHash, txBytesSize)
+          loop (i + 1) rest
+    loop 0 items
   v <- V.freeze $ MV.slice 0 n buf
   pure $ MkLeiosEb v
 
@@ -137,7 +134,7 @@ msgLeiosBlockTxsRequest ::
   [(Word16, Word64)] ->
   m (V.Vector LeiosTx)
 msgLeiosBlockTxsRequest _tracer leiosContext point bitmaps = do
-  let MkLeiosFetchContext{leiosDb = db, leiosEbTxsBuffer = buf, leiosWriteLock} = leiosContext
+  let MkLeiosFetchContext{leiosDb = db, leiosEbTxsBuffer = buf} = leiosContext
   do
     let idxs = map fst bitmaps
     let idxLimit = maxTxsPerEb `div` 64
@@ -154,7 +151,7 @@ msgLeiosBlockTxsRequest _tracer leiosContext point bitmaps = do
           Just (i, bitmap') ->
             Just (64 * fromIntegral idx + i, (idx, bitmap') : k)
       txOffsets = unfoldr nextOffset bitmaps
-  n <- MVar.withMVar leiosWriteLock $ \() -> do
+  n <- do
     -- Use new db to batch retrieve transactions
     results <- leiosDbBatchRetrieveTxs db point.pointEbHash txOffsets
     -- Process results and write to buffer
@@ -475,8 +472,7 @@ nextLeiosFetchClientCommand ::
   Tracer m TraceLeiosKernel ->
   Tracer m TraceLeiosPeer ->
   StrictSTM.STM m Bool ->
-  ( MVar m ()
-  , MVar m (LeiosOutstanding pid)
+  ( MVar m (LeiosOutstanding pid)
   , MVar m ()
   ) ->
   LeiosDbHandle m ->
@@ -528,8 +524,7 @@ msgLeiosBlock ::
   ) =>
   Tracer m TraceLeiosKernel ->
   Tracer m TraceLeiosPeer ->
-  ( MVar m ()
-  , MVar m (LeiosOutstanding pid)
+  ( MVar m (LeiosOutstanding pid)
   , MVar m ()
   ) ->
   LeiosDbHandle m ->
@@ -537,7 +532,7 @@ msgLeiosBlock ::
   LeiosBlockRequest ->
   LeiosEb ->
   m ()
-msgLeiosBlock ktracer tracer (writeLock, outstandingVar, readyVar) db peerId req eb = do
+msgLeiosBlock ktracer tracer (outstandingVar, readyVar) db peerId req eb = do
   -- validate it
   let MkLeiosBlockRequest point ebBytesSize = req
   traceWith tracer $ MkTraceLeiosPeer $ "[start] MsgLeiosBlock " <> Leios.prettyLeiosPoint point
@@ -552,7 +547,7 @@ msgLeiosBlock ktracer tracer (writeLock, outstandingVar, readyVar) db peerId req
   -- ingest it
   MVar.modifyMVar_ outstandingVar $ \outstanding -> do
     let novel = not $ Set.member ebHash (Leios.acquiredEbBodies outstanding)
-    when novel $ MVar.withMVar writeLock $ \() -> do
+    when novel $ do
       -- TODO don't hold the outstanding mvar during this IO
       traceException tracer TraceLeiosPeerDbException $ do
         -- NOTE: The point should already be in the table because of the
@@ -646,8 +641,7 @@ msgLeiosBlockTxs ::
   ) =>
   Tracer m TraceLeiosKernel ->
   Tracer m TraceLeiosPeer ->
-  ( MVar m ()
-  , MVar m (LeiosOutstanding pid)
+  ( MVar m (LeiosOutstanding pid)
   , MVar m ()
   ) ->
   LeiosDbHandle m ->
@@ -655,7 +649,7 @@ msgLeiosBlockTxs ::
   LeiosBlockTxsRequest ->
   V.Vector LeiosTx ->
   m ()
-msgLeiosBlockTxs ktracer tracer (writeLock, outstandingVar, readyVar) db peerId req txs = do
+msgLeiosBlockTxs ktracer tracer (outstandingVar, readyVar) db peerId req txs = do
   traceWith tracer $ MkTraceLeiosPeer $ "[start] " ++ Leios.prettyLeiosBlockTxsRequest req
   -- validate it
   -- TODO: could validate the returned point + bitmaps too (added to response recently)
@@ -681,15 +675,8 @@ msgLeiosBlockTxs ktracer tracer (writeLock, outstandingVar, readyVar) db peerId 
       offsets = unfoldr nextOffset bitmaps
   -- ingest
   traceException tracer TraceLeiosPeerDbException $ do
-    MVar.withMVar writeLock $ \() -> do
-      -- REVIEW: These operations were previously wrapped in a single dbWithBEGIN
-      -- transaction but are now separate db calls. For SQLite, each operation is
-      -- transactional, but they're not in a single atomic transaction anymore.
-      -- This may need to be fixed by adding a batch update operation to the db or
-      -- ensuring transactional semantics. Use new db for both txCache and ebTxs
-      -- updates
-      completed <- leiosDbInsertTxs db (V.toList $ V.zip txHashes txBytess)
-      forM_ completed $ traceWith ktracer . TraceLeiosBlockTxsAcquired
+    completed <- leiosDbInsertTxs db (V.toList $ V.zip txHashes txBytess)
+    forM_ completed $ traceWith ktracer . TraceLeiosBlockTxsAcquired
   -- update NodeKernel state
   MVar.modifyMVar_ outstandingVar $ \outstanding -> do
     let (requestedTxPeers', txOffsetss', txsBytesSize) =

--- a/ouroboros-consensus/test/consensus-test/Test/LeiosDemoDb.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/LeiosDemoDb.hs
@@ -2,13 +2,12 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedRecordDot #-}
-{-# LANGUAGE ViewPatterns #-}
 
 -- | Tests for the LeiosDemoDb interface.
 --
 -- These tests verify the semantics of the LeiosDbHandle operations for both
 -- InMemory and SQLite implementations. Each test case uses a fresh database
--- to ensure isolation and allow non-priming tests to serve as performance baselines.
+-- to ensure isolation and serve as an (too optimistic) performance baseline.
 module Test.LeiosDemoDb (tests) where
 
 import Cardano.Slotting.Slot (SlotNo (..))
@@ -29,8 +28,7 @@ import LeiosDemoDb
   , newLeiosDBSQLite
   )
 import LeiosDemoTypes
-  ( BytesSize
-  , EbHash (..)
+  ( EbHash (..)
   , LeiosEb (..)
   , LeiosNotification (..)
   , LeiosPoint (..)
@@ -48,16 +46,12 @@ import Test.QuickCheck
   , counterexample
   , forAll
   , forAllBlind
-  , forAllShrinkBlind
   , forAllShrinkShow
   , ioProperty
-  , scale
   , shrink
-  , sized
   , sublistOf
   , tabulate
   , vector
-  , withMaxSuccess
   , (===)
   )
 import Test.Tasty (TestTree, testGroup)
@@ -119,7 +113,6 @@ mkTestGroups impl =
       "transactions"
       [ testProperty "insert then retrieve" $ prop_txsInsertThenRetrieve impl
       , testProperty "retrieve missing returns empty" $ prop_txsRetrieveMissing impl
-      , testProperty "insert tx performance" $ prop_insertTxPerformance impl
       ]
   , testGroup
       "notifications"
@@ -137,19 +130,16 @@ mkTestGroups impl =
       , testProperty "missing bodies reported" $ prop_fetchWorkMissingBodies impl
       , testProperty "missing txs reported" $ prop_fetchWorkMissingTxs impl
       , testProperty "complete eb has no missing txs" $ prop_fetchWorkCompleteTxs impl
-      , testProperty "query performance" $ prop_fetchWorkPerformance impl
       ]
   , testGroup
       "filterMissingEbBodies"
       [ testProperty "empty input returns empty" $ prop_filterEbBodiesEmpty impl
       , testProperty "returns only missing EBs" $ prop_filterEbBodiesCorrect impl
-      , testProperty "filter performance" $ prop_filterEbBodiesPerformance impl
       ]
   , testGroup
       "filterMissingTxs"
       [ testProperty "empty input returns empty" $ prop_filterTxsEmpty impl
       , testProperty "returns only missing TXs" $ prop_filterTxsCorrect impl
-      , testProperty "filter performance" $ prop_filterTxsPerformance impl
       ]
   , testGroup
       "queryCompletedEbByPoint"
@@ -416,51 +406,6 @@ prop_txsRetrieveMissing impl =
         result === []
           & tabulate "batchRetrieveTxs (missing)" [timeBucket retrieveTime]
 
--- | Property: measure leiosDbInsertTxs performance and report timing distribution.
--- Tracks performance across different database sizes and batch configurations.
-prop_insertTxPerformance :: DbImpl -> Property
-prop_insertTxPerformance impl =
-  forAllShrinkBlind genPerfParams shrinkPerfParams $ \(numEBs, numTxs) ->
-    forAllBlind (genPerfData numEBs numTxs) $ \(primeData, point, eb, force -> !txsToInsert) ->
-      ioProperty $ withFreshDb impl $ \db -> do
-        -- Prime the database with additional EBs to simulate load
-        forM_ primeData $ \(primePoint, primeEb) -> do
-          leiosDbInsertEbPoint db primePoint (leiosEbBytesSize primeEb)
-          leiosDbInsertEbBody db primePoint primeEb
-        -- Create the target EB
-        leiosDbInsertEbPoint db point (leiosEbBytesSize eb)
-        leiosDbInsertEbBody db point eb
-        -- Measure time for inserting a batch of txs
-        (_, insertTime) <- timed $ leiosDbInsertTxs db txsToInsert
-        pure $
-          insertTime < milli 10
-            & counterexample ("Took too long: " <> showTime insertTime)
-            & counterexample
-              ("With " <> show (numEBs + 1) <> " EBs in DB (each having " <> show numTxs <> " txs)")
-            & tabulate "insertTxs (primed)" [timeBucket insertTime]
-            & tabulate "numEBs in DB" [magnitudeBucket numEBs]
-            & tabulate "numTxs in EB" [magnitudeBucket numTxs]
- where
-  genPerfParams = sized $ \size -> do
-    dbSize <- chooseInt (0, size)
-    numTxs <- chooseInt (1, max 1 (min (size * 100) 2000))
-    pure (dbSize, numTxs)
-
-  shrinkPerfParams (numEBs, numTxs) =
-    [(n, numTxs) | n <- shrink numEBs]
-      ++ [(numEBs, n) | n <- shrink numTxs, n >= 1]
-
-  -- Generate all data needed for a performance test run
-  genPerfData dbSize numTxs = do
-    primeData <- replicateM dbSize (genPointAndEb 10)
-    point <- genPoint
-    eb <- genEb numTxs
-    -- Generate a single tx to insert (first tx of the EB)
-    let (txHash, _) = V.head (leiosEbTxs eb)
-    txBytes <- genTxBytes
-    let txsToInsert = [(txHash, txBytes)]
-    pure (primeData, point, eb, txsToInsert)
-
 -- * Notification tests
 
 -- | Test that a single subscriber receives a notification when leiosDbInsertEbBody is called.
@@ -695,83 +640,6 @@ prop_fetchWorkCompleteTxs impl =
               & tabulate "queryFetchWork (complete)" [timeBucket queryTime]
               & tabulate "numTxs" [magnitudeBucket numTxs]
 
--- | Property: measure leiosDbQueryFetchWork performance with various database sizes.
--- Tests with many EBs and TXs to ensure queries scale acceptably.
-prop_fetchWorkPerformance :: DbImpl -> Property
-prop_fetchWorkPerformance impl =
-  forAllShrinkBlind genPerfParams shrinkPerfParams $ \(numPointsOnly, numWithBodies, numComplete, txsPerEb) ->
-    forAllBlind (genPerfData numPointsOnly numWithBodies numComplete txsPerEb) $ \perfData ->
-      ioProperty $ withFreshDb impl $ \db -> do
-        -- Prime the database with various states
-        let (pointsOnly, withBodies, complete) = perfData
-        -- Insert points without bodies (will be "missing bodies")
-        forM_ pointsOnly $ \(p, sz) -> leiosDbInsertEbPoint db p sz
-        -- Insert points with bodies but no txs (will be "missing txs")
-        forM_ withBodies $ \(p, eb) -> do
-          leiosDbInsertEbPoint db p (leiosEbBytesSize eb)
-          leiosDbInsertEbBody db p eb
-        -- Insert complete EBs (should not appear in results)
-        forM_ complete $ \(p, eb, txs) -> do
-          leiosDbInsertEbPoint db p (leiosEbBytesSize eb)
-          leiosDbInsertEbBody db p eb
-          leiosDbInsertTxs db txs
-        -- Measure query time
-        (work, queryTime) <- timed $ leiosDbQueryFetchWork db
-        let totalEbs = numPointsOnly + numWithBodies + numComplete
-            expectedMissingBodies = numPointsOnly
-            expectedMissingTxEbs = numWithBodies
-        pure $
-          conjoin
-            [ Map.size (missingEbBodies work) === expectedMissingBodies
-                & counterexample
-                  ( "Missing bodies count wrong: "
-                      ++ show (Map.size $ missingEbBodies work)
-                      ++ " vs "
-                      ++ show expectedMissingBodies
-                  )
-            , Map.size (missingEbTxs work) === expectedMissingTxEbs
-                & counterexample
-                  ( "Missing TX EBs count wrong: "
-                      ++ show (Map.size $ missingEbTxs work)
-                      ++ " vs "
-                      ++ show expectedMissingTxEbs
-                  )
-            , queryTime < milli 50
-                & counterexample ("Query took too long: " <> showTime queryTime)
-            ]
-            & tabulate "queryFetchWork (primed)" [timeBucket queryTime]
-            & tabulate "total EBs" [magnitudeBucket totalEbs]
-            & tabulate "txs per EB" [magnitudeBucket txsPerEb]
- where
-  genPerfParams = sized $ \size -> do
-    numPointsOnly <- chooseInt (0, size)
-    numWithBodies <- chooseInt (0, size)
-    numComplete <- chooseInt (0, size)
-    txsPerEb <- chooseInt (1, max 1 (min (size * 10) 100))
-    pure (numPointsOnly, numWithBodies, numComplete, txsPerEb)
-
-  shrinkPerfParams (a, b, c, d) =
-    [(a', b, c, d) | a' <- shrink a]
-      ++ [(a, b', c, d) | b' <- shrink b]
-      ++ [(a, b, c', d) | c' <- shrink c]
-      ++ [(a, b, c, d') | d' <- shrink d, d' >= 1]
-
-  genPerfData numPointsOnly numWithBodies numComplete txsPerEb = do
-    -- Points only (missing bodies)
-    pointsOnly <- replicateM numPointsOnly $ do
-      p <- genPoint
-      pure (p, 1000 :: BytesSize)
-    -- With bodies (missing TXs)
-    withBodies <- replicateM numWithBodies (genPointAndEb txsPerEb)
-    -- Complete EBs
-    complete <- replicateM numComplete $ do
-      (p, eb) <- genPointAndEb txsPerEb
-      txBytes <- genTxBytes
-      let ebTxList = V.toList (leiosEbTxs eb)
-          txs = [(txHash, txBytes) | (txHash, _) <- ebTxList]
-      pure (p, eb, txs)
-    pure (pointsOnly, withBodies, complete)
-
 -- * Test utilities
 
 -- | Assert that a notification is LeiosOfferBlock with the expected point.
@@ -828,77 +696,6 @@ prop_filterEbBodiesCorrect impl =
                 & tabulate "filterMissingEbBodies" [timeBucket filterTime]
                 & tabulate "numEbs" [magnitudeBucket numEbs]
 
--- | Property: measure filterMissingEbBodies performance.
--- TODO: Cardinalities are too low compared to production workloads.
-prop_filterEbBodiesPerformance :: DbImpl -> Property
-prop_filterEbBodiesPerformance impl =
-  withMaxSuccess 10 $
-    forAllShrinkShow (scale (* 10) genPerfParams) shrinkPerfParams show $ \(numWithBodies, numMissing) ->
-      ioProperty $
-        withFreshDb impl $ \db -> do
-          -- Insert EBs with bodies
-          forM_ [1 .. numWithBodies] $ \i -> do
-            let hash =
-                  MkEbHash $
-                    BS.pack
-                      [ fromIntegral (i `mod` 256)
-                      , fromIntegral ((i `div` 256) `mod` 256)
-                      , fromIntegral ((i `div` 65536) `mod` 256)
-                      ]
-                      <> BS.replicate 29 0
-                point = MkLeiosPoint (SlotNo $ fromIntegral i) hash
-                txHash =
-                  MkTxHash $
-                    BS.pack [fromIntegral (i `mod` 256), fromIntegral ((i `div` 256) `mod` 256)] <> BS.replicate 30 1
-                eb = MkLeiosEb $ V.fromList [(txHash, 100)]
-            leiosDbInsertEbPoint db point (leiosEbBytesSize eb)
-            leiosDbInsertEbBody db point eb
-          -- Generate points that are NOT in DB (these should be returned)
-          let missingPoints =
-                [ MkLeiosPoint
-                    (SlotNo $ fromIntegral (numWithBodies + i))
-                    ( MkEbHash $
-                        BS.pack
-                          [ fromIntegral ((numWithBodies + i) `mod` 256)
-                          , fromIntegral (((numWithBodies + i) `div` 256) `mod` 256)
-                          , fromIntegral (((numWithBodies + i) `div` 65536) `mod` 256)
-                          ]
-                          <> BS.replicate 29 2
-                    )
-                | i <- [1 .. numMissing]
-                ]
-              -- Query with a mix: the DB ones should be filtered out, missing ones returned
-              existingPoints =
-                [ MkLeiosPoint
-                    (SlotNo $ fromIntegral i)
-                    ( MkEbHash $
-                        BS.pack
-                          [ fromIntegral (i `mod` 256)
-                          , fromIntegral ((i `div` 256) `mod` 256)
-                          , fromIntegral ((i `div` 65536) `mod` 256)
-                          ]
-                          <> BS.replicate 29 0
-                    )
-                | i <- [1 .. numWithBodies]
-                ]
-              queryPoints = existingPoints ++ missingPoints
-          (result, filterTime) <- timed $ leiosDbFilterMissingEbBodies db queryPoints
-          pure $
-            conjoin
-              [ length result === numMissing
-              , filterTime < milli 100
-                  & counterexample ("Filter took too long: " <> showTime filterTime)
-              ]
-              & tabulate "filterMissingEbBodies (perf)" [timeBucket filterTime]
-              & tabulate "numWithBodies" [magnitudeBucket numWithBodies]
-              & tabulate "numMissing" [magnitudeBucket numMissing]
- where
-  genPerfParams = sized $ \size -> do
-    numWithBodies <- chooseInt (1, max 1 (size * 5))
-    numMissing <- chooseInt (1, max 1 (size * 2))
-    pure (numWithBodies, numMissing)
-  shrinkPerfParams (a, b) = [(a', b) | a' <- shrink a, a' >= 1] ++ [(a, b') | b' <- shrink b, b' >= 1]
-
 -- * Property tests for filterMissingTxs
 
 -- | Property: filtering empty list returns empty list.
@@ -930,58 +727,6 @@ prop_filterTxsCorrect impl =
                 ]
                 & tabulate "filterMissingTxs" [timeBucket filterTime]
                 & tabulate "numTxs" [magnitudeBucket numTxs]
-
--- | Property: measure filterMissingTxs performance.
--- TODO: Cardinalities are still lower than production workloads
-prop_filterTxsPerformance :: DbImpl -> Property
-prop_filterTxsPerformance impl =
-  withMaxSuccess 10 $
-    forAllShrinkShow (scale (* 20) genPerfParams) shrinkPerfParams show $ \(numInserted, numMissing) ->
-      ioProperty $
-        withFreshDb impl $ \db -> do
-          -- Create and insert TXs
-          let insertedHashes =
-                [ MkTxHash $
-                    BS.pack [fromIntegral (i `mod` 256), fromIntegral ((i `div` 256) `mod` 256)] <> BS.replicate 30 0
-                | i <- [1 .. numInserted]
-                ]
-          -- XXX: Simplify test case generation and use genEBHash?
-          forM_ (zip [1 :: Integer ..] (chunksOf 100 insertedHashes)) $ \(ebIdx, txChunk) -> do
-            let ebHash =
-                  MkEbHash $
-                    BS.pack [fromIntegral (ebIdx `mod` 256), fromIntegral ((ebIdx `div` 256) `mod` 256)]
-                      <> BS.replicate 30 0
-                point = MkLeiosPoint (SlotNo $ fromIntegral ebIdx) ebHash
-                eb = MkLeiosEb $ V.fromList [(h, 100) | h <- txChunk]
-            leiosDbInsertEbPoint db point (leiosEbBytesSize eb)
-            leiosDbInsertEbBody db point eb
-            forM_ txChunk $ \txHash ->
-              leiosDbInsertTxs db [(txHash, maxTxBytesZero)]
-          -- Generate hashes NOT in DB
-          let missingHashes =
-                [ MkTxHash $
-                    BS.pack
-                      [fromIntegral ((numInserted + i) `mod` 256), fromIntegral (((numInserted + i) `div` 256) `mod` 256)]
-                      <> BS.replicate 30 1
-                | i <- [1 .. numMissing]
-                ]
-              queryHashes = insertedHashes ++ missingHashes
-          (result, filterTime) <- timed $ leiosDbFilterMissingTxs db queryHashes
-          pure $
-            conjoin
-              [ length result === numMissing
-              , filterTime < milli 100
-                  & counterexample ("Filter took too long: " <> showTime filterTime)
-              ]
-              & tabulate "filterMissingTxs (perf)" [timeBucket filterTime]
-              & tabulate "numInserted" [magnitudeBucket numInserted]
-              & tabulate "numMissing" [magnitudeBucket numMissing]
- where
-  genPerfParams = sized $ \size -> do
-    numInserted <- chooseInt (1, max 1 (size * 10))
-    numMissing <- chooseInt (1, max 1 (size * 20))
-    pure (numInserted, numMissing)
-  shrinkPerfParams (a, b) = [(a', b) | a' <- shrink a, a' >= 1] ++ [(a, b') | b' <- shrink b, b' >= 1]
 
 -- * Property tests for queryCompletedEbByPoint
 
@@ -1069,8 +814,3 @@ prop_completedEbNoBody impl =
         result === Nothing
           & counterexample "Expected Nothing for EB with no body inserted"
           & tabulate "queryCompletedEbByPoint (no body)" [timeBucket queryTime]
-
--- | Split a list into chunks of given size.
-chunksOf :: Int -> [a] -> [[a]]
-chunksOf _ [] = []
-chunksOf n xs = take n xs : chunksOf n (drop n xs)


### PR DESCRIPTION
This uses a more consistent generation of quantities and resembles the concurrent access similar to the production code.

This is currently quite barebones, but gives us a good first numbers of a reasonably respresentative scenario:

```
λ cabal bench leios-db-bench
Build profile: -w ghc-9.6.6 -O1
In order, the following will be built (use -v for more details):
 - ouroboros-consensus-0.27.0.0 (bench:leios-db-bench) (ephemeral targets)
Preprocessing benchmark 'leios-db-bench' for ouroboros-consensus-0.27.0.0...
Building benchmark 'leios-db-bench' for ouroboros-consensus-0.27.0.0...
Running 1 benchmarks...
Benchmark leios-db-bench: RUNNING...
LeiosDemoDb concurrent benchmark

Database setup:
  EBs pre-populated : 500
  TXs per EB        : 200
  Total TXs         : 100000

Concurrent workload per iteration:
  Active reader (×1): 10 rounds of filterMissingEbBodies (200+200) + filterMissingTxs (500+500)
  Writers       (×2): 20 insertEbPoint/insertEbBody/insertTxs each
  Readers       (×8): 30 lookupEbBody + 10 batchRetrieveTxs each

Runs: 1 warmup + 5 timed

Inserting EBs: 50 100 150 200 250 300 350 400 450 500 done
  run 1/5: 3.830633993 s
  run 2/5: 3.696195071 s
  run 3/5: 3.675190096 s
  run 4/5: 3.789160281 s
  run 5/5: 3.890996196 s
  => min=3.675190096 s  avg=3.7764351274 s  max=3.890996196 s
Benchmark leios-db-bench: FINISH
```