### PR TITLE
Fix error "impossible!" in Leios Prototype's fetch decision logic

### DIFF
--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic.hs
@@ -244,15 +244,15 @@ filterMissingWork db outstanding = do
           Map.map
             (IntMap.filter (\(txHash, _) -> Set.member txHash stillMissingTxSet))
             (Leios.missingEbTxs outstanding)
-      filteredTxOffsetss =
+      filteredReverseEbIndexByTx =
         Map.filterWithKey
           (\txHash _ -> Set.member txHash stillMissingTxSet)
-          (Leios.txOffsetss outstanding)
+          (Leios.reverseEbIndexByTx outstanding)
   pure $
     outstanding
       { Leios.missingEbBodies = filteredMissingEbBodies
       , Leios.missingEbTxs = filteredMissingEbTxs
-      , Leios.txOffsetss = filteredTxOffsetss
+      , Leios.reverseEbIndexByTx = filteredReverseEbIndexByTx
       , Leios.acquiredEbBodies =
           Leios.acquiredEbBodies outstanding `Set.union` Set.fromList acquiredEbHashes
       }
@@ -291,7 +291,7 @@ leiosFetchLogicIteration env offerings =
             peerIds = Map.findWithDefault Set.empty point.pointEbHash (Leios.requestedEbPeers acc) ->
           goEb2 acc accNew targets point ebBytesSize peerIds
     Right (point, txBytesSize, txHash) : targets ->
-      let !txOffsets = case Map.lookup txHash (Leios.txOffsetss acc) of
+      let !txOffsets = case Map.lookup txHash (Leios.reverseEbIndexByTx acc) of
             Nothing -> error "impossible!"
             Just x -> x
           peerIds :: Set (PeerId pid)
@@ -627,12 +627,12 @@ msgLeiosBlock ktracer tracer (outstandingVar, readyVar) db peerId req eb = do
                           (let MkLeiosEb v = eb in v)
                       )
                       (Leios.missingEbTxs outstanding)
-                , Leios.txOffsetss =
+                , Leios.reverseEbIndexByTx =
                     V.ifoldl
                       ( \acc i (txHash, txBytesSize) ->
                           Map.insertWith Map.union txHash (Map.singleton ebHash (i, txBytesSize)) acc
                       )
-                      (Leios.txOffsetss outstanding)
+                      (Leios.reverseEbIndexByTx outstanding)
                       (let MkLeiosEb v = eb in v)
                 , Leios.requestedBytesSize = Leios.requestedBytesSize outstanding - ebBytesSize
                 , Leios.requestedBytesSizePerPeer =
@@ -701,12 +701,12 @@ msgLeiosBlockTxs ktracer tracer (outstandingVar, readyVar) db peerId req txs = d
     forM_ completed $ traceWith ktracer . TraceLeiosBlockTxsAcquired
   -- update NodeKernel state
   MVar.modifyMVar_ outstandingVar $ \outstanding -> do
-    let (requestedTxPeers', txOffsetss', txsBytesSize) =
+    let (requestedTxPeers', reverseEbIndexByTx', txsBytesSize) =
           ( \f ->
               V.foldl
                 f
                 ( Leios.requestedTxPeers outstanding
-                , Leios.txOffsetss outstanding
+                , Leios.reverseEbIndexByTx outstanding
                 , 0
                 )
                 (txHashes `V.zip` txBytess)
@@ -728,7 +728,7 @@ msgLeiosBlockTxs ktracer tracer (outstandingVar, readyVar) db peerId req txs = d
                   (delIf IntMap.null . (`IntMap.withoutKeys` offsetsSet))
                   point
                   (Leios.missingEbTxs outstanding)
-            , Leios.txOffsetss = txOffsetss'
+            , Leios.reverseEbIndexByTx = reverseEbIndexByTx'
             , Leios.blockingPerEb =
                 if IntMap.null beatOtherPeers
                   then Leios.blockingPerEb outstanding

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic.hs
@@ -387,7 +387,7 @@ leiosFetchLogicIteration env offerings =
     Map EbHash (Int, BytesSize) ->
     BytesSize ->
     Maybe (PeerId pid, Map EbHash Int)
-  choosePeerTx peerIds acc txOffsets targetBytesSize =
+  choosePeerTx peerIds acc txOffsets targetTxBytesSize =
     foldr (\a _ -> Just a) Nothing $
       [ (peerId, Map.map fst txOffsets')
       | (peerId, (_ebIds, ebIds)) <-
@@ -400,7 +400,7 @@ leiosFetchLogicIteration env offerings =
       let txOffsets' = txOffsets `Map.restrictKeys` ebIds
       , case Map.lookupMax txOffsets' of
           Nothing -> False
-          Just (_k, (_offset, sz)) -> targetBytesSize == sz -- peer has offered at least one EB closure that includes this tx with the same size
+          Just (_ebHash, (_txOffset, txBytesSize)) -> targetTxBytesSize == txBytesSize -- peer has offered at least one EB closure that includes this tx with the same size
       ]
 
 packRequests ::

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic.hs
@@ -349,7 +349,7 @@ leiosFetchLogicIteration env offerings =
     LeiosPoint ->
     BytesSize ->
     TxHash ->
-    Map EbHash Int ->
+    Map EbHash (Int, BytesSize) ->
     Set (PeerId pid) ->
     (LeiosOutstanding pid, LeiosFetchDecisions pid)
   goTx2 !acc !accNew targets point txBytesSize txHash txOffsets peerIds
@@ -382,10 +382,10 @@ leiosFetchLogicIteration env offerings =
         go1 acc accNew targets
 
   choosePeerTx ::
-    Set (PeerId pid) -> LeiosOutstanding pid -> Map EbHash Int -> Maybe (PeerId pid, Map EbHash Int)
+    Set (PeerId pid) -> LeiosOutstanding pid -> Map EbHash (Int, BytesSize) -> Maybe (PeerId pid, Map EbHash Int)
   choosePeerTx peerIds acc txOffsets =
     foldr (\a _ -> Just a) Nothing $
-      [ (peerId, txOffsets')
+      [ (peerId, Map.map fst txOffsets')
       | (peerId, (_ebIds, ebIds)) <-
           Map.toList $ -- TODO prioritize/shuffle?
             (`Map.withoutKeys` peerIds) $ -- not already requested from this peer
@@ -623,8 +623,8 @@ msgLeiosBlock ktracer tracer (outstandingVar, readyVar) db peerId req eb = do
                       (Leios.missingEbTxs outstanding)
                 , Leios.txOffsetss =
                     V.ifoldl
-                      ( \acc i (txHash, _txBytesSize) ->
-                          Map.insertWith Map.union txHash (Map.singleton ebHash i) acc
+                      ( \acc i (txHash, txBytesSize) ->
+                          Map.insertWith Map.union txHash (Map.singleton ebHash (i, txBytesSize)) acc
                       )
                       (Leios.txOffsetss outstanding)
                       (let MkLeiosEb v = eb in v)

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic.hs
@@ -342,6 +342,15 @@ leiosFetchLogicIteration env offerings =
       ebHash `Set.member` ebHashes -- peer has offered this EB body
       ]
 
+  goTx2 ::
+    LeiosOutstanding pid ->
+    LeiosFetchDecisions pid ->
+    [Either (LeiosPoint, BytesSize) (LeiosPoint, TxHash)] ->
+    LeiosPoint ->
+    TxHash ->
+    Map EbHash Int ->
+    Set (PeerId pid) ->
+    (LeiosOutstanding pid, LeiosFetchDecisions pid)
   goTx2 !acc !accNew targets point txHash txOffsets peerIds
     | Leios.requestedBytesSize acc >= Leios.maxRequestedBytesSize env -- we can't request anything
       =

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic.hs
@@ -275,13 +275,13 @@ leiosFetchLogicIteration env offerings =
     [] -> []
     (point, Left ebBytesSize) : vs -> Left (point, ebBytesSize) : expand vs
     (point, Right v) : vs ->
-      [Right (point, txHash) | (_txOffset, (txHash, _txBytesSize)) <- IntMap.toAscList v]
+      [Right (point, txBytesSize, txHash) | (_txOffset, (txHash, txBytesSize)) <- IntMap.toAscList v]
         <> expand vs
 
   go1 ::
     LeiosOutstanding pid ->
     LeiosFetchDecisions pid ->
-    [Either (LeiosPoint, BytesSize) (LeiosPoint, TxHash)] ->
+    [Either (LeiosPoint, BytesSize) (LeiosPoint, BytesSize, TxHash)] ->
     (LeiosOutstanding pid, LeiosFetchDecisions pid)
   go1 !acc !accNew = \case
     [] ->
@@ -290,13 +290,13 @@ leiosFetchLogicIteration env offerings =
       | let peerIds :: Set (PeerId pid)
             peerIds = Map.findWithDefault Set.empty point.pointEbHash (Leios.requestedEbPeers acc) ->
           goEb2 acc accNew targets point ebBytesSize peerIds
-    Right (point, txHash) : targets ->
+    Right (point, txBytesSize, txHash) : targets ->
       let !txOffsets = case Map.lookup txHash (Leios.txOffsetss acc) of
             Nothing -> error "impossible!"
             Just x -> x
           peerIds :: Set (PeerId pid)
           peerIds = Map.findWithDefault Set.empty txHash (Leios.requestedTxPeers acc)
-       in goTx2 acc accNew targets point txHash txOffsets peerIds
+       in goTx2 acc accNew targets point txBytesSize txHash txOffsets peerIds
 
   goEb2 !acc !accNew targets point ebBytesSize peerIds
     | Leios.requestedBytesSize acc >= Leios.maxRequestedBytesSize env -- we can't request anything
@@ -345,13 +345,14 @@ leiosFetchLogicIteration env offerings =
   goTx2 ::
     LeiosOutstanding pid ->
     LeiosFetchDecisions pid ->
-    [Either (LeiosPoint, BytesSize) (LeiosPoint, TxHash)] ->
+    [Either (LeiosPoint, BytesSize) (LeiosPoint, BytesSize, TxHash)] ->
     LeiosPoint ->
+    BytesSize ->
     TxHash ->
     Map EbHash Int ->
     Set (PeerId pid) ->
     (LeiosOutstanding pid, LeiosFetchDecisions pid)
-  goTx2 !acc !accNew targets point txHash txOffsets peerIds
+  goTx2 !acc !accNew targets point txBytesSize txHash txOffsets peerIds
     | Leios.requestedBytesSize acc >= Leios.maxRequestedBytesSize env -- we can't request anything
       =
         (acc, accNew)
@@ -360,14 +361,7 @@ leiosFetchLogicIteration env offerings =
     -- tx has only been requested at lower priorities?
     , Just (peerId, txOffsets') <- choosePeerTx peerIds acc txOffsets =
         -- there's a peer who offered it and we haven't already requested it from them
-        let txBytesSize = case Map.lookupMax txOffsets' of
-              Nothing -> error "impossible!"
-              Just (_ebHash, txOffset) -> case Map.lookup point (Leios.missingEbTxs acc) of
-                Nothing -> error "impossible!"
-                Just v -> case IntMap.lookup txOffset v of
-                  Nothing -> error "impossible!"
-                  Just (_txHash, x) -> x
-            accNew' =
+        let accNew' =
               MkLeiosFetchDecisions $
                 Map.insertWith
                   (Map.unionWith (<>))
@@ -383,7 +377,7 @@ leiosFetchLogicIteration env offerings =
                 , Leios.requestedBytesSize = txBytesSize + Leios.requestedBytesSize acc
                 }
             peerIds' = Set.insert peerId peerIds
-         in goTx2 acc' accNew' targets point txHash txOffsets peerIds'
+         in goTx2 acc' accNew' targets point txBytesSize txHash txOffsets peerIds'
     | otherwise =
         go1 acc accNew targets
 

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic.hs
@@ -359,7 +359,7 @@ leiosFetchLogicIteration env offerings =
     | Set.size peerIds < Leios.maxRequestsPerTx env -- we would like to request it from an additional peer
     -- TODO if requests list priority, does this limit apply even if the
     -- tx has only been requested at lower priorities?
-    , Just (peerId, txOffsets') <- choosePeerTx peerIds acc txOffsets =
+    , Just (peerId, txOffsets') <- choosePeerTx peerIds acc txOffsets txBytesSize =
         -- there's a peer who offered it and we haven't already requested it from them
         let accNew' =
               MkLeiosFetchDecisions $
@@ -382,8 +382,12 @@ leiosFetchLogicIteration env offerings =
         go1 acc accNew targets
 
   choosePeerTx ::
-    Set (PeerId pid) -> LeiosOutstanding pid -> Map EbHash (Int, BytesSize) -> Maybe (PeerId pid, Map EbHash Int)
-  choosePeerTx peerIds acc txOffsets =
+    Set (PeerId pid) ->
+    LeiosOutstanding pid ->
+    Map EbHash (Int, BytesSize) ->
+    BytesSize ->
+    Maybe (PeerId pid, Map EbHash Int)
+  choosePeerTx peerIds acc txOffsets targetBytesSize =
     foldr (\a _ -> Just a) Nothing $
       [ (peerId, Map.map fst txOffsets')
       | (peerId, (_ebIds, ebIds)) <-
@@ -394,7 +398,9 @@ leiosFetchLogicIteration env offerings =
           <= Leios.maxRequestedBytesSizePerPeer env
       , -- peer can be sent more requests
       let txOffsets' = txOffsets `Map.restrictKeys` ebIds
-      , not $ Map.null txOffsets' -- peer has offered an EB closure that includes this tx
+      , case Map.lookupMax txOffsets' of
+          Nothing -> False
+          Just (_k, (_offset, sz)) -> targetBytesSize == sz -- peer has offered at least one EB closure that includes this tx with the same size
       ]
 
 packRequests ::

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoTypes.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoTypes.hs
@@ -226,7 +226,7 @@ data LeiosOutstanding pid = MkLeiosOutstanding
   --   will be a no-op for all except the first to arrive carrying this EbTx.
   --
   -- TODO this is far too big for the heap
-  , txOffsetss :: !(Map TxHash (Map EbHash Int))
+  , txOffsetss :: !(Map TxHash (Map EbHash (Int, BytesSize)))
   -- ^ Inverse of missingEbTxs - for each TX, which EBs (and offsets) need it
   --
   -- TODO this is far too big for the heap

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoTypes.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoTypes.hs
@@ -195,7 +195,7 @@ newLeiosPeerVars = do
 -- 2. The acquiredEbBodies set is now redundant with DB - we update it in
 --    filterMissingWork but could remove it entirely once we trust DB filtering.
 --
--- 3. The txOffsetss inverse index could be computed on-demand from missingEbTxs
+-- 3. The reverseEbIndexByTx inverse index could be computed on-demand from missingEbTxs
 --    rather than maintained incrementally, simplifying state updates.
 --
 -- 4. Consider separating "offer tracking" from "request tracking" into distinct
@@ -226,7 +226,7 @@ data LeiosOutstanding pid = MkLeiosOutstanding
   --   will be a no-op for all except the first to arrive carrying this EbTx.
   --
   -- TODO this is far too big for the heap
-  , txOffsetss :: !(Map TxHash (Map EbHash (Int, BytesSize)))
+  , reverseEbIndexByTx :: !(Map TxHash (Map EbHash (Int, BytesSize)))
   -- ^ Inverse of missingEbTxs - for each TX, which EBs (and offsets) need it
   --
   -- TODO this is far too big for the heap
@@ -255,7 +255,7 @@ emptyLeiosOutstanding =
     , requestedBytesSizePerPeer = Map.empty
     , requestedBytesSize = 0
     , missingEbTxs = Map.empty
-    , txOffsetss = Map.empty
+    , reverseEbIndexByTx = Map.empty
     , blockingPerEb = Map.empty
     }
 


### PR DESCRIPTION
## Summary

Fixes `error "impossible!"` crashes observed in the Leios ThreadNet test suite (tracked in [ouroboros-leios#862](https://github.com/input-output-hk/ouroboros-leios/issues/862)), plus a silent wrong-size charge in the same code path.

Per @nfrisby's clarification on this PR: the silent wrong-size bug has existed since [commit 9c5584f8e](https://github.com/IntersectMBO/ouroboros-consensus/commit/9c5584f8e) (the commit where the fetch-decision logic was first added, 2025-10-26).
The crash bug was introduced later by [#1859](https://github.com/IntersectMBO/ouroboros-consensus/pull/1859) (commit [ce6324695](https://github.com/IntersectMBO/ouroboros-consensus/commit/ce6324695), 2026-02-10), which removed the `EbId` intermediate naming scheme for EBs.

## Diagnosis

`goTx2` extracted the transaction's byte size via three nested lookups starting with `Map.lookupMax txOffsets'` where `txOffsets' :: Map EbHash Int`.
`lookupMax` picks by lexicographic order of Blake2b-256 hash bytes — effectively arbitrary with respect to the current `point`.
The offset returned belongs to the picked EB's body-coordinate system.
The code then used this offset as a key into `missingEbTxs[point]`'s IntMap, assuming the two coordinate systems coincide.
They only do so if the picked EB happens to equal `point`.

Two observable failure modes:

- **Crash.** `IntMap.lookup` returns `Nothing` and fires `error "impossible!"`.
- **Silent wrong size.** The offset coincidentally indexes a different tx in `point`'s body; its size is adopted for `txHash` without any `TxHash` equality check. `requestedBytesSize` / `requestedBytesSizePerPeer` / the `accNew'` tuple drift.

### Example — crash case

- Tx T1 at offset 0 in EB A (body `[T1, X]`).
- Tx T1 at offset 2 in EB B (body `[Y, Z, T1]`).
- `point = A`; peer offers closure of B only.
- `txOffsets' = {B |-> 2}`; `lookupMax` returns `(B, 2)`.
- `IntMap.lookup 2 v_A` returns `Nothing` — A's body has only offsets 0 and 1. Fires `error "impossible!"`.

### Example — silent wrong-size case

- Tx T1 at offset 0 in EB A, **body `[T1, X, Y]`** (three entries).
- Tx T1 at offset 2 in EB B.
- Same `point`, same peer, same `txOffsets'`.
- `IntMap.lookup 2 v_A` returns `Just (Y, 300)` — Y's size, not T1's. The code takes Y's size as `txBytesSize` for T1.

## Fix (four commits)

### 1. `Add type signature for goTx2`

Non-behavioral; documents the shape that the refactor touches.

### 2. `Thread txBytesSize into goTx2; drop three-layer lookup`

Capture the tx's byte size at target construction in `expand` — it is already paired with the tx hash in the IntMap value extracted from `missingEbTxs[point]`.
Thread it through the `Right` target tuple and as an explicit `goTx2` argument.
The three-layer lookup and all three `error "impossible!"` branches disappear.

The size charged against `requestedBytesSize` and `requestedBytesSizePerPeer` is `point`'s own claim — sourced directly from where `missingEbTxs[point]` was already handing it to us.

### 3. `Carry byte size in txOffsetss`

Enrich the inverse index to `Map TxHash (Map EbHash (Int, BytesSize))`, capturing the size already in scope at EB-body ingest time (previously discarded as `_txBytesSize`).
Non-behavioral on its own: `choosePeerTx` strips the size in its return, so the `accNew'` DList payload, `LeiosFetchDecisions`, and `packRequests` see the same shape as before.

### 4. `Require an offered EB's size to match the target in choosePeerTx`

Per @nfrisby's review: `choosePeerTx` takes `targetBytesSize :: BytesSize` and inspects one arbitrary entry in `txOffsets'` (`Map.lookupMax`), requiring its claimed size to equal the target.
An honest peer wouldn't offer EbClosures for EBs that assign different sizes to the same tx, so every entry in `txOffsets'` has the same size and a single-entry check is representative.
For an adversarial peer it's inevitable that they could send a different amount of bytes than requested, so the accuracy of `requestedBytesSize` / `requestedBytesSizePerPeer` is not particularly important or achievable — the single-entry check is sufficient.

## Why the fix is correct

For any decision recorded by `goTx2`:

1. The charged size (`txBytesSize`) and the tx hash (`txHash`) come from the same IntMap entry in `missingEbTxs[point]`, which is hash-committed and validated by us — no foreign-offset lookup.
2. The chosen peer has offered at least one EB whose validated body claims the same size (single-entry check via `Map.lookupMax`).

Both crash and silent-wrong-size paths are eliminated.

Addresses https://github.com/input-output-hk/ouroboros-leios/issues/862