### PR TITLE
[Peras 22] Generic voting committee API

### DIFF
--- a/changelog.d/20260413_094611_agustin.mista_generic_voting_committee_api.md
+++ b/changelog.d/20260413_094611_agustin.mista_generic_voting_committee_api.md
@@ -1,0 +1,23 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+<!--
+### Breaking
+
+- A bullet item for the Breaking category.
+
+-->
+### Non-Breaking
+
+- Implemented generic voting committee interface.
+
+<!--
+### Patch
+
+- A bullet item for the Patch category.
+
+-->

--- a/ouroboros-consensus.cabal
+++ b/ouroboros-consensus.cabal
@@ -115,6 +115,10 @@ library
     Ouroboros.Consensus.BlockchainTime.WallClock.Simple
     Ouroboros.Consensus.BlockchainTime.WallClock.Types
     Ouroboros.Consensus.BlockchainTime.WallClock.Util
+    Ouroboros.Consensus.Committee.AcrossEpochs
+    Ouroboros.Consensus.Committee.Class
+    Ouroboros.Consensus.Committee.Crypto
+    Ouroboros.Consensus.Committee.Types
     Ouroboros.Consensus.Config
     Ouroboros.Consensus.Config.SecurityParam
     Ouroboros.Consensus.Config.SupportsNode
@@ -372,6 +376,7 @@ library
     monoid-subclasses,
     mtl,
     multiset ^>=0.3,
+    nonempty-containers,
     nothunks ^>=0.2 || ^>=0.3,
     ouroboros-network:{api, api-tests-lib, protocols} ^>=1.1,
     primitive,

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Committee/AcrossEpochs.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Committee/AcrossEpochs.hs
@@ -1,0 +1,74 @@
+-- | This module extends a given voting committee to work across epochs.
+--
+-- This is needed to support the case of validating an old vote or certificate
+-- from a previous epoch arriving too late. In the general case, this means we
+-- would need to store an arbitrary number of past voting committee selections.
+-- However, since:
+--   1. the length of an epoch is much larger than the immutability window, and
+--   2. we don't care about validating votes older than the immutability window,
+--      it follows that we only need to store the voting committee selection for
+--      the current and previous epochs.
+--  NOTE: this rationale might need to be revisited if we ever want to support
+--  validating votes and certificates older than the immutability window, e.g.,
+--  for historical queries.
+module Ouroboros.Consensus.Committee.AcrossEpochs
+  ( InterEpochVotingCommittee (..)
+  , mkInterEpochVotingCommittee
+  , newEpoch
+  , getVotingCommitteeForElection
+  ) where
+
+import Data.Maybe.Strict (StrictMaybe (..))
+import Ouroboros.Consensus.Committee.Class (CryptoSupportsVotingCommittee (..))
+import Ouroboros.Consensus.Committee.Crypto (ElectionId)
+
+data InterEpochVotingCommittee crypto committee
+  = InterEpochVotingCommittee
+  { currEpochVotingCommittee :: !(VotingCommittee crypto committee)
+  , prevEpochVotingCommittee :: !(StrictMaybe (VotingCommittee crypto committee))
+  }
+
+-- | Construct an inter-epoch committee selection for the first epoch
+mkInterEpochVotingCommittee ::
+  CryptoSupportsVotingCommittee crypto committee =>
+  VotingCommitteeInput crypto committee ->
+  Either
+    (VotingCommitteeError crypto committee)
+    (InterEpochVotingCommittee crypto committee)
+mkInterEpochVotingCommittee votingCommitteeInput = do
+  votingCommittee <-
+    mkVotingCommittee votingCommitteeInput
+  pure $
+    InterEpochVotingCommittee
+      { currEpochVotingCommittee =
+          votingCommittee
+      , prevEpochVotingCommittee =
+          SNothing
+      }
+
+-- | Update an inter-epoch committee selection at the beginning of a new epoch
+newEpoch ::
+  CryptoSupportsVotingCommittee crypto committee =>
+  VotingCommitteeInput crypto committee ->
+  InterEpochVotingCommittee crypto committee ->
+  Either
+    (VotingCommitteeError crypto committee)
+    (InterEpochVotingCommittee crypto committee)
+newEpoch newEpochVotingCommitteeInput interEpochVotingCommittee = do
+  newEpochVotingCommittee <-
+    mkVotingCommittee newEpochVotingCommitteeInput
+  pure $
+    InterEpochVotingCommittee
+      { currEpochVotingCommittee =
+          newEpochVotingCommittee
+      , prevEpochVotingCommittee =
+          SJust (currEpochVotingCommittee interEpochVotingCommittee)
+      }
+
+-- | Get the voting committee corresponding to an election, if any
+getVotingCommitteeForElection ::
+  ElectionId crypto ->
+  InterEpochVotingCommittee crypto committee ->
+  Maybe (VotingCommittee crypto committee)
+getVotingCommitteeForElection _electionId _interEpochVotingCommittee = do
+  error "TODO: implement getVotingCommitteeForElection"

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Committee/Class.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Committee/Class.hs
@@ -1,0 +1,188 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TypeFamilies #-}
+
+-- | Generic interface used by implementations of voting committees.
+module Ouroboros.Consensus.Committee.Class
+  ( -- * Voting committee interface
+    CryptoSupportsVotingCommittee (..)
+
+    -- * Votes with same target
+  , VotesWithSameTarget
+  , getElectionIdFromVotes
+  , getVoteCandidateFromVotes
+  , getRawVotes
+  , VotesWithSameTargetError (..)
+  , ensureSameTarget
+  ) where
+
+import Data.Containers.NonEmpty (HasNonEmpty (..))
+import Data.Either (partitionEithers)
+import Data.Kind (Type)
+import Data.List.NonEmpty (NonEmpty (..))
+import Ouroboros.Consensus.Committee.Crypto
+  ( CryptoSupportsVoteSigning
+  , ElectionId
+  , PrivateKey
+  , VoteCandidate
+  )
+import Ouroboros.Consensus.Committee.Types (PoolId, VoteWeight)
+
+-- * Voting committee interface
+
+-- | Interface for voting committee schemes.
+--
+-- This class is parametrized by the crypto primitives and the committee
+-- selection data structure. Instances define how to check whether a party
+-- should vote and how to compute the voting weight of a committee member.
+class
+  CryptoSupportsVoteSigning crypto =>
+  CryptoSupportsVotingCommittee crypto committee
+  where
+  -- | Structure storing the voting committee context
+  data VotingCommittee crypto committee :: Type
+
+  -- | Input information needed to construct a voting committee
+  data VotingCommitteeInput crypto committee :: Type
+
+  -- | Errors that can occur when operating on a voting committee
+  data VotingCommitteeError crypto committee :: Type
+
+  -- | Witness attesting that a party is eligible to vote in a given election
+  --
+  -- NOTE: this is not necessarily the same as the cryptographic proof of
+  -- eligibility used in concrete votes and certificates sent over the wire.
+  data EligibilityWitness crypto committee :: Type
+
+  -- | Abstract vote cast by a committee member in a given election
+  data Vote crypto committee :: Type
+
+  -- | Abstract certificate attesting the winner of a given election
+  data Cert crypto committee :: Type
+
+  -- | Construct a voting committee
+  mkVotingCommittee ::
+    VotingCommitteeInput crypto committee ->
+    Either
+      (VotingCommitteeError crypto committee)
+      (VotingCommittee crypto committee)
+
+  -- | Check whether we should vote in a given election
+  checkShouldVote ::
+    VotingCommittee crypto committee ->
+    PoolId ->
+    PrivateKey crypto ->
+    ElectionId crypto ->
+    Either
+      (VotingCommitteeError crypto committee)
+      (Maybe (EligibilityWitness crypto committee))
+
+  -- | Forge a vote for a given election and candidate
+  forgeVote ::
+    EligibilityWitness crypto committee ->
+    PrivateKey crypto ->
+    ElectionId crypto ->
+    VoteCandidate crypto ->
+    Vote crypto committee
+
+  -- | Verify a vote cast by a committee member in a given election
+  verifyVote ::
+    VotingCommittee crypto committee ->
+    Vote crypto committee ->
+    Either
+      (VotingCommitteeError crypto committee)
+      (EligibilityWitness crypto committee)
+
+  -- | Compute the voting weight of a eligibile party
+  eligiblePartyVoteWeight ::
+    VotingCommittee crypto committee ->
+    EligibilityWitness crypto committee ->
+    VoteWeight
+
+  -- | Forge a certificate attesting the winner of a given election
+  forgeCert ::
+    VotesWithSameTarget crypto committee ->
+    Cert crypto committee
+
+  -- | Verify a certificate attesting the winner of a given election
+  verifyCert ::
+    VotingCommittee crypto committee ->
+    Cert crypto committee ->
+    Either
+      (VotingCommitteeError crypto committee)
+      (NE [EligibilityWitness crypto committee])
+
+-- * Votes with same target
+
+-- | Collection of votes all targeting the same election and candidate
+data VotesWithSameTarget crypto committee
+  = VotesWithSameTarget
+      (ElectionId crypto)
+      (VoteCandidate crypto)
+      (NE [Vote crypto committee])
+
+-- | Get the election identifier targeted by a collection of votes
+getElectionIdFromVotes ::
+  VotesWithSameTarget crypto committee ->
+  ElectionId crypto
+getElectionIdFromVotes (VotesWithSameTarget electionId _ _) =
+  electionId
+
+-- | Get the vote candidate targeted by a collection of votes
+getVoteCandidateFromVotes ::
+  VotesWithSameTarget crypto committee ->
+  VoteCandidate crypto
+getVoteCandidateFromVotes (VotesWithSameTarget _ candidate _) =
+  candidate
+
+-- | Get the raw votes from a collection of votes with the same target.
+--
+-- NOTE: this returns votes in ascending seat index order.
+getRawVotes ::
+  VotesWithSameTarget crypto committee ->
+  NE [Vote crypto committee]
+getRawVotes (VotesWithSameTarget _ _ votes) =
+  votes
+
+-- | Errors when votes do not all target the same election and candidate
+data VotesWithSameTargetError crypto committee
+  = EmptyVotes
+  | TargetMismatch
+      -- First vote and the rest of the votes that match its target
+      (NE [Vote crypto committee])
+      -- Votes that do not match the target of the first vote
+      (NE [Vote crypto committee])
+
+-- | Check that a list of votes all target the same election and candidate
+ensureSameTarget ::
+  ( Eq (ElectionId crypto)
+  , Eq (VoteCandidate crypto)
+  ) =>
+  (Vote crypto committee -> (ElectionId crypto, VoteCandidate crypto)) ->
+  [Vote crypto committee] ->
+  Either
+    (VotesWithSameTargetError crypto committee)
+    (VotesWithSameTarget crypto committee)
+ensureSameTarget getTarget = \case
+  [] ->
+    Left EmptyVotes
+  (firstVote : nextVotes) -> do
+    case partitionEithers (fmap matchesTarget nextVotes) of
+      ([], matchingVotes) ->
+        Right $
+          VotesWithSameTarget
+            electionId
+            candidate
+            (firstVote :| matchingVotes)
+      (firstMismatchingVote : nextMismatchingVotes, matchingVotes) ->
+        Left $
+          TargetMismatch
+            (firstVote :| matchingVotes)
+            (firstMismatchingVote :| nextMismatchingVotes)
+   where
+    target@(electionId, candidate) =
+      getTarget firstVote
+    matchesTarget v'
+      | getTarget v' /= target = Left v'
+      | otherwise = Right v'

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Committee/Crypto.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Committee/Crypto.hs
@@ -1,0 +1,351 @@
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+-- | Generic interface used by implementations of voting committees.
+--
+-- NOTE: concrete implementations might not need to implement all these
+-- interfaces, especially the ones regarding VRF-based eligibility proofs and
+-- aggregate vote signature verification.
+module Ouroboros.Consensus.Committee.Crypto
+  ( -- * Core types associated to voting committees
+    PrivateKey
+  , PublicKey
+  , ElectionId
+  , VoteCandidate
+
+    -- * Vote signing interface
+  , CryptoSupportsVoteSigning (..)
+  , CryptoSupportsAggregateVoteSigning (..)
+
+    -- ** Trivial aggregate vote signature verification helpers
+  , TrivialAggregateVoteVerificationKey (..)
+  , TrivialAggregateVoteSignature (..)
+  , trivialLiftVoteVerificationKey
+  , trivialLiftVoteSignature
+  , trivialVerifyAggregateVoteSignature
+
+    -- * VRF-based eligibility proofs interface
+  , VRFPoolContext (..)
+  , NormalizedVRFOutput (..)
+  , CryptoSupportsVRF (..)
+  , CryptoSupportsAggregateVRF (..)
+
+    -- ** Trivial aggregate VRF verification helpers
+  , TrivialAggregateVRFVerificationKey (..)
+  , TrivialAggregateVRFOutput (..)
+  , trivialLiftVRFVerificationKey
+  , trivialLiftVRFOutput
+  , trivialVerifyAggregateVRFOutput
+  ) where
+
+import Cardano.Ledger.BaseTypes (Nonce)
+import Data.Containers.NonEmpty (HasNonEmpty (..))
+import Data.Either (partitionEithers)
+import Data.Kind (Type)
+import Data.List (intercalate)
+import qualified Data.List.NonEmpty as NonEmpty
+import Data.Proxy (Proxy)
+
+-- * Core types associated to voting committees
+
+-- | Private key used within the voting committee
+type family PrivateKey crypto :: Type
+
+-- | Public key used within the voting committee
+type family PublicKey crypto :: Type
+
+-- | Election identifiers
+type family ElectionId crypto :: Type
+
+-- | Vote candidates, i.e., what's being voted for
+type family VoteCandidate crypto :: Type
+
+-- * Vote signing interface
+
+-- | Crypto interface used for signing and verifying votes
+class CryptoSupportsVoteSigning crypto where
+  -- | Key used for signing votes
+  type VoteSigningKey crypto :: Type
+
+  -- | Key used for verifying votes
+  type VoteVerificationKey crypto :: Type
+
+  -- | Cryptographic signature of a vote
+  data VoteSignature crypto :: Type
+
+  -- | Derive a signing key from a voting committee private key
+  getVoteSigningKey ::
+    Proxy crypto ->
+    PrivateKey crypto ->
+    VoteSigningKey crypto
+
+  -- | Derive a verification key from a voting committee public key
+  getVoteVerificationKey ::
+    Proxy crypto ->
+    PublicKey crypto ->
+    VoteVerificationKey crypto
+
+  -- | Sign a vote candidate in a given election
+  signVote ::
+    VoteSigningKey crypto ->
+    ElectionId crypto ->
+    VoteCandidate crypto ->
+    VoteSignature crypto
+
+  -- | Verify the signature of a vote candidate in a given election
+  verifyVoteSignature ::
+    VoteVerificationKey crypto ->
+    ElectionId crypto ->
+    VoteCandidate crypto ->
+    VoteSignature crypto ->
+    Either String ()
+
+-- | Crypto interface used for verifying aggregate vote signatures
+class
+  ( Semigroup (AggregateVoteVerificationKey crypto)
+  , Semigroup (AggregateVoteSignature crypto)
+  ) =>
+  CryptoSupportsAggregateVoteSigning crypto
+  where
+  -- | Key used for verifying aggregate vote signatures
+  type AggregateVoteVerificationKey crypto :: Type
+
+  -- | Aggregate cryptographic signature of a vote
+  type AggregateVoteSignature crypto :: Type
+
+  -- | Lift a single vote signature verification key into an aggregate one
+  liftVoteVerificationKey ::
+    Proxy crypto ->
+    VoteVerificationKey crypto ->
+    AggregateVoteVerificationKey crypto
+
+  -- | Lift a single vote signature into an aggregate one
+  liftVoteSignature ::
+    Proxy crypto ->
+    VoteSignature crypto ->
+    AggregateVoteSignature crypto
+
+  -- | Verify an aggregate vote signature for a given election and candidate
+  verifyAggregateVoteSignature ::
+    Proxy crypto ->
+    AggregateVoteVerificationKey crypto ->
+    ElectionId crypto ->
+    VoteCandidate crypto ->
+    AggregateVoteSignature crypto ->
+    Either String ()
+
+-- ** Trivial aggregate vote signature verification helpers
+
+newtype TrivialAggregateVoteVerificationKey crypto
+  = TrivialAggregateVoteVerificationKey (NE [VoteVerificationKey crypto])
+  deriving newtype Semigroup
+
+newtype TrivialAggregateVoteSignature crypto
+  = TrivialAggregateVoteSignature (NE [VoteSignature crypto])
+  deriving newtype Semigroup
+
+trivialLiftVoteVerificationKey ::
+  Proxy crypto ->
+  VoteVerificationKey crypto ->
+  TrivialAggregateVoteVerificationKey crypto
+trivialLiftVoteVerificationKey _ =
+  TrivialAggregateVoteVerificationKey
+    . NonEmpty.singleton
+
+trivialLiftVoteSignature ::
+  Proxy crypto ->
+  VoteSignature crypto ->
+  TrivialAggregateVoteSignature crypto
+trivialLiftVoteSignature _ =
+  TrivialAggregateVoteSignature
+    . NonEmpty.singleton
+
+trivialVerifyAggregateVoteSignature ::
+  CryptoSupportsVoteSigning crypto =>
+  Proxy crypto ->
+  TrivialAggregateVoteVerificationKey crypto ->
+  ElectionId crypto ->
+  VoteCandidate crypto ->
+  TrivialAggregateVoteSignature crypto ->
+  Either String ()
+trivialVerifyAggregateVoteSignature
+  _
+  (TrivialAggregateVoteVerificationKey keys)
+  electionId
+  candidate
+  (TrivialAggregateVoteSignature signatures)
+    | length keys /= length signatures =
+        Left $
+          "Aggregate vote signature verification failed: "
+            <> "number of keys and signatures do not match"
+    | not (null errors) =
+        Left $
+          "Aggregate vote signature verification failed: "
+            <> intercalate "; " errors
+    | otherwise =
+        Right ()
+   where
+    (errors, _) =
+      partitionEithers $
+        zipWith
+          ( \key sig ->
+              verifyVoteSignature key electionId candidate sig
+          )
+          (NonEmpty.toList keys)
+          (NonEmpty.toList signatures)
+
+-- * VRF-based eligibility proofs interface
+
+-- | Context in which a VRF input is evaluated.
+--
+-- This distinguishes between the case where we want to compute our own VRF
+-- output, and the case where we want to verify the VRF output of someone else.
+data VRFPoolContext crypto
+  = -- | Compute our own VRF output by signing the VRF input with our signing key
+    VRFSignContext (VRFSigningKey crypto)
+  | -- | Verify the local sortition output of another participant by verifying
+    -- their signature over the VRF input using their verification key
+    VRFVerifyContext (VRFVerificationKey crypto) (VRFOutput crypto)
+
+-- | Normalized VRF outputs as a rational between 0 and 1
+newtype NormalizedVRFOutput = NormalizedVRFOutput
+  { unNormalizedVRFOutput :: Rational
+  }
+  deriving (Eq, Show)
+
+-- | Crypto interface used to proof eligibility via local sortition
+class CryptoSupportsVRF crypto where
+  -- | Private key used for computing our own VRF output
+  type VRFSigningKey crypto :: Type
+
+  -- | Public key used for verifying the VRF output of other participants
+  type VRFVerificationKey crypto :: Type
+
+  -- | Input to the verifiable random function.
+  --
+  -- This is fixed across all participants for a given election.
+  data VRFElectionInput crypto :: Type
+
+  -- | Output of the verifiable random function
+  data VRFOutput crypto :: Type
+
+  -- | Derive a VRF signing key from a voting committee private key
+  getVRFSigningKey ::
+    Proxy crypto ->
+    PrivateKey crypto ->
+    VRFSigningKey crypto
+
+  -- | Derive a VRF verification key from a voting committee public key
+  getVRFVerificationKey ::
+    Proxy crypto ->
+    PublicKey crypto ->
+    VRFVerificationKey crypto
+
+  -- | Construct a VRF input from a nonce and an election identifier
+  mkVRFElectionInput ::
+    Nonce ->
+    ElectionId crypto ->
+    VRFElectionInput crypto
+
+  -- | Evaluate a VRF input in a given context
+  evalVRF ::
+    VRFPoolContext crypto ->
+    VRFElectionInput crypto ->
+    Either String (VRFOutput crypto)
+
+  -- | Normalize a VRF output to a value in [0, 1]
+  normalizeVRFOutput ::
+    VRFOutput crypto ->
+    NormalizedVRFOutput
+
+-- | Crypto interface used for verifying aggregate VRF signatures
+class
+  ( Semigroup (AggregateVRFVerificationKey crypto)
+  , Semigroup (AggregateVRFOutput crypto)
+  ) =>
+  CryptoSupportsAggregateVRF crypto
+  where
+  -- | Key used for verifying aggregate VRF outputs
+  type AggregateVRFVerificationKey crypto :: Type
+
+  -- | Aggregate cryptographic signature of a VRF output
+  type AggregateVRFOutput crypto :: Type
+
+  -- | Lift a single VRF output verification key into an aggregate one
+  liftVRFVerificationKey ::
+    Proxy crypto ->
+    VRFVerificationKey crypto ->
+    AggregateVRFVerificationKey crypto
+
+  -- | Lift a single VRF output into an aggregate one
+  liftVRFOutput ::
+    Proxy crypto ->
+    VRFOutput crypto ->
+    AggregateVRFOutput crypto
+
+  -- | Verify an aggregate vote signature for a given election and candidate
+  verifyAggregateVRFOutput ::
+    AggregateVRFVerificationKey crypto ->
+    VRFElectionInput crypto ->
+    AggregateVRFOutput crypto ->
+    Either String ()
+
+-- ** Trivial aggregate VRF verification helpers
+
+newtype TrivialAggregateVRFVerificationKey crypto
+  = TrivialAggregateVRFVerificationKey (NE [VRFVerificationKey crypto])
+  deriving newtype Semigroup
+
+newtype TrivialAggregateVRFOutput crypto
+  = TrivialAggregateVRFOutput (NE [VRFOutput crypto])
+  deriving newtype Semigroup
+
+trivialLiftVRFVerificationKey ::
+  Proxy crypto ->
+  VRFVerificationKey crypto ->
+  TrivialAggregateVRFVerificationKey crypto
+trivialLiftVRFVerificationKey _ =
+  TrivialAggregateVRFVerificationKey
+    . NonEmpty.singleton
+
+trivialLiftVRFOutput ::
+  Proxy crypto ->
+  VRFOutput crypto ->
+  TrivialAggregateVRFOutput crypto
+trivialLiftVRFOutput _ =
+  TrivialAggregateVRFOutput
+    . NonEmpty.singleton
+
+trivialVerifyAggregateVRFOutput ::
+  CryptoSupportsVRF crypto =>
+  TrivialAggregateVRFVerificationKey crypto ->
+  VRFElectionInput crypto ->
+  TrivialAggregateVRFOutput crypto ->
+  Either String ()
+trivialVerifyAggregateVRFOutput
+  (TrivialAggregateVRFVerificationKey keys)
+  vrfInput
+  (TrivialAggregateVRFOutput vrfOutputs)
+    | length keys /= length vrfOutputs =
+        Left $
+          "Aggregate VRF output verification failed: "
+            <> "number of keys and outputs do not match"
+    | not (null errors) =
+        Left $
+          "Aggregate VRF output verification failed: "
+            <> intercalate "; " errors
+    | otherwise =
+        Right ()
+   where
+    (errors, _) =
+      partitionEithers $
+        zipWith
+          ( \key vrfOutput ->
+              evalVRF (VRFVerifyContext key vrfOutput) vrfInput
+          )
+          (NonEmpty.toList keys)
+          (NonEmpty.toList vrfOutputs)

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Committee/Types.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Committee/Types.hs
@@ -1,0 +1,46 @@
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+-- | Types common to any generic committee selection scheme
+module Ouroboros.Consensus.Committee.Types
+  ( PoolId (..)
+  , LedgerStake (..)
+  , VoteWeight (..)
+  , TargetCommitteeSize (..)
+  , Cumulative (..)
+  ) where
+
+import Cardano.Ledger.BaseTypes (HasZero)
+import Cardano.Ledger.Core (KeyHash, KeyRole (..))
+import Data.Word (Word64)
+
+-- | Identifier of a given voter in the committee selection scheme
+newtype PoolId = PoolId
+  { unPoolId :: KeyHash StakePool
+  }
+  deriving (Show, Eq, Ord)
+
+-- | Stake of a voter as reflected by the ledger state
+newtype LedgerStake = LedgerStake
+  { unLedgerStake :: Rational
+  }
+  deriving (Show, Eq)
+  deriving newtype (Num, HasZero)
+
+-- | Voting power of a voter in the committee selection scheme
+newtype VoteWeight = VoteWeight
+  { unVoteWeight :: Rational
+  }
+  deriving (Show, Eq)
+
+-- | Target committee size
+newtype TargetCommitteeSize = TargetCommitteeSize
+  { unTargetCommitteeSize :: Word64
+  }
+  deriving (Show, Eq)
+
+-- | Wrapper to tag accumulated resources
+newtype Cumulative a = Cumulative
+  { unCumulative :: a
+  }
+  deriving (Show, Eq)


### PR DESCRIPTION
This PR implements a generic interface that can be used to instantiate multiple voting committee schemes using multiple crypto backends for vote and certificate signing and validation.

The main `CryptoSupportsVotingCommittee` type class allows implementations to define abstract votes and certificate types, check when a node should vote, and forge and verify certificates and votes.

In addition, it provides a wrapper that allows us to keep track of two
simultaneous voting committees, the one corresponding to the current epoch, and the one from the previous one. This is needed to validate votes and certificates arriving slightly late at the beginning of a new epoch.