### PR TITLE
Fix handling of Byron snapshots in converter

### DIFF
--- a/changelog.d/20260414_160300_javier.sagredo_snapshot_converter_byron.md
+++ b/changelog.d/20260414_160300_javier.sagredo_snapshot_converter_byron.md
@@ -1,0 +1,23 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+<!--
+### Breaking
+
+- A bullet item for the Breaking category.
+
+-->
+<!--
+### Non-Breaking
+
+- A bullet item for the Non-Breaking category.
+
+-->
+
+### Patch
+
+- Allow for empty UTxO tables in tables streaming (which is only relevant for Byron snapshots)

--- a/ouroboros-consensus-cardano/src/unstable-snapshot-conversion/Ouroboros/Consensus/Cardano/StreamingLedgerTables.hs
+++ b/ouroboros-consensus-cardano/src/unstable-snapshot-conversion/Ouroboros/Consensus/Cardano/StreamingLedgerTables.hs
@@ -42,7 +42,7 @@ mkInMemYieldArgs fs ds (HardForkLedgerState (HardForkState idx)) =
         (Current (Flip LedgerState EmptyMK) -.-> K (Decoders L))
         (CardanoEras StandardCrypto)
     np =
-      (Fn $ const $ K $ error "Byron")
+      (Fn $ K . (\_ -> Decoders (error "Byron") (error "Byron")) . unFlip . currentState)
         :* (Fn $ K . fromEra ShelleyTxOut . unFlip . currentState)
         :* (Fn $ K . fromEra AllegraTxOut . unFlip . currentState)
         :* (Fn $ K . fromEra MaryTxOut . unFlip . currentState)

--- a/ouroboros-consensus/src/ouroboros-consensus-lmdb/Ouroboros/Consensus/Storage/LedgerDB/V1/BackingStore/Impl/LMDB.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus-lmdb/Ouroboros/Consensus/Storage/LedgerDB/V1/BackingStore/Impl/LMDB.hs
@@ -922,12 +922,12 @@ sinkLmdbS writeChunkSize bs copyTo hint s = do
     lift $ bs sl (hint, hint) (LedgerTables $ DiffMK $ Diff.fromMapInserts m)
     go writeChunkSize mempty s'
   go n m s' = do
-    mbs <- S.uncons s'
+    mbs <- S.next s'
     case mbs of
-      Nothing -> do
+      Left r -> do
         lift $ bs sl (hint, hint) (LedgerTables $ DiffMK $ Diff.fromMapInserts m)
-        S.effects s'
-      Just ((k, v), s'') ->
+        pure r
+      Right ((k, v), s'') ->
         go (n - 1) (Map.insert k v m) s''
 
 yieldLmdbS ::

--- a/ouroboros-consensus/src/ouroboros-consensus-lsm/Ouroboros/Consensus/Storage/LedgerDB/V2/LSM.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus-lsm/Ouroboros/Consensus/Storage/LedgerDB/V2/LSM.hs
@@ -786,12 +786,12 @@ sinkLsmS writeChunkSize (SomeHasFS hfs) ds session st stream = do
     lift $ writeToTable lsmTable accUTxOs
     go utxosSize lsmTable writeChunkSize mempty stream'
   go utxosSize lsmTable numToRead accUTxOs stream' = do
-    mItem <- S.uncons stream'
+    mItem <- S.next stream'
     case mItem of
-      Nothing -> do
+      Left r -> do
         lift $ writeToTable lsmTable accUTxOs
-        (,utxosSize) <$> S.effects stream'
-      Just (item, stream'') -> go (utxosSize + 1) lsmTable (numToRead - 1) (item : accUTxOs) stream''
+        pure (r, utxosSize)
+      Right (item, stream'') -> go (utxosSize + 1) lsmTable (numToRead - 1) (item : accUTxOs) stream''
 
 -- | Create Yield arguments for LSM
 mkLSMYieldArgs ::

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/V2/InMemory.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/V2/InMemory.hs
@@ -442,11 +442,11 @@ sinkInMemoryS writeChunkSize encK encV (SomeHasFS fs) ds _ s =
     let !crc1 = updateCRC bs crc
     go tb crc1 writeChunkSize mempty s'
   go tb !crc n m s' = do
-    mbs <- S.uncons s'
+    mbs <- S.next s'
     case mbs of
-      Nothing -> do
+      Left r -> do
         let bs = toStrictByteString $ mconcat [encK k <> encV v | (k, v) <- reverse m]
         lift $ void $ hPutSome fs tb bs
         let !crc1 = updateCRC bs crc
-        (,crc1) <$> S.effects s'
-      Just (item, s'') -> go tb crc (n - 1) (item : m) s''
+        pure (r, crc1)
+      Right (item, s'') -> go tb crc (n - 1) (item : m) s''


### PR DESCRIPTION
`S.uncons + S.effects` was the wrong abstraction when the stream is empty.
