### PR TITLE
[Peras 25] Conformance and property tests for voting committee implementations

### DIFF
--- a/ouroboros-consensus.cabal
+++ b/ouroboros-consensus.cabal
@@ -644,6 +644,7 @@ test-suite consensus-test
   other-modules:
     Test.Consensus.BlockchainTime.Simple
     Test.Consensus.Committee.TestCrypto
+    Test.Consensus.Committee.Utils
     Test.Consensus.Committee.WFALS
     Test.Consensus.Committee.WFALS.Conformance
     Test.Consensus.Committee.WFALS.Model

--- a/ouroboros-consensus.cabal
+++ b/ouroboros-consensus.cabal
@@ -650,6 +650,7 @@ test-suite consensus-test
     Test.Consensus.Committee.WFALS.Model
     Test.Consensus.Committee.WFALS.Model.Tests
     Test.Consensus.Committee.WFALS.Model.Utils
+    Test.Consensus.Committee.WFALS.Tests
     Test.Consensus.HardFork.Forecast
     Test.Consensus.HardFork.History
     Test.Consensus.HardFork.Infra

--- a/ouroboros-consensus.cabal
+++ b/ouroboros-consensus.cabal
@@ -643,6 +643,7 @@ test-suite consensus-test
   main-is: Main.hs
   other-modules:
     Test.Consensus.BlockchainTime.Simple
+    Test.Consensus.Committee.Class
     Test.Consensus.Committee.EveryoneVotes
     Test.Consensus.Committee.EveryoneVotes.Tests
     Test.Consensus.Committee.TestCrypto

--- a/ouroboros-consensus.cabal
+++ b/ouroboros-consensus.cabal
@@ -643,6 +643,8 @@ test-suite consensus-test
   main-is: Main.hs
   other-modules:
     Test.Consensus.BlockchainTime.Simple
+    Test.Consensus.Committee.EveryoneVotes
+    Test.Consensus.Committee.EveryoneVotes.Tests
     Test.Consensus.Committee.TestCrypto
     Test.Consensus.Committee.Utils
     Test.Consensus.Committee.WFALS

--- a/ouroboros-consensus.cabal
+++ b/ouroboros-consensus.cabal
@@ -648,7 +648,8 @@ test-suite consensus-test
     Test.Consensus.Committee.WFALS
     Test.Consensus.Committee.WFALS.Conformance
     Test.Consensus.Committee.WFALS.Model
-    Test.Consensus.Committee.WFALS.Model.Test
+    Test.Consensus.Committee.WFALS.Model.Tests
+    Test.Consensus.Committee.WFALS.Model.Utils
     Test.Consensus.HardFork.Forecast
     Test.Consensus.HardFork.History
     Test.Consensus.HardFork.Infra

--- a/ouroboros-consensus/test/consensus-test/Main.hs
+++ b/ouroboros-consensus/test/consensus-test/Main.hs
@@ -3,6 +3,7 @@
 module Main (main) where
 
 import qualified Test.Consensus.BlockchainTime.Simple (tests)
+import qualified Test.Consensus.Committee.Class (tests)
 import qualified Test.Consensus.Committee.EveryoneVotes (tests)
 import qualified Test.Consensus.Committee.TestCrypto (tests)
 import qualified Test.Consensus.Committee.WFALS (tests)
@@ -45,6 +46,7 @@ tests =
         "Committee"
         [ Test.Consensus.Committee.WFALS.tests
         , Test.Consensus.Committee.EveryoneVotes.tests
+        , Test.Consensus.Committee.Class.tests
         , Test.Consensus.Committee.TestCrypto.tests
         ]
     , Test.Consensus.HeaderValidation.tests

--- a/ouroboros-consensus/test/consensus-test/Main.hs
+++ b/ouroboros-consensus/test/consensus-test/Main.hs
@@ -3,6 +3,7 @@
 module Main (main) where
 
 import qualified Test.Consensus.BlockchainTime.Simple (tests)
+import qualified Test.Consensus.Committee.EveryoneVotes (tests)
 import qualified Test.Consensus.Committee.TestCrypto (tests)
 import qualified Test.Consensus.Committee.WFALS (tests)
 import qualified Test.Consensus.HardFork.Forecast (tests)
@@ -43,6 +44,7 @@ tests =
     , testGroup
         "Committee"
         [ Test.Consensus.Committee.WFALS.tests
+        , Test.Consensus.Committee.EveryoneVotes.tests
         , Test.Consensus.Committee.TestCrypto.tests
         ]
     , Test.Consensus.HeaderValidation.tests

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/Committee/Class.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/Committee/Class.hs
@@ -1,0 +1,182 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# OPTIONS_GHC -Wno-unused-top-binds #-}
+
+-- | Test properties for the generic voting committee class helpers
+module Test.Consensus.Committee.Class (tests) where
+
+import Data.Containers.NonEmpty (HasNonEmpty (..))
+import Data.Function (on)
+import Data.List.NonEmpty (NonEmpty ((:|)))
+import qualified Data.List.NonEmpty as NonEmpty
+import Data.Proxy (Proxy (..))
+import GHC.Word (Word64)
+import Ouroboros.Consensus.Committee.Class
+  ( UniqueVotesWithSameTargetError (..)
+  , checkUniqueVotesWithSameTarget
+  )
+import Ouroboros.Consensus.Committee.Crypto
+  ( ElectionId
+  , VoteCandidate
+  )
+import Test.Consensus.Committee.TestCrypto (TestCrypto)
+import qualified Test.Consensus.Committee.TestCrypto as TestCrypto
+import Test.Consensus.Committee.Utils (mkBucket)
+import Test.QuickCheck
+  ( Arbitrary (..)
+  , Gen
+  , Positive (..)
+  , Property
+  , Small (..)
+  , counterexample
+  , forAll
+  , tabulate
+  , vectorOf
+  , (.&&.)
+  , (===)
+  )
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.QuickCheck (Testable (..), testProperty)
+import Test.Util.TestEnv (adjustQuickCheckTests)
+
+tests :: TestTree
+tests =
+  testGroup
+    "UniqueVotesWithSameTarget properties"
+    [ adjustQuickCheckTests (* 10) $
+        testProperty
+          "prop_checkUniqueVotesWithSameTarget"
+          prop_checkUniqueVotesWithSameTarget
+    ]
+
+-- * Mock committee implementation for testing
+
+type TestVoterId = Word64
+
+data TestVote
+  = TestVote
+  { tvElectionId :: ElectionId TestCrypto
+  , tvCandidate :: VoteCandidate TestCrypto
+  , tvVoterId :: TestVoterId
+  }
+  deriving (Eq, Show)
+
+-- * Test property
+
+prop_checkUniqueVotesWithSameTarget :: Property
+prop_checkUniqueVotesWithSameTarget =
+  forAll genVotes $ \votes -> do
+    let result =
+          checkUniqueVotesWithSameTarget
+            (Proxy @TestCrypto)
+            getVoteTarget
+            cmpVoteId
+            votes
+    tabulate "Outcome" [showOutcome result]
+      . tabulate "List length" [mkBucket 10 (fromIntegral (length votes))]
+      . counterexample
+        ( unlines
+            [ "Unexpected outcome:"
+            , "Votes: " <> show votes
+            , "Result: " <> showOutcome result
+            ]
+        )
+      $ case result of
+        Left (DuplicateVotes duplicateVotes) -> do
+          counterexample
+            ( unlines
+                [ "Duplicate votes: " <> show duplicateVotes
+                ]
+            )
+            $ (length duplicateVotes > 1)
+              .&&. (property (uniqueVoterIdsCount duplicateVotes == 1))
+        Left (TargetMismatch firstVote mismatchingVotes) -> do
+          counterexample
+            ( unlines
+                [ "First vote: " <> show firstVote
+                , "Mismatching votes: " <> show mismatchingVotes
+                ]
+            )
+            $ (allSameTarget votes === Nothing)
+              .&&. (all (\v' -> getVoteTarget v' /= getVoteTarget firstVote) mismatchingVotes)
+        Right () -> do
+          let firstVote = NonEmpty.head votes
+          counterexample
+            ( unlines
+                [ "First votes: " <> show votes
+                ]
+            )
+            $ (allSameTarget votes === Just (getVoteTarget firstVote))
+              .&&. (uniqueVoterIdsCount votes === length votes)
+
+-- * Generators
+
+-- | Generate a vote list (empty, all same target, or mixed targets)
+genVotes :: Gen (NE [TestVote])
+genVotes = do
+  numVotes <- genNumVotes
+  NonEmpty.fromList <$> vectorOf numVotes genVote
+ where
+  genNumVotes = do
+    getSmall . getPositive
+      <$> arbitrary @(Positive (Small Int))
+
+  genVote = do
+    (electionId, candidate) <- genTarget
+    voterId <- genVoterId
+    pure (TestVote electionId candidate voterId)
+
+  genTarget = do
+    electionId <- TestCrypto.genElectionId
+    candidate <- TestCrypto.genVoteCandidate
+    pure (electionId, candidate)
+
+  genVoterId = do
+    getSmall <$> arbitrary @(Small TestVoterId)
+
+-- * Helpers
+
+-- | Get the target from a vote
+getVoteTarget ::
+  TestVote ->
+  (ElectionId TestCrypto, VoteCandidate TestCrypto)
+getVoteTarget = \case
+  TestVote electionId candidate _ -> (electionId, candidate)
+
+-- | Compare two votes by their ID
+cmpVoteId ::
+  TestVote ->
+  TestVote ->
+  Ordering
+cmpVoteId =
+  compare `on` \case
+    TestVote _ _ voteId -> voteId
+
+-- | Check if all votes in a non-empty list have the same target
+allSameTarget ::
+  NE [TestVote] ->
+  Maybe (ElectionId TestCrypto, VoteCandidate TestCrypto)
+allSameTarget (v :| vs)
+  | all (\v' -> getVoteTarget v == getVoteTarget v') vs =
+      Just (getVoteTarget v)
+  | otherwise =
+      Nothing
+
+-- | Get the number of unique voter IDs in a non-empty list of votes
+uniqueVoterIdsCount ::
+  NE [TestVote] ->
+  Int
+uniqueVoterIdsCount votes =
+  length (NonEmpty.nubBy ((==) `on` tvVoterId) votes)
+
+-- | Show the outcome of ensureSameTarget
+showOutcome ::
+  Either (UniqueVotesWithSameTargetError TestVote) () ->
+  String
+showOutcome (Left (TargetMismatch _ _)) = "TargetMismatch"
+showOutcome (Left (DuplicateVotes _)) = "DuplicateVotes"
+showOutcome (Right ()) = "Success"

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/Committee/EveryoneVotes.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/Committee/EveryoneVotes.hs
@@ -1,0 +1,11 @@
+module Test.Consensus.Committee.EveryoneVotes (tests) where
+
+import qualified Test.Consensus.Committee.EveryoneVotes.Tests as Impl
+import Test.Tasty (TestTree, testGroup)
+
+tests :: TestTree
+tests =
+  testGroup
+    "EveryoneVotes"
+    [ Impl.tests
+    ]

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/Committee/EveryoneVotes/Tests.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/Committee/EveryoneVotes/Tests.hs
@@ -1,0 +1,408 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+
+-- | Test properties for the EveryoneVotes implementation using TestCrypto.
+module Test.Consensus.Committee.EveryoneVotes.Tests (tests) where
+
+import Cardano.Ledger.BaseTypes
+import Data.Function (on)
+import Data.List (intercalate, sortOn)
+import Data.List.NonEmpty (NonEmpty ((:|)))
+import qualified Data.List.NonEmpty as NonEmpty
+import Data.Map (Map)
+import qualified Data.Map.Strict as Map
+import Ouroboros.Consensus.Committee.Class
+  ( CryptoSupportsVotingCommittee (..)
+  , ensureUniqueVotesWithSameTarget
+  )
+import Ouroboros.Consensus.Committee.Crypto
+  ( PrivateKey
+  , PublicKey
+  )
+import Ouroboros.Consensus.Committee.EveryoneVotes
+  ( EligibilityWitness (..)
+  , EveryoneVotes
+  , Vote (..)
+  , VotingCommitteeInput (..)
+  , candidateSeats
+  , numActiveVoters
+  )
+import Ouroboros.Consensus.Committee.Types
+  ( LedgerStake (..)
+  , PoolId
+  )
+import Ouroboros.Consensus.Committee.WFA
+  ( NumPoolsWithPositiveStake (..)
+  , SeatIndex (..)
+  , mkExtWFAStakeDistr
+  )
+import Test.Consensus.Committee.TestCrypto (TestCrypto)
+import qualified Test.Consensus.Committee.TestCrypto as TestCrypto
+import Test.Consensus.Committee.Utils
+  ( eqWithShowCmp
+  , genPools
+  , genPositiveStake
+  , mkBucket
+  , onError
+  , tabulateNumPools
+  , tabulatePoolStake
+  , unfairWFATiebreaker
+  )
+import Test.QuickCheck
+  ( Gen
+  , Property
+  , Testable (..)
+  , choose
+  , counterexample
+  , elements
+  , forAll
+  , forAllShow
+  , frequency
+  , tabulate
+  )
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.QuickCheck (testProperty)
+import Test.Util.TestEnv (adjustQuickCheckTests)
+
+tests :: TestTree
+tests =
+  testGroup
+    "Implementation tests using TestCrypto"
+    [ adjustQuickCheckTests (* 10) $
+        testProperty
+          "prop_checkShouldVote_verifyVote"
+          prop_checkShouldVote_verifyVote
+    , adjustQuickCheckTests (* 10) $
+        testProperty
+          "prop_fakeVotesDontVerify"
+          prop_fakeVotesDontVerify
+    , testProperty
+        "prop_forgeCert_verifyCert"
+        prop_forgeCert_verifyCert
+    ]
+
+-- | If a pool is entitled to vote in a given committee, the vote it casts
+-- should be verifiable under the same committee.
+prop_checkShouldVote_verifyVote :: Property
+prop_checkShouldVote_verifyVote =
+  forAll (genPools 1000 TestCrypto.genKeyPair) $ \pools ->
+    forAll (samplePool pools) $ \(poolId, poolPrivateKey, poolStake) ->
+      forAll TestCrypto.genElectionId $ \electionId ->
+        forAll TestCrypto.genVoteCandidate $ \candidate -> do
+          let extWFAStakeDistr =
+                mkExtWFAStakeDistr
+                  unfairWFATiebreaker
+                  (Map.map (\(_, pubKey, stake) -> (stake, pubKey)) pools)
+                  `onError` \err ->
+                    error ("mkExtWFAStakeDistr failed: " <> show err)
+          let committee =
+                mkVotingCommittee @TestCrypto @EveryoneVotes
+                  ( EveryoneVotesVotingCommitteeInput
+                      extWFAStakeDistr
+                  )
+                  `onError` \err ->
+                    error ("mkVotingCommittee failed: " <> show err)
+          let shouldVote =
+                checkShouldVote
+                  committee
+                  poolId
+                  poolPrivateKey
+                  electionId
+                  `onError` \err ->
+                    error ("checkShouldVote failed: " <> show err)
+          tabulateNumPools pools
+            . tabulatePoolStake poolStake
+            . tabulateShouldVote shouldVote
+            $ case shouldVote of
+              -- The pool is eligible to vote => cast a vote using their
+              -- eligibility witness and make sure it verifies under the
+              -- same voting committee.
+              Just witness -> do
+                let vote =
+                      forgeVote
+                        witness
+                        poolPrivateKey
+                        electionId
+                        candidate
+                case verifyVote committee vote of
+                  Left err ->
+                    counterexample
+                      ("vote verification failed: " <> show err)
+                      $ property False
+                  Right witness' ->
+                    counterexample
+                      "vote verification mismatch"
+                      $ eqWithShowCmp
+                        showWitness
+                        cmpWitness
+                        witness
+                        witness'
+              -- The pool is not eligible to vote => do nothing
+              Nothing ->
+                property True
+
+-- | Votes cast using fake eligibility witnesses should fail verification.
+prop_fakeVotesDontVerify :: Property
+prop_fakeVotesDontVerify =
+  forAll (genPools 1000 TestCrypto.genKeyPair) $ \pools -> do
+    forAll (samplePool pools) $ \(_, poolPrivateKey, poolStake) ->
+      forAll TestCrypto.genElectionId $ \electionId ->
+        forAll TestCrypto.genVoteCandidate $ \candidate -> do
+          let extWFAStakeDistr =
+                mkExtWFAStakeDistr
+                  unfairWFATiebreaker
+                  (Map.map (\(_, pubKey, stake) -> (stake, pubKey)) pools)
+                  `onError` \err ->
+                    error ("mkExtWFAStakeDistr failed: " <> show err)
+          let committee =
+                mkVotingCommittee @TestCrypto @EveryoneVotes
+                  ( EveryoneVotesVotingCommitteeInput
+                      extWFAStakeDistr
+                  )
+                  `onError` \err ->
+                    error ("mkVotingCommittee failed: " <> show err)
+          forAllShow
+            ( genFakeEligibilityWitness
+                committee
+                poolStake
+            )
+            (showWitness . snd)
+            $ \(fakeWitnessType, fakeWitness) -> do
+              let fakeVote =
+                    forgeVote
+                      fakeWitness
+                      poolPrivateKey
+                      electionId
+                      candidate
+              tabulateNumPools pools
+                . tabulateFakeWitnessType fakeWitnessType
+                $ case verifyVote committee fakeVote of
+                  Left _ ->
+                    property True
+                  Right _ ->
+                    counterexample
+                      ( unlines
+                          [ "vote verification succeeded but should have failed:"
+                          , "fake witness type: " <> show fakeWitnessType
+                          ]
+                      )
+                      $ property False
+
+-- | If we forge a certificate from many votes with the same target, verifying
+-- it should succeed and return the eligibility witnesses.
+prop_forgeCert_verifyCert :: Property
+prop_forgeCert_verifyCert =
+  forAll (genPools 1000 TestCrypto.genKeyPair) $ \pools ->
+    forAll TestCrypto.genElectionId $ \electionId ->
+      forAll TestCrypto.genVoteCandidate $ \candidate -> do
+        let extWFAStakeDistr =
+              mkExtWFAStakeDistr
+                unfairWFATiebreaker
+                (Map.map (\(_, pubKey, stake) -> (stake, pubKey)) pools)
+                `onError` \err ->
+                  error ("mkExtWFAStakeDistr failed: " <> show err)
+        let committee =
+              mkVotingCommittee @TestCrypto @EveryoneVotes
+                ( EveryoneVotesVotingCommitteeInput
+                    extWFAStakeDistr
+                )
+                `onError` \err ->
+                  error ("mkVotingCommittee failed: " <> show err)
+        -- Forge votes from all eligible pools
+        let (votes, originalWitnesses) =
+              unzip $
+                [ ( forgeVote witness privateKey electionId candidate
+                  , witness
+                  )
+                | (poolId, (privateKey, _, _)) <- Map.toList pools
+                , Just witness <-
+                    [ checkShouldVote
+                        committee
+                        poolId
+                        privateKey
+                        electionId
+                        `onError` \err ->
+                          error ("checkShouldVote failed: " <> show err)
+                    ]
+                ]
+        tabulateNumPools pools
+          . tabulateNumVotes (length votes)
+          $ case votes of
+            [] ->
+              -- No eligible voters, nothing to test
+              property True
+            firstVote : nextVotes -> do
+              let uniqueVotesWithSameTarget =
+                    ensureUniqueVotesWithSameTarget
+                      ( \case
+                          EveryoneVotesVote _ eid cand _ -> (eid, cand)
+                      )
+                      ( compare `on` \case
+                          EveryoneVotesVote seatIndex _ _ _ -> seatIndex
+                      )
+                      (firstVote :| nextVotes)
+                      `onError` \_ ->
+                        error "votes don't have the same target!"
+              let cert =
+                    forgeCert uniqueVotesWithSameTarget
+                      `onError` \err ->
+                        error ("forgeCert failed: " <> show err)
+              case verifyCert committee cert of
+                Left err ->
+                  counterexample
+                    ("certificate verification failed: " <> show err)
+                    $ property False
+                Right witnesses -> do
+                  let witnessesFromCert = NonEmpty.toList witnesses
+                  counterexample
+                    ( unlines
+                        [ "witnesses mismatch!"
+                        , "expected these " <> show (length originalWitnesses) <> " witnesses:"
+                        , intercalate "\n" (fmap showWitness originalWitnesses)
+                        , "but got these " <> show (length witnessesFromCert) <> " witnesses:"
+                        , intercalate "\n" (fmap showWitness witnessesFromCert)
+                        ]
+                    )
+                    $ cmpWitnesses originalWitnesses witnessesFromCert
+
+-- * Generators
+
+samplePool ::
+  Map PoolId (PrivateKey TestCrypto, PublicKey TestCrypto, LedgerStake) ->
+  Gen (PoolId, PrivateKey TestCrypto, LedgerStake)
+samplePool pools =
+  elements
+    [ (poolId, privateKey, ledgerStake)
+    | (poolId, (privateKey, _, ledgerStake)) <- Map.toList pools
+    ]
+
+data FakeEligibilityWitnessType
+  = PoolWithZeroStake
+  | SeatIndexOutOfBounds
+  deriving Show
+
+-- | Generate a fake eligibility witness that would fail verification if used
+-- to cast a vote.
+--
+-- This breaks the structure of a valid witness in two ways:
+--  1. generating a witness for a pool with zero stake, or
+--  2. generating a witness with a seat index outside of the valid range.
+genFakeEligibilityWitness ::
+  VotingCommittee TestCrypto EveryoneVotes ->
+  LedgerStake ->
+  Gen (FakeEligibilityWitnessType, EligibilityWitness TestCrypto EveryoneVotes)
+genFakeEligibilityWitness
+  committee
+  poolStake = do
+    frequency
+      [
+        ( if totalSeats > nonZeroStakeSeats then 1 else 0
+        , genPoolWithZeroStakeWitness
+        )
+      ,
+        ( 1
+        , genSeatIndexOutOfBoundsWitness
+        )
+      ]
+   where
+    totalSeats = fromIntegral (Map.size (candidateSeats committee))
+    nonZeroStakeSeats = unNumPoolsWithPositiveStake (numActiveVoters committee)
+
+    -- This witness points to a valid seat index but it fakes a non-zero stake
+    -- for a pool that actually has zero stake (case 1).
+    genPoolWithZeroStakeWitness = do
+      seatIndex <- SeatIndex <$> choose (nonZeroStakeSeats, totalSeats - 1)
+      ledgerStake <- genPositiveStake
+      -- traceShow (">>>>>", nonZeroStakeSeats, totalSeats, seatIndex) $
+      pure
+        ( PoolWithZeroStake
+        , EveryoneVotesMember
+            seatIndex
+            (unsafeNonZero ledgerStake)
+        )
+
+    -- This witness has a seat index that lies outside the valid range (case 2).
+    genSeatIndexOutOfBoundsWitness = do
+      seatIndex <- SeatIndex <$> choose (totalSeats, totalSeats + 100)
+      pure
+        ( SeatIndexOutOfBounds
+        , EveryoneVotesMember
+            seatIndex
+            (unsafeNonZero poolStake)
+        )
+
+-- * Property helpers
+
+showWitness ::
+  EligibilityWitness TestCrypto EveryoneVotes ->
+  String
+showWitness witness =
+  case witness of
+    EveryoneVotesMember seatIndex stake ->
+      "Member(SeatIndex="
+        <> show seatIndex
+        <> ", Stake="
+        <> show (unLedgerStake (unNonZero stake))
+        <> ")"
+
+cmpWitness ::
+  EligibilityWitness TestCrypto EveryoneVotes ->
+  EligibilityWitness TestCrypto EveryoneVotes ->
+  Bool
+cmpWitness w1 w2 =
+  case (w1, w2) of
+    ( EveryoneVotesMember seatIndex1 stake1
+      , EveryoneVotesMember seatIndex2 stake2
+      ) ->
+        seatIndex1 == seatIndex2
+          && stake1 == stake2
+
+cmpWitnesses ::
+  [EligibilityWitness TestCrypto EveryoneVotes] ->
+  [EligibilityWitness TestCrypto EveryoneVotes] ->
+  Bool
+cmpWitnesses ws1 ws2 =
+  length ws1 == length ws2
+    && all
+      (uncurry cmpWitness)
+      (zip (sortBySeatIndex ws1) (sortBySeatIndex ws2))
+ where
+  sortBySeatIndex =
+    sortOn $ \case
+      EveryoneVotesMember seatIndex _ -> seatIndex
+
+-- * Tabulation helpers
+
+tabulateShouldVote ::
+  Maybe (EligibilityWitness TestCrypto EveryoneVotes) ->
+  Property ->
+  Property
+tabulateShouldVote shouldVote =
+  tabulate
+    "Should vote"
+    [ case shouldVote of
+        Nothing ->
+          "NoVote"
+        Just (EveryoneVotesMember _ _) ->
+          "Vote"
+    ]
+
+tabulateFakeWitnessType ::
+  FakeEligibilityWitnessType ->
+  Property ->
+  Property
+tabulateFakeWitnessType fakeWitnessType =
+  tabulate
+    "Fake witness type"
+    [show fakeWitnessType]
+
+tabulateNumVotes ::
+  Int ->
+  Property ->
+  Property
+tabulateNumVotes numVotes =
+  tabulate
+    "Number of votes"
+    [mkBucket 100 (fromIntegral numVotes)]

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/Committee/TestCrypto.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/Committee/TestCrypto.hs
@@ -34,7 +34,7 @@ import Cardano.Crypto.DSIGN
   )
 import Cardano.Crypto.Hash (ByteString, Hash)
 import qualified Cardano.Crypto.Hash as Hash
-import Cardano.Ledger.BaseTypes (Nonce (..), mkNonceFromNumber)
+import Cardano.Ledger.BaseTypes (Nonce (..))
 import Cardano.Ledger.Binary (runByteBuilder)
 import Cardano.Ledger.Hashes (HASH)
 import Control.Monad (when)
@@ -63,6 +63,7 @@ import Ouroboros.Consensus.Committee.Crypto
   )
 import Ouroboros.Consensus.Committee.Crypto.BLS (KeyRole (..))
 import qualified Ouroboros.Consensus.Committee.Crypto.BLS as BLS
+import Test.Consensus.Committee.Utils (genEpochNonce)
 import Test.QuickCheck
   ( Arbitrary (..)
   , Gen
@@ -72,7 +73,6 @@ import Test.QuickCheck
   , choose
   , counterexample
   , forAll
-  , frequency
   , suchThat
   , tabulate
   , vectorOf
@@ -233,13 +233,6 @@ instance CryptoSupportsBatchVRFVerification TestCrypto where
         $ sigs
 
 -- * QuickCheck helpers
-
-genEpochNonce :: Gen Nonce
-genEpochNonce =
-  frequency
-    [ (1, pure NeutralNonce)
-    , (9, mkNonceFromNumber <$> arbitrary)
-    ]
 
 genElectionId :: Gen (ElectionId TestCrypto)
 genElectionId =

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/Committee/Utils.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/Committee/Utils.hs
@@ -1,0 +1,202 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE FlexibleContexts #-}
+
+-- | Utility functions for the voting committee tests.
+module Test.Consensus.Committee.Utils
+  ( -- * General utilities
+    mkPoolId
+  , unfairWFATiebreaker
+
+    -- * QuickCheck generators
+  , genEpochNonce
+  , genPositiveStake
+  , genPools
+
+    -- * Property helpers
+  , eqWithShowCmp
+  , onError
+  , mkBucket
+
+    -- * Tabulation helpers
+  , tabulateNumPools
+  , tabulatePoolStake
+  ) where
+
+import qualified Cardano.Crypto.DSIGN.Class as SL
+import qualified Cardano.Crypto.Seed as SL
+import Cardano.Ledger.BaseTypes (Nonce (..), mkNonceFromNumber)
+import qualified Cardano.Ledger.Core as SL
+import qualified Cardano.Ledger.Keys as SL
+import Data.Map (Map)
+import qualified Data.Map.Strict as Map
+import Data.String (IsString (..))
+import Ouroboros.Consensus.Committee.Types (LedgerStake (..), PoolId (..))
+import Ouroboros.Consensus.Committee.WFA (WFATiebreaker (..))
+import Test.QuickCheck
+  ( Arbitrary (..)
+  , Gen
+  , Property
+  , choose
+  , counterexample
+  , elements
+  , frequency
+  , tabulate
+  , vectorOf
+  )
+import Test.Util.QuickCheck (geometric)
+
+-- * General utilities
+
+-- | Create a pool ID from an arbitrary string of any length.
+--
+-- NOTE: we are assuming that this function preserves uniqueness.
+mkPoolId :: String -> PoolId
+mkPoolId str =
+  PoolId
+    . SL.hashKey
+    . SL.VKey
+    . SL.deriveVerKeyDSIGN
+    . SL.genKeyDSIGN
+    . SL.mkSeedFromBytes
+    . fromString
+    $ paddedStr
+ where
+  paddedStr
+    | length str >= neededBytes = take neededBytes str
+    | otherwise = str <> replicate (neededBytes - length str) '0'
+
+  neededBytes = 32
+
+-- | An unfair tie-breaker that compares pool IDs lexicographically.
+unfairWFATiebreaker :: WFATiebreaker
+unfairWFATiebreaker =
+  WFATiebreaker compare
+
+-- * QuickCheck generators
+
+-- | Generate a random nonce for testing purposes.
+genEpochNonce :: Gen Nonce
+genEpochNonce =
+  frequency
+    [ (1, pure NeutralNonce)
+    , (9, mkNonceFromNumber <$> arbitrary)
+    ]
+
+-- | Generate a positive stake value using a geometric distribution.
+genPositiveStake :: Gen LedgerStake
+genPositiveStake =
+  LedgerStake
+    . toRational
+    . (+ 1)
+    <$> geometric 0.25
+
+-- | Generate a non-empty map of pools with crypto keys and varying stakes.
+--
+-- NOTE: the generator ensures at least one pool has positive stake.
+genPools ::
+  -- | Maximum number of pools to generate
+  Int ->
+  -- | Keypair generator
+  Gen (privateKey, publicKey) ->
+  Gen (Map PoolId (privateKey, publicKey, LedgerStake))
+genPools maxPools genKeyPair = do
+  numPools <-
+    choose (1, maxPools)
+  numPoolsWithZeroStake <-
+    choose (0, numPools - 1)
+  poolsWithZeroStake <-
+    vectorOf
+      numPoolsWithZeroStake
+      (genOnePool (pure (LedgerStake 0)))
+  poolsWithPositiveStake <-
+    vectorOf
+      (numPools - numPoolsWithZeroStake)
+      (genOnePool genPositiveStake)
+  pure $
+    Map.fromList (poolsWithZeroStake <> poolsWithPositiveStake)
+ where
+  genOnePool genStake = do
+    poolId <- alphaNumString
+    (privateKey, publicKey) <- genKeyPair
+    stake <- genStake
+    pure (mkPoolId poolId, (privateKey, publicKey, stake))
+
+  alphaNumString =
+    vectorOf 8 $
+      elements $
+        ['a' .. 'z']
+          <> ['A' .. 'Z']
+          <> ['0' .. '9']
+
+-- * Property helpers
+
+-- | Check equality using a custom comparison and show function.
+eqWithShowCmp ::
+  -- | Custom show function
+  (a -> String) ->
+  -- | Custom equality function
+  (a -> a -> Bool) ->
+  -- | First value
+  a ->
+  -- | Second value
+  a ->
+  Property
+eqWithShowCmp showValue eqValue x y =
+  counterexample (showValue x <> interpret res <> showValue y) res
+ where
+  res = eqValue x y
+  interpret True = " == "
+  interpret False = " /= "
+
+-- | Handle 'Either' errors by converting them to values.
+onError :: Either err a -> (err -> a) -> a
+onError action onLeft =
+  case action of
+    Left err -> onLeft err
+    Right val -> val
+
+-- | Create a bucketized label for tabulation.
+mkBucket ::
+  -- | Bucket size
+  Integer ->
+  -- | Value to bucket
+  Integer ->
+  String
+mkBucket size val
+  | val <= 0 =
+      "<= 0"
+  | otherwise =
+      "[ " <> show lo <> ", " <> show hi <> " )"
+ where
+  lo = (val `div` size) * size
+  hi = lo + size
+
+-- * Tabulation helpers
+
+-- | Tabulate the number of pools in a test run.
+tabulateNumPools ::
+  Map
+    PoolId
+    ( privateKey
+    , publicKey
+    , LedgerStake
+    ) ->
+  Property ->
+  Property
+tabulateNumPools pools =
+  tabulate
+    "Number of pools"
+    [mkBucket 100 (fromIntegral (Map.size pools))]
+
+-- | Tabulate whether a pool has positive or zero stake.
+tabulatePoolStake ::
+  LedgerStake ->
+  Property ->
+  Property
+tabulatePoolStake (LedgerStake stake) =
+  tabulate
+    "Pool stake"
+    [ if stake > 0
+        then "> 0"
+        else "== 0"
+    ]

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/Committee/WFALS.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/Committee/WFALS.hs
@@ -1,20 +1,17 @@
-module Test.Consensus.Committee.WFALS
-  ( tests
-  )
-where
+{-# LANGUAGE RankNTypes #-}
+
+module Test.Consensus.Committee.WFALS (tests) where
 
 import qualified Data.Map.Strict as Map
 import Test.Consensus.Committee.WFALS.Conformance (conformsToRustImplementation)
 import qualified Test.Consensus.Committee.WFALS.Model as Model
-import qualified Test.Consensus.Committee.WFALS.Model.Test as Model
+import qualified Test.Consensus.Committee.WFALS.Model.Tests as Model
 import Test.Tasty (TestTree, testGroup)
-import Test.Tasty.QuickCheck (testProperty)
-import Test.Util.TestEnv (adjustQuickCheckTests)
 
 tests :: TestTree
 tests =
   testGroup
-    "weighted Fait-Accompli committee selection tests"
+    "WFALS"
     [ Model.tests
     , modelConformsToRustImplementation
     ]
@@ -22,15 +19,26 @@ tests =
 -- | Check that the model implementation matches the Rust one
 modelConformsToRustImplementation :: TestTree
 modelConformsToRustImplementation =
-  adjustQuickCheckTests (* 10) $
-    testProperty "model conforms to Rust implementation" $
-      conformsToRustImplementation model
+  conformsToRustImplementation
+    "Model conforms to Rust implementation"
+    mkStakeDistr
+    model
  where
-  model stakeDistr targetCommitteeSize =
-    let (persistentSeats, numNonPersistentSeats, _) =
-          Model.weightedFaitAccompliPersistentSeats
-            (fromIntegral targetCommitteeSize)
-            (Map.map Model.rationalToStake stakeDistr)
-     in ( Map.size persistentSeats
+  -- NOTE: this is not a good tiebreaker for real-world use, but it is
+  -- sufficient here because the actual order of pools with the same stake does
+  -- not matter when computing the persistent vs. non-persistent seat /counts/.
+  tiebreaker =
+    compare
+
+  mkStakeDistr =
+    Map.map Model.rationalToStake
+
+  model stakeDistr targetCommitteeSize = do
+    let totalSeats = fromIntegral targetCommitteeSize
+    case Model.weightedFaitAccompliPersistentSeats tiebreaker totalSeats stakeDistr of
+      Left err ->
+        error $ "Model implementation failed with error: " <> show err
+      Right (persistentSeats, numNonPersistentSeats, _) ->
+        ( fromIntegral (Map.size persistentSeats)
         , fromIntegral numNonPersistentSeats
         )

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/Committee/WFALS.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/Committee/WFALS.hs
@@ -27,6 +27,7 @@ import Test.Consensus.Committee.WFALS.Model
 import qualified Test.Consensus.Committee.WFALS.Model as Model
 import qualified Test.Consensus.Committee.WFALS.Model.Tests as Model
 import qualified Test.Consensus.Committee.WFALS.Model.Utils as Model
+import qualified Test.Consensus.Committee.WFALS.Tests as Impl
 import Test.QuickCheck
   ( Property
   , Testable (..)
@@ -44,6 +45,7 @@ tests =
   testGroup
     "WFALS"
     [ Model.tests
+    , Impl.tests
     , modelConformsToRustImplementation
     , realImplementationConformsToRustImplementation
     , modelConformsToRealImplementation

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/Committee/WFALS.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/Committee/WFALS.hs
@@ -1,12 +1,43 @@
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RankNTypes #-}
 
 module Test.Consensus.Committee.WFALS (tests) where
 
+import qualified Cardano.Crypto.DSIGN.Class as SL
+import qualified Cardano.Crypto.Seed as SL
+import qualified Cardano.Ledger.Keys as SL
+import qualified Data.Array as Array
+import Data.Bifunctor (Bifunctor (..))
+import Data.Either (partitionEithers)
+import Data.Function (on)
 import qualified Data.Map.Strict as Map
+import qualified Data.Set as Set
+import Data.String (IsString (..))
+import qualified Ouroboros.Consensus.Committee.Types as WFA
+import Ouroboros.Consensus.Committee.WFA (WFATiebreaker (..))
+import qualified Ouroboros.Consensus.Committee.WFA as WFA
+import Test.Consensus.Committee.Utils (mkPoolId)
 import Test.Consensus.Committee.WFALS.Conformance (conformsToRustImplementation)
+import Test.Consensus.Committee.WFALS.Model
+  ( NumSeats
+  , StakeDistr
+  , StakeRole (..)
+  , StakeType (..)
+  )
 import qualified Test.Consensus.Committee.WFALS.Model as Model
 import qualified Test.Consensus.Committee.WFALS.Model.Tests as Model
+import qualified Test.Consensus.Committee.WFALS.Model.Utils as Model
+import Test.QuickCheck
+  ( Property
+  , Testable (..)
+  , counterexample
+  , tabulate
+  , (.&&.)
+  , (===)
+  )
 import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.QuickCheck (testProperty)
+import Test.Util.TestEnv (adjustQuickCheckTests)
 
 tests :: TestTree
 tests =
@@ -14,6 +45,8 @@ tests =
     "WFALS"
     [ Model.tests
     , modelConformsToRustImplementation
+    , realImplementationConformsToRustImplementation
+    , modelConformsToRealImplementation
     ]
 
 -- | Check that the model implementation matches the Rust one
@@ -42,3 +75,202 @@ modelConformsToRustImplementation =
         ( fromIntegral (Map.size persistentSeats)
         , fromIntegral numNonPersistentSeats
         )
+
+-- | Check that the real implementation matches the Rust one
+realImplementationConformsToRustImplementation :: TestTree
+realImplementationConformsToRustImplementation =
+  conformsToRustImplementation
+    "Real implementation conforms to Rust implementation"
+    mkStakeDistr
+    impl
+ where
+  -- NOTE: this is not a good tiebreaker for real-world use, but it is
+  -- sufficient here because the actual order of pools with the same stake does
+  -- not matter when computing the persistent vs. non-persistent seat /counts/.
+  tiebreaker =
+    WFATiebreaker compare
+
+  mkStakeDistr =
+    expectRight
+      ( \err ->
+          error ("could not build a stake distribution: " <> show err)
+      )
+      . WFA.mkExtWFAStakeDistr tiebreaker
+      . Map.mapKeys
+        ( \str ->
+            WFA.PoolId
+              . SL.hashKey
+              . SL.VKey
+              . SL.deriveVerKeyDSIGN
+              . SL.genKeyDSIGN
+              . SL.mkSeedFromBytes
+              . fromString
+              $ str
+        )
+      . Map.map
+        ( \stake ->
+            (WFA.LedgerStake stake, ())
+        )
+
+  impl stakeDistr targetCommitteeSize =
+    let
+      totalSeats =
+        WFA.TargetCommitteeSize (fromIntegral targetCommitteeSize)
+      (persistentSeats, nonPersistentSeats, _, _) =
+        expectRight
+          ( \err ->
+              error ("weightedFaitAccompliSplitSeats failed: " <> show err)
+          )
+          $ WFA.weightedFaitAccompliSplitSeats stakeDistr totalSeats
+     in
+      ( fromIntegral (WFA.unPersistentCommitteeSize persistentSeats)
+      , fromIntegral (WFA.unNonPersistentCommitteeSize nonPersistentSeats)
+      )
+
+  expectRight onLeft = \case
+    Left err -> onLeft err
+    Right a -> a
+
+-- | Check that the model implementation conforms to the real implementation
+-- using QuickCheck generators
+modelConformsToRealImplementation :: TestTree
+modelConformsToRealImplementation =
+  adjustQuickCheckTests (* 10) $
+    testProperty
+      "Model conforms to real implementation"
+      prop_modelConformsToRealImplementation
+
+-- | Property: the model and real implementations should produce the same
+-- number of persistent and non-persistent seats
+prop_modelConformsToRealImplementation :: Property
+prop_modelConformsToRealImplementation =
+  Model.forAllPossiblyInvalidStakeDistrAndNumSeats $ \stakeDistr numSeats -> do
+    -- NOTE: we use a trivial tiebreaker here because we are not interested in
+    -- fairness here. However, the model's tiebreaker needs to be adapted below
+    -- to produce the same ordering based on the 'PoolId' we derive from the
+    -- string keys in the random stake distribution, so that both
+    -- implementations select the same pools as persistent vs. non-persistent.
+    let realTiebreaker :: WFA.PoolId -> WFA.PoolId -> Ordering
+        realTiebreaker = compare
+    -- Run the model
+    let modelOutput =
+          Model.weightedFaitAccompliPersistentSeats
+            (realTiebreaker `on` mkPoolId)
+            numSeats
+            stakeDistr
+    -- Run the real implementation
+    let realOutput = do
+          let mkEntry stake = (WFA.LedgerStake (Model.stakeToRational stake), ())
+          extWFAStakeDistr <-
+            WFA.mkExtWFAStakeDistr (WFATiebreaker realTiebreaker)
+              . Map.mapKeys (\str -> mkPoolId str)
+              . Map.map (\stake -> mkEntry stake)
+              $ stakeDistr
+          wfaOutput <-
+            WFA.weightedFaitAccompliSplitSeats
+              extWFAStakeDistr
+              (WFA.TargetCommitteeSize (fromIntegral numSeats))
+          return (extWFAStakeDistr, wfaOutput)
+    -- Compare their results
+    tabulateOutcome realOutput
+      . tabulateMoreSeatsThanNodes stakeDistr numSeats
+      $ case (modelOutput, realOutput) of
+        -- Both implementations failed (we don't care about the specific error)
+        (Left _, Left _) ->
+          property True
+        -- Model failed but real implementation succeeded
+        (Left modelErr, Right _) ->
+          counterexample
+            ( "Model implementation failed with error: "
+                <> show modelErr
+                <> " but real implementation succeeded with output: "
+                <> show realOutput
+            )
+            $ property False
+        -- Model succeeded but real implementation failed
+        (Right _, Left realErr) ->
+          counterexample
+            ( "Real implementation failed with error: "
+                <> show realErr
+                <> " but model implementation succeeded with output: "
+                <> show modelOutput
+            )
+            $ property False
+        -- Both implementations succeeded, compare their outputs
+        ( Right
+            ( modelPersistentStakeDistr
+              , modelNonPersistentSeats
+              , modelNonPersistentStakeDistr
+              )
+          , Right
+              ( extWFAStakeDistr
+                , ( WFA.PersistentCommitteeSize realPersistentSeats
+                    , WFA.NonPersistentCommitteeSize realNonPersistentSeats
+                    , WFA.TotalPersistentStake
+                        (WFA.Cumulative (WFA.LedgerStake realPersistentStake))
+                    , WFA.TotalNonPersistentStake
+                        (WFA.Cumulative (WFA.LedgerStake realNonPersistentStake))
+                    )
+                )
+          ) -> do
+            let modelPersistentPools =
+                  Set.map mkPoolId (Map.keysSet modelPersistentStakeDistr)
+            let modelNonPersistentPools =
+                  Set.map mkPoolId (Map.keysSet modelNonPersistentStakeDistr)
+            let Model.StakeLedgerResidual modelNonPersistentStake =
+                  sum (Map.elems modelNonPersistentStakeDistr)
+            let Model.StakeWeightPersistent modelPersistentStake =
+                  sum (Map.elems modelPersistentStakeDistr)
+            let splitPools (WFA.SeatIndex i, (poolId, _, _, _))
+                  | realPersistentSeats == 0 = Right poolId
+                  | i >= realPersistentSeats = Right poolId
+                  | otherwise = Left poolId
+            let (realPersistentPools, realNonPersistentPools) =
+                  bimap Set.fromList Set.fromList
+                    . partitionEithers
+                    . fmap splitPools
+                    . Array.assocs
+                    . WFA.unExtWFAStakeDistr
+                    $ extWFAStakeDistr
+            counterexample
+              ( unlines
+                  [ "Model persistent pools: " <> show modelPersistentPools
+                  , "Model non-persistent pools: " <> show modelNonPersistentPools
+                  , "Model persistent stake: " <> show modelPersistentStake
+                  , "Model non-persistent stake: " <> show modelNonPersistentStake
+                  , "Real persistent pools: " <> show realPersistentPools
+                  , "Real non-persistent pools: " <> show realNonPersistentPools
+                  , "Real persistent stake: " <> show realPersistentStake
+                  , "Real non-persistent stake: " <> show realNonPersistentStake
+                  ]
+              )
+              $ (modelPersistentPools === realPersistentPools)
+                .&&. (modelNonPersistentPools === realNonPersistentPools)
+                .&&. (modelNonPersistentStake === realNonPersistentStake)
+                .&&. (modelPersistentStake === realPersistentStake)
+                .&&. (fromIntegral modelNonPersistentSeats === realNonPersistentSeats)
+
+-- * Tabulation helpers
+
+tabulateMoreSeatsThanNodes ::
+  StakeDistr Ledger Global ->
+  NumSeats Global ->
+  Property ->
+  Property
+tabulateMoreSeatsThanNodes stakeDistr numSeats =
+  tabulate
+    "More target seats than nodes"
+    [ show (numSeats > fromIntegral (Map.size stakeDistr))
+    ]
+
+tabulateOutcome ::
+  Either err a ->
+  Property ->
+  Property
+tabulateOutcome result =
+  tabulate
+    "Outcome"
+    [ case result of
+        Left _ -> "Failure"
+        Right _ -> "Success"
+    ]

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/Committee/WFALS/Conformance.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/Committee/WFALS/Conformance.hs
@@ -3,7 +3,13 @@
 {-# LANGUAGE TemplateHaskell #-}
 
 module Test.Consensus.Committee.WFALS.Conformance
-  ( conformsToRustImplementation
+  ( CommitteeSize
+  , NumPersistent
+  , NumNonPersistent
+  , PoolId
+  , Stake
+  , StakeDistr
+  , conformsToRustImplementation
   )
 where
 
@@ -17,14 +23,14 @@ import Data.Array (Array)
 import qualified Data.Array as Array
 import qualified Data.FileEmbed as FileEmbed
 import Data.Map.Strict (Map)
+import Data.Word (Word64)
 import System.FilePath ((</>))
-import Test.QuickCheck (Property)
-import Test.QuickCheck.Gen (Gen, choose)
-import Test.QuickCheck.Property (counterexample, forAll, (===))
+import Test.Tasty (TestTree)
+import Test.Tasty.HUnit (assertEqual, testCase)
 
-type CommitteeSize = Int
-type NumPersistent = Int
-type NumNonPersistent = Int
+type CommitteeSize = Word64
+type NumPersistent = Word64
+type NumNonPersistent = Word64
 type PoolId = String
 type Stake = Rational
 type StakeDistr = Map PoolId Stake
@@ -66,8 +72,8 @@ rustResults =
     Array.listArray (0, length pairs - 1) pairs
 
 -- | Embedded stake distribution
-stakeDistr :: StakeDistr
-stakeDistr =
+exampleStakeDistr :: StakeDistr
+exampleStakeDistr =
   either error id $
     eitherDecodeStrict $
       $( FileEmbed.embedFile $
@@ -78,41 +84,43 @@ stakeDistr =
              </> "stake_distr.json"
        )
 
--- | Sample a value from an array
-sampleArray :: Array Int a -> Gen a
-sampleArray array = do
-  i <- choose (Array.bounds array)
-  pure $ (Array.!) array i
-
 -- | Check that a weighted fait accompli committee selection implementation
 -- conforms to the Rust implementation by comparing the number persistent and
 -- non-persistent committee members it selects for a given target committee size.
 conformsToRustImplementation ::
-  ( Map PoolId Stake ->
+  String ->
+  (Map PoolId Stake -> stakeDistr) ->
+  ( stakeDistr ->
     CommitteeSize ->
     ( NumPersistent
     , NumNonPersistent
     )
   ) ->
-  Property
-conformsToRustImplementation wfals = do
-  forAll (sampleArray rustResults) $
-    \RustResult
-       { targetCommitteeSize
-       , numPersistent
-       , numNonPersistent
-       } -> do
-        let (actualNumPersistent, actualNumNonPersistent) =
-              wfals stakeDistr targetCommitteeSize
-        counterexample
-          ( unlines
-              [ "Target committee size: "
-                  <> show targetCommitteeSize
-              , "Expected (persistent, non-persistent): "
-                  <> show (numPersistent, numNonPersistent)
-              , "Actual (persistent, non-persistent): "
-                  <> show (actualNumPersistent, actualNumNonPersistent)
-              ]
-          )
-          $ (actualNumPersistent, actualNumNonPersistent)
-            === (numPersistent, numNonPersistent)
+  TestTree
+conformsToRustImplementation name mkStakeDistr wfa = do
+  testCase name (go (Array.bounds rustResults))
+ where
+  stakeDistr = mkStakeDistr exampleStakeDistr
+
+  go (currStep, lastStep)
+    | currStep > lastStep =
+        pure ()
+    | otherwise = do
+        step ((Array.!) rustResults currStep)
+        go (succ currStep, lastStep)
+
+  step RustResult{targetCommitteeSize, numPersistent, numNonPersistent} = do
+    let (actualNumPersistent, actualNumNonPersistent) =
+          wfa stakeDistr targetCommitteeSize
+    assertEqual
+      ( unlines
+          [ "Target committee size: "
+              <> show targetCommitteeSize
+          , "Expected (persistent, non-persistent): "
+              <> show (numPersistent, numNonPersistent)
+          , "Actual (persistent, non-persistent): "
+              <> show (actualNumPersistent, actualNumNonPersistent)
+          ]
+      )
+      (numPersistent, numNonPersistent)
+      (actualNumPersistent, actualNumNonPersistent)

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/Committee/WFALS/Model.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/Committee/WFALS/Model.hs
@@ -39,6 +39,7 @@ module Test.Consensus.Committee.WFALS.Model
   , stakeDistrTotalStake
 
     -- * Fait Accompli Committee Selection
+  , WFAError
   , weightedFaitAccompliWith
   , weightedFaitAccompliPersistentSeats
   , weightedFaitAccompliThreshold
@@ -51,7 +52,6 @@ import Data.Kind (Type)
 import Data.List (sortBy)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import Data.Ord (Down (..), comparing)
 import Data.Traversable (mapAccumR)
 import GHC.Generics (Generic)
 import Numeric.Natural (Natural, minusNaturalMaybe)
@@ -156,23 +156,42 @@ stakeDistrTotalStake ::
 stakeDistrTotalStake distr =
   sum (Map.elems distr)
 
--- | View a stake distribution as a non-increasing list of stakes
+-- | View a stake distribution as a non-increasing list of stakes.
+--
+-- Like the real implementation, this also uses a tiebreaker to control how
+-- voters with the same stake are ordered in the resulting list.
 stakeDistrToDecreasingStakes ::
   IsStake (Stake sr st) =>
+  (VoterId -> VoterId -> Ordering) ->
   StakeDistr sr st ->
   [(VoterId, Stake sr st)]
-stakeDistrToDecreasingStakes distr =
-  sortBy (comparing (Down . snd)) (Map.toList distr)
+stakeDistrToDecreasingStakes tiebreaker distr =
+  sortBy
+    descendingStakeWithTiebreaker
+    (Map.toList distr)
+ where
+  descendingStakeWithTiebreaker
+    (poolId1, stake1)
+    (poolId2, stake2)
+      -- The pools have different stake => sort them in descending order
+      | stake1 /= stake2 = compare stake2 stake1
+      -- The pools have the same stake => use the tiebreaker to sort them
+      | otherwise = tiebreaker poolId1 poolId2
 
 -------------------------------------------------------------------------------
 
 -- * Fait Accompli Committee Selection
+
+-- | Errors that can occur while computing a weighted Fait Accompli committee selection.
+type WFAError = String
 
 -- | Weighted Fait Accompli committee selection with a fallback mechanism.
 --
 -- This is mostly just plumbing to connect the result of
 -- 'weightedFaitAccompliPersistentSeats' with a given fallback scheme.
 weightedFaitAccompliWith ::
+  -- | Tiebreaker to control the order of voters with the same stake
+  (VoterId -> VoterId -> Ordering) ->
   -- | Fallback function for non-persistent seats
   ( NumSeats Residual ->
     StakeDistr Ledger Residual ->
@@ -184,21 +203,22 @@ weightedFaitAccompliWith ::
   StakeDistr Ledger Global ->
   -- | Selected persistent and non-persistent seats with their corresponding
   -- voting stakes
-  ( StakeDistr Weight Persistent
-  , StakeDistr Weight Residual
-  )
-weightedFaitAccompliWith fallback globalNumSeats stakeDistr =
-  (persistentSeats, nonPersistentSeats)
- where
-  (persistentSeats, numNonPersistentSeats, residualStakeDistr) =
+  Either
+    WFAError
+    ( StakeDistr Weight Persistent
+    , StakeDistr Weight Residual
+    )
+weightedFaitAccompliWith tiebreaker fallback globalNumSeats stakeDistr = do
+  (persistentSeats, numNonPersistentSeats, residualStakeDistr) <-
     weightedFaitAccompliPersistentSeats
+      tiebreaker
       globalNumSeats
       stakeDistr
-
-  nonPersistentSeats =
-    fallback
-      numNonPersistentSeats
-      residualStakeDistr
+  let nonPersistentSeats =
+        fallback
+          numNonPersistentSeats
+          residualStakeDistr
+  pure (persistentSeats, nonPersistentSeats)
 
 -- | First step of the weighted Fait Accompli committee selection.
 --
@@ -206,22 +226,35 @@ weightedFaitAccompliWith fallback globalNumSeats stakeDistr =
 -- Fait Accompli threshold, and returns the remaining stake distribution for the
 -- non-persistent seats selection.
 weightedFaitAccompliPersistentSeats ::
+  (VoterId -> VoterId -> Ordering) ->
   NumSeats Global ->
   StakeDistr Ledger Global ->
-  ( StakeDistr Weight Persistent
-  , NumSeats Residual
-  , StakeDistr Ledger Residual
-  )
-weightedFaitAccompliPersistentSeats globalNumSeats stakeDistr
+  Either
+    WFAError
+    ( StakeDistr Weight Persistent
+    , NumSeats Residual
+    , StakeDistr Ledger Residual
+    )
+weightedFaitAccompliPersistentSeats tiebreaker globalNumSeats stakeDistr
   | globalNumSeats <= 0 =
-      error "Number of seats must be positive"
+      Left "Number of seats must be positive"
   | Map.size stakeDistr == 0 =
-      error "Stake distribution cannot be empty"
+      Left "Stake distribution cannot be empty"
   | sum stakeDistr == 0 =
-      error "Total stake must be positive"
+      Left "Total stake must be positive"
+  | numPoolsWithPositiveStake < globalNumSeats =
+      Left "Not enough voters with positive stake to fill all expected seats"
   | otherwise =
-      (persistentSeats, numNonPersistentSeats, residualStakeDistr)
+      Right (persistentSeats, numNonPersistentSeats, residualStakeDistr)
  where
+  -- Number of voters with positive stake in the input distribution
+  numPoolsWithPositiveStake =
+    fromIntegral
+      . length
+      . filter (> 0)
+      . Map.elems
+      $ stakeDistr
+
   -- Persistent seats selected deterministically based on their ledger stake.
   -- NOTE: their voting stake is *exactly* their ledger stake.
   persistentSeats =
@@ -264,7 +297,7 @@ weightedFaitAccompliPersistentSeats globalNumSeats stakeDistr
   rightCumulativeDecreasingStakes =
     accumStakeR $
       addSeatIndex $
-        stakeDistrToDecreasingStakes $
+        stakeDistrToDecreasingStakes tiebreaker $
           stakeDistr
    where
     -- Add an increasing seat index to each candidate

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/Committee/WFALS/Model/Tests.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/Committee/WFALS/Model/Tests.hs
@@ -1,22 +1,17 @@
 {-# LANGUAGE TypeApplications #-}
 
 -- | Test properties for the weighted Fait-Accompli committee selection model
-module Test.Consensus.Committee.WFALS.Model.Test (tests) where
+module Test.Consensus.Committee.WFALS.Model.Tests (tests) where
 
 import Data.List (mapAccumR)
 import qualified Data.Map.Strict as Map
-import Data.Ratio ((%))
-import qualified Data.Set as Set
-import Data.Word (Word64)
 import Numeric.Natural (minusNaturalMaybe)
 import Test.Consensus.Committee.WFALS.Model
   ( IsStake (..)
-  , NumSeats
   , Stake (..)
-  , StakeDistr
   , StakeRole (..)
   , StakeType (..)
-  , VoterId
+  , WFAError
   , adjustStake
   , coerceStake
   , stakeDistrToDecreasingStakes
@@ -24,18 +19,19 @@ import Test.Consensus.Committee.WFALS.Model
   , weightedFaitAccompliPersistentSeats
   , weightedFaitAccompliThreshold
   )
+import Test.Consensus.Committee.WFALS.Model.Utils
+  ( forAllValidStakeDistrAndNumSeats
+  , genStakeDistr
+  , tabulatePersistentToNonPersistentRatio
+  , tabulateStakeDistrSize
+  , tabulateTargetNumSeats
+  )
 import Test.QuickCheck
-  ( Arbitrary (..)
-  , Gen
-  , Positive (..)
-  , Property
+  ( Property
   , Testable (..)
-  , choose
   , counterexample
   , forAll
   , sized
-  , tabulate
-  , vectorOf
   , (===)
   , (==>)
   )
@@ -43,121 +39,14 @@ import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.QuickCheck (testProperty)
 import Test.Util.TestEnv (adjustQuickCheckTests)
 
--- * Property tests
-
--- ** Generators
-
--- | Generate a random stake as a Rational number
-genStake :: Gen (Stake Ledger Global)
-genStake = do
-  Positive num <- arbitrary
-  Positive den <- arbitrary
-  pure (StakeLedgerGlobal (num % den))
-
--- | Generate a non-empty list of unique voter IDs of a given size.
-genUniqueVoterIds :: Int -> Gen [VoterId]
-genUniqueVoterIds size =
-  fmap show <$> go size Set.empty
- where
-  go 0 acc =
-    return (Set.toList acc)
-  go k acc = do
-    voterId <- choose (0, maxBound :: Word64)
-    if voterId `Set.member` acc
-      then
-        go k acc
-      else do
-        rest <- go (k - 1) (Set.insert voterId acc)
-        pure (voterId : rest)
-
--- | Generate a non-empty random stake distribution of a given size
---
--- NOTE: the size is shifted up by one to ensure non-emptiness.
-genStakeDistr :: Int -> Gen (StakeDistr Ledger Global)
-genStakeDistr size = do
-  ids <- genUniqueVoterIds (succ size)
-  stakes <- vectorOf (succ size) genStake
-  pure (Map.fromList (zip ids stakes))
-
--- * Property helpers
-
--- | Helper to generate stake distributions along with a number of seats that
--- could possibly exceed the number of nodes in the stake distribution.
-forAllStakeDistrAndNumSeats ::
-  (StakeDistr Ledger Global -> NumSeats Global -> Property) ->
-  Property
-forAllStakeDistrAndNumSeats p =
-  forAll (sized genStakeDistr) $ \stakeDistr -> do
-    let numNodes = fromIntegral (Map.size stakeDistr)
-    -- generate a number of seats that could possibly exceed the number of nodes
-    let genNumSeats = fromInteger <$> choose (1, numNodes + 1)
-    forAll genNumSeats $ \numSeats -> p stakeDistr numSeats
-
--- | Tabulate the target number of seats
-tabulateTargetNumSeats :: NumSeats Global -> Property -> Property
-tabulateTargetNumSeats numSeats =
-  tabulate "Target number of seats" [bucket]
- where
-  -- Divide in buckets of 10
-  bucket
-    | lower == upper = show lower
-    | otherwise = show lower <> "-" <> show upper
-  lower = (numSeats `div` 10) * 10
-  upper = lower + 9
-
--- | Tabulate the size of a stake distribution
-tabulateStakeDistrSize :: StakeDistr Ledger Global -> Property -> Property
-tabulateStakeDistrSize stakeDistr =
-  tabulate "Stake distribution size" [bucket]
- where
-  -- Divide in buckets of 10
-  bucket
-    | lower == upper = show lower
-    | otherwise = show lower <> "-" <> show upper
-  lower = (size `div` 10) * 10
-  upper = lower + 9
-  size = Map.size stakeDistr
-
--- | Tabulate whether we are asking for more seats than nodes in the stake
--- distribution or not
-tabulateMoreSeatsThanNodes ::
-  StakeDistr Ledger Global ->
-  NumSeats Global ->
-  Property ->
-  Property
-tabulateMoreSeatsThanNodes stakeDistr numSeats =
-  tabulate
-    "More target seats than nodes"
-    [ show (numSeats > fromIntegral (Map.size stakeDistr))
-    ]
-
--- | Tabulate the ratio of persistent to non-persistent seats as the percentage
--- of persistent seats out of the total number of seats.
-tabulatePersistentToNonPersistentRatio ::
-  NumSeats Global ->
-  NumSeats Global ->
-  Property ->
-  Property
-tabulatePersistentToNonPersistentRatio
-  numPersistentSeats
-  numNonPersistentSeats =
-    tabulate "Persistent to non-persistent seat ratio" [bucket]
-   where
-    -- Divide buckets in 10% increments
-    bucket
-      | lower == upper = show lower <> "%"
-      | otherwise = show lower <> "%-" <> show upper <> "%"
-    lower = (numPersistentSeats * 100) `div` totalSeats `div` 10 * 10
-    upper = min 100 (lower + 10)
-    totalSeats = numPersistentSeats + numNonPersistentSeats
-
--- ** Properties
+-- * Properties
 
 -- | Stakes returned by 'stakeDistrToDecreasingStakes' are non-increasing
 prop_stakeDistrDecreasingStakes :: Property
 prop_stakeDistrDecreasingStakes =
   forAll (sized genStakeDistr) $ \stakeDistr -> do
-    let stakes = fmap snd (stakeDistrToDecreasingStakes stakeDistr)
+    let tiebreaker = compare -- unfair tiebreaker
+    let stakes = fmap snd (stakeDistrToDecreasingStakes tiebreaker stakeDistr)
     case stakes of
       [] -> True -- vacuously true for empty stake distributions
       (_ : rest) -> and (zipWith (>=) stakes rest)
@@ -166,9 +55,14 @@ prop_stakeDistrDecreasingStakes =
 -- exceed the requested number of seats.
 prop_weightedFaitAccompliPersistentSeats_persistentSeatsRespectNumSeats :: Property
 prop_weightedFaitAccompliPersistentSeats_persistentSeatsRespectNumSeats =
-  forAllStakeDistrAndNumSeats $ \stakeDistr numSeats -> do
+  forAllValidStakeDistrAndNumSeats $ \stakeDistr numSeats -> do
+    let tiebreaker = compare -- unfair tiebreaker
     let (persistentSeats, numNonPersistentSeats, _) =
-          weightedFaitAccompliPersistentSeats numSeats stakeDistr
+          expectSuccess $
+            weightedFaitAccompliPersistentSeats
+              tiebreaker
+              numSeats
+              stakeDistr
     let numPersistentSeats = fromIntegral (Map.size persistentSeats)
     tabulateTargetNumSeats numSeats
       . tabulateStakeDistrSize stakeDistr
@@ -187,15 +81,19 @@ prop_weightedFaitAccompliPersistentSeats_persistentSeatsRespectNumSeats =
 -- of the remaining the nodes in the residual stake distribution.
 prop_weightedFaitAccompliPersistentSeats_persistentSeatsHaveLargeStake :: Property
 prop_weightedFaitAccompliPersistentSeats_persistentSeatsHaveLargeStake =
-  forAllStakeDistrAndNumSeats $ \stakeDistr numSeats -> do
+  forAllValidStakeDistrAndNumSeats $ \stakeDistr numSeats -> do
+    let tiebreaker = compare -- unfair tiebreaker
     let (persistentSeats, numNonPersistentSeats, residualStakeDistr) =
-          weightedFaitAccompliPersistentSeats numSeats stakeDistr
+          expectSuccess $
+            weightedFaitAccompliPersistentSeats
+              tiebreaker
+              numSeats
+              stakeDistr
     let numPersistentSeats = fromIntegral (Map.size persistentSeats)
     let persistentStakes = Map.elems persistentSeats
     let residualStakes = Map.elems residualStakeDistr
     tabulateStakeDistrSize stakeDistr
       . tabulateTargetNumSeats numSeats
-      . tabulateMoreSeatsThanNodes stakeDistr numSeats
       . tabulatePersistentToNonPersistentRatio numPersistentSeats numNonPersistentSeats
       $ counterexample
         ( unlines
@@ -215,9 +113,14 @@ prop_weightedFaitAccompliPersistentSeats_persistentSeatsHaveLargeStake =
 -- total stake.
 prop_weightedFaitAccompliPersistentSeats_totalStakePreserved :: Property
 prop_weightedFaitAccompliPersistentSeats_totalStakePreserved =
-  forAllStakeDistrAndNumSeats $ \stakeDistr numSeats -> do
+  forAllValidStakeDistrAndNumSeats $ \stakeDistr numSeats -> do
+    let tiebreaker = compare -- unfair tiebreaker
     let (persistentSeats, numNonPersistentSeats, residualStakeDistr) =
-          weightedFaitAccompliPersistentSeats numSeats stakeDistr
+          expectSuccess $
+            weightedFaitAccompliPersistentSeats
+              tiebreaker
+              numSeats
+              stakeDistr
     let numPersistentSeats = fromIntegral (Map.size persistentSeats)
     let totalOriginalStake = stakeDistrTotalStake stakeDistr
     let totalPersistentStake = stakeDistrTotalStake persistentSeats
@@ -227,7 +130,6 @@ prop_weightedFaitAccompliPersistentSeats_totalStakePreserved =
             + stakeToRational totalResidualStake
     tabulateStakeDistrSize stakeDistr
       . tabulateTargetNumSeats numSeats
-      . tabulateMoreSeatsThanNodes stakeDistr numSeats
       . tabulatePersistentToNonPersistentRatio numPersistentSeats numNonPersistentSeats
       $ counterexample
         ( unlines
@@ -244,13 +146,17 @@ prop_weightedFaitAccompliPersistentSeats_totalStakePreserved =
 -- original number of seats minus the number of persistent seats.
 prop_weightedFaitAccompliPersistentSeats_nonPersistentSeatsCountCorrect :: Property
 prop_weightedFaitAccompliPersistentSeats_nonPersistentSeatsCountCorrect =
-  forAllStakeDistrAndNumSeats $ \stakeDistr numSeats -> do
+  forAllValidStakeDistrAndNumSeats $ \stakeDistr numSeats -> do
+    let tiebreaker = compare -- unfair tiebreaker
     let (persistentSeats, numNonPersistentSeats, _) =
-          weightedFaitAccompliPersistentSeats numSeats stakeDistr
+          expectSuccess $
+            weightedFaitAccompliPersistentSeats
+              tiebreaker
+              numSeats
+              stakeDistr
     let numPersistentSeats = fromIntegral (Map.size persistentSeats)
     tabulateStakeDistrSize stakeDistr
       . tabulateTargetNumSeats numSeats
-      . tabulateMoreSeatsThanNodes stakeDistr numSeats
       . tabulatePersistentToNonPersistentRatio numPersistentSeats numNonPersistentSeats
       $ counterexample
         ( unlines
@@ -268,9 +174,14 @@ prop_weightedFaitAccompliPersistentSeats_nonPersistentSeatsCountCorrect =
 -- seat according to the weighted Fait Accompli threshold.
 prop_weightedFaitAccompliPersistentSeats_residualSeatsDoNotQualify :: Property
 prop_weightedFaitAccompliPersistentSeats_residualSeatsDoNotQualify =
-  forAllStakeDistrAndNumSeats $ \stakeDistr numSeats -> do
+  forAllValidStakeDistrAndNumSeats $ \stakeDistr numSeats -> do
+    let tiebreaker = compare -- unfair tiebreaker
     let (persistentSeats, numNonPersistentSeats, residualStakeDistr) =
-          weightedFaitAccompliPersistentSeats numSeats stakeDistr
+          expectSuccess $
+            weightedFaitAccompliPersistentSeats
+              tiebreaker
+              numSeats
+              stakeDistr
     let numPersistentSeats =
           fromIntegral (Map.size persistentSeats)
     let addSeatIndex =
@@ -296,7 +207,7 @@ prop_weightedFaitAccompliPersistentSeats_residualSeatsDoNotQualify =
     let rightCumulativeDecreasingResidualStakes =
           accumStakeR $
             addSeatIndex $
-              stakeDistrToDecreasingStakes residualStakeDistr
+              stakeDistrToDecreasingStakes tiebreaker residualStakeDistr
 
     let judgments =
           fmap
@@ -318,7 +229,6 @@ prop_weightedFaitAccompliPersistentSeats_residualSeatsDoNotQualify =
             rightCumulativeDecreasingResidualStakes
     tabulateStakeDistrSize stakeDistr
       . tabulateTargetNumSeats numSeats
-      . tabulateMoreSeatsThanNodes stakeDistr numSeats
       . tabulatePersistentToNonPersistentRatio numPersistentSeats numNonPersistentSeats
       $ counterexample
         ( unlines
@@ -334,12 +244,18 @@ prop_weightedFaitAccompliPersistentSeats_residualSeatsDoNotQualify =
         (\(_, _, _, _, aboveThreshold) -> not aboveThreshold)
         judgments
 
+expectSuccess :: Either WFAError a -> a
+expectSuccess result =
+  case result of
+    Left err -> error $ "Model failed unexpectedly: " <> err
+    Right val -> val
+
 -- | Test suite
 tests :: TestTree
 tests =
   adjustQuickCheckTests (* 100) $
     testGroup
-      "weighted Fait-Accompli committee selection model property tests"
+      "Model property tests"
       [ testProperty
           "prop_stakeDistrDecreasingStakes"
           prop_stakeDistrDecreasingStakes

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/Committee/WFALS/Model/Utils.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/Committee/WFALS/Model/Utils.hs
@@ -1,0 +1,140 @@
+-- | Utility functions for the WFALS model tests.
+module Test.Consensus.Committee.WFALS.Model.Utils
+  ( -- * Generators
+    genStake
+  , genUniqueVoterIds
+  , genStakeDistr
+
+    -- * Property helpers
+  , forAllValidStakeDistrAndNumSeats
+  , forAllPossiblyInvalidStakeDistrAndNumSeats
+  , tabulateTargetNumSeats
+  , tabulateStakeDistrSize
+  , tabulatePersistentToNonPersistentRatio
+  ) where
+
+import qualified Data.Map.Strict as Map
+import Data.Ratio ((%))
+import qualified Data.Set as Set
+import Data.Word (Word64)
+import Test.Consensus.Committee.Utils (mkBucket)
+import Test.Consensus.Committee.WFALS.Model
+  ( IsStake (..)
+  , NumSeats
+  , Stake (..)
+  , StakeDistr
+  , StakeRole (..)
+  , StakeType (..)
+  , VoterId
+  )
+import Test.QuickCheck
+  ( Arbitrary (..)
+  , Gen
+  , Positive (..)
+  , Property
+  , choose
+  , forAll
+  , sized
+  , tabulate
+  , vectorOf
+  )
+
+-- * Generators
+
+-- | Generate a random stake as a Rational number
+genStake :: Gen (Stake Ledger Global)
+genStake = do
+  Positive num <- arbitrary
+  Positive den <- arbitrary
+  pure (StakeLedgerGlobal (num % den))
+
+-- | Generate a non-empty list of unique voter IDs of a given size.
+genUniqueVoterIds :: Int -> Gen [VoterId]
+genUniqueVoterIds size =
+  fmap show <$> go size Set.empty
+ where
+  go 0 acc =
+    return (Set.toList acc)
+  go k acc = do
+    voterId <- choose (0, maxBound :: Word64)
+    if voterId `Set.member` acc
+      then
+        go k acc
+      else do
+        rest <- go (k - 1) (Set.insert voterId acc)
+        pure (voterId : rest)
+
+-- | Generate a non-empty random stake distribution of a given size
+--
+-- NOTE: the size is shifted up by one to ensure non-emptiness.
+genStakeDistr :: Int -> Gen (StakeDistr Ledger Global)
+genStakeDistr size = do
+  ids <- genUniqueVoterIds (succ size)
+  stakes <- vectorOf (succ size) genStake
+  pure (Map.fromList (zip ids stakes))
+
+-- * Property helpers
+
+-- | Helper to generate stake distributions along with a number of seats that
+-- lies within the acceptable range [1, #{nodes with positive stake}]
+forAllValidStakeDistrAndNumSeats ::
+  (StakeDistr Ledger Global -> NumSeats Global -> Property) ->
+  Property
+forAllValidStakeDistrAndNumSeats p =
+  forAll (sized genStakeDistr) $ \stakeDistr -> do
+    let numPositiveStakeNodes =
+          fromIntegral
+            . length
+            . filter ((> 0) . stakeToRational)
+            . Map.elems
+            $ stakeDistr
+    let genNumSeats =
+          fromInteger <$> choose (1, numPositiveStakeNodes)
+    forAll genNumSeats $ \numSeats ->
+      p stakeDistr numSeats
+
+-- | Helper to generate stake distributions along with a number of seats that
+-- could possibly be invalid in different ways, e.g., too many expected seats
+-- or an empty stake distribution.
+forAllPossiblyInvalidStakeDistrAndNumSeats ::
+  (StakeDistr Ledger Global -> NumSeats Global -> Property) ->
+  Property
+forAllPossiblyInvalidStakeDistrAndNumSeats p =
+  forAll (sized genStakeDistr) $ \stakeDistr -> do
+    let numNodes =
+          fromIntegral (Map.size stakeDistr)
+    let genNumSeats =
+          fromInteger <$> choose (1, numNodes + 1)
+    forAll genNumSeats $ \numSeats ->
+      p stakeDistr numSeats
+
+-- | Tabulate the target number of seats
+tabulateTargetNumSeats :: NumSeats Global -> Property -> Property
+tabulateTargetNumSeats numSeats =
+  tabulate
+    "Target number of seats"
+    [mkBucket 10 (fromIntegral numSeats)]
+
+-- | Tabulate the size of a stake distribution
+tabulateStakeDistrSize :: StakeDistr Ledger Global -> Property -> Property
+tabulateStakeDistrSize stakeDistr =
+  tabulate
+    "Stake distribution size"
+    [mkBucket 10 (fromIntegral (Map.size stakeDistr))]
+
+-- | Tabulate the ratio of persistent to non-persistent seats as the percentage
+-- of persistent seats out of the total number of seats.
+tabulatePersistentToNonPersistentRatio ::
+  NumSeats Global ->
+  NumSeats Global ->
+  Property ->
+  Property
+tabulatePersistentToNonPersistentRatio
+  numPersistentSeats
+  numNonPersistentSeats =
+    tabulate
+      "Persistent to non-persistent seat ratio (%)"
+      [mkBucket 10 ratio]
+   where
+    ratio = fromIntegral numPersistentSeats * 100 `div` fromIntegral totalSeats
+    totalSeats = numPersistentSeats + numNonPersistentSeats

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/Committee/WFALS/Tests.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/Committee/WFALS/Tests.hs
@@ -1,0 +1,526 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+
+-- | Test properties for the weighted Fait-Accompli implementation using TestCrypto.
+module Test.Consensus.Committee.WFALS.Tests (tests) where
+
+import Cardano.Ledger.BaseTypes
+import Data.Function (on)
+import Data.List (intercalate, sortOn)
+import Data.List.NonEmpty (NonEmpty ((:|)))
+import qualified Data.List.NonEmpty as NonEmpty
+import Data.Map (Map)
+import qualified Data.Map.Strict as Map
+import Data.Proxy (Proxy (..))
+import Ouroboros.Consensus.Committee.Class
+  ( CryptoSupportsVotingCommittee (..)
+  , ensureUniqueVotesWithSameTarget
+  )
+import Ouroboros.Consensus.Committee.Crypto
+  ( CryptoSupportsVRF (..)
+  , ElectionId
+  , PrivateKey
+  , PublicKey
+  , VRFPoolContext (..)
+  , evalVRF
+  , mkVRFElectionInput
+  )
+import Ouroboros.Consensus.Committee.LS (LocalSortitionNumSeats (..))
+import qualified Ouroboros.Consensus.Committee.LS as LS
+import Ouroboros.Consensus.Committee.Types
+  ( LedgerStake (..)
+  , PoolId
+  , TargetCommitteeSize (..)
+  )
+import Ouroboros.Consensus.Committee.WFA
+  ( NonPersistentCommitteeSize (..)
+  , PersistentCommitteeSize (..)
+  , SeatIndex (..)
+  , mkExtWFAStakeDistr
+  )
+import Ouroboros.Consensus.Committee.WFALS
+  ( EligibilityWitness (..)
+  , Vote (..)
+  , VotingCommitteeInput (..)
+  , WFALS
+  , nonPersistentCommitteeSize
+  , persistentCommitteeSize
+  , totalNonPersistentStake
+  )
+import Test.Consensus.Committee.TestCrypto (TestCrypto)
+import qualified Test.Consensus.Committee.TestCrypto as TestCrypto
+import Test.Consensus.Committee.Utils
+  ( eqWithShowCmp
+  , genEpochNonce
+  , genPools
+  , mkBucket
+  , onError
+  , tabulateNumPools
+  , tabulatePoolStake
+  , unfairWFATiebreaker
+  )
+import Test.QuickCheck
+  ( Gen
+  , Property
+  , Testable (..)
+  , choose
+  , counterexample
+  , elements
+  , forAll
+  , forAllShow
+  , frequency
+  , tabulate
+  )
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.QuickCheck (testProperty)
+import Test.Util.TestEnv (adjustQuickCheckTests)
+
+tests :: TestTree
+tests =
+  testGroup
+    "Implementation tests using TestCrypto"
+    [ adjustQuickCheckTests (* 10) $
+        testProperty
+          "prop_checkShouldVote_verifyVote"
+          prop_checkShouldVote_verifyVote
+    , adjustQuickCheckTests (* 10) $
+        testProperty
+          "prop_fakeVotesDontVerify"
+          prop_fakeVotesDontVerify
+    , testProperty
+        "prop_forgeCert_verifyCert"
+        prop_forgeCert_verifyCert
+    ]
+
+-- | If a pool is entitled to vote in a given committee, the vote it casts
+-- should be verifiable under the same committee.
+prop_checkShouldVote_verifyVote :: Property
+prop_checkShouldVote_verifyVote =
+  forAll (genPools 1000 TestCrypto.genKeyPair) $ \pools ->
+    forAll (genTargetCommitteeSize pools) $ \targetCommitteeSize ->
+      forAll (samplePool pools) $ \(poolId, poolPrivateKey, poolStake) ->
+        forAll genEpochNonce $ \epochNonce ->
+          forAll TestCrypto.genElectionId $ \electionId ->
+            forAll TestCrypto.genVoteCandidate $ \candidate -> do
+              let extWFAStakeDistr =
+                    mkExtWFAStakeDistr
+                      unfairWFATiebreaker
+                      (Map.map (\(_, pubKey, stake) -> (stake, pubKey)) pools)
+                      `onError` \err ->
+                        error ("mkExtWFAStakeDistr failed: " <> show err)
+              let committee =
+                    mkVotingCommittee @TestCrypto @WFALS
+                      ( WFALSVotingCommitteeInput
+                          epochNonce
+                          targetCommitteeSize
+                          extWFAStakeDistr
+                      )
+                      `onError` \err ->
+                        error ("mkVotingCommittee failed: " <> show err)
+              let shouldVote =
+                    checkShouldVote
+                      committee
+                      poolId
+                      poolPrivateKey
+                      electionId
+                      `onError` \err ->
+                        error ("checkShouldVote failed: " <> show err)
+              tabulateNumPools pools
+                . tabulateTargetCommitteeSize targetCommitteeSize
+                . tabulatePoolStake poolStake
+                . tabulateShouldVote shouldVote
+                $ case shouldVote of
+                  -- The pool is eligible to vote => cast a vote using their
+                  -- eligibility witness and make sure it verifies under the
+                  -- same voting committee.
+                  Just witness -> do
+                    let vote =
+                          forgeVote
+                            witness
+                            poolPrivateKey
+                            electionId
+                            candidate
+                    case verifyVote committee vote of
+                      Left err ->
+                        counterexample
+                          ("vote verification failed: " <> show err)
+                          $ property False
+                      Right witness' ->
+                        counterexample
+                          "vote verification mismatch"
+                          $ eqWithShowCmp
+                            showWitness
+                            cmpWitness
+                            witness
+                            witness'
+                  -- The pool is not eligible to vote => do nothing
+                  Nothing ->
+                    property True
+
+-- | Votes cast using fake eligibility witnesses should fail verification.
+prop_fakeVotesDontVerify :: Property
+prop_fakeVotesDontVerify =
+  forAll (genPools 1000 TestCrypto.genKeyPair) $ \pools ->
+    forAll (genTargetCommitteeSize pools) $ \targetCommitteeSize -> do
+      forAll (samplePool pools) $ \(_, poolPrivateKey, poolStake) ->
+        forAll genEpochNonce $ \epochNonce ->
+          forAll TestCrypto.genElectionId $ \electionId ->
+            forAll TestCrypto.genVoteCandidate $ \candidate -> do
+              let extWFAStakeDistr =
+                    mkExtWFAStakeDistr
+                      unfairWFATiebreaker
+                      (Map.map (\(_, pubKey, stake) -> (stake, pubKey)) pools)
+                      `onError` \err ->
+                        error ("mkExtWFAStakeDistr failed: " <> show err)
+              let committee =
+                    mkVotingCommittee @TestCrypto @WFALS
+                      ( WFALSVotingCommitteeInput
+                          epochNonce
+                          targetCommitteeSize
+                          extWFAStakeDistr
+                      )
+                      `onError` \err ->
+                        error ("mkVotingCommittee failed: " <> show err)
+              forAllShow
+                ( genFakeEligibilityWitness
+                    committee
+                    poolPrivateKey
+                    poolStake
+                    epochNonce
+                    electionId
+                )
+                (showWitness . snd)
+                $ \(fakeWitnessType, fakeWitness) -> do
+                  let fakeVote =
+                        forgeVote
+                          fakeWitness
+                          poolPrivateKey
+                          electionId
+                          candidate
+                  tabulateNumPools pools
+                    . tabulateTargetCommitteeSize targetCommitteeSize
+                    . tabulateFakePersistentWitnessType fakeWitnessType
+                    $ do
+                      case verifyVote committee fakeVote of
+                        Left _ ->
+                          property True
+                        Right _ ->
+                          counterexample
+                            ( unlines
+                                [ "vote verification succeeded but should have failed:"
+                                , "fake witness type: " <> show fakeWitnessType
+                                ]
+                            )
+                            $ property False
+
+-- | If we forge a certificate from many votes with the same target, verifying
+-- it should succeed and return the eligibility witnesses.
+prop_forgeCert_verifyCert :: Property
+prop_forgeCert_verifyCert =
+  forAll (genPools 1000 TestCrypto.genKeyPair) $ \pools ->
+    forAll (genTargetCommitteeSize pools) $ \targetCommitteeSize ->
+      forAll genEpochNonce $ \epochNonce ->
+        forAll TestCrypto.genElectionId $ \electionId ->
+          forAll TestCrypto.genVoteCandidate $ \candidate -> do
+            let extWFAStakeDistr =
+                  mkExtWFAStakeDistr
+                    unfairWFATiebreaker
+                    (Map.map (\(_, pubKey, stake) -> (stake, pubKey)) pools)
+                    `onError` \err ->
+                      error ("mkExtWFAStakeDistr failed: " <> show err)
+            let committee =
+                  mkVotingCommittee @TestCrypto @WFALS
+                    ( WFALSVotingCommitteeInput
+                        epochNonce
+                        targetCommitteeSize
+                        extWFAStakeDistr
+                    )
+                    `onError` \err ->
+                      error ("mkVotingCommittee failed: " <> show err)
+            -- Forge votes from all eligible pools
+            let (votes, originalWitnesses) =
+                  unzip $
+                    [ ( forgeVote witness privateKey electionId candidate
+                      , witness
+                      )
+                    | (poolId, (privateKey, _, _)) <- Map.toList pools
+                    , Just witness <-
+                        [ checkShouldVote
+                            committee
+                            poolId
+                            privateKey
+                            electionId
+                            `onError` \err ->
+                              error ("checkShouldVote failed: " <> show err)
+                        ]
+                    ]
+            tabulateNumPools pools
+              . tabulateNumVotes (length votes)
+              . tabulateTargetCommitteeSize targetCommitteeSize
+              $ case votes of
+                [] ->
+                  -- No eligible voters, nothing to test
+                  property True
+                firstVote : nextVotes -> do
+                  let uniqueVotesWithSameTarget =
+                        ensureUniqueVotesWithSameTarget
+                          ( \case
+                              WFALSPersistentVote _ eid cand _ -> (eid, cand)
+                              WFALSNonPersistentVote _ eid cand _ _ -> (eid, cand)
+                          )
+                          ( compare `on` \case
+                              WFALSPersistentVote seatIndex _ _ _ -> seatIndex
+                              WFALSNonPersistentVote seatIndex _ _ _ _ -> seatIndex
+                          )
+                          (firstVote :| nextVotes)
+                          `onError` \_ ->
+                            error "votes don't have the same target!"
+                  let cert =
+                        forgeCert uniqueVotesWithSameTarget
+                          `onError` \err ->
+                            error ("forgeCert failed: " <> show err)
+                  case verifyCert committee cert of
+                    Left err ->
+                      counterexample
+                        ("certificate verification failed: " <> show err)
+                        $ property False
+                    Right witnesses -> do
+                      let witnessesFromCert = NonEmpty.toList witnesses
+                      counterexample
+                        ( unlines
+                            [ "witnesses mismatch!"
+                            , "expected these " <> show (length originalWitnesses) <> " witnesses:"
+                            , intercalate "\n" (fmap showWitness originalWitnesses)
+                            , "but got these " <> show (length witnessesFromCert) <> " witnesses:"
+                            , intercalate "\n" (fmap showWitness witnessesFromCert)
+                            ]
+                        )
+                        $ cmpWitnesses originalWitnesses witnessesFromCert
+
+-- * Generators
+
+samplePool ::
+  Map PoolId (PrivateKey TestCrypto, PublicKey TestCrypto, LedgerStake) ->
+  Gen (PoolId, PrivateKey TestCrypto, LedgerStake)
+samplePool pools =
+  elements
+    [ (poolId, privateKey, ledgerStake)
+    | (poolId, (privateKey, _, ledgerStake)) <- Map.toList pools
+    ]
+
+genTargetCommitteeSize ::
+  Map PoolId (PrivateKey TestCrypto, PublicKey TestCrypto, LedgerStake) ->
+  Gen TargetCommitteeSize
+genTargetCommitteeSize pools = do
+  let hasPositiveStake (_, _, LedgerStake stake) =
+        stake > 0
+  let poolsWithPositiveStake =
+        Map.filter hasPositiveStake pools
+  numPools <-
+    choose (1, Map.size poolsWithPositiveStake)
+  pure $ TargetCommitteeSize (fromIntegral numPools)
+
+data FakeEligibilityWitnessType
+  = NotAPersistentMember
+  | NotANonPersistentMember
+  | NonPersistentMemberWithZeroSeats
+  deriving Show
+
+-- | Generate a fake eligibility witness that would fail verification if used
+-- to cast a vote.
+--
+-- This breaks the structure of a valid witnesses in three ways:
+--  1. generating a persistent member witness with an index outside of the
+--     persistent members range,
+--  2. generating a non-persistent member witness with an index outside of the
+--     non-persistent members range, and
+--  3. generating a non-persistent member witness with a VRF output that leads
+--     to zero non-persistent seats.
+genFakeEligibilityWitness ::
+  VotingCommittee TestCrypto WFALS ->
+  PrivateKey TestCrypto ->
+  LedgerStake ->
+  Nonce ->
+  ElectionId TestCrypto ->
+  Gen (FakeEligibilityWitnessType, EligibilityWitness TestCrypto WFALS)
+genFakeEligibilityWitness
+  committee
+  poolPrivateKey
+  poolStake
+  epochNonce
+  electionId = do
+    frequency
+      [
+        ( if numNonPersistentSeats > 0 then 1 else 0
+        , genFakePersistentMemberWitness
+        )
+      ,
+        ( if numPersistentSeats > 0 then 1 else 0
+        , genFakeNonPersistentMemberWitness
+        )
+      ]
+   where
+    numPersistentSeats =
+      unPersistentCommitteeSize (persistentCommitteeSize committee)
+
+    numNonPersistentSeats =
+      unNonPersistentCommitteeSize (nonPersistentCommitteeSize committee)
+
+    persistentRange =
+      (0, numPersistentSeats - 1)
+
+    nonPersistentRange =
+      (numPersistentSeats, numPersistentSeats + numNonPersistentSeats - 1)
+
+    -- This witness looks like a persistent member, but its seat index lies
+    -- outside the persistent members range (case 1).
+    genFakePersistentMemberWitness = do
+      seatIndex <- SeatIndex <$> choose nonPersistentRange
+      pure
+        ( NotAPersistentMember
+        , WFALSPersistentMember
+            seatIndex
+            poolStake
+        )
+
+    -- This witness looks like a non-persistent member, but depending on whether
+    -- the VRF output leads to a positive number of seats or not, it breaks
+    -- the structure of a valid witness either by having an index outside of the
+    -- non-persistent members range (case 2) or by failing to claim a non-zero
+    -- number of non-persistent seats (case 3).
+    genFakeNonPersistentMemberWitness = do
+      let vrfOutput =
+            evalVRF @TestCrypto
+              (VRFSignContext (getVRFSigningKey (Proxy @TestCrypto) poolPrivateKey))
+              (mkVRFElectionInput epochNonce electionId)
+              `onError` \err ->
+                error ("evalVRF failed: " <> show err)
+      let numSeats =
+            LS.localSortitionNumSeats
+              (nonPersistentCommitteeSize committee)
+              (totalNonPersistentStake committee)
+              poolStake
+              (normalizeVRFOutput vrfOutput)
+
+      case nonZero numSeats of
+        Just nonZeroNumSeats -> do
+          seatIndex <- SeatIndex <$> choose persistentRange
+          pure
+            ( NotANonPersistentMember
+            , WFALSNonPersistentMember
+                seatIndex
+                poolStake
+                vrfOutput
+                nonZeroNumSeats
+            )
+        Nothing -> do
+          seatIndex <- SeatIndex <$> choose nonPersistentRange
+          pure
+            ( NonPersistentMemberWithZeroSeats
+            , WFALSNonPersistentMember
+                seatIndex
+                poolStake
+                vrfOutput
+                (unsafeNonZero numSeats)
+            )
+
+-- * Property helpers
+
+showWitness ::
+  EligibilityWitness TestCrypto WFALS ->
+  String
+showWitness witness =
+  case witness of
+    WFALSPersistentMember seatIndex _ ->
+      "PersistentMember(SeatIndex=" <> show seatIndex <> ")"
+    WFALSNonPersistentMember seatIndex _ vrfOutput numSeats ->
+      "NonPersistentMember(SeatIndex="
+        <> show seatIndex
+        <> ", VRFOutput="
+        <> show vrfOutput
+        <> ", NumSeats="
+        <> show (unLocalSortitionNumSeats (unNonZero numSeats))
+        <> ")"
+
+cmpWitness ::
+  EligibilityWitness TestCrypto WFALS ->
+  EligibilityWitness TestCrypto WFALS ->
+  Bool
+cmpWitness w1 w2 =
+  case (w1, w2) of
+    ( WFALSPersistentMember seatIndex1 _
+      , WFALSPersistentMember seatIndex2 _
+      ) ->
+        seatIndex1 == seatIndex2
+    ( WFALSNonPersistentMember seatIndex1 _ vrfOutput1 numSeats1
+      , WFALSNonPersistentMember seatIndex2 _ vrfOutput2 numSeats2
+      ) ->
+        seatIndex1 == seatIndex2
+          && vrfOutput1 == vrfOutput2
+          && numSeats1 == numSeats2
+    _ ->
+      False
+
+cmpWitnesses ::
+  [EligibilityWitness TestCrypto WFALS] ->
+  [EligibilityWitness TestCrypto WFALS] ->
+  Bool
+cmpWitnesses ws1 ws2 =
+  length ws1 == length ws2
+    && all
+      (uncurry cmpWitness)
+      (zip (sortBySeatIndex ws1) (sortBySeatIndex ws2))
+ where
+  sortBySeatIndex =
+    sortOn $ \case
+      WFALSPersistentMember seatIndex _ -> seatIndex
+      WFALSNonPersistentMember seatIndex _ _ _ -> seatIndex
+
+-- * Tabulation helpers
+
+tabulateTargetCommitteeSize ::
+  TargetCommitteeSize ->
+  Property ->
+  Property
+tabulateTargetCommitteeSize (TargetCommitteeSize size) =
+  tabulate
+    "Target committee size"
+    [mkBucket 100 (fromIntegral size)]
+
+tabulateShouldVote ::
+  Maybe (EligibilityWitness TestCrypto WFALS) ->
+  Property ->
+  Property
+tabulateShouldVote shouldVote =
+  tabulate
+    "Should vote"
+    [ case shouldVote of
+        Nothing ->
+          "NoVote"
+        Just (WFALSPersistentMember _ _) ->
+          "PersistentVote"
+        Just (WFALSNonPersistentMember _ _ _ numSeats) ->
+          "NonPersistentVote(NumSeats="
+            <> show (unLocalSortitionNumSeats (unNonZero numSeats))
+            <> ")"
+    ]
+
+tabulateFakePersistentWitnessType ::
+  FakeEligibilityWitnessType ->
+  Property ->
+  Property
+tabulateFakePersistentWitnessType fakeWitnessType =
+  tabulate
+    "Fake witness type"
+    [show fakeWitnessType]
+
+tabulateNumVotes ::
+  Int ->
+  Property ->
+  Property
+tabulateNumVotes numVotes =
+  tabulate
+    "Number of votes"
+    [mkBucket 100 (fromIntegral numVotes)]


### PR DESCRIPTION
This PR provides:

* Property tests for generic committee helpers (`VotesWithSameTarget`)
* Conformance tests for `WFALS` between the real implementation and:
  + the (Haskell) model, against randomly generated stake distributions,
  + the (Rust) prototype, against its precomputed outputs for the example stake distribution taken from mainnet.
* Property tests for both `WFALS` and `EveryoneVotes`, asserting that:
  + votes cast by eligible voters are successfully verifiable under the same voting committee, and
  + fake (illegal) votes are successfully rejected.

NOTES:

* The first two commits reorganize a bit the test suite (originally only containing WFALS tests), to share definitions and make room for `EveryoneVotes` tests. 