### PR TITLE
Allow LSQ clients to connect during initial LedgerDB replay (EarlyN2C)

### DIFF
--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Node.hs
@@ -114,7 +114,7 @@ import Ouroboros.Consensus.Block
 import Ouroboros.Consensus.BlockchainTime hiding (getSystemStart)
 import Ouroboros.Consensus.Config
 import Ouroboros.Consensus.Config.SupportsNode
-import Ouroboros.Consensus.Ledger.Basics (ValuesMK)
+import Ouroboros.Consensus.Ledger.Basics (EmptyMK, ValuesMK)
 import Ouroboros.Consensus.Ledger.Extended (ExtLedgerState (..))
 import qualified Ouroboros.Consensus.Mempool as Mempool
 import Ouroboros.Consensus.MiniProtocol.ChainSync.Client.HistoricityCheck
@@ -398,6 +398,15 @@ data StdRunNodeArgs m blk
   -- ^ The 'StdGen' will be used to initialize the salt for the LSM backend. It
   -- is expected that it is the same 'StdGen' that is passed elsewhere in
   -- Consensus, i.e. 'llrnRng'.
+  , srnEarlyN2C :: ChainDB.EarlyN2C
+  -- ^ See 'EarlyN2C'. Default
+  -- 'EarlyN2CDisabled' preserves the original
+  -- synchronous-open / late-bind behaviour.
+  , srnSynthesiseLedger ::
+      Maybe (Point blk -> Maybe (ExtLedgerState blk EmptyMK))
+  -- ^ Optional synthesised ledger view used by the LSQ server when
+  -- 'EarlyN2C' is enabled and the LedgerDB is replaying.
+  -- See 'cdbsSynthesiseLedger' on 'ChainDbSpecificArgs' for details.
   }
 
 {-------------------------------------------------------------------------------
@@ -548,30 +557,16 @@ runWith RunNodeArgs{..} encAddrNtN decAddrNtN LowLevelRunNodeArgs{..} =
               )
 
           continueWithCleanChainDB chainDB $ do
-            btime <-
-              hardForkBlockchainTime $
-                llrnCustomiseHardForkBlockchainTimeArgs $
-                  HardForkBlockchainTimeArgs
-                    { hfbtBackoffDelay = pure $ BackoffDelay 60
-                    , hfbtGetLedgerState =
-                        ledgerState <$> ChainDB.getCurrentLedger chainDB
-                    , hfbtLedgerConfig = configLedger cfg
-                    , hfbtRegistry = registry
-                    , hfbtSystemTime = systemTime
-                    , hfbtTracer =
-                        contramap
-                          (fmap (fromRelativeTime systemStart))
-                          (blockchainTimeTracer rnTraceConsensus)
-                    , hfbtMaxClockRewind = secondsToNominalDiffTime 20
-                    }
+            -- 'hardForkBlockchainTime' and 'GSM.realDurationUntilTooOld' both
+            -- eagerly read the current ledger. Substitute pending 'StrictTMVar'
+            -- wrappers here and have the thread forked below populate them
+            -- once the LedgerDB is ready.
+            btimeVar <- newEmptyTMVarIO
+            durationVar <- newEmptyTMVarIO
+            let pendingBtime = mkPendingBlockchainTime btimeVar
+                pendingDuration = mkPendingDurationUntilTooOld durationVar
 
             nodeKernelArgs <- do
-              durationUntilTooOld <-
-                GSM.realDurationUntilTooOld
-                  (configLedger cfg)
-                  (ledgerState <$> ChainDB.getCurrentLedger chainDB)
-                  llrnMaxCaughtUpAge
-                  systemTime
               let gsmMarkerFileView =
                     case ChainDB.cdbsHasFSGsmDB $ ChainDB.cdbsArgs finalArgs of
                       SomeHasFS x -> GSM.realMarkerFileView chainDB x
@@ -589,13 +584,13 @@ runWith RunNodeArgs{..} encAddrNtN decAddrNtN LowLevelRunNodeArgs{..} =
                   cfg
                   llrnFeatureFlags
                   rnTraceConsensus
-                  btime
+                  pendingBtime
                   systemTime
                   (InFutureCheck.realHeaderInFutureCheck llrnMaxClockSkew systemTime)
                   historicityCheck
                   chainDB
                   llrnMaxCaughtUpAge
-                  (Just durationUntilTooOld)
+                  (Just pendingDuration)
                   gsmMarkerFileView
                   rnGetUseBootstrapPeers
                   llrnPublicPeerSelectionStateVar
@@ -603,7 +598,7 @@ runWith RunNodeArgs{..} encAddrNtN decAddrNtN LowLevelRunNodeArgs{..} =
                   DiffusionPipeliningOn
                   rnMempoolTimeoutConfig
                   rnTxSubmissionInitDelay
-            nodeKernel <- initNodeKernel nodeKernelArgs
+            (nodeKernel, completeNodeKernel) <- initNodeKernelEarly nodeKernelArgs
             rnNodeKernelHook registry nodeKernel
             churnModeVar <- StrictSTM.newTVarIO ChurnModeNormal
             churnMetrics <- newPeerMetric Diffusion.peerMetricsConfiguration
@@ -649,6 +644,52 @@ runWith RunNodeArgs{..} encAddrNtN decAddrNtN LowLevelRunNodeArgs{..} =
                     ntnApps
                     ntcApps
                     nodeKernel
+
+            -- Build BlockchainTime + WrapDurationUntilTooOld, publish them
+            -- via the pending-wrapper TMVars, then run 'completeNodeKernel'
+            -- which opens the real mempool, computes the real GsmState, and
+            -- spawns the ledger-dependent background threads (GSM, block
+            -- forging, block fetch logic, tx submission decision logic).
+            let runLateInit = do
+                  btime <-
+                    hardForkBlockchainTime $
+                      llrnCustomiseHardForkBlockchainTimeArgs $
+                        HardForkBlockchainTimeArgs
+                          { hfbtBackoffDelay = pure $ BackoffDelay 60
+                          , hfbtGetLedgerState =
+                              ledgerState <$> ChainDB.getCurrentLedger chainDB
+                          , hfbtLedgerConfig = configLedger cfg
+                          , hfbtRegistry = registry
+                          , hfbtSystemTime = systemTime
+                          , hfbtTracer =
+                              contramap
+                                (fmap (fromRelativeTime systemStart))
+                                (blockchainTimeTracer rnTraceConsensus)
+                          , hfbtMaxClockRewind = secondsToNominalDiffTime 20
+                          }
+                  durationUntilTooOld <-
+                    GSM.realDurationUntilTooOld
+                      (configLedger cfg)
+                      (ledgerState <$> ChainDB.getCurrentLedger chainDB)
+                      llrnMaxCaughtUpAge
+                      systemTime
+                  -- Both TMVars must be filled /before/ 'completeNodeKernel'
+                  -- is invoked: the completer calls
+                  -- 'GSM.initializationGsmState' which reads through
+                  -- 'pendingDuration' to compute the real initial 'GsmState'.
+                  atomically $ do
+                    putTMVar btimeVar btime
+                    putTMVar durationVar durationUntilTooOld
+                  completeNodeKernel
+
+            -- When 'EarlyN2C' is enabled, fork late-init so
+            -- 'llrnRunDataDiffusion' can run immediately; otherwise run it
+            -- inline (matches the original synchronous boot sequence).
+            case ChainDB.cdbsEarlyN2C (ChainDB.cdbsArgs finalArgs) of
+              ChainDB.EarlyN2CEnabled ->
+                void $ forkLinkedThread registry "Node.lateInit" runLateInit
+              ChainDB.EarlyN2CDisabled ->
+                runLateInit
 
             llrnRunDataDiffusion nodeKernel consensusDiffusionArgs apps
  where
@@ -1125,6 +1166,19 @@ stdLowLevelRunNodeArgsIO
               then id
               else ChainDB.ensureValidateAll
           )
+        . updateEarlyN2C
+
+    updateEarlyN2C ::
+      Incomplete ChainDbArgs IO blk ->
+      Incomplete ChainDbArgs IO blk
+    updateEarlyN2C args =
+      args
+        { ChainDB.cdbsArgs =
+            (ChainDB.cdbsArgs args)
+              { ChainDB.cdbsEarlyN2C = srnEarlyN2C
+              , ChainDB.cdbsSynthesiseLedger = srnSynthesiseLedger
+              }
+        }
 
     llrnCustomiseNodeKernelArgs ::
       NodeKernelArgs m addrNTN (ConnectionId addrNTC) blk ->

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
@@ -24,6 +24,10 @@ module Ouroboros.Consensus.NodeKernel
   , getPeersFromCurrentLedger
   , getPeersFromCurrentLedgerAfterSlot
   , initNodeKernel
+  , initNodeKernelEarly
+  , mkPendingBlockchainTime
+  , mkPendingDurationUntilTooOld
+  , mkPendingMempool
   , toConsensusMode
   ) where
 
@@ -165,6 +169,73 @@ import qualified Ouroboros.Network.TxSubmission.Mempool.Reader as MempoolReader
 import System.Random (StdGen)
 
 {-------------------------------------------------------------------------------
+  Pending wrappers for fields that depend on a not-yet-ready LedgerDB
+-------------------------------------------------------------------------------}
+
+-- | A 'Mempool' that forwards every operation to the 'Mempool' stored in the
+-- given 'StrictTMVar', blocking on each call until the variable has been
+-- populated.
+--
+-- Used so that NtC TxSubmission and TxMonitor handlers can be wired up with a
+-- usable 'Mempool' value before the LedgerDB has finished its initial replay.
+-- Once a real 'Mempool' has been written to the variable, all subsequent
+-- forwarded calls proceed without blocking.
+mkPendingMempool ::
+  IOLike m => StrictTMVar m (Mempool m blk) -> Mempool m blk
+mkPendingMempool var =
+  Mempool
+    { addTx = \onBehalfOf tx -> do
+        m <- atomically (readTMVar var)
+        addTx m onBehalfOf tx
+    , removeTxsEvenIfValid = \txids -> do
+        m <- atomically (readTMVar var)
+        removeTxsEvenIfValid m txids
+    , getSnapshot = readTMVar var >>= getSnapshot
+    , getSnapshotFor = \slot tickedLst readKeys -> do
+        m <- atomically (readTMVar var)
+        getSnapshotFor m slot tickedLst readKeys
+    , getCapacity = readTMVar var >>= getCapacity
+    , testTryAddTx = \dt onBehalfOf tx -> do
+        m <- atomically (readTMVar var)
+        testTryAddTx m dt onBehalfOf tx
+    , testSyncWithLedger = do
+        m <- atomically (readTMVar var)
+        testSyncWithLedger m
+    }
+
+-- | A 'BlockchainTime' that forwards 'getCurrentSlot' to the 'BlockchainTime'
+-- stored in the given 'StrictTMVar', retrying in STM until the variable has
+-- been populated.
+--
+-- Used so that the 'NodeKernel' can be constructed before
+-- 'hardForkBlockchainTime' has run; consumers querying the current slot block
+-- harmlessly via STM 'retry' until the real 'BlockchainTime' is available.
+mkPendingBlockchainTime ::
+  IOLike m => StrictTMVar m (BlockchainTime m) -> BlockchainTime m
+mkPendingBlockchainTime var =
+  BlockchainTime
+    { getCurrentSlot = readTMVar var >>= getCurrentSlot
+    }
+
+-- | A 'GSM.WrapDurationUntilTooOld' that forwards
+-- 'GSM.getDurationUntilTooOld' to the wrapper stored in the given
+-- 'StrictTMVar', blocking on each call until the variable has been populated.
+--
+-- Used so that 'NodeKernelArgs' can be constructed (and hence
+-- 'initNodeKernelEarly' can run) before 'GSM.realDurationUntilTooOld' has
+-- executed. 'GSM.realDurationUntilTooOld' eagerly reads the current ledger
+-- to set up a hard-fork summary cache, so calling it synchronously during
+-- early init would block until the LedgerDB has finished replaying.
+mkPendingDurationUntilTooOld ::
+  IOLike m =>
+  StrictTMVar m (GSM.WrapDurationUntilTooOld m blk) ->
+  GSM.WrapDurationUntilTooOld m blk
+mkPendingDurationUntilTooOld var =
+  GSM.DurationUntilTooOld $ \slot -> do
+    wd <- atomically (readTMVar var)
+    GSM.getDurationUntilTooOld wd slot
+
+{-------------------------------------------------------------------------------
   Relay node
 -------------------------------------------------------------------------------}
 
@@ -241,7 +312,30 @@ data NodeKernelArgs m addrNTN addrNTC blk = NodeKernelArgs
   , getDiffusionPipeliningSupport :: DiffusionPipeliningSupport
   }
 
-initNodeKernel ::
+-- | Initialise the ledger-independent portion of the 'NodeKernel'.
+--
+-- Returns:
+--
+-- 1. A 'NodeKernel' suitable for handing to the diffusion layer immediately.
+--    Its @getChainDB@, @getTopLevelConfig@, @getTracers@, peer-sharing,
+--    tx-submission, and outbound-connections fields all hold their final
+--    values. Its @getMempool@ is a 'mkPendingMempool' wrapper backed by an
+--    internally-allocated 'StrictTMVar'. Its @getBlockchainTime@ is whatever
+--    the caller put in @args.btime@; pass a 'mkPendingBlockchainTime'
+--    wrapper if you want to defer blockchain-time construction.
+-- 2. An action that runs the late phase: opens the real 'Mempool', publishes
+--    it via the internal TMVar, computes the real initial 'GsmState', and
+--    spawns the four background threads that touch the LedgerDB (GSM, block
+--    forging, block fetch logic, tx submission decision logic) plus the GDD
+--    watcher (if LoE/GDD is enabled).
+--
+-- Pre-condition for invoking the late action: the 'ChainDB''s LedgerDB has
+-- finished its initial replay, so queries that read the current ledger no
+-- longer block. The caller is also expected to have populated any pending
+-- 'BlockchainTime' wrapper (in @args.btime@) before invoking the action;
+-- otherwise the spawned threads that read the blockchain time will block
+-- until it is filled.
+initNodeKernelEarly ::
   forall m addrNTN addrNTC blk.
   ( IOLike m
   , SI.MonadTimer m
@@ -251,8 +345,8 @@ initNodeKernel ::
   , Typeable addrNTN
   ) =>
   NodeKernelArgs m addrNTN addrNTC blk ->
-  m (NodeKernel m addrNTN addrNTC blk)
-initNodeKernel
+  m (NodeKernel m addrNTN addrNTC blk, m ())
+initNodeKernelEarly
   args@NodeKernelArgs
     { registry
     , cfg
@@ -269,11 +363,17 @@ initNodeKernel
     , getDiffusionPipeliningSupport
     , miniProtocolParameters
     } = do
-    -- using a lazy 'TVar', 'BlockForging' does not have a 'NoThunks' instance.
-    blockForgingVar :: LazySTM.TMVar m [MkBlockForging m blk] <- LazySTM.newTMVarIO []
-    initChainDB (configStorage cfg) (InitChainDB.fromFull chainDB)
+    -- Empty rather than seeded with []: 'setBlockForging' may be called
+    -- before 'blockForgingController' is spawned, in which case 'putTMVar'
+    -- on a full var would block.
+    blockForgingVar :: LazySTM.TMVar m [MkBlockForging m blk] <- LazySTM.newEmptyTMVarIO
 
-    st <- initInternalState args
+    -- Pending 'Mempool' wrapper. The TMVar will be filled inside the late
+    -- action (via 'completeInternalState') once the LedgerDB is ready.
+    mempoolVar <- newEmptyTMVarIO
+    let pendingMempool = mkPendingMempool mempoolVar
+
+    st <- initInternalStateEarly args pendingMempool
     let IS
           { blockFetchInterface
           , fetchClientRegistry
@@ -284,64 +384,6 @@ initNodeKernel
           } = st
 
     varOutboundConnectionsState <- newTVarIO UntrustedState
-
-    do
-      let GsmNodeKernelArgs{..} = gsmArgs
-          gsmTracerArgs =
-            ( castTip . either AF.anchorToTip tipFromHeader . AF.head . fst
-            , gsmTracer tracers
-            )
-
-      let gsm =
-            GSM.realGsmEntryPoints
-              gsmTracerArgs
-              GSM.GsmView
-                { GSM.antiThunderingHerd = Just gsmAntiThunderingHerd
-                , GSM.getCandidateOverSelection = do
-                    weights <- ChainDB.getPerasWeightSnapshot chainDB
-                    pure $ \(headers, _lst) state ->
-                      case AF.intersectionPoint headers (csCandidate state) of
-                        Nothing -> GSM.CandidateDoesNotIntersect
-                        Just{} ->
-                          GSM.WhetherCandidateIsBetter $ -- precondition requires intersection
-                            shouldSwitch
-                              ( preferAnchoredCandidate
-                                  (configBlock cfg)
-                                  (forgetFingerprint weights)
-                                  headers
-                                  (csCandidate state)
-                              )
-                , GSM.peerIsIdle = csIdling
-                , GSM.durationUntilTooOld =
-                    gsmDurationUntilTooOld
-                      <&> \wd (_headers, lst) ->
-                        GSM.getDurationUntilTooOld wd (getTipSlot lst)
-                , GSM.equivalent = (==) `on` (AF.headPoint . fst)
-                , GSM.getChainSyncStates = fmap cschState <$> cschcMap varChainSyncHandles
-                , GSM.getCurrentSelection = do
-                    headers <- ChainDB.getCurrentChainWithTime chainDB
-                    extLedgerState <- ChainDB.getCurrentLedger chainDB
-                    return (headers, ledgerState extLedgerState)
-                , GSM.minCaughtUpDuration = gsmMinCaughtUpDuration
-                , GSM.setCaughtUpPersistentMark = \upd ->
-                    (if upd then GSM.touchMarkerFile else GSM.removeMarkerFile)
-                      gsmMarkerFileView
-                , GSM.writeGsmState = \gsmState ->
-                    atomicallyWithMonotonicTime $ \time -> do
-                      writeTVar varGsmState gsmState
-                      handles <- cschcMap varChainSyncHandles
-                      traverse_ (($ time) . ($ gsmState) . cschOnGsmStateChanged) handles
-                , GSM.isHaaSatisfied = do
-                    readTVar varOutboundConnectionsState <&> \case
-                      -- See the upstream Haddocks for the exact conditions under
-                      -- which the diffusion layer is in this state.
-                      TrustedStateWithExternalPeers -> True
-                      UntrustedState -> False
-                }
-      judgment <- GSM.gsmStateToLedgerJudgement <$> readTVarIO varGsmState
-      void $ forkLinkedThread registry "NodeKernel.GSM" $ case judgment of
-        TooOld -> GSM.enterPreSyncing gsm
-        YoungEnough -> GSM.enterCaughtUp gsm
 
     peerSharingAPI <-
       newPeerSharingAPI
@@ -354,71 +396,157 @@ initNodeKernel
     sharedTxStateVar <- newSharedTxStateVar txSubmissionRng
     txMempoolSem <- newTxMempoolSem
 
-    case gnkaLoEAndGDDArgs genesisArgs of
-      LoEAndGDDDisabled -> pure ()
+    -- LoE/GDD setup: we install the @getLoEFragment@ STM callback eagerly
+    -- (it is cheap and ledger-free), but defer spawning the gddWatcher to
+    -- the late action because the watcher reads
+    -- 'ChainDB.getImmutableLedger' inside its STM reader.
+    spawnGddWatcher <- case gnkaLoEAndGDDArgs genesisArgs of
+      LoEAndGDDDisabled -> pure (pure ())
       LoEAndGDDEnabled lgArgs -> do
         varLoEFragment <- newTVarIO $ AF.Empty AF.AnchorGenesis
         setGetLoEFragment
           (readTVar varGsmState)
           (readTVar varLoEFragment)
           (lgnkaLoEFragmentTVar lgArgs)
+        pure $
+          void $
+            forkLinkedWatcher registry "NodeKernel.GDD" $
+              gddWatcher
+                cfg
+                (gddTracer tracers)
+                chainDB
+                (lgnkaGDDRateLimit lgArgs)
+                (readTVar varGsmState)
+                (cschcMap varChainSyncHandles)
+                varLoEFragment
 
-        void $
-          forkLinkedWatcher registry "NodeKernel.GDD" $
-            gddWatcher
-              cfg
-              (gddTracer tracers)
-              chainDB
-              (lgnkaGDDRateLimit lgArgs)
-              (readTVar varGsmState)
-              (cschcMap varChainSyncHandles)
-              varLoEFragment
+    let kernel =
+          NodeKernel
+            { getChainDB = chainDB
+            , getMempool = mempool
+            , getTopLevelConfig = cfg
+            , getFetchClientRegistry = fetchClientRegistry
+            , getFetchMode = readFetchMode blockFetchInterface
+            , getGsmState = readTVar varGsmState
+            , getChainSyncHandles = varChainSyncHandles
+            , getPeerSharingRegistry = peerSharingRegistry
+            , getTracers = tracers
+            , -- Atomic overwrite so callers never block on a full var.
+              setBlockForging = \a -> atomically $ do
+                _ <- LazySTM.tryTakeTMVar blockForgingVar
+                LazySTM.putTMVar blockForgingVar $! a
+            , getPeerSharingAPI = peerSharingAPI
+            , getOutboundConnectionsState =
+                varOutboundConnectionsState
+            , getDiffusionPipeliningSupport
+            , getBlockchainTime = btime
+            , getTxChannelsVar = txChannelsVar
+            , getSharedTxStateVar = sharedTxStateVar
+            , getTxMempoolSem = txMempoolSem
+            }
 
-    void $
-      forkLinkedThread registry "NodeKernel.blockForging" $
-        blockForgingController st (LazySTM.takeTMVar blockForgingVar)
+    let complete :: m ()
+        complete = do
+          -- Era init must run after the LedgerDB is ready (HardFork dispatch reads the current ledger).
+          initChainDB (configStorage cfg) (InitChainDB.fromFull chainDB)
 
-    -- Run the block fetch logic in the background. This will call
-    -- 'addFetchedBlock' whenever a new block is downloaded.
-    void $
-      forkLinkedThread registry "NodeKernel.blockFetchLogic" $
-        blockFetchLogic
-          (contramap castTraceFetchDecision $ blockFetchDecisionTracer tracers)
-          (contramap (fmap castTraceFetchClientState) $ blockFetchClientTracer tracers)
-          blockFetchInterface
-          fetchClientRegistry
-          blockFetchConfiguration
+          -- Open the real 'Mempool', publish it via 'mempoolVar', and
+          -- write the real initial 'GsmState' to 'varGsmState'.
+          completeInternalState args st mempoolVar
 
-    void $
-      forkLinkedThread registry "NodeKernel.decisionLogicThreads" $
-        decisionLogicThreads
-          (txLogicTracer tracers)
-          (txCountersTracer tracers)
-          (txDecisionPolicy miniProtocolParameters)
-          txChannelsVar
-          sharedTxStateVar
+          -- 2. Spawn the GSM thread. We deliberately fork only after the
+          -- previous step writes the real 'GsmState' so that the 'judgment'
+          -- snapshot (and hence the chosen entry point) is correct. After
+          -- this fork the GSM thread takes ownership of writing
+          -- 'varGsmState' (via its 'GSM.writeGsmState' callback).
+          do
+            let GsmNodeKernelArgs{..} = gsmArgs
+                gsmTracerArgs =
+                  ( castTip . either AF.anchorToTip tipFromHeader . AF.head . fst
+                  , gsmTracer tracers
+                  )
 
-    return
-      NodeKernel
-        { getChainDB = chainDB
-        , getMempool = mempool
-        , getTopLevelConfig = cfg
-        , getFetchClientRegistry = fetchClientRegistry
-        , getFetchMode = readFetchMode blockFetchInterface
-        , getGsmState = readTVar varGsmState
-        , getChainSyncHandles = varChainSyncHandles
-        , getPeerSharingRegistry = peerSharingRegistry
-        , getTracers = tracers
-        , setBlockForging = \a -> atomically . LazySTM.putTMVar blockForgingVar $! a
-        , getPeerSharingAPI = peerSharingAPI
-        , getOutboundConnectionsState =
-            varOutboundConnectionsState
-        , getDiffusionPipeliningSupport
-        , getBlockchainTime = btime
-        , getTxChannelsVar = txChannelsVar
-        , getSharedTxStateVar = sharedTxStateVar
-        , getTxMempoolSem = txMempoolSem
-        }
+            let gsm =
+                  GSM.realGsmEntryPoints
+                    gsmTracerArgs
+                    GSM.GsmView
+                      { GSM.antiThunderingHerd = Just gsmAntiThunderingHerd
+                      , GSM.getCandidateOverSelection = do
+                          weights <- ChainDB.getPerasWeightSnapshot chainDB
+                          pure $ \(headers, _lst) state ->
+                            case AF.intersectionPoint headers (csCandidate state) of
+                              Nothing -> GSM.CandidateDoesNotIntersect
+                              Just{} ->
+                                GSM.WhetherCandidateIsBetter $ -- precondition requires intersection
+                                  shouldSwitch
+                                    ( preferAnchoredCandidate
+                                        (configBlock cfg)
+                                        (forgetFingerprint weights)
+                                        headers
+                                        (csCandidate state)
+                                    )
+                      , GSM.peerIsIdle = csIdling
+                      , GSM.durationUntilTooOld =
+                          gsmDurationUntilTooOld
+                            <&> \wd (_headers, lst) ->
+                              GSM.getDurationUntilTooOld wd (getTipSlot lst)
+                      , GSM.equivalent = (==) `on` (AF.headPoint . fst)
+                      , GSM.getChainSyncStates = fmap cschState <$> cschcMap varChainSyncHandles
+                      , GSM.getCurrentSelection = do
+                          headers <- ChainDB.getCurrentChainWithTime chainDB
+                          extLedgerState <- ChainDB.getCurrentLedger chainDB
+                          return (headers, ledgerState extLedgerState)
+                      , GSM.minCaughtUpDuration = gsmMinCaughtUpDuration
+                      , GSM.setCaughtUpPersistentMark = \upd ->
+                          (if upd then GSM.touchMarkerFile else GSM.removeMarkerFile)
+                            gsmMarkerFileView
+                      , GSM.writeGsmState = \gsmState ->
+                          atomicallyWithMonotonicTime $ \time -> do
+                            writeTVar varGsmState gsmState
+                            handles <- cschcMap varChainSyncHandles
+                            traverse_ (($ time) . ($ gsmState) . cschOnGsmStateChanged) handles
+                      , GSM.isHaaSatisfied = do
+                          readTVar varOutboundConnectionsState <&> \case
+                            -- See the upstream Haddocks for the exact conditions under
+                            -- which the diffusion layer is in this state.
+                            TrustedStateWithExternalPeers -> True
+                            UntrustedState -> False
+                      }
+            judgment <- GSM.gsmStateToLedgerJudgement <$> readTVarIO varGsmState
+            void $ forkLinkedThread registry "NodeKernel.GSM" $ case judgment of
+              TooOld -> GSM.enterPreSyncing gsm
+              YoungEnough -> GSM.enterCaughtUp gsm
+
+          -- 3. Spawn the GDD watcher (no-op if LoE/GDD disabled).
+          spawnGddWatcher
+
+          -- 4. Spawn the block forging controller.
+          void $
+            forkLinkedThread registry "NodeKernel.blockForging" $
+              blockForgingController st (LazySTM.takeTMVar blockForgingVar)
+
+          -- 5. Spawn the block fetch logic in the background. This will
+          -- call 'addFetchedBlock' whenever a new block is downloaded.
+          void $
+            forkLinkedThread registry "NodeKernel.blockFetchLogic" $
+              blockFetchLogic
+                (contramap castTraceFetchDecision $ blockFetchDecisionTracer tracers)
+                (contramap (fmap castTraceFetchClientState) $ blockFetchClientTracer tracers)
+                blockFetchInterface
+                fetchClientRegistry
+                blockFetchConfiguration
+
+          -- 6. Spawn the tx submission decision logic.
+          void $
+            forkLinkedThread registry "NodeKernel.decisionLogicThreads" $
+              decisionLogicThreads
+                (txLogicTracer tracers)
+                (txCountersTracer tracers)
+                (txDecisionPolicy miniProtocolParameters)
+                txChannelsVar
+                sharedTxStateVar
+
+    pure (kernel, complete)
    where
     blockForgingController ::
       InternalState m remotePeer localPeer blk ->
@@ -432,6 +560,27 @@ initNodeKernel
         traverse_ cancelThread forgingThreads
         blockForging' <- traverse (forkBlockForging st) blockForging
         go blockForging'
+
+-- | Backwards-compatible monolithic initialiser.
+--
+-- Calls 'initNodeKernelEarly' and immediately runs the returned complete
+-- action. By the time this returns, all background threads have been
+-- spawned and the mempool / GSM state have been populated.
+initNodeKernel ::
+  forall m addrNTN addrNTC blk.
+  ( IOLike m
+  , SI.MonadTimer m
+  , RunNode blk
+  , Ord addrNTN
+  , Hashable addrNTN
+  , Typeable addrNTN
+  ) =>
+  NodeKernelArgs m addrNTN addrNTC blk ->
+  m (NodeKernel m addrNTN addrNTC blk)
+initNodeKernel args = do
+    (kernel, complete) <- initNodeKernelEarly args
+    complete
+    pure kernel
 
 castTraceFetchDecision ::
   forall remotePeer blk.
@@ -465,17 +614,33 @@ data InternalState m addrNTN addrNTC blk = IS
   , peerSharingRegistry :: PeerSharingRegistry addrNTN m
   }
 
-initInternalState ::
+-- | Initialise the ledger-independent portion of the 'InternalState'.
+--
+-- The returned record has placeholders in the two slots that genuinely need a
+-- ready 'LedgerDB':
+--
+-- * @varGsmState@ is seeded with 'GSM.PreSyncing' — the most conservative
+--   state, which corresponds to 'LedgerStateJudgement' 'TooOld'. This is the
+--   correct judgement to expose to the diffusion layer while the LedgerDB is
+--   still replaying.
+-- * @mempool@ is whatever 'Mempool' value the caller passes in. Normally
+--   the caller passes a 'mkPendingMempool' wrapper over a freshly-allocated
+--   'StrictTMVar'; that same TMVar is then handed to 'completeInternalState'
+--   which fills it with a real 'Mempool'.
+initInternalStateEarly ::
   forall m addrNTN addrNTC blk.
   ( IOLike m
-  , SI.MonadTimer m
   , Ord addrNTN
   , Typeable addrNTN
   , RunNode blk
   ) =>
   NodeKernelArgs m addrNTN addrNTC blk ->
+  -- | A 'Mempool' value to install in the @mempool@ field. Use
+  -- 'mkPendingMempool' over an empty 'StrictTMVar' to defer the real
+  -- 'Mempool' until 'completeInternalState' runs.
+  Mempool m blk ->
   m (InternalState m addrNTN addrNTC blk)
-initInternalState
+initInternalStateEarly
   NodeKernelArgs
     { tracers
     , chainDB
@@ -483,31 +648,17 @@ initInternalState
     , cfg
     , blockFetchSize
     , btime
-    , mempoolCapacityOverride
-    , mempoolTimeoutConfig
-    , gsmArgs
     , getUseBootstrapPeers
     , getDiffusionPipeliningSupport
     , genesisArgs
-    } = do
-    varGsmState <- do
-      let GsmNodeKernelArgs{..} = gsmArgs
-      gsmState <-
-        GSM.initializationGsmState
-          (atomically $ ledgerState <$> ChainDB.getCurrentLedger chainDB)
-          gsmDurationUntilTooOld
-          gsmMarkerFileView
-      newTVarIO gsmState
+    }
+  mempool = do
+    -- Conservative default. The real value is computed from the current
+    -- ledger by 'completeInternalState' once the LedgerDB has finished its
+    -- initial replay.
+    varGsmState <- newTVarIO GSM.PreSyncing
 
     varChainSyncHandles <- atomically newChainSyncClientHandleCollection
-    mempool <-
-      openMempool
-        registry
-        (chainDBLedgerInterface chainDB)
-        (configLedger cfg)
-        mempoolCapacityOverride
-        mempoolTimeoutConfig
-        (mempoolTracer tracers)
 
     fetchClientRegistry <- newFetchClientRegistry
 
@@ -532,7 +683,62 @@ initInternalState
 
     peerSharingRegistry <- newPeerSharingRegistry
 
-    return IS{..}
+    pure IS{..}
+
+-- | Finish initialising the ledger-dependent portion of the 'InternalState'.
+--
+-- Pre-condition: the 'ChainDB''s LedgerDB has finished its initial replay, so
+-- queries that read the current ledger no longer block.
+--
+-- This action:
+--
+-- 1. Opens the real 'Mempool'.
+-- 2. Publishes it into the supplied 'StrictTMVar' so any 'mkPendingMempool'
+--    wrapper backed by that var begins forwarding directly to it.
+-- 3. Computes the real initial 'GsmState' via 'GSM.initializationGsmState'
+--    and writes it to @varGsmState@. This may transition 'PreSyncing' to
+--    'CaughtUp' if the marker file is present and the ledger tip is recent.
+completeInternalState ::
+  forall m addrNTN addrNTC blk.
+  ( IOLike m
+  , SI.MonadTimer m
+  , RunNode blk
+  ) =>
+  NodeKernelArgs m addrNTN addrNTC blk ->
+  InternalState m addrNTN addrNTC blk ->
+  -- | The 'StrictTMVar' backing the pending mempool that was passed to
+  -- 'initInternalStateEarly'. It must be empty.
+  StrictTMVar m (Mempool m blk) ->
+  m ()
+completeInternalState
+  NodeKernelArgs
+    { tracers
+    , chainDB
+    , registry
+    , cfg
+    , mempoolCapacityOverride
+    , mempoolTimeoutConfig
+    , gsmArgs
+    }
+  IS{varGsmState}
+  mempoolVar = do
+    realMempool <-
+      openMempool
+        registry
+        (chainDBLedgerInterface chainDB)
+        (configLedger cfg)
+        mempoolCapacityOverride
+        mempoolTimeoutConfig
+        (mempoolTracer tracers)
+    atomically $ putTMVar mempoolVar realMempool
+
+    let GsmNodeKernelArgs{gsmDurationUntilTooOld, gsmMarkerFileView} = gsmArgs
+    gsmState <-
+      GSM.initializationGsmState
+        (atomically $ ledgerState <$> ChainDB.getCurrentLedger chainDB)
+        gsmDurationUntilTooOld
+        gsmMarkerFileView
+    atomically $ writeTVar varGsmState gsmState
 
 toConsensusMode :: forall a. LoEAndGDDConfig a -> ConsensusMode
 toConsensusMode = \case

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/LocalStateQuery/Server.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/LocalStateQuery/Server.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Ouroboros.Consensus.MiniProtocol.LocalStateQuery.Server (localStateQueryServer) where
@@ -57,6 +58,9 @@ localStateQueryServer cfg getView =
             SendMsgFailure AcquireFailurePointTooOld idle
           PointNotOnChain ->
             SendMsgFailure AcquireFailurePointNotOnChain idle
+          -- LedgerDB still replaying; reuse PointTooOld so clients retry.
+          LedgerNotReady ->
+            SendMsgFailure AcquireFailurePointTooOld idle
 
   acquired ::
     ResourceKey m ->

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/API.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/API.hs
@@ -78,6 +78,9 @@ module Ouroboros.Consensus.Storage.ChainDB.API
     -- * Genesis
   , GetLoEFragment
   , LoE (..)
+
+    -- * Background ledger replay
+  , EarlyN2C (..)
   ) where
 
 import Control.Monad (void)
@@ -239,8 +242,15 @@ data ChainDB m blk = ChainDB
   -- ^ Allocate a read only forker at the given point in the given resource
   -- registry.
   --
-  -- This function is to be used by LocalStateQuery server. Note ChainSel uses
-  -- the LedgerDB directly, none of these methods are used there.
+  -- This function is to be used by the LocalStateQuery server. When
+  -- 'EarlyN2C' is enabled and the LedgerDB is still
+  -- replaying, the returned forker may be a /synthesised/ forker (see
+  -- 'EarlyN2C') whose 'roforkerGetLedgerState' returns a
+  -- state built from genesis + known hard-fork triggers. The synthesised
+  -- state is sufficient for history-only queries like @GetInterpreter@;
+  -- queries that read ledger tables (e.g. @GetUTxO*@) will fail noisily
+  -- on the synthesised forker. Note ChainSel uses the LedgerDB directly,
+  -- none of these methods are used there.
   , openReadOnlyForkerAtPoint ::
       Target (Point blk) ->
       m (Either GetForkerError (ReadOnlyForker' m blk))
@@ -1022,3 +1032,26 @@ data LoE a
 -- details. This fragment must be anchored in a (recent) point on the immutable
 -- chain, just like candidate fragments.
 type GetLoEFragment m blk = m (LoE (AnchoredFragment (HeaderWithTime blk)))
+
+-- | Whether the local node-to-client (N2C) socket is bound early in
+-- the boot sequence, so clients can connect while ledger replay
+-- continues in the background.
+--
+-- The default 'EarlyN2CDisabled' preserves the original
+-- synchronous-open / late-bind behaviour byte-for-byte: the LedgerDB
+-- replay blocks 'openDB' and the local socket is bound only after
+-- replay completes.
+--
+-- 'EarlyN2CEnabled' enables the two-phase pipeline: the
+-- LedgerDB replay is forked, 'openDB' returns as soon as the
+-- ImmutableDB is ready, the local socket binds early, and a
+-- synthesised forker serves history-only LSQ queries during the replay
+-- window. Lets clients (notably @cardano-db-sync-new@) start ingesting
+-- finalised blocks while replay continues in the background.
+data EarlyN2C
+  = -- | Original behaviour: synchronous open, late socket bind.
+    EarlyN2CDisabled
+  | -- | Two-phase open: bind socket early, replay in background, serve a
+    -- synthesised forker for history-only LSQ queries during replay.
+    EarlyN2CEnabled
+  deriving (Eq, Show, Generic, NoThunks)

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl.hs
@@ -44,6 +44,8 @@ import Control.Monad.Trans.Class (lift)
 import qualified Control.RAWLock as RAW
 import Control.ResourceRegistry
   ( allocate
+  , cancelThread
+  , forkLinkedThread
   , runWithTempRegistry
   )
 import Control.Tracer
@@ -56,7 +58,7 @@ import NoThunks.Class
 import Ouroboros.Consensus.Block
 import Ouroboros.Consensus.Config
 import Ouroboros.Consensus.HardFork.Abstract
-import Ouroboros.Consensus.HeaderValidation (mkHeaderWithTime)
+import Ouroboros.Consensus.HeaderValidation (HeaderWithTime, mkHeaderWithTime)
 import Ouroboros.Consensus.Ledger.Extended (ledgerState)
 import Ouroboros.Consensus.Ledger.Inspect
 import Ouroboros.Consensus.Ledger.SupportsPeras (LedgerSupportsPeras)
@@ -169,8 +171,11 @@ openDBInternal args launchBgTasks = runWithTempRegistry $ do
     volatileDB <- VolatileDB.openDB argsVolatileDb
     maxSlot <- atomically $ VolatileDB.getMaxSlotNo volatileDB
     traceWith tracer $ TraceOpenEvent (OpenedVolatileDB maxSlot)
-    traceWith tracer $ TraceOpenEvent StartedOpeningLgrDB
-    (ledgerDbGetVolatileSuffix, setGetCurrentChainForLedgerDB) <- mkLedgerDbGetVolatileSuffix
+    -- The 'StartedOpeningLgrDB' / 'OpenedLgrDB' trace events fire later,
+    -- inside 'runInitLedgerDB', once the background thread starts the
+    -- LedgerDB-open work.
+    (ledgerDbGetVolatileSuffix, setGetCurrentChainForLedgerDB) <-
+      mkLedgerDbGetVolatileSuffix
     pure
       ( immutableDB
       , immutableDbTipPoint
@@ -179,59 +184,30 @@ openDBInternal args launchBgTasks = runWithTempRegistry $ do
       , setGetCurrentChainForLedgerDB
       )
 
-  -- Note this is the only step that actually cares about the temporary registry
-  -- while initializing the ChainDB. It opens the handle to the backend and we
-  -- want to track that one to close it on exception. See "Resource management
-  -- in the LedgerDB" in "Ouroboros.Consensus.Storage.LedgerDB.API" for an
-  -- explanation of why.
-  lgrDB <-
-    LedgerDB.openDB
-      argsLgrDb
-      (ImmutableDB.streamAPI immutableDB)
-      immutableDbTipPoint
-      (Query.getAnyKnownBlock immutableDB volatileDB)
-      ledgerDbGetVolatileSuffix
-
+  -- The LedgerDB is opened later inside 'runInitLedgerDB' so that, when
+  -- 'EarlyN2C' is enabled, the (potentially long) initial replay can run
+  -- on a background thread. See "Resource management in the LedgerDB" in
+  -- "Ouroboros.Consensus.Storage.LedgerDB.API" for the temp-registry
+  -- handover details.
   lift $ do
-    traceWith tracer $ TraceOpenEvent OpenedLgrDB
-
     perasCertDB <- PerasCertDB.createDB argsPerasCertDB
     perasVoteDB <- PerasVoteDB.createDB argsPerasVoteDB
 
     varInvalid <- newTVarIO (WithFingerprint Map.empty (Fingerprint 0))
+    varLdbStatus <- newTVarIO LdbReplaying
+    varCancelInit <- newTVarIO (return ())
 
-    let initChainSelTracer = TraceInitChainSelEvent >$< tracer
+    -- Empty current chain anchored at the immutable tip; the background
+    -- initialiser populates this once initial chain selection runs.
+    immutableTipAnchor <- atomically $ ImmutableDB.getTipAnchor immutableDB
+    let initialChain :: AnchoredFragment (Header blk)
+        initialChain = AF.Empty (AF.castAnchor immutableTipAnchor)
+        initialChainWithTime :: AnchoredFragment (HeaderWithTime blk)
+        initialChainWithTime = AF.Empty (AF.castAnchor immutableTipAnchor)
 
-    traceWith initChainSelTracer StartedInitChainSelection
-    initialLoE <- Args.cdbsLoE cdbSpecificArgs
-    initialWeights <- atomically $ PerasCertDB.getWeightSnapshot perasCertDB
-    chain <-
-      ChainSel.initialChainSelection
-        immutableDB
-        volatileDB
-        lgrDB
-        initChainSelTracer
-        (Args.cdbsTopLevelConfig cdbSpecificArgs)
-        varInvalid
-        (void initialLoE)
-        (forgetFingerprint initialWeights)
-    traceWith initChainSelTracer InitialChainSelected
-    LedgerDB.tryFlush lgrDB
-
-    curLedger <- atomically $ LedgerDB.getVolatileTip lgrDB
-    let lcfg = configLedger (Args.cdbsTopLevelConfig cdbSpecificArgs)
-
-        -- the volatile tip ledger state can translate the slots of the volatile
-        -- headers
-        chainWithTime =
-          AF.mapAnchoredFragment
-            ( mkHeaderWithTime
-                lcfg
-                (ledgerState curLedger)
-            )
-            chain
-
-    varChain <- newTVarWithInvariantIO checkInternalChain $ InternalChain chain chainWithTime
+    varChain <-
+      newTVarWithInvariantIO checkInternalChain $
+        InternalChain initialChain initialChainWithTime
     varTentativeState <- newTVarIO $ initialTentativeHeaderState (Proxy @blk)
     varTentativeHeader <- newTVarIO SNothing
     varIterators <- newTVarIO Map.empty
@@ -245,11 +221,20 @@ openDBInternal args launchBgTasks = runWithTempRegistry $ do
     varChainSelStarvation <- newTVarIO ChainSelStarvationOngoing
     varSnapshotDelayRNG <- newTVarIO (Args.cdbsSnapshotDelayRNG cdbSpecificArgs)
 
-    let env =
+    let synthesisedLedger =
+          case Args.cdbsSynthesiseLedger cdbSpecificArgs of
+            Nothing -> Nothing
+            Just f -> f immutableDbTipPoint
+        env =
           CDB
             { cdbImmutableDB = immutableDB
+            , cdbImmutableDBLock = immdbLock
             , cdbVolatileDB = volatileDB
-            , cdbLedgerDB = lgrDB
+            , cdbLedgerDBStatus = varLdbStatus
+            , cdbCancelInit = varCancelInit
+            , cdbEarlyN2C =
+                Args.cdbsEarlyN2C cdbSpecificArgs
+            , cdbSyntheticLedger = synthesisedLedger
             , cdbChain = varChain
             , cdbTentativeState = varTentativeState
             , cdbTentativeHeader = varTentativeHeader
@@ -259,7 +244,6 @@ openDBInternal args launchBgTasks = runWithTempRegistry $ do
             , cdbInvalid = varInvalid
             , cdbNextIteratorKey = varNextIteratorKey
             , cdbNextFollowerKey = varNextFollowerKey
-            , cdbImmutableDBLock = immdbLock
             , cdbChainSelFuse = chainSelFuse
             , cdbTracer = tracer
             , cdbRegistry = Args.cdbsRegistry cdbSpecificArgs
@@ -273,8 +257,6 @@ openDBInternal args launchBgTasks = runWithTempRegistry $ do
             , cdbPerasVoteDB = perasVoteDB
             , cdbSnapshotDelayRNG = varSnapshotDelayRNG
             }
-
-    setGetCurrentChainForLedgerDB $ Query.getCurrentChain env
 
     h <- fmap CDBHandle $ newTVarIO $ ChainDbOpen env
     let chainDB =
@@ -322,19 +304,46 @@ openDBInternal args launchBgTasks = runWithTempRegistry $ do
             , intGarbageCollect = \slot -> getEnv h $ \e -> do
                 Background.garbageCollectBlocks e slot
                 Background.garbageCollectPeras e slot
-                LedgerDB.garbageCollect (cdbLedgerDB e) slot
-            , intTryTakeSnapshot = getEnv2 h $ LedgerDB.tryTakeSnapshot . cdbLedgerDB
+                ldb <- atomically $ awaitLedgerDB e
+                LedgerDB.garbageCollect ldb slot
+            , intTryTakeSnapshot = getEnv2 h $ \env' cb delay -> do
+                ldb <- atomically $ awaitLedgerDB env'
+                LedgerDB.tryTakeSnapshot ldb cb delay
             , intAddBlockRunner = getEnv h (Background.addBlockRunner addBlockTestFuse)
             , intKillBgThreads = varKillBgThreads
             }
 
-    traceWith tracer $
-      TraceOpenEvent $
-        OpenedDB
-          (castPoint $ AF.anchorPoint chain)
-          (castPoint $ AF.headPoint chain)
+    -- When 'EarlyN2C' is enabled, fork the LedgerDB
+    -- initialiser so 'openDB' can return immediately; otherwise run it
+    -- inline (original synchronous open).
+    case Args.cdbsEarlyN2C cdbSpecificArgs of
+      API.EarlyN2CEnabled -> do
+        traceWith tracer $
+          TraceOpenEvent $
+            OpenedDBImmutableReady immutableDbTipPoint
 
-    when launchBgTasks $ Background.launchBgTasks env
+        initThread <-
+          forkLinkedThread (Args.cdbsRegistry cdbSpecificArgs) "ChainDB.initLedgerDB" $
+            runInitLedgerDB
+              args
+              env
+              immutableDB
+              volatileDB
+              immutableDbTipPoint
+              ledgerDbGetVolatileSuffix
+              setGetCurrentChainForLedgerDB
+              launchBgTasks
+        atomically $ writeTVar varCancelInit (cancelThread initThread)
+      API.EarlyN2CDisabled ->
+        runInitLedgerDB
+          args
+          env
+          immutableDB
+          volatileDB
+          immutableDbTipPoint
+          ledgerDbGetVolatileSuffix
+          setGetCurrentChainForLedgerDB
+          launchBgTasks
 
     -- Note we put the ChainDB in the top level registry before exiting the
     -- 'runWithTempRegistry' scope. This way, the critical resources (actually
@@ -351,20 +360,22 @@ openDBInternal args launchBgTasks = runWithTempRegistry $ do
   Args.ChainDbArgs
     argsImmutableDb
     argsVolatileDb
-    argsLgrDb
+    _argsLgrDb
     argsPerasCertDB
     argsPerasVoteDB
     cdbSpecificArgs = args
 
   -- The LedgerDB requires a criterion ('LedgerDB.GetVolatileSuffix')
-  -- determining which of its states are volatile/immutable. Once we have
-  -- initialized the ChainDB we can defer this decision to
+  -- determining which of its states are volatile/immutable. Once initial
+  -- chain selection has run we can defer this decision to
   -- 'Query.getCurrentChain'.
   --
-  -- However, we initialize the LedgerDB before the ChainDB (for initial chain
-  -- selection), so during that period, we temporarily consider no state (apart
-  -- from the anchor state) as immutable. This is fine as we don't perform eg
-  -- any rollbacks during this period.
+  -- The LedgerDB is initialised on the background thread spawned by
+  -- 'openDBInternal' (see 'runInitLedgerDB'). 'setVarChain' is only invoked
+  -- once that background work has selected an initial chain. While the
+  -- LedgerDB is replaying, the TMVar is empty and the suffix defaults to
+  -- 'id', i.e. the entire suffix is treated as volatile. This is fine as we
+  -- don't perform any rollbacks during this period.
   mkLedgerDbGetVolatileSuffix ::
     m
       ( LedgerDB.GetVolatileSuffix m blk
@@ -387,6 +398,104 @@ openDBInternal args launchBgTasks = runWithTempRegistry $ do
                 pure $ AF.anchorNewest (fromIntegral curChainLen)
         setVarChain = atomically . writeTMVar varGetCurrentChain . OnlyCheckWhnf
     pure (getVolatileSuffix, setVarChain)
+
+-- | Background initialisation of the LedgerDB and initial chain selection.
+--
+-- Runs on a registry-linked thread spawned by 'openDBInternal'. On success
+-- the result of initial chain selection is written to 'cdbChain',
+-- 'cdbLedgerDBStatus' is transitioned to 'LdbReady', 'cdbCancelInit' is
+-- cleared, and (when requested) the ChainDB background tasks are launched.
+-- On failure the linked-thread exception propagates to the parent registry.
+runInitLedgerDB ::
+  forall m blk.
+  ( IOLike m
+  , LedgerSupportsProtocol blk
+  , BlockSupportsDiffusionPipelining blk
+  , InspectLedger blk
+  , HasHardForkHistory blk
+  , LedgerSupportsLedgerDB blk
+  ) =>
+  Complete Args.ChainDbArgs m blk ->
+  ChainDbEnv m blk ->
+  ImmutableDB.ImmutableDB m blk ->
+  VolatileDB.VolatileDB m blk ->
+  Point blk ->
+  LedgerDB.GetVolatileSuffix m blk ->
+  (STM m (AnchoredFragment (Header blk)) -> m ()) ->
+  Bool ->
+  m ()
+runInitLedgerDB
+  args
+  env
+  immutableDB
+  volatileDB
+  immutableDbTipPoint
+  ledgerDbGetVolatileSuffix
+  setGetCurrentChainForLedgerDB
+  launchBgTasks = runWithTempRegistry $ do
+    lift $ traceWith tracer $ TraceOpenEvent StartedOpeningLgrDB
+
+    lgrDB <-
+      LedgerDB.openDB
+        argsLgrDb
+        (ImmutableDB.streamAPI immutableDB)
+        immutableDbTipPoint
+        (Query.getAnyKnownBlock immutableDB volatileDB)
+        ledgerDbGetVolatileSuffix
+
+    lift $ do
+      traceWith tracer $ TraceOpenEvent OpenedLgrDB
+
+      let initChainSelTracer = TraceInitChainSelEvent >$< tracer
+      traceWith initChainSelTracer StartedInitChainSelection
+      initialLoE <- Args.cdbsLoE cdbSpecificArgs
+      initialWeights <-
+        atomically $ PerasCertDB.getWeightSnapshot (cdbPerasCertDB env)
+      chain <-
+        ChainSel.initialChainSelection
+          immutableDB
+          volatileDB
+          lgrDB
+          initChainSelTracer
+          (cdbTopLevelConfig env)
+          (cdbInvalid env)
+          (void initialLoE)
+          (forgetFingerprint initialWeights)
+      traceWith initChainSelTracer InitialChainSelected
+      LedgerDB.tryFlush lgrDB
+
+      curLedger <- atomically $ LedgerDB.getVolatileTip lgrDB
+      let lcfg = configLedger (cdbTopLevelConfig env)
+          chainWithTime =
+            AF.mapAnchoredFragment
+              (mkHeaderWithTime lcfg (ledgerState curLedger))
+              chain
+
+      atomically $ do
+        writeTVar (cdbChain env) (InternalChain chain chainWithTime)
+        writeTVar (cdbLedgerDBStatus env) (LdbReady lgrDB)
+        writeTVar (cdbCancelInit env) (return ())
+
+      setGetCurrentChainForLedgerDB $ Query.getCurrentChain env
+
+      traceWith tracer $
+        TraceOpenEvent $
+          OpenedDB
+            (castPoint (AF.anchorPoint chain) :: Point blk)
+            (castPoint (AF.headPoint chain) :: Point blk)
+
+      when launchBgTasks $ Background.launchBgTasks env
+
+      return ((), env)
+   where
+    Args.ChainDbArgs
+      _argsImmutableDb
+      _argsVolatileDb
+      argsLgrDb
+      _argsPerasCertDB
+      _argsPerasVoteDB
+      cdbSpecificArgs = args
+    tracer = Args.cdbsTracer cdbSpecificArgs
 
 isOpen :: IOLike m => ChainDbHandle m blk -> STM m Bool
 isOpen (CDBHandle varState) =
@@ -413,6 +522,11 @@ closeDB (CDBHandle varState) = do
 
   -- Only when the ChainDB was open
   whenJust mbOpenEnv $ \cdb@CDB{..} -> do
+    -- If the LedgerDB is still being initialised in the background, cancel
+    -- that work first so it cannot race with the cleanup below.
+    cancelInit <- atomically $ readTVar cdbCancelInit
+    cancelInit
+
     Follower.closeAllFollowers cdb
     Iterator.closeAllIterators cdb
 
@@ -421,7 +535,12 @@ closeDB (CDBHandle varState) = do
 
     ImmutableDB.closeDB cdbImmutableDB
     VolatileDB.closeDB cdbVolatileDB
-    LedgerDB.closeDB cdbLedgerDB
+
+    -- The LedgerDB is only opened by the background initialisation; if that
+    -- never reached 'LdbReady', there is no LedgerDB handle to close.
+    atomically (readTVar cdbLedgerDBStatus) >>= \case
+      LdbReplaying -> pure ()
+      LdbReady ldb -> LedgerDB.closeDB ldb
 
     chain <- atomically $ icWithoutTime <$> readTVar cdbChain
 

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Args.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Args.hs
@@ -32,7 +32,8 @@ import Ouroboros.Consensus.Ledger.Extended
 import Ouroboros.Consensus.Ledger.SupportsProtocol
 import Ouroboros.Consensus.Protocol.Abstract
 import Ouroboros.Consensus.Storage.ChainDB.API
-  ( GetLoEFragment
+  ( EarlyN2C (..)
+  , GetLoEFragment
   , LoE (LoEDisabled)
   )
 import Ouroboros.Consensus.Storage.ChainDB.Impl.Types
@@ -98,6 +99,16 @@ data ChainDbSpecificArgs f m blk = ChainDbSpecificArgs
   -- current LoE fragment.
   , cdbsSnapshotDelayRNG :: HKD f StdGen
   -- ^ RNG used to randomly determine the duration of snapshot delays
+  , cdbsEarlyN2C :: EarlyN2C
+  -- ^ See 'EarlyN2C'. Defaults to
+  -- 'EarlyN2CDisabled'.
+  , cdbsSynthesiseLedger ::
+      Maybe (Point blk -> Maybe (ExtLedgerState blk EmptyMK))
+  -- ^ Used when 'EarlyN2C' is enabled to build a read-only
+  -- ledger view at the immutable tip. Evaluated once at 'openDB' time
+  -- and cached on the 'ChainDbEnv'. If 'Nothing' (default) or if the
+  -- function returns 'Nothing' for the tip, LSQ Acquire during replay
+  -- fails with 'AcquireFailurePointTooOld'.
   }
 
 -- | Default arguments
@@ -133,6 +144,8 @@ defaultSpecificArgs =
     , cdbsTopLevelConfig = noDefault
     , cdbsLoE = pure LoEDisabled
     , cdbsSnapshotDelayRNG = noDefault
+    , cdbsEarlyN2C = EarlyN2CDisabled
+    , cdbsSynthesiseLedger = Nothing
     }
 
 -- | Default arguments

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Background.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Background.hs
@@ -254,9 +254,14 @@ copyToImmutableDBRunner ::
   GcSchedule m ->
   m Void
 copyToImmutableDBRunner cdb@CDB{..} ledgerDbTasksTrigger gcSchedule = do
+  -- This runner only fires after the initial chain selection has completed,
+  -- so the LedgerDB is guaranteed to be ready by the time we read it via
+  -- 'awaitLedgerDB'. Acquire it once at the top so subsequent flushes inside
+  -- the loop don't re-enter STM.
+  ldb <- atomically $ awaitLedgerDB cdb
   -- this first flush will persist the differences that come from the initial
   -- chain selection.
-  LedgerDB.tryFlush cdbLedgerDB
+  LedgerDB.tryFlush ldb
   forever copyAndTrigger
  where
   copyAndTrigger :: m ()
@@ -327,14 +332,18 @@ ledgerDbTaskWatcher cdb@CDB{..} (LedgerDbTasksTrigger varSt) =
     , wInitial = Nothing
     , wReader = blockUntilJust $ withOriginToMaybe <$> readTVar varSt
     , wNotify = \slotNo -> do
-        LedgerDB.tryFlush cdbLedgerDB
-        LedgerDB.tryTakeSnapshot cdbLedgerDB (void $ copyToImmutableDB cdb) mkRandomDelay
+        -- This watcher is only forked after initial chain selection has
+        -- completed (see 'launchBgTasks'), so the LedgerDB is guaranteed
+        -- to be ready and 'awaitLedgerDB' returns immediately.
+        ldb <- atomically $ awaitLedgerDB cdb
+        LedgerDB.tryFlush ldb
+        LedgerDB.tryTakeSnapshot ldb (void $ copyToImmutableDB cdb) mkRandomDelay
         -- tryTakeSnapshot is blocking, so the randomised snapshot delay will also delay
         -- the call to LedgerDB.garbageCollect below
         --
         -- TODO: once we have deleted V1, we can run the snapshot routine in a separate thread, which
         -- would allow us to eliminate the delay before LedgerDB.garbageCollect.
-        LedgerDB.garbageCollect cdbLedgerDB slotNo
+        LedgerDB.garbageCollect ldb slotNo
     }
  where
   mkRandomDelay :: LedgerDB.SnapshotDelayRange -> m DiffTime

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/ChainSel.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/ChainSel.hs
@@ -370,15 +370,16 @@ chainSelSync ::
 -- blocks that were originally postponed by the LoE, but can be adopted once we
 -- conclude that we are caught-up (and hence are longer bound by the LoE).
 chainSelSync cdb@CDB{..} (ChainSelReprocessLoEBlocks varProcessed) = lift $ do
-  (succsOf, lookupBlockInfo, curChain, weights) <- atomically $ do
+  (succsOf, lookupBlockInfo, curChain, weights, ldb) <- atomically $ do
     invalid <- forgetFingerprint <$> readTVar cdbInvalid
-    (,,,)
+    (,,,,)
       <$> ( ignoreInvalidSuc cdbVolatileDB invalid
               <$> VolatileDB.filterByPredecessor cdbVolatileDB
           )
       <*> VolatileDB.getBlockInfo cdbVolatileDB
       <*> Query.getCurrentChain cdb
       <*> (forgetFingerprint <$> Query.getPerasWeightSnapshot cdb)
+      <*> awaitLedgerDB cdb
   let
     -- All immediate successor blocks of blocks on the current chain (including
     -- the anchor), excluding those on the current chain.
@@ -393,7 +394,7 @@ chainSelSync cdb@CDB{..} (ChainSelReprocessLoEBlocks varProcessed) = lift $ do
       , not $ AF.pointOnFragment (realPointToPoint loePt) curChain
       ]
 
-    chainSelEnv = mkChainSelEnv cdb BlockCache.empty weights curChain Nothing
+    chainSelEnv = mkChainSelEnv cdb ldb BlockCache.empty weights curChain Nothing
 
   chainDiffs :: [[(ChainDiff (Header blk), ReasonForSwitch' blk)]] <-
     for
@@ -613,12 +614,13 @@ chainSelectionForBlock ::
   InvalidBlockPunishment m ->
   Electric m ()
 chainSelectionForBlock cdb@CDB{..} blockCache hdr punish = electric $ do
-  (invalid, curChain, weights) <-
+  (invalid, curChain, weights, ldb) <-
     atomically $
-      (,,)
+      (,,,)
         <$> (forgetFingerprint <$> readTVar cdbInvalid)
         <*> Query.getCurrentChain cdb
         <*> (forgetFingerprint <$> Query.getPerasWeightSnapshot cdb)
+        <*> awaitLedgerDB cdb
 
   -- The current chain we're working with here is not longer than @k@ blocks
   -- (see 'getCurrentChain' and 'cdbChain'), which is easier to reason about
@@ -658,7 +660,7 @@ chainSelectionForBlock cdb@CDB{..} blockCache hdr punish = electric $ do
 
         let traceNoChange = traceWith addBlockTracer $ StoreButDontChange p
 
-            chainSelEnv = mkChainSelEnv cdb blockCache weights curChain (Just (p, punish))
+            chainSelEnv = mkChainSelEnv cdb ldb blockCache weights curChain (Just (p, punish))
 
         case NE.nonEmpty chainDiffs of
           Just chainDiffs' -> do
@@ -883,14 +885,14 @@ switchTo ::
   ReasonForSwitch' blk ->
   -- | Forker at the tip of the above ChainDiff
   SuccessForkerAction m (ExtLedgerState blk)
-switchTo CDB{..} weights triggerPt chainDiff reason = MkSuccessForkerAction $ \forker -> do
+switchTo env@CDB{..} weights triggerPt chainDiff reason = MkSuccessForkerAction $ \forker -> do
   traceWith addBlockTracer $
     ChangingSelection $
       castPoint $
         Diff.getTip chainDiff
   (curChain, newChain, events, prevTentativeHeader, newLedger, closeOrphanedStates) <- atomically $ do
     InternalChain curChain curChainWithTime <- readTVar cdbChain -- Not Query.getCurrentChain!
-    curLedger <- getVolatileTip cdbLedgerDB
+    curLedger <- getVolatileTip =<< awaitLedgerDB env
     newLedger <- forkerGetLedgerState forker
     case Diff.apply curChain chainDiff of
       -- Impossible, as described in the docstring
@@ -1058,6 +1060,9 @@ data ChainSelEnv m blk = ChainSelEnv
 mkChainSelEnv ::
   IOLike m =>
   ChainDbEnv m blk ->
+  -- | The opened LedgerDB. Callers acquire it via 'awaitLedgerDB' (so that
+  -- this function never observes the @LdbReplaying@ status).
+  LedgerDB' m blk ->
   -- | See 'blockCache'
   BlockCache blk ->
   -- | See 'weights'
@@ -1067,9 +1072,9 @@ mkChainSelEnv ::
   -- | See 'punish'.
   Maybe (RealPoint blk, InvalidBlockPunishment m) ->
   ChainSelEnv m blk
-mkChainSelEnv CDB{..} blockCache weights curChain punish =
+mkChainSelEnv CDB{..} ldb blockCache weights curChain punish =
   ChainSelEnv
-    { lgrDB = cdbLedgerDB
+    { lgrDB = ldb
     , bcfg = configBlock cdbTopLevelConfig
     , varInvalid = cdbInvalid
     , varTentativeState = cdbTentativeState

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Query.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Query.hs
@@ -68,7 +68,8 @@ import Ouroboros.Consensus.Peras.Weight
   )
 import Ouroboros.Consensus.Protocol.Abstract
 import Ouroboros.Consensus.Storage.ChainDB.API
-  ( BlockComponent (..)
+  ( EarlyN2C (..)
+  , BlockComponent (..)
   , ChainDbFailure (..)
   )
 import Ouroboros.Consensus.Storage.ChainDB.Impl.Types
@@ -159,8 +160,13 @@ getCurrentChainLike cdb@CDB{..} getCurChain = do
 
 -- | Get a 'HeaderStateHistory' populated with the 'HeaderState's of the
 -- last @k@ blocks of the current chain.
-getHeaderStateHistory :: ChainDbEnv m blk -> STM m (HeaderStateHistory blk)
-getHeaderStateHistory = LedgerDB.getHeaderStateHistory . cdbLedgerDB
+--
+-- Blocks via 'awaitLedgerDB' until the LedgerDB has finished its initial
+-- replay.
+getHeaderStateHistory ::
+  IOLike m => ChainDbEnv m blk -> STM m (HeaderStateHistory blk)
+getHeaderStateHistory env =
+  awaitLedgerDB env >>= LedgerDB.getHeaderStateHistory
 
 getTipBlock ::
   forall m blk.
@@ -248,8 +254,9 @@ getIsValid ::
   (IOLike m, HasHeader blk) =>
   ChainDbEnv m blk ->
   STM m (RealPoint blk -> Maybe Bool)
-getIsValid CDB{..} = do
-  prevApplied <- LedgerDB.getPrevApplied cdbLedgerDB
+getIsValid env@CDB{..} = do
+  ldb <- awaitLedgerDB env
+  prevApplied <- LedgerDB.getPrevApplied ldb
   invalid <- forgetFingerprint <$> readTVar cdbInvalid
   return $ \pt@(RealPoint _ hash) ->
     -- A block can not both be in the set of invalid blocks and
@@ -283,25 +290,41 @@ getMaxSlotNo CDB{..} = do
   return $ curChainMaxSlotNo `max` volatileDbMaxSlotNo `max` queuedMaxSlotNo
 
 -- | Get current ledger
-getCurrentLedger :: ChainDbEnv m blk -> STM m (ExtLedgerState blk EmptyMK)
-getCurrentLedger CDB{..} = LedgerDB.getVolatileTip cdbLedgerDB
+--
+-- Blocks via 'awaitLedgerDB' until the LedgerDB has finished its initial
+-- replay.
+getCurrentLedger ::
+  IOLike m => ChainDbEnv m blk -> STM m (ExtLedgerState blk EmptyMK)
+getCurrentLedger env = awaitLedgerDB env >>= LedgerDB.getVolatileTip
 
 -- | Get the immutable ledger, i.e., typically @k@ blocks back.
-getImmutableLedger :: ChainDbEnv m blk -> STM m (ExtLedgerState blk EmptyMK)
-getImmutableLedger CDB{..} = LedgerDB.getImmutableTip cdbLedgerDB
+--
+-- Blocks via 'awaitLedgerDB' until the LedgerDB has finished its initial
+-- replay.
+getImmutableLedger ::
+  IOLike m => ChainDbEnv m blk -> STM m (ExtLedgerState blk EmptyMK)
+getImmutableLedger env = awaitLedgerDB env >>= LedgerDB.getImmutableTip
 
 -- | Get the ledger for the given point.
 --
 -- When the given point is not among the last @k@ blocks of the current
 -- chain (i.e., older than @k@ or not on the current chain), 'Nothing' is
 -- returned.
+--
+-- Blocks via 'awaitLedgerDB' until the LedgerDB has finished its initial
+-- replay.
 getPastLedger ::
+  IOLike m =>
   ChainDbEnv m blk ->
   Point blk ->
   STM m (Maybe (ExtLedgerState blk EmptyMK))
-getPastLedger CDB{..} = LedgerDB.getPastLedgerState cdbLedgerDB
+getPastLedger env pt =
+  awaitLedgerDB env >>= \ldb -> LedgerDB.getPastLedgerState ldb pt
 
+-- | Allocate a read-only forker via 'openReadOnlyForkerAtPoint' in the
+-- given registry.
 allocInRegistryReadOnlyForkerAtPoint ::
+  forall m blk.
   IOLike m =>
   ChainDbEnv m blk ->
   Target (Point blk) ->
@@ -317,12 +340,49 @@ allocInRegistryReadOnlyForkerAtPoint cdb tgt rr = do
     Left err -> void (release rk) >> pure (Left err)
     Right v -> pure (Right (rk, v))
 
+-- | Open a read-only forker at the given point.
+--
+-- When the LedgerDB is ready, delegates to the LedgerDB. While it is
+-- replaying, the result depends on 'EarlyN2C':
+-- 'EarlyN2CDisabled' returns 'LedgerNotReady';
+-- 'EarlyN2CEnabled' (with a cached synthesised state)
+-- returns a 'mkSyntheticForker'.
 openReadOnlyForkerAtPoint ::
   IOLike m =>
   ChainDbEnv m blk ->
   Target (Point blk) ->
   m (Either LedgerDB.GetForkerError (LedgerDB.ReadOnlyForker' m blk))
-openReadOnlyForkerAtPoint CDB{..} = LedgerDB.openReadOnlyForker cdbLedgerDB
+openReadOnlyForkerAtPoint env tgt =
+  atomically (readTVar (cdbLedgerDBStatus env)) >>= \case
+    LdbReady ldb -> LedgerDB.openReadOnlyForker ldb tgt
+    LdbReplaying -> case cdbEarlyN2C env of
+      EarlyN2CDisabled -> pure (Left LedgerDB.LedgerNotReady)
+      EarlyN2CEnabled -> case cdbSyntheticLedger env of
+        Nothing -> pure (Left LedgerDB.LedgerNotReady)
+        Just synth -> pure (Right (mkSyntheticForker synth))
+
+-- | A 'ReadOnlyForker'' that serves a synthesised 'ExtLedgerState'.
+--
+-- Only 'roforkerGetLedgerState' is implemented. This is sufficient for
+-- history-only LSQ queries — notably @GetInterpreter@, which goes
+-- through 'hardForkSummary' on the returned state. The table-reading
+-- methods 'error' on use: they should never be called on a synthetic
+-- forker, and we prefer a loud crash to silently-empty UTxO data.
+mkSyntheticForker ::
+  forall m blk.
+  IOLike m =>
+  ExtLedgerState blk EmptyMK ->
+  LedgerDB.ReadOnlyForker' m blk
+mkSyntheticForker synth =
+  LedgerDB.ReadOnlyForker
+    { LedgerDB.roforkerClose = pure ()
+    , LedgerDB.roforkerReadTables =
+        \_ -> error "mkSyntheticForker: roforkerReadTables called on synthetic forker"
+    , LedgerDB.roforkerRangeReadTables =
+        \_ -> error "mkSyntheticForker: roforkerRangeReadTables called on synthetic forker"
+    , LedgerDB.roforkerGetLedgerState = pure synth
+    , LedgerDB.roforkerReadStatistics = pure (LedgerDB.Statistics 0)
+    }
 
 withReadOnlyForkerAtPoint ::
   IOLike m =>
@@ -338,7 +398,8 @@ withReadOnlyForkerAtPoint cdb tgt =
     (either (const $ pure ()) (lift . LedgerDB.roforkerClose))
 
 getStatistics :: IOLike m => ChainDbEnv m blk -> m LedgerDB.Statistics
-getStatistics CDB{..} = LedgerDB.getTipStatistics cdbLedgerDB
+getStatistics env =
+  atomically (awaitLedgerDB env) >>= LedgerDB.getTipStatistics
 
 getPerasWeightSnapshot ::
   ChainDbEnv m blk -> STM m (WithFingerprint (PerasWeightSnapshot blk))
@@ -406,8 +467,9 @@ getLatestPerasCertOnChainRound ::
   (IOLike m, LedgerSupportsPeras blk) =>
   ChainDbEnv m blk ->
   STM m (Maybe PerasRoundNo)
-getLatestPerasCertOnChainRound CDB{..} = do
-  volatileLedger <- ledgerState <$> LedgerDB.getVolatileTip cdbLedgerDB
+getLatestPerasCertOnChainRound env = do
+  ldb <- awaitLedgerDB env
+  volatileLedger <- ledgerState <$> LedgerDB.getVolatileTip ldb
   pure (getLatestPerasCertRound volatileLedger)
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Types.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Types.hs
@@ -24,7 +24,9 @@ module Ouroboros.Consensus.Storage.ChainDB.Impl.Types
   , ChainDbHandle (..)
   , ChainDbState (..)
   , ChainSelectionPromise (..)
+  , LedgerDBStatus (..)
   , SerialiseDiskConstraints
+  , awaitLedgerDB
   , getEnv
   , getEnv1
   , getEnv2
@@ -101,7 +103,11 @@ import Ouroboros.Consensus.BlockchainTime.WallClock.Types (WithArrivalTime)
 import Ouroboros.Consensus.Config
 import Ouroboros.Consensus.Fragment.Diff (ChainDiff)
 import Ouroboros.Consensus.HeaderValidation (HeaderWithTime (..))
-import Ouroboros.Consensus.Ledger.Extended (ExtValidationError)
+import Ouroboros.Consensus.Ledger.Abstract (EmptyMK)
+import Ouroboros.Consensus.Ledger.Extended
+  ( ExtLedgerState
+  , ExtValidationError
+  )
 import Ouroboros.Consensus.Ledger.Inspect
 import Ouroboros.Consensus.Ledger.SupportsProtocol
 import Ouroboros.Consensus.Peras.SelectView (WeightedSelectView)
@@ -113,6 +119,7 @@ import Ouroboros.Consensus.Storage.ChainDB.API
   , ChainDbError (..)
   , ChainSelectionPromise (..)
   , ChainType
+  , EarlyN2C
   , LoE
   , StreamFrom
   , StreamTo
@@ -249,6 +256,27 @@ getEnvSTM1 (CDBHandle varState) f a =
     ChainDbOpen env -> f env a
     ChainDbClosed -> throwSTM $ ClosedDBError @blk prettyCallStack
 
+-- | Whether the LedgerDB has finished its initial replay yet.
+--
+-- The ChainDB starts in 'LdbReplaying' while the LedgerDB is being
+-- initialised in the background and transitions atomically to 'LdbReady'
+-- once initialisation completes.
+data LedgerDBStatus m blk
+  = LdbReplaying
+  | LdbReady !(LedgerDB' m blk)
+  deriving Generic
+
+instance
+  (IOLike m, LedgerSupportsProtocol blk, BlockSupportsDiffusionPipelining blk) =>
+  NoThunks (LedgerDBStatus m blk)
+
+-- | Block in STM until the LedgerDB is ready, then return it.
+awaitLedgerDB :: IOLike m => ChainDbEnv m blk -> STM m (LedgerDB' m blk)
+awaitLedgerDB CDB{cdbLedgerDBStatus} =
+  readTVar cdbLedgerDBStatus >>= \case
+    LdbReplaying -> retry
+    LdbReady ldb -> pure ldb
+
 data ChainDbState m blk
   = ChainDbOpen !(ChainDbEnv m blk)
   | ChainDbClosed
@@ -300,7 +328,15 @@ data ChainDbEnv m blk = CDB
   { cdbImmutableDB :: !(ImmutableDB m blk)
   , cdbImmutableDBLock :: !(RAWLock m ())
   , cdbVolatileDB :: !(VolatileDB m blk)
-  , cdbLedgerDB :: !(LedgerDB' m blk)
+  , cdbLedgerDBStatus :: !(StrictTVar m (LedgerDBStatus m blk))
+  -- ^ See 'LedgerDBStatus'. Use 'awaitLedgerDB' to read.
+  , cdbCancelInit :: !(StrictTVar m (m ()))
+  -- ^ Cancellation action for the background LedgerDB initialisation.
+  -- Run by 'closeDB'; reset to @return ()@ once initialisation completes.
+  , cdbEarlyN2C :: !EarlyN2C
+  -- ^ See 'EarlyN2C'.
+  , cdbSyntheticLedger :: !(Maybe (ExtLedgerState blk EmptyMK))
+  -- ^ Synthesised LSQ ledger view; see 'cdbsSynthesiseLedger'.
   , cdbChain :: !(StrictTVar m (InternalChain blk))
   -- ^ Contains the current chain fragment.
   --
@@ -807,6 +843,12 @@ data TraceOpenEvent blk
       -- | Immutable tip
       (Point blk)
       -- | Tip of the current chain
+      (Point blk)
+  | -- | The ImmutableDB and VolatileDB are open; the LedgerDB is still
+    -- being initialised in the background. LedgerDB-dependent operations
+    -- will block until 'OpenedDB' fires.
+    OpenedDBImmutableReady
+      -- | Immutable tip
       (Point blk)
   | -- | The ChainDB was closed.
     ClosedDB

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/Forker.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/Forker.hs
@@ -184,6 +184,8 @@ data GetForkerError
   | -- | The requested point was not found in the LedgerDB because the point
     -- older than the immutable tip.
     PointTooOld !(Maybe ExceededRollback)
+  | -- | The LedgerDB has not finished its initial replay yet.
+    LedgerNotReady
   deriving (Show, Eq)
 
 -- | Exceeded maximum rollback supported by the current ledger DB state

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/MiniProtocol/LocalStateQuery/Server.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/MiniProtocol/LocalStateQuery/Server.hs
@@ -1,7 +1,9 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 -- | Tests for the local state query server.
@@ -19,7 +21,7 @@
 module Test.Consensus.MiniProtocol.LocalStateQuery.Server (tests) where
 
 import Cardano.Crypto.DSIGN.Mock
-import Cardano.Ledger.BaseTypes (nonZero, unNonZero)
+import Cardano.Ledger.BaseTypes (knownNonZeroBounded, nonZero, unNonZero)
 import Control.Concurrent.Class.MonadSTM.Strict.TMVar
 import Control.Monad (join)
 import Control.Monad.IOSim (runSimOrThrow)
@@ -82,6 +84,8 @@ tests =
   testGroup
     "LocalStateQueryServer"
     [ testProperty "localStateQueryServer" prop_localStateQueryServer
+    , testProperty "acquireFailsDuringLedgerReplay" prop_acquireFailsDuringLedgerReplay
+    , testProperty "acquireSucceedsAfterLedgerReady" prop_acquireSucceedsAfterLedgerReady
     ]
 
 {-------------------------------------------------------------------------------
@@ -313,6 +317,91 @@ testCfg securityParam =
 
   eraParams :: HardFork.EraParams
   eraParams = HardFork.defaultEraParams securityParam slotLength
+
+{-------------------------------------------------------------------------------
+  Option A: LSQ Acquire fail-fast during LedgerDB replay
+-------------------------------------------------------------------------------}
+
+-- | When the LedgerDB is still replaying, the production
+-- 'openReadOnlyForkerAtPoint' returns @Left LedgerNotReady@. The LSQ server
+-- must translate that into @MsgFailure AcquireFailurePointTooOld@ regardless
+-- of which 'Target' the client requested.
+prop_acquireFailsDuringLedgerReplay :: Property
+prop_acquireFailsDuringLedgerReplay = once $
+  conjoin
+    [ counterexample ("target " ++ show t ++ ", got: " ++ show res) $
+        case res of
+          Left AcquireFailurePointTooOld -> property True
+          _ -> property False
+    | (t, res) <- outcomes
+    ]
+ where
+  outcomes :: [(Target (Point TestBlock), Either AcquireFailure (Point TestBlock))]
+  outcomes = runSimOrThrow $ do
+    let getView _ = pure (Left LedgerNotReady)
+        server = localStateQueryServer cfg getView
+        points = [VolatileTip, ImmutableTip, SpecificPoint GenesisPoint]
+        client = mkClient points
+    (\(a, _, _) -> a)
+      <$> connect
+        StateIdle
+        (localStateQueryClientPeer client)
+        (localStateQueryServerPeer server)
+
+  cfg :: ExtLedgerCfg TestBlock
+  cfg = ExtLedgerCfg $ testCfg (SecurityParam $ knownNonZeroBounded @2)
+
+-- | Once the LedgerDB transitions from replaying to ready, subsequent
+-- @MsgAcquire@s must succeed. We simulate the transition by flipping a
+-- 'TVar' between two acquires in the same session: the first call to
+-- 'getView' returns @Left LedgerNotReady@, the second falls through to
+-- the real LedgerDB-backed forker.
+prop_acquireSucceedsAfterLedgerReady ::
+  SecurityParam ->
+  BlockTree ->
+  Property
+prop_acquireSucceedsAfterLedgerReady k bt = once $
+  counterexample ("outcomes: " ++ show outcomes) $
+    case outcomes of
+      [(_, Left AcquireFailurePointTooOld), (_, Right _)] -> property True
+      _ -> property False
+ where
+  chain :: Chain TestBlock
+  chain = treePreferredChain emptyPerasWeightSnapshot bt
+
+  outcomes :: [(Target (Point TestBlock), Either AcquireFailure (Point TestBlock))]
+  outcomes = runSimOrThrow $ withRegistry $ \rr -> do
+    firstCall <- atomically $ newTVar True
+    lgrDB <- initLedgerDB k chain
+    let getView t = do
+          isFirst <- atomically $ do
+            b <- readTVar firstCall
+            writeTVar firstCall False
+            pure b
+          if isFirst
+            then pure (Left LedgerNotReady)
+            else do
+              (rk, res) <-
+                allocate
+                  rr
+                  (\_ -> LedgerDB.openReadOnlyForker lgrDB t)
+                  ( \case
+                      Left{} -> pure ()
+                      Right v -> roforkerClose v
+                  )
+              case res of
+                Left err -> release rk >> pure (Left err)
+                Right v -> pure (Right (rk, v))
+        server = localStateQueryServer cfg getView
+        client = mkClient [VolatileTip, VolatileTip]
+    (\(a, _, _) -> a)
+      <$> connect
+        StateIdle
+        (localStateQueryClientPeer client)
+        (localStateQueryServerPeer server)
+
+  cfg :: ExtLedgerCfg TestBlock
+  cfg = ExtLedgerCfg $ testCfg k
 
 {-------------------------------------------------------------------------------
   Orphans


### PR DESCRIPTION
# Allow LSQ clients to connect during initial LedgerDB replay (opt-in)

Today, cardano-node binds its local n2c socket only after the LedgerDB finishes its initial replay (typically 10–30 minutes from genesis). Any local client — notably `cardano-db-sync` — blocks on a missing socket until then. This PR adds an opt-in `EarlyN2C` flag on `ChainDbSpecificArgs` that:

- binds the local socket as soon as the ImmutableDB is ready,
- runs the LedgerDB replay on a background thread, and
- serves a *synthesised* read-only forker for LSQ Acquire requests while replay is in progress, so history-only queries (e.g. `GetInterpreter`) succeed.

The default (`EarlyN2CDisabled`) preserves the existing single-phase open and late-bind behaviour byte-for-byte. The opt-in (`EarlyN2CEnabled`) is enabled via the node config; cardano-node supplies the synthesis function (typically a closure over `pInfoInitLedger`).

```
EarlyN2CDisabled (default — unchanged)
  open ImmutableDB ─► replay LedgerDB ─► socket bind ─► clients
                     └─── synchronous ──┘                arrive

EarlyN2CEnabled (opt-in)
  open ImmutableDB ─► socket bind ─► clients arrive
                                      │
                   replay LedgerDB    ▼
                   (background)      Acquire ─► synthetic forker
                       │                        (history-only)
                       │
                       └─► ready ────────────► real forker
```

In `config.json` the operator opts in with:

```json
"EarlyN2C": "Enabled"
```

## Synthetic forker scope

Only `roforkerGetLedgerState` is implemented. The synthesised state suffices for `GetInterpreter` via `hardForkSummary`. Queries that touch the ledger tables (`GetUTxO*` etc.) hit the `error`-stubbed methods — we fail loudly rather than return empty data to a wallet.

## Wire format

Unchanged. `LedgerNotReady` is mapped to the existing `AcquireFailurePointTooOld` constructor; clients that already retry  on that failure (incl. older `cardano-db-sync`) work without changes.

## Tests

Two new properties in
`Test.Consensus.MiniProtocol.LocalStateQuery.Server`:

- `acquireFailsDuringLedgerReplay` checks that `LedgerNotReady` is reported as `AcquireFailurePointTooOld` regardless of `Target`.
- `acquireSucceedsAfterLedgerReady` checks the cross-state transition in a single LSQ session.

