### PR TITLE
Update LSM-trees packages

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -44,6 +44,12 @@ if os (windows)
   constraints:
     bitvec -simd
 
+constraints:
+  tasty <1.5.4,
+  plutus-core ^>=1.61,
+  plutus-ledger-api ^>=1.61,
+  plutus-tx ^>=1.61
+
 -- ouroboros-network dependency after introducing `bracketKeepAlive` (PR#5371)
 source-repository-package
   type: git

--- a/cabal.project
+++ b/cabal.project
@@ -14,9 +14,9 @@ repository cardano-haskell-packages
 -- update either of these.
 index-state:
   -- Bump this if you need newer packages from Hackage
-  , hackage.haskell.org 2026-03-17T01:21:06Z
+  , hackage.haskell.org 2026-05-18T17:14:36Z
   -- Bump this if you need newer packages from CHaP
-  , cardano-haskell-packages 2026-04-13T13:33:52Z
+  , cardano-haskell-packages 2026-05-18T13:56:34Z
 
 active-repositories:
   , :rest

--- a/changelog.d/20260430_124955_javier.sagredo.md
+++ b/changelog.d/20260430_124955_javier.sagredo.md
@@ -1,0 +1,24 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+<!--
+### Breaking
+
+- A bullet item for the Breaking category.
+
+-->
+
+### Patch
+
+- Updates on the LSM-trees ecosystem:
+  - blockio-uring 0.1.0.3 -> 0.2.0.0
+  - blockio 0.1.1.1 -> 0.2.0.0
+  - lsm-trees 1.0.0.1 -> 1.1.0.0
+
+- Update to `fs-sim 0.5.0.0`.
+
+- Update to `QuickCheck 2.18`.

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1776096450,
-        "narHash": "sha256-8s+VK+POr8jCU5369xihcFGgF6PgN+UkJYKxo1hxBdo=",
+        "lastModified": 1779114033,
+        "narHash": "sha256-68Yi51Ps5hwP80M0UXw4GTROmyzRL02PEXDEYfVEB4M=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "4faa15e7a38f5724da07275ffc9fb8f409190f2f",
+        "rev": "b20f09de9ba3099e0981a3bb9145847e7e2cfc24",
         "type": "github"
       },
       "original": {
@@ -253,11 +253,11 @@
     "hackageNix": {
       "flake": false,
       "locked": {
-        "lastModified": 1777960911,
-        "narHash": "sha256-4dBdNFA2DgDsw+iAGXj63w8qEtk3NzCXop0prqPdb1s=",
+        "lastModified": 1779172532,
+        "narHash": "sha256-gpH7CeWhkhhVR2ybollB6NM4LkaOOrgmSqVGu7jig6Q=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "802b7e98989df0e790fe2abc37bd799449d13c83",
+        "rev": "5099214b42826edce22cd8fbc52a0417fed83e29",
         "type": "github"
       },
       "original": {

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -40,10 +40,6 @@ hsPkgs.shellFor {
         allow-newer: haddock-library:base
       '';
     };
-    hoogle.cabalProjectLocal = ''
-      if impl(ghc <9.7)
-        constraints: alfred-margaret <2.1.1.0 || >2.1.1.0
-    '';
   };
 
   shellHook = ''

--- a/nix/tools.nix
+++ b/nix/tools.nix
@@ -2,7 +2,7 @@ inputs: final: prev:
 
 let
   inherit (final) lib;
-  tool-index-state = "2026-04-06T15:25:10Z";
+  tool-index-state = "2026-05-08T14:12:57Z";
   tool = name: version: other:
     final.haskell-nix.tool "ghc98" name ({
       version = version;
@@ -28,11 +28,6 @@ in
       rev = "f3a230de36a08920f8ad47766b0528b9229b3ce6";
       hash = "sha256-WiSq1uBjuSCEW7vp/81a1PVdo/7pf86dqy+R7lDCOdY=";
     };
-    cabalProject = ''
-      packages: .
-      constraints:
-        alfred-margaret <2.1.1.0
-    '';
   };
 
   cabal-gild = tool "cabal-gild" "1.8.4.1" { compiler-nix-name = "ghc912"; };

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Mempool.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Mempool.hs
@@ -101,6 +101,7 @@ import Data.Word (Word32)
 import GHC.Generics (Generic)
 import GHC.Natural (Natural)
 import Lens.Micro ((^.))
+import Lens.Micro.Extras (view)
 import NoThunks.Class (NoThunks (..))
 import Ouroboros.Consensus.Block
 import Ouroboros.Consensus.Ledger.Abstract
@@ -370,12 +371,12 @@ validateMaybe ::
   SL.ApplyTxError era ->
   Maybe a ->
   V.Validation (TxErrorSG era) a
-validateMaybe err mb = V.validate (TxErrorSG err) id mb
+validateMaybe err mb = maybe (V.Failure (TxErrorSG err)) V.Success mb
 
 runValidation ::
   V.Validation (TxErrorSG era) a ->
   Except (SL.ApplyTxError era) a
-runValidation = liftEither . (unTxErrorSG +++ id) . V.toEither
+runValidation = liftEither . (unTxErrorSG +++ id) . view V.either
 
 -----
 

--- a/ouroboros-consensus.cabal
+++ b/ouroboros-consensus.cabal
@@ -413,14 +413,14 @@ library lsm
 
   build-depends:
     base,
-    blockio,
+    blockio ^>=0.2,
     bytestring,
     containers,
     contra-tracer,
     filepath,
     fs-api,
     io-classes:mtl,
-    lsm-tree,
+    lsm-tree ^>=1.1,
     mempack,
     mtl,
     nothunks,
@@ -519,7 +519,7 @@ library unstable-consensus-testlib
     file-embed,
     filepath,
     fs-api,
-    fs-sim ^>=0.4,
+    fs-sim ^>=0.5,
     generics-sop,
     hashable,
     io-classes:{io-classes, si-timers, strict-mvar, strict-stm},
@@ -1391,7 +1391,7 @@ library cardano
     strict-sop-core,
     text,
     these,
-    validation,
+    validation >=1.1.5,
 
 library unstable-byronspec
   import: common-lib

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/QuickCheck.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/QuickCheck.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -42,6 +43,9 @@ module Test.Util.QuickCheck
 
     -- * Typeclass laws
   , prop_lawfulEqAndTotalOrd
+
+    -- * Deprecated symbols
+  , withNumTests
   ) where
 
 import Control.Monad.Except (Except, runExcept)
@@ -53,7 +57,19 @@ import Data.SOP.Constraint
 import Data.SOP.Strict
 import Ouroboros.Consensus.Util (repeatedly)
 import Ouroboros.Consensus.Util.Condense (Condense, condense)
+#if !MIN_VERSION_QuickCheck(2,18,0)
 import Test.QuickCheck
+#else
+import Test.QuickCheck hiding (withNumTests)
+import qualified Test.QuickCheck as QC
+#endif
+
+withNumTests :: Testable prop => Int -> prop -> Property
+#if !MIN_VERSION_QuickCheck(2,18,0)
+withNumTests = withMaxSuccess
+#else
+withNumTests = QC.withNumTests
+#endif
 
 {-------------------------------------------------------------------------------
   Generic QuickCheck utilities

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/Serialisation/Roundtrip.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/Serialisation/Roundtrip.hs
@@ -100,6 +100,7 @@ import Test.QuickCheck.Monadic
 import Test.Tasty
 import Test.Tasty.QuickCheck
 import Test.Util.Orphans.Arbitrary ()
+import qualified Test.Util.QuickCheck as QC
 import Test.Util.Serialisation.CDDL
 import Test.Util.Serialisation.Examples (Examples (..), Labelled)
 import Test.Util.Serialisation.SomeResult (SomeResult (..))
@@ -660,7 +661,7 @@ roundtrip_SerialiseNodeToClient shouldCheckCBORvalidity ccfg =
     -- require an 'Eq' and 'Show' instance for all ledger config types which
     -- we'd like to avoid (as the EpochInfo is a record of functions).
     testProperty "roundtrip (comparing encoding) LedgerConfig" $
-      withMaxSuccess 20 $ \(Blind (WithVersion version a)) ->
+      QC.withNumTests 20 $ \(Blind (WithVersion version a)) ->
         roundtripComparingEncoding @(LedgerConfig blk) (enc version) (dec version) a
   , rtWith
       @(SomeSecond Query blk)

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/Mempool/StateMachine.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/Mempool/StateMachine.hs
@@ -82,6 +82,7 @@ import qualified Test.StateMachine.Types.Rank2 as Rank2
 import Test.Tasty
 import Test.Tasty.QuickCheck
 import Test.Util.Orphans.ToExpr ()
+import qualified Test.Util.QuickCheck as QC
 import Test.Util.ToExpr ()
 
 {-------------------------------------------------------------------------------
@@ -798,17 +799,17 @@ tests =
   testGroup
     "QSM"
     [ testProperty "sequential" $
-        withMaxSuccess 1000 $
+        QC.withNumTests 1000 $
           prop_mempoolSequential testLedgerConfigNoSizeLimits txMaxBytes' testInitLedger $
             \i -> fmap (fmap fst . fst) . genTxs i
     , testGroup
         "parallel"
         [ testProperty "atomic" $
-            withMaxSuccess 10000 $
+            QC.withNumTests 10000 $
               prop_mempoolParallel testLedgerConfigNoSizeLimits txMaxBytes' testInitLedger Atomic $
                 \i -> fmap (fmap fst . fst) . genTxs i
         , testProperty "non atomic" $
-            withMaxSuccess 10 $
+            QC.withNumTests 10 $
               prop_mempoolParallel testLedgerConfigNoSizeLimits txMaxBytes' testInitLedger NonAtomic $
                 \i -> fmap (fmap fst . fst) . genTxs i
         ]

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ImmutableDB/StateMachine.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ImmutableDB/StateMachine.hs
@@ -750,14 +750,14 @@ generateCmd Model{..} =
         )
       ]
 
-  chooseWord64 :: Coercible a Word64 => (a, a) -> Gen a
-  chooseWord64 (start, end) = coerce $ choose @Word64 (coerce start, coerce end)
+  chooseWord64' :: Coercible a Word64 => (a, a) -> Gen a
+  chooseWord64' (start, end) = coerce $ choose @Word64 (coerce start, coerce end)
 
   chooseSlot :: (SlotNo, SlotNo) -> Gen SlotNo
-  chooseSlot = chooseWord64
+  chooseSlot = chooseWord64'
 
   chooseEpoch :: (EpochNo, EpochNo) -> Gen EpochNo
-  chooseEpoch = chooseWord64
+  chooseEpoch = chooseWord64'
 
   genCorruption :: Gen Corruption
   genCorruption = MkCorruption <$> generateCorruptions (NE.fromList dbFiles)

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/LedgerDB/StateMachine.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/LedgerDB/StateMachine.hs
@@ -75,6 +75,7 @@ import qualified Test.QuickCheck.Monadic as QC
 import Test.QuickCheck.StateModel
 import Test.Tasty
 import Test.Tasty.QuickCheck (frequency, tabulate, testProperty)
+import qualified Test.Util.QuickCheck as QC'
 import Test.Util.TestBlock hiding
   ( TestBlock
   , TestBlockCodecConfig
@@ -99,7 +100,7 @@ prop_sequential ::
   Actions Model ->
   QC.Property
 prop_sequential maxSuccess mkTestArguments getDiskDir fsOps actions =
-  QC.withMaxSuccess maxSuccess $
+  QC'.withNumTests maxSuccess $
     QC.monadic runner $
       Monad.void $
         runActions $

--- a/scripts/ci/run-dos2unix.sh
+++ b/scripts/ci/run-dos2unix.sh
@@ -2,4 +2,15 @@
 
 set -euo pipefail
 
-fd -X dos2unix
+fdcmd="fd"
+if ! command -v "$fdcmd" &> /dev/null; then
+    # In Ubuntu systems the fd command is called fdfind.
+    # If 'fd' is not found, try 'fdfind'
+    fdcmd="fdfind"
+    if ! command -v "$fdcmd" &> /dev/null; then
+        echo "Error: Neither 'fd' nor 'fdfind' command found." >&2
+        exit 1
+    fi
+fi
+
+$fdcmd -X dos2unix


### PR DESCRIPTION
# Description

This should close a number of issues but it is still blocked by getting everything into Hackage.

- LSM-trees: https://github.com/IntersectMBO/lsm-tree/pull/843
  - Both released [[1](https://hackage.haskell.org/package/lsm-tree-1.0.0.2)], [[2](https://hackage.haskell.org/package/blockio-0.1.1.2)] at 2026-04-24T17:55:00Z
  - Closes https://github.com/IntersectMBO/ouroboros-consensus/issues/2004
 
Further changes that will require an LSM-trees release:

- BlockIO-uring: https://github.com/well-typed/blockio-uring/pull/62
  - [Released](https://hackage.haskell.org/package/blockio-uring-0.2.0.0) at 2026-04-30T10:58:23Z  
  - Closes https://github.com/IntersectMBO/ouroboros-consensus/issues/2005
  - Closes https://github.com/IntersectMBO/ouroboros-consensus/issues/2001
- fs-sim 0.5 on LSM-trees: https://github.com/IntersectMBO/lsm-tree/pull/845
- LSM-trees: https://github.com/IntersectMBO/lsm-tree/pull/846/
  - Both released at 2026-05-13T21:15:11Z 

Update to QuickCheck 2.18:
- Foundational libraries like `ral` dropped support for 2.17 so that drags us down.
- https://github.com/input-output-hk/fs-sim/pull/131
  - https://github.com/IntersectMBO/cardano-haskell-packages/pull/1369 Releasing in CHaP at 2026-05-18T13:56:34Z 
- https://github.com/stevana/quickcheck-state-machine/pull/57
- [Released](https://hackage.haskell.org/package/quickcheck-state-machine-0.10.4) at 2026-05-18T17:14:36Z

The diff:

```diff
OneTuple                             0.4.2.1  -> 0.4.3
QuickCheck                           2.17.1.0 -> 2.18.0.0
aeson                                2.2.3.0  -> 2.2.5.0
bin                                  0.1.4    -> 0.1.4.1
binary-orphans                       1.0.5    -> 1.0.6
blockio                              0.1.1.1  -> 0.2.0.0
blockio-uring                        0.1.0.3  -> 0.2.0.0
boring                               0.2.2    -> 0.2.2.1
cardano-ledger-conway                1.22.0.0 -> 1.22.1.0
colour                               2.3.6    -> 2.3.7
criterion                            1.6.4.1  -> 1.6.5.0
criterion-measurement                0.2.3.0  -> 0.2.4.0
deque                                0.4.4.2  -> 0.4.4.4
directory                            1.3.10.1 -> 1.3.10.0
file-io                              0.1.6    -> 0.1.5
fs-sim                               0.4.1.0  -> 0.5.0.1
indexed-traversable                  0.1.4    -> 0.1.5
indexed-traversable-instances        0.1.2    -> 0.1.2.1
lsm-tree                             1.0.0.1  -> 1.1.0.0
microstache                          1.0.3    -> 1.0.3.1
plutus-core                          1.61.0.0 -> 1.64.0.0
plutus-ledger-api                    1.61.0.0 -> 1.64.0.0
plutus-tx                            1.61.0.0 -> 1.64.0.0
prettyprinter                        1.7.1    -> 1.7.2
prettyprinter-ansi-terminal          1.1.3    -> 1.1.4
process                              1.6.27.0 -> 1.6.26.1
quickcheck-state-machine             0.10.3   -> 0.10.4
semialign                            1.3.1    -> 1.3.1.1
strict-list                          0.1.7.6  -> 1.0.0.1
string-interpolate                   0.2.0.1  -> 0.3.4.0
text-iso8601                         0.1.1    -> 0.1.1.1
time                                 1.14     -> 1.15
time-manager                         0.3.1.1  -> 0.3.2
tree-diff                            0.3.4    -> 0.4.1
typed-protocols                      1.2.0.0  -> 1.2.1.0
unix-time                            0.4.17   -> 0.5.0
uuid-types                           1.0.6    -> 1.0.6.1
validation                           1.1.5    -> 1.2.2

deleted  ansi-wl-pprint                       1.0.2
deleted  generically                          0.1.1
deleted  prettyprinter-compat-ansi-wl-pprint  1.0.2
```