### PR TITLE
drop support for x86_64-darwin

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -50,7 +50,6 @@
     let
       supportedSystems = [
         "x86_64-linux"
-        "x86_64-darwin"
         #"aarch64-linux"
         "aarch64-darwin"
       ];


### PR DESCRIPTION
# Description

- Nixpkgs expects to drop support for intel macs in 26.11 as per Nixpkgs 25.11 [release notes](https://nixos.org/manual/nixpkgs/stable/release-notes#sec-nixpkgs-release-25.11-highlights).                          
- It was [decided](https://input-output-rnd.slack.com/archives/CG1FBSDMM/p1776704401411139?thread_ts=1776677872.325309&cid=CG1FBSDMM) to no longer build x86_64-darwin on [ci.iog.io](https://ci.iog.io) to reduce strain on the struggling mac builders.