### PR TITLE
Index LedgerTables and TxIn/TxOut by `blk`

### DIFF
--- a/changelog.d/20260430_175713_javier.sagredo_index_tables_blk.md
+++ b/changelog.d/20260430_175713_javier.sagredo_index_tables_blk.md
@@ -1,0 +1,30 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+### Breaking
+
+- Index `LedgerTables`, `TxIn`, and `TxOut` by `blk` instead of by the ledger-state shape `l`. Combined with the prior eta-expansion, this collapses the duplicate `LedgerState`/`Ticked LedgerState`/`ExtLedgerState` instances into one.
+  - `TxIn  :: Type -> Type`, `TxOut :: Type -> Type` — keyed by blk
+  - `LedgerTables blk mk` — was LedgerTables l mk
+  - `HasLedgerTables l blk` — separate l and blk parameters
+  - `LedgerTablesAreTrivial l blk`, `SerializeTablesWithHint l blk` — same reshape
+  - `IndexedMemPack l blk a` — was IndexedMemPack idx a
+  - New `GetBlockKeySets blk` class — `getBlockKeySets` split out of `ApplyBlock`. Necessary to avoid `Proxy l` or `AllowAmbiguousTypes` as `getBlockKeySets` doesn't mention `l` anymore.
+  - Removed: `MemPackIdx`, `SameUtxoTypes`, `castLedgerTables`, `TrivialLedgerTables`
+
+<!--
+### Non-Breaking
+
+- A bullet item for the Non-Breaking category.
+
+-->
+<!--
+### Patch
+
+- A bullet item for the Patch category.
+
+-->

--- a/ouroboros-consensus-cardano/src/byron/Ouroboros/Consensus/Byron/ByronHFC.hs
+++ b/ouroboros-consensus-cardano/src/byron/Ouroboros/Consensus/Byron/ByronHFC.hs
@@ -22,6 +22,8 @@ import Cardano.Binary
 import qualified Cardano.Chain.Common as CC
 import qualified Cardano.Chain.Genesis as CC.Genesis
 import qualified Cardano.Chain.Update as CC.Update
+import qualified Codec.CBOR.Decoding as CBOR
+import qualified Codec.CBOR.Encoding as CBOR
 import Control.Monad
 import qualified Data.Map.Strict as Map
 import Data.Maybe (listToMaybe, mapMaybe)
@@ -309,11 +311,7 @@ instance HasHardForkTxOut '[ByronBlock] where
 deriving via
   Void
   instance
-    IndexedMemPack (LedgerState (HardForkBlock '[ByronBlock]) EmptyMK) Void
-deriving via
-  Void
-  instance
-    IndexedMemPack (Ticked LedgerState (HardForkBlock '[ByronBlock]) EmptyMK) Void
+    IndexedMemPack LedgerState (HardForkBlock '[ByronBlock]) Void
 
 instance BlockSupportsHFLedgerQuery '[ByronBlock] where
   answerBlockQueryHFLookup IZ _cfg (q :: BlockQuery ByronBlock QFLookupTables result) _dlv = case q of {}
@@ -325,7 +323,8 @@ instance BlockSupportsHFLedgerQuery '[ByronBlock] where
   queryLedgerGetTraversingFilter IZ (q :: BlockQuery ByronBlock QFTraverseTables result) = case q of {}
   queryLedgerGetTraversingFilter (IS is) _q = case is of {}
 
-deriving via
-  TrivialLedgerTables (LedgerState (HardForkBlock '[ByronBlock]))
-  instance
-    SerializeTablesWithHint (LedgerState (HardForkBlock '[ByronBlock]))
+instance SerializeTablesWithHint LedgerState (HardForkBlock '[ByronBlock]) where
+  decodeTablesWithHint _ = do
+    _ <- CBOR.decodeMapLen
+    pure (LedgerTables $ ValuesMK Map.empty)
+  encodeTablesWithHint _ _ = CBOR.encodeMapLen 0

--- a/ouroboros-consensus-cardano/src/byron/Ouroboros/Consensus/Byron/Ledger/Ledger.hs
+++ b/ouroboros-consensus-cardano/src/byron/Ouroboros/Consensus/Byron/Ledger/Ledger.hs
@@ -91,7 +91,6 @@ import Ouroboros.Consensus.Ledger.Query
 import Ouroboros.Consensus.Ledger.SupportsPeerSelection
 import Ouroboros.Consensus.Ledger.SupportsProtocol
 import Ouroboros.Consensus.Ledger.Tables.Utils
-import Ouroboros.Consensus.Storage.LedgerDB
 import Ouroboros.Consensus.Util (ShowProxy (..))
 import Ouroboros.Consensus.Util.IndexedMemPack
 

--- a/ouroboros-consensus-cardano/src/byron/Ouroboros/Consensus/Byron/Ledger/Ledger.hs
+++ b/ouroboros-consensus-cardano/src/byron/Ouroboros/Consensus/Byron/Ledger/Ledger.hs
@@ -198,39 +198,32 @@ instance IsLedger LedgerState ByronBlock where
             byronLedgerTransition
         }
 
-type instance TxIn (LedgerState ByronBlock) = Void
-type instance TxOut (LedgerState ByronBlock) = Void
+type instance TxIn ByronBlock = Void
+type instance TxOut ByronBlock = Void
 
-instance LedgerTablesAreTrivial (LedgerState ByronBlock) where
-  convertMapKind (ByronLedgerState x y z) = ByronLedgerState x y z
-instance LedgerTablesAreTrivial (Ticked LedgerState ByronBlock) where
-  convertMapKind (TickedByronLedgerState x y) = TickedByronLedgerState x y
+instance LedgerTablesAreTrivial LedgerState ByronBlock where
+  convertMapKind ByronLedgerState{..} = ByronLedgerState{..}
 
-deriving via
-  Void
-  instance
-    IndexedMemPack (LedgerState ByronBlock EmptyMK) Void
-deriving via
-  Void
-  instance
-    IndexedMemPack (Ticked LedgerState ByronBlock EmptyMK) Void
+instance LedgerTablesAreTrivial (Ticked LedgerState) ByronBlock where
+  convertMapKind TickedByronLedgerState{..} = TickedByronLedgerState{..}
 
-deriving via
-  TrivialLedgerTables (LedgerState ByronBlock)
-  instance
-    HasLedgerTables (LedgerState ByronBlock)
-deriving via
-  TrivialLedgerTables (Ticked LedgerState ByronBlock)
-  instance
-    HasLedgerTables (Ticked LedgerState ByronBlock)
-deriving via
-  TrivialLedgerTables (LedgerState ByronBlock)
-  instance
-    CanStowLedgerTables (LedgerState ByronBlock)
-deriving via
-  TrivialLedgerTables (LedgerState ByronBlock)
-  instance
-    SerializeTablesWithHint (LedgerState ByronBlock)
+instance HasLedgerTables LedgerState ByronBlock where
+  projectLedgerTables = trivialProjectLedgerTables
+  withLedgerTables = trivialWithLedgerTables
+
+instance HasLedgerTables (Ticked LedgerState) ByronBlock where
+  projectLedgerTables = trivialProjectLedgerTables
+  withLedgerTables = trivialWithLedgerTables
+
+instance CanStowLedgerTables (LedgerState ByronBlock) where
+  stowLedgerTables = trivialStowLedgerTables
+  unstowLedgerTables = trivialUnstowLedgerTables
+
+instance SerializeTablesWithHint LedgerState ByronBlock where
+  encodeTablesWithHint = trivialEncodeTablesWithHint
+  decodeTablesWithHint = trivialDecodeTablesWithHint
+
+deriving via Void instance IndexedMemPack LedgerState ByronBlock Void
 
 {-------------------------------------------------------------------------------
   Supporting the various consensus interfaces
@@ -242,6 +235,7 @@ instance ApplyBlock LedgerState ByronBlock where
   applyBlockLedgerResult = defaultApplyBlockLedgerResult
   reapplyBlockLedgerResult = defaultReapplyBlockLedgerResult validationErrorImpossible
 
+instance GetBlockKeySets ByronBlock where
   getBlockKeySets _ = emptyLedgerTables
 
 data instance BlockQuery ByronBlock fp result where
@@ -579,5 +573,5 @@ decodeByronResult ::
 decodeByronResult query = case query of
   GetUpdateInterfaceState -> fromByronCBOR
 
-instance CanUpgradeLedgerTables (LedgerState ByronBlock) where
+instance CanUpgradeLedgerTables LedgerState ByronBlock where
   upgradeTables _ _ = id

--- a/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/Ledger.hs
+++ b/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/Ledger.hs
@@ -120,7 +120,6 @@ eliminateCardanoTxOut ::
   forall r c.
   CardanoHardForkConstraints c =>
   ( forall x.
-    -- TODO ProtoCrypto constraint should be in IsShelleyBlock
     IsShelleyBlock x =>
     Index (CardanoEras c) x ->
     TxOut x ->

--- a/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/Ledger.hs
+++ b/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/Ledger.hs
@@ -104,13 +104,13 @@ instance CardanoHardForkConstraints c => MemPack (CanonicalTxIn (CardanoEras c))
   unpackM = CardanoTxIn <$> unpackM
 
 data CardanoTxOut c
-  = ShelleyTxOut {-# UNPACK #-} !(TxOut (LedgerState (ShelleyBlock (TPraos c) ShelleyEra)))
-  | AllegraTxOut {-# UNPACK #-} !(TxOut (LedgerState (ShelleyBlock (TPraos c) AllegraEra)))
-  | MaryTxOut {-# UNPACK #-} !(TxOut (LedgerState (ShelleyBlock (TPraos c) MaryEra)))
-  | AlonzoTxOut !(TxOut (LedgerState (ShelleyBlock (TPraos c) AlonzoEra)))
-  | BabbageTxOut !(TxOut (LedgerState (ShelleyBlock (Praos c) BabbageEra)))
-  | ConwayTxOut !(TxOut (LedgerState (ShelleyBlock (Praos c) ConwayEra)))
-  | DijkstraTxOut !(TxOut (LedgerState (ShelleyBlock (Praos c) DijkstraEra)))
+  = ShelleyTxOut {-# UNPACK #-} !(TxOut (ShelleyBlock (TPraos c) ShelleyEra))
+  | AllegraTxOut {-# UNPACK #-} !(TxOut (ShelleyBlock (TPraos c) AllegraEra))
+  | MaryTxOut {-# UNPACK #-} !(TxOut (ShelleyBlock (TPraos c) MaryEra))
+  | AlonzoTxOut !(TxOut (ShelleyBlock (TPraos c) AlonzoEra))
+  | BabbageTxOut !(TxOut (ShelleyBlock (Praos c) BabbageEra))
+  | ConwayTxOut !(TxOut (ShelleyBlock (Praos c) ConwayEra))
+  | DijkstraTxOut !(TxOut (ShelleyBlock (Praos c) DijkstraEra))
   deriving stock (Show, Eq, Generic)
   deriving anyclass NoThunks
 
@@ -123,7 +123,7 @@ eliminateCardanoTxOut ::
     -- TODO ProtoCrypto constraint should be in IsShelleyBlock
     IsShelleyBlock x =>
     Index (CardanoEras c) x ->
-    TxOut (LedgerState x) ->
+    TxOut x ->
     r
   ) ->
   CardanoTxOut c ->
@@ -154,7 +154,7 @@ instance CardanoHardForkConstraints c => HasHardForkTxOut (CardanoEras c) where
     forall y.
     Index (CardanoEras c) y ->
     HardForkTxOut (CardanoEras c) ->
-    TxOut (LedgerState y)
+    TxOut y
   ejectHardForkTxOut targetIdx =
     eliminateCardanoTxOut
       ( \origIdx ->
@@ -166,9 +166,9 @@ instance CardanoHardForkConstraints c => HasHardForkTxOut (CardanoEras c) where
 
 instance
   CardanoHardForkConstraints c =>
-  IndexedMemPack (LedgerState (HardForkBlock (CardanoEras c)) EmptyMK) (CardanoTxOut c)
+  IndexedMemPack LedgerState (HardForkBlock (CardanoEras c)) (CardanoTxOut c)
   where
-  indexedTypeName _ = "CardanoTxOut"
+  indexedTypeName _ _ = "CardanoTxOut"
   indexedPackM _ = eliminateCardanoTxOut (const packM)
   indexedPackedByteCount _ = eliminateCardanoTxOut (const packedByteCount)
   indexedUnpackM (HardForkLedgerState (HardForkState idx)) = do
@@ -190,31 +190,7 @@ instance
 
 instance
   CardanoHardForkConstraints c =>
-  IndexedMemPack (Ticked LedgerState (HardForkBlock (CardanoEras c)) EmptyMK) (CardanoTxOut c)
-  where
-  indexedTypeName _ = "CardanoTxOut"
-  indexedPackM _ = eliminateCardanoTxOut (const packM)
-  indexedPackedByteCount _ = eliminateCardanoTxOut (const packedByteCount)
-  indexedUnpackM (TickedHardForkLedgerState _ (HardForkState idx)) = do
-    let
-      -- These could be made into a CAF to avoid recomputing it, but
-      -- it is only used in serialization so it is not critical.
-      np =
-        ( (Fn $ const $ error "unpacking a byron txout")
-            :* (Fn $ const $ Comp $ K . ShelleyTxOut <$> unpackM)
-            :* (Fn $ const $ Comp $ K . AllegraTxOut <$> unpackM)
-            :* (Fn $ const $ Comp $ K . MaryTxOut <$> unpackM)
-            :* (Fn $ const $ Comp $ K . AlonzoTxOut <$> unpackM)
-            :* (Fn $ const $ Comp $ K . BabbageTxOut <$> unpackM)
-            :* (Fn $ const $ Comp $ K . ConwayTxOut <$> unpackM)
-            :* (Fn $ const $ Comp $ K . DijkstraTxOut <$> unpackM)
-            :* Nil
-        )
-    hcollapse <$> (hsequence' $ hap np $ Telescope.tip idx)
-
-instance
-  CardanoHardForkConstraints c =>
-  SerializeTablesWithHint (LedgerState (HardForkBlock (CardanoEras c)))
+  SerializeTablesWithHint LedgerState (HardForkBlock (CardanoEras c))
   where
   encodeTablesWithHint (HardForkLedgerState (HardForkState idx)) (LedgerTables (ValuesMK tbs)) =
     let
@@ -241,7 +217,7 @@ instance
   decodeTablesWithHint ::
     forall s.
     LedgerState (HardForkBlock (CardanoEras c)) EmptyMK ->
-    Decoder s (LedgerTables (LedgerState (HardForkBlock (CardanoEras c))) ValuesMK)
+    Decoder s (LedgerTables (HardForkBlock (CardanoEras c)) ValuesMK)
   decodeTablesWithHint (HardForkLedgerState (HardForkState idx)) =
     let
       -- These could be made into a CAF to avoid recomputing it, but
@@ -250,7 +226,7 @@ instance
         ( Fn $
             const $
               Comp $
-                K . LedgerTables @(LedgerState (HardForkBlock (CardanoEras c))) . ValuesMK
+                K . LedgerTables . ValuesMK
                   <$> (Codec.CBOR.Decoding.decodeMapLen >> pure Map.empty)
         )
           :* (Fn $ Comp . fmap K . getOne ShelleyTxOut . unFlip . currentState)
@@ -267,9 +243,9 @@ instance
     getOne ::
       forall proto era.
       ShelleyCompatible proto era =>
-      (TxOut (LedgerState (ShelleyBlock proto era)) -> CardanoTxOut c) ->
+      (TxOut (ShelleyBlock proto era) -> CardanoTxOut c) ->
       LedgerState (ShelleyBlock proto era) EmptyMK ->
-      Decoder s (LedgerTables (LedgerState (HardForkBlock (CardanoEras c))) ValuesMK)
+      Decoder s (LedgerTables (HardForkBlock (CardanoEras c)) ValuesMK)
     getOne toCardanoTxOut st =
       let certInterns =
             internsFromMap $

--- a/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/QueryHF.hs
+++ b/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/QueryHF.hs
@@ -88,7 +88,7 @@ shelleyCardanoFilter ::
   , ShelleyCompatible proto era
   ) =>
   BlockQuery (ShelleyBlock proto era) QFTraverseTables result ->
-  TxOut (LedgerState (HardForkBlock (CardanoEras c))) ->
+  TxOut (HardForkBlock (CardanoEras c)) ->
   Bool
 shelleyCardanoFilter q = eliminateCardanoTxOut (\_ -> shelleyQFTraverseTablesPredicate q)
 
@@ -125,6 +125,6 @@ instance CardanoHardForkConstraints c => BlockSupportsHFLedgerQuery (CardanoEras
 
 byronCardanoFilter ::
   BlockQuery ByronBlock QFTraverseTables result ->
-  TxOut (LedgerState (HardForkBlock (CardanoEras c))) ->
+  TxOut (HardForkBlock (CardanoEras c)) ->
   Bool
 byronCardanoFilter = \case {}

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Ledger.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Ledger.hs
@@ -285,7 +285,7 @@ data instance LedgerState (ShelleyBlock proto era) mk = ShelleyLedgerState
   { shelleyLedgerTip :: !(WithOrigin (ShelleyTip proto era))
   , shelleyLedgerState :: !(SL.NewEpochState era)
   , shelleyLedgerTransition :: !ShelleyTransition
-  , shelleyLedgerTables :: !(LedgerTables (LedgerState (ShelleyBlock proto era)) mk)
+  , shelleyLedgerTables :: !(LedgerTables (ShelleyBlock proto era) mk)
   , shelleyLedgerLatestPerasCertRound :: !(StrictMaybe PerasRoundNo)
   }
   deriving Generic
@@ -359,30 +359,21 @@ instance MemPack BigEndianTxIn where
   unpackM = do
     BigEndianTxIn <$> (SL.TxIn <$> unpackM <*> (getOriginalTxIx <$> unpackM))
 
-type instance TxIn (LedgerState (ShelleyBlock proto era)) = BigEndianTxIn
-type instance TxOut (LedgerState (ShelleyBlock proto era)) = Core.TxOut era
+type instance TxIn (ShelleyBlock proto era) = BigEndianTxIn
+type instance TxOut (ShelleyBlock proto era) = Core.TxOut era
 
 instance
   (txout ~ Core.TxOut era, MemPack txout) =>
-  IndexedMemPack (LedgerState (ShelleyBlock proto era) EmptyMK) txout
+  IndexedMemPack LedgerState (ShelleyBlock proto era) txout
   where
-  indexedTypeName _ = typeName @txout
-  indexedPackedByteCount _ = packedByteCount
-  indexedPackM _ = packM
-  indexedUnpackM _ = unpackM
-
-instance
-  (txout ~ Core.TxOut era, MemPack txout) =>
-  IndexedMemPack (Ticked LedgerState (ShelleyBlock proto era) EmptyMK) txout
-  where
-  indexedTypeName _ = typeName @txout
+  indexedTypeName _ _ = typeName @txout
   indexedPackedByteCount _ = packedByteCount
   indexedPackM _ = packM
   indexedUnpackM _ = unpackM
 
 instance
   ShelleyCompatible proto era =>
-  SerializeTablesWithHint (LedgerState (ShelleyBlock proto era))
+  SerializeTablesWithHint LedgerState (ShelleyBlock proto era)
   where
   encodeTablesWithHint _ (LedgerTables (ValuesMK tbs)) =
     toPlainEncoding (Core.eraProtVerLow @era) $ encodeMap encodeMemPack encodeMemPack tbs
@@ -400,7 +391,7 @@ instance
 
 instance
   ShelleyBasedEra era =>
-  HasLedgerTables (LedgerState (ShelleyBlock proto era))
+  HasLedgerTables LedgerState (ShelleyBlock proto era)
   where
   projectLedgerTables = shelleyLedgerTables
   withLedgerTables st tables =
@@ -421,15 +412,15 @@ instance
 
 instance
   ShelleyBasedEra era =>
-  HasLedgerTables (Ticked LedgerState (ShelleyBlock proto era))
+  HasLedgerTables (Ticked LedgerState) (ShelleyBlock proto era)
   where
-  projectLedgerTables = castLedgerTables . tickedShelleyLedgerTables
+  projectLedgerTables = tickedShelleyLedgerTables
   withLedgerTables st tables =
     TickedShelleyLedgerState
       { untickedShelleyLedgerTip
       , tickedShelleyLedgerTransition
       , tickedShelleyLedgerState
-      , tickedShelleyLedgerTables = castLedgerTables tables
+      , tickedShelleyLedgerTables = tables
       , tickedShelleyLedgerLatestPerasCertRound
       }
    where
@@ -551,8 +542,7 @@ data instance Ticked LedgerState (ShelleyBlock proto era) mk = TickedShelleyLedg
   -- 2. However, we count within an epoch, which is slot-based. So the count
   --    must be reset when /ticking/, not when applying a block.
   , tickedShelleyLedgerState :: !(SL.NewEpochState era)
-  , tickedShelleyLedgerTables ::
-      !(LedgerTables (LedgerState (ShelleyBlock proto era)) mk)
+  , tickedShelleyLedgerTables :: !(LedgerTables (ShelleyBlock proto era) mk)
   , tickedShelleyLedgerLatestPerasCertRound :: !(StrictMaybe PerasRoundNo)
   }
   deriving Generic
@@ -647,6 +637,10 @@ instance
   reapplyBlockLedgerResult =
     defaultReapplyBlockLedgerResult (\err -> Exception.throw $! ShelleyReapplyException @era err)
 
+instance
+  ShelleyCompatible proto era =>
+  GetBlockKeySets (ShelleyBlock proto era)
+  where
   getBlockKeySets =
     LedgerTables
       . KeysMK
@@ -921,7 +915,7 @@ decodeShelleyLedgerState =
         , shelleyLedgerLatestPerasCertRound
         }
 
-instance CanUpgradeLedgerTables (LedgerState (ShelleyBlock proto era)) where
+instance CanUpgradeLedgerTables LedgerState (ShelleyBlock proto era) where
   upgradeTables _ _ = id
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Ledger.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Ledger.hs
@@ -136,7 +136,6 @@ import Ouroboros.Consensus.Shelley.Protocol.Abstract
   , envelopeChecks
   , mkHeaderView
   )
-import Ouroboros.Consensus.Storage.LedgerDB
 import Ouroboros.Consensus.Util
 import Ouroboros.Consensus.Util.CBOR
   ( decodeStrictMaybe

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Query.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Query.hs
@@ -75,7 +75,7 @@ import Ouroboros.Consensus.Config
 import Ouroboros.Consensus.HardFork.Combinator.Basics
 import Ouroboros.Consensus.HardFork.Combinator.Ledger.Query
 import Ouroboros.Consensus.HeaderValidation
-import Ouroboros.Consensus.Ledger.Basics
+import Ouroboros.Consensus.Ledger.Abstract
 import Ouroboros.Consensus.Ledger.Extended
 import Ouroboros.Consensus.Ledger.Query
 import Ouroboros.Consensus.Ledger.SupportsPeerSelection
@@ -1164,13 +1164,13 @@ answerShelleyLookupQueries ::
   , ShelleyCompatible proto era
   ) =>
   -- | Inject ledger tables
-  ( LedgerTables (LedgerState (ShelleyBlock proto era)) KeysMK ->
-    LedgerTables (LedgerState blk) KeysMK
+  ( LedgerTables (ShelleyBlock proto era) KeysMK ->
+    LedgerTables blk KeysMK
   ) ->
   -- | Eject TxOut
-  (TxOut (LedgerState blk) -> LC.TxOut era) ->
+  (TxOut blk -> LC.TxOut era) ->
   -- | Eject TxIn
-  (TxIn (LedgerState blk) -> SL.TxIn) ->
+  (TxIn blk -> SL.TxIn) ->
   ExtLedgerCfg (ShelleyBlock proto era) ->
   BlockQuery (ShelleyBlock proto era) QFLookupTables result ->
   ReadOnlyForker' m blk ->
@@ -1194,7 +1194,7 @@ answerShelleyLookupQueries injTables ejTxOut ejTxIn cfg q forker =
     LedgerTables (ValuesMK values) <-
       LedgerDB.roforkerReadTables
         forker
-        (castLedgerTables $ injTables (LedgerTables $ KeysMK $ coerceSet txins))
+        (injTables (LedgerTables $ KeysMK $ coerceSet txins))
     pure $
       SL.UTxO $
         Map.mapKeys ejTxIn $
@@ -1210,7 +1210,7 @@ shelleyQFTraverseTablesPredicate ::
   forall proto era proto' era' result.
   (ShelleyBasedEra era, ShelleyBasedEra era') =>
   BlockQuery (ShelleyBlock proto era) QFTraverseTables result ->
-  TxOut (LedgerState (ShelleyBlock proto' era')) ->
+  TxOut (ShelleyBlock proto' era') ->
   Bool
 shelleyQFTraverseTablesPredicate q = case q of
   GetUTxOByAddress addr -> filterGetUTxOByAddressOne addr
@@ -1234,20 +1234,20 @@ shelleyQFTraverseTablesPredicate q = case q of
 answerShelleyTraversingQueries ::
   forall proto era m result blk.
   ( ShelleyCompatible proto era
-  , Ord (TxIn (LedgerState blk))
-  , Eq (TxOut (LedgerState blk))
-  , MemPack (TxIn (LedgerState blk))
-  , IndexedMemPack (LedgerState blk EmptyMK) (TxOut (LedgerState blk))
+  , Ord (TxIn blk)
+  , Eq (TxOut blk)
+  , MemPack (TxIn blk)
+  , IndexedMemPack LedgerState blk (TxOut blk)
   ) =>
   Monad m =>
   -- | Eject TxOut
-  (TxOut (LedgerState blk) -> LC.TxOut era) ->
+  (TxOut blk -> LC.TxOut era) ->
   -- | Eject TxIn
-  (TxIn (LedgerState blk) -> SL.TxIn) ->
+  (TxIn blk -> SL.TxIn) ->
   -- | Get filter by query
   ( forall result'.
     BlockQuery (ShelleyBlock proto era) QFTraverseTables result' ->
-    TxOut (LedgerState blk) ->
+    TxOut blk ->
     Bool
   ) ->
   ExtLedgerCfg (ShelleyBlock proto era) ->
@@ -1270,8 +1270,8 @@ answerShelleyTraversingQueries ejTxOut ejTxIn filt cfg q forker = case q of
   combUtxo (SL.UTxO l) vs = SL.UTxO $ Map.union l vs
 
   partial ::
-    (TxOut (LedgerState blk) -> Bool) ->
-    LedgerTables (ExtLedgerState blk) ValuesMK ->
+    (TxOut blk -> Bool) ->
+    LedgerTables blk ValuesMK ->
     Map SL.TxIn (LC.TxOut era)
   partial queryPredicate (LedgerTables (ValuesMK vs)) =
     Map.mapKeys ejTxIn $

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/ShelleyHFC.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/ShelleyHFC.hs
@@ -388,8 +388,8 @@ translateShelleyTables ::
   , ShelleyBasedEra era
   , ShelleyBasedEra (SL.PreviousEra era)
   ) =>
-  LedgerTables (LedgerState (ShelleyBlock proto (SL.PreviousEra era))) mk ->
-  LedgerTables (LedgerState (ShelleyBlock proto era)) mk
+  LedgerTables (ShelleyBlock proto (SL.PreviousEra era)) mk ->
+  LedgerTables (ShelleyBlock proto era) mk
 translateShelleyTables (LedgerTables utxoTable) =
   LedgerTables $ mapKeysMK coerce $ mapMK SL.upgradeTxOut utxoTable
 
@@ -460,7 +460,7 @@ instance ShelleyCompatible proto era => HasHardForkTxOut '[ShelleyBlock proto er
 instance
   ( ShelleyCompatible proto era
   , ShelleyBasedEra era
-  , TxOut (LedgerState (ShelleyBlock proto era)) ~ SL.TxOut era
+  , TxOut (ShelleyBlock proto era) ~ SL.TxOut era
   , HasHardForkTxOut '[ShelleyBlock proto era]
   ) =>
   BlockSupportsHFLedgerQuery '[ShelleyBlock proto era]
@@ -483,29 +483,20 @@ instance
 
 instance
   (txout ~ SL.TxOut era, MemPack txout) =>
-  IndexedMemPack (LedgerState (HardForkBlock '[ShelleyBlock proto era]) EmptyMK) txout
+  IndexedMemPack LedgerState (HardForkBlock '[ShelleyBlock proto era]) txout
   where
-  indexedTypeName _ = typeName @txout
-  indexedPackedByteCount _ = packedByteCount
-  indexedPackM _ = packM
-  indexedUnpackM _ = unpackM
-
-instance
-  (txout ~ SL.TxOut era, MemPack txout) =>
-  IndexedMemPack (Ticked LedgerState (HardForkBlock '[ShelleyBlock proto era]) EmptyMK) txout
-  where
-  indexedTypeName _ = typeName @txout
+  indexedTypeName _ _ = typeName @txout
   indexedPackedByteCount _ = packedByteCount
   indexedPackM _ = packM
   indexedUnpackM _ = unpackM
 
 instance
   ShelleyCompatible proto era =>
-  SerializeTablesWithHint (LedgerState (HardForkBlock '[ShelleyBlock proto era]))
+  SerializeTablesWithHint LedgerState (HardForkBlock '[ShelleyBlock proto era])
   where
   encodeTablesWithHint ::
     LedgerState (HardForkBlock '[ShelleyBlock proto era]) EmptyMK ->
-    LedgerTables (LedgerState (HardForkBlock '[ShelleyBlock proto era])) ValuesMK ->
+    LedgerTables (HardForkBlock '[ShelleyBlock proto era]) ValuesMK ->
     Encoding
   encodeTablesWithHint (HardForkLedgerState (HardForkState idx)) (LedgerTables (ValuesMK tbs)) =
     let
@@ -519,7 +510,7 @@ instance
   decodeTablesWithHint ::
     forall s.
     LedgerState (HardForkBlock '[ShelleyBlock proto era]) EmptyMK ->
-    Decoder s (LedgerTables (LedgerState (HardForkBlock '[ShelleyBlock proto era])) ValuesMK)
+    Decoder s (LedgerTables (HardForkBlock '[ShelleyBlock proto era]) ValuesMK)
   decodeTablesWithHint (HardForkLedgerState (HardForkState idx)) =
     let
       np = (Fn $ Comp . fmap K . getOne . unFlip . currentState) :* Nil
@@ -528,7 +519,7 @@ instance
    where
     getOne ::
       LedgerState (ShelleyBlock proto era) EmptyMK ->
-      Decoder s (LedgerTables (LedgerState (HardForkBlock '[ShelleyBlock proto era])) ValuesMK)
+      Decoder s (LedgerTables (HardForkBlock '[ShelleyBlock proto era]) ValuesMK)
     getOne st =
       let certInterns =
             internsFromMap $

--- a/ouroboros-consensus-cardano/src/unstable-byron-testlib/Test/Consensus/Byron/Generators.hs
+++ b/ouroboros-consensus-cardano/src/unstable-byron-testlib/Test/Consensus/Byron/Generators.hs
@@ -425,7 +425,7 @@ genByronLedgerState = do
       Left _ -> pure Origin
       Right _ -> NotOrigin <$> arbitrary
 
-instance ZeroableMK mk => Arbitrary (LedgerTables (LedgerState ByronBlock) mk) where
+instance ZeroableMK mk => Arbitrary (LedgerTables ByronBlock mk) where
   arbitrary = pure emptyLedgerTables
 
 genByronLedgerConfig :: Gen Byron.Config

--- a/ouroboros-consensus-cardano/src/unstable-byronspec/Ouroboros/Consensus/ByronSpec/Ledger/Ledger.hs
+++ b/ouroboros-consensus-cardano/src/unstable-byronspec/Ouroboros/Consensus/ByronSpec/Ledger/Ledger.hs
@@ -126,34 +126,24 @@ instance IsLedger LedgerState ByronSpecBlock where
   Ledger Tables
 -------------------------------------------------------------------------------}
 
-type instance TxIn (LedgerState ByronSpecBlock) = Void
-type instance TxOut (LedgerState ByronSpecBlock) = Void
-instance LedgerTablesAreTrivial (LedgerState ByronSpecBlock) where
-  convertMapKind (ByronSpecLedgerState x y) =
-    ByronSpecLedgerState x y
-instance LedgerTablesAreTrivial (Ticked LedgerState ByronSpecBlock) where
+type instance TxIn ByronSpecBlock = Void
+type instance TxOut ByronSpecBlock = Void
+
+instance LedgerTablesAreTrivial LedgerState ByronSpecBlock where
+  convertMapKind (ByronSpecLedgerState x y) = ByronSpecLedgerState x y
+instance LedgerTablesAreTrivial (Ticked LedgerState) ByronSpecBlock where
   convertMapKind (TickedByronSpecLedgerState x y) =
     TickedByronSpecLedgerState x y
 deriving via
   Void
   instance
-    IndexedMemPack (LedgerState ByronSpecBlock EmptyMK) Void
-deriving via
-  Void
-  instance
-    IndexedMemPack (Ticked LedgerState ByronSpecBlock EmptyMK) Void
-deriving via
-  TrivialLedgerTables (LedgerState ByronSpecBlock)
-  instance
-    HasLedgerTables (LedgerState ByronSpecBlock)
-deriving via
-  TrivialLedgerTables (Ticked LedgerState ByronSpecBlock)
-  instance
-    HasLedgerTables (Ticked LedgerState ByronSpecBlock)
-deriving via
-  TrivialLedgerTables (LedgerState ByronSpecBlock)
-  instance
-    CanStowLedgerTables (LedgerState ByronSpecBlock)
+    IndexedMemPack LedgerState ByronSpecBlock Void
+instance HasLedgerTables LedgerState ByronSpecBlock where
+  projectLedgerTables _ = emptyLedgerTables
+  withLedgerTables st _ = convertMapKind st
+instance HasLedgerTables (Ticked LedgerState) ByronSpecBlock where
+  projectLedgerTables _ = emptyLedgerTables
+  withLedgerTables st _ = convertMapKind st
 
 {-------------------------------------------------------------------------------
   Applying blocks
@@ -176,6 +166,7 @@ instance ApplyBlock LedgerState ByronSpecBlock where
   reapplyBlockLedgerResult =
     defaultReapplyBlockLedgerResult (error . ("reapplyBlockLedgerResult: unexpected error " ++) . show)
 
+instance GetBlockKeySets ByronSpecBlock where
   getBlockKeySets _ = emptyLedgerTables
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus-cardano/src/unstable-cardano-testlib/Test/Consensus/Cardano/Examples.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-testlib/Test/Consensus/Cardano/Examples.hs
@@ -57,7 +57,6 @@ import Ouroboros.Consensus.Ledger.SupportsMempool (ApplyTxErr)
 import Ouroboros.Consensus.Ledger.Tables
   ( EmptyMK
   , ValuesMK
-  , castLedgerTables
   )
 import Ouroboros.Consensus.Protocol.TPraos (TPraos)
 import Ouroboros.Consensus.Shelley.Ledger (ShelleyBlock)
@@ -140,7 +139,7 @@ combineEras perEraExamples =
       eraName = singleEraName $ singleEraInfo es
 
   exampleLedgerTablesCardano ::
-    Labelled (LedgerTables (LedgerState (HardForkBlock (CardanoEras Crypto))) ValuesMK)
+    Labelled (LedgerTables (HardForkBlock (CardanoEras Crypto)) ValuesMK)
   exampleLedgerTablesCardano =
     mconcat $
       hcollapse $
@@ -243,13 +242,12 @@ instance Inject Examples where
 
 -- | This wrapper is used only in the 'Example' instance of 'Inject' so that we
 -- can use a type that matches the kind expected by 'inj'.
-newtype WrapLedgerTables blk = WrapLedgerTables (LedgerTables (ExtLedgerState blk) ValuesMK)
+newtype WrapLedgerTables blk = WrapLedgerTables (LedgerTables blk ValuesMK)
 
 instance Inject WrapLedgerTables where
   inject idx (WrapLedgerTables lt) =
     WrapLedgerTables $
-      castLedgerTables $
-        injectLedgerTables (forgetInjectionIndex idx) (castLedgerTables lt)
+      injectLedgerTables (forgetInjectionIndex idx) lt
 
 {-------------------------------------------------------------------------------
   Setup

--- a/ouroboros-consensus-cardano/src/unstable-cardano-testlib/Test/ThreadNet/Infra/ShelleyBasedHardFork.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-testlib/Test/ThreadNet/Infra/ShelleyBasedHardFork.hs
@@ -198,8 +198,8 @@ type ShelleyBasedHardForkConstraints proto1 era1 proto2 era2 =
   , PraosCrypto (ProtoCrypto proto1)
   , proto1 ~ TPraos (ProtoCrypto proto1)
   , proto1 ~ proto2
-  , MemPack (TxOut (LedgerState (ShelleyBlock proto1 era1)))
-  , MemPack (TxOut (LedgerState (ShelleyBlock proto2 era2)))
+  , MemPack (TxOut (ShelleyBlock proto1 era1))
+  , MemPack (TxOut (ShelleyBlock proto2 era2))
   )
 
 class TranslateTxMeasure a b where
@@ -532,12 +532,13 @@ instance
 instance
   ShelleyBasedHardForkConstraints proto1 era1 proto2 era2 =>
   SerializeTablesWithHint
-    (LedgerState (HardForkBlock (ShelleyBasedHardForkEras proto1 era1 proto2 era2)))
+    LedgerState
+    (HardForkBlock (ShelleyBasedHardForkEras proto1 era1 proto2 era2))
   where
   encodeTablesWithHint ::
     LedgerState (HardForkBlock (ShelleyBasedHardForkEras proto1 era1 proto2 era2)) EmptyMK ->
     LedgerTables
-      (LedgerState (HardForkBlock (ShelleyBasedHardForkEras proto1 era1 proto2 era2)))
+      (HardForkBlock (ShelleyBasedHardForkEras proto1 era1 proto2 era2))
       ValuesMK ->
     Encoding
   encodeTablesWithHint (HardForkLedgerState (HardForkState idx)) (LedgerTables (ValuesMK tbs)) =
@@ -566,7 +567,7 @@ instance
     Decoder
       s
       ( LedgerTables
-          (LedgerState (HardForkBlock (ShelleyBasedHardForkEras proto1 era1 proto2 era2)))
+          (HardForkBlock (ShelleyBasedHardForkEras proto1 era1 proto2 era2))
           ValuesMK
       )
   decodeTablesWithHint (HardForkLedgerState (HardForkState idx)) =
@@ -581,14 +582,14 @@ instance
     getOne ::
       forall proto era.
       ShelleyCompatible proto era =>
-      ( TxOut (LedgerState (ShelleyBlock proto era)) ->
-        TxOut (LedgerState (HardForkBlock (ShelleyBasedHardForkEras proto1 era1 proto2 era2)))
+      ( TxOut (ShelleyBlock proto era) ->
+        TxOut (HardForkBlock (ShelleyBasedHardForkEras proto1 era1 proto2 era2))
       ) ->
       LedgerState (ShelleyBlock proto era) EmptyMK ->
       Decoder
         s
         ( LedgerTables
-            (LedgerState (HardForkBlock (ShelleyBasedHardForkEras proto1 era1 proto2 era2)))
+            (HardForkBlock (ShelleyBasedHardForkEras proto1 era1 proto2 era2))
             ValuesMK
         )
     getOne toShelleyTxOut st =
@@ -608,10 +609,11 @@ instance
 instance
   ShelleyBasedHardForkConstraints proto1 era1 proto2 era2 =>
   IndexedMemPack
-    (LedgerState (HardForkBlock (ShelleyBasedHardForkEras proto1 era1 proto2 era2)) EmptyMK)
+    LedgerState
+    (HardForkBlock (ShelleyBasedHardForkEras proto1 era1 proto2 era2))
     (DefaultHardForkTxOut (ShelleyBasedHardForkEras proto1 era1 proto2 era2))
   where
-  indexedTypeName _ =
+  indexedTypeName _ _ =
     typeName @(DefaultHardForkTxOut (ShelleyBasedHardForkEras proto1 era1 proto2 era2))
   indexedPackedByteCount _ txout =
     hcollapse $
@@ -636,10 +638,11 @@ instance
 instance
   ShelleyBasedHardForkConstraints proto1 era1 proto2 era2 =>
   IndexedMemPack
-    (Ticked LedgerState (HardForkBlock (ShelleyBasedHardForkEras proto1 era1 proto2 era2)) EmptyMK)
+    (Ticked LedgerState)
+    (HardForkBlock (ShelleyBasedHardForkEras proto1 era1 proto2 era2))
     (DefaultHardForkTxOut (ShelleyBasedHardForkEras proto1 era1 proto2 era2))
   where
-  indexedTypeName _ =
+  indexedTypeName _ _ =
     typeName @(DefaultHardForkTxOut (ShelleyBasedHardForkEras proto1 era1 proto2 era2))
   indexedPackedByteCount _ txout =
     hcollapse $

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Analysis.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Analysis.hs
@@ -60,13 +60,6 @@ import Ouroboros.Consensus.HeaderValidation
   , validateHeader
   )
 import Ouroboros.Consensus.Ledger.Abstract
-  ( ApplyBlock (getBlockKeySets, reapplyBlockLedgerResult)
-  , applyBlockLedgerResult
-  , tickThenApply
-  , tickThenApplyLedgerResult
-  , tickThenReapply
-  )
-import Ouroboros.Consensus.Ledger.Basics
 import Ouroboros.Consensus.Ledger.Extended
 import Ouroboros.Consensus.Ledger.SupportsMempool
   ( LedgerSupportsMempool
@@ -100,6 +93,8 @@ runAnalysis ::
   , LedgerSupportsMempool blk
   , LedgerSupportsProtocol blk
   , CanStowLedgerTables (LedgerState blk)
+  , Show (TxIn blk)
+  , Show (TxOut blk)
   ) =>
   AnalysisName -> SomeAnalysis blk
 runAnalysis analysisName = case go analysisName of
@@ -850,6 +845,8 @@ reproMempoolForge ::
   , LedgerSupportsMempool.HasTxs blk
   , LedgerSupportsMempool blk
   , LedgerSupportsProtocol blk
+  , Show (TxIn blk)
+  , Show (TxOut blk)
   ) =>
   Int ->
   Analysis blk StartFromLedgerState
@@ -960,7 +957,7 @@ reproMempoolForge numBlks env = do
             ((), durSnap, mutSnap, gcSnap) <- timed $ do
               snap <-
                 Mempool.getSnapshotFor mempool slot ticked $
-                  fmap castLedgerTables . LedgerDB.forkerReadTables forker . castLedgerTables
+                  LedgerDB.forkerReadTables forker
 
               pure $ length (Mempool.snapshotTxs snap) `seq` Mempool.snapshotStateHash snap `seq` ()
 

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Run.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Run.hs
@@ -68,7 +68,7 @@ openLedgerDB ::
   ( LedgerSupportsProtocol blk
   , InspectLedger blk
   , HasHardForkHistory blk
-  , LedgerDB.LedgerSupportsLedgerDB blk
+  , LedgerDB.LedgerDbSerialiseConstraints blk
   ) =>
   Complete LedgerDB.LedgerDbArgs IO blk ->
   IO

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Run.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Run.hs
@@ -24,7 +24,7 @@ import qualified Debug.Trace as Debug
 import Ouroboros.Consensus.Block
 import Ouroboros.Consensus.Config
 import Ouroboros.Consensus.HardFork.Abstract
-import Ouroboros.Consensus.Ledger.Basics
+import Ouroboros.Consensus.Ledger.Abstract
 import Ouroboros.Consensus.Ledger.Extended
 import Ouroboros.Consensus.Ledger.Inspect
 import qualified Ouroboros.Consensus.Ledger.SupportsMempool as LedgerSupportsMempool
@@ -129,6 +129,8 @@ analyse ::
   ( Node.RunNode blk
   , Show (Header blk)
   , Show (ReasonForSwitch (TiebreakerView (BlockProtocol blk)))
+  , Show (TxIn blk)
+  , Show (TxOut blk)
   , HasAnalysis blk
   , HasProtocolInfo blk
   , LedgerSupportsMempool.HasTxs blk

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBSynthesizer/Forging.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBSynthesizer/Forging.hs
@@ -40,8 +40,7 @@ import Ouroboros.Consensus.HeaderValidation
   ( BasicEnvelopeValidation (..)
   , HeaderState (..)
   )
-import Ouroboros.Consensus.Ledger.Abstract (Validated)
-import Ouroboros.Consensus.Ledger.Basics
+import Ouroboros.Consensus.Ledger.Abstract
 import Ouroboros.Consensus.Ledger.Extended
 import Ouroboros.Consensus.Ledger.SupportsMempool (GenTx)
 import Ouroboros.Consensus.Ledger.SupportsProtocol
@@ -89,7 +88,7 @@ initialForgeState = ForgeState 0 0 0 0
 -- | An action to generate transactions for a given block
 type GenTxs blk =
   SlotNo ->
-  ReadOnlyForker IO (ExtLedgerState blk) ->
+  ReadOnlyForker' IO blk ->
   TickedLedgerState blk DiffMK ->
   IO [Validated (GenTx blk)]
 

--- a/ouroboros-consensus-cardano/src/unstable-shelley-testlib/Test/Consensus/Shelley/Examples.hs
+++ b/ouroboros-consensus-cardano/src/unstable-shelley-testlib/Test/Consensus/Shelley/Examples.hs
@@ -96,7 +96,7 @@ mkLedgerTables ::
   forall proto era.
   ShelleyCompatible proto era =>
   LC.Tx LC.TopTx era ->
-  LedgerTables (LedgerState (ShelleyBlock proto era)) ValuesMK
+  LedgerTables (ShelleyBlock proto era) ValuesMK
 mkLedgerTables tx =
   LedgerTables $
     ValuesMK $

--- a/ouroboros-consensus-cardano/src/unstable-snapshot-conversion/Ouroboros/Consensus/Cardano/SnapshotConversion.hs
+++ b/ouroboros-consensus-cardano/src/unstable-snapshot-conversion/Ouroboros/Consensus/Cardano/SnapshotConversion.hs
@@ -32,7 +32,7 @@ import Ouroboros.Consensus.Cardano.Block
 import Ouroboros.Consensus.Cardano.Node ()
 import Ouroboros.Consensus.Cardano.StreamingLedgerTables
 import Ouroboros.Consensus.Config
-import Ouroboros.Consensus.Ledger.Basics
+import Ouroboros.Consensus.Ledger.Abstract
 import Ouroboros.Consensus.Ledger.Extended
 import Ouroboros.Consensus.Node.ProtocolInfo
 import Ouroboros.Consensus.Storage.LedgerDB.API
@@ -160,8 +160,8 @@ data OutEnv backend = OutEnv
 
 data SomeBackend c where
   SomeBackend ::
-    StreamingBackend IO backend (LedgerState (CardanoBlock StandardCrypto)) =>
-    c IO backend (LedgerState (CardanoBlock StandardCrypto)) -> SomeBackend c
+    StreamingBackend IO backend LedgerState (CardanoBlock StandardCrypto) =>
+    c IO backend LedgerState (CardanoBlock StandardCrypto) -> SomeBackend c
 
 instance NoThunks (SomeBackend c) where
   wNoThunks _ (SomeBackend _) = pure Nothing
@@ -382,12 +382,16 @@ convertSnapshot interactive (configCodec . pInfoConfig -> ccfg) from to = do
     ExceptT $
       bracket
         ((,) <$> mYieldArgs <*> mSinkArgs)
-        ( \(SomeBackend (yArgs :: YieldArgs IO backend1 l), (SomeBackend (sArgs :: SinkArgs IO backend2 l))) -> do
-            releaseYieldArgs yArgs
-            releaseSinkArgs sArgs
+        ( \( SomeBackend (yArgs :: YieldArgs IO backend1 l (CardanoBlock StandardCrypto))
+             , (SomeBackend (sArgs :: SinkArgs IO backend2 l (CardanoBlock StandardCrypto)))
+             ) -> do
+              releaseYieldArgs yArgs
+              releaseSinkArgs sArgs
         )
-        ( \(SomeBackend (yArgs :: YieldArgs IO backend1 l), (SomeBackend (sArgs :: SinkArgs IO backend2 l))) -> do
-            runExceptT $ yield (Proxy @backend1) yArgs st $ sink (Proxy @backend2) sArgs st
+        ( \( SomeBackend (yArgs :: YieldArgs IO backend1 l (CardanoBlock StandardCrypto))
+             , (SomeBackend (sArgs :: SinkArgs IO backend2 l (CardanoBlock StandardCrypto)))
+             ) -> do
+              runExceptT $ yield (Proxy @backend1) yArgs st $ sink (Proxy @backend2) sArgs st
         )
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus-cardano/src/unstable-snapshot-conversion/Ouroboros/Consensus/Cardano/StreamingLedgerTables.hs
+++ b/ouroboros-consensus-cardano/src/unstable-snapshot-conversion/Ouroboros/Consensus/Cardano/StreamingLedgerTables.hs
@@ -34,12 +34,16 @@ import System.FS.API
 
 type L = LedgerState (CardanoBlock StandardCrypto)
 
-mkInMemYieldArgs :: SomeHasFS IO -> DiskSnapshot -> L EmptyMK -> YieldArgs IO V2.Mem L
+mkInMemYieldArgs ::
+  SomeHasFS IO ->
+  DiskSnapshot ->
+  L EmptyMK ->
+  YieldArgs IO V2.Mem LedgerState (CardanoBlock StandardCrypto)
 mkInMemYieldArgs fs ds (HardForkLedgerState (HardForkState idx)) =
   let
     np ::
       NP
-        (Current (Flip LedgerState EmptyMK) -.-> K (Decoders L))
+        (Current (Flip LedgerState EmptyMK) -.-> K (Decoders (CardanoBlock StandardCrypto)))
         (CardanoEras StandardCrypto)
     np =
       (Fn $ K . (\_ -> Decoders (error "Byron") (error "Byron")) . unFlip . currentState)
@@ -60,9 +64,9 @@ mkInMemYieldArgs fs ds (HardForkLedgerState (HardForkState idx)) =
   fromEra ::
     forall proto era.
     ShelleyCompatible proto era =>
-    (TxOut (LedgerState (ShelleyBlock proto era)) -> CardanoTxOut StandardCrypto) ->
+    (TxOut (ShelleyBlock proto era) -> CardanoTxOut StandardCrypto) ->
     LedgerState (ShelleyBlock proto era) EmptyMK ->
-    Decoders L
+    Decoders (CardanoBlock StandardCrypto)
   fromEra toCardanoTxOut st =
     let certInterns =
           internsFromMap $
@@ -81,7 +85,7 @@ mkInMemSinkArgs ::
   SomeHasFS IO ->
   DiskSnapshot ->
   L EmptyMK ->
-  SinkArgs IO V2.Mem L
+  SinkArgs IO V2.Mem LedgerState (CardanoBlock StandardCrypto)
 mkInMemSinkArgs fs ds (HardForkLedgerState (HardForkState idx)) = do
   let
     np =
@@ -107,6 +111,8 @@ mkInMemSinkArgs fs ds (HardForkLedgerState (HardForkState idx)) = do
     forall era.
     Era era =>
     Proxy era ->
-    (TxIn L -> Codec.CBOR.Encoding.Encoding, TxOut L -> Codec.CBOR.Encoding.Encoding)
+    ( TxIn (CardanoBlock StandardCrypto) -> Codec.CBOR.Encoding.Encoding
+    , TxOut (CardanoBlock StandardCrypto) -> Codec.CBOR.Encoding.Encoding
+    )
   encOne _ =
     (toEraCBOR @era . encodeMemPack, toEraCBOR @era . eliminateCardanoTxOut (const encodeMemPack))

--- a/ouroboros-consensus-cardano/test/shelley-test/Test/Consensus/Shelley/LedgerTables.hs
+++ b/ouroboros-consensus-cardano/test/shelley-test/Test/Consensus/Shelley/LedgerTables.hs
@@ -56,22 +56,26 @@ tests =
       ]
 
 class
-  ( HasLedgerTables (LedgerState blk)
+  ( HasLedgerTables LedgerState blk
   , CanStowLedgerTables (LedgerState blk)
   , (Show `And` Arbitrary) (LedgerState blk EmptyMK)
   , (Show `And` Arbitrary) (LedgerState blk ValuesMK)
-  , (Show `And` Arbitrary) (LedgerTables (LedgerState blk) ValuesMK)
+  , (Show `And` Arbitrary) (LedgerTables blk ValuesMK)
   , L.Era (ShelleyBlockLedgerEra blk)
+  , Show (TxIn blk)
+  , Show (TxOut blk)
   ) =>
   TestLedgerTables blk
 
 instance
-  ( HasLedgerTables (LedgerState blk)
+  ( HasLedgerTables LedgerState blk
   , CanStowLedgerTables (LedgerState blk)
   , (Show `And` Arbitrary) (LedgerState blk EmptyMK)
   , (Show `And` Arbitrary) (LedgerState blk ValuesMK)
-  , (Show `And` Arbitrary) (LedgerTables (LedgerState blk) ValuesMK)
+  , (Show `And` Arbitrary) (LedgerTables blk ValuesMK)
   , L.Era (ShelleyBlockLedgerEra blk)
+  , Show (TxIn blk)
+  , Show (TxOut blk)
   ) =>
   TestLedgerTables blk
 
@@ -79,9 +83,9 @@ instance
   ( CanMock proto era
   , Arbitrary (LedgerState (ShelleyBlock proto era) EmptyMK)
   ) =>
-  Arbitrary (LedgerTables (LedgerState (ShelleyBlock proto era)) ValuesMK)
+  Arbitrary (LedgerTables (ShelleyBlock proto era) ValuesMK)
   where
-  arbitrary = projectLedgerTables . unstowLedgerTables <$> arbitrary
+  arbitrary = projectLedgerTables @LedgerState . unstowLedgerTables <$> arbitrary
 
 testBigEndianTxInPreservesOrder :: L.TxId -> L.TxIx -> L.TxIx -> Property
 testBigEndianTxInPreservesOrder txid txix1 txix2 =

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Node.hs
@@ -114,7 +114,7 @@ import Ouroboros.Consensus.Block
 import Ouroboros.Consensus.BlockchainTime hiding (getSystemStart)
 import Ouroboros.Consensus.Config
 import Ouroboros.Consensus.Config.SupportsNode
-import Ouroboros.Consensus.Ledger.Basics (ValuesMK)
+import Ouroboros.Consensus.Ledger.Abstract (ValuesMK)
 import Ouroboros.Consensus.Ledger.Extended (ExtLedgerState (..))
 import qualified Ouroboros.Consensus.Mempool as Mempool
 import Ouroboros.Consensus.MiniProtocol.ChainSync.Client.HistoricityCheck

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Node/GSM.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Node/GSM.hs
@@ -53,7 +53,7 @@ import qualified Ouroboros.Consensus.BlockchainTime.WallClock.Types as Clock
 import qualified Ouroboros.Consensus.HardFork.Abstract as HardFork
 import qualified Ouroboros.Consensus.HardFork.History as HardFork
 import qualified Ouroboros.Consensus.HardFork.History.Qry as Qry
-import qualified Ouroboros.Consensus.Ledger.Basics as L
+import qualified Ouroboros.Consensus.Ledger.Abstract as L
 import Ouroboros.Consensus.Node.GsmState
 import Ouroboros.Consensus.Storage.ChainDB.API (ChainDB)
 import Ouroboros.Consensus.Util.NormalForm.StrictTVar (StrictTVar)

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
@@ -687,15 +687,13 @@ forkBlockForging IS{..} (MkBlockForging blockForgingM) =
             snap <- getSnapshot mempool -- only used for its tip-like information
             pure (castHash $ snapshotStateHash snap, snapshotSlotNo snap)
 
-          let readTables = fmap castLedgerTables . roforkerReadTables forker . castLedgerTables
-
           mempoolSnapshot <-
             lift $
               getSnapshotFor
                 mempool
                 currentSlot
                 tickedLedgerState
-                readTables
+                (roforkerReadTables forker)
 
           let (txs, txssz) =
                 snapshotTake mempoolSnapshot $

--- a/ouroboros-consensus-diffusion/src/unstable-mock-testlib/Test/Consensus/Ledger/Mock/Generators.hs
+++ b/ouroboros-consensus-diffusion/src/unstable-mock-testlib/Test/Consensus/Ledger/Mock/Generators.hs
@@ -18,7 +18,7 @@ import qualified Data.Set as Set
 import Data.Typeable
 import Ouroboros.Consensus.Block
 import Ouroboros.Consensus.HeaderValidation
-import Ouroboros.Consensus.Ledger.Basics
+import Ouroboros.Consensus.Ledger.Abstract
 import Ouroboros.Consensus.Ledger.Query
 import Ouroboros.Consensus.Ledger.SupportsMempool
 import Ouroboros.Consensus.Ledger.Tables.Utils
@@ -136,7 +136,7 @@ instance
       . flip SimpleLedgerState emptyLedgerTables
       <$> arbitrary
 
-instance Arbitrary (LedgerTables (LedgerState (SimpleBlock c ext)) ValuesMK) where
+instance Arbitrary (LedgerTables (SimpleBlock c ext) ValuesMK) where
   arbitrary = LedgerTables . ValuesMK <$> arbitrary
 
 instance Arbitrary ByteSize32 where

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup.hs
@@ -169,7 +169,7 @@ runGenesisTest ::
   , InspectLedger blk
   , HasHardForkHistory blk
   , ConvertRawHash blk
-  , CanUpgradeLedgerTables (LedgerState blk)
+  , CanUpgradeLedgerTables LedgerState blk
   , HasPointScheduleTestParams blk
   , Eq (Header blk)
   , Eq blk
@@ -231,7 +231,7 @@ runConformanceTest ::
   , InspectLedger blk
   , HasHardForkHistory blk
   , ConvertRawHash blk
-  , CanUpgradeLedgerTables (LedgerState blk)
+  , CanUpgradeLedgerTables LedgerState blk
   , HasPointScheduleTestParams blk
   , Eq (Header blk)
   , Eq blk

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/TestSuite.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/TestSuite.hs
@@ -192,7 +192,7 @@ toTestTree ::
   , InspectLedger blk
   , HasHardForkHistory blk
   , ConvertRawHash blk
-  , CanUpgradeLedgerTables (LedgerState blk)
+  , CanUpgradeLedgerTables LedgerState blk
   , HasPointScheduleTestParams blk
   , Eq (Header blk)
   , Eq blk

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator.hs
@@ -478,16 +478,17 @@ instance SerialiseHFC '[BlockA, BlockB]
 
 -- Use defaults
 
-instance SerializeTablesWithHint (LedgerState (HardForkBlock '[BlockA, BlockB])) where
+instance SerializeTablesWithHint LedgerState (HardForkBlock '[BlockA, BlockB]) where
   encodeTablesWithHint = defaultEncodeTablesWithHint
   decodeTablesWithHint = defaultDecodeTablesWithHint
 
 instance
   IndexedMemPack
-    (LedgerState (HardForkBlock '[BlockA, BlockB]) EmptyMK)
+    LedgerState
+    (HardForkBlock '[BlockA, BlockB])
     (DefaultHardForkTxOut '[BlockA, BlockB])
   where
-  indexedTypeName _ = typeName @(DefaultHardForkTxOut '[BlockA, BlockB])
+  indexedTypeName _ _ = typeName @(DefaultHardForkTxOut '[BlockA, BlockB])
   indexedPackedByteCount _ txout =
     hcollapse $
       hcmap
@@ -510,10 +511,11 @@ instance
 
 instance
   IndexedMemPack
-    (Ticked LedgerState (HardForkBlock '[BlockA, BlockB]) EmptyMK)
+    (Ticked LedgerState)
+    (HardForkBlock '[BlockA, BlockB])
     (DefaultHardForkTxOut '[BlockA, BlockB])
   where
-  indexedTypeName _ = typeName @(DefaultHardForkTxOut '[BlockA, BlockB])
+  indexedTypeName _ _ = typeName @(DefaultHardForkTxOut '[BlockA, BlockB])
   indexedPackedByteCount _ txout =
     hcollapse $
       hcmap

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator/A.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator/A.hs
@@ -89,7 +89,6 @@ import Ouroboros.Consensus.Node.Run
 import Ouroboros.Consensus.Node.Serialisation
 import Ouroboros.Consensus.Protocol.Abstract
 import Ouroboros.Consensus.Storage.ImmutableDB (simpleChunkInfo)
-import Ouroboros.Consensus.Storage.LedgerDB
 import Ouroboros.Consensus.Storage.Serialisation
 import Ouroboros.Consensus.Util (repeatedlyM)
 import Ouroboros.Consensus.Util.Condense

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator/A.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator/A.hs
@@ -43,6 +43,8 @@ module Test.Consensus.HardFork.Combinator.A
 import Cardano.Binary (DecoderError)
 import Cardano.Ledger.BaseTypes.NonZero
 import Cardano.Slotting.EpochInfo
+import qualified Codec.CBOR.Decoding as CBOR
+import qualified Codec.CBOR.Encoding as CBOR
 import Codec.Serialise
 import Control.Monad (guard)
 import qualified Data.Binary as B
@@ -208,41 +210,36 @@ newtype instance Ticked LedgerState BlockA mk = TickedLedgerStateA
   Ledger Tables
 -------------------------------------------------------------------------------}
 
-type instance TxIn (LedgerState BlockA) = Void
-type instance TxOut (LedgerState BlockA) = Void
+type instance TxIn BlockA = Void
+type instance TxOut BlockA = Void
 
-instance LedgerTablesAreTrivial (LedgerState BlockA) where
+instance LedgerTablesAreTrivial LedgerState BlockA where
   convertMapKind (LgrA x y) = LgrA x y
-instance LedgerTablesAreTrivial (Ticked LedgerState BlockA) where
+instance LedgerTablesAreTrivial (Ticked LedgerState) BlockA where
   convertMapKind (TickedLedgerStateA x) = TickedLedgerStateA (convertMapKind x)
-deriving via
-  Void
-  instance
-    IndexedMemPack (LedgerState BlockA EmptyMK) Void
-deriving via
-  Void
-  instance
-    IndexedMemPack (Ticked LedgerState BlockA EmptyMK) Void
-deriving via
-  TrivialLedgerTables (LedgerState BlockA)
-  instance
-    HasLedgerTables (LedgerState BlockA)
-deriving via
-  TrivialLedgerTables (Ticked LedgerState BlockA)
-  instance
-    HasLedgerTables (Ticked LedgerState BlockA)
-deriving via
-  TrivialLedgerTables (LedgerState BlockA)
-  instance
-    CanStowLedgerTables (LedgerState BlockA)
-deriving via
-  TrivialLedgerTables (LedgerState BlockA)
-  instance
-    CanUpgradeLedgerTables (LedgerState BlockA)
-deriving via
-  TrivialLedgerTables (LedgerState BlockA)
-  instance
-    SerializeTablesWithHint (LedgerState BlockA)
+
+deriving via Void instance IndexedMemPack LedgerState BlockA Void
+
+instance HasLedgerTables LedgerState BlockA where
+  projectLedgerTables _ = emptyLedgerTables
+  withLedgerTables st _ = convertMapKind st
+
+instance HasLedgerTables (Ticked LedgerState) BlockA where
+  projectLedgerTables _ = emptyLedgerTables
+  withLedgerTables st _ = convertMapKind st
+
+instance CanStowLedgerTables (LedgerState BlockA) where
+  stowLedgerTables = convertMapKind
+  unstowLedgerTables = convertMapKind
+
+instance CanUpgradeLedgerTables LedgerState BlockA where
+  upgradeTables _ _ = id
+
+instance SerializeTablesWithHint LedgerState BlockA where
+  decodeTablesWithHint _ = do
+    _ <- CBOR.decodeMapLen
+    pure (LedgerTables $ ValuesMK Map.empty)
+  encodeTablesWithHint _ _ = CBOR.encodeMapLen 0
 
 data PartialLedgerConfigA = LCfgA
   { lcfgA_k :: SecurityParam
@@ -295,7 +292,8 @@ instance ApplyBlock LedgerState BlockA where
   reapplyBlockLedgerResult =
     defaultReapplyBlockLedgerResult absurd
 
-  getBlockKeySets _blk = trivialLedgerTables
+instance GetBlockKeySets BlockA where
+  getBlockKeySets _blk = emptyLedgerTables
 
 instance UpdateLedger BlockA
 
@@ -400,7 +398,7 @@ instance LedgerSupportsMempool BlockA where
 
   txForgetValidated = forgetValidatedGenTxA
 
-  getTransactionKeySets _tx = trivialLedgerTables
+  getTransactionKeySets _tx = emptyLedgerTables
 
   mkMempoolApplyTxError = nothingMkMempoolApplyTxError
 

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator/B.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator/B.hs
@@ -74,7 +74,6 @@ import Ouroboros.Consensus.Node.Run
 import Ouroboros.Consensus.Node.Serialisation
 import Ouroboros.Consensus.Protocol.Abstract
 import Ouroboros.Consensus.Storage.ImmutableDB (simpleChunkInfo)
-import Ouroboros.Consensus.Storage.LedgerDB
 import Ouroboros.Consensus.Storage.Serialisation
 import Ouroboros.Consensus.Util.Condense
 import Ouroboros.Consensus.Util.IndexedMemPack

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator/B.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator/B.hs
@@ -37,10 +37,13 @@ module Test.Consensus.HardFork.Combinator.B
 
 import Cardano.Binary (DecoderError)
 import Cardano.Ledger.BaseTypes (unNonZero)
+import qualified Codec.CBOR.Decoding as CBOR
+import qualified Codec.CBOR.Encoding as CBOR
 import Codec.Serialise
 import qualified Data.Binary as B
 import qualified Data.ByteString as Strict
 import qualified Data.ByteString.Lazy as Lazy
+import qualified Data.Map.Strict as Map
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.Void
@@ -181,42 +184,39 @@ data instance LedgerState BlockB mk = LgrB
   Ledger Tables
 -------------------------------------------------------------------------------}
 
-type instance TxIn (LedgerState BlockB) = Void
-type instance TxOut (LedgerState BlockB) = Void
+type instance TxIn BlockB = Void
+type instance TxOut BlockB = Void
 
-instance LedgerTablesAreTrivial (LedgerState BlockB) where
+instance LedgerTablesAreTrivial LedgerState BlockB where
   convertMapKind (LgrB x) = LgrB x
-instance LedgerTablesAreTrivial (Ticked LedgerState BlockB) where
+instance LedgerTablesAreTrivial (Ticked LedgerState) BlockB where
   convertMapKind (TickedLedgerStateB x) = TickedLedgerStateB (convertMapKind x)
 
-deriving via
-  TrivialLedgerTables (LedgerState BlockB)
-  instance
-    HasLedgerTables (LedgerState BlockB)
-deriving via
-  TrivialLedgerTables (Ticked LedgerState BlockB)
-  instance
-    HasLedgerTables (Ticked LedgerState BlockB)
-deriving via
-  TrivialLedgerTables (LedgerState BlockB)
-  instance
-    CanStowLedgerTables (LedgerState BlockB)
-deriving via
-  TrivialLedgerTables (LedgerState BlockB)
-  instance
-    CanUpgradeLedgerTables (LedgerState BlockB)
-deriving via
-  TrivialLedgerTables (LedgerState BlockB)
-  instance
-    SerializeTablesWithHint (LedgerState BlockB)
-deriving via
-  Void
-  instance
-    IndexedMemPack (LedgerState BlockB EmptyMK) Void
+instance HasLedgerTables LedgerState BlockB where
+  projectLedgerTables _ = emptyLedgerTables
+  withLedgerTables st _ = convertMapKind st
+
+instance HasLedgerTables (Ticked LedgerState) BlockB where
+  projectLedgerTables _ = emptyLedgerTables
+  withLedgerTables st _ = convertMapKind st
+
+instance CanStowLedgerTables (LedgerState BlockB) where
+  stowLedgerTables = convertMapKind
+  unstowLedgerTables = convertMapKind
+
+instance CanUpgradeLedgerTables LedgerState BlockB where
+  upgradeTables _ _ = id
+
+instance SerializeTablesWithHint LedgerState BlockB where
+  decodeTablesWithHint _ = do
+    _ <- CBOR.decodeMapLen
+    pure (LedgerTables $ ValuesMK Map.empty)
+  encodeTablesWithHint _ _ = CBOR.encodeMapLen 0
+
 deriving via
   Void
   instance
-    IndexedMemPack (Ticked LedgerState BlockB EmptyMK) Void
+    IndexedMemPack LedgerState BlockB Void
 
 type PartialLedgerCfgB = ()
 
@@ -249,7 +249,8 @@ instance ApplyBlock LedgerState BlockB where
   applyBlockLedgerResult = defaultApplyBlockLedgerResult
   reapplyBlockLedgerResult = defaultReapplyBlockLedgerResult absurd
 
-  getBlockKeySets _blk = trivialLedgerTables
+instance GetBlockKeySets BlockB where
+  getBlockKeySets _blk = emptyLedgerTables
 
 instance UpdateLedger BlockB
 
@@ -331,7 +332,7 @@ instance LedgerSupportsMempool BlockB where
 
   txForgetValidated = \case {}
 
-  getTransactionKeySets _tx = trivialLedgerTables
+  getTransactionKeySets _tx = emptyLedgerTables
 
   mkMempoolApplyTxError = nothingMkMempoolApplyTxError
 

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/NodeLifecycle.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/NodeLifecycle.hs
@@ -140,7 +140,7 @@ mkChainDb ::
   , InspectLedger blk
   , HasHardForkHistory blk
   , ConvertRawHash blk
-  , CanUpgradeLedgerTables (LedgerState blk)
+  , CanUpgradeLedgerTables LedgerState blk
   ) =>
   LiveResources blk m ->
   m (ChainDB m blk, m (WithOrigin SlotNo))
@@ -193,7 +193,7 @@ restoreNode ::
   , InspectLedger blk
   , HasHardForkHistory blk
   , ConvertRawHash blk
-  , CanUpgradeLedgerTables (LedgerState blk)
+  , CanUpgradeLedgerTables LedgerState blk
   ) =>
   LiveResources blk m ->
   LiveIntervalResult blk ->
@@ -223,7 +223,7 @@ lifecycleStart ::
   , InspectLedger blk
   , HasHardForkHistory blk
   , ConvertRawHash blk
-  , CanUpgradeLedgerTables (LedgerState blk)
+  , CanUpgradeLedgerTables LedgerState blk
   ) =>
   (LiveInterval blk m -> m ()) ->
   LiveResources blk m ->

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Run.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Run.hs
@@ -557,7 +557,7 @@ nodeLifecycle ::
   , InspectLedger blk
   , HasHardForkHistory blk
   , ConvertRawHash blk
-  , CanUpgradeLedgerTables (LedgerState blk)
+  , CanUpgradeLedgerTables LedgerState blk
   , HasPointScheduleTestParams blk
   , Eq (Header blk)
   ) =>
@@ -616,7 +616,7 @@ runPointSchedule ::
   , InspectLedger blk
   , HasHardForkHistory blk
   , ConvertRawHash blk
-  , CanUpgradeLedgerTables (LedgerState blk)
+  , CanUpgradeLedgerTables LedgerState blk
   , HasPointScheduleTestParams blk
   , Eq (Header blk)
   , Eq blk

--- a/ouroboros-consensus.cabal
+++ b/ouroboros-consensus.cabal
@@ -195,6 +195,7 @@ library
     Ouroboros.Consensus.Ledger.Tables.Basics
     Ouroboros.Consensus.Ledger.Tables.Combinators
     Ouroboros.Consensus.Ledger.Tables.Diff
+    Ouroboros.Consensus.Ledger.Tables.Kinds
     Ouroboros.Consensus.Ledger.Tables.MapKind
     Ouroboros.Consensus.Ledger.Tables.Utils
     Ouroboros.Consensus.Mempool
@@ -1286,6 +1287,7 @@ test-suite consensus-diffusion-test
     cardano-ledger-core,
     cardano-slotting:{cardano-slotting, testlib},
     cardano-strict-containers,
+    cborg,
     containers,
     contra-tracer,
     directory,

--- a/ouroboros-consensus/bench/mempool-bench/Bench/Consensus/Mempool/TestBlock.hs
+++ b/ouroboros-consensus/bench/mempool-bench/Bench/Consensus/Mempool/TestBlock.hs
@@ -42,7 +42,7 @@ import NoThunks.Class (NoThunks)
 import qualified Ouroboros.Consensus.Block as Block
 import Ouroboros.Consensus.Config.SecurityParam as Consensus
 import qualified Ouroboros.Consensus.HardFork.History as HardFork
-import qualified Ouroboros.Consensus.Ledger.Basics as Ledger
+import qualified Ouroboros.Consensus.Ledger.Abstract as Ledger
 import qualified Ouroboros.Consensus.Ledger.SupportsMempool as Ledger
 import Ouroboros.Consensus.Ledger.Tables
 import qualified Ouroboros.Consensus.Ledger.Tables.Diff as Diff
@@ -174,10 +174,10 @@ data instance Block.StorageConfig TestBlock = TestBlockStorageConfig
   Ledger tables
 -------------------------------------------------------------------------------}
 
-type instance TxIn (LedgerState TestBlock) = Token
-type instance TxOut (LedgerState TestBlock) = ()
+type instance TxIn TestBlock = Token
+type instance TxOut TestBlock = ()
 
-instance HasLedgerTables (LedgerState TestBlock) where
+instance HasLedgerTables LedgerState TestBlock where
   projectLedgerTables st =
     LedgerTables $ getTestPLDS $ payloadDependentState st
   withLedgerTables st table =
@@ -190,25 +190,18 @@ instance HasLedgerTables (LedgerState TestBlock) where
    where
     TestLedger{payloadDependentState = plds} = st
 
-instance HasLedgerTables (Ticked LedgerState TestBlock) where
+instance HasLedgerTables (Ticked LedgerState) TestBlock where
   projectLedgerTables (TickedTestLedger st) =
-    Ledger.castLedgerTables $
-      Ledger.projectLedgerTables st
+    Ledger.projectLedgerTables st
   withLedgerTables (TickedTestLedger st) tables =
-    TickedTestLedger $ Ledger.withLedgerTables st $ Ledger.castLedgerTables tables
+    TickedTestLedger $ Ledger.withLedgerTables st tables
 
 instance CanStowLedgerTables (LedgerState TestBlock) where
   stowLedgerTables = error "Mempool bench TestBlock unused: stowLedgerTables"
   unstowLedgerTables = error "Mempool bench TestBlock unused: unstowLedgerTables"
 
-instance IndexedMemPack (LedgerState TestBlock EmptyMK) () where
-  indexedTypeName _ = typeName @()
-  indexedPackedByteCount _ = packedByteCount
-  indexedPackM _ = packM
-  indexedUnpackM _ = unpackM
-
-instance IndexedMemPack (Ticked LedgerState TestBlock EmptyMK) () where
-  indexedTypeName _ = typeName @()
+instance IndexedMemPack LedgerState TestBlock () where
+  indexedTypeName _ _ = typeName @()
   indexedPackedByteCount _ = packedByteCount
   indexedPackM _ = packM
   indexedUnpackM _ = unpackM

--- a/ouroboros-consensus/src/ouroboros-consensus-lmdb/Ouroboros/Consensus/Storage/LedgerDB/V1/BackingStore/Impl/LMDB.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus-lmdb/Ouroboros/Consensus/Storage/LedgerDB/V1/BackingStore/Impl/LMDB.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
@@ -102,6 +103,13 @@ import System.IO.Temp
   Database definition
 -------------------------------------------------------------------------------}
 
+type LMDBConstraints l blk =
+  ( Ord (TxIn blk)
+  , MemPack (TxIn blk)
+  , Eq (TxOut blk)
+  , IndexedMemPack l blk (TxOut blk)
+  )
+
 -- | The LMDB database that underlies the backing store.
 data Db m blk = Db
   { dbEnv :: !(LMDB.Environment LMDB.ReadWrite)
@@ -182,7 +190,7 @@ getDb ::
 getDb (K2 name) = LMDBMK name <$> LMDB.getDatabase (Just name)
 
 readAll ::
-  (Ord (TxIn blk), MemPack (TxIn blk), IndexedMemPack l blk (TxOut blk)) =>
+  LMDBConstraints l blk =>
   l blk EmptyMK ->
   LMDBMK (TxIn blk) (TxOut blk) ->
   LMDB.Transaction mode (ValuesMK (TxIn blk) (TxOut blk))
@@ -208,7 +216,7 @@ readAll st (LMDBMK _ dbMK) =
 -- function will be unexpected.
 rangeRead ::
   forall mode l blk.
-  (Ord (TxIn blk), MemPack (TxIn blk), IndexedMemPack l blk (TxOut blk)) =>
+  LMDBConstraints l blk =>
   API.RangeQuery (LedgerTables blk KeysMK) ->
   l blk EmptyMK ->
   LMDBMK (TxIn blk) (TxOut blk) ->
@@ -236,7 +244,7 @@ rangeRead rq st dbMK =
       db
 
 initLMDBTable ::
-  (IndexedMemPack l blk (TxOut blk), MemPack (TxIn blk)) =>
+  LMDBConstraints l blk =>
   l blk EmptyMK ->
   LMDBMK (TxIn blk) (TxOut blk) ->
   ValuesMK (TxIn blk) (TxOut blk) ->
@@ -253,7 +261,7 @@ initLMDBTable st (LMDBMK tblName db) (ValuesMK utxoVals) =
         utxoVals
 
 readLMDBTable ::
-  (Ord (TxIn blk), MemPack (TxIn blk), IndexedMemPack l blk (TxOut blk)) =>
+  LMDBConstraints l blk =>
   l blk EmptyMK ->
   LMDBMK (TxIn blk) (TxOut blk) ->
   KeysMK (TxIn blk) (TxOut blk) ->
@@ -269,7 +277,7 @@ readLMDBTable st (LMDBMK _ db) (KeysMK keys) =
         Just v -> Map.insert k v m
 
 writeLMDBTable ::
-  (MemPack (TxIn blk), IndexedMemPack l blk (TxOut blk)) =>
+  LMDBConstraints l blk =>
   l blk EmptyMK ->
   LMDBMK (TxIn blk) (TxOut blk) ->
   DiffMK (TxIn blk) (TxOut blk) ->
@@ -374,9 +382,8 @@ checkAndOpenDbDirWithRetry gdd shfs@(FS.SomeHasFS fs) path =
 -- | Initialise an LMDB database from these provided values.
 initFromVals ::
   forall l blk m.
-  ( HasLedgerTables l blk
-  , IndexedMemPack l blk (TxOut blk)
-  , MonadIO m
+  ( MonadIO m
+  , LMDBConstraints l blk
   ) =>
   Trace.Tracer m API.BackingStoreTrace ->
   -- | The slot number up to which the ledger tables contain values.
@@ -455,10 +462,9 @@ lmdbCopy from0 tracer e to = do
 newLMDBBackingStore ::
   forall m l blk.
   ( HasCallStack
-  , HasLedgerTables l blk
-  , IndexedMemPack l blk (TxOut blk)
   , MonadIO m
   , IOLike m
+  , LMDBConstraints l blk
   ) =>
   Trace.Tracer m API.BackingStoreTrace ->
   -- | Configuration parameters for the LMDB database that we
@@ -605,11 +611,10 @@ newLMDBBackingStore dbTracer limits liveFS@(API.LiveLMDBFS liveFS') snapFS@(API.
 -- current database state.
 mkLMDBBackingStoreValueHandle ::
   forall l blk m.
-  ( HasLedgerTables l blk
-  , IndexedMemPack l blk (TxOut blk)
-  , MonadIO m
+  ( MonadIO m
   , IOLike m
   , HasCallStack
+  , LMDBConstraints l blk
   ) =>
   -- | The LMDB database for which the backing store value handle is
   -- created.
@@ -840,10 +845,9 @@ prettyPrintLMDBErr = \case
 type data LMDB
 
 instance
-  ( HasLedgerTables l blk
-  , IndexedMemPack l blk (TxOut blk)
-  , MonadIO m
+  ( MonadIO m
   , IOLike m
+  , LMDBConstraints l blk
   ) =>
   Backend m LMDB l blk
   where
@@ -866,11 +870,11 @@ instance
 -- | Create arguments for initializing the LedgerDB using the LMDB backend.
 mkLMDBArgs ::
   ( MonadIOPrim m
-  , HasLedgerTables LedgerState blk
   , IOLike m
+  , LMDBConstraints LedgerState blk
   ) =>
-  V1.FlushFrequency -> FilePath -> LMDBLimits -> a -> (LedgerDbBackendArgs m blk, a)
-mkLMDBArgs flushing lmdbPath limits =
+  Proxy l -> V1.FlushFrequency -> FilePath -> LMDBLimits -> a -> (LedgerDbBackendArgs m blk, a)
+mkLMDBArgs _ flushing lmdbPath limits =
   (,) $
     LedgerDbBackendArgsV1 $
       V1.V1Args flushing $
@@ -968,9 +972,7 @@ yieldLmdbS readChunkSize bsvh hint k = do
 -- in the alloc step of a bracket.
 mkLMDBYieldArgs ::
   forall blk.
-  ( HasCallStack
-  , HasLedgerTables LedgerState blk
-  ) =>
+  (LMDBConstraints LedgerState blk, HasCallStack) =>
   FS.SomeHasFS IO ->
   DiskSnapshot ->
   LMDBLimits ->
@@ -997,9 +999,7 @@ mkLMDBYieldArgs fs ds limits hint = do
 -- in the alloc step of a bracket.
 mkLMDBSinkArgs ::
   forall blk.
-  ( HasCallStack
-  , HasLedgerTables LedgerState blk
-  ) =>
+  (HasCallStack, LMDBConstraints LedgerState blk) =>
   FS.SomeHasFS IO ->
   DiskSnapshot ->
   LMDBLimits ->

--- a/ouroboros-consensus/src/ouroboros-consensus-lmdb/Ouroboros/Consensus/Storage/LedgerDB/V1/BackingStore/Impl/LMDB.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus-lmdb/Ouroboros/Consensus/Storage/LedgerDB/V1/BackingStore/Impl/LMDB.hs
@@ -10,7 +10,6 @@
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TupleSections #-}
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeData #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
@@ -50,7 +49,6 @@ import Data.Functor.Contravariant ((>$<))
 import Data.Map (Map)
 import qualified Data.Map.Strict as Map
 import Data.MemPack
-import Data.Proxy
 import qualified Data.SOP.Dict as Dict
 import qualified Data.Set as Set
 import qualified Data.Text as Strict
@@ -63,6 +61,7 @@ import GHC.Generics (Generic)
 import GHC.Stack (HasCallStack)
 import Ouroboros.Consensus.Block
 import Ouroboros.Consensus.Ledger.Basics
+import Ouroboros.Consensus.Ledger.Tables
 import qualified Ouroboros.Consensus.Ledger.Tables.Diff as Diff
 import Ouroboros.Consensus.Ledger.Tables.Utils (emptyLedgerTables)
 import Ouroboros.Consensus.Storage.LedgerDB.API
@@ -104,7 +103,7 @@ import System.IO.Temp
 -------------------------------------------------------------------------------}
 
 -- | The LMDB database that underlies the backing store.
-data Db m l = Db
+data Db m blk = Db
   { dbEnv :: !(LMDB.Environment LMDB.ReadWrite)
   -- ^ The LMDB environment is a pointer to the directory that contains the
   -- @`Db`@.
@@ -113,7 +112,7 @@ data Db m l = Db
   --
   -- The state is kept in an LDMB table with only one key and one value:
   -- The current sequence number of the @`Db`@.
-  , dbBackingTables :: !(LedgerTables l LMDBMK)
+  , dbBackingTables :: !(LedgerTables blk LMDBMK)
   -- ^ The LMDB tables with the key-value stores.
   , dbFilePath :: !FilePath
   , dbTracer :: !(Trace.Tracer m API.BackingStoreTrace)
@@ -183,12 +182,11 @@ getDb ::
 getDb (K2 name) = LMDBMK name <$> LMDB.getDatabase (Just name)
 
 readAll ::
-  (Ord (TxIn l), MemPack (TxIn l), IndexedMemPack idx (TxOut l)) =>
-  Proxy l ->
-  idx ->
-  LMDBMK (TxIn l) (TxOut l) ->
-  LMDB.Transaction mode (ValuesMK (TxIn l) (TxOut l))
-readAll _ st (LMDBMK _ dbMK) =
+  (Ord (TxIn blk), MemPack (TxIn blk), IndexedMemPack l blk (TxOut blk)) =>
+  l blk EmptyMK ->
+  LMDBMK (TxIn blk) (TxOut blk) ->
+  LMDB.Transaction mode (ValuesMK (TxIn blk) (TxOut blk))
+readAll st (LMDBMK _ dbMK) =
   ValuesMK
     <$> Bridge.runCursorAsTransaction'
       st
@@ -209,12 +207,12 @@ readAll _ st (LMDBMK _ dbMK) =
 -- lexicographical ordering of the serialised keys, or the result of this
 -- function will be unexpected.
 rangeRead ::
-  forall mode l idx.
-  (Ord (TxIn l), MemPack (TxIn l), IndexedMemPack idx (TxOut l)) =>
-  API.RangeQuery (LedgerTables l KeysMK) ->
-  idx ->
-  LMDBMK (TxIn l) (TxOut l) ->
-  LMDB.Transaction mode (ValuesMK (TxIn l) (TxOut l), Maybe (TxIn l))
+  forall mode l blk.
+  (Ord (TxIn blk), MemPack (TxIn blk), IndexedMemPack l blk (TxOut blk)) =>
+  API.RangeQuery (LedgerTables blk KeysMK) ->
+  l blk EmptyMK ->
+  LMDBMK (TxIn blk) (TxOut blk) ->
+  LMDB.Transaction mode (ValuesMK (TxIn blk) (TxOut blk), Maybe (TxIn blk))
 rangeRead rq st dbMK =
   first ValuesMK <$> case ksMK of
     Nothing -> runCursorHelper Nothing
@@ -228,9 +226,9 @@ rangeRead rq st dbMK =
   API.RangeQuery ksMK count = rq
 
   runCursorHelper ::
-    Maybe (TxIn l, LMDB.Cursor.Bound) ->
+    Maybe (TxIn blk, LMDB.Cursor.Bound) ->
     -- \^ Lower bound on read range
-    LMDB.Transaction mode (Map (TxIn l) (TxOut l), Maybe (TxIn l))
+    LMDB.Transaction mode (Map (TxIn blk) (TxOut blk), Maybe (TxIn blk))
   runCursorHelper lb =
     Bridge.runCursorAsTransaction'
       st
@@ -238,11 +236,11 @@ rangeRead rq st dbMK =
       db
 
 initLMDBTable ::
-  (IndexedMemPack idx v, MemPack k) =>
-  idx ->
-  LMDBMK k v ->
-  ValuesMK k v ->
-  LMDB.Transaction LMDB.ReadWrite (EmptyMK k v)
+  (IndexedMemPack l blk (TxOut blk), MemPack (TxIn blk)) =>
+  l blk EmptyMK ->
+  LMDBMK (TxIn blk) (TxOut blk) ->
+  ValuesMK (TxIn blk) (TxOut blk) ->
+  LMDB.Transaction LMDB.ReadWrite (EmptyMK (TxIn blk) (TxOut blk))
 initLMDBTable st (LMDBMK tblName db) (ValuesMK utxoVals) =
   EmptyMK <$ lmdbInitTable
  where
@@ -255,12 +253,11 @@ initLMDBTable st (LMDBMK tblName db) (ValuesMK utxoVals) =
         utxoVals
 
 readLMDBTable ::
-  (IndexedMemPack idx v, MemPack k) =>
-  Ord k =>
-  idx ->
-  LMDBMK k v ->
-  KeysMK k v ->
-  LMDB.Transaction mode (ValuesMK k v)
+  (Ord (TxIn blk), MemPack (TxIn blk), IndexedMemPack l blk (TxOut blk)) =>
+  l blk EmptyMK ->
+  LMDBMK (TxIn blk) (TxOut blk) ->
+  KeysMK (TxIn blk) (TxOut blk) ->
+  LMDB.Transaction mode (ValuesMK (TxIn blk) (TxOut blk))
 readLMDBTable st (LMDBMK _ db) (KeysMK keys) =
   ValuesMK <$> lmdbReadTable
  where
@@ -272,11 +269,11 @@ readLMDBTable st (LMDBMK _ db) (KeysMK keys) =
         Just v -> Map.insert k v m
 
 writeLMDBTable ::
-  (IndexedMemPack idx v, MemPack k) =>
-  idx ->
-  LMDBMK k v ->
-  DiffMK k v ->
-  LMDB.Transaction LMDB.ReadWrite (EmptyMK k v)
+  (MemPack (TxIn blk), IndexedMemPack l blk (TxOut blk)) =>
+  l blk EmptyMK ->
+  LMDBMK (TxIn blk) (TxOut blk) ->
+  DiffMK (TxIn blk) (TxOut blk) ->
+  LMDB.Transaction LMDB.ReadWrite (EmptyMK (TxIn blk) (TxOut blk))
 writeLMDBTable st (LMDBMK _ db) (DiffMK d) =
   EmptyMK <$ lmdbWriteTable
  where
@@ -376,18 +373,21 @@ checkAndOpenDbDirWithRetry gdd shfs@(FS.SomeHasFS fs) path =
 
 -- | Initialise an LMDB database from these provided values.
 initFromVals ::
-  forall l m.
-  (HasLedgerTables l, MonadIO m, MemPackIdx l EmptyMK ~ l EmptyMK) =>
+  forall l blk m.
+  ( HasLedgerTables l blk
+  , IndexedMemPack l blk (TxOut blk)
+  , MonadIO m
+  ) =>
   Trace.Tracer m API.BackingStoreTrace ->
   -- | The slot number up to which the ledger tables contain values.
   WithOrigin SlotNo ->
   -- | The ledger tables to initialise the LMDB database tables with.
-  LedgerTables l ValuesMK ->
+  LedgerTables blk ValuesMK ->
   -- | The LMDB environment.
   LMDB.Environment LMDB.Internal.ReadWrite ->
   LMDB.Database () DbSeqNo ->
-  l EmptyMK ->
-  LedgerTables l LMDBMK ->
+  l blk EmptyMK ->
+  LedgerTables blk LMDBMK ->
   m ()
 initFromVals tracer dbsSeq vals env st lst backingTables = do
   Trace.traceWith tracer $ API.BSInitialisingFromValues dbsSeq
@@ -395,8 +395,10 @@ initFromVals tracer dbsSeq vals env st lst backingTables = do
     LMDB.readWriteTransaction env $
       withDbSeqNoRWMaybeNull st $ \case
         Nothing ->
-          ltzipWith2A (initLMDBTable lst) backingTables vals
-            $> ((), DbSeqNo{dbsSeq})
+          let dbMK = getLedgerTables backingTables
+              LedgerTables vals' = vals
+           in initLMDBTable lst dbMK vals'
+                $> ((), DbSeqNo{dbsSeq})
         Just _ -> liftIO . throwIO $ LMDBErrInitialisingAlreadyHasState
   Trace.traceWith tracer $ API.BSInitialisedFromValues dbsSeq
 
@@ -451,12 +453,12 @@ lmdbCopy from0 tracer e to = do
 
 -- | Initialise a backing store.
 newLMDBBackingStore ::
-  forall m l.
+  forall m l blk.
   ( HasCallStack
-  , HasLedgerTables l
+  , HasLedgerTables l blk
+  , IndexedMemPack l blk (TxOut blk)
   , MonadIO m
   , IOLike m
-  , MemPackIdx l EmptyMK ~ l EmptyMK
   ) =>
   Trace.Tracer m API.BackingStoreTrace ->
   -- | Configuration parameters for the LMDB database that we
@@ -467,8 +469,8 @@ newLMDBBackingStore ::
   -- | The FS for the LMDB live database
   API.LiveLMDBFS m ->
   API.SnapshotsFS m ->
-  API.InitFrom (LedgerTables l ValuesMK) ->
-  m (API.LedgerBackingStore m l)
+  API.InitFrom l (LedgerTables blk ValuesMK) ->
+  m (API.LedgerBackingStore m l blk)
 newLMDBBackingStore dbTracer limits liveFS@(API.LiveLMDBFS liveFS') snapFS@(API.SnapshotsFS snapFS') initFrom = do
   Trace.traceWith dbTracer API.BSOpening
 
@@ -491,7 +493,7 @@ newLMDBBackingStore dbTracer limits liveFS@(API.LiveLMDBFS liveFS') snapFS@(API.
     API.InitFromCopy st' _ -> st'
     API.InitFromValues _ st' _ -> st'
 
-  createOrGetDB :: m (Db m l)
+  createOrGetDB :: m (Db m blk)
   createOrGetDB = do
     dbOpenHandles <- IOLike.newTVarIO Map.empty
     dbStatusLock <- Status.new Open
@@ -535,7 +537,7 @@ newLMDBBackingStore dbTracer limits liveFS@(API.LiveLMDBFS liveFS') snapFS@(API.
   maybePopulate ::
     LMDB.Internal.Environment LMDB.Internal.ReadWrite ->
     LMDB.Internal.Database () DbSeqNo ->
-    LedgerTables l LMDBMK ->
+    LedgerTables blk LMDBMK ->
     m ()
   maybePopulate dbEnv dbState dbBackingTables = do
     -- now initialise those tables if appropriate
@@ -543,7 +545,7 @@ newLMDBBackingStore dbTracer limits liveFS@(API.LiveLMDBFS liveFS') snapFS@(API.
       API.InitFromValues slot _ vals -> initFromVals dbTracer slot vals dbEnv dbState st dbBackingTables
       API.InitFromCopy{} -> pure ()
 
-  mkBackingStore :: HasCallStack => Db m l -> API.LedgerBackingStore m l
+  mkBackingStore :: HasCallStack => Db m blk -> API.LedgerBackingStore m l blk
   mkBackingStore db =
     let bsClose :: m ()
         bsClose = Status.withWriteAccess dbStatusLock traceAlreadyClosed $ do
@@ -564,7 +566,11 @@ newLMDBBackingStore dbTracer limits liveFS@(API.LiveLMDBFS liveFS') snapFS@(API.
         bsValueHandle = Status.withReadAccess dbStatusLock (throwIO LMDBErrClosed) $ do
           mkLMDBBackingStoreValueHandle db
 
-        bsWrite :: SlotNo -> (l EmptyMK, l EmptyMK) -> LedgerTables l DiffMK -> m ()
+        bsWrite ::
+          SlotNo ->
+          (l blk EmptyMK, l blk EmptyMK) ->
+          LedgerTables blk DiffMK ->
+          m ()
         bsWrite slot (_st, st') diffs = do
           Trace.traceWith dbTracer $ API.BSWriting slot
           Status.withReadAccess dbStatusLock (throwIO LMDBErrClosed) $ do
@@ -574,7 +580,9 @@ newLMDBBackingStore dbTracer limits liveFS@(API.LiveLMDBFS liveFS') snapFS@(API.
                 -- same slot as its predecessor.
                 liftIO . throwIO $
                   LMDBErrNonMonotonicSeq (At slot) dbsSeq
-              void $ ltzipWith2A (writeLMDBTable st') dbBackingTables diffs
+              let dbMK = getLedgerTables dbBackingTables
+                  LedgerTables diffs' = diffs
+              void $ writeLMDBTable st' dbMK diffs'
               pure (dbsSeq, s{dbsSeq = At slot})
             Trace.traceWith dbTracer $ API.BSWritten oldSlot slot
      in API.BackingStore
@@ -596,12 +604,17 @@ newLMDBBackingStore dbTracer limits liveFS@(API.LiveLMDBFS liveFS') snapFS@(API.
 -- | Create a backing store value handle that has a consistent view of the
 -- current database state.
 mkLMDBBackingStoreValueHandle ::
-  forall l m.
-  (HasLedgerTables l, MonadIO m, IOLike m, HasCallStack, MemPackIdx l EmptyMK ~ l EmptyMK) =>
+  forall l blk m.
+  ( HasLedgerTables l blk
+  , IndexedMemPack l blk (TxOut blk)
+  , MonadIO m
+  , IOLike m
+  , HasCallStack
+  ) =>
   -- | The LMDB database for which the backing store value handle is
   -- created.
-  Db m l ->
-  m (API.LedgerBackingStoreValueHandle m l)
+  Db m blk ->
+  m (API.LedgerBackingStoreValueHandle m l blk)
 mkLMDBBackingStoreValueHandle db = do
   vhId <- IOLike.atomically $ do
     vhId <- IOLike.readTVar dbNextId
@@ -641,7 +654,7 @@ mkLMDBBackingStoreValueHandle db = do
       traceAlreadyClosed = Trace.traceWith dbTracer API.BSAlreadyClosed
       traceTVHAlreadyClosed = Trace.traceWith tracer API.BSVHAlreadyClosed
 
-    bsvhRead :: l EmptyMK -> LedgerTables l KeysMK -> m (LedgerTables l ValuesMK)
+    bsvhRead :: l blk EmptyMK -> LedgerTables blk KeysMK -> m (LedgerTables blk ValuesMK)
     bsvhRead st keys =
       Status.withReadAccess dbStatusLock (throwIO LMDBErrClosed) $ do
         Status.withReadAccess vhStatusLock (throwIO (LMDBErrNoValueHandle vhId)) $ do
@@ -649,14 +662,16 @@ mkLMDBBackingStoreValueHandle db = do
           res <-
             liftIO $
               TrH.submitReadOnly trh $
-                ltzipWith2A (readLMDBTable st) dbBackingTables keys
+                let dbMK = getLedgerTables dbBackingTables
+                    LedgerTables keys' = keys
+                 in LedgerTables <$> readLMDBTable st dbMK keys'
           Trace.traceWith tracer API.BSVHRead
           pure res
 
     bsvhRangeRead ::
-      l EmptyMK ->
-      API.RangeQuery (LedgerTables l KeysMK) ->
-      m (LedgerTables l ValuesMK, Maybe (TxIn l))
+      l blk EmptyMK ->
+      API.RangeQuery (LedgerTables blk KeysMK) ->
+      m (LedgerTables blk ValuesMK, Maybe (TxIn blk))
     bsvhRangeRead st rq =
       Status.withReadAccess dbStatusLock (throwIO LMDBErrClosed) $ do
         Status.withReadAccess vhStatusLock (throwIO (LMDBErrNoValueHandle vhId)) $ do
@@ -683,7 +698,7 @@ mkLMDBBackingStoreValueHandle db = do
           Trace.traceWith tracer API.BSVHStatted
           pure res
 
-    bsvhReadAll :: l EmptyMK -> m (LedgerTables l ValuesMK)
+    bsvhReadAll :: l blk EmptyMK -> m (LedgerTables blk ValuesMK)
     bsvhReadAll st =
       Status.withReadAccess dbStatusLock (throwIO LMDBErrClosed) $ do
         Status.withReadAccess vhStatusLock (throwIO (LMDBErrNoValueHandle vhId)) $ do
@@ -692,7 +707,7 @@ mkLMDBBackingStoreValueHandle db = do
             liftIO $
               TrH.submitReadOnly trh $
                 let dbMK = getLedgerTables dbBackingTables
-                 in LedgerTables <$> readAll (Proxy @l) st dbMK
+                 in LedgerTables <$> readAll st dbMK
           Trace.traceWith tracer API.BSVHRangeRead
           pure res
 
@@ -825,12 +840,12 @@ prettyPrintLMDBErr = \case
 type data LMDB
 
 instance
-  ( HasLedgerTables l
+  ( HasLedgerTables l blk
+  , IndexedMemPack l blk (TxOut blk)
   , MonadIO m
   , IOLike m
-  , MemPackIdx l EmptyMK ~ l EmptyMK
   ) =>
-  Backend m LMDB l
+  Backend m LMDB l blk
   where
   data Args m LMDB
     = LMDBBackingStoreArgs FilePath LMDBLimits (Dict.Dict MonadIOPrim m)
@@ -839,8 +854,8 @@ instance
     | OnDiskBackingStoreTrace BackingStoreTrace
     deriving (Eq, Show)
 
-  isRightBackendForSnapshot _ _ UTxOHDLMDBSnapshot = True
-  isRightBackendForSnapshot _ _ _ = False
+  isRightBackendForSnapshot _ _ _ UTxOHDLMDBSnapshot = True
+  isRightBackendForSnapshot _ _ _ _ = False
 
   newBackingStoreInitialiser trcr (LMDBBackingStoreArgs fs limits Dict.Dict) =
     newLMDBBackingStore
@@ -851,7 +866,7 @@ instance
 -- | Create arguments for initializing the LedgerDB using the LMDB backend.
 mkLMDBArgs ::
   ( MonadIOPrim m
-  , HasLedgerTables (LedgerState blk)
+  , HasLedgerTables LedgerState blk
   , IOLike m
   ) =>
   V1.FlushFrequency -> FilePath -> LMDBLimits -> a -> (LedgerDbBackendArgs m blk, a)
@@ -869,30 +884,30 @@ instance (MonadIO m, PrimState m ~ PrimState IO) => MonadIOPrim m
   Streaming
 -------------------------------------------------------------------------------}
 
-instance (Ord (TxIn l), GetTip l) => StreamingBackend IO LMDB l where
-  data SinkArgs IO LMDB l
+instance (Ord (TxIn blk), GetTip (l blk)) => StreamingBackend IO LMDB l blk where
+  data SinkArgs IO LMDB l blk
     = SinkLMDB
         -- \| Chunk size
         Int
         -- \| Only to be deleted by 'releaseSinkArgs'
         FilePath
-        (LedgerBackingStore IO l)
+        (LedgerBackingStore IO l blk)
         -- \| bsWrite
         ( SlotNo ->
-          (l EmptyMK, l EmptyMK) ->
-          LedgerTables l DiffMK ->
+          (l blk EmptyMK, l blk EmptyMK) ->
+          LedgerTables blk DiffMK ->
           IO ()
         )
-        (l EmptyMK -> IO ())
+        (l blk EmptyMK -> IO ())
 
-  data YieldArgs IO LMDB l
+  data YieldArgs IO LMDB l blk
     = YieldLMDB
         Int
         -- \| Only to be deleted by 'releaseSinkArgs'
         FilePath
         -- \| Only to be closed by 'releaseYieldArgs'
-        (LedgerBackingStore IO l)
-        (LedgerBackingStoreValueHandle IO l)
+        (LedgerBackingStore IO l blk)
+        (LedgerBackingStoreValueHandle IO l blk)
 
   yield _ (YieldLMDB chunkSize _ _ valueHandle) = yieldLmdbS chunkSize valueHandle
   sink _ (SinkLMDB chunkSize _ _ write copy) = sinkLmdbS chunkSize write copy
@@ -905,12 +920,12 @@ instance (Ord (TxIn l), GetTip l) => StreamingBackend IO LMDB l where
     bsClose bs
 
 sinkLmdbS ::
-  forall m l.
-  (Ord (TxIn l), GetTip l, Monad m) =>
+  forall m l blk.
+  (Ord (TxIn blk), GetTip (l blk), Monad m) =>
   Int ->
-  (SlotNo -> (l EmptyMK, l EmptyMK) -> LedgerTables l DiffMK -> m ()) ->
-  (l EmptyMK -> m ()) ->
-  Sink m l
+  (SlotNo -> (l blk EmptyMK, l blk EmptyMK) -> LedgerTables blk DiffMK -> m ()) ->
+  (l blk EmptyMK -> m ()) ->
+  Sink m l blk
 sinkLmdbS writeChunkSize bs copyTo hint s = do
   r <- go writeChunkSize mempty s
   lift $ copyTo hint
@@ -933,8 +948,8 @@ sinkLmdbS writeChunkSize bs copyTo hint s = do
 yieldLmdbS ::
   Monad m =>
   Int ->
-  LedgerBackingStoreValueHandle m l ->
-  Yield m l
+  LedgerBackingStoreValueHandle m l blk ->
+  Yield m l blk
 yieldLmdbS readChunkSize bsvh hint k = do
   r <- k (go (RangeQuery Nothing readChunkSize))
   lift $ S.effects r
@@ -952,16 +967,15 @@ yieldLmdbS readChunkSize bsvh hint k = do
 -- Note we don't need to keep track of resources here because this will be run
 -- in the alloc step of a bracket.
 mkLMDBYieldArgs ::
-  forall l.
+  forall blk.
   ( HasCallStack
-  , HasLedgerTables l
-  , MemPackIdx l EmptyMK ~ l EmptyMK
+  , HasLedgerTables LedgerState blk
   ) =>
   FS.SomeHasFS IO ->
   DiskSnapshot ->
   LMDBLimits ->
-  l EmptyMK ->
-  IO (YieldArgs IO LMDB l)
+  LedgerState blk EmptyMK ->
+  IO (YieldArgs IO LMDB LedgerState blk)
 mkLMDBYieldArgs fs ds limits hint = do
   tempDir <- getCanonicalTemporaryDirectory
   let lmdbTemp = tempDir FilePath.</> "lmdb_streaming_in"
@@ -982,16 +996,15 @@ mkLMDBYieldArgs fs ds limits hint = do
 -- Note we don't need to keep track of resources here because this will be run
 -- in the alloc step of a bracket.
 mkLMDBSinkArgs ::
-  forall l.
+  forall blk.
   ( HasCallStack
-  , HasLedgerTables l
-  , MemPackIdx l EmptyMK ~ l EmptyMK
+  , HasLedgerTables LedgerState blk
   ) =>
   FS.SomeHasFS IO ->
   DiskSnapshot ->
   LMDBLimits ->
-  l EmptyMK ->
-  IO (SinkArgs IO LMDB l)
+  LedgerState blk EmptyMK ->
+  IO (SinkArgs IO LMDB LedgerState blk)
 mkLMDBSinkArgs fs ds limits hint = do
   tempDir <- getCanonicalTemporaryDirectory
   let lmdbTemp = tempDir FilePath.</> "lmdb_streaming_out"

--- a/ouroboros-consensus/src/ouroboros-consensus-lmdb/Ouroboros/Consensus/Storage/LedgerDB/V1/BackingStore/Impl/LMDB/Bridge.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus-lmdb/Ouroboros/Consensus/Storage/LedgerDB/V1/BackingStore/Impl/LMDB/Bridge.hs
@@ -42,6 +42,7 @@ import qualified Database.LMDB.Simple.Cursor as Cursor
 import qualified Database.LMDB.Simple.Internal as Internal
 import Foreign (Storable (peek, poke), castPtr)
 import GHC.Exts
+import Ouroboros.Consensus.Ledger.Abstract
 import Ouroboros.Consensus.Util.IndexedMemPack
 
 instance Buffer MDB_val where
@@ -70,17 +71,17 @@ peekMDBValMemPack = peek >=> pure . unpackError
 pokeMDBValMemPack :: MemPack a => Ptr MDB_val -> a -> IO ()
 pokeMDBValMemPack ptr x = Internal.marshalOutBS (packByteString x) (poke ptr)
 
-indexedPeekMDBValMemPack :: IndexedMemPack idx a => idx -> Ptr MDB_val -> IO a
+indexedPeekMDBValMemPack :: IndexedMemPack l blk a => l blk EmptyMK -> Ptr MDB_val -> IO a
 indexedPeekMDBValMemPack idx = peek >=> pure . indexedUnpackError idx
 
-indexedPokeMDBValMemPack :: IndexedMemPack idx a => idx -> Ptr MDB_val -> a -> IO ()
+indexedPokeMDBValMemPack :: IndexedMemPack l blk a => l blk EmptyMK -> Ptr MDB_val -> a -> IO ()
 indexedPokeMDBValMemPack idx ptr x = Internal.marshalOutBS (indexedPackByteString idx x) (poke ptr)
 
 {-------------------------------------------------------------------------------
   Cursor
 -------------------------------------------------------------------------------}
 
-fromCodecMK :: (IndexedMemPack idx v, MemPack k) => idx -> Cursor.PeekPoke k v
+fromCodecMK :: (IndexedMemPack l blk v, MemPack k) => l blk EmptyMK -> Cursor.PeekPoke k v
 fromCodecMK idx =
   Cursor.PeekPoke
     { Cursor.kPeek = peekMDBValMemPack
@@ -92,8 +93,8 @@ fromCodecMK idx =
 -- | Wrapper around @'Cursor.runCursorAsTransaction''@ that requires a
 -- @'CodecMK'@ instead of a @'PeekPoke'@.
 runCursorAsTransaction' ::
-  (MemPack k, IndexedMemPack idx v) =>
-  idx ->
+  (MemPack k, IndexedMemPack l blk v) =>
+  l blk EmptyMK ->
   CursorM k v mode a ->
   Database k v ->
   Transaction mode a
@@ -121,16 +122,16 @@ getBS db k =
     >>= maybe (return Nothing) (liftIO . fmap Just . pure . unpackError)
 
 indexedGet ::
-  (IndexedMemPack idx v, MemPack k) =>
-  idx ->
+  (IndexedMemPack l blk v, MemPack k) =>
+  l blk EmptyMK ->
   Database k v ->
   k ->
   Transaction mode (Maybe v)
 indexedGet idx db = indexedGetBS idx db . packByteString
 
 indexedGetBS ::
-  IndexedMemPack idx v =>
-  idx ->
+  IndexedMemPack l blk v =>
+  l blk EmptyMK ->
   Database k v ->
   BS.ByteString ->
   Transaction mode (Maybe v)
@@ -164,8 +165,8 @@ putBS (Internal.Db _ dbi) keyBS value = Internal.Txn $ \txn ->
     Monad.void $ assert (len' == sz) $ Internal.copyBS (castPtr ptr, len') valueBS
 
 indexedPut ::
-  (IndexedMemPack idx v, MemPack k) =>
-  idx ->
+  (IndexedMemPack l blk v, MemPack k) =>
+  l blk EmptyMK ->
   Database k v ->
   k ->
   v ->
@@ -173,8 +174,8 @@ indexedPut ::
 indexedPut idx db = indexedPutBS idx db . packByteString
 
 indexedPutBS ::
-  IndexedMemPack idx v =>
-  idx ->
+  IndexedMemPack l blk v =>
+  l blk EmptyMK ->
   Database k v ->
   BS.ByteString ->
   v ->

--- a/ouroboros-consensus/src/ouroboros-consensus-lsm/Ouroboros/Consensus/Storage/LedgerDB/V2/LSM.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus-lsm/Ouroboros/Consensus/Storage/LedgerDB/V2/LSM.hs
@@ -117,12 +117,12 @@ data LSMClosedExn = LSMClosedExn
 
 newtype TxOutBytes = TxOutBytes {unTxOutBytes :: LSM.RawBytes}
 
-toTxOutBytes :: IndexedMemPack (l EmptyMK) (TxOut l) => l EmptyMK -> TxOut l -> TxOutBytes
+toTxOutBytes :: IndexedMemPack l blk (TxOut blk) => l blk EmptyMK -> TxOut blk -> TxOutBytes
 toTxOutBytes st txout =
   let barr = indexedPackByteArray True st txout
    in TxOutBytes $ LSM.RawBytes (VP.Vector 0 (PBA.sizeofByteArray barr) barr)
 
-fromTxOutBytes :: IndexedMemPack (l EmptyMK) (TxOut l) => l EmptyMK -> TxOutBytes -> TxOut l
+fromTxOutBytes :: IndexedMemPack l blk (TxOut blk) => l blk EmptyMK -> TxOutBytes -> TxOut blk
 fromTxOutBytes st (TxOutBytes (LSM.RawBytes vec)) =
   case indexedUnpackEither st vec of
     Left err ->
@@ -146,12 +146,12 @@ deriving via LSM.ResolveAsFirst TxOutBytes instance LSM.ResolveValue TxOutBytes
 
 newtype TxInBytes = TxInBytes {unTxInBytes :: LSM.RawBytes}
 
-toTxInBytes :: MemPack (TxIn l) => Proxy l -> TxIn l -> TxInBytes
+toTxInBytes :: MemPack (TxIn blk) => Proxy blk -> TxIn blk -> TxInBytes
 toTxInBytes _ txin =
   let barr = packByteArray True txin
    in TxInBytes $ LSM.RawBytes (VP.Vector 0 (PBA.sizeofByteArray barr) barr)
 
-fromTxInBytes :: MemPack (TxIn l) => Proxy l -> TxInBytes -> TxIn l
+fromTxInBytes :: MemPack (TxIn blk) => Proxy blk -> TxInBytes -> TxIn blk
 fromTxInBytes _ (TxInBytes (LSM.RawBytes vec)) =
   case unpackEither vec of
     Left err ->
@@ -188,16 +188,16 @@ duplicateLSMTable tracer t = do
 -------------------------------------------------------------------------------}
 
 newLSMLedgerTablesHandle ::
-  forall m l.
+  forall m l blk.
   ( IOLike m
-  , HasLedgerTables l
-  , IndexedMemPack (l EmptyMK) (TxOut l)
+  , HasLedgerTables l blk
+  , IndexedMemPack l blk (TxOut blk)
   ) =>
   Tracer m LedgerDBV2Trace ->
   -- | The size of the tables
   Word64 ->
   UTxOTable m ->
-  m (LedgerTablesHandle m l)
+  m (LedgerTablesHandle m l blk)
 newLSMLedgerTablesHandle tracer utxosSize t =
   encloseTimedWith (TraceLedgerTablesHandleCreate >$< tracer) $ do
     pure
@@ -221,13 +221,13 @@ newLSMLedgerTablesHandle tracer utxosSize t =
 
 implDuplicate ::
   ( IOLike m
-  , HasLedgerTables l
-  , IndexedMemPack (l EmptyMK) (TxOut l)
+  , HasLedgerTables l blk
+  , IndexedMemPack l blk (TxOut blk)
   ) =>
   Word64 ->
   UTxOTable m ->
   Tracer m LedgerDBV2Trace ->
-  m (LedgerTablesHandle m l)
+  m (LedgerTablesHandle m l blk)
 implDuplicate size t tracer =
   duplicateLSMTable tracer t
     >>= newLSMLedgerTablesHandle
@@ -235,17 +235,17 @@ implDuplicate size t tracer =
       size
 
 implDuplicateWithDiffs ::
-  forall m l mk.
+  forall m l blk mk.
   ( IOLike m
-  , HasLedgerTables l
-  , IndexedMemPack (l EmptyMK) (TxOut l)
+  , HasLedgerTables l blk
+  , IndexedMemPack l blk (TxOut blk)
   ) =>
   Tracer m LedgerDBV2Trace ->
   UTxOTable m ->
   Word64 ->
-  l mk ->
-  l DiffMK ->
-  m (LedgerTablesHandle m l)
+  l blk mk ->
+  l blk DiffMK ->
+  m (LedgerTablesHandle m l blk)
 implDuplicateWithDiffs tracer t0 size _ !st1 = do
   t <- duplicateLSMTable tracer t0
   encloseTimedWith (TraceLedgerTablesHandleRead >$< tracer) $ do
@@ -253,7 +253,7 @@ implDuplicateWithDiffs tracer t0 size _ !st1 = do
     let vec = V.create $ do
           vec' <- VM.new (Map.size diffs)
           Monad.foldM_
-            (\idx (k, item) -> VM.write vec' idx (toTxInBytes (Proxy @l) k, (f item)) >> pure (idx + 1))
+            (\idx (k, item) -> VM.write vec' idx (toTxInBytes (Proxy @blk) k, (f item)) >> pure (idx + 1))
             0
             $ Map.toList diffs
           pure vec'
@@ -277,22 +277,22 @@ implDuplicateWithDiffs tracer t0 size _ !st1 = do
   f Diff.Delete = LSM.Delete
 
 implRead ::
-  forall m l.
+  forall m l blk.
   ( IOLike m
-  , HasLedgerTables l
-  , IndexedMemPack (l EmptyMK) (TxOut l)
+  , HasLedgerTables l blk
+  , IndexedMemPack l blk (TxOut blk)
   ) =>
   Tracer m LedgerDBV2Trace ->
   UTxOTable m ->
-  l EmptyMK ->
-  LedgerTables l KeysMK ->
-  m (LedgerTables l ValuesMK)
+  l blk EmptyMK ->
+  LedgerTables blk KeysMK ->
+  m (LedgerTables blk ValuesMK)
 implRead tracer t st (LedgerTables (KeysMK keys)) =
   encloseTimedWith (TraceLedgerTablesHandleRead >$< tracer) $ do
     let vec' = V.create $ do
           vec <- VM.new (Set.size keys)
           Monad.foldM_
-            (\i x -> VM.write vec i (toTxInBytes (Proxy @l) x) >> pure (i + 1))
+            (\i x -> VM.write vec i (toTxInBytes (Proxy @blk) x) >> pure (i + 1))
             0
             keys
           pure vec
@@ -304,7 +304,7 @@ implRead tracer t st (LedgerTables (KeysMK keys)) =
       . Foldable.foldl'
         ( \m (k, item) ->
             case item of
-              LSM.Found v -> Map.insert (fromTxInBytes (Proxy @l) k) (fromTxOutBytes st v) m
+              LSM.Found v -> Map.insert (fromTxInBytes (Proxy @blk) k) (fromTxOutBytes st v) m
               LSM.NotFound -> m
               LSM.FoundWithBlob{} -> m
         )
@@ -312,13 +312,13 @@ implRead tracer t st (LedgerTables (KeysMK keys)) =
       $ V.zip vec' res
 
 implReadRange ::
-  forall m l.
-  (IOLike m, IndexedMemPack (l EmptyMK) (TxOut l)) =>
-  HasLedgerTables l =>
+  forall m l blk.
+  (IOLike m, IndexedMemPack l blk (TxOut blk)) =>
+  HasLedgerTables l blk =>
   UTxOTable m ->
-  l EmptyMK ->
-  (Maybe (TxIn l), Int) ->
-  m (LedgerTables l ValuesMK, Maybe (TxIn l))
+  l blk EmptyMK ->
+  (Maybe (TxIn blk), Int) ->
+  m (LedgerTables blk ValuesMK, Maybe (TxIn blk))
 implReadRange table st (mPrev, num) = do
   entries <- maybe cursorFromStart cursorFromKey mPrev
   pure
@@ -326,30 +326,30 @@ implReadRange table st (mPrev, num) = do
         . ValuesMK
         . V.foldl'
           ( \m -> \case
-              LSM.Entry k v -> Map.insert (fromTxInBytes (Proxy @l) k) (fromTxOutBytes st v) m
+              LSM.Entry k v -> Map.insert (fromTxInBytes (Proxy @blk) k) (fromTxOutBytes st v) m
               LSM.EntryWithBlob{} -> m
           )
           Map.empty
         $ entries
     , case snd <$> V.unsnoc entries of
         Nothing -> Nothing
-        Just (LSM.Entry k _) -> Just (fromTxInBytes (Proxy @l) k)
-        Just (LSM.EntryWithBlob k _ _) -> Just (fromTxInBytes (Proxy @l) k)
+        Just (LSM.Entry k _) -> Just (fromTxInBytes (Proxy @blk) k)
+        Just (LSM.EntryWithBlob k _ _) -> Just (fromTxInBytes (Proxy @blk) k)
     )
  where
   cursorFromStart = LSM.withCursor table (LSM.take num)
   -- Here we ask for one value more and we drop one value because the
   -- cursor returns also the key at which it was opened.
-  cursorFromKey k = fmap (V.drop 1) $ LSM.withCursorAtOffset table (toTxInBytes (Proxy @l) k) (LSM.take $ num + 1)
+  cursorFromKey k = fmap (V.drop 1) $ LSM.withCursorAtOffset table (toTxInBytes (Proxy @blk) k) (LSM.take $ num + 1)
 
 implReadAll ::
   ( IOLike m
-  , HasLedgerTables l
-  , IndexedMemPack (l EmptyMK) (TxOut l)
+  , HasLedgerTables l blk
+  , IndexedMemPack l blk (TxOut blk)
   ) =>
   UTxOTable m ->
-  l EmptyMK ->
-  m (LedgerTables l ValuesMK)
+  l blk EmptyMK ->
+  m (LedgerTables blk ValuesMK)
 implReadAll t st =
   let readAll' m = do
         (v, n) <- implReadRange t st (m, 100000)
@@ -398,7 +398,7 @@ snapshotManager ::
   CodecConfig blk ->
   Tracer m (TraceSnapshotEvent blk) ->
   SomeHasFS m ->
-  SnapshotManager m m blk (StateRef m (ExtLedgerState blk))
+  SnapshotManager m m blk (StateRef m ExtLedgerState blk)
 snapshotManager session ccfg tracer fs =
   SnapshotManager
     { listSnapshots = defaultListSnapshots fs
@@ -418,7 +418,7 @@ implTakeSnapshot ::
   Tracer m (TraceSnapshotEvent blk) ->
   SomeHasFS m ->
   Maybe String ->
-  StateRef m (ExtLedgerState blk) ->
+  StateRef m ExtLedgerState blk ->
   m (Maybe (DiskSnapshot, RealPoint blk))
 implTakeSnapshot ccfg tracer shfs@(SomeHasFS hasFs) suffix st =
   case pointToWithOriginRealPoint (castPoint (getTip $ state st)) of
@@ -526,7 +526,7 @@ loadSnapshot ::
   SomeHasFS m ->
   Session m ->
   DiskSnapshot ->
-  ExceptT (SnapshotFailure blk) m (StateRef m (ExtLedgerState blk), RealPoint blk)
+  ExceptT (SnapshotFailure blk) m (StateRef m ExtLedgerState blk, RealPoint blk)
 loadSnapshot tracer ccfg fs@(SomeHasFS hfs) session ds = do
   fileEx <- lift $ doesFileExist hfs (snapshotToDirPath ds)
   Monad.when fileEx $ throwE $ InitFailureRead ReadSnapshotIsLegacy
@@ -563,15 +563,15 @@ loadSnapshot tracer ccfg fs@(SomeHasFS hfs) session ds = do
 -- | Create the initial LSM table from values, which should happen only at
 -- Genesis.
 tableFromValuesMK ::
-  forall m l.
+  forall m l blk.
   ( IOLike m
-  , IndexedMemPack (l EmptyMK) (TxOut l)
-  , MemPack (TxIn l)
+  , IndexedMemPack l blk (TxOut blk)
+  , MemPack (TxIn blk)
   ) =>
   Tracer m LedgerDBV2Trace ->
   Session m ->
-  l EmptyMK ->
-  LedgerTables l ValuesMK ->
+  l blk EmptyMK ->
+  LedgerTables blk ValuesMK ->
   m (UTxOTable m, Word64)
 tableFromValuesMK tracer session st (LedgerTables (ValuesMK values)) = do
   table <-
@@ -582,7 +582,7 @@ tableFromValuesMK tracer session st (LedgerTables (ValuesMK values)) = do
   go table items =
     LSM.inserts table $
       V.fromListN (length items) $
-        map (\(k, v) -> (toTxInBytes (Proxy @l) k, toTxOutBytes st v, Nothing)) items
+        map (\(k, v) -> (toTxInBytes (Proxy @blk) k, toTxOutBytes st v, Nothing)) items
 
 {-------------------------------------------------------------------------------
   Helpers
@@ -621,7 +621,7 @@ instance
   ( LedgerSupportsProtocol blk
   , IOLike m
   , LedgerDbSerialiseConstraints blk
-  , HasLedgerTables (LedgerState blk)
+  , HasLedgerTables LedgerState blk
   ) =>
   Backend m LSM blk
   where
@@ -680,23 +680,23 @@ instance
   snapshotManager _ res = Ouroboros.Consensus.Storage.LedgerDB.V2.LSM.snapshotManager (sessionResource res)
 
 instance
-  ( MemPack (TxIn l)
-  , IndexedMemPack (l EmptyMK) (TxOut l)
+  ( MemPack (TxIn blk)
+  , IndexedMemPack l blk (TxOut blk)
   , IOLike m
   ) =>
-  StreamingBackend m LSM l
+  StreamingBackend m LSM l blk
   where
-  data YieldArgs m LSM l
+  data YieldArgs m LSM l blk
     = -- \| Yield an LSM snapshot
       YieldLSM
         Int
-        (LedgerTablesHandle m l)
+        (LedgerTablesHandle m l blk)
         -- \| Only to be closed by 'releaseYieldArgs'
         (Session m)
         -- \| Only to be closed by 'releaseYieldArgs'
         (SomeHasFSAndBlockIO m)
 
-  data SinkArgs m LSM l
+  data SinkArgs m LSM l blk
     = SinkLSM
         -- \| Chunk size
         Int
@@ -735,8 +735,8 @@ instance IOLike m => NoThunks (Resources m LSM) where
 yieldLsmS ::
   Monad m =>
   Int ->
-  LedgerTablesHandle m l ->
-  Yield m l
+  LedgerTablesHandle m l blk ->
+  Yield m l blk
 yieldLsmS readChunkSize tb hint k = do
   r <- k (go (Nothing, readChunkSize))
   lift $ S.effects r
@@ -750,21 +750,21 @@ yieldLsmS readChunkSize tb hint k = do
         go (mx, readChunkSize)
 
 sinkLsmS ::
-  forall m l.
+  forall m l blk.
   ( MonadAsync m
   , MonadMVar m
   , MonadThrow (STM m)
   , MonadMask m
   , MonadST m
   , MonadEvaluate m
-  , MemPack (TxIn l)
-  , IndexedMemPack (l EmptyMK) (TxOut l)
+  , MemPack (TxIn blk)
+  , IndexedMemPack l blk (TxOut blk)
   ) =>
   Int ->
   SomeHasFS m ->
   DiskSnapshot ->
   Session m ->
-  Sink m l
+  Sink m l blk
 sinkLsmS writeChunkSize (SomeHasFS hfs) ds session st stream = do
   r <-
     bracket
@@ -782,11 +782,11 @@ sinkLsmS writeChunkSize (SomeHasFS hfs) ds session st stream = do
       )
   pure (fmap (,Nothing) r)
  where
-  writeToTable :: UTxOTable m -> [(TxIn l, TxOut l)] -> m ()
+  writeToTable :: UTxOTable m -> [(TxIn blk, TxOut blk)] -> m ()
   writeToTable lsmTable accUTxOs =
     LSM.inserts lsmTable $
       V.fromList
-        [(toTxInBytes (Proxy @l) txin, toTxOutBytes st txout, Nothing) | (txin, txout) <- accUTxOs]
+        [(toTxInBytes (Proxy @blk) txin, toTxOutBytes st txout, Nothing) | (txin, txout) <- accUTxOs]
 
   go utxosSize lsmTable 0 accUTxOs stream' = do
     lift $ writeToTable lsmTable accUTxOs
@@ -802,8 +802,8 @@ sinkLsmS writeChunkSize (SomeHasFS hfs) ds session st stream = do
 -- | Create Yield arguments for LSM
 mkLSMYieldArgs ::
   ( IOLike m
-  , HasLedgerTables l
-  , IndexedMemPack (l EmptyMK) (TxOut l)
+  , HasLedgerTables l blk
+  , IndexedMemPack l blk (TxOut blk)
   ) =>
   -- | The filepath in which the LSM database lives. Must not have a trailing slash!
   FilePath ->
@@ -813,7 +813,7 @@ mkLSMYieldArgs ::
   (FilePath -> WithTempRegistry () m (SomeHasFSAndBlockIO m)) ->
   -- | Usually 'newStdGen'
   (m StdGen) ->
-  m (YieldArgs m LSM l)
+  m (YieldArgs m LSM l blk)
 mkLSMYieldArgs lsmDbPath ds mkFS mkGen = do
   shfsbio@(SomeHasFSAndBlockIO hasFS blockIO) <-
     -- The Yield args will be created in the alloc step of a bracket so we do the
@@ -843,7 +843,7 @@ mkLSMSinkArgs ::
   (FilePath -> WithTempRegistry () m (SomeHasFSAndBlockIO m)) ->
   -- | Usually 'newStdGen'
   (m StdGen) ->
-  m (SinkArgs m LSM l)
+  m (SinkArgs m LSM l blk)
 mkLSMSinkArgs (splitFileName -> (lsmDbParentPath, lsmDbPath)) ds snapFs mkBlockIOFS mkGen = do
   shfsbio@(SomeHasFSAndBlockIO hasFS blockIO) <-
     -- The Sink args will be created in the alloc step of a bracket so we do the

--- a/ouroboros-consensus/src/ouroboros-consensus-lsm/Ouroboros/Consensus/Storage/LedgerDB/V2/LSM.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus-lsm/Ouroboros/Consensus/Storage/LedgerDB/V2/LSM.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingVia #-}
@@ -187,11 +188,13 @@ duplicateLSMTable tracer t = do
   LedgerTablesHandle
 -------------------------------------------------------------------------------}
 
+type LSMConstraints l blk =
+  (HasLedgerTables l blk, MemPack (TxIn blk), IndexedMemPack l blk (TxOut blk))
+
 newLSMLedgerTablesHandle ::
   forall m l blk.
   ( IOLike m
-  , HasLedgerTables l blk
-  , IndexedMemPack l blk (TxOut blk)
+  , LSMConstraints l blk
   ) =>
   Tracer m LedgerDBV2Trace ->
   -- | The size of the tables
@@ -221,8 +224,7 @@ newLSMLedgerTablesHandle tracer utxosSize t =
 
 implDuplicate ::
   ( IOLike m
-  , HasLedgerTables l blk
-  , IndexedMemPack l blk (TxOut blk)
+  , LSMConstraints l blk
   ) =>
   Word64 ->
   UTxOTable m ->
@@ -237,8 +239,7 @@ implDuplicate size t tracer =
 implDuplicateWithDiffs ::
   forall m l blk mk.
   ( IOLike m
-  , HasLedgerTables l blk
-  , IndexedMemPack l blk (TxOut blk)
+  , LSMConstraints l blk
   ) =>
   Tracer m LedgerDBV2Trace ->
   UTxOTable m ->
@@ -279,8 +280,7 @@ implDuplicateWithDiffs tracer t0 size _ !st1 = do
 implRead ::
   forall m l blk.
   ( IOLike m
-  , HasLedgerTables l blk
-  , IndexedMemPack l blk (TxOut blk)
+  , LSMConstraints l blk
   ) =>
   Tracer m LedgerDBV2Trace ->
   UTxOTable m ->
@@ -313,8 +313,7 @@ implRead tracer t st (LedgerTables (KeysMK keys)) =
 
 implReadRange ::
   forall m l blk.
-  (IOLike m, IndexedMemPack l blk (TxOut blk)) =>
-  HasLedgerTables l blk =>
+  (IOLike m, LSMConstraints l blk) =>
   UTxOTable m ->
   l blk EmptyMK ->
   (Maybe (TxIn blk), Int) ->
@@ -344,8 +343,7 @@ implReadRange table st (mPrev, num) = do
 
 implReadAll ::
   ( IOLike m
-  , HasLedgerTables l blk
-  , IndexedMemPack l blk (TxOut blk)
+  , LSMConstraints l blk
   ) =>
   UTxOTable m ->
   l blk EmptyMK ->
@@ -519,6 +517,7 @@ loadSnapshot ::
   forall blk m.
   ( LedgerDbSerialiseConstraints blk
   , LedgerSupportsProtocol blk
+  , LSMConstraints LedgerState blk
   , IOLike m
   ) =>
   Tracer m LedgerDBV2Trace ->
@@ -565,8 +564,7 @@ loadSnapshot tracer ccfg fs@(SomeHasFS hfs) session ds = do
 tableFromValuesMK ::
   forall m l blk.
   ( IOLike m
-  , IndexedMemPack l blk (TxOut blk)
-  , MemPack (TxIn blk)
+  , LSMConstraints l blk
   ) =>
   Tracer m LedgerDBV2Trace ->
   Session m ->
@@ -680,8 +678,7 @@ instance
   snapshotManager _ res = Ouroboros.Consensus.Storage.LedgerDB.V2.LSM.snapshotManager (sessionResource res)
 
 instance
-  ( MemPack (TxIn blk)
-  , IndexedMemPack l blk (TxOut blk)
+  ( LSMConstraints l blk
   , IOLike m
   ) =>
   StreamingBackend m LSM l blk
@@ -757,8 +754,7 @@ sinkLsmS ::
   , MonadMask m
   , MonadST m
   , MonadEvaluate m
-  , MemPack (TxIn blk)
-  , IndexedMemPack l blk (TxOut blk)
+  , LSMConstraints l blk
   ) =>
   Int ->
   SomeHasFS m ->
@@ -802,8 +798,7 @@ sinkLsmS writeChunkSize (SomeHasFS hfs) ds session st stream = do
 -- | Create Yield arguments for LSM
 mkLSMYieldArgs ::
   ( IOLike m
-  , HasLedgerTables l blk
-  , IndexedMemPack l blk (TxOut blk)
+  , LSMConstraints l blk
   ) =>
   -- | The filepath in which the LSM database lives. Must not have a trailing slash!
   FilePath ->

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Genesis/Governor.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Genesis/Governor.hs
@@ -64,7 +64,7 @@ import Ouroboros.Consensus.HardFork.History.Qry
   , slotToGenesisWindow
   )
 import Ouroboros.Consensus.HeaderValidation (HeaderWithTime (..))
-import Ouroboros.Consensus.Ledger.Basics (EmptyMK)
+import Ouroboros.Consensus.Ledger.Abstract (EmptyMK)
 import Ouroboros.Consensus.Ledger.Extended
   ( ExtLedgerState
   , ledgerState

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Abstract/CanHardFork.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Abstract/CanHardFork.hs
@@ -21,7 +21,6 @@ import Ouroboros.Consensus.HardFork.Combinator.Abstract.SingleEraBlock
 import Ouroboros.Consensus.HardFork.Combinator.InjectTxs
 import Ouroboros.Consensus.HardFork.Combinator.Protocol.ChainSel
 import Ouroboros.Consensus.HardFork.Combinator.Translation
-import Ouroboros.Consensus.Ledger.Basics
 import Ouroboros.Consensus.Ledger.SupportsMempool
 import Ouroboros.Consensus.TypeFamilyWrappers
 
@@ -31,8 +30,6 @@ import Ouroboros.Consensus.TypeFamilyWrappers
 
 class
   ( All SingleEraBlock xs
-  , All (Compose HasLedgerTables LedgerState) xs
-  , All (Compose HasLedgerTables (Ticked LedgerState)) xs
   , Typeable xs
   , IsNonEmpty xs
   , Measure (HardForkTxMeasure xs)

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Abstract/SingleEraBlock.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Abstract/SingleEraBlock.hs
@@ -77,8 +77,8 @@ class
   , SerialiseNodeToClient blk (PartialLedgerConfig blk)
   , -- LedgerTables
     CanStowLedgerTables (LedgerState blk)
-  , HasLedgerTables (LedgerState blk)
-  , HasLedgerTables (Ticked LedgerState blk)
+  , HasLedgerTables LedgerState blk
+  , HasLedgerTables (Ticked LedgerState) blk
   , -- Instances required to support testing
     Eq (GenTx blk)
   , Eq (Validated (GenTx blk))

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Embed/Nary.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Embed/Nary.hs
@@ -46,7 +46,7 @@ import Ouroboros.Consensus.HeaderValidation
   , HeaderState (..)
   , genesisHeaderState
   )
-import Ouroboros.Consensus.Ledger.Basics
+import Ouroboros.Consensus.Ledger.Abstract
 import Ouroboros.Consensus.Ledger.Extended (ExtLedgerState (..))
 import Ouroboros.Consensus.Ledger.Query
 import Ouroboros.Consensus.Ledger.Tables.Utils
@@ -268,7 +268,7 @@ instance Inject (Flip ExtLedgerState mk) where
 -- not rely on that class.
 injectInitialExtLedgerState ::
   forall x xs.
-  (CanHardFork (x ': xs), HasLedgerTables (LedgerState (HardForkBlock (x : xs)))) =>
+  (CanHardFork (x ': xs), HasLedgerTables LedgerState (HardForkBlock (x : xs))) =>
   TopLevelConfig (HardForkBlock (x ': xs)) ->
   ExtLedgerState x ValuesMK ->
   ExtLedgerState (HardForkBlock (x ': xs)) ValuesMK

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Ledger.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Ledger.hs
@@ -278,6 +278,7 @@ instance
           error "reapplyBlockLedgerResult: can't be from other era"
       )
 
+instance (HasCanonicalTxIn xs, HasHardForkTxOut xs, CanHardFork xs) => GetBlockKeySets (HardForkBlock xs) where
   getBlockKeySets (HardForkBlock (OneEraBlock ns)) =
     hcollapse $
       hcimap proxySingle f ns
@@ -286,7 +287,7 @@ instance
       SingleEraBlock x =>
       Index xs x ->
       I x ->
-      K (LedgerTables (LedgerState (HardForkBlock xs)) KeysMK) x
+      K (LedgerTables (HardForkBlock xs) KeysMK) x
     f idx (I blk) = K $ injectLedgerTables idx $ getBlockKeySets blk
 
 apply ::
@@ -311,12 +312,7 @@ apply doValidate opts index (WrapLedgerConfig cfg) (Pair (I block) (FlipTickedLe
   UpdateLedger
 -------------------------------------------------------------------------------}
 
-instance
-  ( CanHardFork xs
-  , HasCanonicalTxIn xs
-  , HasHardForkTxOut xs
-  ) =>
-  UpdateLedger (HardForkBlock xs)
+instance ApplyBlock LedgerState (HardForkBlock xs) => UpdateLedger (HardForkBlock xs)
 
 {-------------------------------------------------------------------------------
   HasHardForkHistory
@@ -886,22 +882,21 @@ instance
   , HasCanonicalTxIn xs
   , HasHardForkTxOut xs
   ) =>
-  HasLedgerTables (LedgerState (HardForkBlock xs))
+  HasLedgerTables LedgerState (HardForkBlock xs)
   where
   projectLedgerTables ::
     forall mk.
     (CanMapMK mk, CanMapKeysMK mk, ZeroableMK mk) =>
     LedgerState (HardForkBlock xs) mk ->
-    LedgerTables (LedgerState (HardForkBlock xs)) mk
+    LedgerTables (HardForkBlock xs) mk
   projectLedgerTables (HardForkLedgerState st) =
-    hcollapse $
-      hcimap (Proxy @(Compose HasLedgerTables LedgerState)) projectOne st
+    hcollapse $ hcimap proxySingle projectOne st
    where
     projectOne ::
-      Compose HasLedgerTables LedgerState x =>
+      SingleEraBlock x =>
       Index xs x ->
       Flip LedgerState mk x ->
-      K (LedgerTables (LedgerState (HardForkBlock xs)) mk) x
+      K (LedgerTables (HardForkBlock xs) mk) x
     projectOne i l =
       K $
         injectLedgerTables i $
@@ -912,14 +907,14 @@ instance
     forall mk any.
     (CanMapMK mk, CanMapKeysMK mk, ZeroableMK mk) =>
     LedgerState (HardForkBlock xs) any ->
-    LedgerTables (LedgerState (HardForkBlock xs)) mk ->
+    LedgerTables (HardForkBlock xs) mk ->
     LedgerState (HardForkBlock xs) mk
   withLedgerTables (HardForkLedgerState st) tables =
     HardForkLedgerState $
-      hcimap (Proxy @(Compose HasLedgerTables LedgerState)) withLedgerTablesOne st
+      hcimap proxySingle withLedgerTablesOne st
    where
     withLedgerTablesOne ::
-      Compose HasLedgerTables LedgerState x =>
+      SingleEraBlock x =>
       Index xs x ->
       Flip LedgerState any x ->
       Flip LedgerState mk x
@@ -933,58 +928,55 @@ instance
   , HasCanonicalTxIn xs
   , HasHardForkTxOut xs
   ) =>
-  HasLedgerTables (Ticked LedgerState (HardForkBlock xs))
+  HasLedgerTables (Ticked LedgerState) (HardForkBlock xs)
   where
   projectLedgerTables ::
     forall mk.
     (CanMapMK mk, CanMapKeysMK mk, ZeroableMK mk) =>
     Ticked LedgerState (HardForkBlock xs) mk ->
-    LedgerTables (Ticked LedgerState (HardForkBlock xs)) mk
+    LedgerTables (HardForkBlock xs) mk
   projectLedgerTables st =
     hcollapse $
       hcimap
-        (Proxy @(Compose HasLedgerTables (Ticked LedgerState)))
+        proxySingle
         projectOne
         (tickedHardForkLedgerStatePerEra st)
    where
     projectOne ::
-      HasLedgerTables (Ticked LedgerState x) =>
+      SingleEraBlock x =>
       Index xs x ->
       FlipTickedLedgerState mk x ->
-      K (LedgerTables (Ticked LedgerState (HardForkBlock xs)) mk) x
+      K (LedgerTables (HardForkBlock xs) mk) x
     projectOne i l =
       K $
-        castLedgerTables $
-          injectLedgerTables i $
-            castLedgerTables $
-              projectLedgerTables $
-                getFlipTickedLedgerState l
+        injectLedgerTables i $
+          projectLedgerTables $
+            getFlipTickedLedgerState l
 
   withLedgerTables ::
     forall mk any.
     (CanMapMK mk, CanMapKeysMK mk, ZeroableMK mk) =>
     Ticked LedgerState (HardForkBlock xs) any ->
-    LedgerTables (Ticked LedgerState (HardForkBlock xs)) mk ->
+    LedgerTables (HardForkBlock xs) mk ->
     Ticked LedgerState (HardForkBlock xs) mk
   withLedgerTables st tables =
     st
       { tickedHardForkLedgerStatePerEra =
           hcimap
-            (Proxy @(Compose HasLedgerTables (Ticked LedgerState)))
+            proxySingle
             withLedgerTablesOne
             (tickedHardForkLedgerStatePerEra st)
       }
    where
     withLedgerTablesOne ::
-      HasLedgerTables (Ticked LedgerState x) =>
+      SingleEraBlock x =>
       Index xs x ->
       FlipTickedLedgerState any x ->
       FlipTickedLedgerState mk x
     withLedgerTablesOne i l =
       FlipTickedLedgerState $
         withLedgerTables (getFlipTickedLedgerState l) $
-          castLedgerTables $
-            ejectLedgerTables i (castLedgerTables tables)
+          ejectLedgerTables i tables
 
 instance
   All (Compose CanStowLedgerTables LedgerState) xs =>
@@ -1024,22 +1016,22 @@ injectLedgerTables ::
   , HasHardForkTxOut xs
   ) =>
   Index xs x ->
-  LedgerTables (LedgerState x) mk ->
-  LedgerTables (LedgerState (HardForkBlock xs)) mk
+  LedgerTables x mk ->
+  LedgerTables (HardForkBlock xs) mk
 injectLedgerTables idx =
   bimapLedgerTables (injectCanonicalTxIn idx) (injectHardForkTxOut idx)
 
 ejectLedgerTables ::
   forall xs x mk.
   ( CanMapKeysMK mk
-  , Ord (TxIn (LedgerState x))
+  , Ord (TxIn x)
   , HasCanonicalTxIn xs
   , CanMapMK mk
   , HasHardForkTxOut xs
   ) =>
   Index xs x ->
-  LedgerTables (LedgerState (HardForkBlock xs)) mk ->
-  LedgerTables (LedgerState x) mk
+  LedgerTables (HardForkBlock xs) mk ->
+  LedgerTables x mk
 ejectLedgerTables idx =
   bimapLedgerTables (ejectCanonicalTxIn idx) (ejectHardForkTxOut idx)
 
@@ -1049,7 +1041,7 @@ ejectLedgerTables idx =
 
 -- | Must be the 'CannonicalTxIn' type, but this will probably change in the
 -- future to @NS 'WrapTxIn' xs@. See 'HasCanonicalTxIn'.
-type instance TxIn (LedgerState (HardForkBlock xs)) = CanonicalTxIn xs
+type instance TxIn (HardForkBlock xs) = CanonicalTxIn xs
 
 -- | Canonical TxIn
 --
@@ -1073,21 +1065,21 @@ class
   -- | Inject an era-specific 'TxIn' into a 'TxIn' for a 'HardForkBlock'.
   injectCanonicalTxIn ::
     Index xs x ->
-    TxIn (LedgerState x) ->
+    TxIn x ->
     CanonicalTxIn xs
 
   -- | Distribute a 'TxIn' for a 'HardForkBlock' to an era-specific 'TxIn'.
   ejectCanonicalTxIn ::
     Index xs x ->
     CanonicalTxIn xs ->
-    TxIn (LedgerState x)
+    TxIn x
 
 {-------------------------------------------------------------------------------
   HardForkTxOut
 -------------------------------------------------------------------------------}
 
 -- | Must be the 'HardForkTxOut' type
-type instance TxOut (LedgerState (HardForkBlock xs)) = HardForkTxOut xs
+type instance TxOut (HardForkBlock xs) = HardForkTxOut xs
 
 -- | This choice for 'HardForkTxOut' imposes some complications on the code.
 --
@@ -1168,17 +1160,16 @@ class
   ( Show (HardForkTxOut xs)
   , Eq (HardForkTxOut xs)
   , NoThunks (HardForkTxOut xs)
-  , IndexedMemPack (LedgerState (HardForkBlock xs) EmptyMK) (HardForkTxOut xs)
-  , IndexedMemPack (Ticked LedgerState (HardForkBlock xs) EmptyMK) (HardForkTxOut xs)
-  , SerializeTablesWithHint (LedgerState (HardForkBlock xs))
+  , IndexedMemPack LedgerState (HardForkBlock xs) (HardForkTxOut xs)
+  , SerializeTablesWithHint LedgerState (HardForkBlock xs)
   ) =>
   HasHardForkTxOut xs
   where
   type HardForkTxOut xs :: Type
   type HardForkTxOut xs = DefaultHardForkTxOut xs
 
-  injectHardForkTxOut :: Index xs x -> TxOut (LedgerState x) -> HardForkTxOut xs
-  ejectHardForkTxOut :: Index xs x -> HardForkTxOut xs -> TxOut (LedgerState x)
+  injectHardForkTxOut :: Index xs x -> TxOut x -> HardForkTxOut xs
+  ejectHardForkTxOut :: Index xs x -> HardForkTxOut xs -> TxOut x
 
   -- | This method is a null-arity method in a typeclass to make it a CAF, such
   -- that we only compute it once, then it is cached for the duration of the
@@ -1205,7 +1196,7 @@ class
 
 instance
   (CanHardFork xs, HasHardForkTxOut xs) =>
-  CanUpgradeLedgerTables (LedgerState (HardForkBlock xs))
+  CanUpgradeLedgerTables LedgerState (HardForkBlock xs)
   where
   upgradeTables
     (HardForkLedgerState (HardForkState hs0))
@@ -1222,11 +1213,11 @@ extendTables ::
   (CanHardFork xs, HasHardForkTxOut xs) =>
   NS (K ()) xs ->
   Map.Map
-    (TxIn (LedgerState (HardForkBlock xs)))
-    (TxOut (LedgerState (HardForkBlock xs))) ->
+    (TxIn (HardForkBlock xs))
+    (TxOut (HardForkBlock xs)) ->
   Map.Map
-    (TxIn (LedgerState (HardForkBlock xs)))
-    (TxOut (LedgerState (HardForkBlock xs)))
+    (TxIn (HardForkBlock xs))
+    (TxOut (HardForkBlock xs))
 extendTables st =
   Map.map
     ( \txout ->
@@ -1245,7 +1236,7 @@ extendTables st =
 injectHardForkTxOutDefault ::
   SListI xs =>
   Index xs x ->
-  TxOut (LedgerState x) ->
+  TxOut x ->
   DefaultHardForkTxOut xs
 injectHardForkTxOutDefault idx = injectNS idx . WrapTxOut
 
@@ -1254,7 +1245,7 @@ ejectHardForkTxOutDefault ::
   HasHardForkTxOut xs =>
   Index xs x ->
   DefaultHardForkTxOut xs ->
-  TxOut (LedgerState x)
+  TxOut x
 ejectHardForkTxOutDefault idx =
   unwrapTxOut
     . apFn (projectNP idx txOutEjections)
@@ -1291,8 +1282,8 @@ composeTxOutTranslations = \case
     Z x -> l x
     S x -> r x
 
-class MemPack (TxOut (LedgerState x)) => MemPackTxOut x
-instance MemPack (TxOut (LedgerState x)) => MemPackTxOut x
+class MemPack (TxOut x) => MemPackTxOut x
+instance MemPack (TxOut x) => MemPackTxOut x
 
 instance
   (All MemPackTxOut xs, Typeable xs) =>

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Ledger.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Ledger.hs
@@ -101,7 +101,6 @@ import Ouroboros.Consensus.Ledger.Abstract
 import Ouroboros.Consensus.Ledger.Inspect
 import Ouroboros.Consensus.Ledger.SupportsProtocol
 import Ouroboros.Consensus.Ledger.Tables.Utils
-import Ouroboros.Consensus.Storage.LedgerDB
 import Ouroboros.Consensus.TypeFamilyWrappers
 import Ouroboros.Consensus.Util.Condense
 import Ouroboros.Consensus.Util.IndexedMemPack (IndexedMemPack)

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Ledger/Query.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Ledger/Query.hs
@@ -124,8 +124,8 @@ class
   ( All (Compose NoThunks WrapTxOut) xs
   , All (Compose Show WrapTxOut) xs
   , All (Compose Eq WrapTxOut) xs
-  , All (Compose HasLedgerTables (Ticked LedgerState)) xs
-  , All (Compose HasLedgerTables LedgerState) xs
+  , All (HasLedgerTables (Ticked LedgerState)) xs
+  , All (HasLedgerTables LedgerState) xs
   ) =>
   BlockSupportsHFLedgerQuery xs
   where
@@ -153,7 +153,7 @@ class
   queryLedgerGetTraversingFilter ::
     Index xs x ->
     BlockQuery x QFTraverseTables result ->
-    TxOut (LedgerState (HardForkBlock xs)) ->
+    TxOut (HardForkBlock xs) ->
     Bool
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Mempool.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Mempool.hs
@@ -253,7 +253,7 @@ instance
       SingleEraBlock x =>
       Index xs x ->
       GenTx x ->
-      K (LedgerTables (LedgerState (HardForkBlock xs)) KeysMK) x
+      K (LedgerTables (HardForkBlock xs) KeysMK) x
     f idx tx = K $ injectLedgerTables idx $ getTransactionKeySets tx
 
   -- This optimization is worthwile because we can save the projection and

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Serialisation/Common.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Serialisation/Common.hs
@@ -200,7 +200,7 @@ class
   , All BlockSupportsLedgerQuery xs
   , -- LedgerTables on the HardForkBlock might not be compositionally
     -- defined, but we need to require this instances for any instantiation.
-    HasLedgerTables (LedgerState (HardForkBlock xs))
+    HasLedgerTables LedgerState (HardForkBlock xs)
   , LedgerSupportsLedgerDB (HardForkBlock xs)
   ) =>
   SerialiseHFC xs

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Serialisation/Common.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Serialisation/Common.hs
@@ -196,7 +196,15 @@ class
     All HasBinaryBlockInfo xs
   , All HasNetworkProtocolVersion xs
   , All BlockSupportsLedgerQuery xs
-  , SerialiseDiskConstraints (HardForkBlock xs)
+  , -- The constituents of 'SerialiseDiskConstraints (HardForkBlock xs)'.
+    -- We expand the constraint here rather than naming the empty class so
+    -- that the superclass cycle through
+    -- @instance SerialiseHFC xs => SerialiseDiskConstraints (HardForkBlock xs)@
+    -- is not formed (it would produce a self-referential dictionary at runtime).
+    ImmutableDbSerialiseConstraints (HardForkBlock xs)
+  , LedgerDbSerialiseConstraints (HardForkBlock xs)
+  , VolatileDbSerialiseConstraints (HardForkBlock xs)
+  , EncodeDiskDep (NestedCtxt Header) (HardForkBlock xs)
   ) =>
   SerialiseHFC xs
   where

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Serialisation/Common.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Serialisation/Common.hs
@@ -102,10 +102,8 @@ import Ouroboros.Consensus.HardFork.Combinator.NetworkVersion
 import Ouroboros.Consensus.HardFork.Combinator.State
 import Ouroboros.Consensus.HardFork.Combinator.State.Instances
 import Ouroboros.Consensus.Ledger.Query
-import Ouroboros.Consensus.Ledger.Tables
 import Ouroboros.Consensus.Node.NetworkProtocolVersion
 import Ouroboros.Consensus.Node.Run
-import Ouroboros.Consensus.Storage.LedgerDB
 import Ouroboros.Consensus.Storage.Serialisation
 import Ouroboros.Consensus.TypeFamilyWrappers
 import Ouroboros.Network.Block (Serialised)
@@ -198,10 +196,7 @@ class
     All HasBinaryBlockInfo xs
   , All HasNetworkProtocolVersion xs
   , All BlockSupportsLedgerQuery xs
-  , -- LedgerTables on the HardForkBlock might not be compositionally
-    -- defined, but we need to require this instances for any instantiation.
-    HasLedgerTables LedgerState (HardForkBlock xs)
-  , LedgerSupportsLedgerDB (HardForkBlock xs)
+  , SerialiseDiskConstraints (HardForkBlock xs)
   ) =>
   SerialiseHFC xs
   where

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Serialisation/SerialiseDisk.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Serialisation/SerialiseDisk.hs
@@ -19,7 +19,7 @@ import Ouroboros.Consensus.HardFork.Combinator.Basics
 import Ouroboros.Consensus.HardFork.Combinator.Protocol
 import Ouroboros.Consensus.HardFork.Combinator.Serialisation.Common
 import Ouroboros.Consensus.HeaderValidation
-import Ouroboros.Consensus.Ledger.Basics
+import Ouroboros.Consensus.Ledger.Abstract
 import Ouroboros.Consensus.Storage.ChainDB
 import Ouroboros.Consensus.Storage.Serialisation
 import Ouroboros.Consensus.TypeFamilyWrappers

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/State.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/State.hs
@@ -290,7 +290,7 @@ extendToSlot ledgerCfg@HardForkLedgerConfig{..} slot ledgerSt@(HardForkState st)
         return endBound
 
   howExtend ::
-    (HasLedgerTables (LedgerState blk), HasLedgerTables (LedgerState blk')) =>
+    (HasLedgerTables LedgerState blk, HasLedgerTables LedgerState blk') =>
     TranslateLedgerState blk blk' ->
     TranslateLedgerTables blk blk' ->
     History.Bound ->
@@ -305,25 +305,29 @@ extendToSlot ledgerCfg@HardForkLedgerConfig{..} slot ledgerSt@(HardForkState st)
     , Current
         { currentStart = currentEnd
         , currentState =
-            Flip
-              -- We need to bring back the diffs provided by previous
-              -- translations. Note that if there is only one translation or
-              -- if the previous translations don't add any new tables this
-              -- will just be a no-op. See the haddock for
-              -- 'translateLedgerTablesWith' and 'extendToSlot' for more
-              -- information.
-              . prependDiffs
-                ( translateLedgerTablesWith f'
-                    . projectLedgerTables
+            let cur' =
+                  translateLedgerStateWith f (History.boundEpoch currentEnd)
+                    . forgetLedgerTables
                     . unFlip
                     . currentState
                     $ cur
-                )
-              . translateLedgerStateWith f (History.boundEpoch currentEnd)
-              . forgetLedgerTables
-              . unFlip
-              . currentState
-              $ cur
+             in Flip
+                  -- We need to bring back the diffs provided by previous
+                  -- translations. Note that if there is only one translation or
+                  -- if the previous translations don't add any new tables this
+                  -- will just be a no-op. See the haddock for
+                  -- 'translateLedgerTablesWith' and 'extendToSlot' for more
+                  -- information.
+                  . prependDiffs
+                    ( cur'
+                        `withLedgerTables` ( translateLedgerTablesWith f'
+                                               . projectLedgerTables
+                                               . unFlip
+                                               . currentState
+                                               $ cur
+                                           )
+                    )
+                  $ cur'
         }
     )
 

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/State.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/State.hs
@@ -312,22 +312,22 @@ extendToSlot ledgerCfg@HardForkLedgerConfig{..} slot ledgerSt@(HardForkState st)
                     . currentState
                     $ cur
              in Flip
-                  -- We need to bring back the diffs provided by previous
-                  -- translations. Note that if there is only one translation or
-                  -- if the previous translations don't add any new tables this
-                  -- will just be a no-op. See the haddock for
-                  -- 'translateLedgerTablesWith' and 'extendToSlot' for more
-                  -- information.
-                  . prependDiffs
-                    ( cur'
-                        `withLedgerTables` ( translateLedgerTablesWith f'
-                                               . projectLedgerTables
-                                               . unFlip
-                                               . currentState
-                                               $ cur
-                                           )
+                  . (cur' `withLedgerTables`)
+                  . ltliftA2
+                    rawPrependDiffs
+                    ( -- We need to bring back the diffs provided by previous
+                      -- translations. Note that if there is only one
+                      -- translation or if the previous translations don't add
+                      -- any new tables this will just be a no-op. See the
+                      -- haddock for 'translateLedgerTablesWith' and
+                      -- 'extendToSlot' for more information.
+                      translateLedgerTablesWith f'
+                        . projectLedgerTables
+                        . unFlip
+                        . currentState
+                        $ cur
                     )
-                  $ cur'
+                  $ projectLedgerTables cur'
         }
     )
 

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/State/Types.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/State/Types.hs
@@ -33,7 +33,7 @@ import NoThunks.Class (NoThunks (..))
 import Ouroboros.Consensus.Block
 import Ouroboros.Consensus.Forecast
 import Ouroboros.Consensus.HardFork.History (Bound)
-import Ouroboros.Consensus.Ledger.Basics
+import Ouroboros.Consensus.Ledger.Abstract
 import qualified Ouroboros.Consensus.Ledger.Tables.Diff as Diff
 
 {-------------------------------------------------------------------------------
@@ -166,17 +166,17 @@ newtype TranslateLedgerState x y = TranslateLedgerState
 
 -- | Transate a 'LedgerTables' across an era transition.
 data TranslateLedgerTables x y = TranslateLedgerTables
-  { translateTxInWith :: !(TxIn (LedgerState x) -> TxIn (LedgerState y))
+  { translateTxInWith :: !(TxIn x -> TxIn y)
   -- ^ Translate a 'TxIn' across an era transition.
   --
   -- See 'translateLedgerTablesWith'.
-  , translateTxOutWith :: !(TxOut (LedgerState x) -> TxOut (LedgerState y))
+  , translateTxOutWith :: !(TxOut x -> TxOut y)
   -- ^ Translate a 'TxOut' across an era transition.
   --
   -- See 'translateLedgerTablesWith'.
   }
 
-newtype TranslateTxOut x y = TranslateTxOut (TxOut (LedgerState x) -> TxOut (LedgerState y))
+newtype TranslateTxOut x y = TranslateTxOut (TxOut x -> TxOut y)
 
 -- | Translate a 'LedgerTables' across an era transition.
 --
@@ -203,10 +203,10 @@ newtype TranslateTxOut x y = TranslateTxOut (TxOut (LedgerState x) -> TxOut (Led
 -- previous eras, so it will be called only when crossing era boundaries,
 -- therefore the translation won't be equivalent to 'id'.
 translateLedgerTablesWith ::
-  Ord (TxIn (LedgerState y)) =>
+  Ord (TxIn y) =>
   TranslateLedgerTables x y ->
-  LedgerTables (LedgerState x) DiffMK ->
-  LedgerTables (LedgerState y) DiffMK
+  LedgerTables x DiffMK ->
+  LedgerTables y DiffMK
 translateLedgerTablesWith f =
   LedgerTables
     . DiffMK

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Abstract.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Abstract.hs
@@ -18,6 +18,7 @@ module Ouroboros.Consensus.Ledger.Abstract
 
     -- * Apply block
   , ApplyBlock (..)
+  , GetBlockKeySets (..)
   , ComputeLedgerEvents (..)
   , UpdateLedger
   , defaultApplyBlockLedgerResult
@@ -40,6 +41,8 @@ module Ouroboros.Consensus.Ledger.Abstract
 
     -- * Re-exports
   , module Ouroboros.Consensus.Ledger.Basics
+  , module Ouroboros.Consensus.Ledger.Tables
+  , module Ouroboros.Consensus.Ledger.Tables.MapKind
   ) where
 
 import Control.Monad.Except
@@ -48,6 +51,8 @@ import Data.Kind (Type)
 import GHC.Stack (HasCallStack)
 import Ouroboros.Consensus.Block.Abstract
 import Ouroboros.Consensus.Ledger.Basics
+import Ouroboros.Consensus.Ledger.Tables
+import Ouroboros.Consensus.Ledger.Tables.MapKind
 import Ouroboros.Consensus.Ledger.Tables.Utils
 import Ouroboros.Consensus.Ticked
 import Ouroboros.Consensus.Util
@@ -87,8 +92,9 @@ class
   , HeaderHash (l blk) ~ HeaderHash blk
   , HasHeader blk
   , HasHeader (Header blk)
-  , HasLedgerTables (l blk)
-  , HasLedgerTables (Ticked l blk)
+  , HasLedgerTables l blk
+  , HasLedgerTables (Ticked l) blk
+  , GetBlockKeySets blk
   ) =>
   ApplyBlock l blk
   where
@@ -140,9 +146,10 @@ class
     Ticked l blk ValuesMK ->
     LedgerResult blk (l blk DiffMK)
 
+class GetBlockKeySets blk where
   -- | Given a block, get the key-sets that we need to apply it to a ledger
   -- state.
-  getBlockKeySets :: blk -> LedgerTables (l blk) KeysMK
+  getBlockKeySets :: blk -> LedgerTables blk KeysMK
 
 defaultApplyBlockLedgerResult ::
   (HasCallStack, ApplyBlock l blk) =>

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Basics.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Basics.hs
@@ -45,16 +45,15 @@ module Ouroboros.Consensus.Ledger.Basics
     -- * Associated types by block type
   , LedgerConfig
   , LedgerError
-
-    -- * Re-exports
-  , module Ouroboros.Consensus.Ledger.Tables
   ) where
 
 import Data.Kind (Constraint, Type)
 import GHC.Generics
 import Ouroboros.Consensus.Block.Abstract
-import Ouroboros.Consensus.Ledger.Tables
+import Ouroboros.Consensus.Ledger.Tables.Kinds
+import Ouroboros.Consensus.Ledger.Tables.MapKind
 import Ouroboros.Consensus.Ticked
+import Ouroboros.Consensus.Util ((...:))
 import Ouroboros.Consensus.Util.IOLike
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Dual.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Dual.hs
@@ -95,7 +95,6 @@ import Ouroboros.Consensus.Ledger.SupportsMempool
 import Ouroboros.Consensus.Ledger.SupportsPeerSelection
 import Ouroboros.Consensus.Ledger.SupportsProtocol
 import Ouroboros.Consensus.Ledger.Tables.Utils
-import Ouroboros.Consensus.Storage.LedgerDB
 import Ouroboros.Consensus.Storage.Serialisation
 import Ouroboros.Consensus.Util (ShowProxy (..))
 import Ouroboros.Consensus.Util.Condense

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Dual.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Dual.hs
@@ -73,6 +73,7 @@ import Control.Arrow ((+++))
 import Control.Monad.Except
 import qualified Data.ByteString.Lazy as Lazy
 import qualified Data.ByteString.Short as Short
+import Data.Coerce
 import Data.Functor ((<&>))
 import Data.Kind (Type)
 import Data.Typeable
@@ -501,10 +502,8 @@ instance Bridge m a => ApplyBlock LedgerState (DualBlock m a) where
           dualBlockMain
           tickedDualLedgerStateMain
 
-  getBlockKeySets =
-    castLedgerTables
-      . getBlockKeySets @LedgerState @m
-      . dualBlockMain
+instance GetBlockKeySets m => GetBlockKeySets (DualBlock m a) where
+  getBlockKeySets = coerce . getBlockKeySets @m . dualBlockMain
 
 data instance LedgerState (DualBlock m a) mk = DualLedgerState
   { dualLedgerStateMain :: LedgerState m mk
@@ -730,10 +729,7 @@ instance Bridge m a => LedgerSupportsMempool (DualBlock m a) where
       , vDualGenTxBridge
       } = vtx
 
-  getTransactionKeySets =
-    castLedgerTables
-      . getTransactionKeySets @m
-      . dualGenTxMain
+  getTransactionKeySets = coerce . getTransactionKeySets @m . dualGenTxMain
 
   mkMempoolApplyTxError TickedDualLedgerState{..} txt = do
     x <- mkMempoolApplyTxError tickedDualLedgerStateMain txt
@@ -1105,84 +1101,59 @@ decodeDualLedgerState decodeMain = do
   Ledger Tables
 -------------------------------------------------------------------------------}
 
-type instance TxIn (LedgerState (DualBlock m a)) = TxIn (LedgerState m)
-type instance TxOut (LedgerState (DualBlock m a)) = TxOut (LedgerState m)
+type instance TxIn (DualBlock m a) = TxIn m
+type instance TxOut (DualBlock m a) = TxOut m
 
-instance CanUpgradeLedgerTables (LedgerState (DualBlock m a)) where
+instance CanUpgradeLedgerTables LedgerState (DualBlock m a) where
   upgradeTables _ _ = id
 
 instance
-  (txout ~ TxOut (LedgerState m), IndexedMemPack (LedgerState m EmptyMK) txout) =>
-  IndexedMemPack (LedgerState (DualBlock m a) EmptyMK) txout
+  (txout ~ TxOut m, IndexedMemPack LedgerState m txout) =>
+  IndexedMemPack LedgerState (DualBlock m a) txout
   where
-  indexedTypeName (DualLedgerState st _ _) = indexedTypeName @(LedgerState m EmptyMK) @txout st
+  indexedTypeName p (DualLedgerState st _ _) = indexedTypeName p st
   indexedPackedByteCount (DualLedgerState st _ _) = indexedPackedByteCount st
   indexedPackM (DualLedgerState st _ _) = indexedPackM st
   indexedUnpackM (DualLedgerState st _ _) = indexedUnpackM st
 
 instance
-  (txout ~ TxOut (LedgerState m), IndexedMemPack (Ticked LedgerState m EmptyMK) txout) =>
-  IndexedMemPack (Ticked LedgerState (DualBlock m a) EmptyMK) txout
-  where
-  indexedTypeName (TickedDualLedgerState st _ _ _) = indexedTypeName @(Ticked LedgerState m EmptyMK) @txout st
-  indexedPackedByteCount (TickedDualLedgerState st _ _ _) = indexedPackedByteCount st
-  indexedPackM (TickedDualLedgerState st _ _ _) = indexedPackM st
-  indexedUnpackM (TickedDualLedgerState st _ _ _) = indexedUnpackM st
-
-instance
-  (Ord (TxIn (LedgerState m)), MemPack (TxIn (LedgerState m)), MemPack (TxOut (LedgerState m))) =>
-  SerializeTablesWithHint (LedgerState (DualBlock m a))
+  (Ord (TxIn m), MemPack (TxIn m), MemPack (TxOut m)) =>
+  SerializeTablesWithHint LedgerState (DualBlock m a)
   where
   encodeTablesWithHint = defaultEncodeTablesWithHint
   decodeTablesWithHint = defaultDecodeTablesWithHint
 
 instance
   ( Bridge m a
-  , NoThunks (TxOut (LedgerState m))
-  , NoThunks (TxIn (LedgerState m))
-  , Show (TxOut (LedgerState m))
-  , Show (TxIn (LedgerState m))
-  , Eq (TxOut (LedgerState m))
-  , Ord (TxIn (LedgerState m))
-  , MemPack (TxIn (LedgerState m))
+  , HasLedgerTables LedgerState m
   ) =>
-  HasLedgerTables (LedgerState (DualBlock m a))
+  HasLedgerTables LedgerState (DualBlock m a)
   where
   projectLedgerTables DualLedgerState{..} =
-    castLedgerTables
-      (projectLedgerTables dualLedgerStateMain)
+    coerce $ projectLedgerTables @LedgerState @m dualLedgerStateMain
 
   withLedgerTables DualLedgerState{..} main =
     DualLedgerState
-      { dualLedgerStateMain =
-          withLedgerTables dualLedgerStateMain $
-            castLedgerTables main
+      { dualLedgerStateMain = withLedgerTables @LedgerState @m dualLedgerStateMain (coerce main)
       , dualLedgerStateAux = dualLedgerStateAux
       , dualLedgerStateBridge = dualLedgerStateBridge
       }
 
 instance
   ( Bridge m a
-  , NoThunks (TxOut (LedgerState m))
-  , NoThunks (TxIn (LedgerState m))
-  , Show (TxOut (LedgerState m))
-  , Show (TxIn (LedgerState m))
-  , Eq (TxOut (LedgerState m))
-  , Ord (TxIn (LedgerState m))
-  , MemPack (TxIn (LedgerState m))
+  , HasLedgerTables (Ticked LedgerState) m
   ) =>
-  HasLedgerTables (Ticked LedgerState (DualBlock m a))
+  HasLedgerTables (Ticked LedgerState) (DualBlock m a)
   where
   projectLedgerTables TickedDualLedgerState{..} =
-    castLedgerTables
-      (projectLedgerTables tickedDualLedgerStateMain)
+    coerce $ projectLedgerTables @(Ticked LedgerState) @m tickedDualLedgerStateMain
 
   withLedgerTables
     TickedDualLedgerState{..}
     main =
       TickedDualLedgerState
         { tickedDualLedgerStateMain =
-            withLedgerTables tickedDualLedgerStateMain $ castLedgerTables main
+            withLedgerTables @(Ticked LedgerState) @m tickedDualLedgerStateMain $ coerce main
         , tickedDualLedgerStateAux
         , tickedDualLedgerStateBridge
         , tickedDualLedgerStateAuxOrig

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Extended.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Extended.hs
@@ -38,7 +38,6 @@ import Codec.CBOR.Encoding (Encoding, encodeListLen)
 import Control.DeepSeq (NFData)
 import Control.Monad.Except
 import Data.Functor ((<&>))
-import Data.MemPack
 import Data.Proxy
 import Data.Typeable
 import GHC.Generics (Generic)
@@ -205,7 +204,7 @@ applyHelper f opts cfg blk TickedExtLedgerState{..} = do
         tickedHeaderState
   pure $ (\l -> ExtLedgerState l hdr) <$> castLedgerResult ledgerResult
 
-instance LedgerSupportsProtocol blk => ApplyBlock ExtLedgerState blk where
+instance (GetBlockKeySets blk, LedgerSupportsProtocol blk) => ApplyBlock ExtLedgerState blk where
   applyBlockLedgerResultWithValidation doValidate =
     applyHelper (applyBlockLedgerResultWithValidation doValidate)
 
@@ -227,8 +226,6 @@ instance LedgerSupportsProtocol blk => ApplyBlock ExtLedgerState blk where
         ledgerView
         (getHeader blk)
         tickedHeaderState
-
-  getBlockKeySets = castLedgerTables . getBlockKeySets @LedgerState @blk
 
 {-------------------------------------------------------------------------------
   Serialisation
@@ -305,60 +302,28 @@ decodeDiskExtLedgerState cfg =
   Ledger Tables
 -------------------------------------------------------------------------------}
 
-type instance TxIn (ExtLedgerState blk) = TxIn (LedgerState blk)
-type instance TxOut (ExtLedgerState blk) = TxOut (LedgerState blk)
-
 instance
-  ( HasLedgerTables (LedgerState blk)
-  , NoThunks (TxOut (LedgerState blk))
-  , NoThunks (TxIn (LedgerState blk))
-  , Show (TxOut (LedgerState blk))
-  , Show (TxIn (LedgerState blk))
-  , Eq (TxOut (LedgerState blk))
-  , Ord (TxIn (LedgerState blk))
-  , MemPack (TxIn (LedgerState blk))
-  ) =>
-  HasLedgerTables (ExtLedgerState blk)
+  (NoThunks (TxIn blk), NoThunks (TxOut blk), HasLedgerTables LedgerState blk) =>
+  HasLedgerTables ExtLedgerState blk
   where
   projectLedgerTables (ExtLedgerState lstate _) =
-    castLedgerTables (projectLedgerTables lstate)
+    projectLedgerTables lstate
   withLedgerTables (ExtLedgerState lstate hstate) tables =
     ExtLedgerState
-      (lstate `withLedgerTables` castLedgerTables tables)
+      (lstate `withLedgerTables` tables)
       hstate
 
 instance
-  LedgerTablesAreTrivial (LedgerState blk) =>
-  LedgerTablesAreTrivial (ExtLedgerState blk)
-  where
-  convertMapKind (ExtLedgerState x y) = ExtLedgerState (convertMapKind x) y
-
-instance
-  LedgerTablesAreTrivial (Ticked LedgerState blk) =>
-  LedgerTablesAreTrivial (Ticked ExtLedgerState blk)
-  where
-  convertMapKind (TickedExtLedgerState x y z) =
-    TickedExtLedgerState (convertMapKind x) y z
-
-instance
-  ( HasLedgerTables (Ticked LedgerState blk)
-  , NoThunks (TxOut (LedgerState blk))
-  , NoThunks (TxIn (LedgerState blk))
-  , Show (TxOut (LedgerState blk))
-  , Show (TxIn (LedgerState blk))
-  , Eq (TxOut (LedgerState blk))
-  , Ord (TxIn (LedgerState blk))
-  , MemPack (TxIn (LedgerState blk))
-  ) =>
-  HasLedgerTables (Ticked ExtLedgerState blk)
+  (NoThunks (TxIn blk), NoThunks (TxOut blk), HasLedgerTables (Ticked LedgerState) blk) =>
+  HasLedgerTables (Ticked ExtLedgerState) blk
   where
   projectLedgerTables (TickedExtLedgerState lstate _view _hstate) =
-    castLedgerTables (projectLedgerTables lstate)
+    projectLedgerTables lstate
   withLedgerTables
     (TickedExtLedgerState lstate view hstate)
     tables =
       TickedExtLedgerState
-        (lstate `withLedgerTables` castLedgerTables tables)
+        (lstate `withLedgerTables` tables)
         view
         hstate
 
@@ -373,23 +338,17 @@ instance
     ExtLedgerState (unstowLedgerTables lstate) hstate
 
 instance
-  (txout ~ (TxOut (LedgerState blk)), IndexedMemPack (LedgerState blk EmptyMK) txout) =>
-  IndexedMemPack (ExtLedgerState blk EmptyMK) txout
+  (txout ~ TxOut blk, IndexedMemPack LedgerState blk txout) =>
+  IndexedMemPack ExtLedgerState blk txout
   where
-  indexedTypeName (ExtLedgerState st _) = indexedTypeName @(LedgerState blk EmptyMK) @txout st
+  indexedTypeName p (ExtLedgerState st _) = indexedTypeName p st
   indexedPackedByteCount (ExtLedgerState st _) = indexedPackedByteCount st
   indexedPackM (ExtLedgerState st _) = indexedPackM st
   indexedUnpackM (ExtLedgerState st _) = indexedUnpackM st
 
-instance
-  (txout ~ (TxOut (LedgerState blk)), IndexedMemPack (Ticked LedgerState blk EmptyMK) txout) =>
-  IndexedMemPack (Ticked ExtLedgerState blk EmptyMK) txout
-  where
-  indexedTypeName (TickedExtLedgerState st _ _) = indexedTypeName @(Ticked LedgerState blk EmptyMK) @txout st
-  indexedPackedByteCount (TickedExtLedgerState st _ _) = indexedPackedByteCount st
-  indexedPackM (TickedExtLedgerState st _ _) = indexedPackM st
-  indexedUnpackM (TickedExtLedgerState st _ _) = indexedUnpackM st
+instance LedgerTablesAreTrivial LedgerState blk => LedgerTablesAreTrivial ExtLedgerState blk where
+  convertMapKind (ExtLedgerState st hst) = ExtLedgerState (convertMapKind st) hst
 
-instance SerializeTablesWithHint (LedgerState blk) => SerializeTablesWithHint (ExtLedgerState blk) where
-  decodeTablesWithHint st = castLedgerTables <$> decodeTablesWithHint (ledgerState st)
-  encodeTablesWithHint st tbs = encodeTablesWithHint (ledgerState st) (castLedgerTables tbs)
+instance SerializeTablesWithHint LedgerState blk => SerializeTablesWithHint ExtLedgerState blk where
+  decodeTablesWithHint st = decodeTablesWithHint (ledgerState st)
+  encodeTablesWithHint st tbs = encodeTablesWithHint (ledgerState st) tbs

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Extended.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Extended.hs
@@ -338,6 +338,13 @@ instance
     ExtLedgerState (unstowLedgerTables lstate) hstate
 
 instance
+  CanUpgradeLedgerTables LedgerState blk =>
+  CanUpgradeLedgerTables ExtLedgerState blk
+  where
+  upgradeTables (ExtLedgerState st0 _) (ExtLedgerState st1 _) =
+    upgradeTables st0 st1
+
+instance
   (txout ~ TxOut blk, IndexedMemPack LedgerState blk txout) =>
   IndexedMemPack ExtLedgerState blk txout
   where

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/SupportsMempool.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/SupportsMempool.hs
@@ -98,7 +98,7 @@ type data WhatToDoWithTxDiffs = Collect | Discard
 -- differences, we don't even have differences around that we might misuse.
 type family InputTxDiffs blk wtd where
   InputTxDiffs blk Discard = ()
-  InputTxDiffs blk Collect = LedgerTables (TickedLedgerState blk) DiffMK
+  InputTxDiffs blk Collect = LedgerTables blk DiffMK
 
 class
   ( UpdateLedger blk
@@ -200,7 +200,7 @@ class
   -- ledger state. This is implemented in the Ledger. An example of non-obvious
   -- needed keys in Cardano are those of reference scripts for computing the
   -- transaction size.
-  getTransactionKeySets :: GenTx blk -> LedgerTables (LedgerState blk) KeysMK
+  getTransactionKeySets :: GenTx blk -> LedgerTables blk KeysMK
 
   -- Mempools live in a single slot so in the hard fork block case
   -- it is cheaper to perform these operations on LedgerStates, saving
@@ -228,8 +228,8 @@ class
   -- Intended to be non-default in the HardFork instance for optimizing
   -- performance.
   applyMempoolDiffs ::
-    LedgerTables (LedgerState blk) ValuesMK ->
-    LedgerTables (LedgerState blk) KeysMK ->
+    LedgerTables blk ValuesMK ->
+    LedgerTables blk KeysMK ->
     TickedLedgerState blk DiffMK ->
     TickedLedgerState blk ValuesMK
   applyMempoolDiffs = applyDiffForKeysOnTables

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Tables.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Tables.hs
@@ -179,9 +179,13 @@ module Ouroboros.Consensus.Ledger.Tables
   , valuesMKEncoder
 
     -- * Special classes
-  , LedgerTablesAreTrivial
-  , TrivialLedgerTables (..)
-  , convertMapKind
+  , LedgerTablesAreTrivial (..)
+  , trivialProjectLedgerTables
+  , trivialWithLedgerTables
+  , trivialStowLedgerTables
+  , trivialUnstowLedgerTables
+  , trivialEncodeTablesWithHint
+  , trivialDecodeTablesWithHint
   , trivialLedgerTables
   ) where
 
@@ -190,12 +194,13 @@ import qualified Codec.CBOR.Encoding as CBOR
 import Data.Kind (Constraint, Type)
 import qualified Data.Map.Strict as Map
 import Data.MemPack
-import Data.Void (Void)
-import NoThunks.Class (NoThunks (..))
+import Data.Proxy
+import Data.Void
+import NoThunks.Class
 import Ouroboros.Consensus.Ledger.Tables.Basics
 import Ouroboros.Consensus.Ledger.Tables.Combinators
 import Ouroboros.Consensus.Ledger.Tables.MapKind
-import Ouroboros.Consensus.Util.IndexedMemPack
+import Ouroboros.Consensus.Util.RedundantConstraints
 
 {-------------------------------------------------------------------------------
   Basic LedgerState classes
@@ -203,27 +208,16 @@ import Ouroboros.Consensus.Util.IndexedMemPack
 
 -- | Extracting @'LedgerTables'@ from @l mk@ (which will share the same @mk@),
 -- or replacing the @'LedgerTables'@ associated to a particular @l@.
-type HasLedgerTables :: LedgerStateKind -> Constraint
-class
-  ( Ord (TxIn l)
-  , Eq (TxOut l)
-  , Show (TxIn l)
-  , Show (TxOut l)
-  , NoThunks (TxIn l)
-  , NoThunks (TxOut l)
-  , MemPack (TxIn l)
-  , IndexedMemPack (MemPackIdx l EmptyMK) (TxOut l)
-  ) =>
-  HasLedgerTables l
-  where
+type HasLedgerTables :: StateKind -> Type -> Constraint
+class (NoThunks (TxIn blk), NoThunks (TxOut blk), LedgerTableConstraints blk) => HasLedgerTables l blk where
   -- | Extract the ledger tables from a ledger state
   --
   -- The constraints on @mk@ are necessary because the 'CardanoBlock' instance
   -- uses them.
   projectLedgerTables ::
     (CanMapMK mk, CanMapKeysMK mk, ZeroableMK mk) =>
-    l mk ->
-    LedgerTables l mk
+    l blk mk ->
+    LedgerTables blk mk
 
   -- | Overwrite the tables in the given ledger state.
   --
@@ -237,24 +231,9 @@ class
   -- uses them.
   withLedgerTables ::
     (CanMapMK mk, CanMapKeysMK mk, ZeroableMK mk) =>
-    l any ->
-    LedgerTables l mk ->
-    l mk
-
-instance
-  ( Ord (TxIn l)
-  , Eq (TxOut l)
-  , Show (TxIn l)
-  , Show (TxOut l)
-  , NoThunks (TxIn l)
-  , NoThunks (TxOut l)
-  , MemPack (TxIn l)
-  , IndexedMemPack (MemPackIdx l EmptyMK) (TxOut l)
-  ) =>
-  HasLedgerTables (LedgerTables l)
-  where
-  projectLedgerTables = castLedgerTables
-  withLedgerTables _ = castLedgerTables
+    l blk any ->
+    LedgerTables blk mk ->
+    l blk mk
 
 -- | LedgerTables are projections of data from a LedgerState and as such they
 -- can be injected back into a LedgerState. This is necessary because the Ledger
@@ -278,10 +257,9 @@ class CanStowLedgerTables l where
 -- | Default encoder of @'LedgerTables' l ''ValuesMK'@ to be used by the
 -- in-memory backing store.
 valuesMKEncoder ::
-  forall l.
-  SerializeTablesWithHint l =>
-  l EmptyMK ->
-  LedgerTables l ValuesMK ->
+  SerializeTablesWithHint l blk =>
+  l blk EmptyMK ->
+  LedgerTables blk ValuesMK ->
   CBOR.Encoding
 valuesMKEncoder st tbs =
   CBOR.encodeListLen 1 <> encodeTablesWithHint st tbs
@@ -289,10 +267,10 @@ valuesMKEncoder st tbs =
 -- | Default decoder of @'LedgerTables' l ''ValuesMK'@ to be used by the
 -- in-memory backing store.
 valuesMKDecoder ::
-  forall l s.
-  SerializeTablesWithHint l =>
-  l EmptyMK ->
-  CBOR.Decoder s (LedgerTables l ValuesMK)
+  forall l blk s.
+  SerializeTablesWithHint l blk =>
+  l blk EmptyMK ->
+  CBOR.Decoder s (LedgerTables blk ValuesMK)
 valuesMKDecoder st =
   CBOR.decodeListLenOf 1 >> decodeTablesWithHint st
 
@@ -308,27 +286,28 @@ valuesMKDecoder st =
 -- See @SerializeTablesWithHint (LedgerState (HardForkBlock
 -- (CardanoBlock c)))@ for a good example, the rest of the instances
 -- are somewhat degenerate.
-class SerializeTablesWithHint l where
+class SerializeTablesWithHint l blk where
   encodeTablesWithHint ::
-    SerializeTablesHint (LedgerTables l ValuesMK) ->
-    LedgerTables l ValuesMK ->
+    SerializeTablesHint l (LedgerTables blk ValuesMK) ->
+    LedgerTables blk ValuesMK ->
     CBOR.Encoding
   decodeTablesWithHint ::
-    SerializeTablesHint (LedgerTables l ValuesMK) ->
-    CBOR.Decoder s (LedgerTables l ValuesMK)
+    SerializeTablesHint l (LedgerTables blk ValuesMK) ->
+    CBOR.Decoder s (LedgerTables blk ValuesMK)
 
 -- This is just for the BackingStore Lockstep tests. Once V1 is gone
 -- we can inline it above.
 
 -- | The hint for 'SerializeTablesWithHint'
-type family SerializeTablesHint values :: Type
+type SerializeTablesHint :: StateKind -> Type -> Type
+type family SerializeTablesHint l values :: Type
 
-type instance SerializeTablesHint (LedgerTables l ValuesMK) = l EmptyMK
+type instance SerializeTablesHint l (LedgerTables blk ValuesMK) = l blk EmptyMK
 
 defaultEncodeTablesWithHint ::
-  (MemPack (TxIn l), MemPack (TxOut l)) =>
-  SerializeTablesHint (LedgerTables l ValuesMK) ->
-  LedgerTables l ValuesMK ->
+  (MemPack (TxIn blk), MemPack (TxOut blk)) =>
+  SerializeTablesHint l (LedgerTables blk ValuesMK) ->
+  LedgerTables blk ValuesMK ->
   CBOR.Encoding
 defaultEncodeTablesWithHint _ (LedgerTables (ValuesMK tbs)) =
   mconcat
@@ -344,9 +323,9 @@ defaultEncodeTablesWithHint _ (LedgerTables (ValuesMK tbs)) =
     ]
 
 defaultDecodeTablesWithHint ::
-  (Ord (TxIn l), MemPack (TxIn l), MemPack (TxOut l)) =>
-  SerializeTablesHint (LedgerTables l ValuesMK) ->
-  CBOR.Decoder s (LedgerTables l ValuesMK)
+  (Ord (TxIn blk), MemPack (TxIn blk), MemPack (TxOut blk)) =>
+  SerializeTablesHint l (LedgerTables blk ValuesMK) ->
+  CBOR.Decoder s (LedgerTables blk ValuesMK)
 defaultDecodeTablesWithHint _ = do
   n <- CBOR.decodeMapLen
   LedgerTables . ValuesMK <$> go n Map.empty
@@ -365,48 +344,54 @@ defaultDecodeTablesWithHint _ = do
 -- states that are defined this way can be made instances of this class which
 -- allows for easy manipulation of the types of @mk@ required at any step of the
 -- program.
-type LedgerTablesAreTrivial :: LedgerStateKind -> Constraint
-class (TxIn l ~ Void, TxOut l ~ Void) => LedgerTablesAreTrivial l where
+type LedgerTablesAreTrivial :: StateKind -> Type -> Constraint
+class (TxIn blk ~ Void, TxOut blk ~ Void) => LedgerTablesAreTrivial l blk where
   -- | If the ledger state is always in memory, then @l mk@ will be isomorphic
   -- to @l mk'@ for all @mk@, @mk'@. As a result, we can convert between ledgers
   -- states indexed by different map kinds.
   --
   -- This function is useful to combine functions that operate on functions that
   -- transform the map kind on a ledger state (eg @applyChainTickLedgerResult@).
-  convertMapKind :: l mk -> l mk'
+  convertMapKind :: l blk mk -> l blk mk'
 
 trivialLedgerTables ::
-  (ZeroableMK mk, LedgerTablesAreTrivial l) =>
-  LedgerTables l mk
-trivialLedgerTables = LedgerTables emptyMK
+  (ZeroableMK mk, LedgerTablesAreTrivial l blk) =>
+  Proxy l ->
+  LedgerTables blk mk
+trivialLedgerTables _ = LedgerTables emptyMK
 
--- | A newtype to @derive via@ the instances for blocks with trivial ledger
--- tables.
-type TrivialLedgerTables :: LedgerStateKind -> MapKind -> Type
-newtype TrivialLedgerTables l mk = TrivialLedgerTables {untrivialLedgerTables :: l mk}
+trivialProjectLedgerTables ::
+  forall l blk mk.
+  (LedgerTablesAreTrivial l blk, ZeroableMK mk) =>
+  l blk mk ->
+  LedgerTables blk mk
+trivialProjectLedgerTables _ = trivialLedgerTables (Proxy @l)
+trivialWithLedgerTables ::
+  LedgerTablesAreTrivial l blk =>
+  l blk any ->
+  LedgerTables blk mk ->
+  l blk mk
+trivialWithLedgerTables st _ = convertMapKind st
 
-type instance TxIn (TrivialLedgerTables l) = TxIn l
-type instance TxOut (TrivialLedgerTables l) = TxOut l
+trivialStowLedgerTables :: LedgerTablesAreTrivial l blk => l blk ValuesMK -> l blk EmptyMK
+trivialStowLedgerTables = convertMapKind
+trivialUnstowLedgerTables :: LedgerTablesAreTrivial l blk => l blk EmptyMK -> l blk ValuesMK
+trivialUnstowLedgerTables = convertMapKind
 
-instance LedgerTablesAreTrivial l => LedgerTablesAreTrivial (TrivialLedgerTables l) where
-  convertMapKind = TrivialLedgerTables . convertMapKind . untrivialLedgerTables
-
-instance LedgerTablesAreTrivial l => HasLedgerTables (TrivialLedgerTables l) where
-  projectLedgerTables _ = trivialLedgerTables
-  withLedgerTables st _ = convertMapKind st
-
-instance LedgerTablesAreTrivial l => CanStowLedgerTables (TrivialLedgerTables l) where
-  stowLedgerTables = convertMapKind
-  unstowLedgerTables = convertMapKind
-
-instance IndexedMemPack (TrivialLedgerTables l EmptyMK) Void where
-  indexedTypeName _ = typeName @Void
-  indexedPackedByteCount _ = packedByteCount
-  indexedPackM _ = packM
-  indexedUnpackM _ = unpackM
-
-instance SerializeTablesWithHint (TrivialLedgerTables l) where
-  decodeTablesWithHint _ = do
-    _ <- CBOR.decodeMapLen
-    pure (LedgerTables $ ValuesMK Map.empty)
-  encodeTablesWithHint _ _ = CBOR.encodeMapLen 0
+trivialDecodeTablesWithHint ::
+  forall l blk s.
+  LedgerTablesAreTrivial l blk =>
+  SerializeTablesHint l (LedgerTables blk ValuesMK) ->
+  CBOR.Decoder s (LedgerTables blk ValuesMK)
+trivialDecodeTablesWithHint _ = do
+  _ <- CBOR.decodeMapLen
+  pure $ trivialLedgerTables (Proxy @l)
+trivialEncodeTablesWithHint ::
+  forall l blk.
+  LedgerTablesAreTrivial l blk =>
+  SerializeTablesHint l (LedgerTables blk ValuesMK) ->
+  LedgerTables blk ValuesMK ->
+  CBOR.Encoding
+trivialEncodeTablesWithHint _ _ = CBOR.encodeMapLen 0
+ where
+  _ = keepRedundantConstraint (Proxy @(LedgerTablesAreTrivial l blk))

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Tables.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Tables.hs
@@ -164,11 +164,14 @@ module Ouroboros.Consensus.Ledger.Tables
 
     -- * Basic LedgerState classes
 
+    -- ** Extracting and injecting ledger tables
+  , HasLedgerTables (..)
+
     -- ** Stowing ledger tables
   , CanStowLedgerTables (..)
 
-    -- ** Extracting and injecting ledger tables
-  , HasLedgerTables (..)
+    -- ** Upgrading ledger tables
+  , CanUpgradeLedgerTables (..)
 
     -- * Serialization
   , SerializeTablesHint
@@ -249,6 +252,26 @@ type CanStowLedgerTables :: LedgerStateKind -> Constraint
 class CanStowLedgerTables l where
   stowLedgerTables :: l ValuesMK -> l EmptyMK
   unstowLedgerTables :: l EmptyMK -> l ValuesMK
+
+-- | When pushing differences on InMemory Ledger DBs, we will sometimes need to
+-- update ledger tables to the latest era. For unary blocks this is a no-op, but
+-- for the Cardano block, we will need to upgrade all TxOuts in memory.
+--
+-- No correctness property relies on this, as Consensus can work with TxOuts
+-- from multiple eras, but the performance depends on it as otherwise we will be
+-- upgrading the TxOuts every time we consult them.
+type CanUpgradeLedgerTables :: StateKind -> Type -> Constraint
+class CanUpgradeLedgerTables l blk where
+  upgradeTables ::
+    -- | The original ledger state before the upgrade. This will be the
+    -- tip before applying the block.
+    l blk mk1 ->
+    -- | The ledger state after the upgrade, which might be in a
+    -- different era than the one above.
+    l blk mk2 ->
+    -- | The tables we want to maybe upgrade.
+    LedgerTables blk ValuesMK ->
+    LedgerTables blk ValuesMK
 
 {-------------------------------------------------------------------------------
   Serialization Codecs

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Tables/Basics.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Tables/Basics.hs
@@ -7,13 +7,10 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE StandaloneKindSignatures #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Ouroboros.Consensus.Ledger.Tables.Basics
   ( -- * Kinds
-
-  --
 
     -- | For convenience' sake, we define these kinds which convey the intended
     -- instantiation for the type variables.
@@ -23,37 +20,14 @@ module Ouroboros.Consensus.Ledger.Tables.Basics
 
     -- * Ledger tables
   , LedgerTables (..)
-  , MemPackIdx
-  , SameUtxoTypes
   , TxIn
   , TxOut
-  , castLedgerTables
   ) where
 
-import Data.Coerce (coerce)
 import Data.Kind (Type)
 import GHC.Generics (Generic)
 import NoThunks.Class (NoThunks)
-import Ouroboros.Consensus.Ticked (Ticked)
-
-{-------------------------------------------------------------------------------
-  Kinds
--------------------------------------------------------------------------------}
-
--- | Something that holds two types, which intend to represent /keys/ and
--- /values/.
-type MapKind = Type {- key -} -> Type {- value -} -> Type
-
--- | A @LedgerStateKind@ is the kind of any type that takes a single @MapKind@
--- parameter. The canonical inhabitant is a ledger state applied to a block type,
--- for example @LedgerState blk@.
-type LedgerStateKind = MapKind -> Type
-
--- | A @StateKind@ is the kind of a ledger state *before* it receives
--- its block argument.
---
--- The four inhabitants in this codebase are @[Ticked] [Ext]LedgerState@.
-type StateKind = Type -> LedgerStateKind
+import Ouroboros.Consensus.Ledger.Tables.Kinds
 
 {-------------------------------------------------------------------------------
   Ledger tables
@@ -78,51 +52,31 @@ type StateKind = Type -> LedgerStateKind
 --
 -- The @mk@ can be instantiated to anything that is map-like, i.e. that expects
 -- two type parameters, the key and the value.
-type LedgerTables :: LedgerStateKind -> MapKind -> Type
-newtype LedgerTables l mk = LedgerTables
-  { getLedgerTables :: mk (TxIn l) (TxOut l)
+type LedgerTables :: Type -> MapKind -> Type
+newtype LedgerTables blk mk = LedgerTables
+  { getLedgerTables :: mk (TxIn blk) (TxOut blk)
   }
   deriving stock Generic
 
 deriving stock instance
-  Show (mk (TxIn l) (TxOut l)) =>
-  Show (LedgerTables l mk)
+  Show (mk (TxIn blk) (TxOut blk)) =>
+  Show (LedgerTables blk mk)
 deriving stock instance
-  Eq (mk (TxIn l) (TxOut l)) =>
-  Eq (LedgerTables l mk)
+  Eq (mk (TxIn blk) (TxOut blk)) =>
+  Eq (LedgerTables blk mk)
 deriving newtype instance
-  NoThunks (mk (TxIn l) (TxOut l)) =>
-  NoThunks (LedgerTables l mk)
+  NoThunks (mk (TxIn blk) (TxOut blk)) =>
+  NoThunks (LedgerTables blk mk)
 
 -- | Each @LedgerState@ instance will have the notion of a @TxIn@ for the tables.
 --
 -- This will change once there is more than one table.
-type TxIn :: LedgerStateKind -> Type
-type family TxIn l
+type TxIn :: Type -> Type
+type family TxIn blk
 
 -- | Each @LedgerState@ instance will have the notion of a @TxOut@ for the
 -- tables.
 --
 -- This will change once there is more than one table.
-type TxOut :: LedgerStateKind -> Type
-type family TxOut l
-
-type instance TxIn (LedgerTables l) = TxIn l
-type instance TxOut (LedgerTables l) = TxOut l
-type instance TxIn (Ticked l blk) = TxIn (l blk)
-type instance TxOut (Ticked l blk) = TxOut (l blk)
-
--- | Auxiliary information for @IndexedMemPack@.
-type MemPackIdx :: LedgerStateKind -> MapKind -> Type
-type family MemPackIdx l mk where
-  MemPackIdx (LedgerTables l) mk = MemPackIdx l mk
-  MemPackIdx (Ticked l) mk = MemPackIdx l mk
-  MemPackIdx l mk = l mk
-
-type SameUtxoTypes l l' = (TxIn l ~ TxIn l', TxOut l ~ TxOut l')
-
-castLedgerTables ::
-  SameUtxoTypes l l' =>
-  LedgerTables l mk ->
-  LedgerTables l' mk
-castLedgerTables = coerce
+type TxOut :: Type -> Type
+type family TxOut blk

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Tables/Combinators.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Tables/Combinators.hs
@@ -79,8 +79,8 @@ module Ouroboros.Consensus.Ledger.Tables.Combinators
 import Data.Bifunctor
 import Data.Kind
 import Data.SOP.Functors
+import Ouroboros.Consensus.Ledger.Basics
 import Ouroboros.Consensus.Ledger.Tables.Basics
-import Ouroboros.Consensus.Ledger.Tables.MapKind
 import Ouroboros.Consensus.Util ((...:), (..:), (.:))
 import Ouroboros.Consensus.Util.IndexedMemPack
 
@@ -92,18 +92,18 @@ import Ouroboros.Consensus.Util.IndexedMemPack
 -- 'Ouroboros.Consensus.Ledger.Tables.Diff.diff'. Once the ledger provides
 -- deltas instead of us being the ones that compute them, we can probably drop
 -- this constraint.
-type LedgerTableConstraints l =
-  ( Ord (TxIn l)
-  , Eq (TxOut l)
-  , MemPack (TxIn l)
-  , IndexedMemPack (MemPackIdx l EmptyMK) (TxOut l)
+type LedgerTableConstraints blk =
+  ( Ord (TxIn blk)
+  , Eq (TxOut blk)
+  , MemPack (TxIn blk)
+  , IndexedMemPack LedgerState blk (TxOut blk)
   )
 
-type LedgerTableConstraints' l k v =
+type LedgerTableConstraints' blk k v =
   ( Ord k
   , Eq v
   , MemPack k
-  , IndexedMemPack (MemPackIdx l EmptyMK) v
+  , IndexedMemPack LedgerState blk v
   )
 
 {-------------------------------------------------------------------------------
@@ -230,12 +230,12 @@ ltcollapse = unK2 . getLedgerTables
 -------------------------------------------------------------------------------}
 
 instance
-  ( forall k v. LedgerTableConstraints' l k v => Semigroup (mk k v)
-  , LedgerTableConstraints l
+  ( forall k v. LedgerTableConstraints' blk k v => Semigroup (mk k v)
+  , LedgerTableConstraints blk
   ) =>
-  Semigroup (LedgerTables l mk)
+  Semigroup (LedgerTables blk mk)
   where
-  (<>) :: LedgerTables l mk -> LedgerTables l mk -> LedgerTables l mk
+  (<>) :: LedgerTables blk mk -> LedgerTables blk mk -> LedgerTables blk mk
   (<>) = ltliftA2 (<>)
 
 instance

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Tables/Combinators.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Tables/Combinators.hs
@@ -79,10 +79,8 @@ module Ouroboros.Consensus.Ledger.Tables.Combinators
 import Data.Bifunctor
 import Data.Kind
 import Data.SOP.Functors
-import Ouroboros.Consensus.Ledger.Basics
 import Ouroboros.Consensus.Ledger.Tables.Basics
 import Ouroboros.Consensus.Util ((...:), (..:), (.:))
-import Ouroboros.Consensus.Util.IndexedMemPack
 
 {-------------------------------------------------------------------------------
   Common constraints
@@ -95,15 +93,11 @@ import Ouroboros.Consensus.Util.IndexedMemPack
 type LedgerTableConstraints blk =
   ( Ord (TxIn blk)
   , Eq (TxOut blk)
-  , MemPack (TxIn blk)
-  , IndexedMemPack LedgerState blk (TxOut blk)
   )
 
 type LedgerTableConstraints' blk k v =
   ( Ord k
   , Eq v
-  , MemPack k
-  , IndexedMemPack LedgerState blk v
   )
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Tables/Kinds.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Tables/Kinds.hs
@@ -1,0 +1,22 @@
+module Ouroboros.Consensus.Ledger.Tables.Kinds (MapKind, LedgerStateKind, StateKind) where
+
+import Data.Kind
+
+{-------------------------------------------------------------------------------
+  Kinds
+-------------------------------------------------------------------------------}
+
+-- | Something that holds two types, which intend to represent /keys/ and
+-- /values/.
+type MapKind = Type {- key -} -> Type {- value -} -> Type
+
+-- | A @LedgerStateKind@ is the kind of any type that takes a single @MapKind@
+-- parameter. The canonical inhabitant is a ledger state applied to a block type,
+-- for example @LedgerState blk@.
+type LedgerStateKind = MapKind -> Type
+
+-- | A @StateKind@ is the kind of a ledger state *before* it receives
+-- its block argument.
+--
+-- The four inhabitants in this codebase are @[Ticked] [Ext]LedgerState@.
+type StateKind = Type -> LedgerStateKind

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Tables/Utils.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Tables/Utils.hs
@@ -46,6 +46,7 @@ module Ouroboros.Consensus.Ledger.Tables.Utils
 
     -- ** Reduce
   , trackingToDiffs
+  , rawTrackingDiffs
   , trackingToValues
 
     -- * Union values
@@ -59,7 +60,6 @@ module Ouroboros.Consensus.Ledger.Tables.Utils
   , applyDiffs'
   , rawAttachAndApplyDiffs -- used in test
   , rawCalculateDifference -- used in test
-  , restrictValues'
   ) where
 
 import qualified Data.Map.Strict as Map
@@ -71,21 +71,21 @@ import qualified Ouroboros.Consensus.Ledger.Tables.Diff as Diff
 -------------------------------------------------------------------------------}
 
 ltwith ::
-  ( HasLedgerTables l
+  ( HasLedgerTables l blk
   , CanMapMK mk'
   , CanMapKeysMK mk'
   , ZeroableMK mk'
   ) =>
-  l mk ->
-  LedgerTables l mk' ->
-  l mk'
+  l blk mk ->
+  LedgerTables blk mk' ->
+  l blk mk'
 ltwith = withLedgerTables
 
 ltprj ::
-  (HasLedgerTables l, SameUtxoTypes l l', CanMapMK mk, CanMapKeysMK mk, ZeroableMK mk) =>
-  l mk ->
-  LedgerTables l' mk
-ltprj = castLedgerTables . projectLedgerTables
+  (HasLedgerTables l blk, CanMapMK mk, CanMapKeysMK mk, ZeroableMK mk) =>
+  l blk mk ->
+  LedgerTables blk mk
+ltprj = projectLedgerTables
 
 {-------------------------------------------------------------------------------
   Utils aliases: tables
@@ -94,17 +94,17 @@ ltprj = castLedgerTables . projectLedgerTables
 -- | Replace tables with an empty diff. Can be used to specify that a ledger
 -- state tick produces no new UTXO entries.
 noNewTickingDiffs ::
-  HasLedgerTables l =>
-  l any ->
-  l DiffMK
+  HasLedgerTables l blk =>
+  l blk any ->
+  l blk DiffMK
 noNewTickingDiffs l = withLedgerTables l emptyLedgerTables
 
 -- | Remove the ledger tables
-forgetLedgerTables :: HasLedgerTables l => l mk -> l EmptyMK
+forgetLedgerTables :: HasLedgerTables l blk => l blk mk -> l blk EmptyMK
 forgetLedgerTables l = withLedgerTables l emptyLedgerTables
 
 -- | Empty values for every table
-emptyLedgerTables :: (ZeroableMK mk, LedgerTableConstraints l) => LedgerTables l mk
+emptyLedgerTables :: (ZeroableMK mk, LedgerTableConstraints blk) => LedgerTables blk mk
 emptyLedgerTables = ltpure emptyMK
 
 --
@@ -114,7 +114,7 @@ emptyLedgerTables = ltpure emptyMK
 rawTrackingDiffs :: TrackingMK k v -> DiffMK k v
 rawTrackingDiffs (TrackingMK _vs d) = DiffMK d
 
-trackingToDiffs :: (HasLedgerTables l, LedgerTableConstraints l) => l TrackingMK -> l DiffMK
+trackingToDiffs :: HasLedgerTables l blk => l blk TrackingMK -> l blk DiffMK
 trackingToDiffs l = ltwith l $ ltmap rawTrackingDiffs (ltprj l)
 
 --
@@ -124,7 +124,7 @@ trackingToDiffs l = ltwith l $ ltmap rawTrackingDiffs (ltprj l)
 rawTrackingValues :: TrackingMK k v -> ValuesMK k v
 rawTrackingValues (TrackingMK vs _ds) = ValuesMK vs
 
-trackingToValues :: (LedgerTableConstraints l, HasLedgerTables l) => l TrackingMK -> l ValuesMK
+trackingToValues :: HasLedgerTables l blk => l blk TrackingMK -> l blk ValuesMK
 trackingToValues l = ltwith l $ ltmap rawTrackingValues (ltprj l)
 
 --
@@ -143,19 +143,16 @@ rawPrependDiffs (DiffMK d1) (DiffMK d2) = DiffMK (d1 <> d2)
 -- | Prepend diffs from the first ledger state to the diffs from the second
 -- ledger state. Returns ledger tables.
 prependDiffs' ::
-  ( SameUtxoTypes l l''
-  , SameUtxoTypes l' l''
-  , HasLedgerTables l
-  , HasLedgerTables l'
-  , HasLedgerTables l''
+  ( HasLedgerTables l blk
+  , HasLedgerTables l' blk
   ) =>
-  l DiffMK -> l' DiffMK -> LedgerTables l'' DiffMK
+  l blk DiffMK -> l' blk DiffMK -> LedgerTables blk DiffMK
 prependDiffs' l1 l2 = ltliftA2 rawPrependDiffs (ltprj l1) (ltprj l2)
 
 -- | Prepend the diffs from @l1@ to @l2@. Returns @l2@.
 prependDiffs ::
-  (SameUtxoTypes l l', HasLedgerTables l, HasLedgerTables l') =>
-  l DiffMK -> l' DiffMK -> l' DiffMK
+  (HasLedgerTables l blk, HasLedgerTables l' blk) =>
+  l blk DiffMK -> l' blk DiffMK -> l' blk DiffMK
 prependDiffs l1 l2 = ltwith l2 $ prependDiffs' l1 l2
 
 --
@@ -174,19 +171,16 @@ applyDiffsMK (ValuesMK vals) (DiffMK diffs) = ValuesMK (Diff.applyDiff vals diff
 -- | Apply diffs from the second ledger state to the values of the first ledger
 -- state. Returns ledger tables.
 applyDiffs' ::
-  ( SameUtxoTypes l l''
-  , SameUtxoTypes l' l''
-  , HasLedgerTables l
-  , HasLedgerTables l'
-  , HasLedgerTables l''
+  ( HasLedgerTables l blk
+  , HasLedgerTables l' blk
   ) =>
-  l ValuesMK -> l' DiffMK -> LedgerTables l'' ValuesMK
+  l blk ValuesMK -> l' blk DiffMK -> LedgerTables blk ValuesMK
 applyDiffs' l1 l2 = ltliftA2 applyDiffsMK (ltprj l1) (ltprj l2)
 
 -- | Apply diffs from @l2@ on values from @l1@. Returns @l2@.
 applyDiffs ::
-  (SameUtxoTypes l l', HasLedgerTables l, HasLedgerTables l') =>
-  l ValuesMK -> l' DiffMK -> l' ValuesMK
+  (HasLedgerTables l blk, HasLedgerTables l' blk) =>
+  l blk ValuesMK -> l' blk DiffMK -> l' blk ValuesMK
 applyDiffs l1 l2 = ltwith l2 $ applyDiffs' l1 l2
 
 rawApplyDiffForKeys ::
@@ -200,24 +194,19 @@ rawApplyDiffForKeys (ValuesMK vals) (KeysMK keys) (DiffMK diffs) =
 
 -- | Apply diffs in @l3@ for keys in @l2@ and @l1@ on values from @l1@. Returns @l3@.
 applyDiffForKeys ::
-  (SameUtxoTypes l l', HasLedgerTables l, HasLedgerTables l') =>
-  l ValuesMK -> LedgerTables l KeysMK -> l' DiffMK -> l' ValuesMK
+  (HasLedgerTables l blk, HasLedgerTables l' blk) =>
+  l blk ValuesMK -> LedgerTables blk KeysMK -> l' blk DiffMK -> l' blk ValuesMK
 applyDiffForKeys l1 l2 l3 = ltwith l3 $ applyDiffForKeys' (ltprj l1) l2 l3
 
 applyDiffForKeys' ::
-  ( SameUtxoTypes l l''
-  , SameUtxoTypes l l'
-  , HasLedgerTables l
-  , HasLedgerTables l'
-  , HasLedgerTables l''
-  ) =>
-  LedgerTables l ValuesMK -> LedgerTables l KeysMK -> l' DiffMK -> LedgerTables l'' ValuesMK
-applyDiffForKeys' l1 l2 l3 = ltliftA3 rawApplyDiffForKeys (castLedgerTables l1) (castLedgerTables l2) (ltprj l3)
+  HasLedgerTables l blk =>
+  LedgerTables blk ValuesMK -> LedgerTables blk KeysMK -> l blk DiffMK -> LedgerTables blk ValuesMK
+applyDiffForKeys' l1 l2 l3 = ltliftA3 rawApplyDiffForKeys l1 l2 (ltprj l3)
 
 -- | Apply diffs in @l3@ for keys in @l2@ and @l1@ on values from @l1@. Returns @l3@.
 applyDiffForKeysOnTables ::
-  (SameUtxoTypes l l', HasLedgerTables l, HasLedgerTables l') =>
-  LedgerTables l ValuesMK -> LedgerTables l KeysMK -> l' DiffMK -> l' ValuesMK
+  HasLedgerTables l blk =>
+  LedgerTables blk ValuesMK -> LedgerTables blk KeysMK -> l blk DiffMK -> l blk ValuesMK
 applyDiffForKeysOnTables l1 l2 l3 = ltwith l3 $ applyDiffForKeys' l1 l2 l3
 
 --
@@ -234,30 +223,25 @@ rawCalculateDifference (ValuesMK before) (ValuesMK after) = TrackingMK after (Di
 -- | Promote values to diffs, for cases in which all existing values must be
 -- considered diffs. In particular this is used when populating the ledger
 -- tables for the first time.
-valuesAsDiffs ::
-  (LedgerTableConstraints l, HasLedgerTables l) =>
-  l ValuesMK -> l DiffMK
+valuesAsDiffs :: HasLedgerTables l blk => l blk ValuesMK -> l blk DiffMK
 valuesAsDiffs l = trackingToDiffs $ ltwith l $ ltliftA (rawCalculateDifference emptyMK) (ltprj l)
 
 -- | Calculate the differences between two ledger states. The first ledger state
 -- is considered /before/, the second ledger state is considered /after/.
 -- Returns ledger tables.
 calculateDifference' ::
-  ( SameUtxoTypes l l''
-  , SameUtxoTypes l' l''
-  , HasLedgerTables l
-  , HasLedgerTables l'
-  , HasLedgerTables l''
+  ( HasLedgerTables l blk
+  , HasLedgerTables l' blk
   ) =>
-  l ValuesMK -> l' ValuesMK -> LedgerTables l'' TrackingMK
+  l blk ValuesMK -> l' blk ValuesMK -> LedgerTables blk TrackingMK
 calculateDifference' l1 l2 = ltliftA2 rawCalculateDifference (ltprj l1) (ltprj l2)
 
 -- | Calculate the differences between two ledger states. The first ledger state
 -- is considered /before/, the second ledger state is considered /after/.
 -- Returns the second ledger state.
 calculateDifference ::
-  (SameUtxoTypes l l', HasLedgerTables l, HasLedgerTables l') =>
-  l ValuesMK -> l' ValuesMK -> l' TrackingMK
+  (HasLedgerTables l blk, HasLedgerTables l' blk) =>
+  l blk ValuesMK -> l' blk ValuesMK -> l' blk TrackingMK
 calculateDifference l1 l2 = ltwith l2 $ calculateDifference' l1 l2
 
 --
@@ -275,28 +259,25 @@ rawAttachAndApplyDiffs (ValuesMK v) (DiffMK d) = TrackingMK (Diff.applyDiff v d)
 -- second ledger state, and returns the resulting values together with the
 -- applied diff.
 attachAndApplyDiffs' ::
-  ( SameUtxoTypes l l''
-  , SameUtxoTypes l' l''
-  , HasLedgerTables l
-  , HasLedgerTables l'
-  , HasLedgerTables l''
+  ( HasLedgerTables l blk
+  , HasLedgerTables l' blk
   ) =>
-  l' ValuesMK -> l DiffMK -> LedgerTables l'' TrackingMK
+  l blk ValuesMK -> l' blk DiffMK -> LedgerTables blk TrackingMK
 attachAndApplyDiffs' l1 l2 = ltliftA2 rawAttachAndApplyDiffs (ltprj l1) (ltprj l2)
 
 -- | Apply the differences from the first ledger state to the values of the
 -- second ledger state. Returns the second ledger state with a 'TrackingMK' of
 -- the final values and all the diffs.
 attachAndApplyDiffs ::
-  (SameUtxoTypes l l', HasLedgerTables l, HasLedgerTables l') =>
-  l ValuesMK -> l' DiffMK -> l' TrackingMK
+  (HasLedgerTables l blk, HasLedgerTables l' blk) =>
+  l blk ValuesMK -> l' blk DiffMK -> l' blk TrackingMK
 attachAndApplyDiffs l1 l2 = ltwith l2 $ attachAndApplyDiffs' l1 l2
 
 rawAttachEmptyDiffs :: Ord k => ValuesMK k v -> TrackingMK k v
 rawAttachEmptyDiffs (ValuesMK v) = TrackingMK v mempty
 
 -- | Make a 'TrackingMK' with empty diffs.
-attachEmptyDiffs :: HasLedgerTables l => l ValuesMK -> l TrackingMK
+attachEmptyDiffs :: HasLedgerTables l blk => l blk ValuesMK -> l blk TrackingMK
 attachEmptyDiffs l1 = ltwith l1 $ ltmap rawAttachEmptyDiffs (ltprj l1)
 
 --
@@ -323,13 +304,10 @@ rawPrependTrackingDiffs (TrackingMK _ d1) (TrackingMK v d2) =
 --
 -- PRECONDITION:  See 'rawPrependTrackingDiffs'.
 prependTrackingDiffs' ::
-  ( SameUtxoTypes l l''
-  , SameUtxoTypes l' l''
-  , HasLedgerTables l
-  , HasLedgerTables l'
-  , HasLedgerTables l''
+  ( HasLedgerTables l blk
+  , HasLedgerTables l' blk
   ) =>
-  l TrackingMK -> l' TrackingMK -> LedgerTables l'' TrackingMK
+  l blk TrackingMK -> l' blk TrackingMK -> LedgerTables blk TrackingMK
 prependTrackingDiffs' l1 l2 = ltliftA2 rawPrependTrackingDiffs (ltprj l1) (ltprj l2)
 
 -- | Prepend tracking diffs from the first ledger state to the tracking diffs
@@ -338,8 +316,8 @@ prependTrackingDiffs' l1 l2 = ltliftA2 rawPrependTrackingDiffs (ltprj l1) (ltprj
 --
 -- PRECONDITION:  See 'rawPrependTrackingDiffs'.
 prependTrackingDiffs ::
-  (SameUtxoTypes l l', HasLedgerTables l, HasLedgerTables l') =>
-  l TrackingMK -> l' TrackingMK -> l' TrackingMK
+  (HasLedgerTables l blk, HasLedgerTables l' blk) =>
+  l blk TrackingMK -> l' blk TrackingMK -> l' blk TrackingMK
 prependTrackingDiffs l1 l2 = ltwith l2 $ prependTrackingDiffs' l1 l2
 
 -- Restrict values
@@ -350,16 +328,6 @@ restrictValuesMK ::
   KeysMK k v ->
   ValuesMK k v
 restrictValuesMK (ValuesMK v) (KeysMK k) = ValuesMK $ v `Map.restrictKeys` k
-
-restrictValues' ::
-  ( SameUtxoTypes l l''
-  , SameUtxoTypes l' l''
-  , HasLedgerTables l
-  , HasLedgerTables l'
-  , HasLedgerTables l''
-  ) =>
-  l ValuesMK -> l' KeysMK -> LedgerTables l'' ValuesMK
-restrictValues' l1 l2 = ltliftA2 restrictValuesMK (ltprj l1) (ltprj l2)
 
 ---
 

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/API.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/API.hs
@@ -188,7 +188,7 @@ data Mempool m blk = Mempool
   , getSnapshotFor ::
       SlotNo ->
       TickedLedgerState blk DiffMK ->
-      (LedgerTables (LedgerState blk) KeysMK -> m (LedgerTables (LedgerState blk) ValuesMK)) ->
+      (LedgerTables blk KeysMK -> m (LedgerTables blk ValuesMK)) ->
       m (MempoolSnapshot blk)
   -- ^ Get a snapshot of the mempool state that is valid with respect to
   -- the given ledger state
@@ -314,7 +314,7 @@ data MempoolTimeoutConfig = MempoolTimeoutConfig
 -- | The result of attempting to add a transaction to the mempool.
 data MempoolAddTxResult blk
   = -- | The transaction was added to the mempool.
-    MempoolTxAdded !(Validated (GenTx blk)) !(LedgerTables (TickedLedgerState blk) DiffMK)
+    MempoolTxAdded !(Validated (GenTx blk)) !(LedgerTables blk DiffMK)
   | -- | The transaction was rejected and could not be added to the mempool
     -- for the specified reason.
     MempoolTxRejected !(GenTx blk) !(ApplyTxErr blk)
@@ -323,14 +323,14 @@ deriving instance
   ( Eq (GenTx blk)
   , Eq (Validated (GenTx blk))
   , Eq (ApplyTxErr blk)
-  , Eq (LedgerTables (TickedLedgerState blk) DiffMK)
+  , Eq (LedgerTables blk DiffMK)
   ) =>
   Eq (MempoolAddTxResult blk)
 deriving instance
   ( Show (GenTx blk)
   , Show (Validated (GenTx blk))
   , Show (ApplyTxErr blk)
-  , Show (LedgerTables (TickedLedgerState blk) DiffMK)
+  , Show (LedgerTables blk DiffMK)
   ) =>
   Show (MempoolAddTxResult blk)
 

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Impl/Common.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Impl/Common.hs
@@ -89,14 +89,14 @@ import Ouroboros.Network.Protocol.LocalStateQuery.Type
 -- will have to reconsider what we can cache and what we can't.
 data ValidatedTxWithDiffs blk = ValidatedTxWithDiffs
   { validatedTx :: !(Validated (GenTx blk))
-  , validatedTxDiffs :: !(LedgerTables (TickedLedgerState blk) DiffMK)
+  , validatedTxDiffs :: !(LedgerTables blk DiffMK)
   }
   deriving Generic
 
 deriving instance
   ( NoThunks (Validated (GenTx blk))
-  , NoThunks (TxIn (LedgerState blk))
-  , NoThunks (TxOut (LedgerState blk))
+  , NoThunks (TxIn blk)
+  , NoThunks (TxOut blk)
   ) =>
   NoThunks (ValidatedTxWithDiffs blk)
 
@@ -119,12 +119,12 @@ data InternalState blk = IS
   -- 'MempoolSnapshot' (see 'snapshotHasTx').
   --
   -- This should always be in-sync with the transactions in 'isTxs'.
-  , isTxKeys :: !(LedgerTables (LedgerState blk) KeysMK)
+  , isTxKeys :: !(LedgerTables blk KeysMK)
   -- ^ The cached set of keys needed for the transactions
   -- currently in the mempool.
   --
   -- INVARIANT: @'isTxKeys' == foldMap (getTransactionKeySets . txForgetValidated) $ toList 'isTxs'@
-  , isTxValues :: !(LedgerTables (LedgerState blk) ValuesMK)
+  , isTxValues :: !(LedgerTables blk ValuesMK)
   -- ^ The cached values corresponding to reading 'isTxKeys' at
   -- 'isLedgerState'. These values can be used unless we switch to
   -- a different ledger state. It usually happens in the forging
@@ -175,8 +175,8 @@ deriving instance
   ( NoThunks (Validated (GenTx blk))
   , NoThunks (GenTxId blk)
   , NoThunks (TickedLedgerState blk DiffMK)
-  , NoThunks (TxIn (LedgerState blk))
-  , NoThunks (TxOut (LedgerState blk))
+  , NoThunks (TxIn blk)
+  , NoThunks (TxOut blk)
   , NoThunks (TxMeasure blk)
   , StandardHash blk
   , Typeable blk
@@ -226,7 +226,7 @@ newtype LedgerInterface m blk = LedgerInterface
 data MempoolLedgerDBView m blk = MempoolLedgerDBView
   { mldViewState :: LedgerState blk EmptyMK
   -- ^ The ledger state currently at the tip of the LedgerDB
-  , mldViewGetForker :: m (Either GetForkerError (ReadOnlyForker m (LedgerState blk)))
+  , mldViewGetForker :: m (Either GetForkerError (ReadOnlyForker m LedgerState blk))
   -- ^ An action to get a forker at 'mldViewState' or an error in the unlikely
   -- case that such state is now gone from the LedgerDB.
   --
@@ -261,7 +261,7 @@ chainDBLedgerInterface chainDB =
 -- different operations.
 data MempoolEnv m blk = MempoolEnv
   { mpEnvLedger :: LedgerInterface m blk
-  , mpEnvForker :: StrictMVar m (ReadOnlyForker m (LedgerState blk))
+  , mpEnvForker :: StrictMVar m (ReadOnlyForker m LedgerState blk)
   , mpEnvLedgerCfg :: LedgerConfig blk
   , mpEnvStateVar :: StrictTMVar m (InternalState blk)
   , mpEnvAddTxsRemoteFifo :: StrictMVar m ()
@@ -350,14 +350,14 @@ validateNewTransaction ::
   GenTx blk ->
   TxMeasure blk ->
   -- | Values to cache if success
-  LedgerTables (LedgerState blk) ValuesMK ->
+  LedgerTables blk ValuesMK ->
   -- | This state is the internal state with the tables for this transaction
   -- advanced through the diffs in the internal state. One could think we can
   -- create this value here, but it is needed for some other uses like calling
   -- 'txMeasure' before this function.
   TickedLedgerState blk ValuesMK ->
   InternalState blk ->
-  ( Either (ApplyTxErr blk) (Validated (GenTx blk), LedgerTables (TickedLedgerState blk) DiffMK)
+  ( Either (ApplyTxErr blk) (Validated (GenTx blk), LedgerTables blk DiffMK)
   , DiffTimeMeasure -> InternalState blk
   )
 validateNewTransaction cfg wti tx txsz origValues st is =
@@ -409,7 +409,7 @@ revalidateTxsFor ::
   -- | The ticked ledger state againt which txs will be revalidated
   TickedLedgerState blk DiffMK ->
   -- | The tables with all the inputs for the transactions
-  LedgerTables (LedgerState blk) ValuesMK ->
+  LedgerTables blk ValuesMK ->
   -- | 'isLastTicketNo' and 'vrLastTicketNo'
   TicketNo ->
   [TxTicket (TxMeasureWithDiffTime blk) (ValidatedTxWithDiffs blk)] ->
@@ -464,7 +464,7 @@ computeSnapshot ::
   -- | The ticked ledger state againt which txs will be revalidated
   TickedLedgerState blk DiffMK ->
   -- | The tables with all the inputs for the transactions
-  LedgerTables (LedgerState blk) ValuesMK ->
+  LedgerTables blk ValuesMK ->
   [TxTicket (TxMeasureWithDiffTime blk) (Validated (GenTx blk))] ->
   MempoolSnapshot blk
 computeSnapshot cfg slot st values txTickets =

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Query.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Query.hs
@@ -24,7 +24,7 @@ implGetSnapshotFor ::
   TickedLedgerState blk DiffMK ->
   -- | A function that returns values corresponding to the given keys for
   -- the unticked ledger state.
-  (LedgerTables (LedgerState blk) KeysMK -> m (LedgerTables (LedgerState blk) ValuesMK)) ->
+  (LedgerTables blk KeysMK -> m (LedgerTables blk ValuesMK)) ->
   m (MempoolSnapshot blk)
 implGetSnapshotFor mpEnv slot ticked readUntickedTables = do
   is <- atomically $ readTMVar istate

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Update.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Update.hs
@@ -212,9 +212,7 @@ doAddTx mpEnv caller wti tx = do
     eRes <- withTMVarAnd istate additionalCheck $
       \is () -> do
         frkr <- readMVar forker
-        tbs <-
-          castLedgerTables
-            <$> roforkerReadTables frkr (castLedgerTables $ getTransactionKeySets tx)
+        tbs <- roforkerReadTables frkr (getTransactionKeySets tx)
         before <- getMonotonicTime
         mbX <- do
           let f m = case mbToCfg of
@@ -309,7 +307,7 @@ pureTryAddTx ::
   GenTx blk ->
   -- | The current internal state of the mempool.
   InternalState blk ->
-  LedgerTables (LedgerState blk) ValuesMK ->
+  LedgerTables blk ValuesMK ->
   TriedToAddTx blk
 pureTryAddTx mpEnv cfg wti tx is values =
   let MempoolEnv
@@ -455,7 +453,7 @@ implRemoveTxsEvenIfValid mpEnv toRemove =
               (getTransactionKeySets . txForgetValidated . validatedTx . TxSeq.txTicketTx)
               toKeep
       frkr <- readMVar forker
-      tbs <- castLedgerTables <$> roforkerReadTables frkr (castLedgerTables toKeep')
+      tbs <- roforkerReadTables frkr toKeep'
       let (is', t) =
             pureRemoveTxs
               capacityOverride
@@ -487,7 +485,7 @@ pureRemoveTxs ::
   LedgerConfig blk ->
   SlotNo ->
   TickedLedgerState blk DiffMK ->
-  LedgerTables (LedgerState blk) ValuesMK ->
+  LedgerTables blk ValuesMK ->
   TicketNo ->
   -- | Txs to keep
   [TxTicket (TxMeasureWithDiffTime blk) (ValidatedTxWithDiffs blk)] ->
@@ -584,7 +582,7 @@ implSyncWithLedger projectResult mpEnv =
                         roforkerClose frkOld
                         pure frk
                     )
-                  tbs <- castLedgerTables <$> roforkerReadTables frk (castLedgerTables $ isTxKeys is)
+                  tbs <- roforkerReadTables frk (isTxKeys is)
                   let (is', mTrace) =
                         pureSyncWithLedger
                           capacityOverride
@@ -618,7 +616,7 @@ pureSyncWithLedger ::
   LedgerConfig blk ->
   SlotNo ->
   TickedLedgerState blk DiffMK ->
-  LedgerTables (LedgerState blk) ValuesMK ->
+  LedgerTables blk ValuesMK ->
   InternalState blk ->
   ( InternalState blk
   , Maybe (TraceEventMempool blk)

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ChainSync/Client.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ChainSync/Client.hs
@@ -111,7 +111,7 @@ import Ouroboros.Consensus.HeaderStateHistory
   )
 import qualified Ouroboros.Consensus.HeaderStateHistory as HeaderStateHistory
 import Ouroboros.Consensus.HeaderValidation hiding (validateHeader)
-import Ouroboros.Consensus.Ledger.Basics
+import Ouroboros.Consensus.Ledger.Abstract
 import Ouroboros.Consensus.Ledger.Extended
 import Ouroboros.Consensus.Ledger.SupportsProtocol
 import Ouroboros.Consensus.MiniProtocol.ChainSync.Client.HistoricityCheck

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ChainSync/Client/InFutureCheck.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ChainSync/Client/InFutureCheck.hs
@@ -52,7 +52,7 @@ import Ouroboros.Consensus.HardFork.History.Qry
   ( runQuery
   , slotToWallclock
   )
-import Ouroboros.Consensus.Ledger.Basics
+import Ouroboros.Consensus.Ledger.Abstract
   ( EmptyMK
   , LedgerConfig
   , LedgerState

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Node/ProtocolInfo.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Node/ProtocolInfo.hs
@@ -13,7 +13,7 @@ import Data.Word
 import NoThunks.Class (NoThunks)
 import Ouroboros.Consensus.Block
 import Ouroboros.Consensus.Config
-import Ouroboros.Consensus.Ledger.Basics (ValuesMK)
+import Ouroboros.Consensus.Ledger.Abstract (ValuesMK)
 import Ouroboros.Consensus.Ledger.Extended
 import Ouroboros.Consensus.NodeId
 

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Node/Run.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Node/Run.hs
@@ -121,7 +121,7 @@ class
   , ShowProxy (BlockQuery blk)
   , ShowProxy (TxId (GenTx blk))
   , (forall fp. ShowQuery (BlockQuery blk fp))
-  , LedgerSupportsLedgerDB blk
+  , CanUpgradeLedgerTables LedgerState blk
   ) =>
   RunNode blk
 

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl.hs
@@ -76,7 +76,6 @@ import qualified Ouroboros.Consensus.Storage.ChainDB.Impl.Query as Query
 import Ouroboros.Consensus.Storage.ChainDB.Impl.Types
 import qualified Ouroboros.Consensus.Storage.ImmutableDB as ImmutableDB
 import qualified Ouroboros.Consensus.Storage.ImmutableDB.Stream as ImmutableDB
-import Ouroboros.Consensus.Storage.LedgerDB (LedgerSupportsLedgerDB)
 import qualified Ouroboros.Consensus.Storage.LedgerDB as LedgerDB
 import qualified Ouroboros.Consensus.Storage.PerasCertDB as PerasCertDB
 import qualified Ouroboros.Consensus.Storage.PerasVoteDB as PerasVoteDB
@@ -108,7 +107,6 @@ withDB ::
   , HasHardForkHistory blk
   , ConvertRawHash blk
   , SerialiseDiskConstraints blk
-  , LedgerSupportsLedgerDB blk
   ) =>
   Complete Args.ChainDbArgs m blk ->
   (ChainDB m blk -> m a) ->
@@ -125,7 +123,6 @@ openDB ::
   , HasHardForkHistory blk
   , ConvertRawHash blk
   , SerialiseDiskConstraints blk
-  , LedgerSupportsLedgerDB blk
   ) =>
   Complete Args.ChainDbArgs m blk ->
   m (ChainDB m blk)
@@ -142,7 +139,6 @@ openDBInternal ::
   , ConvertRawHash blk
   , SerialiseDiskConstraints blk
   , HasCallStack
-  , LedgerSupportsLedgerDB blk
   ) =>
   Complete Args.ChainDbArgs m blk ->
   -- | 'True' = Launch background tasks

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Args.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Args.hs
@@ -145,7 +145,7 @@ defaultArgs ::
   ( IOLike m
   , LedgerDB.LedgerDbSerialiseConstraints blk
   , LedgerSupportsProtocol blk
-  , LedgerDB.LedgerSupportsInMemoryLedgerDB (LedgerState blk)
+  , LedgerDB.LedgerSupportsInMemoryLedgerDB LedgerState blk
   ) =>
   Incomplete ChainDbArgs m blk
 defaultArgs =

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Args.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Args.hs
@@ -145,7 +145,7 @@ defaultArgs ::
   ( IOLike m
   , LedgerDB.LedgerDbSerialiseConstraints blk
   , LedgerSupportsProtocol blk
-  , LedgerDB.LedgerSupportsInMemoryLedgerDB LedgerState blk
+  , LedgerDB.CanUpgradeLedgerTables LedgerState blk
   ) =>
   Incomplete ChainDbArgs m blk
 defaultArgs =

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/ChainSel.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/ChainSel.hs
@@ -882,7 +882,7 @@ switchTo ::
   ChainDiff (Header blk) ->
   ReasonForSwitch' blk ->
   -- | Forker at the tip of the above ChainDiff
-  SuccessForkerAction m (ExtLedgerState blk)
+  SuccessForkerAction m ExtLedgerState blk
 switchTo CDB{..} weights triggerPt chainDiff reason = MkSuccessForkerAction $ \forker -> do
   traceWith addBlockTracer $
     ChangingSelection $
@@ -1106,7 +1106,7 @@ chainSelection ::
   -- | The candidates
   NonEmpty (ChainDiff (Header blk), ReasonForSwitch' blk) ->
   -- | The continuation to run on succesfully validating a candidate.
-  (ChainDiff (Header blk) -> ReasonForSwitch' blk -> SuccessForkerAction m (ExtLedgerState blk)) ->
+  (ChainDiff (Header blk) -> ReasonForSwitch' blk -> SuccessForkerAction m ExtLedgerState blk) ->
   -- | The (valid) chain diff and corresponding LedgerDB that was selected,
   -- or 'Nothing' if there is no valid chain diff preferred over the current
   -- chain.
@@ -1282,7 +1282,7 @@ validateCandidate ::
   ChainDiff (Header blk) ->
   -- | Invariant: This non-empty list of headers is the list of headers in the ChainDiff above
   NonEmpty (Header blk) ->
-  SuccessForkerAction m (ExtLedgerState blk) ->
+  SuccessForkerAction m ExtLedgerState blk ->
   m (ValidationResult blk)
 validateCandidate chainSelEnv chainDiff@(ChainDiff rollback suffix) neHeaders onSuccess =
   LedgerDB.validateFork

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB.hs
@@ -54,7 +54,7 @@ openDB ::
   , InspectLedger blk
   , HasCallStack
   , HasHardForkHistory blk
-  , LedgerSupportsLedgerDB blk
+  , LedgerDbSerialiseConstraints blk
   ) =>
   -- | Stateless initializaton arguments
   Complete LedgerDbArgs m blk ->

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/API.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/API.hs
@@ -258,11 +258,9 @@ import Data.ByteString (ByteString)
 import Data.Functor.Contravariant ((>$<))
 import Data.Kind
 import Data.List.NonEmpty (NonEmpty)
-import qualified Data.Map.Strict as Map
 import Data.MemPack
 import Data.Proxy
 import Data.Set (Set)
-import Data.Void (absurd)
 import Data.Word
 import GHC.Generics (Generic)
 import NoThunks.Class
@@ -305,10 +303,10 @@ type LedgerDbSerialiseConstraints blk =
   , EncodeDisk blk (ChainDepState (BlockProtocol blk))
   , DecodeDisk blk (ChainDepState (BlockProtocol blk))
   , -- For InMemory LedgerDBs
-    MemPack (TxIn (LedgerState blk))
-  , SerializeTablesWithHint (LedgerState blk)
+    MemPack (TxIn blk)
+  , SerializeTablesWithHint LedgerState blk
   , -- For OnDisk LedgerDBs
-    IndexedMemPack (LedgerState blk EmptyMK) (TxOut (LedgerState blk))
+    IndexedMemPack LedgerState blk (TxOut blk)
   )
 
 -- | The core API of the LedgerDB component
@@ -327,7 +325,7 @@ data LedgerDB m l blk = LedgerDB
   -- ^ Get the header state history for all ledger states in the LedgerDB.
   , openForkerAtTarget ::
       Target (Point blk) ->
-      m (Either GetForkerError (Forker m (l blk)))
+      m (Either GetForkerError (Forker m l blk))
   -- ^ Acquire a 'Forker' at the requested point. If a ledger state associated
   -- with the requested point does not exist in the LedgerDB, it will return a
   -- 'GetForkerError'.
@@ -339,7 +337,7 @@ data LedgerDB m l blk = LedgerDB
       BlockCache blk ->
       Word64 ->
       NonEmpty (Header blk) ->
-      SuccessForkerAction m (l blk) ->
+      SuccessForkerAction m l blk ->
       m (ValidateResult l blk)
   -- ^ Try to apply a sequence of blocks on top of the LedgerDB, first rolling
   -- back as many blocks as the passed @Word64@.
@@ -473,7 +471,7 @@ data LedgerDbError
 withTipForker ::
   IOLike m =>
   LedgerDB m l blk ->
-  (Forker m (l blk) -> m a) ->
+  (Forker m l blk -> m a) ->
   m a
 withTipForker ldb =
   bracket
@@ -496,7 +494,7 @@ openReadOnlyForker ::
   MonadSTM m =>
   LedgerDB m l blk ->
   Target (Point blk) ->
-  m (Either GetForkerError (ReadOnlyForker m (l blk)))
+  m (Either GetForkerError (ReadOnlyForker m l blk))
 openReadOnlyForker ldb pt = fmap readOnlyForker <$> openForkerAtTarget ldb pt
 
 {-------------------------------------------------------------------------------
@@ -793,53 +791,46 @@ data TraceReplayProgressEvent blk
 -- No correctness property relies on this, as Consensus can work with TxOuts
 -- from multiple eras, but the performance depends on it as otherwise we will be
 -- upgrading the TxOuts every time we consult them.
-class CanUpgradeLedgerTables l where
+type CanUpgradeLedgerTables :: StateKind -> Type -> Constraint
+class CanUpgradeLedgerTables l blk where
   upgradeTables ::
     -- | The original ledger state before the upgrade. This will be the
     -- tip before applying the block.
-    l mk1 ->
+    l blk mk1 ->
     -- | The ledger state after the upgrade, which might be in a
     -- different era than the one above.
-    l mk2 ->
+    l blk mk2 ->
     -- | The tables we want to maybe upgrade.
-    LedgerTables l ValuesMK ->
-    LedgerTables l ValuesMK
+    LedgerTables blk ValuesMK ->
+    LedgerTables blk ValuesMK
 
 instance
-  CanUpgradeLedgerTables (LedgerState blk) =>
-  CanUpgradeLedgerTables (ExtLedgerState blk)
+  CanUpgradeLedgerTables LedgerState blk =>
+  CanUpgradeLedgerTables ExtLedgerState blk
   where
   upgradeTables (ExtLedgerState st0 _) (ExtLedgerState st1 _) =
-    castLedgerTables . upgradeTables st0 st1 . castLedgerTables
-
-instance
-  LedgerTablesAreTrivial l =>
-  CanUpgradeLedgerTables (TrivialLedgerTables l)
-  where
-  upgradeTables _ _ (LedgerTables (ValuesMK mk)) =
-    LedgerTables (ValuesMK (Map.map absurd mk))
+    upgradeTables st0 st1
 
 {-------------------------------------------------------------------------------
   LedgerDB constraints
 -------------------------------------------------------------------------------}
 
-type LedgerSupportsInMemoryLedgerDB l =
-  (CanUpgradeLedgerTables l, SerializeTablesWithHint l)
+type LedgerSupportsInMemoryLedgerDB l blk =
+  (CanUpgradeLedgerTables l blk, SerializeTablesWithHint l blk)
 
-type LedgerSupportsLMDBLedgerDB l =
-  (IndexedMemPack (l EmptyMK) (TxOut l), MemPackIdx l EmptyMK ~ l EmptyMK)
+type LedgerSupportsLMDBLedgerDB l blk = IndexedMemPack l blk (TxOut blk)
 
-type LedgerSupportsV1LedgerDB l =
-  (LedgerSupportsInMemoryLedgerDB l, LedgerSupportsLMDBLedgerDB l)
+type LedgerSupportsV1LedgerDB l blk =
+  (LedgerSupportsInMemoryLedgerDB l blk, LedgerSupportsLMDBLedgerDB l blk)
 
-type LedgerSupportsV2LedgerDB l =
-  (LedgerSupportsInMemoryLedgerDB l, MemPack (TxIn l))
+type LedgerSupportsV2LedgerDB l blk =
+  (LedgerSupportsInMemoryLedgerDB l blk, MemPack (TxIn blk))
 
-type LedgerSupportsLedgerDB blk = LedgerSupportsLedgerDB' (LedgerState blk) blk
+type LedgerSupportsLedgerDB blk = LedgerSupportsLedgerDB' LedgerState blk
 
 type LedgerSupportsLedgerDB' l blk =
-  ( LedgerSupportsV1LedgerDB l
-  , LedgerSupportsV2LedgerDB l
+  ( LedgerSupportsV1LedgerDB l blk
+  , LedgerSupportsV2LedgerDB l blk
   , LedgerDbSerialiseConstraints blk
   )
 
@@ -861,21 +852,21 @@ data LedgerDbPrune
 -------------------------------------------------------------------------------}
 
 -- | A backend that supports streaming the ledger tables
-class StreamingBackend m backend l where
-  data YieldArgs m backend l
+class StreamingBackend m backend l blk where
+  data YieldArgs m backend l blk
 
-  data SinkArgs m backend l
+  data SinkArgs m backend l blk
 
-  yield :: Proxy backend -> YieldArgs m backend l -> Yield m l
-  releaseYieldArgs :: YieldArgs m backend l -> m ()
+  yield :: Proxy backend -> YieldArgs m backend l blk -> Yield m l blk
+  releaseYieldArgs :: YieldArgs m backend l blk -> m ()
 
-  sink :: Proxy backend -> SinkArgs m backend l -> Sink m l
-  releaseSinkArgs :: SinkArgs m backend l -> m ()
+  sink :: Proxy backend -> SinkArgs m backend l blk -> Sink m l blk
+  releaseSinkArgs :: SinkArgs m backend l blk -> m ()
 
-type Yield m l =
-  l EmptyMK ->
+type Yield m l blk =
+  l blk EmptyMK ->
   ( ( Stream
-        (Of (TxIn l, TxOut l))
+        (Of (TxIn blk, TxOut blk))
         (ExceptT DeserialiseFailure m)
         (Stream (Of ByteString) m (Maybe CRC)) ->
       ExceptT DeserialiseFailure m (Stream (Of ByteString) m (Maybe CRC, Maybe CRC))
@@ -883,15 +874,15 @@ type Yield m l =
   ) ->
   ExceptT DeserialiseFailure m (Maybe CRC, Maybe CRC)
 
-type Sink m l =
-  l EmptyMK ->
+type Sink m l blk =
+  l blk EmptyMK ->
   Stream
-    (Of (TxIn l, TxOut l))
+    (Of (TxIn blk, TxOut blk))
     (ExceptT DeserialiseFailure m)
     (Stream (Of ByteString) m (Maybe CRC)) ->
   ExceptT DeserialiseFailure m (Stream (Of ByteString) m (Maybe CRC, Maybe CRC))
 
-data Decoders l
+data Decoders blk
   = Decoders
-      (forall s. Decoder s (TxIn l))
-      (forall s. Decoder s (TxOut l))
+      (forall s. Decoder s (TxIn blk))
+      (forall s. Decoder s (TxOut blk))

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/API.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/API.hs
@@ -774,37 +774,6 @@ data TraceReplayProgressEvent blk
   deriving (Generic, Eq, Show)
 
 {-------------------------------------------------------------------------------
-  Updating ledger tables
--------------------------------------------------------------------------------}
-
--- | When pushing differences on InMemory Ledger DBs, we will sometimes need to
--- update ledger tables to the latest era. For unary blocks this is a no-op, but
--- for the Cardano block, we will need to upgrade all TxOuts in memory.
---
--- No correctness property relies on this, as Consensus can work with TxOuts
--- from multiple eras, but the performance depends on it as otherwise we will be
--- upgrading the TxOuts every time we consult them.
-type CanUpgradeLedgerTables :: StateKind -> Type -> Constraint
-class CanUpgradeLedgerTables l blk where
-  upgradeTables ::
-    -- | The original ledger state before the upgrade. This will be the
-    -- tip before applying the block.
-    l blk mk1 ->
-    -- | The ledger state after the upgrade, which might be in a
-    -- different era than the one above.
-    l blk mk2 ->
-    -- | The tables we want to maybe upgrade.
-    LedgerTables blk ValuesMK ->
-    LedgerTables blk ValuesMK
-
-instance
-  CanUpgradeLedgerTables LedgerState blk =>
-  CanUpgradeLedgerTables ExtLedgerState blk
-  where
-  upgradeTables (ExtLedgerState st0 _) (ExtLedgerState st1 _) =
-    upgradeTables st0 st1
-
-{-------------------------------------------------------------------------------
   Pruning
 -------------------------------------------------------------------------------}
 

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/API.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/API.hs
@@ -202,11 +202,6 @@ module Ouroboros.Consensus.Storage.LedgerDB.API
   , LedgerDB'
   , LedgerDbPrune (..)
   , LedgerDbSerialiseConstraints
-  , LedgerSupportsInMemoryLedgerDB
-  , LedgerSupportsLedgerDB
-  , LedgerSupportsLMDBLedgerDB
-  , LedgerSupportsV1LedgerDB
-  , LedgerSupportsV2LedgerDB
   , ResolveBlock
   , currentPoint
 
@@ -302,11 +297,9 @@ type LedgerDbSerialiseConstraints blk =
   , DecodeDisk blk (AnnTip blk)
   , EncodeDisk blk (ChainDepState (BlockProtocol blk))
   , DecodeDisk blk (ChainDepState (BlockProtocol blk))
-  , -- For InMemory LedgerDBs
-    MemPack (TxIn blk)
+  , IndexedMemPack LedgerState blk (TxOut blk)
+  , MemPack (TxIn blk)
   , SerializeTablesWithHint LedgerState blk
-  , -- For OnDisk LedgerDBs
-    IndexedMemPack LedgerState blk (TxOut blk)
   )
 
 -- | The core API of the LedgerDB component
@@ -810,29 +803,6 @@ instance
   where
   upgradeTables (ExtLedgerState st0 _) (ExtLedgerState st1 _) =
     upgradeTables st0 st1
-
-{-------------------------------------------------------------------------------
-  LedgerDB constraints
--------------------------------------------------------------------------------}
-
-type LedgerSupportsInMemoryLedgerDB l blk =
-  (CanUpgradeLedgerTables l blk, SerializeTablesWithHint l blk)
-
-type LedgerSupportsLMDBLedgerDB l blk = IndexedMemPack l blk (TxOut blk)
-
-type LedgerSupportsV1LedgerDB l blk =
-  (LedgerSupportsInMemoryLedgerDB l blk, LedgerSupportsLMDBLedgerDB l blk)
-
-type LedgerSupportsV2LedgerDB l blk =
-  (LedgerSupportsInMemoryLedgerDB l blk, MemPack (TxIn blk))
-
-type LedgerSupportsLedgerDB blk = LedgerSupportsLedgerDB' LedgerState blk
-
-type LedgerSupportsLedgerDB' l blk =
-  ( LedgerSupportsV1LedgerDB l blk
-  , LedgerSupportsV2LedgerDB l blk
-  , LedgerDbSerialiseConstraints blk
-  )
 
 {-------------------------------------------------------------------------------
   Pruning

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/Args.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/Args.hs
@@ -85,7 +85,7 @@ defaultArgs backendArgs =
     }
 
 data LedgerDbBackendArgs m blk
-  = LedgerDbBackendArgsV1 (V1.LedgerDbBackendArgs m (ExtLedgerState blk))
+  = LedgerDbBackendArgsV1 (V1.LedgerDbBackendArgs m ExtLedgerState blk)
   | LedgerDbBackendArgsV2 (V2.SomeBackendArgs m blk)
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/Forker.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/Forker.hs
@@ -28,7 +28,6 @@ module Ouroboros.Consensus.Storage.LedgerDB.Forker
   , RangeQueryPrevious (..)
   , Statistics (..)
   , forkerCurrentPoint
-  , castRangeQueryPrevious
   , ledgerStateReadOnlyForker
 
     -- ** Read only
@@ -60,7 +59,6 @@ module Ouroboros.Consensus.Storage.LedgerDB.Forker
 import Control.Monad.Except
   ( runExcept
   )
-import Data.Bifunctor (first)
 import Data.Kind
 import Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NE
@@ -85,8 +83,8 @@ import Ouroboros.Consensus.Util.IOLike
 -- | An independent handle to a point in the LedgerDB, which can be advanced to
 -- evaluate forks in the chain.
 -- TODO @js split l in l blk
-type Forker :: (Type -> Type) -> LedgerStateKind -> Type
-data Forker m l = Forker
+type Forker :: (Type -> Type) -> StateKind -> Type -> Type
+data Forker m l blk = Forker
   { forkerClose :: !(m ())
   -- ^ Close the current forker (idempotent).
   --
@@ -100,9 +98,10 @@ data Forker m l = Forker
   -- and not by the LedgerDB.
   , -- Queries
 
-    forkerReadTables :: !(LedgerTables l KeysMK -> m (LedgerTables l ValuesMK))
+    forkerReadTables :: !(LedgerTables blk KeysMK -> m (LedgerTables blk ValuesMK))
   -- ^ Read ledger tables from disk.
-  , forkerRangeReadTables :: !(RangeQueryPrevious l -> m (LedgerTables l ValuesMK, Maybe (TxIn l)))
+  , forkerRangeReadTables ::
+      !(RangeQueryPrevious blk -> m (LedgerTables blk ValuesMK, Maybe (TxIn blk)))
   -- ^ Range-read ledger tables from disk.
   --
   -- This range read will return as many values as the 'QueryBatchSize' that was
@@ -116,7 +115,7 @@ data Forker m l = Forker
   -- back into the next iteration of the range read. If the function returns
   -- Nothing, it means the read returned no results, or in other words, we
   -- reached the end of the ledger tables.
-  , forkerGetLedgerState :: !(STM m (l EmptyMK))
+  , forkerGetLedgerState :: !(STM m (l blk EmptyMK))
   -- ^ Get the full ledger state without tables.
   --
   -- If an empty ledger state is all you need, use 'getVolatileTip',
@@ -127,7 +126,7 @@ data Forker m l = Forker
   -- Returns 'Nothing' if the implementation is backed by @lsm-tree@.
   , -- Updates
 
-    forkerPush :: !(l DiffMK -> m ())
+    forkerPush :: !(l blk DiffMK -> m ())
   -- ^ Advance the fork handle by pushing a new ledger state to the tip of the
   -- current fork.
   , forkerCommit :: !(STM m (m ()))
@@ -138,29 +137,24 @@ data Forker m l = Forker
   -- resources from the LedgerDB.
   }
   deriving Generic
-  deriving NoThunks via OnlyCheckWhnf (Forker m l)
+  deriving NoThunks via OnlyCheckWhnf (Forker m l blk)
 
 -- | An identifier for a 'Forker'. See 'ldbForkers'.
 newtype ForkerKey = ForkerKey Word16
   deriving stock (Show, Eq, Ord)
   deriving newtype (Enum, NoThunks, Num)
 
-type instance HeaderHash (Forker m l) = HeaderHash l
+type instance HeaderHash (Forker m l blk) = HeaderHash (l blk)
 
-type Forker' m blk = Forker m (ExtLedgerState blk)
+type Forker' m blk = Forker m ExtLedgerState blk
 
 instance
-  (GetTip l, MonadSTM m) =>
-  GetTipSTM m (Forker m l)
+  (GetTip (l blk), MonadSTM m) =>
+  GetTipSTM m (Forker m l blk)
   where
   getTipSTM forker = castPoint . getTip <$> forkerGetLedgerState forker
 
 data RangeQueryPrevious l = NoPreviousQuery | PreviousQueryWasFinal | PreviousQueryWasUpTo (TxIn l)
-
-castRangeQueryPrevious :: TxIn l ~ TxIn l' => RangeQueryPrevious l -> RangeQueryPrevious l'
-castRangeQueryPrevious NoPreviousQuery = NoPreviousQuery
-castRangeQueryPrevious PreviousQueryWasFinal = PreviousQueryWasFinal
-castRangeQueryPrevious (PreviousQueryWasUpTo txin) = PreviousQueryWasUpTo txin
 
 data RangeQuery l = RangeQuery
   { rqPrev :: !(RangeQueryPrevious l)
@@ -201,9 +195,9 @@ data ExceededRollback = ExceededRollback
   deriving (Show, Eq)
 
 forkerCurrentPoint ::
-  (GetTip l, HeaderHash l ~ HeaderHash blk, Functor (STM m)) =>
+  (GetTip (l blk), HeaderHash (l blk) ~ HeaderHash blk, Functor (STM m)) =>
   Proxy blk ->
-  Forker m l ->
+  Forker m l blk ->
   STM m (Point blk)
 forkerCurrentPoint _ forker =
   castPoint
@@ -211,13 +205,12 @@ forkerCurrentPoint _ forker =
     <$> forkerGetLedgerState forker
 
 ledgerStateReadOnlyForker ::
-  IOLike m => ReadOnlyForker m (ExtLedgerState blk) -> ReadOnlyForker m (LedgerState blk)
+  IOLike m => ReadOnlyForker' m blk -> ReadOnlyForker m LedgerState blk
 ledgerStateReadOnlyForker frk =
   ReadOnlyForker
     { roforkerClose = roforkerClose
-    , roforkerReadTables = fmap castLedgerTables . roforkerReadTables . castLedgerTables
-    , roforkerRangeReadTables =
-        fmap (first castLedgerTables) . roforkerRangeReadTables . castRangeQueryPrevious
+    , roforkerReadTables = roforkerReadTables
+    , roforkerRangeReadTables = roforkerRangeReadTables
     , roforkerGetLedgerState = ledgerState <$> roforkerGetLedgerState
     , roforkerReadStatistics = roforkerReadStatistics
     }
@@ -244,30 +237,31 @@ ledgerStateReadOnlyForker frk =
 -- - Forging loop.
 --
 -- - Mempool.
-type ReadOnlyForker :: (Type -> Type) -> LedgerStateKind -> Type
-data ReadOnlyForker m l = ReadOnlyForker
+type ReadOnlyForker :: (Type -> Type) -> StateKind -> Type -> Type
+data ReadOnlyForker m l blk = ReadOnlyForker
   { roforkerClose :: !(m ())
   -- ^ See 'forkerClose'
-  , roforkerReadTables :: !(LedgerTables l KeysMK -> m (LedgerTables l ValuesMK))
+  , roforkerReadTables :: !(LedgerTables blk KeysMK -> m (LedgerTables blk ValuesMK))
   -- ^ See 'forkerReadTables'
-  , roforkerRangeReadTables :: !(RangeQueryPrevious l -> m (LedgerTables l ValuesMK, Maybe (TxIn l)))
+  , roforkerRangeReadTables ::
+      !(RangeQueryPrevious blk -> m (LedgerTables blk ValuesMK, Maybe (TxIn blk)))
   -- ^ See 'forkerRangeReadTables'.
-  , roforkerGetLedgerState :: !(STM m (l EmptyMK))
+  , roforkerGetLedgerState :: !(STM m (l blk EmptyMK))
   -- ^ See 'forkerGetLedgerState'
   , roforkerReadStatistics :: !(m Statistics)
   -- ^ See 'forkerReadStatistics'
   }
   deriving Generic
 
-instance NoThunks (ReadOnlyForker m l) where
+instance NoThunks (ReadOnlyForker m l blk) where
   wNoThunks _ _ = pure Nothing
   showTypeOf _ = "ReadOnlyForker"
 
 type instance HeaderHash (ReadOnlyForker m l) = HeaderHash l
 
-type ReadOnlyForker' m blk = ReadOnlyForker m (ExtLedgerState blk)
+type ReadOnlyForker' m blk = ReadOnlyForker m ExtLedgerState blk
 
-readOnlyForker :: Forker m l -> ReadOnlyForker m l
+readOnlyForker :: Forker m l blk -> ReadOnlyForker m l blk
 readOnlyForker forker =
   ReadOnlyForker
     { roforkerClose = forkerClose forker
@@ -291,9 +285,9 @@ data ValidateArgs m l blk = ValidateArgs
   , prevApplied :: !(STM m (Set (RealPoint blk)))
   -- ^ Get the current set of previously applied blocks
   , withForkerAtFromTip ::
-      !(forall r. Word64 -> (Forker m (l blk) -> m r) -> m (Either GetForkerError r))
+      !(forall r. Word64 -> (Forker m l blk -> m r) -> m (Either GetForkerError r))
   -- ^ Create a forker from the tip
-  , onSuccess :: !(SuccessForkerAction m (l blk))
+  , onSuccess :: !(SuccessForkerAction m l blk)
   -- ^ Continuation to run when the validation was successful
   , trace :: !(TraceValidateEvent blk -> m ())
   -- ^ A tracer for validate events
@@ -378,7 +372,7 @@ validate evs args = do
 -- new blocks.
 switch ::
   (ApplyBlock l blk, MonadSTM m) =>
-  (forall r. Word64 -> (Forker m (l blk) -> m r) -> m (Either GetForkerError r)) ->
+  (forall r. Word64 -> (Forker m l blk -> m r) -> m (Either GetForkerError r)) ->
   ComputeLedgerEvents ->
   LedgerCfg l blk ->
   -- | How many blocks to roll back
@@ -387,7 +381,7 @@ switch ::
   -- | New blocks to apply
   NonEmpty (Ap m l blk) ->
   ResolveBlock m blk ->
-  SuccessForkerAction m (l blk) ->
+  SuccessForkerAction m l blk ->
   m (Either GetForkerError (Either (AnnLedgerError l blk) ()))
 switch withForkerAtFromTip evs cfg numRollbacks trace newBlocks doResolve onSuccess = do
   withForkerAtFromTip numRollbacks $ \fo -> do
@@ -436,7 +430,7 @@ applyBlock ::
   ComputeLedgerEvents ->
   LedgerCfg l blk ->
   Ap m l blk ->
-  Forker m (l blk) ->
+  Forker m l blk ->
   ResolveBlock m blk ->
   m (Either (AnnLedgerError l blk) (l blk DiffMK))
 applyBlock evs cfg ap fo doResolveBlock = case ap of
@@ -473,7 +467,7 @@ applyThenPush ::
   ComputeLedgerEvents ->
   LedgerCfg l blk ->
   Ap m l blk ->
-  Forker m (l blk) ->
+  Forker m l blk ->
   ResolveBlock m blk ->
   m (Either (AnnLedgerError l blk) ())
 applyThenPush evs cfg ap fo doResolve = do
@@ -489,7 +483,7 @@ applyThenPushMany ::
   ComputeLedgerEvents ->
   LedgerCfg l blk ->
   [Ap m l blk] ->
-  Forker m (l blk) ->
+  Forker m l blk ->
   ResolveBlock m blk ->
   m (Either (AnnLedgerError l blk) ())
 applyThenPushMany trace evs cfg aps fo doResolveBlock = pushAndTrace aps
@@ -534,8 +528,8 @@ type ResolveBlock m blk = RealPoint blk -> m blk
 -- commonly used as "how to close a @res@", which is *NOT* the case
 -- here. So it's preferable to use this more perspicious type in
 -- signatures.
-newtype SuccessForkerAction m l = MkSuccessForkerAction
-  { applySuccessForkerAction :: Forker m l -> m ()
+newtype SuccessForkerAction m l blk = MkSuccessForkerAction
+  { applySuccessForkerAction :: Forker m l blk -> m ()
   }
 
 -- | When validating a sequence of blocks, these are the possible outcomes.

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/V1.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/V1.hs
@@ -81,7 +81,7 @@ mkInitDb ::
   , LedgerSupportsLedgerDB blk
   ) =>
   Complete LedgerDbArgs m blk ->
-  V1.LedgerDbBackendArgs m (ExtLedgerState blk) ->
+  V1.LedgerDbBackendArgs m ExtLedgerState blk ->
   ResolveBlock m blk ->
   SnapshotManagerV1 m blk ->
   GetVolatileSuffix m blk ->
@@ -165,7 +165,6 @@ implMkLedgerDb ::
   forall m blk.
   ( IOLike m
   , HasCallStack
-  , LedgerDbSerialiseConstraints blk
   , LedgerSupportsProtocol blk
   , HasHardForkHistory blk
   ) =>
@@ -212,7 +211,7 @@ implGetPastLedgerState ::
   , HasHeader blk
   , IsLedger l blk
   , StandardHash (l blk)
-  , HasLedgerTables (l blk)
+  , HasLedgerTables l blk
   , HeaderHash (l blk) ~ HeaderHash blk
   ) =>
   LedgerDBEnv m l blk -> Point blk -> STM m (Maybe (l blk EmptyMK))
@@ -269,7 +268,7 @@ implValidate ::
   BlockCache blk ->
   Word64 ->
   NonEmpty (Header blk) ->
-  SuccessForkerAction m (l blk) ->
+  SuccessForkerAction m l blk ->
   m (ValidateResult l blk)
 implValidate h ldbEnv tr cache rollbacks hdrs onSuccess =
   validate (ledgerDbCfgComputeLedgerEvents $ ldbCfg ldbEnv) $
@@ -305,7 +304,7 @@ implGarbageCollect env slotNo = atomically $ do
     Set.dropWhileAntitone ((< slotNo) . realPointSlot)
 
 implTryTakeSnapshot ::
-  (IsLedger LedgerState blk, HasLedgerTables (LedgerState blk), IOLike m) =>
+  (IsLedger LedgerState blk, HasLedgerTables LedgerState blk, IOLike m) =>
   SnapshotManagerV1 m blk ->
   LedgerDBEnv m ExtLedgerState blk ->
   m () ->
@@ -370,7 +369,7 @@ implTryTakeSnapshot snapManager env copyBlocks getRandomDelay = do
 -- with which this LedgerDB was opened), flush differences to the backing
 -- store. Note this acquires a write lock on the backing store.
 implTryFlush ::
-  (IOLike m, HasLedgerTables (l blk), GetTip (l blk)) =>
+  (IOLike m, HasLedgerTables l blk, GetTip (l blk)) =>
   LedgerDBEnv m l blk -> m ()
 implTryFlush env = do
   ldb <- readTVarIO $ ldbChangelog env
@@ -400,7 +399,6 @@ implCloseDB (LDBHandle varState) = do
 
 mkInternals ::
   ( IOLike m
-  , LedgerDbSerialiseConstraints blk
   , LedgerSupportsProtocol blk
   ) =>
   LedgerDBHandle m ExtLedgerState blk ->
@@ -437,7 +435,6 @@ implIntTruncateSnapshots (SnapshotsFS (SomeHasFS fs)) = do
 
 implIntTakeSnapshot ::
   ( IOLike m
-  , LedgerDbSerialiseConstraints blk
   , LedgerSupportsProtocol blk
   ) =>
   SnapshotManagerV1 m blk ->
@@ -482,9 +479,9 @@ implIntReapplyThenPush env blk = do
 -------------------------------------------------------------------------------}
 
 flushLedgerDB ::
-  (MonadSTM m, GetTip l, HasLedgerTables l) =>
-  StrictTVar m (DbChangelog l) ->
-  LedgerBackingStore m l ->
+  (MonadSTM m, GetTip (l blk), HasLedgerTables l blk) =>
+  StrictTVar m (DbChangelog l blk) ->
+  LedgerBackingStore m l blk ->
   WriteLocked m ()
 flushLedgerDB chlogVar bstore = do
   diffs <- writeLocked $ atomically $ do
@@ -502,7 +499,7 @@ flushLedgerDB chlogVar bstore = do
 -- immutable tip and produce two 'DbChangelog's, one to flush and one to keep.
 --
 -- The write lock must be held before calling this function.
-flushIntoBackingStore :: LedgerBackingStore m l -> DiffsToFlush l -> WriteLocked m ()
+flushIntoBackingStore :: LedgerBackingStore m l blk -> DiffsToFlush l blk -> WriteLocked m ()
 flushIntoBackingStore backingStore dblog =
   writeLocked $
     bsWrite
@@ -527,18 +524,18 @@ deriving instance
   ( IOLike m
   , LedgerSupportsProtocol blk
   , NoThunks (l blk EmptyMK)
-  , NoThunks (TxIn (l blk))
-  , NoThunks (TxOut (l blk))
+  , NoThunks (TxIn blk)
+  , NoThunks (TxOut blk)
   , NoThunks (LedgerCfg l blk)
   ) =>
   NoThunks (LedgerDBState m l blk)
 
 type LedgerDBEnv :: (Type -> Type) -> StateKind -> Type -> Type
 data LedgerDBEnv m l blk = LedgerDBEnv
-  { ldbChangelog :: !(StrictTVar m (DbChangelog (l blk)))
+  { ldbChangelog :: !(StrictTVar m (DbChangelog l blk))
   -- ^ INVARIANT: the tip of the 'LedgerDB' is always in sync with the tip of
   -- the current chain of the ChainDB.
-  , ldbBackingStore :: !(LedgerBackingStore m (l blk))
+  , ldbBackingStore :: !(LedgerBackingStore m l blk)
   -- ^ Handle to the ledger's backing store, containing the parts that grow too
   -- big for in-memory residency
   , ldbLock :: !(LedgerDBLock m)
@@ -592,8 +589,8 @@ deriving instance
   ( IOLike m
   , LedgerSupportsProtocol blk
   , NoThunks (l blk EmptyMK)
-  , NoThunks (TxIn (l blk))
-  , NoThunks (TxOut (l blk))
+  , NoThunks (TxIn blk)
+  , NoThunks (TxOut blk)
   , NoThunks (LedgerCfg l blk)
   ) =>
   NoThunks (LedgerDBEnv m l blk)
@@ -678,12 +675,12 @@ openNewForkerAtTarget ::
   , IOLike m
   , IsLedger l blk
   , StandardHash (l blk)
-  , HasLedgerTables (l blk)
+  , HasLedgerTables l blk
   , LedgerSupportsProtocol blk
   ) =>
   LedgerDBHandle m l blk ->
   Target (Point blk) ->
-  m (Either GetForkerError (Forker m (l blk)))
+  m (Either GetForkerError (Forker m l blk))
 openNewForkerAtTarget h pt = withTransferrableReadAccess h (Right pt)
 
 withForkerByRollback ::
@@ -691,13 +688,13 @@ withForkerByRollback ::
   , IOLike m
   , IsLedger l blk
   , StandardHash (l blk)
-  , HasLedgerTables (l blk)
+  , HasLedgerTables l blk
   , LedgerSupportsProtocol blk
   ) =>
   LedgerDBHandle m l blk ->
   -- | How many blocks to rollback from the tip
   Word64 ->
-  (Forker m (l blk) -> m r) ->
+  (Forker m l blk -> m r) ->
   m (Either GetForkerError r)
 withForkerByRollback h n k =
   bracket
@@ -712,12 +709,12 @@ withTransferrableReadAccess ::
   , IOLike m
   , IsLedger l blk
   , StandardHash (l blk)
-  , HasLedgerTables (l blk)
+  , HasLedgerTables l blk
   , LedgerSupportsProtocol blk
   ) =>
   LedgerDBHandle m l blk ->
   Either Word64 (Target (Point blk)) ->
-  m (Either GetForkerError (Forker m (l blk)))
+  m (Either GetForkerError (Forker m l blk))
 withTransferrableReadAccess h f = getEnv h $ \ldbEnv -> do
   -- This TVar will be used to maybe release the read lock by the resource
   -- registry. Once the forker was opened it will be emptied.
@@ -751,12 +748,12 @@ unsafeAcquireAtTarget ::
   , IOLike m
   , IsLedger l blk
   , StandardHash (l blk)
-  , HasLedgerTables (l blk)
+  , HasLedgerTables l blk
   , LedgerSupportsProtocol blk
   ) =>
   LedgerDBEnv m l blk ->
   Either Word64 (Target (Point blk)) ->
-  ReadLocked m (Either GetForkerError (DbChangelog (l blk)))
+  ReadLocked m (Either GetForkerError (DbChangelog l blk))
 unsafeAcquireAtTarget ldbEnv target = readLocked $ runExceptT $ do
   (dblog, volStates) <- lift $ atomically $ do
     dblog <- readTVar (ldbChangelog ldbEnv)
@@ -801,15 +798,15 @@ unsafeAcquireAtTarget ldbEnv target = readLocked $ runExceptT $ do
 newForker ::
   forall m l blk.
   ( IOLike m
-  , HasLedgerTables (l blk)
+  , HasLedgerTables l blk
   , NoThunks (l blk EmptyMK)
   , GetTip (l blk)
   , StandardHash (l blk)
   ) =>
   LedgerDBEnv m l blk ->
   StrictTVar m (m ()) ->
-  DbChangelog (l blk) ->
-  ReadLocked m (Forker m (l blk))
+  DbChangelog l blk ->
+  ReadLocked m (Forker m l blk)
 newForker ldbEnv releaseVar dblog = readLocked $ do
   dblogVar <- newTVarIO dblog
   forkerKey <- atomically $ stateTVar (ldbNextForkerKey ldbEnv) $ \r -> (r, r + 1)

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/V1.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/V1.hs
@@ -78,7 +78,7 @@ mkInitDb ::
   ( LedgerSupportsProtocol blk
   , IOLike m
   , HasHardForkHistory blk
-  , LedgerSupportsLedgerDB blk
+  , LedgerDbSerialiseConstraints blk
   ) =>
   Complete LedgerDbArgs m blk ->
   V1.LedgerDbBackendArgs m ExtLedgerState blk ->

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/V1/Args.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/V1/Args.hs
@@ -29,7 +29,7 @@ shouldFlush requestedFlushFrequency = case requestedFlushFrequency of
   DefaultFlushFrequency -> (>= 100)
   DisableFlushing -> const False
 
-data LedgerDbBackendArgs m l = V1Args
+data LedgerDbBackendArgs m l blk = V1Args
   { v1FlushFrequency :: FlushFrequency
-  , v1BackendArgs :: SomeBackendArgs m l
+  , v1BackendArgs :: SomeBackendArgs m l blk
   }

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/V1/BackingStore.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/V1/BackingStore.hs
@@ -33,39 +33,39 @@ import Cardano.Slotting.Slot
 import Control.Tracer
 import Data.Proxy
 import Data.Typeable
-import Ouroboros.Consensus.Ledger.Basics
+import Ouroboros.Consensus.Ledger.Abstract
 import Ouroboros.Consensus.Storage.LedgerDB.Snapshots
 import Ouroboros.Consensus.Storage.LedgerDB.V1.BackingStore.API
 import System.FS.API
 
-type BackingStoreInitialiser m l =
-  InitFrom (LedgerTables l ValuesMK) ->
-  m (LedgerBackingStore m l)
+type BackingStoreInitialiser m l blk =
+  InitFrom l (LedgerTables blk ValuesMK) ->
+  m (LedgerBackingStore m l blk)
 
 -- | Overwrite the 'BackingStore' tables with the snapshot's tables
 restoreBackingStore ::
   Tracer m SomeBackendTrace ->
-  SomeBackendArgs m l ->
+  SomeBackendArgs m l blk ->
   SnapshotsFS m ->
-  l EmptyMK ->
+  l blk EmptyMK ->
   FsPath ->
-  m (LedgerBackingStore m l)
+  m (LedgerBackingStore m l blk)
 restoreBackingStore trcr (SomeBackendArgs bArgs) fs st loadPath =
   newBackingStoreInitialiser trcr bArgs fs (InitFromCopy st loadPath)
 
 -- | Create a 'BackingStore' from the given initial tables.
 newBackingStore ::
   Tracer m SomeBackendTrace ->
-  SomeBackendArgs m l ->
+  SomeBackendArgs m l blk ->
   SnapshotsFS m ->
-  l EmptyMK ->
-  LedgerTables l ValuesMK ->
-  m (LedgerBackingStore m l)
+  l blk EmptyMK ->
+  LedgerTables blk ValuesMK ->
+  m (LedgerBackingStore m l blk)
 newBackingStore trcr (SomeBackendArgs bArgs) fs st tables =
   newBackingStoreInitialiser trcr bArgs fs (InitFromValues Origin st tables)
 
-data SomeBackendArgs m l where
-  SomeBackendArgs :: Backend m backend l => Args m backend -> SomeBackendArgs m l
+data SomeBackendArgs m l blk where
+  SomeBackendArgs :: Backend m backend l blk => Args m backend -> SomeBackendArgs m l blk
 
 data SomeBackendTrace where
   SomeBackendTrace :: (Show (Trace backend), Typeable backend) => Trace backend -> SomeBackendTrace
@@ -73,13 +73,14 @@ data SomeBackendTrace where
 instance Show SomeBackendTrace where
   show (SomeBackendTrace tr) = show tr
 
-class Backend m backend l where
+class Backend m backend l blk where
   data Args m backend
 
   data Trace backend
 
   isRightBackendForSnapshot ::
     Proxy l ->
+    Proxy blk ->
     Args m backend ->
     SnapshotBackend ->
     Bool
@@ -88,4 +89,4 @@ class Backend m backend l where
     Tracer m SomeBackendTrace ->
     Args m backend ->
     SnapshotsFS m ->
-    BackingStoreInitialiser m l
+    BackingStoreInitialiser m l blk

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/V1/BackingStore/API.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/V1/BackingStore/API.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE StandaloneKindSignatures #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 
@@ -59,7 +60,7 @@ import Data.Bifunctor
 import Data.Kind
 import GHC.Generics
 import NoThunks.Class (OnlyCheckWhnfNamed (..))
-import Ouroboros.Consensus.Ledger.Basics
+import Ouroboros.Consensus.Ledger.Abstract
 import Ouroboros.Consensus.Ledger.Extended
 import Ouroboros.Consensus.Storage.LedgerDB.Snapshots
 import Ouroboros.Consensus.Util.IOLike
@@ -80,10 +81,10 @@ newtype LiveLMDBFS m = LiveLMDBFS {liveLMDBFs :: SomeHasFS m}
 
 -- | A container for differences that are inteded to be flushed to a
 -- 'BackingStore'
-data DiffsToFlush l = DiffsToFlush
-  { toFlushDiffs :: !(LedgerTables l DiffMK)
+data DiffsToFlush l blk = DiffsToFlush
+  { toFlushDiffs :: !(LedgerTables blk DiffMK)
   -- ^ The set of differences that should be flushed into the 'BackingStore'
-  , toFlushState :: !(l EmptyMK, l EmptyMK)
+  , toFlushState :: !(l blk EmptyMK, l blk EmptyMK)
   -- ^ The last flushed state and the newly flushed state. This will be the
   -- immutable tip.
   , toFlushSlot :: !SlotNo
@@ -91,13 +92,13 @@ data DiffsToFlush l = DiffsToFlush
   -- considered as "last flushed" in the kept 'DbChangelog'
   }
 
-data BackingStore m keys key values diff = BackingStore
+data BackingStore m l keys key values diff = BackingStore
   { bsClose :: !(m ())
   -- ^ Close the backing store
   --
   -- Other methods throw exceptions if called on a closed store. 'bsClose'
   -- itself is idempotent.
-  , bsCopy :: !(SerializeTablesHint values -> FS.FsPath -> m ())
+  , bsCopy :: !(SerializeTablesHint l values -> FS.FsPath -> m ())
   -- ^ Create a persistent copy
   --
   -- Each backing store implementation will offer a way to initialize itself
@@ -105,10 +106,10 @@ data BackingStore m keys key values diff = BackingStore
   --
   -- The destination path must not already exist. After this operation, it
   -- will be a directory.
-  , bsValueHandle :: !(m (BackingStoreValueHandle m keys key values))
+  , bsValueHandle :: !(m (BackingStoreValueHandle m l keys key values))
   -- ^ Open a 'BackingStoreValueHandle' capturing the current value of the
   -- entire database
-  , bsWrite :: !(SlotNo -> WriteHint diff -> diff -> m ())
+  , bsWrite :: !(SlotNo -> WriteHint l diff -> diff -> m ())
   -- ^ Apply a valid diff to the contents of the backing store
   , bsSnapshotBackend :: !SnapshotBackend
   -- ^ The name of the BackingStore backend, for loading and writing snapshots
@@ -116,36 +117,40 @@ data BackingStore m keys key values diff = BackingStore
   }
 
 deriving via
-  OnlyCheckWhnfNamed "BackingStore" (BackingStore m keys key values diff)
+  OnlyCheckWhnfNamed "BackingStore" (BackingStore m l keys key values diff)
   instance
-    NoThunks (BackingStore m keys key values diff)
+    NoThunks (BackingStore m l keys key values diff)
 
-type LedgerBackingStore m l =
+type LedgerBackingStore m l blk =
   BackingStore
     m
-    (LedgerTables l KeysMK)
-    (TxIn l)
-    (LedgerTables l ValuesMK)
-    (LedgerTables l DiffMK)
+    l
+    (LedgerTables blk KeysMK)
+    (TxIn blk)
+    (LedgerTables blk ValuesMK)
+    (LedgerTables blk DiffMK)
 
-type BackingStore' m blk = LedgerBackingStore m (ExtLedgerState blk)
+type BackingStore' m blk = LedgerBackingStore m ExtLedgerState blk
 
-type family InitHint values :: Type
-type instance InitHint (LedgerTables l ValuesMK) = l EmptyMK
+type InitHint :: StateKind -> Type -> Type
+type family InitHint l values :: Type
+type instance InitHint l (LedgerTables blk ValuesMK) = l blk EmptyMK
 
-type family WriteHint diffs :: Type
-type instance WriteHint (LedgerTables l DiffMK) = (l EmptyMK, l EmptyMK)
+type WriteHint :: StateKind -> Type -> Type
+type family WriteHint l diffs :: Type
+type instance WriteHint l (LedgerTables blk DiffMK) = (l blk EmptyMK, l blk EmptyMK)
 
-type family ReadHint values :: Type
-type instance ReadHint (LedgerTables l ValuesMK) = l EmptyMK
+type ReadHint :: StateKind -> Type -> Type
+type family ReadHint l values :: Type
+type instance ReadHint l (LedgerTables blk ValuesMK) = l blk EmptyMK
 
 -- | Choose how to initialize the backing store
-data InitFrom values
+data InitFrom l values
   = -- | Initialize from a set of values, at the given slot.
-    InitFromValues !(WithOrigin SlotNo) !(InitHint values) !values
+    InitFromValues !(WithOrigin SlotNo) !(InitHint l values) !values
   | -- | Use a snapshot at the given path to overwrite the set of values in the
     -- opened database.
-    InitFromCopy !(InitHint values) !FS.FsPath
+    InitFromCopy !(InitHint l values) !FS.FsPath
 
 {-------------------------------------------------------------------------------
   Value handles
@@ -156,7 +161,7 @@ data InitFrom values
 -- The performance cost is usually minimal unless this handle is held open too
 -- long. We expect clients of the 'BackingStore' to not retain handles for a
 -- long time.
-data BackingStoreValueHandle m keys key values = BackingStoreValueHandle
+data BackingStoreValueHandle m l keys key values = BackingStoreValueHandle
   { bsvhAtSlot :: !(WithOrigin SlotNo)
   -- ^ At which slot this handle was created
   , bsvhClose :: !(m ())
@@ -164,12 +169,12 @@ data BackingStoreValueHandle m keys key values = BackingStoreValueHandle
   --
   -- Other methods throw exceptions if called on a closed handle. 'bsvhClose'
   -- itself is idempotent.
-  , bsvhRangeRead :: !(ReadHint values -> RangeQuery keys -> m (values, Maybe key))
+  , bsvhRangeRead :: !(ReadHint l values -> RangeQuery keys -> m (values, Maybe key))
   -- ^ See 'RangeQuery'
-  , bsvhReadAll :: !(ReadHint values -> m values)
+  , bsvhReadAll :: !(ReadHint l values -> m values)
   -- ^ Costly read all operation, not to be used in Consensus but only in
   -- snapshot-converter executable.
-  , bsvhRead :: !(ReadHint values -> keys -> m values)
+  , bsvhRead :: !(ReadHint l values -> keys -> m values)
   -- ^ Read the given keys from the handle
   --
   -- Absent keys will merely not be present in the result instead of causing a
@@ -179,26 +184,27 @@ data BackingStoreValueHandle m keys key values = BackingStoreValueHandle
   }
 
 deriving via
-  OnlyCheckWhnfNamed "BackingStoreValueHandle" (BackingStoreValueHandle m keys key values)
+  OnlyCheckWhnfNamed "BackingStoreValueHandle" (BackingStoreValueHandle m l keys key values)
   instance
-    NoThunks (BackingStoreValueHandle m keys key values)
+    NoThunks (BackingStoreValueHandle m l keys key values)
 
-type LedgerBackingStoreValueHandle m l =
+type LedgerBackingStoreValueHandle m l blk =
   BackingStoreValueHandle
     m
-    (LedgerTables l KeysMK)
-    (TxIn l)
-    (LedgerTables l ValuesMK)
+    l
+    (LedgerTables blk KeysMK)
+    (TxIn blk)
+    (LedgerTables blk ValuesMK)
 
-type BackingStoreValueHandle' m blk = LedgerBackingStoreValueHandle m (ExtLedgerState blk)
+type BackingStoreValueHandle' m blk = LedgerBackingStoreValueHandle m ExtLedgerState blk
 
 castBackingStoreValueHandle ::
-  (Functor m, ReadHint values ~ ReadHint values') =>
+  (Functor m, ReadHint l values ~ ReadHint l values') =>
   (values -> values') ->
   (keys' -> keys) ->
   (key -> key') ->
-  BackingStoreValueHandle m keys key values ->
-  BackingStoreValueHandle m keys' key' values'
+  BackingStoreValueHandle m l keys key values ->
+  BackingStoreValueHandle m l keys' key' values'
 castBackingStoreValueHandle f g h bsvh =
   BackingStoreValueHandle
     { bsvhAtSlot
@@ -222,8 +228,8 @@ castBackingStoreValueHandle f g h bsvh =
 -- | A combination of 'bsValueHandle' and 'bsvhRead'
 bsRead ::
   MonadThrow m =>
-  BackingStore m keys key values diff ->
-  ReadHint values ->
+  BackingStore m l keys key values diff ->
+  ReadHint l values ->
   keys ->
   m (WithOrigin SlotNo, values)
 bsRead store rhint keys = withBsValueHandle store $ \vh -> do
@@ -232,16 +238,16 @@ bsRead store rhint keys = withBsValueHandle store $ \vh -> do
 
 bsReadAll ::
   MonadThrow m =>
-  BackingStore m keys key values diff ->
-  ReadHint values ->
+  BackingStore m l keys key values diff ->
+  ReadHint l values ->
   m values
 bsReadAll store rhint = withBsValueHandle store $ \vh -> bsvhReadAll vh rhint
 
 -- | A 'IOLike.bracket'ed 'bsValueHandle'
 withBsValueHandle ::
   MonadThrow m =>
-  BackingStore m keys key values diff ->
-  (BackingStoreValueHandle m keys key values -> m a) ->
+  BackingStore m l keys key values diff ->
+  (BackingStoreValueHandle m l keys key values -> m a) ->
   m a
 withBsValueHandle store =
   bracket

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/V1/BackingStore/Impl/InMemory.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/V1/BackingStore/Impl/InMemory.hs
@@ -37,7 +37,7 @@ import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 import Data.String (fromString)
 import GHC.Generics
-import Ouroboros.Consensus.Ledger.Basics
+import Ouroboros.Consensus.Ledger.Abstract
 import qualified Ouroboros.Consensus.Ledger.Tables.Diff as Diff
 import Ouroboros.Consensus.Storage.LedgerDB.API
 import Ouroboros.Consensus.Storage.LedgerDB.Snapshots
@@ -90,16 +90,16 @@ deriving instance
 
 -- | Use a 'TVar' as a trivial backing store
 newInMemoryBackingStore ::
-  forall l m.
+  forall l blk m.
   ( IOLike m
-  , HasLedgerTables l
-  , CanUpgradeLedgerTables l
-  , SerializeTablesWithHint l
+  , HasLedgerTables l blk
+  , CanUpgradeLedgerTables l blk
+  , SerializeTablesWithHint l blk
   ) =>
   Tracer m BackingStoreTrace ->
   SnapshotsFS m ->
-  InitFrom (LedgerTables l ValuesMK) ->
-  m (LedgerBackingStore m l)
+  InitFrom l (LedgerTables blk ValuesMK) ->
+  m (LedgerBackingStore m l blk)
 newInMemoryBackingStore tracer (SnapshotsFS (SomeHasFS fs)) initialization = do
   traceWith tracer BSOpening
   ref <- do
@@ -236,9 +236,9 @@ newInMemoryBackingStore tracer (SnapshotsFS (SomeHasFS fs)) initialization = do
     fsPathFromList $ fsPathToList path <> [fromString "tvar"]
 
   lookup ::
-    LedgerTables l KeysMK ->
-    LedgerTables l ValuesMK ->
-    LedgerTables l ValuesMK
+    LedgerTables blk KeysMK ->
+    LedgerTables blk ValuesMK ->
+    LedgerTables blk ValuesMK
   lookup = ltliftA2 lookup'
 
   lookup' ::
@@ -250,9 +250,9 @@ newInMemoryBackingStore tracer (SnapshotsFS (SomeHasFS fs)) initialization = do
     ValuesMK (Map.restrictKeys vs ks)
 
   rangeRead ::
-    RangeQuery (LedgerTables l KeysMK) ->
-    LedgerTables l ValuesMK ->
-    (LedgerTables l ValuesMK, Maybe (TxIn l))
+    RangeQuery (LedgerTables blk KeysMK) ->
+    LedgerTables blk ValuesMK ->
+    (LedgerTables blk ValuesMK, Maybe (TxIn blk))
   rangeRead rq values =
     let vs@(LedgerTables (ValuesMK m)) = case rqPrev rq of
           Nothing ->
@@ -280,9 +280,9 @@ newInMemoryBackingStore tracer (SnapshotsFS (SomeHasFS fs)) initialization = do
       Just k -> ValuesMK $ Map.take n $ snd $ Map.split k vs
 
   appDiffs ::
-    LedgerTables l ValuesMK ->
-    LedgerTables l DiffMK ->
-    LedgerTables l ValuesMK
+    LedgerTables blk ValuesMK ->
+    LedgerTables blk DiffMK ->
+    LedgerTables blk ValuesMK
   appDiffs = ltliftA2 applyDiff_
 
   applyDiff_ ::
@@ -293,7 +293,7 @@ newInMemoryBackingStore tracer (SnapshotsFS (SomeHasFS fs)) initialization = do
   applyDiff_ (ValuesMK values) (DiffMK diff) =
     ValuesMK (Diff.applyDiff values diff)
 
-  count :: LedgerTables l ValuesMK -> Int
+  count :: LedgerTables blk ValuesMK -> Int
   count = ltcollapse . ltmap (K2 . count')
 
   count' :: ValuesMK k v -> Int
@@ -353,11 +353,11 @@ type data Mem
 
 instance
   ( IOLike m
-  , HasLedgerTables l
-  , CanUpgradeLedgerTables l
-  , SerializeTablesWithHint l
+  , HasLedgerTables l blk
+  , CanUpgradeLedgerTables l blk
+  , SerializeTablesWithHint l blk
   ) =>
-  Backend m Mem l
+  Backend m Mem l blk
   where
   data Args m Mem = InMemArgs
   data Trace Mem
@@ -365,8 +365,8 @@ instance
     | InMemoryBackingStoreTrace BackingStoreTrace
     deriving (Eq, Show)
 
-  isRightBackendForSnapshot _ _ UTxOHDMemSnapshot = True
-  isRightBackendForSnapshot _ _ _ = False
+  isRightBackendForSnapshot _ _ _ UTxOHDMemSnapshot = True
+  isRightBackendForSnapshot _ _ _ _ = False
 
   newBackingStoreInitialiser trcr InMemArgs =
     newInMemoryBackingStore

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/V1/BackingStore/Impl/InMemory.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/V1/BackingStore/Impl/InMemory.hs
@@ -39,7 +39,6 @@ import Data.String (fromString)
 import GHC.Generics
 import Ouroboros.Consensus.Ledger.Abstract
 import qualified Ouroboros.Consensus.Ledger.Tables.Diff as Diff
-import Ouroboros.Consensus.Storage.LedgerDB.API
 import Ouroboros.Consensus.Storage.LedgerDB.Snapshots
   ( SnapshotBackend (..)
   )

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/V1/DbChangelog.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/V1/DbChangelog.hs
@@ -146,7 +146,6 @@ module Ouroboros.Consensus.Storage.LedgerDB.V1.DbChangelog
   , UnforwardedReadSets (..)
   , readKeySets
   , readKeySetsWith
-  , trivialKeySetsReader
 
     -- **** Forward
   , RewindReadFwdError (..)
@@ -263,21 +262,21 @@ import qualified Ouroboros.Network.AnchoredSeq as AS
 --
 -- As said above, this @DbChangelog@ has to be coupled with a @BackingStore@
 -- which provides the pointers to the on-disk data.
-data DbChangelog l = DbChangelog
-  { changelogLastFlushedState :: !(l EmptyMK)
+data DbChangelog l blk = DbChangelog
+  { changelogLastFlushedState :: !(l blk EmptyMK)
   -- ^ The last flushed ledger state.
   --
   -- We need to keep track of this one as this will be the state written to
   -- disk when we make a snapshot
-  , changelogDiffs :: !(LedgerTables l SeqDiffMK)
+  , changelogDiffs :: !(LedgerTables blk SeqDiffMK)
   -- ^ The sequence of differences between the last flushed state
   -- ('changelogLastFlushedState') and the tip of the volatile sequence
   -- ('changelogStates').
   , changelogStates ::
       !( AnchoredSeq
            (WithOrigin SlotNo)
-           (l EmptyMK)
-           (l EmptyMK)
+           (l blk EmptyMK)
+           (l blk EmptyMK)
        )
   -- ^ The volatile sequence of states.
   --
@@ -290,22 +289,22 @@ data DbChangelog l = DbChangelog
   deriving Generic
 
 deriving instance
-  (Eq (TxIn l), Eq (TxOut l), Eq (l EmptyMK)) =>
-  Eq (DbChangelog l)
+  (Eq (TxIn blk), Eq (TxOut blk), Eq (l blk EmptyMK)) =>
+  Eq (DbChangelog l blk)
 deriving instance
-  (NoThunks (TxIn l), NoThunks (TxOut l), NoThunks (l EmptyMK)) =>
-  NoThunks (DbChangelog l)
+  (NoThunks (TxIn blk), NoThunks (TxOut blk), NoThunks (l blk EmptyMK)) =>
+  NoThunks (DbChangelog l blk)
 deriving instance
-  (Show (TxIn l), Show (TxOut l), Show (l EmptyMK)) =>
-  Show (DbChangelog l)
+  (Show (TxIn blk), Show (TxOut blk), Show (l blk EmptyMK)) =>
+  Show (DbChangelog l blk)
 
-type DbChangelog' blk = DbChangelog (ExtLedgerState blk)
+type DbChangelog' blk = DbChangelog ExtLedgerState blk
 
 instance GetTip l => AS.Anchorable (WithOrigin SlotNo) (l EmptyMK) (l EmptyMK) where
   asAnchor = id
   getAnchorMeasure _ = getTipSlot
 
-instance IsLedger l blk => GetTip (K (DbChangelog (l blk))) where
+instance IsLedger l blk => GetTip (K (DbChangelog l blk)) where
   getTip =
     castPoint
       . getTip
@@ -315,8 +314,8 @@ instance IsLedger l blk => GetTip (K (DbChangelog (l blk))) where
       . unK
 
 type instance
-  HeaderHash (K @MapKind (DbChangelog l)) =
-    HeaderHash l
+  HeaderHash (K @MapKind (DbChangelog l blk)) =
+    HeaderHash (l blk)
 
 {-------------------------------------------------------------------------------
   Construction
@@ -324,8 +323,8 @@ type instance
 
 -- | Creates an empty @DbChangelog@.
 empty ::
-  (HasLedgerTables l, GetTip l) =>
-  l EmptyMK -> DbChangelog l
+  (HasLedgerTables l blk, GetTip (l blk)) =>
+  l blk EmptyMK -> DbChangelog l blk
 empty theAnchor =
   DbChangelog
     { changelogLastFlushedState = theAnchor
@@ -343,8 +342,8 @@ reapplyBlock ::
   ComputeLedgerEvents ->
   LedgerCfg l blk ->
   blk ->
-  KeySetsReader m (l blk) ->
-  DbChangelog (l blk) ->
+  KeySetsReader m l blk ->
+  DbChangelog l blk ->
   m (l blk DiffMK)
 reapplyBlock evs cfg b ksReader db =
   withKeysReadSets (current db) ksReader db (getBlockKeySets b) (return . tickThenReapply evs cfg b)
@@ -355,9 +354,9 @@ reapplyThenPush ::
   (Monad m, ApplyBlock l blk) =>
   LedgerDbCfg l blk ->
   blk ->
-  KeySetsReader m (l blk) ->
-  DbChangelog (l blk) ->
-  m (DbChangelog (l blk))
+  KeySetsReader m l blk ->
+  DbChangelog l blk ->
+  m (DbChangelog l blk)
 reapplyThenPush cfg ap ksReader db =
   (\current' -> pruneToImmTipOnly $ extend current' db)
     <$> reapplyBlock (ledgerDbCfgComputeLedgerEvents cfg) (ledgerDbCfg cfg) ap ksReader db
@@ -376,10 +375,10 @@ reapplyThenPush cfg ap ksReader db =
 --
 -- where the state @LX@ is from slot @X@.
 prune ::
-  GetTip l =>
+  GetTip (l blk) =>
   LedgerDbPrune ->
-  DbChangelog l ->
-  DbChangelog l
+  DbChangelog l blk ->
+  DbChangelog l blk
 prune LedgerDbPruneAll dblog =
   dblog{changelogStates = vol'}
  where
@@ -417,10 +416,10 @@ prune (LedgerDbPruneBeforeSlot slot) dblog =
 -- | @L2@ | @L2 :> [ L3, L4, L5, L6 ]@ | @[ D3, D4, D5, D6 ]@ |
 -- +------+----------------------------+----------------------+
 extend ::
-  (GetTip l, HasLedgerTables l) =>
-  l DiffMK ->
-  DbChangelog l ->
-  DbChangelog l
+  (GetTip (l blk), HasLedgerTables l blk) =>
+  l blk DiffMK ->
+  DbChangelog l blk ->
+  DbChangelog l blk
 extend newState dblog =
   DbChangelog
     { changelogLastFlushedState = changelogLastFlushedState
@@ -453,19 +452,19 @@ extend newState dblog =
   Read
 -------------------------------------------------------------------------------}
 
-type KeySetsReader m l = l EmptyMK -> LedgerTables l KeysMK -> m (UnforwardedReadSets l)
+type KeySetsReader m l blk = l blk EmptyMK -> LedgerTables blk KeysMK -> m (UnforwardedReadSets blk)
 
 readKeySets ::
   IOLike m =>
-  LedgerBackingStore m l ->
-  KeySetsReader m l
+  LedgerBackingStore m l blk ->
+  KeySetsReader m l blk
 readKeySets backingStore st rew = do
   withBsValueHandle backingStore (\bsvh -> readKeySetsWith bsvh st rew)
 
 readKeySetsWith ::
   Monad m =>
-  LedgerBackingStoreValueHandle m l ->
-  KeySetsReader m l
+  LedgerBackingStoreValueHandle m l blk ->
+  KeySetsReader m l blk
 readKeySetsWith bsvh st rew = do
   values <- bsvhRead bsvh st rew
   pure
@@ -476,12 +475,12 @@ readKeySetsWith bsvh st rew = do
       }
 
 withKeysReadSets ::
-  (HasLedgerTables l, Monad m, GetTip l) =>
-  l EmptyMK ->
-  KeySetsReader m l ->
-  DbChangelog l ->
-  LedgerTables l KeysMK ->
-  (l ValuesMK -> m a) ->
+  (HasLedgerTables l blk, Monad m, GetTip (l blk)) =>
+  l blk EmptyMK ->
+  KeySetsReader m l blk ->
+  DbChangelog l blk ->
+  LedgerTables blk KeysMK ->
+  (l blk ValuesMK -> m a) ->
   m a
 withKeysReadSets st ksReader dbch ks f = do
   urs <- ksReader st ks
@@ -505,24 +504,17 @@ withKeysReadSets st ksReader dbch ks f = do
       . withLedgerTables st
       <$> forwardTableKeySets dbch urs
 
-trivialKeySetsReader ::
-  (Monad m, LedgerTablesAreTrivial l) =>
-  WithOrigin SlotNo ->
-  KeySetsReader m l
-trivialKeySetsReader s _st _ =
-  pure $ UnforwardedReadSets s trivialLedgerTables trivialLedgerTables
-
 {-------------------------------------------------------------------------------
   Forward
 -------------------------------------------------------------------------------}
 
-data UnforwardedReadSets l = UnforwardedReadSets
+data UnforwardedReadSets blk = UnforwardedReadSets
   { ursSeqNo :: !(WithOrigin SlotNo)
   -- ^ The Slot number of the anchor of the 'DbChangelog' that was used when
   -- rewinding and reading.
-  , ursValues :: !(LedgerTables l ValuesMK)
+  , ursValues :: !(LedgerTables blk ValuesMK)
   -- ^ The values that were found in the 'BackingStore'.
-  , ursKeys :: !(LedgerTables l KeysMK)
+  , ursKeys :: !(LedgerTables blk KeysMK)
   -- ^ All the requested keys, being or not present in the 'BackingStore'.
   }
 
@@ -535,13 +527,13 @@ data RewindReadFwdError = RewindReadFwdError
   deriving Show
 
 forwardTableKeySets' ::
-  HasLedgerTables l =>
+  LedgerTableConstraints blk =>
   WithOrigin SlotNo ->
-  LedgerTables l SeqDiffMK ->
-  UnforwardedReadSets l ->
+  LedgerTables blk SeqDiffMK ->
+  UnforwardedReadSets blk ->
   Either
     RewindReadFwdError
-    (LedgerTables l ValuesMK)
+    (LedgerTables blk ValuesMK)
 forwardTableKeySets' seqNo chdiffs = \(UnforwardedReadSets seqNo' values keys) ->
   if seqNo /= seqNo'
     then Left $ RewindReadFwdError seqNo' seqNo
@@ -557,12 +549,12 @@ forwardTableKeySets' seqNo chdiffs = \(UnforwardedReadSets seqNo' values keys) -
     ValuesMK $ AntiDiff.applyDiffForKeys values keys (DS.cumulativeDiff diffs)
 
 forwardTableKeySets ::
-  (HasLedgerTables l, GetTip l) =>
-  DbChangelog l ->
-  UnforwardedReadSets l ->
+  (HasLedgerTables l blk, GetTip (l blk)) =>
+  DbChangelog l blk ->
+  UnforwardedReadSets blk ->
   Either
     RewindReadFwdError
-    (LedgerTables l ValuesMK)
+    (LedgerTables blk ValuesMK)
 forwardTableKeySets dblog =
   forwardTableKeySets'
     (getTipSlot $ changelogLastFlushedState dblog)
@@ -592,9 +584,9 @@ forwardTableKeySets dblog =
 -- |     @L0@     | @L4 :> [                ]@ | @[ D1, D2, D3, D4 ]@ |
 -- +--------------+----------------------------+----------------------+
 pruneToImmTipOnly ::
-  GetTip l =>
-  DbChangelog l ->
-  DbChangelog l
+  GetTip (l blk) =>
+  DbChangelog l blk ->
+  DbChangelog l blk
 pruneToImmTipOnly = prune LedgerDbPruneAll
 
 {-------------------------------------------------------------------------------
@@ -616,10 +608,10 @@ pruneToImmTipOnly = prune LedgerDbPruneAll
 -- |     @L2@     | @L3 :> [ ]           @ | @[ D2, D3             ]@ |
 -- +--------------+------------------------+--------------------------+
 rollbackN ::
-  (GetTip l, HasLedgerTables l) =>
+  (GetTip (l blk), HasLedgerTables l blk) =>
   Word64 ->
-  DbChangelog l ->
-  Maybe (DbChangelog l)
+  DbChangelog l blk ->
+  Maybe (DbChangelog l blk)
 rollbackN n dblog
   | n <= maxRollback dblog =
       Just $
@@ -658,10 +650,10 @@ rollbackN n dblog
 -- |     @L3@     | @L3 :> [ L4, L5, L6 ]@ | @[         D4, D5, D6 ]@                 |
 -- +--------------+------------------------+------------------------------------------+
 splitForFlushing ::
-  forall l.
-  (GetTip l, HasLedgerTables l) =>
-  DbChangelog l ->
-  (Maybe (DiffsToFlush l), DbChangelog l)
+  forall l blk.
+  (GetTip (l blk), HasLedgerTables l blk) =>
+  DbChangelog l blk ->
+  (Maybe (DiffsToFlush l blk), DbChangelog l blk)
 splitForFlushing dblog =
   if getTipSlot immTip == Origin || ltcollapse (ltmap (K2 . DS.length . getSeqDiffMK) l) == 0
     then (Nothing, dblog)
@@ -719,7 +711,7 @@ splitForFlushing dblog =
 -------------------------------------------------------------------------------}
 
 -- | The ledger state at the tip of the chain
-current :: GetTip l => DbChangelog l -> l EmptyMK
+current :: GetTip (l blk) => DbChangelog l blk -> l blk EmptyMK
 current =
   either id id
     . AS.head
@@ -727,7 +719,7 @@ current =
 
 -- | The ledger state at the anchor of the Volatile chain (i.e. the immutable
 -- tip).
-anchor :: DbChangelog l -> l EmptyMK
+anchor :: DbChangelog l blk -> l blk EmptyMK
 anchor =
   AS.anchor
     . changelogStates
@@ -736,25 +728,25 @@ anchor =
 --
 -- This also includes the snapshot at the anchor. For each snapshot we also
 -- return the distance from the tip.
-snapshots :: DbChangelog l -> [(Word64, l EmptyMK)]
+snapshots :: DbChangelog l blk -> [(Word64, l blk EmptyMK)]
 snapshots =
   zip [0 ..]
     . AS.toNewestFirst
     . changelogStates
 
 -- | How many blocks can we currently roll back?
-maxRollback :: GetTip l => DbChangelog l -> Word64
+maxRollback :: GetTip (l blk) => DbChangelog l blk -> Word64
 maxRollback =
   fromIntegral
     . AS.length
     . changelogStates
 
 -- | Reference to the block at the tip of the chain
-tip :: GetTip l => DbChangelog l -> Point l
+tip :: GetTip (l blk) => DbChangelog l blk -> Point (l blk)
 tip = castPoint . getTip . current
 
 -- | Have we seen at least @k@ blocks?
-isSaturated :: GetTip l => SecurityParam -> DbChangelog l -> Bool
+isSaturated :: GetTip (l blk) => SecurityParam -> DbChangelog l blk -> Bool
 isSaturated (SecurityParam k) db =
   maxRollback db >= unNonZero k
 
@@ -769,20 +761,20 @@ getPastLedgerAt ::
   , IsLedger l blk
   , HeaderHash (l blk) ~ HeaderHash blk
   , StandardHash (l blk)
-  , HasLedgerTables (l blk)
+  , HasLedgerTables l blk
   ) =>
   Point blk ->
-  DbChangelog (l blk) ->
+  DbChangelog l blk ->
   Maybe (l blk EmptyMK)
 getPastLedgerAt pt db = current <$> rollback pt db
 
 -- | Roll back the volatile states up to the specified point.
 rollbackToPoint ::
-  ( StandardHash l
-  , GetTip l
-  , HasLedgerTables l
+  ( StandardHash (l blk)
+  , GetTip (l blk)
+  , HasLedgerTables l blk
   ) =>
-  Point l -> DbChangelog l -> Maybe (DbChangelog l)
+  Point (l blk) -> DbChangelog l blk -> Maybe (DbChangelog l blk)
 rollbackToPoint pt dblog = do
   vol' <-
     AS.rollback
@@ -807,8 +799,8 @@ rollbackToPoint pt dblog = do
 
 -- | Rollback the volatile states up to the volatile anchor.
 rollbackToAnchor ::
-  (GetTip l, HasLedgerTables l) =>
-  DbChangelog l -> DbChangelog l
+  (GetTip (l blk), HasLedgerTables l blk) =>
+  DbChangelog l blk -> DbChangelog l blk
 rollbackToAnchor dblog =
   DbChangelog
     { changelogLastFlushedState
@@ -842,11 +834,11 @@ rollback ::
   , IsLedger l blk
   , HeaderHash (l blk) ~ HeaderHash blk
   , StandardHash (l blk)
-  , HasLedgerTables (l blk)
+  , HasLedgerTables l blk
   ) =>
   Point blk ->
-  DbChangelog (l blk) ->
-  Maybe (DbChangelog (l blk))
+  DbChangelog l blk ->
+  Maybe (DbChangelog l blk)
 rollback pt db
   | pt == castPoint (getTip (anchor db)) =
       Just $ rollbackToAnchor db
@@ -854,8 +846,8 @@ rollback pt db
       rollbackToPoint (castPoint pt) db
 
 immutableTipSlot ::
-  GetTip l =>
-  DbChangelog l -> WithOrigin SlotNo
+  GetTip (l blk) =>
+  DbChangelog l blk -> WithOrigin SlotNo
 immutableTipSlot =
   getTipSlot
     . AS.anchor
@@ -865,8 +857,8 @@ immutableTipSlot =
 --
 -- NOTE: This will be wrong once we have more than one table.
 flushableLength ::
-  (HasLedgerTables l, GetTip l) =>
-  DbChangelog l ->
+  (HasLedgerTables l blk, GetTip (l blk)) =>
+  DbChangelog l blk ->
   Word64
 flushableLength chlog =
   (\x -> x - fromIntegral (AS.length (changelogStates chlog)))
@@ -883,9 +875,9 @@ flushableLength chlog =
 -- | Transform the underlying volatile 'AnchoredSeq' using the given functions.
 volatileStatesBimap ::
   AS.Anchorable (WithOrigin SlotNo) a b =>
-  (l EmptyMK -> a) ->
-  (l EmptyMK -> b) ->
-  DbChangelog l ->
+  (l blk EmptyMK -> a) ->
+  (l blk EmptyMK -> b) ->
+  DbChangelog l blk ->
   AS.AnchoredSeq (WithOrigin SlotNo) a b
 volatileStatesBimap f g =
   AS.bimap f g
@@ -899,29 +891,18 @@ reapplyThenPush' ::
   ApplyBlock l blk =>
   LedgerDbCfg l blk ->
   blk ->
-  KeySetsReader Identity (l blk) ->
-  DbChangelog (l blk) ->
-  DbChangelog (l blk)
+  KeySetsReader Identity l blk ->
+  DbChangelog l blk ->
+  DbChangelog l blk
 reapplyThenPush' cfg b bk = runIdentity . reapplyThenPush cfg b bk
-
-reapplyThenPushMany' ::
-  (ApplyBlock l blk, LedgerTablesAreTrivial (l blk)) =>
-  LedgerDbCfg l blk ->
-  [blk] ->
-  DbChangelog (l blk) ->
-  DbChangelog (l blk)
-reapplyThenPushMany' cfg bs dblog =
-  runIdentity
-    . reapplyThenPushMany cfg bs (trivialKeySetsReader (getTipSlot (changelogLastFlushedState dblog)))
-    $ dblog
 
 reapplyThenPushMany ::
   (ApplyBlock l blk, Monad m) =>
   LedgerDbCfg l blk ->
   [blk] ->
-  KeySetsReader m (l blk) ->
-  DbChangelog (l blk) ->
-  m (DbChangelog (l blk))
+  KeySetsReader m l blk ->
+  DbChangelog l blk ->
+  m (DbChangelog l blk)
 reapplyThenPushMany cfg aps ksReader =
   repeatedlyM (\ap -> reapplyThenPush cfg ap ksReader) aps
 
@@ -930,9 +911,9 @@ switch ::
   LedgerDbCfg l blk ->
   Word64 ->
   [blk] ->
-  KeySetsReader m (l blk) ->
-  DbChangelog (l blk) ->
-  m (Either ExceededRollback (DbChangelog (l blk)))
+  KeySetsReader m l blk ->
+  DbChangelog l blk ->
+  m (Either ExceededRollback (DbChangelog l blk))
 switch cfg numRollbacks newBlocks ksReader db =
   case rollbackN numRollbacks db of
     Nothing ->
@@ -954,13 +935,32 @@ switch cfg numRollbacks newBlocks ksReader db =
               ksReader
               db'
 
+trivialKeySetsReader ::
+  forall m l blk.
+  (Monad m, LedgerTablesAreTrivial l blk) =>
+  WithOrigin SlotNo ->
+  KeySetsReader m l blk
+trivialKeySetsReader s _st _ =
+  pure $ UnforwardedReadSets s (trivialLedgerTables (Proxy @l)) (trivialLedgerTables (Proxy @l))
+
+reapplyThenPushMany' ::
+  (ApplyBlock l blk, LedgerTablesAreTrivial l blk) =>
+  LedgerDbCfg l blk ->
+  [blk] ->
+  DbChangelog l blk ->
+  DbChangelog l blk
+reapplyThenPushMany' cfg bs dblog =
+  runIdentity
+    . reapplyThenPushMany cfg bs (trivialKeySetsReader (getTipSlot (changelogLastFlushedState dblog)))
+    $ dblog
+
 switch' ::
-  (ApplyBlock l blk, LedgerTablesAreTrivial (l blk)) =>
+  (ApplyBlock l blk, LedgerTablesAreTrivial l blk) =>
   LedgerDbCfg l blk ->
   Word64 ->
   [blk] ->
-  DbChangelog (l blk) ->
-  Maybe (DbChangelog (l blk))
+  DbChangelog l blk ->
+  Maybe (DbChangelog l blk)
 switch' cfg n bs db =
   case runIdentity $ switch cfg n bs (trivialKeySetsReader (getTipSlot (changelogLastFlushedState db))) db of
     Left ExceededRollback{} -> Nothing

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/V1/Forker.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/V1/Forker.hs
@@ -57,17 +57,17 @@ data ForkerEnv m l blk = ForkerEnv
       !( StrictMVar
            m
            ( Either
-               (LedgerDBLock m, LedgerBackingStore m l)
-               (LedgerBackingStoreValueHandle m l)
+               (LedgerDBLock m, LedgerBackingStore m l blk)
+               (LedgerBackingStoreValueHandle m l blk)
            )
        )
   -- ^ Either the ingredients to create a value handle or a value handle, i.e. a
   -- local, consistent view of backing store. Use 'getValueHandle' to promote
   -- this from a Left to a Right if needed.
-  , foeChangelog :: !(StrictTVar m (DbChangelog l))
+  , foeChangelog :: !(StrictTVar m (DbChangelog l blk))
   -- ^ In memory db changelog, 'foeBackingStoreValueHandle' must refer to
   -- the anchor of this changelog.
-  , foeSwitchVar :: !(StrictTVar m (DbChangelog l))
+  , foeSwitchVar :: !(StrictTVar m (DbChangelog l blk))
   -- ^ The same 'StrictTVar' as 'ldbChangelog'
   --
   -- The anchor of this and 'foeChangelog' might get out of sync if diffs are
@@ -81,9 +81,9 @@ data ForkerEnv m l blk = ForkerEnv
 deriving instance
   ( IOLike m
   , LedgerSupportsProtocol blk
-  , NoThunks (l EmptyMK)
-  , NoThunks (TxIn l)
-  , NoThunks (TxOut l)
+  , NoThunks (l blk EmptyMK)
+  , NoThunks (TxIn blk)
+  , NoThunks (TxOut blk)
   ) =>
   NoThunks (ForkerEnv m l blk)
 
@@ -110,7 +110,8 @@ closeForkerEnv ForkerEnv{foeBackingStoreValueHandle, foeTracer, foeWasCommitted}
 
 -- | Get the value handle in a forker, creating it on demand if this is the
 -- first time we access the tables.
-getValueHandle :: (GetTip l, IOLike m) => ForkerEnv m l blk -> m (LedgerBackingStoreValueHandle m l)
+getValueHandle ::
+  (GetTip (l blk), IOLike m) => ForkerEnv m l blk -> m (LedgerBackingStoreValueHandle m l blk)
 getValueHandle ForkerEnv{foeBackingStoreValueHandle, foeChangelog} = mask_ $ do
   -- Note this is masked, so the inner function in 'modifyMVar' will also be
   -- masked.
@@ -135,10 +136,10 @@ getValueHandle ForkerEnv{foeBackingStoreValueHandle, foeChangelog} = mask_ $ do
               )
 
 implForkerReadTables ::
-  (IOLike m, HasLedgerTables l, GetTip l) =>
+  (IOLike m, HasLedgerTables l blk, GetTip (l blk)) =>
   ForkerEnv m l blk ->
-  LedgerTables l KeysMK ->
-  m (LedgerTables l ValuesMK)
+  LedgerTables blk KeysMK ->
+  m (LedgerTables blk ValuesMK)
 implForkerReadTables env ks =
   encloseTimedWith (ForkerReadTables >$< foeTracer env) $ do
     chlog <- readTVarIO (foeChangelog env)
@@ -149,11 +150,11 @@ implForkerReadTables env ks =
       Right vs -> pure vs
 
 implForkerRangeReadTables ::
-  (IOLike m, GetTip l, HasLedgerTables l) =>
+  (IOLike m, GetTip (l blk), HasLedgerTables l blk) =>
   QueryBatchSize ->
   ForkerEnv m l blk ->
-  RangeQueryPrevious l ->
-  m (LedgerTables l ValuesMK, Maybe (TxIn l))
+  RangeQueryPrevious blk ->
+  m (LedgerTables blk ValuesMK, Maybe (TxIn blk))
 implForkerRangeReadTables qbs env rq0 =
   encloseTimedWith (ForkerRangeReadTables >$< foeTracer env) $ do
     ldb <- readTVarIO $ foeChangelog env
@@ -268,15 +269,15 @@ implForkerRangeReadTables qbs env rq0 =
                       (Diff.filterWithKeyOnly (< k) ds)
 
 implForkerGetLedgerState ::
-  (MonadSTM m, GetTip l) =>
+  (MonadSTM m, GetTip (l blk)) =>
   ForkerEnv m l blk ->
-  STM m (l EmptyMK)
+  STM m (l blk EmptyMK)
 implForkerGetLedgerState env = current <$> readTVar (foeChangelog env)
 
 -- | Obtain statistics for a combination of backing store value handle and
 -- changelog.
 implForkerReadStatistics ::
-  (IOLike m, HasLedgerTables l, GetTip l) =>
+  (IOLike m, HasLedgerTables l blk, GetTip (l blk)) =>
   ForkerEnv m l blk ->
   m Forker.Statistics
 implForkerReadStatistics env = do
@@ -313,9 +314,9 @@ implForkerReadStatistics env = do
           }
 
 implForkerPush ::
-  (IOLike m, GetTip l, HasLedgerTables l) =>
+  (IOLike m, GetTip (l blk), HasLedgerTables l blk) =>
   ForkerEnv m l blk ->
-  l DiffMK ->
+  l blk DiffMK ->
   m ()
 implForkerPush env newState =
   encloseTimedWith (ForkerPush >$< foeTracer env) $ do
@@ -325,7 +326,7 @@ implForkerPush env newState =
       writeTVar (foeChangelog env) chlog'
 
 implForkerCommit ::
-  (MonadSTM m, GetTip l, StandardHash l, HasLedgerTables l) =>
+  (MonadSTM m, GetTip (l blk), StandardHash (l blk), HasLedgerTables l blk) =>
   ForkerEnv m l blk ->
   STM m ()
 implForkerCommit env = do

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/V1/Snapshots.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/V1/Snapshots.hs
@@ -284,7 +284,6 @@ loadSnapshot ::
   forall m blk.
   ( IOLike m
   , LedgerSupportsProtocol blk
-  , LedgerSupportsV1LedgerDB LedgerState blk
   , LedgerDbSerialiseConstraints blk
   ) =>
   Tracer m V1.SomeBackendTrace ->

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/V1/Snapshots.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/V1/Snapshots.hs
@@ -284,18 +284,18 @@ loadSnapshot ::
   forall m blk.
   ( IOLike m
   , LedgerSupportsProtocol blk
-  , LedgerSupportsV1LedgerDB (LedgerState blk)
+  , LedgerSupportsV1LedgerDB LedgerState blk
   , LedgerDbSerialiseConstraints blk
   ) =>
   Tracer m V1.SomeBackendTrace ->
-  SomeBackendArgs m (ExtLedgerState blk) ->
+  SomeBackendArgs m ExtLedgerState blk ->
   CodecConfig blk ->
   SnapshotsFS m ->
   DiskSnapshot ->
   ExceptT
     (SnapshotFailure blk)
     m
-    ((DbChangelog' blk, LedgerBackingStore m (ExtLedgerState blk)), RealPoint blk)
+    ((DbChangelog' blk, LedgerBackingStore m ExtLedgerState blk), RealPoint blk)
 loadSnapshot tracer bArgs@(SomeBackendArgs bss) ccfg fs@(SnapshotsFS fs'@(SomeHasFS hfs)) s = do
   fileEx <- lift $ FS.doesFileExist hfs (snapshotToDirPath s)
   Monad.when fileEx $ throwError $ InitFailureRead ReadSnapshotIsLegacy
@@ -306,7 +306,7 @@ loadSnapshot tracer bArgs@(SomeBackendArgs bss) ccfg fs@(SnapshotsFS fs'@(SomeHa
     withExceptT (InitFailureRead . ReadMetadataError (snapshotToMetadataPath s)) $
       loadSnapshotMetadata fs' s
   Monad.unless
-    (isRightBackendForSnapshot (Proxy @(ExtLedgerState blk)) bss (snapshotBackend snapshotMeta))
+    (isRightBackendForSnapshot (Proxy @ExtLedgerState) (Proxy @blk) bss (snapshotBackend snapshotMeta))
     $ throwError
     $ InitFailureRead
     $ ReadMetadataError (snapshotToMetadataPath s) MetadataBackendMismatch

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/V2.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/V2.hs
@@ -65,7 +65,7 @@ import Ouroboros.Network.Protocol.LocalStateQuery.Type
 import System.FS.API
 import Prelude hiding (read)
 
-type SnapshotManagerV2 m blk = SnapshotManager m m blk (StateRef m (ExtLedgerState blk))
+type SnapshotManagerV2 m blk = SnapshotManager m m blk (StateRef m ExtLedgerState blk)
 
 newtype SnapshotExc blk = SnapshotExc {getSnapshotFailure :: SnapshotFailure blk}
   deriving (Show, Exception)
@@ -150,7 +150,7 @@ implMkLedgerDb ::
   , ApplyBlock l blk
   ) =>
   LedgerDBHandle m l blk ->
-  SnapshotManager m m blk (StateRef m (l blk)) ->
+  SnapshotManager m m blk (StateRef m l blk) ->
   (LedgerDB m l blk, TestInternals m l blk)
 implMkLedgerDb h snapManager =
   let ldb =
@@ -176,7 +176,7 @@ mkInternals ::
   ) =>
   LedgerDB m l blk ->
   LedgerDBHandle m l blk ->
-  SnapshotManager m m blk (StateRef m (l blk)) ->
+  SnapshotManager m m blk (StateRef m l blk) ->
   TestInternals m l blk
 mkInternals ldb h snapManager =
   TestInternals
@@ -295,7 +295,7 @@ implValidate ::
   BlockCache blk ->
   Word64 ->
   NonEmpty (Header blk) ->
-  SuccessForkerAction m (l blk) ->
+  SuccessForkerAction m l blk ->
   m (ValidateResult l blk)
 implValidate h ldbEnv tr cache rollbacks hdrs onSuccess =
   validate (ledgerDbCfgComputeLedgerEvents $ ldbCfg ldbEnv) $
@@ -333,7 +333,7 @@ implTryTakeSnapshot ::
   ( IOLike m
   , GetTip (l blk)
   ) =>
-  SnapshotManager m m blk (StateRef m (l blk)) ->
+  SnapshotManager m m blk (StateRef m l blk) ->
   LedgerDBEnv m l blk ->
   m () ->
   (SnapshotDelayRange -> m DiffTime) ->
@@ -389,7 +389,7 @@ implTryTakeSnapshot snapManager env copyBlocks getRandomDelay = do
       traceWith (LedgerDBSnapshotEvent >$< ldbTracer env) $
         SnapshotRequestCompleted
  where
-  duplicateStateRef :: StateRef m (l blk) -> m (StateRef m (l blk))
+  duplicateStateRef :: StateRef m l blk -> m (StateRef m l blk)
   duplicateStateRef StateRef{state, tables} = do
     h <- duplicate tables
     pure $ StateRef state h
@@ -425,7 +425,7 @@ implCloseDB (LDBHandle varState) = do
 
 type LedgerDBEnv :: (Type -> Type) -> StateKind -> Type -> Type
 data LedgerDBEnv m l blk = LedgerDBEnv
-  { ldbSeq :: !(StrictTVar m (LedgerSeq m (l blk)))
+  { ldbSeq :: !(StrictTVar m (LedgerSeq m l blk))
   -- ^ INVARIANT: the tip of the 'LedgerDB' is always in sync with the tip of
   -- the current chain of the ChainDB.
   , ldbPrevApplied :: !(StrictTVar m (Set (RealPoint blk)))
@@ -476,8 +476,8 @@ deriving instance
   ( IOLike m
   , LedgerSupportsProtocol blk
   , NoThunks (l blk EmptyMK)
-  , NoThunks (TxIn (l blk))
-  , NoThunks (TxOut (l blk))
+  , NoThunks (TxIn blk)
+  , NoThunks (TxOut blk)
   , NoThunks (LedgerCfg l blk)
   , NoThunks (SomeResources m blk)
   ) =>
@@ -501,8 +501,8 @@ deriving instance
   ( IOLike m
   , LedgerSupportsProtocol blk
   , NoThunks (l blk EmptyMK)
-  , NoThunks (TxIn (l blk))
-  , NoThunks (TxOut (l blk))
+  , NoThunks (TxIn blk)
+  , NoThunks (TxOut blk)
   , NoThunks (LedgerCfg l blk)
   , NoThunks (SomeResources m blk)
   ) =>
@@ -566,7 +566,7 @@ getEnvSTM (LDBHandle varState) f =
 -- collection has not yet been run.
 getVolatileLedgerSeq ::
   (MonadSTM m, GetTip (l blk)) =>
-  LedgerDBEnv m l blk -> STM m (LedgerSeq m (l blk))
+  LedgerDBEnv m l blk -> STM m (LedgerSeq m l blk)
 getVolatileLedgerSeq env = do
   volSuffix <- getVolatileSuffix (ldbGetVolatileSuffix env)
   LedgerSeq . volSuffix . getLedgerSeq <$> readTVar (ldbSeq env)
@@ -582,8 +582,8 @@ getVolatileLedgerSeq env = do
 openStateRef ::
   (IOLike m, Traversable t, GetTip (l blk)) =>
   LedgerDBEnv m l blk ->
-  (LedgerSeq m (l blk) -> t (StateRef m (l blk))) ->
-  m (t (StateRef m (l blk)))
+  (LedgerSeq m l blk -> t (StateRef m l blk)) ->
+  m (t (StateRef m l blk))
 openStateRef ldbEnv project =
   RAWLock.withReadAccess (ldbOpenHandlesLock ldbEnv) $ \() -> do
     tst <- project <$> atomically (getVolatileLedgerSeq ldbEnv)
@@ -596,8 +596,8 @@ openStateRef ldbEnv project =
 withStateRef ::
   (IOLike m, Traversable t, GetTip (l blk)) =>
   LedgerDBEnv m l blk ->
-  (LedgerSeq m (l blk) -> t (StateRef m (l blk))) ->
-  (t (StateRef m (l blk)) -> m a) ->
+  (LedgerSeq m l blk -> t (StateRef m l blk)) ->
+  (t (StateRef m l blk) -> m a) ->
   m a
 withStateRef ldbEnv project f =
   bracket
@@ -614,7 +614,7 @@ openStateRefAtTarget ::
   ) =>
   LedgerDBEnv m l blk ->
   Either Word64 (Target (Point blk)) ->
-  m (Either GetForkerError (StateRef m (l blk)))
+  m (Either GetForkerError (StateRef m l blk))
 openStateRefAtTarget ldbEnv target =
   openStateRef ldbEnv $ \l -> case target of
     Right VolatileTip -> pure $ currentHandle l
@@ -641,13 +641,13 @@ openNewForkerAtTarget ::
   ( HeaderHash (l blk) ~ HeaderHash blk
   , IOLike m
   , IsLedger l blk
-  , HasLedgerTables (l blk)
+  , HasLedgerTables l blk
   , LedgerSupportsProtocol blk
   , StandardHash (l blk)
   ) =>
   LedgerDBHandle m l blk ->
   Target (Point blk) ->
-  m (Either GetForkerError (Forker m (l blk)))
+  m (Either GetForkerError (Forker m l blk))
 openNewForkerAtTarget h pt = getEnv h $ \ldbEnv ->
   openStateRefAtTarget ldbEnv (Right pt) >>= traverse (newForker ldbEnv)
 
@@ -656,12 +656,12 @@ withForkerByRollback ::
   , IOLike m
   , IsLedger l blk
   , StandardHash (l blk)
-  , HasLedgerTables (l blk)
+  , HasLedgerTables l blk
   , LedgerSupportsProtocol blk
   ) =>
   LedgerDBHandle m l blk ->
   Word64 ->
-  (Forker m (l blk) -> m r) ->
+  (Forker m l blk -> m r) ->
   m (Either GetForkerError r)
 withForkerByRollback h n k = getEnv h $ \ldbEnv ->
   bracket
@@ -673,7 +673,7 @@ withForkerByRollback h n k = getEnv h $ \ldbEnv ->
 -- first duplicate if the forker has been committed.
 implForkerClose ::
   IOLike m =>
-  ForkerEnv m l ->
+  ForkerEnv m l blk ->
   m ()
 implForkerClose env = do
   wasCommitted <- readTVarIO (foeWasCommitted env)
@@ -686,14 +686,14 @@ implForkerClose env = do
 
 newForker ::
   ( IOLike m
-  , HasLedgerTables (l blk)
+  , HasLedgerTables l blk
   , NoThunks (l blk EmptyMK)
   , GetTip (l blk)
   , StandardHash (l blk)
   ) =>
   LedgerDBEnv m l blk ->
-  StateRef m (l blk) ->
-  m (Forker m (l blk))
+  StateRef m l blk ->
+  m (Forker m l blk)
 newForker ldbEnv st = do
   forkerKey <- atomically $ stateTVar (ldbNextForkerKey ldbEnv) $ \r -> (r, r + 1)
   let tr = LedgerDBForkerEvent . TraceForkerEventWithKey forkerKey >$< ldbTracer ldbEnv

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/V2/Backend.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/V2/Backend.hs
@@ -62,7 +62,7 @@ class NoThunks (Resources m backend) => Backend m backend blk where
     Tracer m LedgerDBV2Trace ->
     Resources m backend ->
     ExtLedgerState blk ValuesMK ->
-    m (StateRef m (ExtLedgerState blk))
+    m (StateRef m ExtLedgerState blk)
 
   -- | Create a new handle from a snapshot.
   openStateRefFromSnapshot ::
@@ -74,7 +74,7 @@ class NoThunks (Resources m backend) => Backend m backend blk where
     ExceptT
       (SnapshotFailure blk)
       m
-      (StateRef m (ExtLedgerState blk), RealPoint blk)
+      (StateRef m ExtLedgerState blk, RealPoint blk)
 
   -- | Instantiate the 'SnapshotManager' for this backend.
   snapshotManager ::
@@ -83,7 +83,7 @@ class NoThunks (Resources m backend) => Backend m backend blk where
     CodecConfig blk ->
     Tracer m (TraceSnapshotEvent blk) ->
     SomeHasFS m ->
-    SnapshotManager m m blk (StateRef m (ExtLedgerState blk))
+    SnapshotManager m m blk (StateRef m ExtLedgerState blk)
 
 {-------------------------------------------------------------------------------
   Existentials

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/V2/Forker.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/V2/Forker.hs
@@ -43,10 +43,10 @@ import qualified Ouroboros.Network.AnchoredSeq as AS
 import Prelude hiding (read)
 
 -- | The state inside a forker.
-data ForkerEnv m l = ForkerEnv
-  { foeLedgerSeq :: !(StrictTVar m (LedgerSeq m l))
+data ForkerEnv m l blk = ForkerEnv
+  { foeLedgerSeq :: !(StrictTVar m (LedgerSeq m l blk))
   -- ^ Local version of the LedgerSeq
-  , foeSwitchVar :: !(StrictTVar m (LedgerSeq m l))
+  , foeSwitchVar :: !(StrictTVar m (LedgerSeq m l blk))
   -- ^ This TVar is the same as the LedgerDB one
   , foeTracer :: !(Tracer m TraceForkerEvent)
   -- ^ Config
@@ -58,32 +58,32 @@ data ForkerEnv m l = ForkerEnv
 
 deriving instance
   ( IOLike m
-  , NoThunks (l EmptyMK)
-  , NoThunks (TxIn l)
-  , NoThunks (TxOut l)
+  , NoThunks (l blk EmptyMK)
+  , NoThunks (TxIn blk)
+  , NoThunks (TxOut blk)
   ) =>
-  NoThunks (ForkerEnv m l)
+  NoThunks (ForkerEnv m l blk)
 
 {-------------------------------------------------------------------------------
   Forker operations
 -------------------------------------------------------------------------------}
 
 implForkerReadTables ::
-  (IOLike m, GetTip l) =>
-  ForkerEnv m l ->
-  LedgerTables l KeysMK ->
-  m (LedgerTables l ValuesMK)
+  (IOLike m, GetTip (l blk)) =>
+  ForkerEnv m l blk ->
+  LedgerTables blk KeysMK ->
+  m (LedgerTables blk ValuesMK)
 implForkerReadTables env ks =
   encloseTimedWith (ForkerReadTables >$< foeTracer env) $ do
     stateRef <- currentHandle <$> readTVarIO (foeLedgerSeq env)
     read (tables stateRef) (state stateRef) ks
 
 implForkerRangeReadTables ::
-  (IOLike m, GetTip l, HasLedgerTables l) =>
+  (IOLike m, GetTip (l blk), HasLedgerTables l blk) =>
   QueryBatchSize ->
-  ForkerEnv m l ->
-  RangeQueryPrevious l ->
-  m (LedgerTables l ValuesMK, Maybe (TxIn l))
+  ForkerEnv m l blk ->
+  RangeQueryPrevious blk ->
+  m (LedgerTables blk ValuesMK, Maybe (TxIn blk))
 implForkerRangeReadTables qbs env rq0 =
   encloseTimedWith (ForkerRangeReadTables >$< foeTracer env) $ do
     let n = fromIntegral $ defaultQueryBatchSize qbs
@@ -95,23 +95,23 @@ implForkerRangeReadTables qbs env rq0 =
         readRange (tables stateRef) (state stateRef) (Just k, n)
 
 implForkerGetLedgerState ::
-  (MonadSTM m, GetTip l) =>
-  ForkerEnv m l ->
-  STM m (l EmptyMK)
+  (MonadSTM m, GetTip (l blk)) =>
+  ForkerEnv m l blk ->
+  STM m (l blk EmptyMK)
 implForkerGetLedgerState = fmap current . readTVar . foeLedgerSeq
 
 implForkerReadStatistics ::
-  (MonadSTM m, GetTip l) =>
-  ForkerEnv m l ->
+  (MonadSTM m, GetTip (l blk)) =>
+  ForkerEnv m l blk ->
   m Statistics
 implForkerReadStatistics env = do
   traceWith (foeTracer env) ForkerReadStatistics
   Statistics . tablesSize . tables . currentHandle <$> readTVarIO (foeLedgerSeq env)
 
 implForkerPush ::
-  (IOLike m, GetTip l, HasLedgerTables l, HasCallStack) =>
-  ForkerEnv m l ->
-  l DiffMK ->
+  (IOLike m, GetTip (l blk), HasLedgerTables l blk, HasCallStack) =>
+  ForkerEnv m l blk ->
+  l blk DiffMK ->
   m ()
 implForkerPush env newState = do
   encloseTimedWith (ForkerPush >$< foeTracer env) $ do
@@ -128,8 +128,8 @@ implForkerPush env newState = do
     atomically $ writeTVar (foeLedgerSeq env) (extend (StateRef st tbs) lseq)
 
 implForkerCommit ::
-  (IOLike m, GetTip l, StandardHash l) =>
-  ForkerEnv m l ->
+  (IOLike m, GetTip (l blk), StandardHash (l blk)) =>
+  ForkerEnv m l blk ->
   STM m (m ())
 implForkerCommit env = do
   wasCommitted <- readTVar (foeWasCommitted env)

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/V2/InMemory.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/V2/InMemory.hs
@@ -74,20 +74,20 @@ import Prelude hiding (read)
 -------------------------------------------------------------------------------}
 
 newInMemoryLedgerTablesHandle ::
-  forall m l.
+  forall m l blk.
   ( IOLike m
-  , HasLedgerTables l
-  , CanUpgradeLedgerTables l
-  , SerializeTablesWithHint l
-  , StandardHash l
-  , GetTip l
+  , HasLedgerTables l blk
+  , CanUpgradeLedgerTables l blk
+  , SerializeTablesWithHint l blk
+  , StandardHash (l blk)
+  , GetTip (l blk)
   ) =>
   Tracer m LedgerDBV2Trace ->
   -- | FileSystem in order to take snapshots
   SomeHasFS m ->
   -- | The tables
-  LedgerTables l ValuesMK ->
-  m (LedgerTablesHandle m l)
+  LedgerTables blk ValuesMK ->
+  m (LedgerTablesHandle m l blk)
 newInMemoryLedgerTablesHandle !tracer !someFS@(SomeHasFS !hasFS) tables =
   encloseTimedWith (TraceLedgerTablesHandleCreate >$< tracer) $
     let h =
@@ -110,39 +110,39 @@ newInMemoryLedgerTablesHandle !tracer !someFS@(SomeHasFS !hasFS) tables =
 
 implRead ::
   ( IOLike m
-  , HasLedgerTables l
+  , HasLedgerTables l blk
   ) =>
-  LedgerTables l ValuesMK ->
-  l EmptyMK ->
-  LedgerTables l KeysMK ->
-  m (LedgerTables l ValuesMK)
+  LedgerTables blk ValuesMK ->
+  l blk EmptyMK ->
+  LedgerTables blk KeysMK ->
+  m (LedgerTables blk ValuesMK)
 implRead tables _ keys = do
   pure $ flip (ltliftA2 (\(ValuesMK v) (KeysMK k) -> ValuesMK $ v `Map.restrictKeys` k)) keys tables
 
 implReadRange ::
-  (IOLike m, HasLedgerTables l) =>
-  LedgerTables l ValuesMK ->
-  l EmptyMK ->
-  (Maybe (TxIn l), Int) ->
-  m (LedgerTables l ValuesMK, Maybe (TxIn l))
+  (IOLike m, HasLedgerTables l blk) =>
+  LedgerTables blk ValuesMK ->
+  l blk EmptyMK ->
+  (Maybe (TxIn blk), Int) ->
+  m (LedgerTables blk ValuesMK, Maybe (TxIn blk))
 implReadRange (LedgerTables (ValuesMK m)) _ (f, t) =
   let m' = Map.take t . (maybe id (\g -> snd . Map.split g) f) $ m
    in pure (LedgerTables (ValuesMK m'), fst <$> Map.lookupMax m')
 
 implDuplicateWithDiffs ::
   ( IOLike m
-  , HasLedgerTables l
-  , CanUpgradeLedgerTables l
-  , StandardHash l
-  , GetTip l
-  , SerializeTablesWithHint l
+  , HasLedgerTables l blk
+  , CanUpgradeLedgerTables l blk
+  , StandardHash (l blk)
+  , GetTip (l blk)
+  , SerializeTablesWithHint l blk
   ) =>
   Tracer m LedgerDBV2Trace ->
-  LedgerTables l ValuesMK ->
+  LedgerTables blk ValuesMK ->
   SomeHasFS m ->
-  l mk1 ->
-  l DiffMK ->
-  m (LedgerTablesHandle m l)
+  l blk mk1 ->
+  l blk DiffMK ->
+  m (LedgerTablesHandle m l blk)
 implDuplicateWithDiffs !tracer tables !someFS st0 !diffs = do
   let newtables =
         flip
@@ -153,10 +153,10 @@ implDuplicateWithDiffs !tracer tables !someFS st0 !diffs = do
   newInMemoryLedgerTablesHandle tracer someFS newtables
 
 implTakeHandleSnapshot ::
-  (IOLike m, SerializeTablesWithHint l) =>
-  LedgerTables l ValuesMK ->
+  (IOLike m, SerializeTablesWithHint l blk) =>
+  LedgerTables blk ValuesMK ->
   HasFS m h ->
-  l EmptyMK ->
+  l blk EmptyMK ->
   String ->
   m (Maybe CRC)
 implTakeHandleSnapshot values hasFS hint snapshotName = do
@@ -179,7 +179,7 @@ snapshotManager ::
   CodecConfig blk ->
   Tracer m (TraceSnapshotEvent blk) ->
   SomeHasFS m ->
-  SnapshotManager m m blk (StateRef m (ExtLedgerState blk))
+  SnapshotManager m m blk (StateRef m ExtLedgerState blk)
 snapshotManager ccfg tracer fs =
   SnapshotManager
     { listSnapshots = defaultListSnapshots fs
@@ -197,7 +197,7 @@ implTakeSnapshot ::
   Tracer m (TraceSnapshotEvent blk) ->
   SomeHasFS m ->
   Maybe String ->
-  StateRef m (ExtLedgerState blk) ->
+  StateRef m ExtLedgerState blk ->
   m (Maybe (DiskSnapshot, RealPoint blk))
 implTakeSnapshot ccfg tracer shfs@(SomeHasFS hasFS) suffix st = do
   case pointToWithOriginRealPoint (castPoint (getTip $ state st)) of
@@ -234,13 +234,13 @@ loadSnapshot ::
   ( LedgerDbSerialiseConstraints blk
   , LedgerSupportsProtocol blk
   , IOLike m
-  , LedgerSupportsInMemoryLedgerDB (LedgerState blk)
+  , LedgerSupportsInMemoryLedgerDB LedgerState blk
   ) =>
   Tracer m LedgerDBV2Trace ->
   CodecConfig blk ->
   SomeHasFS m ->
   DiskSnapshot ->
-  ExceptT (SnapshotFailure blk) m (StateRef m (ExtLedgerState blk), RealPoint blk)
+  ExceptT (SnapshotFailure blk) m (StateRef m ExtLedgerState blk, RealPoint blk)
 loadSnapshot tracer ccfg fs@(SomeHasFS hfs) ds = do
   fileEx <- lift $ doesFileExist hfs (snapshotToDirPath ds)
   Monad.when fileEx $ throwE $ InitFailureRead ReadSnapshotIsLegacy
@@ -284,7 +284,7 @@ instance
   ( IOLike m
   , LedgerDbSerialiseConstraints blk
   , LedgerSupportsProtocol blk
-  , LedgerSupportsInMemoryLedgerDB (LedgerState blk)
+  , LedgerSupportsInMemoryLedgerDB LedgerState blk
   ) =>
   Backend m Mem blk
   where
@@ -309,26 +309,26 @@ mkInMemoryArgs ::
   ( IOLike m
   , LedgerDbSerialiseConstraints blk
   , LedgerSupportsProtocol blk
-  , LedgerSupportsInMemoryLedgerDB (LedgerState blk)
+  , LedgerSupportsInMemoryLedgerDB LedgerState blk
   ) =>
   a -> (LedgerDbBackendArgs m blk, a)
 mkInMemoryArgs = (,) $ LedgerDbBackendArgsV2 $ SomeBackendArgs InMemArgs
 
-instance IOLike m => StreamingBackend m Mem l where
-  data YieldArgs m Mem l
+instance IOLike m => StreamingBackend m Mem l blk where
+  data YieldArgs m Mem l blk
     = -- \| Yield an in-memory snapshot
       YieldInMemory
         -- \| The file system anchored at the snapshots directory
         (SomeHasFS m)
         -- \| The snapshot
         DiskSnapshot
-        (Decoders l)
+        (Decoders blk)
 
-  data SinkArgs m Mem l
+  data SinkArgs m Mem l blk
     = SinkInMemory
         Int
-        (TxIn l -> Encoding)
-        (TxOut l -> Encoding)
+        (TxIn blk -> Encoding)
+        (TxOut blk -> Encoding)
         (SomeHasFS m)
         DiskSnapshot
 
@@ -406,22 +406,22 @@ yieldInMemoryS ::
   (MonadThrow m, MonadST m) =>
   SomeHasFS m ->
   DiskSnapshot ->
-  (forall s. Decoder s (TxIn l)) ->
-  (forall s. Decoder s (TxOut l)) ->
-  Yield m l
+  (forall s. Decoder s (TxIn blk)) ->
+  (forall s. Decoder s (TxOut blk)) ->
+  Yield m l blk
 yieldInMemoryS fs ds decK decV _ k =
   streamingFile fs (snapshotToTablesPath ds) $ \s -> do
     k $ yieldCborMapS decK decV s
 
 sinkInMemoryS ::
-  forall m l.
+  forall m l blk.
   MonadThrow m =>
   Int ->
-  (TxIn l -> Encoding) ->
-  (TxOut l -> Encoding) ->
+  (TxIn blk -> Encoding) ->
+  (TxOut blk -> Encoding) ->
   SomeHasFS m ->
   DiskSnapshot ->
-  Sink m l
+  Sink m l blk
 sinkInMemoryS writeChunkSize encK encV (SomeHasFS fs) ds _ s =
   ExceptT $ withFile fs (snapshotToTablesPath ds) (WriteMode MustBeNew) $ \hdl -> do
     let bs = toStrictByteString (encodeListLen 1 <> encodeMapLenIndef)

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/V2/InMemory.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/V2/InMemory.hs
@@ -233,8 +233,8 @@ loadSnapshot ::
   forall blk m.
   ( LedgerDbSerialiseConstraints blk
   , LedgerSupportsProtocol blk
+  , CanUpgradeLedgerTables LedgerState blk
   , IOLike m
-  , LedgerSupportsInMemoryLedgerDB LedgerState blk
   ) =>
   Tracer m LedgerDBV2Trace ->
   CodecConfig blk ->
@@ -284,7 +284,7 @@ instance
   ( IOLike m
   , LedgerDbSerialiseConstraints blk
   , LedgerSupportsProtocol blk
-  , LedgerSupportsInMemoryLedgerDB LedgerState blk
+  , CanUpgradeLedgerTables LedgerState blk
   ) =>
   Backend m Mem blk
   where
@@ -309,7 +309,7 @@ mkInMemoryArgs ::
   ( IOLike m
   , LedgerDbSerialiseConstraints blk
   , LedgerSupportsProtocol blk
-  , LedgerSupportsInMemoryLedgerDB LedgerState blk
+  , CanUpgradeLedgerTables LedgerState blk
   ) =>
   a -> (LedgerDbBackendArgs m blk, a)
 mkInMemoryArgs = (,) $ LedgerDbBackendArgsV2 $ SomeBackendArgs InMemArgs

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/V2/LedgerSeq.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/V2/LedgerSeq.hs
@@ -90,10 +90,10 @@ import Prelude hiding (read)
 -- When applying diffs to a table, we will first duplicate the handle, then
 -- apply the diffs in the copy. It is expected that duplicating the handle
 -- takes constant time.
-data LedgerTablesHandle m l = LedgerTablesHandle
+data LedgerTablesHandle m l blk = LedgerTablesHandle
   { close :: !(m ())
   -- ^ Close the handle
-  , duplicateWithDiffs :: !(l EmptyMK -> l DiffMK -> m (LedgerTablesHandle m l))
+  , duplicateWithDiffs :: !(l blk EmptyMK -> l blk DiffMK -> m (LedgerTablesHandle m l blk))
   -- ^ Create a new handle by duplicating this one and push some diffs to it.
   --
   -- The first argument has to be the ledger state before applying
@@ -105,14 +105,15 @@ data LedgerTablesHandle m l = LedgerTablesHandle
   -- This is expected to be used when applying new blocks onto a forker, which
   -- happens only in chain selection (see 'forkerPush') and initial chain
   -- selection (see 'reapplyBlock').
-  , duplicate :: !(m (LedgerTablesHandle m l))
+  , duplicate :: !(m (LedgerTablesHandle m l blk))
   -- ^ Create an duplicate of a handle. This will be used when opening read-only
   -- forkers and also to open the first handle for a forker used in chain
   -- selection.
-  , read :: !(l EmptyMK -> LedgerTables l KeysMK -> m (LedgerTables l ValuesMK))
+  , read :: !(l blk EmptyMK -> LedgerTables blk KeysMK -> m (LedgerTables blk ValuesMK))
   -- ^ Read values for the given keys from the tables, and deserialize them as
   -- if they were from the same era as the given ledger state.
-  , readRange :: !(l EmptyMK -> (Maybe (TxIn l), Int) -> m (LedgerTables l ValuesMK, Maybe (TxIn l)))
+  , readRange ::
+      !(l blk EmptyMK -> (Maybe (TxIn blk), Int) -> m (LedgerTables blk ValuesMK, Maybe (TxIn blk)))
   -- ^ Read the requested number of values, possibly starting from the given
   -- key, from the tables, and deserialize them as if they were from the same
   -- era as the given ledger state.
@@ -127,11 +128,11 @@ data LedgerTablesHandle m l = LedgerTablesHandle
   -- back into the next iteration of the range read. If the function returns
   -- Nothing, it means the read returned no results, or in other words, we
   -- reached the end of the ledger tables.
-  , readAll :: !(l EmptyMK -> m (LedgerTables l ValuesMK))
+  , readAll :: !(l blk EmptyMK -> m (LedgerTables blk ValuesMK))
   -- ^ Costly read all operation, not to be used in Consensus but only in
   -- snapshot-converter executable. The values will be read as if they were from
   -- the same era as the given ledger state.
-  , takeHandleSnapshot :: !(l EmptyMK -> String -> m (Maybe CRC))
+  , takeHandleSnapshot :: !(l blk EmptyMK -> String -> m (Maybe CRC))
   -- ^ Take a snapshot of a handle. The given ledger state is used to decide the
   -- encoding of the values based on the current era.
   --
@@ -139,7 +140,7 @@ data LedgerTablesHandle m l = LedgerTablesHandle
   , tablesSize :: !Int
   -- ^ Consult the size of the ledger tables in the database.
   }
-  deriving NoThunks via OnlyCheckWhnfNamed "LedgerTablesHandle" (LedgerTablesHandle m l)
+  deriving NoThunks via OnlyCheckWhnfNamed "LedgerTablesHandle" (LedgerTablesHandle m l blk)
 
 {-------------------------------------------------------------------------------
   StateRef, represents a full ledger state, i.e. with a handle for its tables
@@ -162,21 +163,21 @@ data LedgerTablesHandle m l = LedgerTablesHandle
 -- Therefore it sounds reasonable to hold a @LedgerState blk EmptyMK@ with no
 -- values, and a @LedgerTables blk ValuesMK@ next to it, that will live its
 -- entire lifetime as @LedgerTables@ of the @HardForkBlock@.
-data StateRef m l = StateRef
-  { state :: !(l EmptyMK)
-  , tables :: !(LedgerTablesHandle m l)
+data StateRef m l blk = StateRef
+  { state :: !(l blk EmptyMK)
+  , tables :: !(LedgerTablesHandle m l blk)
   }
   deriving Generic
 
-deriving instance (IOLike m, NoThunks (l EmptyMK)) => NoThunks (StateRef m l)
+deriving instance (IOLike m, NoThunks (l blk EmptyMK)) => NoThunks (StateRef m l blk)
 
-instance Eq (l EmptyMK) => Eq (StateRef m l) where
+instance Eq (l blk EmptyMK) => Eq (StateRef m l blk) where
   (==) = (==) `on` state
 
-instance Show (l EmptyMK) => Show (StateRef m l) where
+instance Show (l blk EmptyMK) => Show (StateRef m l blk) where
   show = show . state
 
-instance GetTip l => Anchorable (WithOrigin SlotNo) (StateRef m l) (StateRef m l) where
+instance GetTip (l blk) => Anchorable (WithOrigin SlotNo) (StateRef m l blk) (StateRef m l blk) where
   asAnchor = id
   getAnchorMeasure _ = getTipSlot . state
 
@@ -184,17 +185,17 @@ instance GetTip l => Anchorable (WithOrigin SlotNo) (StateRef m l) (StateRef m l
   The LedgerSeq
 -------------------------------------------------------------------------------}
 
-newtype LedgerSeq m l = LedgerSeq
-  { getLedgerSeq :: AnchoredSeq (WithOrigin SlotNo) (StateRef m l) (StateRef m l)
+newtype LedgerSeq m l blk = LedgerSeq
+  { getLedgerSeq :: AnchoredSeq (WithOrigin SlotNo) (StateRef m l blk) (StateRef m l blk)
   }
   deriving Generic
 
-deriving newtype instance (IOLike m, NoThunks (l EmptyMK)) => NoThunks (LedgerSeq m l)
+deriving newtype instance (IOLike m, NoThunks (l blk EmptyMK)) => NoThunks (LedgerSeq m l blk)
 
-deriving newtype instance Eq (l EmptyMK) => Eq (LedgerSeq m l)
-deriving newtype instance Show (l EmptyMK) => Show (LedgerSeq m l)
+deriving newtype instance Eq (l blk EmptyMK) => Eq (LedgerSeq m l blk)
+deriving newtype instance Show (l blk EmptyMK) => Show (LedgerSeq m l blk)
 
-type LedgerSeq' m blk = LedgerSeq m (ExtLedgerState blk)
+type LedgerSeq' m blk = LedgerSeq m ExtLedgerState blk
 
 {-------------------------------------------------------------------------------
   Construction
@@ -202,29 +203,29 @@ type LedgerSeq' m blk = LedgerSeq m (ExtLedgerState blk)
 
 -- | Creates an empty @LedgerSeq@
 empty ::
-  ( GetTip l
+  ( GetTip (l blk)
   , IOLike m
   ) =>
-  l EmptyMK ->
+  l blk EmptyMK ->
   init ->
-  (init -> m (LedgerTablesHandle m l)) ->
-  m (LedgerSeq m l)
+  (init -> m (LedgerTablesHandle m l blk)) ->
+  m (LedgerSeq m l blk)
 empty st tbs new = LedgerSeq . AS.Empty . StateRef st <$> new tbs
 
 -- | Creates an empty @LedgerSeq@
 empty' ::
-  ( GetTip l
+  ( GetTip (l blk)
   , IOLike m
-  , HasLedgerTables l
+  , HasLedgerTables l blk
   ) =>
-  l ValuesMK ->
-  (l ValuesMK -> m (LedgerTablesHandle m l)) ->
-  m (LedgerSeq m l)
+  l blk ValuesMK ->
+  (l blk ValuesMK -> m (LedgerTablesHandle m l blk)) ->
+  m (LedgerSeq m l blk)
 empty' st = empty (forgetLedgerTables st) st
 
 -- | Close all 'LedgerTablesHandle' in this 'LedgerSeq', in particular that on
 -- the anchor.
-closeLedgerSeq :: Monad m => LedgerSeq m l -> m ()
+closeLedgerSeq :: Monad m => LedgerSeq m l blk -> m ()
 closeLedgerSeq (LedgerSeq l) =
   mapM_ (close . tables) $ AS.anchor l : AS.toOldestFirst l
 
@@ -240,8 +241,8 @@ reapplyThenPush ::
   (IOLike m, ApplyBlock l blk) =>
   LedgerDbCfg l blk ->
   blk ->
-  LedgerSeq m (l blk) ->
-  m (LedgerSeq m (l blk))
+  LedgerSeq m l blk ->
+  m (LedgerSeq m l blk)
 reapplyThenPush cfg ap db = do
   newSt <- reapplyBlock (ledgerDbCfgComputeLedgerEvents cfg) (ledgerDbCfg cfg) ap db
   let (m, db') = pruneToImmTipOnly $ extend newSt db
@@ -254,8 +255,8 @@ reapplyBlock ::
   ComputeLedgerEvents ->
   LedgerCfg l blk ->
   blk ->
-  LedgerSeq m (l blk) ->
-  m (StateRef m (l blk))
+  LedgerSeq m l blk ->
+  m (StateRef m l blk)
 reapplyBlock evs cfg b db = do
   let ks = getBlockKeySets b
       StateRef st tbs = currentHandle db
@@ -278,10 +279,10 @@ reapplyBlock evs cfg b db = do
 --
 -- where @lX@ is a ledger state from slot @X-1@ (or 'Origin' for @l0@).
 prune ::
-  (Monad m, GetTip l) =>
+  (Monad m, GetTip (l blk)) =>
   LedgerDbPrune ->
-  LedgerSeq m l ->
-  (m (), LedgerSeq m l)
+  LedgerSeq m l blk ->
+  (m (), LedgerSeq m l blk)
 prune howToPrune (LedgerSeq ldb) = case howToPrune of
   LedgerDbPruneAll ->
     (closeButHead before, LedgerSeq after)
@@ -319,10 +320,10 @@ prune howToPrune (LedgerSeq ldb) = case howToPrune of
 -- >>> AS.toOldestFirst ldb' == [l1, l2, l3, l4]
 -- True
 extend ::
-  GetTip l =>
-  StateRef m l ->
-  LedgerSeq m l ->
-  LedgerSeq m l
+  GetTip (l blk) =>
+  StateRef m l blk ->
+  LedgerSeq m l blk ->
+  LedgerSeq m l blk
 extend newState =
   LedgerSeq . (:> newState) . getLedgerSeq
 
@@ -337,9 +338,9 @@ extend newState =
 -- >>> AS.anchor ldb' == l3 && AS.toOldestFirst ldb' == []
 -- True
 pruneToImmTipOnly ::
-  (Monad m, GetTip l) =>
-  LedgerSeq m l ->
-  (m (), LedgerSeq m l)
+  (Monad m, GetTip (l blk)) =>
+  LedgerSeq m l blk ->
+  (m (), LedgerSeq m l blk)
 pruneToImmTipOnly = prune LedgerDbPruneAll
 
 {-------------------------------------------------------------------------------
@@ -355,10 +356,10 @@ pruneToImmTipOnly = prune LedgerDbPruneAll
 -- >>> fmap (([l1] ==) . AS.toOldestFirst . getLedgerSeq) (rollbackN 2 ldb)
 -- Just True
 rollbackN ::
-  GetTip l =>
+  GetTip (l blk) =>
   Word64 ->
-  LedgerSeq m l ->
-  Maybe (LedgerSeq m l)
+  LedgerSeq m l blk ->
+  Maybe (LedgerSeq m l blk)
 rollbackN n ldb
   | n <= maxRollback ldb =
       Just $ LedgerSeq (AS.dropNewest (fromIntegral n) $ getLedgerSeq ldb)
@@ -374,10 +375,10 @@ rollbackN n ldb
 -- >>> ldb = LedgerSeq $ AS.fromOldestFirst l0 [l1, l2, l3]
 -- >>> l3s == current ldb
 -- True
-current :: GetTip l => LedgerSeq m l -> l EmptyMK
+current :: GetTip (l blk) => LedgerSeq m l blk -> l blk EmptyMK
 current = state . currentHandle
 
-currentHandle :: GetTip l => LedgerSeq m l -> StateRef m l
+currentHandle :: GetTip (l blk) => LedgerSeq m l blk -> StateRef m l blk
 currentHandle = headAnchor . getLedgerSeq
 
 -- | The ledger state at the anchor of the Volatile chain (i.e. the immutable
@@ -386,10 +387,10 @@ currentHandle = headAnchor . getLedgerSeq
 -- >>> ldb = LedgerSeq $ AS.fromOldestFirst l0 [l1, l2, l3]
 -- >>> l0s == anchor ldb
 -- True
-anchor :: LedgerSeq m l -> l EmptyMK
+anchor :: LedgerSeq m l blk -> l blk EmptyMK
 anchor = state . anchorHandle
 
-anchorHandle :: LedgerSeq m l -> StateRef m l
+anchorHandle :: LedgerSeq m l blk -> StateRef m l blk
 anchorHandle = AS.anchor . getLedgerSeq
 
 -- | All snapshots currently stored by the ledger DB (new to old)
@@ -400,7 +401,7 @@ anchorHandle = AS.anchor . getLedgerSeq
 -- >>> ldb = LedgerSeq $ AS.fromOldestFirst l0 [l1, l2, l3]
 -- >>> [(0, l3s), (1, l2s), (2, l1s)] == snapshots ldb
 -- True
-snapshots :: LedgerSeq m l -> [(Word64, l EmptyMK)]
+snapshots :: LedgerSeq m l blk -> [(Word64, l blk EmptyMK)]
 snapshots =
   zip [0 ..]
     . map state
@@ -412,7 +413,7 @@ snapshots =
 -- >>> ldb = LedgerSeq $ AS.fromOldestFirst l0 [l1, l2, l3]
 -- >>> maxRollback ldb
 -- 3
-maxRollback :: GetTip l => LedgerSeq m l -> Word64
+maxRollback :: GetTip (l blk) => LedgerSeq m l blk -> Word64
 maxRollback =
   fromIntegral
     . AS.length
@@ -423,7 +424,7 @@ maxRollback =
 -- >>> ldb = LedgerSeq $ AS.fromOldestFirst l0 [l1, l2, l3]
 -- >>> tip ldb == getTip l3s
 -- True
-tip :: GetTip l => LedgerSeq m l -> Point l
+tip :: GetTip (l blk) => LedgerSeq m l blk -> Point (l blk)
 tip = castPoint . getTip . current
 
 -- | Have we seen at least @k@ blocks?
@@ -433,7 +434,7 @@ tip = castPoint . getTip . current
 -- True
 -- >>> isSaturated (SecurityParam (unsafeNonZero 4)) ldb
 -- False
-isSaturated :: GetTip l => SecurityParam -> LedgerSeq m l -> Bool
+isSaturated :: GetTip (l blk) => SecurityParam -> LedgerSeq m l blk -> Bool
 isSaturated (SecurityParam k) db =
   maxRollback db >= unNonZero k
 
@@ -451,13 +452,13 @@ isSaturated (SecurityParam k) db =
 -- True
 getPastLedgerAt ::
   ( HasHeader blk
-  , GetTip l
-  , HeaderHash l ~ HeaderHash blk
-  , StandardHash l
+  , GetTip (l blk)
+  , HeaderHash (l blk) ~ HeaderHash blk
+  , StandardHash (l blk)
   ) =>
   Point blk ->
-  LedgerSeq m l ->
-  Maybe (l EmptyMK)
+  LedgerSeq m l blk ->
+  Maybe (l blk EmptyMK)
 getPastLedgerAt pt db = current <$> rollback pt db
 
 -- | Roll back the volatile states up to the specified point.
@@ -472,10 +473,10 @@ getPastLedgerAt pt db = current <$> rollback pt db
 -- >>> AS.anchor ldb' == l0 && AS.toOldestFirst ldb' == [l1, l2]
 -- True
 rollbackToPoint ::
-  ( StandardHash l
-  , GetTip l
+  ( StandardHash (l blk)
+  , GetTip (l blk)
   ) =>
-  Point l -> LedgerSeq m l -> Maybe (LedgerSeq m l)
+  Point (l blk) -> LedgerSeq m l blk -> Maybe (LedgerSeq m l blk)
 rollbackToPoint pt (LedgerSeq ldb) = do
   LedgerSeq
     <$> AS.rollback
@@ -490,8 +491,8 @@ rollbackToPoint pt (LedgerSeq ldb) = do
 -- >>> AS.anchor ldb' == l0 && AS.toOldestFirst ldb' == []
 -- True
 rollbackToAnchor ::
-  GetTip l =>
-  LedgerSeq m l -> LedgerSeq m l
+  GetTip (l blk) =>
+  LedgerSeq m l blk -> LedgerSeq m l blk
 rollbackToAnchor (LedgerSeq vol) =
   LedgerSeq (AS.Empty (AS.anchor vol))
 
@@ -503,13 +504,13 @@ rollbackToAnchor (LedgerSeq vol) =
 -- returned.
 rollback ::
   ( HasHeader blk
-  , GetTip l
-  , HeaderHash l ~ HeaderHash blk
-  , StandardHash l
+  , GetTip (l blk)
+  , HeaderHash (l blk) ~ HeaderHash blk
+  , StandardHash (l blk)
   ) =>
   Point blk ->
-  LedgerSeq m l ->
-  Maybe (LedgerSeq m l)
+  LedgerSeq m l blk ->
+  Maybe (LedgerSeq m l blk)
 rollback pt db
   | pt == castPoint (getTip (anchor db)) =
       Just $ rollbackToAnchor db
@@ -517,8 +518,8 @@ rollback pt db
       rollbackToPoint (castPoint pt) db
 
 immutableTipSlot ::
-  GetTip l =>
-  LedgerSeq m l -> WithOrigin SlotNo
+  GetTip (l blk) =>
+  LedgerSeq m l blk -> WithOrigin SlotNo
 immutableTipSlot =
   getTipSlot
     . state
@@ -528,9 +529,9 @@ immutableTipSlot =
 -- | Transform the underlying volatile 'AnchoredSeq' using the given functions.
 volatileStatesBimap ::
   AS.Anchorable (WithOrigin SlotNo) a b =>
-  (l EmptyMK -> a) ->
-  (l EmptyMK -> b) ->
-  LedgerSeq m l ->
+  (l blk EmptyMK -> a) ->
+  (l blk EmptyMK -> b) ->
+  LedgerSeq m l blk ->
   AS.AnchoredSeq (WithOrigin SlotNo) a b
 volatileStatesBimap f g =
   AS.bimap (f . state) (g . state)
@@ -555,29 +556,58 @@ volatileStatesBimap f g =
 -- >>> import Cardano.Ledger.BaseTypes.NonZero
 -- >>> import Data.Void
 -- >>> import Cardano.Slotting.Slot
+-- >>> import Data.Proxy
+--
 -- >>> data B
--- >>> data LS (mk :: MapKind) = LS (Point LS)
--- >>> type instance HeaderHash LS = Int
--- >>> type instance HeaderHash B = HeaderHash LS
--- >>> instance StandardHash LS
--- >>> type instance TxIn LS = Void
--- >>> type instance TxOut LS = Void
--- >>> instance LedgerTablesAreTrivial LS where convertMapKind (LS p) = LS p
--- >>> s = [LS (Point Origin), LS (Point (At (Block 0 0))), LS (Point (At (Block 1 1))), LS (Point (At (Block 2 2))), LS (Point (At (Block 3 3)))]
--- >>> [l0s, l1s, l2s, l3s, l4s] = s
--- >>> emptyHandle = LedgerTablesHandle (pure ()) (\_ _ -> pure emptyHandle) (pure emptyHandle) (\_ _ -> pure trivialLedgerTables) (\_ _ -> pure (trivialLedgerTables, Nothing)) (\_ -> pure trivialLedgerTables) (\_ _ -> undefined) 0 :: LedgerTablesHandle IO LS
--- >>> [l0, l1, l2, l3, l4] = map (flip StateRef emptyHandle) s
--- >>> instance GetTip LS where getTip (LS p) = p
--- >>> instance Eq (LS EmptyMK) where LS p1 == LS p2 = p1 == p2
+-- >>> type instance HeaderHash B = Int
 -- >>> instance StandardHash B
 -- >>> instance HasHeader B where getHeaderFields = undefined
+--
+-- >>> type instance TxIn B = Void
+-- >>> type instance TxOut B = Void
+--
+-- >>> data instance LedgerState B (mk :: MapKind) = LS (Point B)
+-- >>> instance Eq (LedgerState B EmptyMK) where LS p1 == LS p2 = p1 == p2
 -- >>> :{
---  instance HasLedgerTables LS where
---    projectLedgerTables _ = trivialLedgerTables
+--  instance GetTip (LedgerState B) where
+--    getTip (LS p) = castPoint p
+-- :}
+--
+-- >>> :{
+--  s = [ LS (Point Origin)
+--      , LS (Point (At (Block 0 0)))
+--      , LS (Point (At (Block 1 1)))
+--      , LS (Point (At (Block 2 2)))
+--      , LS (Point (At (Block 3 3)))
+--      ]
+-- :}
+--
+-- >>> [l0s, l1s, l2s, l3s, l4s] = s
+--
+-- >>> :{
+--  instance LedgerTablesAreTrivial LedgerState B where
+--    convertMapKind (LS p) = LS p
+--  instance HasLedgerTables LedgerState B where
+--    projectLedgerTables _ = trivialLedgerTables (Proxy @LedgerState)
 --    withLedgerTables st _ = convertMapKind st
---  instance IndexedMemPack (LS EmptyMK) Void where
---    indexedTypeName _ = typeName @Void
+--  instance IndexedMemPack LedgerState B Void where
+--    indexedTypeName _ _ = typeName @Void
 --    indexedPackedByteCount _ = packedByteCount
 --    indexedPackM _ = packM
 --    indexedUnpackM _ = unpackM
 -- :}
+--
+-- >>> :{
+--  emptyHandle =
+--     LedgerTablesHandle
+--        (pure ())
+--        (\_ _ -> pure emptyHandle)
+--        (pure emptyHandle)
+--        (\_ _ -> pure (trivialLedgerTables (Proxy @LedgerState)))
+--        (\_ _ -> pure (trivialLedgerTables (Proxy @LedgerState), Nothing))
+--        (\_ -> pure (trivialLedgerTables (Proxy @LedgerState)))
+--        (\_ _ -> undefined)
+--        0 :: LedgerTablesHandle IO LedgerState B
+-- :}
+--
+-- >>> [l0, l1, l2, l3, l4] = map (flip StateRef emptyHandle) s

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/TypeFamilyWrappers.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/TypeFamilyWrappers.hs
@@ -90,8 +90,8 @@ newtype WrapValidatedGenTx blk = WrapValidatedGenTx {unwrapValidatedGenTx :: Val
 
 newtype WrapTxMeasure blk = WrapTxMeasure {unwrapTxMeasure :: TxMeasure blk}
 
-newtype WrapTxIn blk = WrapTxIn {unwrapTxIn :: TxIn (LedgerState blk)}
-newtype WrapTxOut blk = WrapTxOut {unwrapTxOut :: TxOut (LedgerState blk)}
+newtype WrapTxIn blk = WrapTxIn {unwrapTxIn :: TxIn blk}
+newtype WrapTxOut blk = WrapTxOut {unwrapTxOut :: TxOut blk}
 
 {-------------------------------------------------------------------------------
   Consensus based
@@ -163,15 +163,15 @@ deriving instance
 deriving instance
   NoThunks (Validated (GenTx blk)) => NoThunks (WrapValidatedGenTx blk)
 
-deriving instance Show (TxIn (LedgerState blk)) => Show (WrapTxIn blk)
-deriving instance Eq (TxIn (LedgerState blk)) => Eq (WrapTxIn blk)
-deriving instance Ord (TxIn (LedgerState blk)) => Ord (WrapTxIn blk)
-deriving instance NoThunks (TxIn (LedgerState blk)) => NoThunks (WrapTxIn blk)
+deriving instance Show (TxIn blk) => Show (WrapTxIn blk)
+deriving instance Eq (TxIn blk) => Eq (WrapTxIn blk)
+deriving instance Ord (TxIn blk) => Ord (WrapTxIn blk)
+deriving instance NoThunks (TxIn blk) => NoThunks (WrapTxIn blk)
 
-deriving instance Show (TxOut (LedgerState blk)) => Show (WrapTxOut blk)
-deriving instance Eq (TxOut (LedgerState blk)) => Eq (WrapTxOut blk)
-deriving instance Ord (TxOut (LedgerState blk)) => Ord (WrapTxOut blk)
-deriving instance NoThunks (TxOut (LedgerState blk)) => NoThunks (WrapTxOut blk)
+deriving instance Show (TxOut blk) => Show (WrapTxOut blk)
+deriving instance Eq (TxOut blk) => Eq (WrapTxOut blk)
+deriving instance Ord (TxOut blk) => Ord (WrapTxOut blk)
+deriving instance NoThunks (TxOut blk) => NoThunks (WrapTxOut blk)
 
 {-------------------------------------------------------------------------------
   .. consensus based

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Util/IndexedMemPack.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Util/IndexedMemPack.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
@@ -29,69 +28,73 @@ import Data.ByteString
 import Data.MemPack
 import Data.MemPack.Buffer
 import Data.MemPack.Error
+import Data.Proxy
 import GHC.Stack
+import Ouroboros.Consensus.Ledger.Tables.MapKind
 
 -- | See 'MemPack'.
-class IndexedMemPack idx a where
-  indexedPackedByteCount :: idx -> a -> Int
-  indexedPackM :: idx -> a -> Pack s ()
-  indexedUnpackM :: Buffer b => forall s. idx -> Unpack s b a
-  indexedTypeName :: idx -> String
+class IndexedMemPack l blk a where
+  indexedPackedByteCount :: l blk EmptyMK -> a -> Int
+  indexedPackM :: l blk EmptyMK -> a -> Pack s ()
+  indexedUnpackM :: Buffer b => forall s. l blk EmptyMK -> Unpack s b a
+  indexedTypeName :: Proxy a -> l blk EmptyMK -> String
 
 indexedPackByteString ::
-  forall a idx. (IndexedMemPack idx a, HasCallStack) => idx -> a -> ByteString
+  forall a l blk. (IndexedMemPack l blk a, HasCallStack) => l blk EmptyMK -> a -> ByteString
 indexedPackByteString idx = pinnedByteArrayToByteString . indexedPackByteArray True idx
 {-# INLINE indexedPackByteString #-}
 
 indexedPackByteArray ::
-  forall a idx.
-  (IndexedMemPack idx a, HasCallStack) =>
+  forall a l blk.
+  (IndexedMemPack l blk a, HasCallStack) =>
   Bool ->
-  idx ->
+  l blk EmptyMK ->
   a ->
   ByteArray
 indexedPackByteArray isPinned idx a =
   packWithByteArray
     isPinned
-    (indexedTypeName @idx @a idx)
+    (indexedTypeName (Proxy @a) idx)
     (indexedPackedByteCount idx a)
     (indexedPackM idx a)
 {-# INLINE indexedPackByteArray #-}
 
 indexedUnpackError ::
-  forall idx a b. (Buffer b, IndexedMemPack idx a, HasCallStack) => idx -> b -> a
+  forall l blk a b. (Buffer b, IndexedMemPack l blk a, HasCallStack) => l blk EmptyMK -> b -> a
 indexedUnpackError idx = errorFail . indexedUnpackFail idx
 {-# INLINEABLE indexedUnpackError #-}
 
 indexedUnpackFail ::
-  forall idx a b. (IndexedMemPack idx a, Buffer b, HasCallStack) => idx -> b -> Fail SomeError a
+  forall l blk a b.
+  (IndexedMemPack l blk a, Buffer b, HasCallStack) => l blk EmptyMK -> b -> Fail SomeError a
 indexedUnpackFail idx b = do
   let len = bufferByteCount b
   (a, consumedBytes) <- indexedUnpackLeftOver idx b
   Monad.when (consumedBytes /= len) $
-    unpackFailNotFullyConsumed (indexedTypeName @idx @a idx) consumedBytes len
+    unpackFailNotFullyConsumed (indexedTypeName (Proxy @a) idx) consumedBytes len
   pure a
 {-# INLINEABLE indexedUnpackFail #-}
 
 indexedUnpackLeftOver ::
-  forall idx a b.
-  (IndexedMemPack idx a, Buffer b, HasCallStack) => idx -> b -> Fail SomeError (a, Int)
+  forall l blk a b.
+  (IndexedMemPack l blk a, Buffer b, HasCallStack) => l blk EmptyMK -> b -> Fail SomeError (a, Int)
 indexedUnpackLeftOver idx b = FailT $ pure $ runST $ runFailAggT $ indexedUnpackLeftOverST idx b
 {-# INLINEABLE indexedUnpackLeftOver #-}
 
 indexedUnpackLeftOverST ::
-  forall idx a b s.
-  (IndexedMemPack idx a, Buffer b, HasCallStack) => idx -> b -> FailT SomeError (ST s) (a, Int)
+  forall l blk a b s.
+  (IndexedMemPack l blk a, Buffer b, HasCallStack) =>
+  l blk EmptyMK -> b -> FailT SomeError (ST s) (a, Int)
 indexedUnpackLeftOverST idx b = do
   let len = bufferByteCount b
   res@(_, consumedBytes) <- runStateT (runUnpack (indexedUnpackM idx) b) 0
-  Monad.when (consumedBytes > len) $ errorLeftOver (indexedTypeName @idx @a idx) consumedBytes len
+  Monad.when (consumedBytes > len) $ errorLeftOver (indexedTypeName (Proxy @a) idx) consumedBytes len
   pure res
 {-# INLINEABLE indexedUnpackLeftOverST #-}
 
 indexedUnpackEither ::
-  forall idx a b.
-  (IndexedMemPack idx a, Buffer b, HasCallStack) => idx -> b -> Either SomeError a
+  forall l blk a b.
+  (IndexedMemPack l blk a, Buffer b, HasCallStack) => l blk EmptyMK -> b -> Either SomeError a
 indexedUnpackEither idx = first fromMultipleErrors . runFailAgg . indexedUnpackFail idx
 {-# INLINEABLE indexedUnpackEither #-}
 

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/LedgerTables.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/LedgerTables.hs
@@ -6,7 +6,7 @@ module Test.LedgerTables
   ) where
 
 import Data.Function (on)
-import Ouroboros.Consensus.Ledger.Basics
+import Ouroboros.Consensus.Ledger.Abstract
 import Test.QuickCheck
 
 -- | We compare the Ledger Tables of the result because the comparison with the
@@ -17,7 +17,9 @@ import Test.QuickCheck
   , ZeroableMK mk
   , EqMK mk
   , ShowMK mk
-  , HasLedgerTables (LedgerState blk)
+  , HasLedgerTables LedgerState blk
+  , Show (TxIn blk)
+  , Show (TxOut blk)
   ) =>
   LedgerState blk mk ->
   LedgerState blk mk ->
@@ -32,8 +34,10 @@ infix 4 ==?
 --
 -- > unstow . stow == id
 prop_stowable_laws ::
-  ( HasLedgerTables (LedgerState blk)
+  ( HasLedgerTables LedgerState blk
   , CanStowLedgerTables (LedgerState blk)
+  , Show (TxIn blk)
+  , Show (TxOut blk)
   ) =>
   LedgerState blk EmptyMK ->
   LedgerState blk ValuesMK ->
@@ -48,9 +52,12 @@ prop_stowable_laws = \ls ls' ->
 --
 -- > project . with == id
 prop_hasledgertables_laws ::
-  HasLedgerTables (LedgerState blk) =>
+  ( HasLedgerTables LedgerState blk
+  , Show (TxIn blk)
+  , Show (TxOut blk)
+  ) =>
   LedgerState blk EmptyMK ->
-  LedgerTables (LedgerState blk) ValuesMK ->
+  LedgerTables blk ValuesMK ->
   Property
 prop_hasledgertables_laws = \ls tbs ->
   (ls `withLedgerTables` (projectLedgerTables ls)) ==? ls

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Storage/TestBlock.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Storage/TestBlock.hs
@@ -66,6 +66,8 @@ module Test.Ouroboros.Storage.TestBlock
 import Cardano.Binary (DecoderError)
 import Cardano.Crypto.DSIGN
 import Cardano.Ledger.BaseTypes (unNonZero)
+import qualified Codec.CBOR.Decoding as CBOR
+import qualified Codec.CBOR.Encoding as CBOR
 import qualified Codec.CBOR.Read as CBOR
 import qualified Codec.CBOR.Write as CBOR
 import Codec.Serialise (Serialise (decode, encode), serialise)
@@ -581,41 +583,32 @@ instance IsLedger LedgerState TestBlock where
       . TickedTestLedger
       . noNewTickingDiffs
 
-type instance TxIn (LedgerState TestBlock) = Void
-type instance TxOut (LedgerState TestBlock) = Void
-
-instance LedgerTablesAreTrivial (LedgerState TestBlock) where
+type instance TxIn TestBlock = Void
+type instance TxOut TestBlock = Void
+instance LedgerTablesAreTrivial LedgerState TestBlock where
   convertMapKind (TestLedger x y z) = TestLedger x y z
-instance LedgerTablesAreTrivial (Ticked LedgerState TestBlock) where
+instance LedgerTablesAreTrivial (Ticked LedgerState) TestBlock where
   convertMapKind (TickedTestLedger x) = TickedTestLedger (convertMapKind x)
 deriving via
-  TrivialLedgerTables (LedgerState TestBlock)
-  instance
-    HasLedgerTables (LedgerState TestBlock)
-deriving via
-  TrivialLedgerTables (Ticked LedgerState TestBlock)
-  instance
-    HasLedgerTables (Ticked LedgerState TestBlock)
-deriving via
-  TrivialLedgerTables (LedgerState TestBlock)
-  instance
-    CanStowLedgerTables (LedgerState TestBlock)
-deriving via
-  TrivialLedgerTables (LedgerState TestBlock)
-  instance
-    CanUpgradeLedgerTables (LedgerState TestBlock)
-deriving via
-  TrivialLedgerTables (LedgerState TestBlock)
-  instance
-    SerializeTablesWithHint (LedgerState TestBlock)
-deriving via
   Void
   instance
-    IndexedMemPack (LedgerState TestBlock EmptyMK) Void
-deriving via
-  Void
-  instance
-    IndexedMemPack (Ticked LedgerState TestBlock EmptyMK) Void
+    IndexedMemPack LedgerState TestBlock Void
+instance HasLedgerTables LedgerState TestBlock where
+  projectLedgerTables _ = emptyLedgerTables
+  withLedgerTables st _ = convertMapKind st
+instance HasLedgerTables (Ticked LedgerState) TestBlock where
+  projectLedgerTables _ = emptyLedgerTables
+  withLedgerTables st _ = convertMapKind st
+instance CanStowLedgerTables (LedgerState TestBlock) where
+  stowLedgerTables = convertMapKind
+  unstowLedgerTables = convertMapKind
+instance SerializeTablesWithHint LedgerState TestBlock where
+  decodeTablesWithHint _ = do
+    _ <- CBOR.decodeMapLen
+    pure (LedgerTables $ ValuesMK Map.empty)
+  encodeTablesWithHint _ _ = CBOR.encodeMapLen 0
+instance CanUpgradeLedgerTables LedgerState TestBlock where
+  upgradeTables _ _ = id
 
 instance ApplyBlock LedgerState TestBlock where
   applyBlockLedgerResultWithValidation _ _ _ tb@TestBlock{..} (TickedTestLedger TestLedger{..})
@@ -650,7 +643,8 @@ instance ApplyBlock LedgerState TestBlock where
   reapplyBlockLedgerResult =
     defaultReapplyBlockLedgerResult (error . ("reapplyBlockLedgerResult: impossible " <>) . show)
 
-  getBlockKeySets _blk = trivialLedgerTables
+instance GetBlockKeySets TestBlock where
+  getBlockKeySets _blk = emptyLedgerTables
 
 data instance LedgerState TestBlock mk
   = TestLedger

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Storage/TestBlock.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Storage/TestBlock.hs
@@ -120,7 +120,6 @@ import Ouroboros.Consensus.Protocol.ModChainSel
 import Ouroboros.Consensus.Protocol.Signed
 import Ouroboros.Consensus.Storage.ImmutableDB (Tip)
 import Ouroboros.Consensus.Storage.ImmutableDB.Chunks
-import Ouroboros.Consensus.Storage.LedgerDB
 import Ouroboros.Consensus.Storage.Serialisation
 import Ouroboros.Consensus.Storage.VolatileDB
 import Ouroboros.Consensus.Util.Condense

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/ChainDB.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/ChainDB.hs
@@ -19,7 +19,7 @@ import Ouroboros.Consensus.Config
   , configCodec
   )
 import Ouroboros.Consensus.HardFork.History.EraParams (eraEpochSize)
-import Ouroboros.Consensus.Ledger.Basics
+import Ouroboros.Consensus.Ledger.Abstract
 import Ouroboros.Consensus.Ledger.Extended (ExtLedgerState)
 import Ouroboros.Consensus.Ledger.SupportsProtocol
 import Ouroboros.Consensus.Peras.Params (mkPerasParams)

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/ChainDB.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/ChainDB.hs
@@ -90,7 +90,8 @@ mkTestChunkInfo = simpleChunkInfo . eraEpochSize . tblcHardForkParams . topLevel
 fromMinimalChainDbArgs ::
   ( IOLike m
   , LedgerSupportsProtocol blk
-  , LedgerSupportsLedgerDB blk
+  , LedgerDbSerialiseConstraints blk
+  , CanUpgradeLedgerTables LedgerState blk
   ) =>
   MinimalChainDbArgs m blk -> Complete ChainDbArgs m blk
 fromMinimalChainDbArgs MinimalChainDbArgs{..} =

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/LedgerStateOnlyTables.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/LedgerStateOnlyTables.hs
@@ -29,7 +29,6 @@ import NoThunks.Class (NoThunks)
 import Ouroboros.Consensus.Ledger.Basics (LedgerState)
 import Ouroboros.Consensus.Ledger.Tables
 import Ouroboros.Consensus.Ledger.Tables.Utils (emptyLedgerTables)
-import Ouroboros.Consensus.Storage.LedgerDB.API
 import Ouroboros.Consensus.Util.IndexedMemPack
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/LedgerStateOnlyTables.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/LedgerStateOnlyTables.hs
@@ -60,7 +60,7 @@ deriving instance
   NoThunks (OTLedgerState k v mk)
 
 emptyOTLedgerState ::
-  (Ord k, Eq v, MemPack k, MemPack v, ZeroableMK mk) =>
+  (Ord k, Eq v, ZeroableMK mk) =>
   LedgerState (OTBlock k v) mk
 emptyOTLedgerState = OTLedgerState emptyMK emptyLedgerTables
 
@@ -85,7 +85,7 @@ instance (Ord k, MemPack k, MemPack v) => SerializeTablesWithHint LedgerState (O
 -------------------------------------------------------------------------------}
 
 instance
-  (Ord k, Eq v, MemPack k, MemPack v) =>
+  (Ord k, Eq v) =>
   CanStowLedgerTables (OTLedgerState k v)
   where
   stowLedgerTables OTLedgerState{otlsLedgerTables} =
@@ -104,7 +104,7 @@ type instance TxIn (OTBlock k v) = k
 type instance TxOut (OTBlock k v) = v
 
 instance
-  (Ord k, Eq v, MemPack k, MemPack v, NoThunks k, NoThunks v) =>
+  (Ord k, Eq v, NoThunks k, NoThunks v) =>
   HasLedgerTables LedgerState (OTBlock k v)
   where
   projectLedgerTables OTLedgerState{otlsLedgerTables} =

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/LedgerStateOnlyTables.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/LedgerStateOnlyTables.hs
@@ -18,6 +18,7 @@
 module Test.Util.LedgerStateOnlyTables
   ( OTLedgerState
   , OTLedgerTables
+  , OTBlock
   , emptyOTLedgerState
   , pattern OTLedgerState
   ) where
@@ -36,7 +37,7 @@ import Ouroboros.Consensus.Util.IndexedMemPack
 -------------------------------------------------------------------------------}
 
 type OTLedgerState k v = LedgerState (OTBlock k v)
-type OTLedgerTables k v = LedgerTables (OTLedgerState k v)
+type OTLedgerTables k v = LedgerTables (OTBlock k v)
 
 -- | An empty type for blocks, which is only used to record the types @k@ and
 -- @v@.
@@ -63,19 +64,19 @@ emptyOTLedgerState ::
   LedgerState (OTBlock k v) mk
 emptyOTLedgerState = OTLedgerState emptyMK emptyLedgerTables
 
-instance CanUpgradeLedgerTables (LedgerState (OTBlock k v)) where
+instance CanUpgradeLedgerTables LedgerState (OTBlock k v) where
   upgradeTables _ _ = id
 
 instance
   MemPack v =>
-  IndexedMemPack (LedgerState (OTBlock k v) EmptyMK) v
+  IndexedMemPack LedgerState (OTBlock k v) v
   where
-  indexedTypeName _ = typeName @v
+  indexedTypeName _ _ = typeName @v
   indexedPackedByteCount _ = packedByteCount
   indexedPackM _ = packM
   indexedUnpackM _ = unpackM
 
-instance (Ord k, MemPack k, MemPack v) => SerializeTablesWithHint (LedgerState (OTBlock k v)) where
+instance (Ord k, MemPack k, MemPack v) => SerializeTablesWithHint LedgerState (OTBlock k v) where
   encodeTablesWithHint = defaultEncodeTablesWithHint
   decodeTablesWithHint = defaultDecodeTablesWithHint
 
@@ -99,12 +100,12 @@ instance
   Simple ledger tables
 -------------------------------------------------------------------------------}
 
-type instance TxIn (OTLedgerState k v) = k
-type instance TxOut (OTLedgerState k v) = v
+type instance TxIn (OTBlock k v) = k
+type instance TxOut (OTBlock k v) = v
 
 instance
-  (Ord k, Eq v, Show k, Show v, MemPack k, MemPack v, NoThunks k, NoThunks v) =>
-  HasLedgerTables (OTLedgerState k v)
+  (Ord k, Eq v, MemPack k, MemPack v, NoThunks k, NoThunks v) =>
+  HasLedgerTables LedgerState (OTBlock k v)
   where
   projectLedgerTables OTLedgerState{otlsLedgerTables} =
     otlsLedgerTables

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/Serialisation/Examples.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/Serialisation/Examples.hs
@@ -64,7 +64,7 @@ data Examples blk = Examples
   , exampleExtLedgerState :: Labelled (ExtLedgerState blk EmptyMK)
   , exampleSlotNo :: Labelled SlotNo
   , exampleLedgerConfig :: Labelled (LedgerConfig blk)
-  , exampleLedgerTables :: Labelled (LedgerTables (LedgerState blk) ValuesMK)
+  , exampleLedgerTables :: Labelled (LedgerTables blk ValuesMK)
   }
 
 emptyExamples :: Examples blk

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/Serialisation/Roundtrip.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/Serialisation/Roundtrip.hs
@@ -68,7 +68,7 @@ import GHC.Generics (Generic)
 import Language.Haskell.TH (runIO)
 import Ouroboros.Consensus.Block
 import Ouroboros.Consensus.HeaderValidation (AnnTip)
-import Ouroboros.Consensus.Ledger.Basics
+import Ouroboros.Consensus.Ledger.Abstract
 import Ouroboros.Consensus.Ledger.Extended
   ( decodeDiskExtLedgerState
   , encodeDiskExtLedgerState

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/TestBlock.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/TestBlock.hs
@@ -1045,6 +1045,7 @@ instance
       LedgerState
       (TestBlockWith ptype)
       (TxOut (TestBlockWith ptype))
+  , MemPack (TxIn (TestBlockWith ptype))
   , SerializeTablesWithHint LedgerState (TestBlockWith ptype)
   ) =>
   SerialiseDiskConstraints (TestBlockWith ptype)

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/TestBlock.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/TestBlock.hs
@@ -150,7 +150,6 @@ import Ouroboros.Consensus.Protocol.BFT
 import Ouroboros.Consensus.Protocol.MockChainSel
 import Ouroboros.Consensus.Protocol.Signed
 import Ouroboros.Consensus.Storage.ChainDB (SerialiseDiskConstraints)
-import Ouroboros.Consensus.Storage.LedgerDB
 import Ouroboros.Consensus.Storage.Serialisation
 import Ouroboros.Consensus.Util (ShowProxy (..))
 import Ouroboros.Consensus.Util.Condense

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/TestBlock.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/TestBlock.hs
@@ -94,6 +94,8 @@ module Test.Util.TestBlock
 import Cardano.Binary (DecoderError)
 import Cardano.Crypto.DSIGN
 import Cardano.Ledger.BaseTypes (knownNonZeroBounded, unNonZero)
+import qualified Codec.CBOR.Decoding as CBOR
+import qualified Codec.CBOR.Encoding as CBOR
 import Codec.Serialise (Serialise (..), serialise)
 import Control.DeepSeq (NFData, force)
 import Control.Monad (guard, replicateM, replicateM_)
@@ -405,8 +407,8 @@ class
   , forall mk. ShowMK mk => Show (PayloadDependentState ptype mk)
   , forall mk. Generic (PayloadDependentState ptype mk)
   , Serialise (PayloadDependentState ptype EmptyMK)
-  , HasLedgerTables (LedgerState (TestBlockWith ptype))
-  , HasLedgerTables (Ticked LedgerState (TestBlockWith ptype))
+  , HasLedgerTables LedgerState (TestBlockWith ptype)
+  , HasLedgerTables (Ticked LedgerState) (TestBlockWith ptype)
   , CanStowLedgerTables (LedgerState (TestBlockWith ptype))
   , Eq (PayloadDependentError ptype)
   , Show (PayloadDependentError ptype)
@@ -432,7 +434,7 @@ class
   -- 'ApplyBlock' class. Thus we assume that the payload contains all the
   -- information needed to determine which keys should be retrieved from the
   -- backing store to apply a 'TestBlockWith'.
-  getPayloadKeySets :: ptype -> LedgerTables (LedgerState (TestBlockWith ptype)) KeysMK
+  getPayloadKeySets :: ptype -> LedgerTables (TestBlockWith ptype) KeysMK
 
 instance PayloadSemantics () where
   data PayloadDependentState () mk = EmptyPLDS
@@ -443,7 +445,7 @@ instance PayloadSemantics () where
 
   applyPayload _ _ = Right EmptyPLDS
 
-  getPayloadKeySets = const trivialLedgerTables
+  getPayloadKeySets = const emptyLedgerTables
 
 -- | Apply the payload directly to the payload dependent state portion of a
 -- ticked state, leaving the rest of the input ticked state unaltered.
@@ -532,42 +534,33 @@ instance
     signKey :: SlotNo -> SignKeyDSIGN MockDSIGN
     signKey (SlotNo n) = SignKeyMockDSIGN $ n `mod` numCore
 
-type instance TxIn (LedgerState TestBlock) = Void
-type instance TxOut (LedgerState TestBlock) = Void
+type instance TxIn TestBlock = Void
+type instance TxOut TestBlock = Void
 
-instance LedgerTablesAreTrivial (LedgerState TestBlock) where
+instance LedgerTablesAreTrivial LedgerState TestBlock where
   convertMapKind (TestLedger x EmptyPLDS) = TestLedger x EmptyPLDS
-instance LedgerTablesAreTrivial (Ticked LedgerState TestBlock) where
+instance LedgerTablesAreTrivial (Ticked LedgerState) TestBlock where
   convertMapKind (TickedTestLedger x) = TickedTestLedger $ convertMapKind x
-
-deriving via
-  TrivialLedgerTables (LedgerState TestBlock)
-  instance
-    HasLedgerTables (LedgerState TestBlock)
-deriving via
-  TrivialLedgerTables (LedgerState TestBlock)
-  instance
-    HasLedgerTables (Ticked LedgerState TestBlock)
-deriving via
-  TrivialLedgerTables (LedgerState TestBlock)
-  instance
-    CanStowLedgerTables (LedgerState TestBlock)
-deriving via
-  TrivialLedgerTables (LedgerState TestBlock)
-  instance
-    CanUpgradeLedgerTables (LedgerState TestBlock)
-deriving via
-  TrivialLedgerTables (LedgerState TestBlock)
-  instance
-    SerializeTablesWithHint (LedgerState TestBlock)
 deriving via
   Void
   instance
-    IndexedMemPack (LedgerState TestBlock EmptyMK) Void
-deriving via
-  Void
-  instance
-    IndexedMemPack (Ticked LedgerState TestBlock EmptyMK) Void
+    IndexedMemPack LedgerState TestBlock Void
+instance HasLedgerTables LedgerState TestBlock where
+  projectLedgerTables _ = emptyLedgerTables
+  withLedgerTables st _ = convertMapKind st
+instance HasLedgerTables (Ticked LedgerState) TestBlock where
+  projectLedgerTables _ = emptyLedgerTables
+  withLedgerTables st _ = convertMapKind st
+instance CanStowLedgerTables (LedgerState TestBlock) where
+  stowLedgerTables = convertMapKind
+  unstowLedgerTables = convertMapKind
+instance CanUpgradeLedgerTables LedgerState TestBlock where
+  upgradeTables _ _ = id
+instance SerializeTablesWithHint LedgerState TestBlock where
+  decodeTablesWithHint _ = do
+    _ <- CBOR.decodeMapLen
+    pure (LedgerTables $ ValuesMK Map.empty)
+  encodeTablesWithHint _ _ = CBOR.encodeMapLen 0
 
 instance
   PayloadSemantics ptype =>
@@ -594,6 +587,10 @@ instance
   reapplyBlockLedgerResult =
     defaultReapplyBlockLedgerResult (error . ("Found an error when reapplying a block: " ++) . show)
 
+instance
+  PayloadSemantics ptype =>
+  GetBlockKeySets (TestBlockWith ptype)
+  where
   getBlockKeySets = getPayloadKeySets . tbPayload
 
 data instance LedgerState (TestBlockWith ptype) mk
@@ -1045,9 +1042,10 @@ instance
   ( Serialise ptype
   , PayloadSemantics ptype
   , IndexedMemPack
-      (LedgerState (TestBlockWith ptype) EmptyMK)
-      (TxOut (LedgerState (TestBlockWith ptype)))
-  , SerializeTablesWithHint (LedgerState (TestBlockWith ptype))
+      LedgerState
+      (TestBlockWith ptype)
+      (TxOut (TestBlockWith ptype))
+  , SerializeTablesWithHint LedgerState (TestBlockWith ptype)
   ) =>
   SerialiseDiskConstraints (TestBlockWith ptype)
 

--- a/ouroboros-consensus/src/unstable-mempool-test-utils/Test/Consensus/Mempool/Mocked.hs
+++ b/ouroboros-consensus/src/unstable-mempool-test-utils/Test/Consensus/Mempool/Mocked.hs
@@ -28,13 +28,13 @@ import Control.DeepSeq (NFData (rnf))
 import Control.Tracer (Tracer)
 import qualified Data.List.NonEmpty as NE
 import Ouroboros.Consensus.HeaderValidation as Header
-import Ouroboros.Consensus.Ledger.Basics
+import Ouroboros.Consensus.Ledger.Abstract
 import qualified Ouroboros.Consensus.Ledger.Basics as Ledger
 import qualified Ouroboros.Consensus.Ledger.SupportsMempool as Ledger
 import Ouroboros.Consensus.Ledger.Tables.Utils
   ( emptyLedgerTables
   , forgetLedgerTables
-  , restrictValues'
+  , restrictValuesMK
   )
 import Ouroboros.Consensus.Mempool (Mempool)
 import qualified Ouroboros.Consensus.Mempool as Mempool
@@ -93,7 +93,7 @@ openMockedMempool capacityOverride tracer initialParams = do
                           { roforkerClose = pure ()
                           , roforkerGetLedgerState = pure (forgetLedgerTables st)
                           , roforkerReadTables = \keys ->
-                              pure $ projectLedgerTables st `restrictValues'` keys
+                              pure $ ltliftA2 restrictValuesMK (projectLedgerTables st) keys
                           , roforkerReadStatistics = pure $ Statistics 0
                           , roforkerRangeReadTables = \_ -> pure (emptyLedgerTables, Nothing)
                           }

--- a/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Ledger/Block.hs
+++ b/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Ledger/Block.hs
@@ -435,12 +435,13 @@ instance
   reapplyBlockLedgerResult =
     defaultReapplyBlockLedgerResult (error . ("reapplyBlockLedgerResult: unexpected error: " <>) . show)
 
+instance GetBlockKeySets (SimpleBlock c ext) where
   getBlockKeySets SimpleBlock{simpleBody = SimpleBody txs} =
     LedgerTables $ KeysMK $ Mock.txIns txs
 
 data instance LedgerState (SimpleBlock c ext) mk = SimpleLedgerState
   { simpleLedgerState :: MockState (SimpleBlock c ext)
-  , simpleLedgerTables :: LedgerTables (LedgerState (SimpleBlock c ext)) mk
+  , simpleLedgerTables :: LedgerTables (SimpleBlock c ext) mk
   }
   deriving stock Generic
 
@@ -527,39 +528,32 @@ instance LedgerSupportsPeras (SimpleBlock c ext)
   LedgerTables
 -------------------------------------------------------------------------------}
 
-type instance TxIn (LedgerState (SimpleBlock c ext)) = Mock.TxIn
-type instance TxOut (LedgerState (SimpleBlock c ext)) = Mock.TxOut
+type instance TxIn (SimpleBlock c ext) = Mock.TxIn
+type instance TxOut (SimpleBlock c ext) = Mock.TxOut
 
-instance CanUpgradeLedgerTables (LedgerState (SimpleBlock c ext)) where
+instance CanUpgradeLedgerTables LedgerState (SimpleBlock c ext) where
   upgradeTables _ _ = id
 
-instance IndexedMemPack (LedgerState (SimpleBlock c ext) EmptyMK) Mock.TxOut where
-  indexedTypeName _ = typeName @Mock.TxOut
+instance IndexedMemPack LedgerState (SimpleBlock c ext) Mock.TxOut where
+  indexedTypeName _ _ = typeName @Mock.TxOut
   indexedPackedByteCount _ = packedByteCount
   indexedPackM _ = packM
   indexedUnpackM _ = unpackM
 
-instance IndexedMemPack (Ticked LedgerState (SimpleBlock c ext) EmptyMK) Mock.TxOut where
-  indexedTypeName _ = typeName @Mock.TxOut
-  indexedPackedByteCount _ = packedByteCount
-  indexedPackM _ = packM
-  indexedUnpackM _ = unpackM
-
-instance SerializeTablesWithHint (LedgerState (SimpleBlock c ext)) where
+instance SerializeTablesWithHint LedgerState (SimpleBlock c ext) where
   encodeTablesWithHint = defaultEncodeTablesWithHint
   decodeTablesWithHint = defaultDecodeTablesWithHint
 
-instance HasLedgerTables (LedgerState (SimpleBlock c ext)) where
+instance HasLedgerTables LedgerState (SimpleBlock c ext) where
   projectLedgerTables = simpleLedgerTables
   withLedgerTables (SimpleLedgerState s _) = SimpleLedgerState s
 
-instance HasLedgerTables (Ticked LedgerState (SimpleBlock c ext)) where
+instance HasLedgerTables (Ticked LedgerState) (SimpleBlock c ext) where
   projectLedgerTables =
-    castLedgerTables
-      . simpleLedgerTables
+    simpleLedgerTables
       . getTickedSimpleLedgerState
   withLedgerTables (TickedSimpleLedgerState st) tables =
-    TickedSimpleLedgerState $ withLedgerTables st $ castLedgerTables tables
+    TickedSimpleLedgerState $ withLedgerTables st tables
 
 instance CanStowLedgerTables (LedgerState (SimpleBlock c ext)) where
   stowLedgerTables st =

--- a/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Ledger/Block.hs
+++ b/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Ledger/Block.hs
@@ -112,7 +112,6 @@ import Ouroboros.Consensus.Storage.Common
   ( BinaryBlockInfo (..)
   , SizeInBytes
   )
-import Ouroboros.Consensus.Storage.LedgerDB
 import Ouroboros.Consensus.Util (ShowProxy (..), hashFromBytesShortE)
 import Ouroboros.Consensus.Util.Condense
 import Ouroboros.Consensus.Util.IndexedMemPack

--- a/ouroboros-consensus/src/unstable-tutorials/Ouroboros/Consensus/Tutorial/Simple.lhs
+++ b/ouroboros-consensus/src/unstable-tutorials/Ouroboros/Consensus/Tutorial/Simple.lhs
@@ -58,7 +58,7 @@ First, some imports we'll need:
 > import Ouroboros.Consensus.Ledger.Abstract
 >   (AuxLedgerEvent, GetTip(..), IsLedger(..), LedgerCfg,
 >    LedgerResult(LedgerResult, lrEvents, lrResult),
->    LedgerState, ApplyBlock(..), UpdateLedger,
+>    LedgerState, ApplyBlock(..), UpdateLedger, GetBlockKeySets (..),
 >    defaultApplyBlockLedgerResult, defaultReapplyBlockLedgerResult)
 > import Ouroboros.Consensus.Ledger.SupportsProtocol
 >   (LedgerSupportsProtocol(..))
@@ -66,7 +66,7 @@ First, some imports we'll need:
 > import Ouroboros.Consensus.HeaderValidation
 >   (ValidateEnvelope, BasicEnvelopeValidation, HasAnnTip)
 > import Ouroboros.Consensus.Ledger.Tables
-> import Ouroboros.Consensus.Storage.LedgerDB
+> import Ouroboros.Consensus.Ledger.Tables.Utils
 > import Ouroboros.Consensus.Util.IndexedMemPack
 
 Conceptual Overview and Definitions of Key Terms
@@ -630,7 +630,8 @@ the `ApplyBlock` typeclass:
 >   applyBlockLedgerResult = defaultApplyBlockLedgerResult
 >   reapplyBlockLedgerResult = defaultReapplyBlockLedgerResult absurd
 
->   getBlockKeySets = const trivialLedgerTables
+> instance GetBlockKeySets BlockC where
+>   getBlockKeySets = const emptyLedgerTables
 
 `applyBlockLedgerResult` tries to apply a block to the ledger and fails with a
 `LedgerErr` corresponding to the particular `LedgerState blk` if for whatever
@@ -740,23 +741,19 @@ the `LedgerTables`. For a Ledger state definition as simple as the one we are
 defining there the tables are trivially empty so the operations are all trivial
 and we use the default implementation
 
-> type instance TxIn  (LedgerState BlockC) = Void
-> type instance TxOut (LedgerState BlockC) = Void
+> type instance TxIn  BlockC = Void
+> type instance TxOut BlockC = Void
 
-> instance LedgerTablesAreTrivial (LedgerState BlockC) where
+> instance LedgerTablesAreTrivial LedgerState BlockC where
 >   convertMapKind (LedgerC x y) = LedgerC x y
-> instance LedgerTablesAreTrivial (Ticked LedgerState BlockC) where
+> instance LedgerTablesAreTrivial (Ticked LedgerState) BlockC where
 >   convertMapKind (TickedLedgerStateC x) =
 >       TickedLedgerStateC (convertMapKind x)
-> deriving via TrivialLedgerTables (LedgerState BlockC)
->     instance HasLedgerTables (LedgerState BlockC)
 > deriving via Void
->   instance IndexedMemPack (LedgerState BlockC EmptyMK) Void
-> deriving via Void
->   instance IndexedMemPack (Ticked LedgerState BlockC EmptyMK) Void
-> deriving via TrivialLedgerTables (Ticked LedgerState BlockC)
->     instance HasLedgerTables (Ticked LedgerState BlockC)
-> deriving via TrivialLedgerTables (LedgerState BlockC)
->     instance CanStowLedgerTables (LedgerState BlockC)
-> deriving via TrivialLedgerTables (LedgerState BlockC)
->     instance CanUpgradeLedgerTables (LedgerState BlockC)
+>   instance IndexedMemPack LedgerState BlockC Void
+> instance HasLedgerTables LedgerState BlockC where
+>   projectLedgerTables _ = emptyLedgerTables
+>   withLedgerTables st _ = convertMapKind st
+> instance HasLedgerTables (Ticked LedgerState) BlockC where
+>   projectLedgerTables _ = emptyLedgerTables
+>   withLedgerTables st _ = convertMapKind st

--- a/ouroboros-consensus/src/unstable-tutorials/Ouroboros/Consensus/Tutorial/WithEpoch.lhs
+++ b/ouroboros-consensus/src/unstable-tutorials/Ouroboros/Consensus/Tutorial/WithEpoch.lhs
@@ -78,7 +78,7 @@ And imports, of course:
 
 > import Ouroboros.Consensus.Ticked (Ticked, Ticked)
 > import Ouroboros.Consensus.Ledger.Abstract
->   (LedgerState, LedgerCfg, GetTip, LedgerResult (..), ApplyBlock (..),
+>   (LedgerState, LedgerCfg, GetTip, LedgerResult (..), ApplyBlock (..), GetBlockKeySets (..),
 >    UpdateLedger, IsLedger (..), AuxLedgerEvent, defaultApplyBlockLedgerResult,
 >    defaultReapplyBlockLedgerResult)
 
@@ -92,8 +92,8 @@ And imports, of course:
 >   (Forecast (..), OutsideForecastRange (..))
 > import Ouroboros.Consensus.Ledger.Basics (GetTip(..))
 > import Ouroboros.Consensus.Ledger.Tables
+> import Ouroboros.Consensus.Ledger.Tables.Utils
 
-> import Ouroboros.Consensus.Storage.LedgerDB
 > import Ouroboros.Consensus.Util.IndexedMemPack
 
 Epochs
@@ -418,7 +418,8 @@ applying each individual transaction - exactly as it was in for `BlockC`:
 >   applyBlockLedgerResult = defaultApplyBlockLedgerResult
 >   reapplyBlockLedgerResult = defaultReapplyBlockLedgerResult absurd
 
->   getBlockKeySets = const trivialLedgerTables
+> instance GetBlockKeySets BlockD where
+>   getBlockKeySets = const emptyLedgerTables
 
 Note that prior to `applyBlockLedgerResult` being invoked, the calling code will
 have already established that the header is valid and that the header matches
@@ -679,23 +680,19 @@ Appendix: UTxO-HD features
 For reference on these instances and their meaning, please see the appendix in
 [the Simple tutorial](./Simple.lhs).
 
-> type instance TxIn  (LedgerState BlockD) = Void
-> type instance TxOut (LedgerState BlockD) = Void
+> type instance TxIn  BlockD = Void
+> type instance TxOut BlockD = Void
 
-> instance LedgerTablesAreTrivial (LedgerState BlockD) where
->   convertMapKind (LedgerD x y z z') = LedgerD x y z z'
-> instance LedgerTablesAreTrivial (Ticked LedgerState BlockD) where
+> instance LedgerTablesAreTrivial LedgerState BlockD where
+>   convertMapKind (LedgerD x y z v) = LedgerD x y z v
+> instance LedgerTablesAreTrivial (Ticked LedgerState) BlockD where
 >   convertMapKind (TickedLedgerStateD x) =
 >       TickedLedgerStateD (convertMapKind x)
-> deriving via TrivialLedgerTables (LedgerState BlockD)
->     instance HasLedgerTables (LedgerState BlockD)
-> deriving via TrivialLedgerTables (Ticked LedgerState BlockD)
->     instance HasLedgerTables (Ticked LedgerState BlockD)
 > deriving via Void
->     instance IndexedMemPack (LedgerState BlockD EmptyMK) Void
-> deriving via Void
->     instance IndexedMemPack (Ticked LedgerState BlockD EmptyMK) Void
-> deriving via TrivialLedgerTables (LedgerState BlockD)
->     instance CanStowLedgerTables (LedgerState BlockD)
-> deriving via TrivialLedgerTables (LedgerState BlockD)
->     instance CanUpgradeLedgerTables (LedgerState BlockD)
+>   instance IndexedMemPack LedgerState BlockD Void
+> instance HasLedgerTables LedgerState BlockD where
+>   projectLedgerTables _ = emptyLedgerTables
+>   withLedgerTables st _ = convertMapKind st
+> instance HasLedgerTables (Ticked LedgerState) BlockD where
+>   projectLedgerTables _ = emptyLedgerTables
+>   withLedgerTables st _ = convertMapKind st

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/Mempool.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/Mempool.hs
@@ -746,7 +746,7 @@ withTestMempoolWithTimeoutConfig timeoutConfig setup@TestSetup{..} prop =
                           ReadOnlyForker
                             { roforkerClose = pure ()
                             , roforkerReadTables =
-                                pure . (projectLedgerTables st `restrictValues'`)
+                                pure . ltliftA2 restrictValuesMK (projectLedgerTables st)
                             , roforkerRangeReadTables = const $ pure (emptyLedgerTables, Nothing)
                             , roforkerGetLedgerState = pure $ forgetLedgerTables st
                             , roforkerReadStatistics = pure $ Statistics 0

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/Mempool/Fairness/TestBlock.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/Mempool/Fairness/TestBlock.hs
@@ -17,20 +17,23 @@ module Test.Consensus.Mempool.Fairness.TestBlock
   , unGenTx
   ) where
 
+import qualified Codec.CBOR.Decoding as CBOR
+import qualified Codec.CBOR.Encoding as CBOR
 import Codec.Serialise
 import Control.DeepSeq (NFData)
+import qualified Data.Map.Strict as Map
 import Data.Void (Void)
 import GHC.Generics (Generic)
 import NoThunks.Class (NoThunks)
 import qualified Ouroboros.Consensus.Block as Block
 import Ouroboros.Consensus.Ledger.Abstract
-  ( EmptyMK
-  , LedgerState
+  ( LedgerTables (..)
+  , ValuesMK (..)
   , convertMapKind
-  , trivialLedgerTables
   )
 import qualified Ouroboros.Consensus.Ledger.Abstract as Ledger
 import qualified Ouroboros.Consensus.Ledger.SupportsMempool as Ledger
+import Ouroboros.Consensus.Ledger.Tables.Utils
 import Ouroboros.Consensus.Storage.LedgerDB
 import Ouroboros.Consensus.Ticked (Ticked)
 import Ouroboros.Consensus.Util.IndexedMemPack
@@ -66,7 +69,7 @@ instance TestBlock.PayloadSemantics Tx where
 
   applyPayload NoPayLoadDependentState _tx = Right NoPayLoadDependentState
 
-  getPayloadKeySets = const trivialLedgerTables
+  getPayloadKeySets = const emptyLedgerTables
 
 data instance Block.CodecConfig TestBlock = TestBlockCodecConfig
   deriving (Show, Generic, NoThunks)
@@ -113,7 +116,7 @@ instance Ledger.LedgerSupportsMempool TestBlock where
 
   txForgetValidated (ValidatedGenTx tx) = tx
 
-  getTransactionKeySets _ = trivialLedgerTables
+  getTransactionKeySets _ = emptyLedgerTables
 
   mkMempoolApplyTxError = Ledger.nothingMkMempoolApplyTxError
 
@@ -134,39 +137,35 @@ instance Ledger.TxLimits TestBlock where
 
 type instance Ledger.ApplyTxErr TestBlock = ()
 
-type instance Ledger.TxIn (Ledger.LedgerState TestBlock) = Void
-type instance Ledger.TxOut (Ledger.LedgerState TestBlock) = Void
+type instance Ledger.TxIn TestBlock = Void
+type instance Ledger.TxOut TestBlock = Void
 
-deriving via
-  Ledger.TrivialLedgerTables (Ledger.LedgerState TestBlock)
-  instance
-    Ledger.HasLedgerTables (Ledger.LedgerState TestBlock)
-
-deriving via
-  Ledger.TrivialLedgerTables (Ledger.LedgerState TestBlock)
-  instance
-    Ledger.HasLedgerTables (Ticked Ledger.LedgerState TestBlock)
-
-deriving via
-  Void
-  instance
-    IndexedMemPack (LedgerState TestBlock EmptyMK) Void
-deriving via
-  Void
-  instance
-    IndexedMemPack (Ticked LedgerState TestBlock EmptyMK) Void
-
-instance Ledger.LedgerTablesAreTrivial (Ledger.LedgerState TestBlock) where
+instance Ledger.LedgerTablesAreTrivial Ledger.LedgerState TestBlock where
   convertMapKind (TestBlock.TestLedger x NoPayLoadDependentState) =
     TestBlock.TestLedger x NoPayLoadDependentState
-instance Ledger.LedgerTablesAreTrivial (Ticked Ledger.LedgerState TestBlock) where
+instance Ledger.LedgerTablesAreTrivial (Ticked Ledger.LedgerState) TestBlock where
   convertMapKind (TestBlock.TickedTestLedger x) =
     TestBlock.TickedTestLedger (Ledger.convertMapKind x)
-deriving via
-  Ledger.TrivialLedgerTables (Ledger.LedgerState TestBlock)
-  instance
-    Ledger.CanStowLedgerTables (Ledger.LedgerState TestBlock)
-deriving via
-  Ledger.TrivialLedgerTables (Ledger.LedgerState TestBlock)
-  instance
-    CanUpgradeLedgerTables (Ledger.LedgerState TestBlock)
+
+deriving via Void instance IndexedMemPack Ledger.LedgerState TestBlock Void
+
+instance Ledger.HasLedgerTables Ledger.LedgerState TestBlock where
+  projectLedgerTables _ = emptyLedgerTables
+  withLedgerTables st _ = convertMapKind st
+
+instance Ledger.HasLedgerTables (Ticked Ledger.LedgerState) TestBlock where
+  projectLedgerTables _ = emptyLedgerTables
+  withLedgerTables st _ = convertMapKind st
+
+instance Ledger.CanStowLedgerTables (Ledger.LedgerState TestBlock) where
+  stowLedgerTables = convertMapKind
+  unstowLedgerTables = convertMapKind
+
+instance CanUpgradeLedgerTables Ledger.LedgerState TestBlock where
+  upgradeTables _ _ = id
+
+instance Ledger.SerializeTablesWithHint Ledger.LedgerState TestBlock where
+  decodeTablesWithHint _ = do
+    _ <- CBOR.decodeMapLen
+    pure (LedgerTables $ ValuesMK Map.empty)
+  encodeTablesWithHint _ _ = CBOR.encodeMapLen 0

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/Mempool/StateMachine.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/Mempool/StateMachine.hs
@@ -44,11 +44,12 @@ import qualified Data.TreeDiff.OMap as TD
 import GHC.Generics
 import Ouroboros.Consensus.Block
 import Ouroboros.Consensus.HeaderValidation
-import Ouroboros.Consensus.Ledger.Basics hiding (TxIn, TxOut)
+import Ouroboros.Consensus.Ledger.Abstract hiding (TxIn, TxOut)
 import Ouroboros.Consensus.Ledger.SupportsMempool
 import Ouroboros.Consensus.Ledger.SupportsProtocol
   ( LedgerSupportsProtocol
   )
+import qualified Ouroboros.Consensus.Ledger.Tables.Basics as Ledger
 import Ouroboros.Consensus.Ledger.Tables.Utils
 import Ouroboros.Consensus.Mempool
 import Ouroboros.Consensus.Mempool.Impl.Common (MempoolLedgerDBView (..), tickLedgerState)
@@ -543,7 +544,7 @@ newLedgerInterface initialLedger = do
                       ReadOnlyForker
                         { roforkerClose = pure ()
                         , roforkerReadStatistics = pure $ Statistics 0
-                        , roforkerReadTables = pure . (projectLedgerTables st `restrictValues'`)
+                        , roforkerReadTables = pure . ltliftA2 restrictValuesMK (projectLedgerTables st)
                         , roforkerRangeReadTables = const $ pure (emptyLedgerTables, Nothing)
                         , roforkerGetLedgerState = pure $ forgetLedgerTables st
                         }
@@ -629,6 +630,8 @@ postcondition ::
   , ValidateEnvelope blk
   , ToExpr (Command blk Concrete)
   , ToExpr (GenTx blk)
+  , Show (Ledger.TxIn blk)
+  , Show (Ledger.TxOut blk)
   ) =>
   Model blk Concrete ->
   Command blk Concrete ->
@@ -973,7 +976,7 @@ deriving instance ToExpr (GenTx TestBlock)
 deriving instance ToExpr Tx
 deriving instance ToExpr Expiry
 
-instance ToExpr (LedgerTables (LedgerState TestBlock) ValuesMK) where
+instance ToExpr (LedgerTables TestBlock ValuesMK) where
   toExpr (LedgerTables (ValuesMK v)) = Lst [toExpr (condense txin, condense txout) | (txin, txout) <- Map.toList v]
 
 instance ToExpr (ValuesMK TxIn TxOut) where

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/Model.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/Model.hs
@@ -429,7 +429,7 @@ empty loe initLedger =
 
 addBlock ::
   forall blk.
-  (LedgerSupportsProtocol blk, LedgerTablesAreTrivial (ExtLedgerState blk)) =>
+  (LedgerSupportsProtocol blk, LedgerTablesAreTrivial ExtLedgerState blk) =>
   TopLevelConfig blk ->
   blk ->
   Model blk ->
@@ -458,7 +458,7 @@ addBlock cfg blk m
 
 addPerasCert ::
   forall blk.
-  (LedgerSupportsProtocol blk, LedgerTablesAreTrivial (ExtLedgerState blk)) =>
+  (LedgerSupportsProtocol blk, LedgerTablesAreTrivial ExtLedgerState blk) =>
   TopLevelConfig blk ->
   WithArrivalTime (ValidatedPerasCert blk) ->
   Model blk ->
@@ -468,7 +468,7 @@ addPerasCert cfg cert m =
 
 addPerasVote ::
   forall blk.
-  (LedgerSupportsProtocol blk, LedgerTablesAreTrivial (ExtLedgerState blk)) =>
+  (LedgerSupportsProtocol blk, LedgerTablesAreTrivial ExtLedgerState blk) =>
   TopLevelConfig blk ->
   WithArrivalTime (ValidatedPerasVote blk) ->
   Model blk ->
@@ -484,7 +484,7 @@ addPerasVote cfg vote m =
 
 chainSelection ::
   forall blk.
-  ( LedgerTablesAreTrivial (ExtLedgerState blk)
+  ( LedgerTablesAreTrivial ExtLedgerState blk
   , LedgerSupportsProtocol blk
   ) =>
   TopLevelConfig blk ->
@@ -613,7 +613,7 @@ chainSelection cfg m =
         consideredCandidates
 
 addBlocks ::
-  (LedgerSupportsProtocol blk, LedgerTablesAreTrivial (ExtLedgerState blk)) =>
+  (LedgerSupportsProtocol blk, LedgerTablesAreTrivial ExtLedgerState blk) =>
   TopLevelConfig blk ->
   [blk] ->
   Model blk ->
@@ -623,7 +623,7 @@ addBlocks cfg = repeatedly (addBlock cfg)
 -- | Wrapper around 'addBlock' that returns an 'AddBlockPromise'.
 addBlockPromise ::
   forall m blk.
-  (LedgerSupportsProtocol blk, MonadSTM m, LedgerTablesAreTrivial (ExtLedgerState blk)) =>
+  (LedgerSupportsProtocol blk, MonadSTM m, LedgerTablesAreTrivial ExtLedgerState blk) =>
   TopLevelConfig blk ->
   blk ->
   Model blk ->
@@ -644,7 +644,7 @@ addBlockPromise cfg blk m = (result, m')
 -- point.
 updateLoE ::
   forall blk.
-  ( LedgerTablesAreTrivial (ExtLedgerState blk)
+  ( LedgerTablesAreTrivial ExtLedgerState blk
   , LedgerSupportsProtocol blk
   ) =>
   TopLevelConfig blk ->
@@ -845,7 +845,7 @@ data ValidatedChain blk
 -- 'invalid' of the given 'Model'.
 validate ::
   forall blk.
-  (LedgerSupportsProtocol blk, LedgerTablesAreTrivial (ExtLedgerState blk)) =>
+  (LedgerSupportsProtocol blk, LedgerTablesAreTrivial ExtLedgerState blk) =>
   TopLevelConfig blk ->
   Model blk ->
   Chain blk ->
@@ -906,7 +906,7 @@ chains bs = go Chain.Genesis
 
 validChains ::
   forall blk.
-  (LedgerSupportsProtocol blk, LedgerTablesAreTrivial (ExtLedgerState blk)) =>
+  (LedgerSupportsProtocol blk, LedgerTablesAreTrivial ExtLedgerState blk) =>
   TopLevelConfig blk ->
   Model blk ->
   Map (HeaderHash blk) blk ->
@@ -1161,7 +1161,7 @@ reopen m = m{isOpen = True}
 -- see https://github.com/tweag/cardano-peras/issues/122
 wipeVolatileDB ::
   forall blk.
-  (LedgerSupportsProtocol blk, LedgerTablesAreTrivial (ExtLedgerState blk)) =>
+  (LedgerSupportsProtocol blk, LedgerTablesAreTrivial ExtLedgerState blk) =>
   TopLevelConfig blk ->
   Model blk ->
   (Point blk, Model blk)

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
@@ -139,7 +139,6 @@ import qualified Ouroboros.Consensus.Storage.ImmutableDB as ImmutableDB
 import Ouroboros.Consensus.Storage.ImmutableDB.Chunks.Internal
   ( unsafeChunkNoToEpochNo
   )
-import Ouroboros.Consensus.Storage.LedgerDB (CanUpgradeLedgerTables)
 import qualified Ouroboros.Consensus.Storage.LedgerDB.TraceEvent as LedgerDB
 import qualified Ouroboros.Consensus.Storage.LedgerDB.V1.DbChangelog as DbChangelog
 import qualified Ouroboros.Consensus.Storage.PerasCertDB as PerasCertDB

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
@@ -139,7 +139,7 @@ import qualified Ouroboros.Consensus.Storage.ImmutableDB as ImmutableDB
 import Ouroboros.Consensus.Storage.ImmutableDB.Chunks.Internal
   ( unsafeChunkNoToEpochNo
   )
-import Ouroboros.Consensus.Storage.LedgerDB (CanUpgradeLedgerTables, LedgerSupportsLedgerDB)
+import Ouroboros.Consensus.Storage.LedgerDB (CanUpgradeLedgerTables)
 import qualified Ouroboros.Consensus.Storage.LedgerDB.TraceEvent as LedgerDB
 import qualified Ouroboros.Consensus.Storage.LedgerDB.V1.DbChangelog as DbChangelog
 import qualified Ouroboros.Consensus.Storage.PerasCertDB as PerasCertDB
@@ -377,7 +377,6 @@ type TestConstraints blk =
   , Show (LedgerState blk EmptyMK)
   , LedgerTablesAreTrivial LedgerState blk
   , CanUpgradeLedgerTables LedgerState blk
-  , LedgerSupportsLedgerDB blk
   , ImmutableEraParams blk
   )
 

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
@@ -139,7 +139,7 @@ import qualified Ouroboros.Consensus.Storage.ImmutableDB as ImmutableDB
 import Ouroboros.Consensus.Storage.ImmutableDB.Chunks.Internal
   ( unsafeChunkNoToEpochNo
   )
-import Ouroboros.Consensus.Storage.LedgerDB (LedgerSupportsLedgerDB)
+import Ouroboros.Consensus.Storage.LedgerDB (CanUpgradeLedgerTables, LedgerSupportsLedgerDB)
 import qualified Ouroboros.Consensus.Storage.LedgerDB.TraceEvent as LedgerDB
 import qualified Ouroboros.Consensus.Storage.LedgerDB.V1.DbChangelog as DbChangelog
 import qualified Ouroboros.Consensus.Storage.PerasCertDB as PerasCertDB
@@ -375,7 +375,8 @@ type TestConstraints blk =
   , HasHardForkHistory blk
   , SerialiseDiskConstraints blk
   , Show (LedgerState blk EmptyMK)
-  , LedgerTablesAreTrivial (LedgerState blk)
+  , LedgerTablesAreTrivial LedgerState blk
+  , CanUpgradeLedgerTables LedgerState blk
   , LedgerSupportsLedgerDB blk
   , ImmutableEraParams blk
   )

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/Unit.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/Unit.hs
@@ -40,7 +40,7 @@ import Ouroboros.Consensus.Config
   ( TopLevelConfig
   )
 import Ouroboros.Consensus.Config.SecurityParam (SecurityParam (..))
-import Ouroboros.Consensus.Ledger.Basics
+import Ouroboros.Consensus.Ledger.Abstract
 import Ouroboros.Consensus.Ledger.Extended (ExtLedgerState)
 import qualified Ouroboros.Consensus.Storage.ChainDB.API as API
 import Ouroboros.Consensus.Storage.ChainDB.Impl (TraceEvent)
@@ -527,7 +527,7 @@ runModelCmd cmd = do
     Right success -> pure success
 
 instance
-  (TestConstraints blk, LedgerTablesAreTrivial (LedgerState blk)) =>
+  (TestConstraints blk, LedgerTablesAreTrivial LedgerState blk) =>
   SupportsUnitTest (ModelM blk)
   where
   type FollowerId (ModelM blk) = Model.FollowerId

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/LedgerDB/StateMachine/TestBlock.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/LedgerDB/StateMachine/TestBlock.hs
@@ -123,7 +123,7 @@ data TxErr
 instance PayloadSemantics Tx where
   data PayloadDependentState Tx mk
     = UTxTok
-    { utxtoktables :: LedgerTables (LedgerState TestBlock) mk
+    { utxtoktables :: LedgerTables TestBlock mk
     , -- \| All the tokens that ever existed. We use this to
       -- make sure a token is not created more than once. See
       -- the definition of 'applyPayload' in the
@@ -183,18 +183,18 @@ instance PayloadSemantics Tx where
   getPayloadKeySets Tx{consumed} =
     LedgerTables $ KeysMK $ Set.singleton consumed
 
-deriving instance Eq (LedgerTables (LedgerState TestBlock) mk) => Eq (PayloadDependentState Tx mk)
+deriving instance Eq (LedgerTables TestBlock mk) => Eq (PayloadDependentState Tx mk)
 deriving instance
-  NoThunks (LedgerTables (LedgerState TestBlock) mk) => NoThunks (PayloadDependentState Tx mk)
+  NoThunks (LedgerTables TestBlock mk) => NoThunks (PayloadDependentState Tx mk)
 deriving instance
-  Show (LedgerTables (LedgerState TestBlock) mk) => Show (PayloadDependentState Tx mk)
+  Show (LedgerTables TestBlock mk) => Show (PayloadDependentState Tx mk)
 deriving instance
-  Serialise (LedgerTables (LedgerState TestBlock) mk) => Serialise (PayloadDependentState Tx mk)
+  Serialise (LedgerTables TestBlock mk) => Serialise (PayloadDependentState Tx mk)
 
 onValues ::
   (Map Token TValue -> Map Token TValue) ->
-  LedgerTables (LedgerState TestBlock) ValuesMK ->
-  LedgerTables (LedgerState TestBlock) ValuesMK
+  LedgerTables TestBlock ValuesMK ->
+  LedgerTables TestBlock ValuesMK
 onValues f (LedgerTables testUtxtokTable) = LedgerTables $ updateMap testUtxtokTable
  where
   updateMap :: ValuesMK Token TValue -> ValuesMK Token TValue
@@ -203,7 +203,7 @@ onValues f (LedgerTables testUtxtokTable) = LedgerTables $ updateMap testUtxtokT
 
 queryKeys ::
   (Map Token TValue -> a) ->
-  LedgerTables (LedgerState TestBlock) ValuesMK ->
+  LedgerTables TestBlock ValuesMK ->
   a
 queryKeys f (LedgerTables (ValuesMK utxovals)) = f utxovals
 
@@ -211,29 +211,23 @@ queryKeys f (LedgerTables (ValuesMK utxovals)) = f utxovals
   Instances required for on-disk storage of ledger state tables
 -------------------------------------------------------------------------------}
 
-type instance TxIn (LedgerState TestBlock) = Token
-type instance TxOut (LedgerState TestBlock) = TValue
+type instance TxIn TestBlock = Token
+type instance TxOut TestBlock = TValue
 
-instance CanUpgradeLedgerTables (LedgerState TestBlock) where
+instance CanUpgradeLedgerTables LedgerState TestBlock where
   upgradeTables _ _ = id
 
-instance IndexedMemPack (LedgerState TestBlock EmptyMK) TValue where
-  indexedTypeName _ = typeName @TValue
+instance IndexedMemPack LedgerState TestBlock TValue where
+  indexedTypeName _ _ = typeName @TValue
   indexedPackedByteCount _ = packedByteCount
   indexedPackM _ = packM
   indexedUnpackM _ = unpackM
 
-instance IndexedMemPack (Ticked LedgerState TestBlock EmptyMK) TValue where
-  indexedTypeName _ = typeName @TValue
-  indexedPackedByteCount _ = packedByteCount
-  indexedPackM _ = packM
-  indexedUnpackM _ = unpackM
-
-instance SerializeTablesWithHint (LedgerState TestBlock) where
+instance SerializeTablesWithHint LedgerState TestBlock where
   encodeTablesWithHint = defaultEncodeTablesWithHint
   decodeTablesWithHint = defaultDecodeTablesWithHint
 
-instance HasLedgerTables (LedgerState TestBlock) where
+instance HasLedgerTables LedgerState TestBlock where
   projectLedgerTables st = utxtoktables $ payloadDependentState st
   withLedgerTables st table =
     st
@@ -241,13 +235,12 @@ instance HasLedgerTables (LedgerState TestBlock) where
           (payloadDependentState st){utxtoktables = table}
       }
 
-instance HasLedgerTables (Ticked LedgerState TestBlock) where
-  projectLedgerTables (TickedTestLedger st) =
-    castLedgerTables $ projectLedgerTables st
+instance HasLedgerTables (Ticked LedgerState) TestBlock where
+  projectLedgerTables (TickedTestLedger st) = projectLedgerTables st
   withLedgerTables (TickedTestLedger st) tables =
-    TickedTestLedger $ withLedgerTables st $ castLedgerTables tables
+    TickedTestLedger $ withLedgerTables st tables
 
-instance Serialise (LedgerTables (LedgerState TestBlock) EmptyMK) where
+instance Serialise (LedgerTables TestBlock EmptyMK) where
   encode (LedgerTables (_ :: EmptyMK Token TValue)) =
     CBOR.encodeNull
   decode = LedgerTables EmptyMK <$ CBOR.decodeNull
@@ -280,9 +273,9 @@ deriving anyclass instance ToExpr DS.Length
 deriving anyclass instance ToExpr DS.SlotNoUB
 deriving anyclass instance ToExpr DS.SlotNoLB
 deriving anyclass instance
-  ToExpr (mk Token TValue) => ToExpr (LedgerTables (LedgerState TestBlock) mk)
+  ToExpr (mk Token TValue) => ToExpr (LedgerTables TestBlock mk)
 deriving instance
-  ToExpr (LedgerTables (LedgerState TestBlock) mk) => ToExpr (PayloadDependentState Tx mk)
+  ToExpr (LedgerTables TestBlock mk) => ToExpr (PayloadDependentState Tx mk)
 
 deriving newtype instance ToExpr (ValuesMK Token TValue)
 

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/LedgerDB/V1/BackingStore.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/LedgerDB/V1/BackingStore.hs
@@ -33,7 +33,7 @@ import Data.MemPack
 import qualified Data.SOP.Dict as Dict
 import qualified Data.Set as Set
 import Data.Typeable
-import Ouroboros.Consensus.Ledger.Tables
+import Ouroboros.Consensus.Ledger.Abstract
 import qualified Ouroboros.Consensus.Ledger.Tables.Diff as Diff
 import Ouroboros.Consensus.Ledger.Tables.Utils
 import qualified Ouroboros.Consensus.Storage.LedgerDB.V1.BackingStore as BS
@@ -99,14 +99,14 @@ scaleQuickCheckTests :: Int -> QuickCheckTests -> QuickCheckTests
 scaleQuickCheckTests c (QuickCheckTests n) = QuickCheckTests $ c * n
 
 testWithIO ::
-  IO (BSEnv IO K K' V D) ->
+  IO (BSEnv IO LedgerState K K' V D) ->
   Actions (Lockstep T) ->
   Property
 testWithIO mkBSEnv = runActionsBracket pT mkBSEnv bsCleanup runner
 
 runner ::
-  RealMonad m ks k vs d a ->
-  BSEnv m ks k vs d ->
+  RealMonad m LedgerState ks k vs d a ->
+  BSEnv m LedgerState ks k vs d ->
   m a
 runner c r = runReaderT c $ bsRealEnv r
 
@@ -118,8 +118,8 @@ labelledExamples = QC.labelledExamples $ tagActions pT
   Resources
 -------------------------------------------------------------------------------}
 
-data BSEnv m ks k vs d = BSEnv
-  { bsRealEnv :: RealEnv m ks k vs d
+data BSEnv m l ks k vs d = BSEnv
+  { bsRealEnv :: RealEnv m l ks k vs d
   , bsCleanup :: m ()
   }
 
@@ -140,12 +140,12 @@ setupTempDir = do
   pure (qsmTmpDir, liftIO $ Dir.removeDirectoryRecursive qsmTmpDir)
 
 setupBSEnv ::
-  BS.Backend m backend (OTLedgerState (QC.Fixed Word) (QC.Fixed Word)) =>
+  BS.Backend m backend LedgerState (OTBlock (QC.Fixed Word) (QC.Fixed Word)) =>
   IOLike m =>
   BS.Args m backend ->
   m (SomeHasFS m) ->
   m () ->
-  m (BSEnv m K K' V D)
+  m (BSEnv m LedgerState K K' V D)
 setupBSEnv mkBsArgs mkShfs cleanup = do
   shfs@(SomeHasFS hfs) <- mkShfs
 
@@ -187,15 +187,15 @@ closeHandlers =
   Types under test
 -------------------------------------------------------------------------------}
 
-type T = BackingStoreState K K' V D
+type T = BackingStoreState LedgerState K K' V D
 
 pT :: Proxy T
 pT = Proxy
 
-type K = LedgerTables (OTLedgerState (QC.Fixed Word) (QC.Fixed Word)) KeysMK
+type K = LedgerTables (OTBlock (QC.Fixed Word) (QC.Fixed Word)) KeysMK
 type K' = QC.Fixed Word
-type V = LedgerTables (OTLedgerState (QC.Fixed Word) (QC.Fixed Word)) ValuesMK
-type D = LedgerTables (OTLedgerState (QC.Fixed Word) (QC.Fixed Word)) DiffMK
+type V = LedgerTables (OTBlock (QC.Fixed Word) (QC.Fixed Word)) ValuesMK
+type D = LedgerTables (OTBlock (QC.Fixed Word) (QC.Fixed Word)) DiffMK
 
 {-------------------------------------------------------------------------------
   @'HasOps'@ instances
@@ -205,7 +205,7 @@ instance Mock.EmptyValues V where
   emptyValues = emptyLedgerTables
 
 instance Mock.ApplyDiff V D where
-  applyDiff = applyDiffs'
+  applyDiff = ltliftA2 applyDiffsMK
 
 instance Mock.LookupKeysRange K K' V where
   lookupKeysRange = \prev n vs ->
@@ -254,7 +254,7 @@ instance Mock.ValuesLength V where
     Map.size m
 
 instance Mock.MakeDiff V D where
-  diff t1 t2 = trackingToDiffs $ calculateDifference t1 t2
+  diff t1 t2 = ltmap rawTrackingDiffs $ ltliftA2 rawCalculateDifference t1 t2
 
 instance Mock.DiffSize D where
   diffSize (LedgerTables (DiffMK (Diff.Diff m))) = Map.size m
@@ -262,19 +262,19 @@ instance Mock.DiffSize D where
 instance Mock.KeysSize K where
   keysSize (LedgerTables (KeysMK s)) = Set.size s
 
-instance Mock.MakeInitHint V where
-  makeInitHint _ = emptyOTLedgerState
+instance Mock.MakeInitHint LedgerState V where
+  makeInitHint _ _ = emptyOTLedgerState
 
-instance Mock.MakeWriteHint D where
-  makeWriteHint _ = (emptyOTLedgerState, emptyOTLedgerState)
+instance Mock.MakeWriteHint LedgerState D where
+  makeWriteHint _ _ = (emptyOTLedgerState, emptyOTLedgerState)
 
-instance Mock.MakeReadHint V where
-  makeReadHint _ = emptyOTLedgerState
+instance Mock.MakeReadHint LedgerState V where
+  makeReadHint _ _ = emptyOTLedgerState
 
-instance Mock.MakeSerializeTablesHint V where
-  makeSerializeTablesHint _ = emptyOTLedgerState
+instance Mock.MakeSerializeTablesHint LedgerState V where
+  makeSerializeTablesHint _ _ = emptyOTLedgerState
 
-instance Mock.HasOps K K' V D
+instance Mock.HasOps LedgerState K K' V D
 
 {-------------------------------------------------------------------------------
   Orphan Arbitrary instances

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/LedgerDB/V1/BackingStore/Lockstep.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/LedgerDB/V1/BackingStore/Lockstep.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DerivingStrategies #-}
@@ -78,13 +79,13 @@ newtype Values vs = Values {unValues :: vs}
   Model state
 -------------------------------------------------------------------------------}
 
-data BackingStoreState ks k vs d = BackingStoreState
+data BackingStoreState (l :: StateKind) ks k vs d = BackingStoreState
   { bssMock :: Mock vs
   , bssStats :: Stats ks k vs d
   }
   deriving (Show, Eq)
 
-initState :: Mock.EmptyValues vs => BackingStoreState ks k vs d
+initState :: Mock.EmptyValues vs => BackingStoreState l ks k vs d
 initState =
   BackingStoreState
     { bssMock = Mock.emptyMock
@@ -102,96 +103,97 @@ maxOpenValueHandles = 32
   @'StateModel'@ and @'RunModel'@ instances
 -------------------------------------------------------------------------------}
 
-type BackingStoreInitializer m ks k vs d =
-  BS.InitFrom vs ->
-  m (BS.BackingStore m ks k vs d)
+type BackingStoreInitializer m l ks k vs d =
+  BS.InitFrom l vs ->
+  m (BS.BackingStore m l ks k vs d)
 
-data RealEnv m ks k vs d = RealEnv
-  { reBackingStoreInit :: BackingStoreInitializer m ks k vs d
-  , reBackingStore :: StrictMVar m (BS.BackingStore m ks k vs d)
+data RealEnv m l ks k vs d = RealEnv
+  { reBackingStoreInit :: BackingStoreInitializer m l ks k vs d
+  , reBackingStore :: StrictMVar m (BS.BackingStore m l ks k vs d)
   }
 
-type RealMonad m ks k vs d = ReaderT (RealEnv m ks k vs d) m
+type RealMonad m l ks k vs d = ReaderT (RealEnv m l ks k vs d) m
 
-type BSAct ks k vs d a =
+type BSAct l ks k vs d a =
   Action
-    (Lockstep (BackingStoreState ks k vs d))
+    (Lockstep (BackingStoreState l ks k vs d))
     (Either Err a)
-type BSVar ks k vs d a =
-  ModelVar (BackingStoreState ks k vs d) a
+type BSVar l ks k vs d a =
+  ModelVar (BackingStoreState l ks k vs d) a
 
 instance
   ( Show ks
   , Show vs
   , Show k
   , Show d
-  , Show (BS.InitHint vs)
-  , Show (BS.WriteHint d)
-  , Show (BS.ReadHint vs)
+  , Show (BS.InitHint l vs)
+  , Show (BS.WriteHint l d)
+  , Show (BS.ReadHint l vs)
   , Eq ks
   , Eq k
   , Eq vs
   , Eq d
-  , Eq (BS.InitHint vs)
-  , Eq (BS.WriteHint d)
-  , Eq (BS.ReadHint vs)
+  , Eq (BS.InitHint l vs)
+  , Eq (BS.WriteHint l d)
+  , Eq (BS.ReadHint l vs)
   , Typeable ks
   , Typeable k
   , Typeable vs
   , Typeable d
-  , Typeable (BS.WriteHint d)
+  , Typeable (BS.WriteHint l d)
+  , Typeable l
   , QC.Arbitrary ks
   , QC.Arbitrary k
   , QC.Arbitrary vs
   , QC.Arbitrary d
   , QC.Arbitrary (BS.RangeQuery ks)
-  , Mock.HasOps ks k vs d
+  , Mock.HasOps l ks k vs d
   ) =>
-  StateModel (Lockstep (BackingStoreState ks k vs d))
+  StateModel (Lockstep (BackingStoreState l ks k vs d))
   where
-  data Action (Lockstep (BackingStoreState ks k vs d)) a where
+  data Action (Lockstep (BackingStoreState l ks k vs d)) a where
     -- Reopen a backing store by intialising from values.
     BSInitFromValues ::
       WithOrigin SlotNo ->
-      BS.InitHint vs ->
+      BS.InitHint l vs ->
       Values vs ->
-      BSAct ks k vs d ()
+      BSAct l ks k vs d ()
     -- Reopen a backing store by initialising from a copy.
     BSInitFromCopy ::
-      BS.InitHint vs ->
+      BS.InitHint l vs ->
       FS.FsPath ->
-      BSAct ks k vs d ()
-    BSClose :: BSAct ks k vs d ()
+      BSAct l ks k vs d ()
+    BSClose :: BSAct l ks k vs d ()
     BSCopy ::
-      SerializeTablesHint vs ->
+      SerializeTablesHint l vs ->
       FS.FsPath ->
-      BSAct ks k vs d ()
-    BSValueHandle :: BSAct ks k vs d (BS.BackingStoreValueHandle IO ks k vs)
+      BSAct l ks k vs d ()
+    BSValueHandle :: BSAct l ks k vs d (BS.BackingStoreValueHandle IO l ks k vs)
     BSWrite ::
       SlotNo ->
-      BS.WriteHint d ->
+      BS.WriteHint l d ->
       d ->
-      BSAct ks k vs d ()
+      BSAct l ks k vs d ()
     BSVHClose ::
-      BSVar ks k vs d (BS.BackingStoreValueHandle IO ks k vs) ->
-      BSAct ks k vs d ()
+      BSVar l ks k vs d (BS.BackingStoreValueHandle IO l ks k vs) ->
+      BSAct l ks k vs d ()
     BSVHRangeRead ::
-      BSVar ks k vs d (BS.BackingStoreValueHandle IO ks k vs) ->
-      BS.ReadHint vs ->
+      BSVar l ks k vs d (BS.BackingStoreValueHandle IO l ks k vs) ->
+      BS.ReadHint l vs ->
       BS.RangeQuery ks ->
-      BSAct ks k vs d (Values vs, Maybe k)
+      BSAct l ks k vs d (Values vs, Maybe k)
     BSVHRead ::
-      BSVar ks k vs d (BS.BackingStoreValueHandle IO ks k vs) ->
-      BS.ReadHint vs ->
+      BSVar l ks k vs d (BS.BackingStoreValueHandle IO l ks k vs) ->
+      BS.ReadHint l vs ->
       ks ->
-      BSAct ks k vs d (Values vs)
+      BSAct l ks k vs d (Values vs)
     BSVHAtSlot ::
-      BSVar ks k vs d (BS.BackingStoreValueHandle IO ks k vs) ->
-      BSAct ks k vs d (WithOrigin SlotNo)
+      BSVar l ks k vs d (BS.BackingStoreValueHandle IO l ks k vs) ->
+      BSAct l ks k vs d (WithOrigin SlotNo)
     -- \| Corresponds to 'bsvhStat'
     BSVHStat ::
-      BSVar ks k vs d (BS.BackingStoreValueHandle IO ks k vs) ->
-      BSAct ks k vs d BS.Statistics
+      BSVar l ks k vs d (BS.BackingStoreValueHandle IO l ks k vs) ->
+      BSAct l ks k vs d BS.Statistics
 
   initialState = Lockstep.initialState initState
   nextState = Lockstep.nextState
@@ -205,65 +207,66 @@ deriving stock instance
   ( Show ks
   , Show vs
   , Show d
-  , Show (BS.InitHint vs)
-  , Show (BS.WriteHint d)
-  , Show (BS.ReadHint vs)
-  , Show (SerializeTablesHint vs)
+  , Show (BS.InitHint l vs)
+  , Show (BS.WriteHint l d)
+  , Show (BS.ReadHint l vs)
+  , Show (SerializeTablesHint l vs)
   ) =>
-  Show (LockstepAction (BackingStoreState ks k vs d) a)
+  Show (LockstepAction (BackingStoreState l ks k vs d) a)
 deriving stock instance
   ( Eq ks
   , Eq vs
   , Eq d
-  , Eq (BS.InitHint vs)
-  , Eq (BS.WriteHint d)
-  , Eq (BS.ReadHint vs)
-  , Eq (SerializeTablesHint vs)
+  , Eq (BS.InitHint l vs)
+  , Eq (BS.WriteHint l d)
+  , Eq (BS.ReadHint l vs)
+  , Eq (SerializeTablesHint l vs)
   ) =>
-  Eq (LockstepAction (BackingStoreState ks k vs d) a)
+  Eq (LockstepAction (BackingStoreState l ks k vs d) a)
 
 instance
   ( Show ks
   , Show vs
   , Show k
   , Show d
-  , Show (BS.InitHint vs)
-  , Show (BS.WriteHint d)
-  , Show (BS.ReadHint vs)
+  , Show (BS.InitHint l vs)
+  , Show (BS.WriteHint l d)
+  , Show (BS.ReadHint l vs)
   , Eq ks
   , Eq vs
   , Eq k
   , Eq d
-  , Eq (BS.InitHint vs)
-  , Eq (BS.WriteHint d)
-  , Eq (BS.ReadHint vs)
+  , Eq (BS.InitHint l vs)
+  , Eq (BS.WriteHint l d)
+  , Eq (BS.ReadHint l vs)
   , Typeable ks
   , Typeable k
   , Typeable vs
   , Typeable d
-  , Typeable (BS.WriteHint d)
+  , Typeable (BS.WriteHint l d)
+  , Typeable l
   , QC.Arbitrary ks
   , QC.Arbitrary k
   , QC.Arbitrary vs
   , QC.Arbitrary d
   , QC.Arbitrary (BS.RangeQuery ks)
-  , Mock.HasOps ks k vs d
+  , Mock.HasOps l ks k vs d
   ) =>
   RunModel
-    (Lockstep (BackingStoreState ks k vs d))
-    (RealMonad IO ks k vs d)
+    (Lockstep (BackingStoreState l ks k vs d))
+    (RealMonad IO l ks k vs d)
   where
   perform = \_st -> runIO
   postcondition = Lockstep.postcondition
-  monitoring = Lockstep.monitoring (Proxy @(RealMonad IO ks k vs d))
+  monitoring = Lockstep.monitoring (Proxy @(RealMonad IO l ks k vs d))
 
 -- | Custom precondition that prevents errors in the @'LMDB'@ backing store due
 -- to exceeding the maximum number of LMDB readers.
 --
 -- See @'maxOpenValueHandles'@.
 modelPrecondition ::
-  BackingStoreState ks k vs d ->
-  LockstepAction (BackingStoreState ks k vs d) a ->
+  BackingStoreState l ks k vs d ->
+  LockstepAction (BackingStoreState l ks k vs d) a ->
   Bool
 modelPrecondition (BackingStoreState mock _stats) action = case action of
   BSInitFromValues _ _ _ -> isClosed mock
@@ -279,76 +282,78 @@ modelPrecondition (BackingStoreState mock _stats) action = case action of
   @'InLockstep'@ instance
 -------------------------------------------------------------------------------}
 
-type BSVal ks k vs d a = ModelValue (BackingStoreState ks k vs d) a
-type BSObs ks k vs d a = Observable (BackingStoreState ks k vs d) a
+type BSVal l ks k vs d a = ModelValue (BackingStoreState l ks k vs d) a
+type BSObs l ks k vs d a = Observable (BackingStoreState l ks k vs d) a
 
 instance
   ( Show ks
   , Show vs
   , Show d
   , Show k
-  , Show (BS.InitHint vs)
-  , Show (BS.WriteHint d)
-  , Show (BS.ReadHint vs)
+  , Show (BS.InitHint l vs)
+  , Show (BS.WriteHint l d)
+  , Show (BS.ReadHint l vs)
   , Eq ks
   , Eq vs
   , Eq k
   , Eq d
-  , Eq (BS.InitHint vs)
-  , Eq (BS.WriteHint d)
-  , Eq (BS.ReadHint vs)
+  , Eq (BS.InitHint l vs)
+  , Eq (BS.WriteHint l d)
+  , Eq (BS.ReadHint l vs)
   , Typeable ks
   , Typeable k
   , Typeable vs
   , Typeable d
-  , Typeable (BS.WriteHint d)
+  , Typeable (BS.WriteHint l d)
+  , Typeable l
   , QC.Arbitrary ks
   , QC.Arbitrary k
   , QC.Arbitrary vs
   , QC.Arbitrary d
   , QC.Arbitrary (BS.RangeQuery ks)
-  , Mock.HasOps ks k vs d
+  , Mock.HasOps l ks k vs d
   ) =>
-  InLockstep (BackingStoreState ks k vs d)
+  InLockstep (BackingStoreState l ks k vs d)
   where
-  data ModelValue (BackingStoreState ks k vs d) a where
-    MValueHandle :: ValueHandle vs -> BSVal ks k vs d (BS.BackingStoreValueHandle IO ks k vs)
+  data ModelValue (BackingStoreState l ks k vs d) a where
+    MValueHandle :: ValueHandle vs -> BSVal l ks k vs d (BS.BackingStoreValueHandle IO l ks k vs)
     MErr ::
       Err ->
-      BSVal ks k vs d Err
+      BSVal l ks k vs d Err
     MSlotNo ::
       WithOrigin SlotNo ->
-      BSVal ks k vs d (WithOrigin SlotNo)
+      BSVal l ks k vs d (WithOrigin SlotNo)
     MValues ::
       vs ->
-      BSVal ks k vs d (Values vs)
+      BSVal l ks k vs d (Values vs)
     MValuesAndLast ::
       (vs, Maybe k) ->
-      BSVal ks k vs d (Values vs, Maybe k)
+      BSVal l ks k vs d (Values vs, Maybe k)
     MUnit ::
       () ->
-      BSVal ks k vs d ()
+      BSVal l ks k vs d ()
     MStatistics ::
       BS.Statistics ->
-      BSVal ks k vs d BS.Statistics
+      BSVal l ks k vs d BS.Statistics
     MEither ::
-      Either (BSVal ks k vs d a) (BSVal ks k vs d b) ->
-      BSVal ks k vs d (Either a b)
+      Either (BSVal l ks k vs d a) (BSVal l ks k vs d b) ->
+      BSVal l ks k vs d (Either a b)
     MPair ::
-      (BSVal ks k vs d a, BSVal ks k vs d b) ->
-      BSVal ks k vs d (a, b)
+      (BSVal l ks k vs d a, BSVal l ks k vs d b) ->
+      BSVal l ks k vs d (a, b)
 
-  data Observable (BackingStoreState ks k vs d) a where
-    OValueHandle :: BSObs ks k vs d (BS.BackingStoreValueHandle IO ks k vs)
-    OValues :: (Show a, Eq a, Typeable a) => a -> BSObs ks k vs d (Values a)
-    OValuesAndLast :: (Show a, Eq a, Typeable a) => (a, Maybe k) -> BSObs ks k vs d (Values a, Maybe k)
-    OId :: (Show a, Eq a, Typeable a) => a -> BSObs ks k vs d a
+  data Observable (BackingStoreState l ks k vs d) a where
+    OValueHandle :: BSObs l ks k vs d (BS.BackingStoreValueHandle IO l ks k vs)
+    OValues :: (Show a, Eq a, Typeable a) => a -> BSObs l ks k vs d (Values a)
+    OValuesAndLast ::
+      (Show a, Eq a, Typeable a) => (a, Maybe k) -> BSObs l ks k vs d (Values a, Maybe k)
+    OId :: (Show a, Eq a, Typeable a) => a -> BSObs l ks k vs d a
     OEither ::
-      Either (BSObs ks k vs d a) (BSObs ks k vs d b) ->
-      BSObs ks k vs d (Either a b)
-    OPair :: (BSObs ks k vs d a, BSObs ks k vs d b) -> BSObs ks k vs d (a, b)
+      Either (BSObs l ks k vs d a) (BSObs l ks k vs d b) ->
+      BSObs l ks k vs d (Either a b)
+    OPair :: (BSObs l ks k vs d a, BSObs l ks k vs d b) -> BSObs l ks k vs d (a, b)
 
-  observeModel :: BSVal ks k vs d a -> BSObs ks k vs d a
+  observeModel :: BSVal l ks k vs d a -> BSObs l ks k vs d a
   observeModel = \case
     MValueHandle _ -> OValueHandle
     MErr x -> OId x
@@ -362,26 +367,26 @@ instance
 
   modelNextState ::
     forall a.
-    LockstepAction (BackingStoreState ks k vs d) a ->
-    ModelVarContext (BackingStoreState ks k vs d) ->
-    BackingStoreState ks k vs d ->
-    (BSVal ks k vs d a, BackingStoreState ks k vs d)
+    LockstepAction (BackingStoreState l ks k vs d) a ->
+    ModelVarContext (BackingStoreState l ks k vs d) ->
+    BackingStoreState l ks k vs d ->
+    (BSVal l ks k vs d a, BackingStoreState l ks k vs d)
   modelNextState action lookUp (BackingStoreState mock stats) =
     auxStats $ runMock lookUp action mock
    where
     auxStats ::
-      (BSVal ks k vs d a, Mock vs) ->
-      (BSVal ks k vs d a, BackingStoreState ks k vs d)
+      (BSVal l ks k vs d a, Mock vs) ->
+      (BSVal l ks k vs d a, BackingStoreState l ks k vs d)
     auxStats (result, state') =
       ( result
       , BackingStoreState state' $ updateStats action lookUp result stats
       )
 
-  type ModelOp (BackingStoreState ks k vs d) = Op
+  type ModelOp (BackingStoreState l ks k vs d) = Op
 
   usedVars ::
-    LockstepAction (BackingStoreState ks k vs d) a ->
-    [AnyGVar (ModelOp (BackingStoreState ks k vs d))]
+    LockstepAction (BackingStoreState l ks k vs d) a ->
+    [AnyGVar (ModelOp (BackingStoreState l ks k vs d))]
   usedVars = \case
     BSInitFromValues _ _ _ -> []
     BSInitFromCopy _ _ -> []
@@ -396,22 +401,22 @@ instance
     BSVHStat h -> [SomeGVar h]
 
   arbitraryWithVars ::
-    ModelVarContext (BackingStoreState ks k vs d) ->
-    BackingStoreState ks k vs d ->
-    Gen (Any (LockstepAction (BackingStoreState ks k vs d)))
+    ModelVarContext (BackingStoreState l ks k vs d) ->
+    BackingStoreState l ks k vs d ->
+    Gen (Any (LockstepAction (BackingStoreState l ks k vs d)))
   arbitraryWithVars = arbitraryBackingStoreAction
 
   shrinkWithVars ::
-    ModelVarContext (BackingStoreState ks k vs d) ->
-    BackingStoreState ks k vs d ->
-    LockstepAction (BackingStoreState ks k vs d) a ->
-    [Any (LockstepAction (BackingStoreState ks k vs d))]
+    ModelVarContext (BackingStoreState l ks k vs d) ->
+    BackingStoreState l ks k vs d ->
+    LockstepAction (BackingStoreState l ks k vs d) a ->
+    [Any (LockstepAction (BackingStoreState l ks k vs d))]
   shrinkWithVars = shrinkBackingStoreAction
 
   tagStep ::
-    (BackingStoreState ks k vs d, BackingStoreState ks k vs d) ->
-    LockstepAction (BackingStoreState ks k vs d) a ->
-    BSVal ks k vs d a ->
+    (BackingStoreState l ks k vs d, BackingStoreState l ks k vs d) ->
+    LockstepAction (BackingStoreState l ks k vs d) a ->
+    BSVal l ks k vs d a ->
     [String]
   tagStep (BackingStoreState _ before, BackingStoreState _ after) action val =
     map show $ tagBSAction before after action val
@@ -421,30 +426,30 @@ deriving stock instance
   , Show vs
   , Show k
   , Show d
-  , Show (BS.WriteHint d)
-  , Show (BS.ReadHint vs)
+  , Show (BS.WriteHint l d)
+  , Show (BS.ReadHint l vs)
   ) =>
-  Show (BSVal ks k vs d a)
+  Show (BSVal l ks k vs d a)
 
 deriving stock instance
   ( Show ks
   , Show vs
   , Show k
   , Show d
-  , Show (BS.WriteHint d)
-  , Show (BS.ReadHint vs)
+  , Show (BS.WriteHint l d)
+  , Show (BS.ReadHint l vs)
   ) =>
-  Show (BSObs ks k vs d a)
+  Show (BSObs l ks k vs d a)
 
 deriving stock instance
   ( Eq ks
   , Eq vs
   , Eq k
   , Eq d
-  , Eq (BS.WriteHint d)
-  , Eq (BS.ReadHint vs)
+  , Eq (BS.WriteHint l d)
+  , Eq (BS.ReadHint l vs)
   ) =>
-  Eq (BSObs ks k vs d a)
+  Eq (BSObs l ks k vs d a)
 
 {-------------------------------------------------------------------------------
   @'RunLockstep'@ instance
@@ -455,35 +460,36 @@ instance
   , Show vs
   , Show k
   , Show d
-  , Show (BS.InitHint vs)
-  , Show (BS.WriteHint d)
-  , Show (BS.ReadHint vs)
+  , Show (BS.InitHint l vs)
+  , Show (BS.WriteHint l d)
+  , Show (BS.ReadHint l vs)
   , Eq ks
   , Eq vs
   , Eq k
   , Eq d
-  , Eq (BS.InitHint vs)
-  , Eq (BS.WriteHint d)
-  , Eq (BS.ReadHint vs)
+  , Eq (BS.InitHint l vs)
+  , Eq (BS.WriteHint l d)
+  , Eq (BS.ReadHint l vs)
   , Typeable ks
   , Typeable vs
   , Typeable k
   , Typeable d
-  , Typeable (BS.WriteHint d)
+  , Typeable (BS.WriteHint l d)
+  , Typeable l
   , QC.Arbitrary ks
   , QC.Arbitrary vs
   , QC.Arbitrary k
   , QC.Arbitrary d
   , QC.Arbitrary (BS.RangeQuery ks)
-  , Mock.HasOps ks k vs d
+  , Mock.HasOps l ks k vs d
   ) =>
-  RunLockstep (BackingStoreState ks k vs d) (RealMonad IO ks k vs d)
+  RunLockstep (BackingStoreState l ks k vs d) (RealMonad IO l ks k vs d)
   where
   observeReal ::
-    Proxy (RealMonad IO ks k vs d) ->
-    LockstepAction (BackingStoreState ks k vs d) a ->
+    Proxy (RealMonad IO l ks k vs d) ->
+    LockstepAction (BackingStoreState l ks k vs d) a ->
     a ->
-    BSObs ks k vs d a
+    BSObs l ks k vs d a
   observeReal _proxy = \case
     BSInitFromValues _ _ _ -> OEither . bimap OId OId
     BSInitFromCopy _ _ -> OEither . bimap OId OId
@@ -498,8 +504,8 @@ instance
     BSVHStat _ -> OEither . bimap OId OId
 
   showRealResponse ::
-    Proxy (RealMonad IO ks k vs d) ->
-    LockstepAction (BackingStoreState ks k vs d) a ->
+    Proxy (RealMonad IO l ks k vs d) ->
+    LockstepAction (BackingStoreState l ks k vs d) a ->
     Maybe (Dict (Show a))
   showRealResponse _proxy = \case
     BSInitFromValues _ _ _ -> Just Dict
@@ -519,39 +525,41 @@ instance
 -------------------------------------------------------------------------------}
 
 runMock ::
-  forall ks k vs d a.
-  ( Mock.HasOps ks k vs d
+  forall l ks k vs d a.
+  ( Mock.HasOps l ks k vs d
   , QC.Arbitrary ks
   , QC.Arbitrary vs
   , QC.Arbitrary k
   , QC.Arbitrary d
   , QC.Arbitrary (BS.RangeQuery ks)
+  , Typeable l
   ) =>
-  ModelVarContext (BackingStoreState ks k vs d) ->
-  Action (Lockstep (BackingStoreState ks k vs d)) a ->
+  ModelVarContext (BackingStoreState l ks k vs d) ->
+  Action (Lockstep (BackingStoreState l ks k vs d)) a ->
   Mock vs ->
-  ( BSVal ks k vs d a
+  ( BSVal l ks k vs d a
   , Mock vs
   )
 runMock lookUp = \case
   BSInitFromValues sl h (Values vs) ->
-    wrap MUnit . runMockMonad (Mock.mBSInitFromValues sl h vs)
+    wrap MUnit . runMockMonad (Mock.mBSInitFromValues @l sl h vs)
   BSInitFromCopy h bsp ->
-    wrap MUnit . runMockMonad (Mock.mBSInitFromCopy h bsp)
+    wrap MUnit . runMockMonad (Mock.mBSInitFromCopy @l @vs h bsp)
   BSClose ->
     wrap MUnit . runMockMonad Mock.mBSClose
   BSCopy h bsp ->
-    wrap MUnit . runMockMonad (Mock.mBSCopy h bsp)
+    wrap MUnit . runMockMonad (Mock.mBSCopy @l @vs h bsp)
   BSValueHandle ->
     wrap MValueHandle . runMockMonad Mock.mBSValueHandle
   BSWrite sl whint d ->
-    wrap MUnit . runMockMonad (Mock.mBSWrite sl whint d)
+    wrap MUnit . runMockMonad (Mock.mBSWrite @l sl whint d)
   BSVHClose h ->
     wrap MUnit . runMockMonad (Mock.mBSVHClose (getHandle $ lookupVar lookUp h))
   BSVHRangeRead h rhint rq ->
-    wrap MValuesAndLast . runMockMonad (Mock.mBSVHRangeRead (getHandle $ lookupVar lookUp h) rhint rq)
+    wrap MValuesAndLast
+      . runMockMonad (Mock.mBSVHRangeRead @l (getHandle $ lookupVar lookUp h) rhint rq)
   BSVHRead h rhint ks ->
-    wrap MValues . runMockMonad (Mock.mBSVHRead (getHandle $ lookupVar lookUp h) rhint ks)
+    wrap MValues . runMockMonad (Mock.mBSVHRead @l (getHandle $ lookupVar lookUp h) rhint ks)
   BSVHAtSlot h ->
     wrap MSlotNo . runMockMonad (Mock.mBSVHAtSlot (getHandle $ lookupVar lookUp h))
   BSVHStat h ->
@@ -559,7 +567,7 @@ runMock lookUp = \case
  where
   wrap f = first (MEither . bimap MErr f)
 
-  getHandle :: BSVal ks k vs d (BS.BackingStoreValueHandle IO ks k vs) -> ValueHandle vs
+  getHandle :: BSVal l ks k vs d (BS.BackingStoreValueHandle IO l ks k vs) -> ValueHandle vs
   getHandle (MValueHandle h) = h
 
 {-------------------------------------------------------------------------------
@@ -567,57 +575,62 @@ runMock lookUp = \case
 -------------------------------------------------------------------------------}
 
 arbitraryBackingStoreAction ::
-  forall ks k vs d.
-  ( Mock.HasOps ks k vs d
+  forall l ks k vs d.
+  ( Mock.HasOps l ks k vs d
   , QC.Arbitrary ks
   , QC.Arbitrary vs
   , QC.Arbitrary k
   , QC.Arbitrary d
   , QC.Arbitrary (BS.RangeQuery ks)
+  , Typeable l
   ) =>
-  ModelVarContext (BackingStoreState ks k vs d) ->
-  BackingStoreState ks k vs d ->
-  Gen (Any (LockstepAction (BackingStoreState ks k vs d)))
+  ModelVarContext (BackingStoreState l ks k vs d) ->
+  BackingStoreState l ks k vs d ->
+  Gen (Any (LockstepAction (BackingStoreState l ks k vs d)))
 arbitraryBackingStoreAction fv (BackingStoreState mock _stats) =
   QC.frequency $
     withoutVars
-      ++ case findVars fv (Proxy @(Either Err (BS.BackingStoreValueHandle IO ks k vs))) of
+      ++ case findVars fv (Proxy @(Either Err (BS.BackingStoreValueHandle IO l ks k vs))) of
         [] -> []
         vars -> withVars (QC.elements vars)
  where
-  withoutVars :: [(Int, Gen (Any (LockstepAction (BackingStoreState ks k vs d))))]
+  withoutVars :: [(Int, Gen (Any (LockstepAction (BackingStoreState l ks k vs d))))]
   withoutVars =
     [
       ( 5
       , fmap Some $
           BSInitFromValues
             <$> QC.arbitrary
-            <*> pure (Mock.makeInitHint (Proxy @vs))
+            <*> pure (Mock.makeInitHint (Proxy @l) (Proxy @vs))
             <*> (Values <$> QC.arbitrary)
       )
     ,
       ( 5
       , fmap Some $
           BSInitFromCopy
-            <$> pure (Mock.makeInitHint (Proxy @vs))
+            <$> pure (Mock.makeInitHint (Proxy @l) (Proxy @vs))
             <*> genBackingStorePath
       )
     , (2, pure $ Some BSClose)
-    , (5, fmap Some $ BSCopy <$> pure (Mock.makeSerializeTablesHint (Proxy @vs)) <*> genBackingStorePath)
+    ,
+      ( 5
+      , fmap Some $
+          BSCopy <$> pure (Mock.makeSerializeTablesHint (Proxy @l) (Proxy @vs)) <*> genBackingStorePath
+      )
     , (5, pure $ Some BSValueHandle)
     ,
       ( 5
       , fmap Some $
           BSWrite
             <$> genSlotNo
-            <*> pure (Mock.makeWriteHint (Proxy @d))
+            <*> pure (Mock.makeWriteHint (Proxy @l) (Proxy @d))
             <*> genDiff
       )
     ]
 
   withVars ::
-    Gen (BSVar ks k vs d (Either Err (BS.BackingStoreValueHandle IO ks k vs))) ->
-    [(Int, Gen (Any (LockstepAction (BackingStoreState ks k vs d))))]
+    Gen (BSVar l ks k vs d (Either Err (BS.BackingStoreValueHandle IO l ks k vs))) ->
+    [(Int, Gen (Any (LockstepAction (BackingStoreState l ks k vs d))))]
   withVars genVar =
     [ (5, fmap Some $ BSVHClose <$> (opFromRight <$> genVar))
     ,
@@ -625,7 +638,7 @@ arbitraryBackingStoreAction fv (BackingStoreState mock _stats) =
       , fmap Some $
           BSVHRangeRead
             <$> (opFromRight <$> genVar)
-            <*> pure (Mock.makeReadHint (Proxy @vs))
+            <*> pure (Mock.makeReadHint (Proxy @l) (Proxy @vs))
             <*> QC.arbitrary
       )
     ,
@@ -633,7 +646,7 @@ arbitraryBackingStoreAction fv (BackingStoreState mock _stats) =
       , fmap Some $
           BSVHRead
             <$> (opFromRight <$> genVar)
-            <*> pure (Mock.makeReadHint (Proxy @vs))
+            <*> pure (Mock.makeReadHint (Proxy @l) (Proxy @vs))
             <*> QC.arbitrary
       )
     , (5, fmap Some $ BSVHAtSlot <$> (opFromRight <$> genVar))
@@ -677,24 +690,24 @@ arbitraryBackingStoreAction fv (BackingStoreState mock _stats) =
 -------------------------------------------------------------------------------}
 
 shrinkBackingStoreAction ::
-  forall ks k vs d a.
+  forall l ks k vs d a.
   ( Typeable vs
   , Typeable k
   , Eq ks
   , Eq vs
   , Eq d
-  , Eq (BS.InitHint vs)
-  , Eq (BS.WriteHint d)
-  , Eq (BS.ReadHint vs)
-  , Eq (SerializeTablesHint vs)
+  , Eq (BS.InitHint l vs)
+  , Eq (BS.WriteHint l d)
+  , Eq (BS.ReadHint l vs)
+  , Eq (SerializeTablesHint l vs)
   , QC.Arbitrary d
   , QC.Arbitrary (BS.RangeQuery ks)
   , QC.Arbitrary ks
   ) =>
-  ModelVarContext (BackingStoreState ks k vs d) ->
-  BackingStoreState ks k vs d ->
-  LockstepAction (BackingStoreState ks k vs d) a ->
-  [Any (LockstepAction (BackingStoreState ks k vs d))]
+  ModelVarContext (BackingStoreState l ks k vs d) ->
+  BackingStoreState l ks k vs d ->
+  LockstepAction (BackingStoreState l ks k vs d) a ->
+  [Any (LockstepAction (BackingStoreState l ks k vs d))]
 shrinkBackingStoreAction _findVars (BackingStoreState _mock _) = \case
   BSWrite sl st d ->
     [Some $ BSWrite sl st d' | d' <- QC.shrink d]
@@ -709,7 +722,7 @@ shrinkBackingStoreAction _findVars (BackingStoreState _mock _) = \case
   Interpret @'Op'@ against @'ModelValue'@
 -------------------------------------------------------------------------------}
 
-instance InterpretOp Op (ModelValue (BackingStoreState ks k vs d)) where
+instance InterpretOp Op (ModelValue (BackingStoreState l ks k vs d)) where
   intOp OpId = Just
   intOp OpFst = \case
     MPair x -> Just (fst x)
@@ -726,16 +739,16 @@ instance InterpretOp Op (ModelValue (BackingStoreState ks k vs d)) where
 -------------------------------------------------------------------------------}
 
 runIO ::
-  forall ks k vs d a.
-  LockstepAction (BackingStoreState ks k vs d) a ->
+  forall l ks k vs d a.
+  LockstepAction (BackingStoreState l ks k vs d) a ->
   LookUp ->
-  RealMonad IO ks k vs d a
+  RealMonad IO l ks k vs d a
 runIO action lookUp = ReaderT $ \renv ->
   aux renv action
  where
   aux ::
-    RealEnv IO ks k vs d ->
-    LockstepAction (BackingStoreState ks k vs d) a ->
+    RealEnv IO l ks k vs d ->
+    LockstepAction (BackingStoreState l ks k vs d) a ->
     IO a
   aux renv = \case
     BSInitFromValues sl h (Values vs) -> catchErr $ do
@@ -779,7 +792,7 @@ runIO action lookUp = ReaderT $ \renv ->
       , reBackingStore = bsVar
       } = renv
 
-    lookUp' :: BSVar ks k vs d x -> x
+    lookUp' :: BSVar l ks k vs d x -> x
     lookUp' = realLookupVar lookUp
 
 catchErr :: forall m a. IOLike m => m a -> m (Either Err a)
@@ -815,17 +828,18 @@ initStats =
     }
 
 updateStats ::
-  forall ks k vs d a.
-  ( Mock.HasOps ks k vs d
+  forall l ks k vs d a.
+  ( Mock.HasOps l ks k vs d
   , QC.Arbitrary ks
   , QC.Arbitrary vs
   , QC.Arbitrary k
   , QC.Arbitrary d
   , QC.Arbitrary (BS.RangeQuery ks)
+  , Typeable l
   ) =>
-  LockstepAction (BackingStoreState ks k vs d) a ->
-  ModelVarContext (BackingStoreState ks k vs d) ->
-  BSVal ks k vs d a ->
+  LockstepAction (BackingStoreState l ks k vs d) a ->
+  ModelVarContext (BackingStoreState l ks k vs d) ->
+  BSVal l ks k vs d a ->
   Stats ks k vs d ->
   Stats ks k vs d
 updateStats action lookUp result stats@Stats{handleSlots, writeSlots} =
@@ -835,7 +849,7 @@ updateStats action lookUp result stats@Stats{handleSlots, writeSlots} =
     . updateRangeReadAfterWrite
     $ stats
  where
-  getHandle :: BSVal ks k vs d (BS.BackingStoreValueHandle IO ks k vs) -> ValueHandle vs
+  getHandle :: BSVal l ks k vs d (BS.BackingStoreValueHandle IO l ks k vs) -> ValueHandle vs
   getHandle (MValueHandle h) = h
 
   updateHandleSlots :: Stats ks k vs d -> Stats ks k vs d
@@ -894,7 +908,7 @@ data TagAction
   deriving (Show, Eq, Ord, Bounded, Enum)
 
 -- | Identify actions by their constructor.
-tAction :: LockstepAction (BackingStoreState ks k vs d) a -> TagAction
+tAction :: LockstepAction (BackingStoreState l ks k vs d) a -> TagAction
 tAction = \case
   BSInitFromValues _ _ _ -> TBSInitFromValues
   BSInitFromCopy _ _ -> TBSInitFromCopy
@@ -922,8 +936,8 @@ data Tag
 tagBSAction ::
   Stats ks k vs d ->
   Stats ks k vs d ->
-  LockstepAction (BackingStoreState ks k vs d) a ->
-  BSVal ks k vs d a ->
+  LockstepAction (BackingStoreState l ks k vs d) a ->
+  BSVal l ks k vs d a ->
   [Tag]
 tagBSAction before after action result =
   globalTags ++ case (action, result) of

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/LedgerDB/V1/BackingStore/Mock.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/LedgerDB/V1/BackingStore/Mock.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -145,36 +146,36 @@ class
   , MakeDiff vs d
   , DiffSize d
   , KeysSize ks
-  , MakeInitHint vs
-  , MakeWriteHint d
-  , MakeReadHint vs
-  , MakeSerializeTablesHint vs
+  , MakeInitHint l vs
+  , MakeWriteHint l d
+  , MakeReadHint l vs
+  , MakeSerializeTablesHint l vs
   , Show ks
   , Show vs
   , Show k
   , Show d
-  , Show (BS.InitHint vs)
-  , Show (BS.WriteHint d)
-  , Show (BS.ReadHint vs)
-  , Show (SerializeTablesHint vs)
+  , Show (BS.InitHint l vs)
+  , Show (BS.WriteHint l d)
+  , Show (BS.ReadHint l vs)
+  , Show (SerializeTablesHint l vs)
   , Eq ks
   , Eq vs
   , Eq k
   , Eq d
-  , Eq (BS.InitHint vs)
-  , Eq (BS.WriteHint d)
-  , Eq (BS.ReadHint vs)
-  , Eq (SerializeTablesHint vs)
+  , Eq (BS.InitHint l vs)
+  , Eq (BS.WriteHint l d)
+  , Eq (BS.ReadHint l vs)
+  , Eq (SerializeTablesHint l vs)
   , Typeable ks
   , Typeable vs
   , Typeable k
   , Typeable d
-  , Typeable (BS.InitHint vs)
-  , Typeable (BS.WriteHint d)
-  , Typeable (BS.ReadHint vs)
-  , Typeable (SerializeTablesHint vs)
+  , Typeable (BS.InitHint l vs)
+  , Typeable (BS.WriteHint l d)
+  , Typeable (BS.ReadHint l vs)
+  , Typeable (SerializeTablesHint l vs)
   ) =>
-  HasOps ks k vs d
+  HasOps l ks k vs d
 
 class EmptyValues vs where
   emptyValues :: vs
@@ -202,17 +203,17 @@ class DiffSize d where
 class KeysSize ks where
   keysSize :: ks -> Int
 
-class MakeInitHint vs where
-  makeInitHint :: Proxy vs -> BS.InitHint vs
+class MakeInitHint l vs where
+  makeInitHint :: Proxy l -> Proxy vs -> BS.InitHint l vs
 
-class MakeWriteHint d where
-  makeWriteHint :: Proxy d -> BS.WriteHint d
+class MakeWriteHint l d where
+  makeWriteHint :: Proxy l -> Proxy d -> BS.WriteHint l d
 
-class MakeReadHint vs where
-  makeReadHint :: Proxy vs -> BS.ReadHint vs
+class MakeReadHint l vs where
+  makeReadHint :: Proxy l -> Proxy vs -> BS.ReadHint l vs
 
-class MakeSerializeTablesHint vs where
-  makeSerializeTablesHint :: Proxy vs -> SerializeTablesHint vs
+class MakeSerializeTablesHint l vs where
+  makeSerializeTablesHint :: Proxy l -> Proxy vs -> SerializeTablesHint l vs
 
 {-------------------------------------------------------------------------------
   State monad to run the mock in
@@ -240,10 +241,10 @@ runMockMonad (MockMonad t) = runState . runExceptT $ t
 ------------------------------------------------------------------------------}
 
 mBSInitFromValues ::
-  forall vs m.
+  forall l vs m.
   MonadState (Mock vs) m =>
   WithOrigin SlotNo ->
-  BS.InitHint vs ->
+  BS.InitHint l vs ->
   vs ->
   m ()
 mBSInitFromValues sl _st vs =
@@ -257,9 +258,9 @@ mBSInitFromValues sl _st vs =
     )
 
 mBSInitFromCopy ::
-  forall vs m.
+  forall l vs m.
   (MonadState (Mock vs) m, MonadError Err m) =>
-  BS.InitHint vs ->
+  BS.InitHint l vs ->
   FS.FsPath ->
   m ()
 mBSInitFromCopy _st bsp = do
@@ -300,7 +301,8 @@ mBSClose = do
 
 -- | Copy the contents of the backing store to the given path.
 mBSCopy ::
-  (MonadState (Mock vs) m, MonadError Err m) => SerializeTablesHint vs -> FS.FsPath -> m ()
+  forall l vs m.
+  (MonadState (Mock vs) m, MonadError Err m) => SerializeTablesHint l vs -> FS.FsPath -> m ()
 mBSCopy _ bsp = do
   mGuardBSClosed
   cps <- gets copies
@@ -337,9 +339,10 @@ mBSValueHandle = do
 
 -- | Write a diff to the backing store.
 mBSWrite ::
+  forall l vs d m.
   (MonadState (Mock vs) m, MonadError Err m, ApplyDiff vs d) =>
   SlotNo ->
-  BS.WriteHint d ->
+  BS.WriteHint l d ->
   d ->
   m ()
 mBSWrite sl _st d = do
@@ -401,9 +404,10 @@ mBSVHClose vh = do
 
 -- | Perform a range read on a backing store value handle.
 mBSVHRangeRead ::
+  forall l vs k ks m.
   (MonadState (Mock vs) m, MonadError Err m, LookupKeysRange ks k vs) =>
   ValueHandle vs ->
-  BS.ReadHint vs ->
+  BS.ReadHint l vs ->
   BS.RangeQuery ks ->
   m (vs, Maybe k)
 mBSVHRangeRead vh _ BS.RangeQuery{BS.rqPrev, BS.rqCount} = do
@@ -415,9 +419,10 @@ mBSVHRangeRead vh _ BS.RangeQuery{BS.rqPrev, BS.rqCount} = do
 
 -- | Perform a regular read on a backing store value handle
 mBSVHRead ::
+  forall l vs ks m.
   (MonadState (Mock vs) m, MonadError Err m, LookupKeys ks vs) =>
   ValueHandle vs ->
-  BS.ReadHint vs ->
+  BS.ReadHint l vs ->
   ks ->
   m vs
 mBSVHRead vh _ ks = do

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/LedgerDB/V1/DbChangelog.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/LedgerDB/V1/DbChangelog.hs
@@ -199,11 +199,11 @@ data ChainSetup = ChainSetup
   -- we don't guarantee this during shrinking. If 'csPrefixLen' is larger
   -- than 'csNumBlocks', the prefix should simply be considered to be the
   -- entire chain.
-  , csGenSnaps :: DbChangelog (LedgerState TestBlock.TestBlock)
+  , csGenSnaps :: DbChangelog LedgerState TestBlock.TestBlock
   -- ^ Derived: genesis snapshots
   , csChain :: [TestBlock.TestBlock]
   -- ^ Derived: the actual blocks that got applied (old to new)
-  , csPushed :: DbChangelog (LedgerState TestBlock.TestBlock)
+  , csPushed :: DbChangelog LedgerState TestBlock.TestBlock
   -- ^ Derived: the snapshots after all blocks were applied
   }
   deriving Show
@@ -245,7 +245,7 @@ data SwitchSetup = SwitchSetup
   -- ^ Derived: the new blocks themselves
   , ssChain :: [TestBlock.TestBlock]
   -- ^ Derived: the full chain after switching to this fork
-  , ssSwitched :: DbChangelog (LedgerState TestBlock.TestBlock)
+  , ssSwitched :: DbChangelog LedgerState TestBlock.TestBlock
   -- ^ Derived; the snapshots after the switch was performed
   }
   deriving Show
@@ -336,12 +336,16 @@ instance Arbitrary SwitchSetup where
   Test setup
 -------------------------------------------------------------------------------}
 
-data TestLedger (mk :: MapKind) = TestLedger
+data TestBlock
+
+type TestLedger = LedgerState TestBlock
+
+data instance LedgerState TestBlock (mk :: MapKind) = TestLedger
   { tlUtxos :: mk Key Int
   , tlTip :: Point TestLedger
   }
 
-nextState :: DbChangelog TestLedger -> TestLedger DiffMK
+nextState :: DbChangelog LedgerState TestBlock -> TestLedger DiffMK
 nextState dblog =
   TestLedger
     { tlTip = pointAtSlot $ nextSlot (getTipSlot old)
@@ -359,21 +363,21 @@ instance GetTip TestLedger where
 data H = H deriving (Eq, Ord, Show, Generic)
 deriving anyclass instance NoThunks H
 deriving anyclass instance NFData H
-type instance HeaderHash TestLedger = H
+type instance HeaderHash TestBlock = H
 
-instance StandardHash TestLedger
+instance StandardHash TestBlock
 
 deriving instance Eq (TestLedger EmptyMK)
 
-type instance TxIn TestLedger = Key
-type instance TxOut TestLedger = Int
+type instance TxIn TestBlock = Key
+type instance TxOut TestBlock = Int
 
-instance HasLedgerTables TestLedger where
+instance HasLedgerTables LedgerState TestBlock where
   projectLedgerTables = LedgerTables . tlUtxos
   withLedgerTables st (LedgerTables x) = st{tlUtxos = x}
 
-instance IndexedMemPack (TestLedger EmptyMK) Int where
-  indexedTypeName _ = typeName @Int
+instance IndexedMemPack LedgerState TestBlock Int where
+  indexedTypeName _ _ = typeName @Int
   indexedPackedByteCount _ = packedByteCount
   indexedPackM _ = packM
   indexedUnpackM _ = unpackM
@@ -437,15 +441,15 @@ instance Arbitrary DbChangelogTestSetupWithRollbacks where
         , rollbacks = shrinkRollback setup (rollbacks setupWithRollback)
         }
 
-resultingDbChangelog :: DbChangelogTestSetup -> DbChangelog TestLedger
+resultingDbChangelog :: DbChangelogTestSetup -> DbChangelog LedgerState TestBlock
 resultingDbChangelog setup = applyOperations (operations setup) originalDbChangelog
  where
   originalDbChangelog = DbChangelog.empty $ TestLedger EmptyMK theAnchor
   theAnchor = pointAtSlot (dbChangelogStartsAt setup)
 
 applyOperations ::
-  (HasLedgerTables l, GetTip l) =>
-  [Operation l] -> DbChangelog l -> DbChangelog l
+  (HasLedgerTables l blk, GetTip (l blk)) =>
+  [Operation (l blk)] -> DbChangelog l blk -> DbChangelog l blk
 applyOperations ops dblog = foldr' apply' dblog ops
  where
   apply' (Extend newState) dblog' = DbChangelog.extend newState dblog'
@@ -545,7 +549,7 @@ prop_rollBackToVolatileTipIsNoop (Positive n) setup = property $ Just dblog == d
   pt = getTip $ DbChangelog.current dblog
   dblog' = DbChangelog.rollbackToPoint pt $ nExtensions n dblog
 
-nExtensions :: Int -> DbChangelog TestLedger -> DbChangelog TestLedger
+nExtensions :: Int -> DbChangelog LedgerState TestBlock -> DbChangelog LedgerState TestBlock
 nExtensions n dblog = iterate ext dblog !! n
  where
   ext dblog' = DbChangelog.extend (nextState dblog') dblog'


### PR DESCRIPTION
Index `LedgerTables`, `TxIn`, and `TxOut` by `blk` instead of by the ledger-state shape `l`. Combined with the prior eta-expansion, this collapses the duplicate `LedgerState`/`Ticked LedgerState`/`ExtLedgerState` instances into one.

Key type changes

  - `TxIn  :: Type -> Type`, `TxOut :: Type -> Type` — keyed by blk
  - `LedgerTables blk mk` — was LedgerTables l mk
  - `HasLedgerTables l blk` — separate l and blk parameters
  - `LedgerTablesAreTrivial l blk`, `SerializeTablesWithHint l blk` — same reshape
  - `IndexedMemPack l blk a` — was IndexedMemPack idx a
  - New `GetBlockKeySets blk` class — `getBlockKeySets` split out of `ApplyBlock`
  - Removed: `MemPackIdx`, `SameUtxoTypes`, `castLedgerTables`, `TrivialLedgerTables`