### PR TITLE
Use physical path in run-fourmolu.sh

### DIFF
--- a/scripts/ci/run-fourmolu.sh
+++ b/scripts/ci/run-fourmolu.sh
@@ -22,7 +22,7 @@ fi
 
 case "$(uname -s)" in
     MINGW*)     path="$(pwd -W | sed 's_/_\\\\_g')\\\\ouroboros-consensus";;
-    *)          path="$(pwd)/ouroboros-consensus";;
+    *)          path="$(pwd -P)/ouroboros-consensus";;
 esac
 
 $fdcmd --full-path "$path" \


### PR DESCRIPTION
## Summary

`scripts/ci/run-fourmolu.sh` builds a path regex from `$(pwd)` and passes it to `fd --full-path`. `fd` matches that regex against the **canonicalized** path (symlinks resolved), while `$(pwd)` returns the **logical** path. When the script is invoked through a symlink (e.g. a convenience symlink pointing to the real checkout), the regex is built from the symlinked name but `fd` is walking the resolved path, so the regex matches zero files. The script then exits cleanly without formatting anything, which caused the nix fourmolu check to fail on CI while local runs reported "no changes" — a silent and confusing failure mode.

Switching to `pwd -P` emits the physical path, so the regex and the paths `fd` actually walks are in the same namespace.

`scripts/ci/run-cabal-gild.sh` on `main` does not use this pattern, so it needs no change.