### PR TITLE
Swallow exceptions when deleting snapshots

### DIFF
--- a/changelog.d/20260414_105957_javier.sagredo_cleanup_snapshots.md
+++ b/changelog.d/20260414_105957_javier.sagredo_cleanup_snapshots.md
@@ -1,0 +1,23 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+<!--
+### Breaking
+
+- A bullet item for the Breaking category.
+
+-->
+<!--
+### Non-Breaking
+
+- A bullet item for the Non-Breaking category.
+
+-->
+
+### Patch
+
+- Ignore exceptions when deleting a snapshot.

--- a/ouroboros-consensus/src/ouroboros-consensus-lsm/Ouroboros/Consensus/Storage/LedgerDB/V2/LSM.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus-lsm/Ouroboros/Consensus/Storage/LedgerDB/V2/LSM.hs
@@ -476,6 +476,7 @@ readUTxOSizeFile hfs p = do
 
 -- | Delete snapshot from disk and also from the LSM tree database.
 implDeleteSnapshotIfTemporary ::
+  forall m blk.
   IOLike m =>
   Session m ->
   SomeHasFS m ->
@@ -488,7 +489,11 @@ implDeleteSnapshotIfTemporary
   tracer
   ss =
     Monad.when (diskSnapshotIsTemporary ss) $ do
-      deleteState `finally` deleteLsmTable
+      -- If an exception comes up while trying to delete snapshots we just
+      -- swallow it and continue. We don't really care if the snapshot was half
+      -- written or whatever, as the running node does not use existing
+      -- snapshots.
+      mapM_ (try @m @SomeException) [deleteState, deleteLsmTable]
       traceWith tracer (DeletedSnapshot ss)
    where
     deleteState = do

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/Snapshots.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/Snapshots.hs
@@ -304,9 +304,11 @@ defaultListSnapshots (SomeHasFS HasFS{listDirectory}) =
 
 -- | Delete snapshot from disk
 defaultDeleteSnapshotIfTemporary ::
-  (Monad m, HasCallStack) => SomeHasFS m -> Tracer m (TraceSnapshotEvent blk) -> DiskSnapshot -> m ()
+  forall m blk.
+  (MonadCatch m, HasCallStack) =>
+  SomeHasFS m -> Tracer m (TraceSnapshotEvent blk) -> DiskSnapshot -> m ()
 defaultDeleteSnapshotIfTemporary (SomeHasFS HasFS{doesDirectoryExist, removeDirectoryRecursive}) tracer ss =
-  when (diskSnapshotIsTemporary ss) $ do
+  when (diskSnapshotIsTemporary ss) $ void $ try @m @SomeException $ do
     let p = snapshotToDirPath ss
     exists <- doesDirectoryExist p
     when exists (removeDirectoryRecursive p)


### PR DESCRIPTION
# Description

The running node does not care about existing snapshots, so we can safely ignore exceptions that happen when we try to delete those (such as LSM-trees erroring when the snapshot was not fully written).

Fixes #1972 
