### PR TITLE
Fix invalid code signatures on aarch64-darwin after set-git-rev

### DIFF
--- a/nix/tools.nix
+++ b/nix/tools.nix
@@ -49,14 +49,20 @@ in
   };
   set-git-rev = drv:
     let
-      patched-drv = final.applyPatches {
-        name = "${drv.name}-with-git-rev";
-        src = drv;
-        postPatch = ''
-          ${final.haskellBuildUtils}/bin/set-git-rev \
-            ${lib.escapeShellArg inputs.self.rev} bin/*
-        '';
-      };
+      patched-drv = final.buildPackages.runCommand "${drv.name}-with-git-rev" {
+        inherit (drv) meta passthru;
+        nativeBuildInputs = lib.optionals final.stdenv.hostPlatform.isDarwin
+          [ final.darwin.signingUtils ];
+      } (''
+        mkdir -p $out
+        cp --no-preserve=timestamps --recursive ${drv}/* $out/
+        chmod -R +w $out/bin
+        ${final.pkgsBuildBuild.haskellBuildUtils}/bin/set-git-rev ${lib.escapeShellArg inputs.self.rev} $out/bin/*
+      '' + lib.optionalString final.stdenv.hostPlatform.isDarwin ''
+        for exe in $out/bin/*; do
+          signIfRequired "$exe"
+        done
+      '');
     in
     if inputs.self ? rev then patched-drv else drv;
 }

--- a/nix/tools.nix
+++ b/nix/tools.nix
@@ -49,20 +49,22 @@ in
   };
   set-git-rev = drv:
     let
-      patched-drv = final.buildPackages.runCommand "${drv.name}-with-git-rev" {
-        inherit (drv) meta passthru;
-        nativeBuildInputs = lib.optionals final.stdenv.hostPlatform.isDarwin
-          [ final.darwin.signingUtils ];
-      } (''
-        mkdir -p $out
-        cp --no-preserve=timestamps --recursive ${drv}/* $out/
-        chmod -R +w $out/bin
-        ${final.pkgsBuildBuild.haskellBuildUtils}/bin/set-git-rev ${lib.escapeShellArg inputs.self.rev} $out/bin/*
-      '' + lib.optionalString final.stdenv.hostPlatform.isDarwin ''
-        for exe in $out/bin/*; do
-          signIfRequired "$exe"
-        done
-      '');
+      patched-drv = final.buildPackages.runCommand "${drv.name}-with-git-rev"
+        {
+          inherit (drv) meta passthru;
+          nativeBuildInputs = lib.optionals final.stdenv.hostPlatform.isDarwin
+            [ final.darwin.signingUtils ];
+        }
+        (''
+          mkdir -p $out
+          cp --no-preserve=timestamps --recursive ${drv}/* $out/
+          chmod -R +w $out/bin
+          ${final.pkgsBuildBuild.haskellBuildUtils}/bin/set-git-rev ${lib.escapeShellArg inputs.self.rev} $out/bin/*
+        '' + lib.optionalString final.stdenv.hostPlatform.isDarwin ''
+          for exe in $out/bin/*; do
+            signIfRequired "$exe"
+          done
+        '');
     in
     if inputs.self ? rev then patched-drv else drv;
 }


### PR DESCRIPTION
## Summary

- Re-sign Mach-O binaries with ad-hoc code signatures after `set-git-rev` patches them on darwin

## Problem

On aarch64-darwin (Apple Silicon), all executables must have valid code signatures. The `set-git-rev` tool uses `Data.FileEmbed.injectWith` to binary-patch a `dummySpace` placeholder in executables (like `db-analyser`) with the actual git revision hash. This modifies the Mach-O binary content, invalidating the ad-hoc code signature that the linker created.

The wrapper derivation created by `applyPatches` uses `phases = "unpackPhase patchPhase installPhase"` — no `fixupPhase` — so nixpkgs' `autoSignDarwinBinariesHook` never runs. This results in executables being unusable on Apple Silicon (killed by the kernel).

Only executables that import `Cardano.Tools.GitRev` are affected (currently `db-analyser`), as they are the only ones containing the `dummySpace` marker that `set-git-rev` actually patches. `db-synthesizer` and `db-truncater` are unaffected because they don't use the git rev embedding.

## Fix

Add `/usr/bin/codesign -f -s -` after `set-git-rev` on darwin platforms in `nix/tools.nix`.

## Test plan

- [x] Built `db-analyser` with fix on aarch64-darwin
- [x] Verified `codesign -vvv` reports "valid on disk"
- [x] Verified binary runs and shows embedded git rev
- [x] Verified `db-synthesizer` and `db-truncater` remain valid