### PR TITLE
Add Ticking explanation page

### DIFF
--- a/docs/website/contents/explanations/consensus_protocol.md
+++ b/docs/website/contents/explanations/consensus_protocol.md
@@ -185,13 +185,17 @@ The class has five methods, each corresponding to a concept already introduced:
 
 ### Ticked state
 
-Several methods require the protocol state to be *ticked* to a specific slot before use.
-[`tickChainDepState`][consensus-protocol] takes a `ChainDepState p` and produces a [`Ticked`][ticked] `(ChainDepState p)` — a type-level distinction that makes it impossible to accidentally use an unticked state where a ticked one is expected.
+The protocol state evolves due to two factors: headers being applied, and time passing.
+Some updates fire purely from the passage of time — Praos rotates its nonces at epoch boundaries, for example — and must happen even at slots where no header exists.
+*Ticking* is the operation that advances the protocol state to account for these time-only changes, producing a distinct `Ticked` variant of the state.
 
+[`tickChainDepState`][consensus-protocol] takes a `ChainDepState p` and produces a [`Ticked`][ticked] `(ChainDepState p)` — a type-level distinction that makes it impossible to accidentally use an unticked state where a ticked one is expected.
 Both `checkIsLeader` and `updateChainDepState` require a ticked state as input.
-Ticking also requires a `LedgerView` (see below), because some time-dependent state transitions need ledger information — for example, Praos rotates its nonces at epoch boundaries using the ledger's epoch structure.
+Ticking also takes a `LedgerView` (see below), because some time-dependent transitions need ledger information — the Praos nonce rotation above uses the ledger's epoch structure, for instance.
 
 For BFT, ticking is a no-op (`TickedTrivial`) since there is no protocol state.
+
+See [Ticking](ticking.md) for the full picture, including where ticking is invoked across the consensus layer and how it relates to forecasting.
 
 ### LedgerView and forecasting
 

--- a/docs/website/contents/explanations/ledger_interaction.md
+++ b/docs/website/contents/explanations/ledger_interaction.md
@@ -72,6 +72,9 @@ particular blocks defined in the ledger.
 
 ## Ledger state ticking and forecasting
 
+This section covers the Ledger-side implementation of ticking (the `TICK` and `TICKF` transition rules).
+For a consensus-level treatment — what ticking means, where consensus ticks, and how it relates to forecasting — see [Ticking](ticking.md).
+
 Before a block can be applied to a Ledger state, the state has to be transported
 through time up to the slot in which the block was forged. There are mutations
 in the Ledger state that are enacted just by the passing of time, such as epoch

--- a/docs/website/contents/explanations/ticking.md
+++ b/docs/website/contents/explanations/ticking.md
@@ -1,0 +1,116 @@
+# Ticking
+
+Part of: [System Overview](index.md)
+
+Consensus must answer questions about the ledger at slots where no block exists.
+"Would this transaction be valid if included in the next block?"
+"Am I allowed to lead this slot?"
+"What are the block-production limits right now?"
+*Ticking* is the operation that advances a ledger or protocol state in time to answer such questions, without consuming a block.
+
+## Overview
+
+Time in Ouroboros is divided into [slots](../references/glossary.md#slot).
+State on a chain — the [ledger state](../references/glossary.md#ledger-state) and the protocol state (`ChainDepState`) — evolves along two independent axes: *blocks arriving* and *time passing*.
+Ticking captures the second axis: given a state anchored at some slot and a later target slot, it applies every per-slot rule that fires in between.
+
+```mermaid
+flowchart LR
+    S0["LedgerState st₀<br/>(tip: slot s₀)"]
+    T0["Ticked st₀<br/>(at slot s₁)"]
+    S1["LedgerState st₁<br/>(tip: slot s₁)"]
+    T1["Ticked st₁<br/>(at slot s₂)"]
+    S2["LedgerState st₂<br/>(tip: slot s₂)"]
+
+    S0 -- "applyChainTick to s₁" --> T0
+    T0 -- "applyBlock (block at s₁)" --> S1
+    S1 -- "applyChainTick to s₂" --> T1
+    T1 -- "applyBlock (block at s₂)" --> S2
+```
+
+A ticked state carries the effects of every per-slot rule between its source slot and the target slot: epoch transitions, rewards pulsing, nonce switching at epoch boundaries, hard-fork activations, and so on.
+A block is then applied on top of a ticked state — never directly on an unticked one.
+The types enforce this alternation.
+
+## Why ticking is a distinguished operation
+
+If ticking were only ever the first step of applying a block, it would not need its own name — it could just be folded into block application.
+The reason it is distinguished is that consensus routinely needs the state at slots where no block exists:
+
+- The [mempool](../references/glossary.md#mempool) validates incoming transactions against the state *as it would be in the next producible slot*, so that transactions it accepts remain valid when a future block is minted.
+- The leadership check evaluates at the current wall-clock slot whether this node is elected to mint, regardless of whether a block exists at that slot.
+- A block producer needs the ticked state at the slot it is minting for in order to compute block-production limits (size, ExUnits) before any transactions are selected.
+
+Bundling ticking into block application would make all of these impossible.
+Separating it also isolates the per-slot rules into one place — the `TICK` transition rule in the ledger — making their behaviour reproducible and independently testable.
+
+## The `Ticked` type wrapper
+
+The interface exposes two ticking operations:
+
+- [`applyChainTickLedgerResult`][apply-chain-tick] on the ledger state.
+- [`tickChainDepState`][tick-chain-dep-state] on the protocol state.
+
+Both take an unticked state and produce a [`Ticked`][ticked] version of it:
+
+```haskell
+applyChainTickLedgerResult ::
+  ComputeLedgerEvents -> LedgerCfg l -> SlotNo -> l EmptyMK ->
+  LedgerResult l (Ticked l DiffMK)
+
+tickChainDepState ::
+  ConsensusConfig p -> LedgerView p -> SlotNo -> ChainDepState p ->
+  Ticked (ChainDepState p)
+```
+
+`Ticked` is a [data family][ticked] with one instance per state type.
+It encodes a discipline at the type level: applying a block is the *only* operation that turns a `Ticked` state back into an unticked one, and a [`LedgerView`](../references/glossary.md#ledger-view) can only be projected from a `Ticked` state.
+This rules out two classes of bug statically — ticking twice without applying a block in between, or applying a block without ticking first.
+
+## Where ticking is used
+
+| Call site                           | From slot             | To slot                      | Why                                                                                   |
+|-------------------------------------|-----------------------|------------------------------|---------------------------------------------------------------------------------------|
+| Block validation ([ChainDB](../references/glossary.md#chaindb)) | ledger tip | block's slot                 | Advance the state to the block's slot before applying the block body.                 |
+| Block forging / leadership check    | ledger tip            | current wall-clock slot      | Check election and compute block-production limits at the slot being minted for.      |
+| Mempool validation                  | ledger tip            | ledger tip + 1               | Validate transactions against the state of the next producible block.                 |
+| Header validation                   | ledger tip            | header's slot                | Tick the protocol state (`ChainDepState`) to the header's slot before validating it.  |
+| Cross-era ticking                   | final slot of era *n* | some slot in era *n+1*       | Activate the hard-fork transition; handled internally by the Hard Fork Combinator.    |
+
+## Ticking vs. forecasting
+
+Ticking and [forecasting](../references/glossary.md#forecasting) both represent the passage of time, but they answer different questions.
+
+- **Ticking** advances the *full* state to a target slot.
+  Its precondition is that no block exists between the source slot and the target slot — ticking past a block on the chain is unsound.
+- **Forecasting** produces only the slices of the future state that are guaranteed to be stable regardless of intervening blocks — in practice, just the [`LedgerView`](../references/glossary.md#ledger-view) needed to validate future headers.
+  It is bounded by the [forecast horizon](../references/glossary.md#forecast-horizon).
+
+The two agree within the forecast horizon:
+
+> `forecastFor (ledgerViewForecastAt cfg st) slot` ≡ `protocolLedgerView cfg (applyChainTick cfg slot st)`
+
+Consensus always guards its ticks behind a successful forecast: the mempool ticks by a single slot (trivially within range); the leadership check aborts if it cannot forecast the `LedgerView`; the ChainSync client forecasts a `LedgerView` before accepting a header; ChainSel only applies blocks whose headers already passed through one of the above.
+This is why ticking can be a *total* function while forecasting is partial — every tick the node performs is dominated by a forecast that has already succeeded.
+
+## Invariants and preconditions
+
+- **Monotonicity.** The target slot must be strictly greater than the slot at the ledger tip (with the Byron EBB caveat, which shares its predecessor's slot).
+- **Tip invariance.** Ticking does not change the ledger tip; the tip still refers to the most recently applied block:
+  `ledgerTipPoint (applyChainTick cfg slot st) == ledgerTipPoint st`.
+- **Totality.** `applyChainTickLedgerResult` cannot fail.
+  A per-slot rule that could fail would mean a *previous* block set up the ledger so that *any* subsequent block would be invalid as soon as a certain slot was reached — which would break the chain.
+- **No reads from the UTxO.** Ticking is not allowed to read from [`LedgerTables`](../references/glossary.md#ledger-state), though it may produce diffs on them (notably at era transitions).
+- **No cross-era ticking in a single-era instance.** Ticking across a hard-fork boundary is only defined by the [Hard Fork Combinator](../references/glossary.md#hard-fork-combinator); a single-era ledger state cannot be ticked past its era.
+
+## Further reading
+
+- [References/Miscellaneous/Ticking](../references/miscellaneous/ticking.md) — the archival discussion, with additional detail on cross-era ticking, HFC subtleties, and cost bounds.
+- Haddocks: [`Ticked`][ticked], [`applyChainTickLedgerResult`][apply-chain-tick], [`tickChainDepState`][tick-chain-dep-state], [`ledgerViewForecastAt`][ledger-view-forecast], [`Forecast`][forecast].
+- [Issue #345](https://github.com/IntersectMBO/ouroboros-consensus/issues/345) — proposal for a cross-era ticking interface.
+
+[ticked]: https://github.com/IntersectMBO/ouroboros-consensus/blob/main/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ticked.hs
+[apply-chain-tick]: https://github.com/IntersectMBO/ouroboros-consensus/blob/main/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Basics.hs
+[tick-chain-dep-state]: https://github.com/IntersectMBO/ouroboros-consensus/blob/main/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Protocol/Abstract.hs
+[ledger-view-forecast]: https://github.com/IntersectMBO/ouroboros-consensus/blob/main/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/SupportsProtocol.hs
+[forecast]: https://github.com/IntersectMBO/ouroboros-consensus/blob/main/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Forecast.hs

--- a/docs/website/contents/references/glossary.md
+++ b/docs/website/contents/references/glossary.md
@@ -619,6 +619,13 @@ The process of becoming synchronized with the system, either from scratch or due
 TPraos (Transitional Praos) is a Proof-of-Stake consensus protocol used in the early decentralized eras of Cardano (specifically Shelley, Allegra, and Mary).
 It was designed to manage the transition from the initial federated system by using a decentralization parameter (`d`) which controls the ratio of slots produced by legacy bootstrap keys (OBFT slots) versus those produced by stake pools selected via Ouroboros Praos, allowing for a smooth shift toward full decentralization.
 
+## ;Tick, ;Ticking, ;Ticked
+
+Ticking advances a [ledger state](#ledger-state) or protocol state from its current slot to a later target slot, applying every rule that depends only on time (epoch transitions, rewards pulsing, nonce switching, hard-fork activations).
+It is distinct from applying a block: ticking captures the changes that happen between blocks, even at slots where no block exists.
+A *ticked* state is one to which ticking has been applied; the `Ticked` type wrapper enforces that blocks are only applied on top of ticked states.
+See the [Ticking explanation](../explanations/ticking.md) for when and why consensus ticks, and its relationship to [forecasting](#forecasting).
+
 ## ;Transactions
 
 If a slot has multiple leaders or if the leader of a slot hadn't received the latest block, then they will issue multiple blocks that all claim to have the same predecessor.A [block body](#header-and-body) is just a sequence of transactions.

--- a/docs/website/contents/references/miscellaneous/ticking.md
+++ b/docs/website/contents/references/miscellaneous/ticking.md
@@ -1,5 +1,12 @@
 # Ticking
 
+:::note
+
+For an accessible introduction to ticking — what it is, when consensus ticks, and how it relates to forecasting — see the [Ticking explanation](../../explanations/ticking.md).
+This page is the deeper archival discussion: cross-era ticking in the Hard Fork Combinator, bounded computation costs, and the partiality argument.
+
+:::
+
 "Tick" is a common term in discrete systems for time passing.
 Within Ouroboros, time is divided into slots, and to _tick_ a state X means to advance X from one slot to a later slot.
 In the Cardano system, we tick a ledger state, a protocol state, or both at once (see `ExtLedgerState`).

--- a/docs/website/sidebars.js
+++ b/docs/website/sidebars.js
@@ -26,6 +26,7 @@ const sidebars = {
               'explanations/data_flow',
               'explanations/consensus_protocol',
               'explanations/ledger_interaction',
+              'explanations/ticking',
               'explanations/queries',
               'explanations/node_tasks',
              ]


### PR DESCRIPTION
## Summary
- Adds `docs/website/contents/explanations/ticking.md`: a first-elaboration
  explanation of ticking covering what it is, why it is a distinguished
  operation, where consensus ticks, how it relates to forecasting, and the
  key invariants. Includes one Mermaid diagram of the tick/apply alternation
  and a table of the main call sites.
- Distilled from the archival `references/miscellaneous/ticking.md`, which
  remains in place as the deeper reference and now points readers to the new
  explanation.
- Adds a glossary entry (`Tick / Ticking / Ticked`) and registers the new
  page in the sidebar.
- Weaves brief motivating context into `consensus_protocol.md`'s "Ticked
  state" section and adds a framing note at the top of
  `ledger_interaction.md`'s "Ledger state ticking and forecasting" section,
  both linking to the new explanation.