### PR TITLE
[Peras] Improve ChainDB's `addPeras{Vote/Cert}` methods and fix corresponding ChainDB statemachine tests

### DIFF
--- a/changelog.d/20260519_144340_thomas.bagrel_fix_chaindb_statemachine_tests.md
+++ b/changelog.d/20260519_144340_thomas.bagrel_fix_chaindb_statemachine_tests.md
@@ -1,0 +1,25 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+
+### Breaking
+
+- Change ChainDB's `addPerasVoteSync`, `addPerasVoteWithAsyncCertHandling`, `addPerasCertSync`, `addPerasCertAsync` return types to provide explicit information about the outcome of the operation.
+
+
+<!--
+### Non-Breaking
+
+- A bullet item for the Non-Breaking category.
+
+-->
+<!--
+### Patch
+
+- A bullet item for the Patch category.
+
+-->

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/API.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/API.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DeriveTraversable #-}
+{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RankNTypes #-}
@@ -22,7 +23,10 @@ module Ouroboros.Consensus.Storage.ChainDB.API
   , addBlock_
 
     -- * Adding a Peras certificate or vote
+  , AddPerasCertChainSelOutcome (..)
   , AddPerasCertPromise (..)
+  , AddPerasCertResult (..)
+  , AddPerasVoteResult (..)
   , addPerasCertSync
   , addPerasVoteSync
 
@@ -100,10 +104,12 @@ import Ouroboros.Consensus.Storage.LedgerDB
   , Statistics
   )
 import Ouroboros.Consensus.Storage.PerasCertDB.API
-  ( PerasCertTicketNo
+  ( AddPerasCertResult (..)
+  , PerasCertTicketNo
   )
 import Ouroboros.Consensus.Storage.PerasVoteDB.API
-  ( PerasVoteTicketNo
+  ( AddPerasVoteResult (..)
+  , PerasVoteTicketNo
   )
 import Ouroboros.Consensus.Storage.Serialisation
 import Ouroboros.Consensus.Util.CallStack
@@ -446,10 +452,11 @@ data ChainDB m blk = ChainDB
   -- database.
   , addPerasVoteWithAsyncCertHandling ::
       WithArrivalTime (ValidatedPerasVote blk) ->
-      m (Maybe (AddPerasCertPromise m))
-  -- ^ Add a Peras vote to the vote database. If a certificate is produced in
-  -- the process (quorum reached), it will be added via 'addPerasCertAsync'
-  -- under the hood, in which case the corresponding promise will be returned.
+      m (AddPerasVoteResult blk, Maybe (AddPerasCertPromise m))
+  -- ^ Add a Peras vote to the vote database, returning the result of the
+  -- vote addition. If a certificate is produced in the process (quorum
+  -- reached), it will be added via 'addPerasCertAsync' under the hood, in
+  -- which case the corresponding promise will be returned.
   , getPerasVotesAfter ::
       PerasVoteTicketNo ->
       STM m (Map PerasVoteTicketNo (WithArrivalTime (ValidatedPerasVote blk)))
@@ -593,8 +600,21 @@ triggerChainSelection chainDB =
   Adding a Peras certificate or vote
 -------------------------------------------------------------------------------}
 
+-- | The outcome of processing a Peras certificate w.r.t. chain selection.
+data AddPerasCertChainSelOutcome
+  = -- | The certificate was too old to influence chain selection (the boosted
+    -- block is already immutable), so it was ignored entirely.
+    PerasCertIgnoredTooOld
+  | -- | The certificate was not processed because the ChainDB was closing.
+    PerasCertNotProcessedClosing
+  | -- | The certificate was processed; whether it was actually added to the DB
+    -- or was a duplicate is captured by the inner 'AddPerasCertResult'.
+    PerasCertProcessed AddPerasCertResult
+  deriving stock (Generic, Eq, Ord, Show)
+  deriving anyclass NoThunks
+
 newtype AddPerasCertPromise m = AddPerasCertPromise
-  { waitPerasCertProcessed :: m ()
+  { waitPerasCertProcessed :: m AddPerasCertChainSelOutcome
   -- ^ Wait until the Peras certificate has been processed (which potentially
   -- includes switching to a different chain). If the PerasCertDB did already
   -- contain a certificate for this round, the certificate is ignored (as the
@@ -602,16 +622,23 @@ newtype AddPerasCertPromise m = AddPerasCertPromise
   -- impossible).
   }
 
-addPerasCertSync :: IOLike m => ChainDB m blk -> WithArrivalTime (ValidatedPerasCert blk) -> m ()
+addPerasCertSync ::
+  IOLike m =>
+  ChainDB m blk -> WithArrivalTime (ValidatedPerasCert blk) -> m AddPerasCertChainSelOutcome
 addPerasCertSync chainDB cert =
   waitPerasCertProcessed =<< addPerasCertAsync chainDB cert
 
-addPerasVoteSync :: IOLike m => ChainDB m blk -> WithArrivalTime (ValidatedPerasVote blk) -> m ()
+addPerasVoteSync ::
+  IOLike m =>
+  ChainDB m blk ->
+  WithArrivalTime (ValidatedPerasVote blk) ->
+  m (AddPerasVoteResult blk, Maybe AddPerasCertChainSelOutcome)
 addPerasVoteSync chainDB vote = do
-  mCertPromise <- addPerasVoteWithAsyncCertHandling chainDB vote
-  case mCertPromise of
-    Nothing -> return ()
-    Just certPromise -> waitPerasCertProcessed certPromise
+  (voteRes, mCertPromise) <- addPerasVoteWithAsyncCertHandling chainDB vote
+  mCertRes <- case mCertPromise of
+    Nothing -> return Nothing
+    Just certPromise -> Just <$> waitPerasCertProcessed certPromise
+  return (voteRes, mCertRes)
 
 {-------------------------------------------------------------------------------
   Serialised block/header with its point

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Background.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Background.hs
@@ -63,6 +63,7 @@ import Ouroboros.Consensus.Ledger.SupportsProtocol
 import Ouroboros.Consensus.Protocol.Abstract
 import Ouroboros.Consensus.Storage.ChainDB.API
   ( AddBlockResult (..)
+  , AddPerasCertChainSelOutcome (..)
   , BlockComponent (..)
   )
 import Ouroboros.Consensus.Storage.ChainDB.Impl.ChainSel
@@ -603,7 +604,7 @@ addBlockRunner fuse cdb@CDB{..} = forever $ do
                   (FailedToAddBlock "Failed to add block synchronously")
               pure ()
             ChainSelAddPerasCert _cert varProcessed ->
-              void $ tryPutTMVar varProcessed ()
+              void $ tryPutTMVar varProcessed PerasCertNotProcessedClosing
           closeChainSelQueue cdbChainSelQueue
       )
       ( \message -> do

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/ChainSel.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/ChainSel.hs
@@ -33,6 +33,7 @@ import Control.Exception (assert)
 import Control.Monad (forM_, join, void, when)
 import Control.Monad.Except ()
 import Control.Monad.Trans.Class (lift)
+import Control.Monad.Trans.Except (ExceptT, runExceptT, throwE)
 import Control.Monad.Trans.State.Strict
 import Control.Tracer (Tracer, nullTracer, traceWith)
 import Data.Bifunctor (first)
@@ -70,6 +71,7 @@ import Ouroboros.Consensus.Protocol.Abstract
 import Ouroboros.Consensus.Storage.ChainDB.API
   ( AddBlockPromise (..)
   , AddBlockResult (..)
+  , AddPerasCertChainSelOutcome (..)
   , AddPerasCertPromise (..)
   , BlockComponent (..)
   , ChainType (..)
@@ -97,7 +99,6 @@ import Ouroboros.Consensus.Storage.VolatileDB (VolatileDB)
 import qualified Ouroboros.Consensus.Storage.VolatileDB as VolatileDB
 import Ouroboros.Consensus.Util
 import Ouroboros.Consensus.Util.AnchoredFragment
-import Ouroboros.Consensus.Util.EarlyExit (exitEarly, withEarlyExit_)
 import Ouroboros.Consensus.Util.Enclose (encloseWith)
 import Ouroboros.Consensus.Util.IOLike
 import Ouroboros.Consensus.Util.STM (WithFingerprint (..))
@@ -316,14 +317,15 @@ addPerasVoteWithAsyncCertHandling ::
   IOLike m =>
   ChainDbEnv m blk ->
   WithArrivalTime (ValidatedPerasVote blk) ->
-  m (Maybe (AddPerasCertPromise m))
+  m (AddPerasVoteResult blk, Maybe (AddPerasCertPromise m))
 addPerasVoteWithAsyncCertHandling cdb@CDB{cdbPerasVoteDB} vote = do
   addVoteRes <- join . atomically . addVote cdbPerasVoteDB $ vote
   case addVoteRes of
     AddedPerasVoteAndGeneratedNewCert cert -> do
       let certTime = getArrivalTime vote
-      Just <$> addPerasCertAsync cdb (WithArrivalTime (certTime) cert)
-    _ -> pure Nothing
+      promise <- addPerasCertAsync cdb (WithArrivalTime (certTime) cert)
+      pure (addVoteRes, Just promise)
+    _ -> pure (addVoteRes, Nothing)
 
 -- | Schedule reprocessing of blocks postponed by the LoE.
 triggerChainSelectionAsync ::
@@ -482,32 +484,35 @@ chainSelSync cdb@CDB{..} (ChainSelAddPerasCert cert varProcessed) = do
   curChain <- lift $ atomically $ Query.getCurrentChain cdb
   let immTip = AF.castAnchor $ AF.anchor curChain
 
-  withEarlyExit_ $ do
+  certResult <- withEarlyExitId $ do
     -- Ignore the certificate if it boosts a block that is so old that it can't
     -- influence our selection.
     when (pointSlot boostedBlock < AF.anchorToSlotNo immTip) $ do
       lift $ lift $ traceWith tracer $ IgnorePerasCertTooOld certRound boostedBlock immTip
-      exitEarly
+      idExitEarly PerasCertIgnoredTooOld
 
     -- Add the certificate to the PerasCertDB.
     certRes <- lift $ lift $ join $ atomically $ PerasCertDB.addCert cdbPerasCertDB cert
-    case certRes of
-      PerasCertDB.AddedPerasCertToDB -> pure ()
-      -- If it already is in the PerasCertDB, we are done.
-      PerasCertDB.PerasCertAlreadyInDB -> exitEarly
+    -- Here:
+    -- \* if the certificate is already in the PerasCertDB, we exit early with that result
+    -- \* if the certificate is newly added to the PerasCertDB, we bind  the result value that we will return in any of the branches below
+    addedCertRes <-
+      case certRes of
+        PerasCertDB.PerasCertAlreadyInDB -> idExitEarly $ PerasCertProcessed PerasCertDB.PerasCertAlreadyInDB
+        PerasCertDB.AddedPerasCertToDB -> pure $ PerasCertProcessed PerasCertDB.AddedPerasCertToDB
 
     -- If the certificate boosts a block on our current chain (including the
     -- anchor), then it just makes our selection even stronger.
     when (AF.withinFragmentBounds (castPoint boostedBlock) curChain) $ do
       lift $ lift $ traceWith tracer $ PerasCertBoostsCurrentChain certRound boostedBlock
-      exitEarly
+      idExitEarly $ addedCertRes
 
     boostedHash <- case pointHash boostedBlock of
       -- If the certificate boosts the Genesis point, then it can not influence
       -- chain selection as all chains contain it.
       GenesisHash -> do
         lift $ lift $ traceWith tracer $ PerasCertBoostsGenesis certRound
-        exitEarly
+        idExitEarly $ addedCertRes
       -- Otherwise, the certificate boosts a block potentially on a (future)
       -- candidate.
       BlockHash boostedHash -> pure boostedHash
@@ -518,15 +523,16 @@ chainSelSync cdb@CDB{..} (ChainSelAddPerasCert cert varProcessed) = do
         -- it, the additional weight of the certificate is taken into account.
         Nothing -> do
           lift $ lift $ traceWith tracer $ PerasCertBoostsBlockNotYetReceived certRound boostedBlock
-          exitEarly
+          idExitEarly $ addedCertRes
         Just boostedHdr -> pure boostedHdr
 
     -- Trigger chain selection for the boosted block.
     lift $ lift $ traceWith tracer $ ChainSelectionForBoostedBlock certRound boostedBlock
     lift $ chainSelectionForBlock cdb BlockCache.empty boostedHdr noPunishment
+    pure $ addedCertRes
 
   -- Deliver promise indicating that we processed the cert.
-  lift $ atomically $ putTMVar varProcessed ()
+  lift $ atomically $ putTMVar varProcessed certResult
  where
   tracer :: Tracer m (TraceAddPerasCertEvent blk)
   tracer = TraceAddPerasCertEvent >$< cdbTracer
@@ -536,6 +542,14 @@ chainSelSync cdb@CDB{..} (ChainSelAddPerasCert cert varProcessed) = do
 
   boostedBlock :: Point blk
   boostedBlock = getPerasCertBoostedBlock cert
+
+  -- \| Run a block that can exit early with a result value.
+  withEarlyExitId :: ExceptT a (Electric m) a -> Electric m a
+  withEarlyExitId = fmap (either id id) . runExceptT
+
+  -- \| Exit early with the given result.
+  idExitEarly :: a -> ExceptT a (Electric m) b
+  idExitEarly = throwE
 
 -- | Return 'True' when the given header should be ignored when adding it
 -- because it is too old, i.e., we wouldn't be able to switch to a chain

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Types.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Types.hs
@@ -105,6 +105,7 @@ import Ouroboros.Consensus.Protocol.Abstract
 import Ouroboros.Consensus.Storage.ChainDB.API
   ( AddBlockPromise (..)
   , AddBlockResult (..)
+  , AddPerasCertChainSelOutcome (..)
   , AddPerasCertPromise (..)
   , ChainDbError (..)
   , ChainSelectionPromise (..)
@@ -586,7 +587,7 @@ data ChainSelMessage m blk
     ChainSelAddPerasCert
       !(WithArrivalTime (ValidatedPerasCert blk))
       -- | Used for 'AddPerasCertPromise'.
-      !(StrictTMVar m ())
+      !(StrictTMVar m AddPerasCertChainSelOutcome)
   | -- | Reprocess blocks that have been postponed by the LoE.
     ChainSelReprocessLoEBlocks
       -- | Used for 'ChainSelectionPromise'.
@@ -722,7 +723,7 @@ closeChainSelQueue ChainSelQueue{varChainSelQueue = queue} = do
     ChainSelAddBlock ab ->
       tryPutTMVar (varBlockProcessed ab) (FailedToAddBlock "Queue flushed")
     ChainSelAddPerasCert _cert varProcessed ->
-      tryPutTMVar varProcessed ()
+      tryPutTMVar varProcessed PerasCertNotProcessedClosing
     ChainSelReprocessLoEBlocks varProcessed ->
       tryPutTMVar varProcessed ()
 

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/Model.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/Model.hs
@@ -120,6 +120,7 @@ import Ouroboros.Consensus.Protocol.MockChainSel
 import Ouroboros.Consensus.Storage.ChainDB.API
   ( AddBlockPromise (..)
   , AddBlockResult (..)
+  , AddPerasCertChainSelOutcome (..)
   , BlockComponent (..)
   , ChainDbError (..)
   , IteratorResult (..)
@@ -461,9 +462,15 @@ addPerasCert ::
   TopLevelConfig blk ->
   WithArrivalTime (ValidatedPerasCert blk) ->
   Model blk ->
-  Model blk
-addPerasCert cfg cert m =
-  chainSelection cfg m{perasCertModel = PerasCertDBModel.addCert (perasCertModel m) cert}
+  (AddPerasCertChainSelOutcome, Model blk)
+addPerasCert cfg cert m
+  | pointSlot (getPerasCertBoostedBlock cert) < Chain.headSlot (immutableChain secParam m) =
+      (PerasCertIgnoredTooOld, m)
+  | otherwise =
+      let (certRes, perasCertModel') = PerasCertDBModel.addCert (perasCertModel m) cert
+       in (PerasCertProcessed certRes, chainSelection cfg m{perasCertModel = perasCertModel'})
+ where
+  secParam = configSecurityParam cfg
 
 addPerasVote ::
   forall blk.
@@ -471,14 +478,15 @@ addPerasVote ::
   TopLevelConfig blk ->
   WithArrivalTime (ValidatedPerasVote blk) ->
   Model blk ->
-  Model blk
+  ((AddPerasVoteResult blk, Maybe AddPerasCertChainSelOutcome), Model blk)
 addPerasVote cfg vote m =
   case PerasVoteDBModel.addVote vote (perasVoteModel m) of
-    (Right (AddedPerasVoteAndGeneratedNewCert freshCert), perasVoteModel') ->
+    (Right voteRes@(AddedPerasVoteAndGeneratedNewCert freshCert), perasVoteModel') ->
       let creationTime = getArrivalTime vote
           certWithArrival = WithArrivalTime creationTime freshCert
-       in addPerasCert cfg certWithArrival m{perasVoteModel = perasVoteModel'}
-    (Right _, perasVoteModel') -> m{perasVoteModel = perasVoteModel'}
+          (certRes, m') = addPerasCert cfg certWithArrival m{perasVoteModel = perasVoteModel'}
+       in ((voteRes, Just certRes), m')
+    (Right voteRes, perasVoteModel') -> ((voteRes, Nothing), m{perasVoteModel = perasVoteModel'})
     (Left e, _) -> error $ "Unexpected error when adding a vote to the model: " <> show e
 
 chainSelection ::
@@ -1115,10 +1123,16 @@ garbageCollect ::
 garbageCollect secParam m@Model{..} =
   m
     { volatileDbBlocks = Map.filter (not . collectable) volatileDbBlocks
-    -- TODO garbage collection Peras certs?
-    -- See https://github.com/tweag/cardano-peras/issues/121
+    , perasCertModel = case gcSlot of
+        Origin -> perasCertModel
+        NotOrigin slotNo -> PerasCertDBModel.garbageCollect slotNo perasCertModel
+    , perasVoteModel = case gcSlot of
+        Origin -> perasVoteModel
+        NotOrigin slotNo -> PerasVoteDBModel.garbageCollect slotNo perasVoteModel
     }
  where
+  gcSlot = immutableSlotNo secParam m
+
   -- TODO what about iterators that will stream garbage collected blocks?
 
   collectable :: blk -> Bool

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/Model.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/Model.hs
@@ -81,6 +81,7 @@ module Test.Ouroboros.Storage.ChainDB.Model
   , reopen
   , updateLoE
   , perasCertModel
+  , perasVoteModel
   , validChains
   , volatileDbBlocks
   , wipeVolatileDB

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
@@ -100,6 +100,7 @@ import qualified Data.Map.Strict as Map
 import Data.Maybe (fromMaybe)
 import Data.Ord (Down (..))
 import Data.Proxy
+import Data.Ratio ((%))
 import qualified Data.Set as Set
 import Data.TreeDiff
 import Data.Typeable
@@ -161,6 +162,7 @@ import Test.Ouroboros.Storage.ChainDB.Model
 import qualified Test.Ouroboros.Storage.ChainDB.Model as Model
 import Test.Ouroboros.Storage.Orphans ()
 import qualified Test.Ouroboros.Storage.PerasCertDB.Model as PerasCertDBModel
+import qualified Test.Ouroboros.Storage.PerasVoteDB.Model as PerasVoteDBModel
 import qualified Test.Ouroboros.Storage.PerasVoteDB.StateMachine as PerasVoteDB.SM
 import Test.Ouroboros.Storage.TestBlock
 import Test.QuickCheck hiding (forAll)
@@ -1114,7 +1116,7 @@ generator loe genBlock genPerasBlock m@Model{..} =
               LoEDisabled ->
                 -- We must reduce the probability of Peras events to trigger on
                 -- an empty DB since there are no interesting blocks to vote for
-                if empty then 20 else 435
+                if empty then 20 else 500
               -- The LoE does not yet support Peras.
               LoEEnabled () -> 0
          in (freq, genAddPerasVote)
@@ -1292,21 +1294,74 @@ generator loe genBlock genPerasBlock m@Model{..} =
   genAddPerasVote :: Gen (Cmd blk it flr)
   genAddPerasVote = do
     (blk, gapBlks) <- genPerasBlock m
-    -- Use (max roundNo of certs seen) + 1, or 0 if no cert exists
-    -- This should guarantee that we don't generate extra votes once a winner
-    -- has been determined for a round, so we should never run into
-    -- MultipleWinnersInRound exception
-    --
-    -- Note that by this logic, we only generate votes for current/next round.
-    -- This is not a problem because 'PerasRoundNo' should not matter at all for
-    -- chain selection logic.
-    -- We have more complete coverage in PerasVoteDB statemachine tests, where we
-    -- can generate votes for past rounds too.
-    let roundNo = case Model.roundNoOfLatestCertSeen dbModel of
+    -- Pick a round based on the remaining capacity (maxRoundVoteStake -
+    -- currentTotalStake) of existing rounds, with a flat probability for
+    -- selecting a fresh new round. This ensures we never exceed the quorum
+    -- threshold for multiple different blocks in the same round, avoiding the
+    -- MultipleWinnersInRound error.
+    let voteModel = Model.perasVoteModel dbModel
+        -- Compute total stake per round from the vote model
+        stakePerRound :: Map.Map PerasRoundNo Rational
+        stakePerRound =
+          Map.fromListWith
+            (+)
+            [ ( pvtRoundNo target
+              , sum
+                  [ unPerasVoteStake (getPerasVoteStake (PerasVoteDBModel.veVote ve))
+                  | ve <- Set.toList entries
+                  ]
+              )
+            | (target, entries) <- Map.toList (PerasVoteDBModel.votes voteModel)
+            ]
+
+        voteParams = PerasVoteDBModel.params voteModel
+        quorum =
+          unPerasQuorumStakeThreshold (perasQuorumStakeThreshold voteParams)
+            + unPerasQuorumStakeThresholdSafetyMargin (perasQuorumStakeThresholdSafetyMargin voteParams)
+        -- Maximum total vote stake per round: 2 * quorum - epsilon.
+        -- Below this threshold it is impossible for two different blocks to
+        -- both reach quorum in the same round.
+        -- It would be more realistic to use just 'quorum', but by doing so we
+        -- would only have very few voting rounds succeeding with a cert
+        -- creation, because we can't concentrate votes on a few distinct
+        -- candidates easily as we would observe in real world.
+        maxRoundVoteStake :: Rational
+        maxRoundVoteStake = 2 * quorum - (1 % 100)
+        -- Minimum vote stake
+        minVoteStake :: Rational
+        minVoteStake = 1 % 10
+        -- Maximum vote stake
+        maxVoteStake :: Rational
+        maxVoteStake = 1 % 2
+        -- Remaining capacity for each existing round
+        roundCapacities :: [(PerasRoundNo, Rational)]
+        roundCapacities =
+          [ (r, cap)
+          | (r, totalStake) <- Map.toList stakePerRound
+          , let cap = maxRoundVoteStake - totalStake
+          , cap >= minVoteStake
+          ]
+        -- The next fresh round number
+        freshRound :: PerasRoundNo
+        freshRound = case Map.lookupMax stakePerRound of
           Nothing -> PerasRoundNo 0
-          Just (PerasRoundNo r) -> PerasRoundNo (r + 1)
+          Just (PerasRoundNo r, _) -> PerasRoundNo (r + 1)
+        -- Weight for a fresh round (same as a round with 0.25 * maxRoundVoteStake capacity remaining)
+        freshWeight :: Int
+        freshWeight = max 1 $ floor (25 * maxRoundVoteStake)
+        -- Weighted choices: existing rounds by remaining capacity + fresh round
+        choices :: [(Int, Gen (PerasRoundNo, Rational))]
+        choices =
+          [ (max 1 (floor (cap * 100)), pure (r, cap))
+          | (r, cap) <- roundCapacities
+          ]
+            ++ [(freshWeight, pure (freshRound, maxRoundVoteStake))]
+    (roundNo, capacity) <- frequency choices
+    -- Pick a vote stake between minVoteStake and min(capacity, maxVoteStake)
+    let upperBound = min capacity maxVoteStake
+    stakeNumerator <- choose (ceiling (minVoteStake * 100), floor (upperBound * 100)) :: Gen Int
+    let stake = PerasVoteStake (fromIntegral stakeNumerator % 100)
     voterId <- PerasVoteDB.SM.genVoterId
-    stake <- PerasVoteDB.SM.genVoteStake
     -- Include the voted block itself in the persisted seenBlocks
     let seenBlks = fmap (blk :) gapBlks
     -- Build the vote

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
@@ -315,6 +315,8 @@ data Success blk it flr
   | MbPoint (Maybe (Point blk))
   | MaxSlot MaxSlotNo
   | MbPerasRoundNo (Maybe PerasRoundNo)
+  | PerasCertRes ChainDB.AddPerasCertChainSelOutcome
+  | PerasVoteRes (ChainDB.AddPerasVoteResult blk, Maybe ChainDB.AddPerasCertChainSelOutcome)
   deriving (Functor, Foldable, Traversable)
 
 -- | Product of all 'BlockComponent's. As this is a GADT, generating random
@@ -445,8 +447,8 @@ run ::
 run cfg env@ChainDBEnv{varDB, ..} cmd =
   readTVarIO varDB >>= \st@ChainDBState{chainDB = chainDB@ChainDB{..}, internal} -> case cmd of
     AddBlock blk _ -> Point <$> advanceAndAdd st blk
-    AddPerasCert cert _ -> Unit <$> addPerasCertSync chainDB cert
-    AddPerasVote vote _ -> Unit <$> addPerasVoteSync chainDB vote
+    AddPerasCert cert _ -> PerasCertRes <$> addPerasCertSync chainDB cert
+    AddPerasVote vote _ -> PerasVoteRes <$> addPerasVoteSync chainDB vote
     GetCurrentChain -> Chain <$> atomically getCurrentChain
     GetTipBlock -> MbBlock <$> getTipBlock
     GetTipHeader -> MbHeader <$> getTipHeader
@@ -715,8 +717,8 @@ runPure ::
   (Resp blk IteratorId FollowerId, DBModel blk)
 runPure cfg = \case
   AddBlock blk _ -> ok Point $ update (add blk)
-  AddPerasCert cert _ -> ok Unit $ update_ (Model.addPerasCert cfg cert)
-  AddPerasVote vote _ -> ok Unit $ update_ (Model.addPerasVote cfg vote)
+  AddPerasCert cert _ -> ok PerasCertRes $ update (Model.addPerasCert cfg cert)
+  AddPerasVote vote _ -> ok PerasVoteRes $ update (Model.addPerasVote cfg vote)
   GetCurrentChain -> ok Chain $ query (Model.volatileChain k getHeader)
   GetTipBlock -> ok MbBlock $ query Model.tipBlock
   GetTipHeader -> ok MbHeader $ query (fmap getHeader . Model.tipBlock)

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/PerasCertDB/Model.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/PerasCertDB/Model.hs
@@ -23,6 +23,7 @@ import Ouroboros.Consensus.Peras.Weight
   ( PerasWeightSnapshot
   , mkPerasWeightSnapshot
   )
+import Ouroboros.Consensus.Storage.PerasCertDB.API (AddPerasCertResult (..))
 
 data Model blk = Model
   { certs :: Set (WithArrivalTime (ValidatedPerasCert blk))
@@ -44,10 +45,10 @@ openDB model = model{open = True}
 
 addCert ::
   StandardHash blk =>
-  Model blk -> WithArrivalTime (ValidatedPerasCert blk) -> Model blk
+  Model blk -> WithArrivalTime (ValidatedPerasCert blk) -> (AddPerasCertResult, Model blk)
 addCert model@Model{certs, latestCertSeen} cert
-  | certs `hasRoundNo` cert = model
-  | otherwise = model{certs = certs', latestCertSeen = latestCertSeen'}
+  | certs `hasRoundNo` cert = (PerasCertAlreadyInDB, model)
+  | otherwise = (AddedPerasCertToDB, model{certs = certs', latestCertSeen = latestCertSeen'})
  where
   certs' = Set.insert cert certs
   latestCertSeen' = case latestCertSeen of

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/PerasCertDB/StateMachine.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/PerasCertDB/StateMachine.hs
@@ -120,7 +120,7 @@ instance StateModel Model where
 
   nextState (Model model) action _ = Model $ case action of
     OpenDB -> Model.openDB model
-    AddCert cert -> Model.addCert model cert
+    AddCert cert -> snd $ Model.addCert model cert
     GetWeightSnapshot -> model
     GetLatestCertSeen -> model
     GarbageCollect slotNo -> Model.garbageCollect slotNo model
@@ -168,9 +168,7 @@ instance RunModel Model (StateT (PerasCertDB IO TestBlock) IO) where
       lift $ join $ atomically $ PerasCertDB.garbageCollect perasCertDB slotNo
 
   postcondition (Model model, _) (AddCert cert) _ actual = do
-    let expected
-          | model.certs `Model.hasRoundNo` cert = PerasCertAlreadyInDB
-          | otherwise = AddedPerasCertToDB
+    let expected = fst $ Model.addCert model cert
     counterexamplePost $ show expected <> " /= " <> show actual
     pure $ expected == actual
   postcondition (Model model, _) GetWeightSnapshot _ actual = do

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/PerasVoteDB/Model.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/PerasVoteDB/Model.hs
@@ -2,6 +2,7 @@
 
 module Test.Ouroboros.Storage.PerasVoteDB.Model
   ( PerasVoteDbModelError (..)
+  , VoteEntry (..)
   , Model (..)
   , initModel
   , openDB


### PR DESCRIPTION
# Description

@jasagredo identified that ChainDB statemachine tests, updated to support full Peras VoteDB/CertDB in [Peras 3.75](https://github.com/IntersectMBO/ouroboros-consensus/pull/1966/changes/fd19c52bc140868d5c629d6473db78dab5a858ff), were sometimes running into the normally-impossible `MultipleWinnersInRound` exception.

This was a very intricate bug to track down, but ultimately we identified that the model `ChainDB` would not run Peras-related garbage collection, while the SUT would; and that was affecting how a vote reusing an old-but-normally-GCed ID, but with a different boosted block, would be rejected/accepted by the model/SUT, eventually leading to `MultipleWinnersInRound` exception in the SUT. So this PR updates the model to run the same GC behavior as the SUT.

In the process, we also identified that the SUT would conditionnally discard some certs who are considered too old (for chain selection purpose), in a non-visible/non-explicit way, while the model would not. So we made this ignoring behavior explicit, and updated the model to have the same behavior as the SUT, in order to prevent future annoying debugging in statemachine tests, even though it seemed not to create visible issues for now.

Finally, to prevent running into other `MultipleWinnersInRound` exceptions in the future, the generator for `AddPerasVote` commands in ChainDB's statemachine tests has been improved and documented, and now limits the total stake distributed in a given round to never reach 2 x quorum.

The only breaking changes are ChainDB's API methods `addPerasVoteSync`, `addPerasVoteWithAsyncCertHandling`, `addPerasCertSync`, `addPerasCertAsync` who get updated return types.