### PR TITLE
[Peras 25.5] Introduce Bytes32RealPoint

### DIFF
--- a/changelog.d/20260507_102103_agustin.mista_bytes32realpoint.md
+++ b/changelog.d/20260507_102103_agustin.mista_bytes32realpoint.md
@@ -1,0 +1,23 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+<!--
+### Breaking
+
+- A bullet item for the Breaking category.
+
+-->
+### Non-Breaking
+
+- Introduce `Bytes32RealPoint` for real points with 32byte header hashes.
+
+<!--
+### Patch
+
+- A bullet item for the Patch category.
+
+-->

--- a/changelog.d/20260702_105100_agustin.mista_bytes32realpoint.md
+++ b/changelog.d/20260702_105100_agustin.mista_bytes32realpoint.md
@@ -1,0 +1,26 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+### Breaking
+
+- Refactored `ConvertRawHash` type class:
+  + Introduced `HashSize :: Nat` associated type.
+  + Changed `fromRawHash` and `fromShortRawHash` methods to enforce announced size, returning `Maybe` upon failure.
+  + Introduced `unsafeFromRawHash` and `unsafeFromShortRawHash` for backwards compatibility.
+
+<!--
+### Non-Breaking
+
+- A bullet item for the Non-Breaking category.
+
+-->
+<!--
+### Patch
+
+- A bullet item for the Patch category.
+
+-->

--- a/ouroboros-consensus-cardano/src/byron/Ouroboros/Consensus/Byron/Ledger/Block.hs
+++ b/ouroboros-consensus-cardano/src/byron/Ouroboros/Consensus/Byron/Ledger/Block.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
@@ -43,7 +44,6 @@ import qualified Cardano.Chain.Slotting as CC
 import qualified Cardano.Crypto.Hashing as CC
 import Cardano.Ledger.Binary
 import Control.DeepSeq (NFData (..))
-import qualified Crypto.Hash as Crypto
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as Strict
 import Data.Map.Strict (Map)
@@ -73,12 +73,17 @@ mkByronHash :: CC.ABlockOrBoundaryHdr ByteString -> ByronHash
 mkByronHash = ByronHash . CC.abobHdrHash
 
 instance ConvertRawHash ByronBlock where
+  -- Byron header hashes are @AbstractHash Blake2b_256 Header@ (see
+  -- 'Cardano.Crypto.Hashing.Hash'), so
+  -- @HashSize ByronBlock ~ HashDigestSize Blake2b_256 ~ 32@ (a @Blake2b_256@
+  -- digest is 256 bits = 32 bytes).
+  --
+  -- However we can't write @HashSize ByronBlock = HashDigestSize Blake2b_256@
+  -- because the 'HashDigestSize' type family is not exported by the crypton
+  -- library.
+  type HashSize ByronBlock = 32
   toShortRawHash _ = CC.abstractHashToShort . unByronHash
-  fromShortRawHash _ = ByronHash . CC.unsafeAbstractHashFromShort
-  hashSize _ =
-    fromIntegral $
-      Crypto.hashDigestSize
-        (error "proxy" :: Crypto.Blake2b_256)
+  unsafeFromShortRawHash _ = ByronHash . CC.unsafeAbstractHashFromShort
 
 {-------------------------------------------------------------------------------
   Block

--- a/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/CanHardFork.hs
+++ b/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/CanHardFork.hs
@@ -258,9 +258,18 @@ translateHeaderHashByronToShelley ::
   Proxy c ->
   HeaderHash ByronBlock ->
   HeaderHash (ShelleyBlock (TPraos c) ShelleyEra)
-translateHeaderHashByronToShelley _ =
-  fromShortRawHash (Proxy @(ShelleyBlock (TPraos c) ShelleyEra))
-    . toShortRawHash (Proxy @ByronBlock)
+translateHeaderHashByronToShelley _ h =
+  case sameSizeSafety of
+    Refl ->
+      unsafeFromShortRawHash (Proxy @(ShelleyBlock (TPraos c) ShelleyEra)) $
+        toShortRawHash (Proxy @ByronBlock) h
+ where
+  -- Calling 'unsafeFromShortRawHash' is only valid if the raw bytes of a Byron
+  -- header hash are also a valid Shelley header hash, i.e. both hashes have the
+  -- same size. This holds because both are 32-byte Blake2b_256 digests; we
+  -- assert it here so that any future divergence is caught at compile time.
+  sameSizeSafety :: HashSize ByronBlock :~: HashSize (ShelleyBlock (TPraos c) ShelleyEra)
+  sameSizeSafety = Refl
 
 translatePointByronToShelley ::
   forall c.

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Block.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Block.hs
@@ -130,9 +130,11 @@ class
   ShelleyCompatible proto era
 
 instance ShelleyCompatible proto era => ConvertRawHash (ShelleyBlock proto era) where
+  -- 'HASH' is currently 'Blake2b_256', whose digest is 256 bits, i.e. 32 bytes,
+  -- so this resolves to 32.
+  type HashSize (ShelleyBlock proto era) = Crypto.HashSize HASH
   toShortRawHash _ = Crypto.hashToBytesShort . unShelleyHash
-  fromShortRawHash _ = ShelleyHash . hashFromBytesShortE
-  hashSize _ = fromIntegral $ Crypto.hashSize (Proxy @HASH)
+  unsafeFromShortRawHash _ = ShelleyHash . hashFromBytesShortE
 
 {-------------------------------------------------------------------------------
   Shelley blocks and headers

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Node.hs
@@ -622,13 +622,19 @@ runWith RunNodeArgs{..} encAddrNtN decAddrNtN LowLevelRunNodeArgs{..} =
                                 , Cardano.getImmutableBlockPoint = \targetBlock k -> do
                                     case targetBlock of
                                       GenesisPoint -> k (pure (Left Cardano.ImmutableBlockPointGenesisPoint))
-                                      (BlockPoint targetSlot (RawBlockHash targetHash)) -> do
-                                        let targetPoint = RealPoint targetSlot (fromShortRawHash (Proxy @blk) targetHash)
-                                        ChainDB.waitForImmutableBlock (getChainDB nodeKernel) targetPoint >>= \case
-                                          Left ChainDB.TipIsOrigin -> k (pure (Left Cardano.ImmutableBlockPointTipIsOrigin))
-                                          Left ChainDB.TargetNewerThanTip -> k (pure (Left Cardano.ImmutableBlockPointNotYetImmutable))
-                                          Right (RealPoint actualSlot actualHash) ->
-                                            k (pure . Right $ BlockPoint actualSlot (RawBlockHash $ toShortRawHash (Proxy @blk) actualHash))
+                                      (BlockPoint targetSlot (RawBlockHash targetHash)) ->
+                                        case fromShortRawHash (Proxy @blk) targetHash of
+                                          -- TODO: eventually we want to return
+                                          -- a proper error value here, see
+                                          -- https://github.com/IntersectMBO/ouroboros-network/issues/5396
+                                          Nothing -> error "RawBlockHash size does not match the expected size for the HeaderHash of the block type"
+                                          Just targetHeaderHash -> do
+                                            let targetPoint = RealPoint targetSlot targetHeaderHash
+                                            ChainDB.waitForImmutableBlock (getChainDB nodeKernel) targetPoint >>= \case
+                                              Left ChainDB.TipIsOrigin -> k (pure (Left Cardano.ImmutableBlockPointTipIsOrigin))
+                                              Left ChainDB.TargetNewerThanTip -> k (pure (Left Cardano.ImmutableBlockPointNotYetImmutable))
+                                              Right (RealPoint actualSlot actualHash) ->
+                                                k (pure . Right $ BlockPoint actualSlot (RawBlockHash $ toShortRawHash (Proxy @blk) actualHash))
                                 }
                           }
                     , Cardano.Diffusion.readUseBootstrapPeers = rnGetUseBootstrapPeers

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator/A.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator/A.hs
@@ -433,9 +433,10 @@ instance SameDepIndex2 (BlockQuery BlockA) where
   sameDepIndex2 qry _qry' = case qry of {}
 
 instance ConvertRawHash BlockA where
+  -- We use the 'SlotNo' as the hash, which is 'Word64'
+  type HashSize BlockA = 8
   toRawHash _ = id
-  fromRawHash _ = id
-  hashSize _ = 8 -- We use the SlotNo as the hash, which is Word64
+  unsafeFromRawHash _ = id
 
 data instance NestedCtxt_ BlockA f a where
   CtxtA :: NestedCtxt_ BlockA f (f BlockA)

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator/B.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator/B.hs
@@ -366,9 +366,10 @@ instance SameDepIndex2 (BlockQuery BlockB) where
   sameDepIndex2 qry _qry' = case qry of {}
 
 instance ConvertRawHash BlockB where
+  -- We use the 'SlotNo' as the hash, which is 'Word64'
+  type HashSize BlockB = 8
   toRawHash _ = id
-  fromRawHash _ = id
-  hashSize _ = 8 -- We use the SlotNo as the hash, which is Word64
+  unsafeFromRawHash _ = id
 
 data instance NestedCtxt_ BlockB f a where
   CtxtB :: NestedCtxt_ BlockB f (f BlockB)

--- a/ouroboros-consensus-diffusion/test/mock-test/Test/Consensus/Ledger/Mock.hs
+++ b/ouroboros-consensus-diffusion/test/mock-test/Test/Consensus/Ledger/Mock.hs
@@ -77,7 +77,7 @@ prop_simpleBlock_roundtrip_ConvertRawHash ::
   SimpleCrypto c =>
   HeaderHash (SimpleBlock c ext) -> Property
 prop_simpleBlock_roundtrip_ConvertRawHash h =
-  h === fromShortRawHash p (toShortRawHash p h)
+  Just h === fromShortRawHash p (toShortRawHash p h)
  where
   p = Proxy @(SimpleBlock c ext)
 

--- a/ouroboros-consensus.cabal
+++ b/ouroboros-consensus.cabal
@@ -1374,7 +1374,6 @@ library cardano
     cborg,
     containers,
     contra-tracer,
-    crypton,
     deepseq,
     formatting >=6.3 && <7.3,
     measures,

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Block/Abstract.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Block/Abstract.hs
@@ -1,8 +1,11 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 
 module Ouroboros.Consensus.Block.Abstract
@@ -89,7 +92,9 @@ import Data.ByteString.Short (ShortByteString)
 import qualified Data.ByteString.Short as Short
 import Data.Kind (Type)
 import Data.Maybe (isJust)
+import Data.Proxy (Proxy (..))
 import Data.Word (Word32, Word64)
+import GHC.TypeNats (KnownNat, Nat, natVal)
 import NoThunks.Class (NoThunks)
 import Ouroboros.Consensus.Block.EBB
 import Ouroboros.Network.Block
@@ -230,32 +235,68 @@ headerPoint = castPoint . blockPoint
 -- Variants of 'toRawHash' and 'fromRawHash' for 'ShortByteString' are
 -- included. Override the default implementations to avoid an extra step in
 -- case the 'HeaderHash' is a 'ShortByteString' under the hood.
-class ConvertRawHash blk where
+--
+-- The associated type 'HashSize' is the size of the hash in bytes, expressed at
+-- the type level. The 'hashSize' method returns the same value at the term
+-- level.
+--
+-- The hash size is enforced by default: 'fromRawHash' and 'fromShortRawHash'
+-- return 'Nothing' when the input does not have the announced 'hashSize'. One
+-- can opt out of this check through the 'unsafeFromRawHash' and
+-- 'unsafeFromShortRawHash' variants, which must only be used at call sites
+-- where there is no easy way to handle failure and the size is known to be
+-- correct.
+class KnownNat (HashSize blk) => ConvertRawHash blk where
+  -- | The size of the hash in number of bytes, at the type level.
+  --
+  -- See 'hashSize' for the term-level counterpart.
+  type HashSize blk :: Nat
+
   -- | Get the raw bytes from a hash
   toRawHash :: proxy blk -> HeaderHash blk -> Strict.ByteString
   toRawHash p = Short.fromShort . toShortRawHash p
-
-  -- | Construct the hash from a raw hash
-  --
-  -- PRECONDITION: the bytestring's size must match 'hashSize'
-  fromRawHash :: proxy blk -> Strict.ByteString -> HeaderHash blk
-  fromRawHash p = fromShortRawHash p . Short.toShort
 
   -- | Variant of 'toRawHash' for 'ShortByteString'
   toShortRawHash :: proxy blk -> HeaderHash blk -> ShortByteString
   toShortRawHash p = Short.toShort . toRawHash p
 
-  -- | Variant of 'fromRawHash' for 'ShortByteString'
-  fromShortRawHash :: proxy blk -> ShortByteString -> HeaderHash blk
-  fromShortRawHash p = fromRawHash p . Short.fromShort
+  -- | Construct the hash from a raw hash, enforcing that the input has the
+  -- announced 'hashSize'.
+  --
+  -- Returns 'Nothing' on a size mismatch.
+  fromRawHash :: proxy blk -> Strict.ByteString -> Maybe (HeaderHash blk)
+  fromRawHash p bs
+    | fromIntegral (Strict.length bs) == hashSize p = Just (unsafeFromRawHash p bs)
+    | otherwise = Nothing
+
+  -- | Construct the hash from a raw hash, enforcing that the input has the
+  -- announced 'hashSize'.
+  --
+  -- Returns 'Nothing' on a size mismatch.
+  fromShortRawHash :: proxy blk -> ShortByteString -> Maybe (HeaderHash blk)
+  fromShortRawHash p sbs
+    | fromIntegral (Short.length sbs) == hashSize p = Just (unsafeFromShortRawHash p sbs)
+    | otherwise = Nothing
+
+  -- | Construct the hash from a raw hash /without/ enforcing the size.
+  --
+  -- PRECONDITION: the input's size must match 'hashSize'.
+  unsafeFromRawHash :: proxy blk -> Strict.ByteString -> HeaderHash blk
+  unsafeFromRawHash p = unsafeFromShortRawHash p . Short.toShort
+
+  -- | Construct the hash from a raw hash /without/ enforcing the size.
+  --
+  -- PRECONDITION: the input's size must match 'hashSize'.
+  unsafeFromShortRawHash :: proxy blk -> ShortByteString -> HeaderHash blk
+  unsafeFromShortRawHash p = unsafeFromRawHash p . Short.fromShort
 
   -- | The size of the hash in number of bytes
   hashSize :: proxy blk -> Word32
+  hashSize _ = fromIntegral (natVal (Proxy @(HashSize blk)))
 
   {-# MINIMAL
-    hashSize
-    , (toRawHash | toShortRawHash)
-    , (fromRawHash | fromShortRawHash)
+    (toRawHash | toShortRawHash)
+    , (unsafeFromRawHash | unsafeFromShortRawHash)
     #-}
 
 encodeRawHash ::
@@ -266,7 +307,11 @@ encodeRawHash p = Serialise.encode . toShortRawHash p
 decodeRawHash ::
   ConvertRawHash blk =>
   proxy blk -> forall s. Decoder s (HeaderHash blk)
-decodeRawHash p = fromShortRawHash p <$> Serialise.decode
+decodeRawHash p = do
+  sbs <- Serialise.decode
+  case fromShortRawHash p sbs of
+    Just h -> pure h
+    Nothing -> fail "decodeRawHash: hash has unexpected size"
 
 {-------------------------------------------------------------------------------
   Utilities for working with WithOrigin

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Block/RealPoint.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Block/RealPoint.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -22,12 +24,24 @@ module Ouroboros.Consensus.Block.RealPoint
   , realPointSlot
   , realPointToPoint
   , withOriginRealPointToPoint
+
+    -- * Bytes32RealPoint
+  , Bytes32RealPoint
+  , bytes32RealPointHash
+  , bytes32RealPointSlot
+  , decodeBytes32RealPoint
+  , encodeBytes32RealPoint
+  , fromBytes32RealPoint
+  , toBytes32RealPoint
   ) where
 
 import Cardano.Binary (enforceSize)
 import Codec.CBOR.Decoding (Decoder)
 import Codec.CBOR.Encoding (Encoding, encodeListLen)
 import Codec.Serialise (decode, encode)
+import Control.Exception (assert)
+import Data.ByteString.Short (ShortByteString)
+import qualified Data.ByteString.Short as ByteString
 import Data.Coerce
 import Data.Proxy
 import Data.Typeable (Typeable, typeRep)
@@ -120,3 +134,54 @@ castRealPoint ::
   RealPoint blk ->
   RealPoint blk'
 castRealPoint (RealPoint s h) = RealPoint s (coerce h)
+
+{-------------------------------------------------------------------------------
+  Bytes32RealPoint
+-------------------------------------------------------------------------------}
+
+-- | A 'RealPoint' where the hash is always 32 bytes.
+--
+-- The length of the hash is enforced during decoding.
+data Bytes32RealPoint = Bytes32RealPoint !SlotNo !ShortByteString
+  deriving (Show, Eq, Generic, NoThunks)
+
+bytes32RealPointSlot :: Bytes32RealPoint -> SlotNo
+bytes32RealPointSlot (Bytes32RealPoint s _) = s
+
+bytes32RealPointHash :: Bytes32RealPoint -> ShortByteString
+bytes32RealPointHash (Bytes32RealPoint _ h) = h
+
+encodeBytes32RealPoint :: Bytes32RealPoint -> Encoding
+encodeBytes32RealPoint (Bytes32RealPoint s h) =
+  mconcat
+    [ encodeListLen 2
+    , encode s
+    , encode h
+    ]
+
+decodeBytes32RealPoint :: forall s. Decoder s Bytes32RealPoint
+decodeBytes32RealPoint = do
+  enforceSize "Bytes32RealPoint" 2
+  s <- decode
+  h <- decode
+  case ByteString.length h of
+    32 -> pure (Bytes32RealPoint s h)
+    len -> fail $ "decodeBytes32RealPoint: expected 32 bytes, got " <> show len
+
+fromBytes32RealPoint ::
+  forall blk.
+  ConvertRawHash blk =>
+  Bytes32RealPoint ->
+  RealPoint blk
+fromBytes32RealPoint (Bytes32RealPoint s h) =
+  RealPoint s (fromShortRawHash (Proxy @blk) h)
+
+toBytes32RealPoint ::
+  forall blk.
+  ConvertRawHash blk =>
+  RealPoint blk ->
+  Bytes32RealPoint
+toBytes32RealPoint (RealPoint s h) =
+  assert (hashSize (Proxy @blk) == 32) $
+    assert (ByteString.length (toShortRawHash (Proxy @blk) h) == 32) $
+      Bytes32RealPoint s (toShortRawHash (Proxy @blk) h)

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Block/RealPoint.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Block/RealPoint.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -7,6 +8,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Ouroboros.Consensus.Block.RealPoint
@@ -39,7 +41,6 @@ import Cardano.Binary (enforceSize)
 import Codec.CBOR.Decoding (Decoder)
 import Codec.CBOR.Encoding (Encoding, encodeListLen)
 import Codec.Serialise (decode, encode)
-import Control.Exception (assert)
 import Data.ByteString.Short (ShortByteString)
 import qualified Data.ByteString.Short as ByteString
 import Data.Coerce
@@ -49,6 +50,7 @@ import GHC.Generics
 import NoThunks.Class (NoThunks (..))
 import Ouroboros.Consensus.Block.Abstract
 import Ouroboros.Consensus.Util.Condense
+import Ouroboros.Consensus.Util.RedundantConstraints
 
 {-------------------------------------------------------------------------------
   Non-genesis point
@@ -170,18 +172,23 @@ decodeBytes32RealPoint = do
 
 fromBytes32RealPoint ::
   forall blk.
-  ConvertRawHash blk =>
+  (ConvertRawHash blk, HashSize blk ~ 32) =>
   Bytes32RealPoint ->
   RealPoint blk
 fromBytes32RealPoint (Bytes32RealPoint s h) =
-  RealPoint s (fromShortRawHash (Proxy @blk) h)
+  RealPoint s (unsafeFromShortRawHash (Proxy @blk) h)
+ where
+  -- This constraint ensures we are allowed to call 'unsafeFromShortRawHash'.
+  _ = keepRedundantConstraint (Proxy @(HashSize blk ~ 32))
 
 toBytes32RealPoint ::
   forall blk.
-  ConvertRawHash blk =>
+  (ConvertRawHash blk, HashSize blk ~ 32) =>
   RealPoint blk ->
   Bytes32RealPoint
 toBytes32RealPoint (RealPoint s h) =
-  assert (hashSize (Proxy @blk) == 32) $
-    assert (ByteString.length (toShortRawHash (Proxy @blk) h) == 32) $
-      Bytes32RealPoint s (toShortRawHash (Proxy @blk) h)
+  Bytes32RealPoint s (toShortRawHash (Proxy @blk) h)
+ where
+  -- This constraint ensures the hash we are wrapping in 'Bytes32RealPoint' is
+  -- indeed 32 bytes long.
+  _ = keepRedundantConstraint (Proxy @(HashSize blk ~ 32))

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Abstract/CanHardFork.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Abstract/CanHardFork.hs
@@ -1,10 +1,16 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE UndecidableSuperClasses #-}
 
-module Ouroboros.Consensus.HardFork.Combinator.Abstract.CanHardFork (CanHardFork (..)) where
+module Ouroboros.Consensus.HardFork.Combinator.Abstract.CanHardFork
+  ( CanHardFork (..)
+  , HashSizeOfHead
+  ) where
 
 import Data.Measure (Measure)
 import Data.SOP.Constraint
@@ -16,7 +22,9 @@ import qualified Data.SOP.Strict as SOP
 import Data.SOP.Tails (Tails)
 import qualified Data.SOP.Tails as Tails
 import Data.Typeable
+import GHC.TypeNats (KnownNat)
 import NoThunks.Class (NoThunks)
+import Ouroboros.Consensus.Block (HashSize)
 import Ouroboros.Consensus.HardFork.Combinator.Abstract.SingleEraBlock
 import Ouroboros.Consensus.HardFork.Combinator.InjectTxs
 import Ouroboros.Consensus.HardFork.Combinator.Protocol.ChainSel
@@ -28,8 +36,29 @@ import Ouroboros.Consensus.TypeFamilyWrappers
   CanHardFork
 -------------------------------------------------------------------------------}
 
+-- | The hash size shared by all eras of a hard fork, represented by that of the
+-- first era.
+--
+-- See 'EqualHashSizeOfHead' superclass constraint in 'CanHardFork' and the
+-- @ConvertRawHash (HardForkBlock xs)@ instance.
+type family HashSizeOfHead xs where
+  HashSizeOfHead (x ': _) = HashSize x
+
+-- | Witnesses that the hash size of @blk@ coincides with 'HashSizeOfHead' of
+-- @xs@, i.e. with the hash size of the first era.
+--
+-- 'CanHardFork' requires @'All' ('EqualHashSizeOfHead' xs) xs@, which statically
+-- guarantees that all eras of a hard fork use the same hash size. This lets the
+-- @ConvertRawHash (HardForkBlock xs)@ instance enforce
+-- @HashSize (HardForkBlock xs) = HashSizeOfHead xs@ without any runtime check.
+class HashSize blk ~ HashSizeOfHead xs => EqualHashSizeOfHead xs blk
+
+instance HashSize blk ~ HashSizeOfHead xs => EqualHashSizeOfHead xs blk
+
 class
   ( All SingleEraBlock xs
+  , All (EqualHashSizeOfHead xs) xs
+  , KnownNat (HashSizeOfHead xs)
   , Typeable xs
   , IsNonEmpty xs
   , Measure (HardForkTxMeasure xs)

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Abstract/SingleEraBlock.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Abstract/SingleEraBlock.hs
@@ -32,6 +32,7 @@ import Data.SOP.Match
 import Data.SOP.Strict
 import qualified Data.Text as Text
 import Data.Void
+import GHC.TypeNats (KnownNat)
 import Ouroboros.Consensus.Block
 import Ouroboros.Consensus.Config.SupportsNode
 import Ouroboros.Consensus.HardFork.Combinator.Info
@@ -67,6 +68,9 @@ class
   , HasPartialConsensusConfig (BlockProtocol blk)
   , HasPartialLedgerConfig blk
   , ConvertRawHash blk
+  , -- All eras must agree on the size of header hashes; see 'CanHardFork' for
+    -- how this is exploited to give 'HardForkBlock' a 'ConvertRawHash' instance.
+    KnownNat (HashSize blk)
   , ReconstructNestedCtxt Header blk
   , CommonProtocolParams blk
   , LedgerSupportsPeerSelection blk

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Block.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Block.hs
@@ -35,7 +35,6 @@ import Data.SOP.Index
 import qualified Data.SOP.Match as Match
 import Data.SOP.Strict
 import Data.Typeable (Typeable)
-import Data.Word
 import NoThunks.Class (NoThunks)
 import Ouroboros.Consensus.Block
 import Ouroboros.Consensus.HardFork.Combinator.Abstract
@@ -173,15 +172,12 @@ instance CanHardFork xs => HasNestedContent Header (HardForkBlock xs) where
 -------------------------------------------------------------------------------}
 
 instance CanHardFork xs => ConvertRawHash (HardForkBlock xs) where
+  -- All eras share the same hash size; 'CanHardFork' enforces this statically
+  -- via @'All' ('EqualHashSizeOfHead' xs) xs@, so we can represent the common
+  -- size at the type level by that of the first era ('HashSizeOfHead').
+  type HashSize (HardForkBlock xs) = HashSizeOfHead xs
   toShortRawHash _ = getOneEraHash
-  fromShortRawHash _ = OneEraHash
-  hashSize _ = getSameValue hashSizes
-   where
-    hashSizes :: NP (K Word32) xs
-    hashSizes = hcpure proxySingle hashSizeOne
-
-    hashSizeOne :: forall blk. SingleEraBlock blk => K Word32 blk
-    hashSizeOne = K $ hashSize (Proxy @blk)
+  unsafeFromShortRawHash _ = OneEraHash
 
 {-------------------------------------------------------------------------------
   HasAnnTip

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Embed/Unary.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Embed/Unary.hs
@@ -199,7 +199,12 @@ instance Isomorphic WrapHeaderHash where
     WrapHeaderHash (HardForkBlock '[blk]) -> WrapHeaderHash blk
   project =
     WrapHeaderHash
-      . fromShortRawHash (Proxy @blk)
+      -- The input is the header hash of @HardForkBlock '[blk]@, i.e. an
+      -- @OneEraHash '[blk]@ wrapping the raw bytes of @blk@'s header hash. Since
+      -- @HashSize (HardForkBlock '[blk]) ~ HashSize blk@ (see the
+      -- 'ConvertRawHash' instance for 'HardForkBlock'), these bytes are always
+      -- exactly @hashSize blk@ long, so 'unsafeFromShortRawHash' cannot fail.
+      . unsafeFromShortRawHash (Proxy @blk)
       . getOneEraHash
       . unwrapHeaderHash
 

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Dual.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Dual.hs
@@ -138,9 +138,9 @@ type instance HeaderHash (DualBlock m a) = HeaderHash m
 instance StandardHash m => StandardHash (DualBlock m a)
 
 instance ConvertRawHash m => ConvertRawHash (DualBlock m a) where
+  type HashSize (DualBlock m a) = HashSize m
   toShortRawHash _ = toShortRawHash (Proxy @m)
-  fromShortRawHash _ = fromShortRawHash (Proxy @m)
-  hashSize _ = hashSize (Proxy @m)
+  unsafeFromShortRawHash _ = unsafeFromShortRawHash (Proxy @m)
 
 {-------------------------------------------------------------------------------
   Header

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ImmutableDB/Impl/Index/Secondary.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ImmutableDB/Impl/Index/Secondary.hs
@@ -369,7 +369,10 @@ writeAllEntries hasFS chunk entries =
 getHash :: ConvertRawHash blk => Proxy blk -> Get (HeaderHash blk)
 getHash pb = do
   bytes <- Get.getByteString (fromIntegral (hashSize pb))
-  return $! fromRawHash pb bytes
+  -- 'getByteString' reads exactly @hashSize pb@ bytes, which is precisely the
+  -- length 'unsafeFromRawHash' expects, so the calling the unsafe variant is
+  -- fine.
+  return $! unsafeFromRawHash pb bytes
 
 putHash :: ConvertRawHash blk => Proxy blk -> HeaderHash blk -> Put
 putHash pb = Put.putShortByteString . toShortRawHash pb

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Storage/TestBlock.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Storage/TestBlock.hs
@@ -229,9 +229,10 @@ type instance HeaderHash TestBlock = TestHeaderHash
 type instance HeaderHash TestHeader = TestHeaderHash
 
 instance ConvertRawHash TestBlock where
+  -- 'TestHeaderHash' is a newtype over 'Int' thus has size 8
+  type HashSize TestBlock = 8
   toRawHash _ = Lazy.toStrict . Binary.encode
-  fromRawHash _ = Binary.decode . Lazy.fromStrict
-  hashSize _ = 8
+  unsafeFromRawHash _ = Binary.decode . Lazy.fromStrict
 
 instance HasHeader TestBlock where
   getHeaderFields = getBlockHeaderFields

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/Serialisation/Roundtrip.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/Serialisation/Roundtrip.hs
@@ -813,7 +813,7 @@ roundtrip_ConvertRawHash ::
   (StandardHash blk, ConvertRawHash blk) =>
   Proxy blk -> HeaderHash blk -> Property
 roundtrip_ConvertRawHash p h =
-  h === fromShortRawHash p (toShortRawHash p h)
+  Just h === fromShortRawHash p (toShortRawHash p h)
 
 prop_hashSize ::
   ConvertRawHash blk =>

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/TestBlock.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/TestBlock.hs
@@ -981,8 +981,8 @@ instance Serialise (RealPoint (TestBlockWith ptype)) where
 -- 'ConvertRawHash' expects a constant-size hash. As a compromise, we allow to
 -- encode hashes with a block length of up to 100.
 instance ConvertRawHash (TestBlockWith ptype) where
-  -- 8 + 100 * 8: size of the list, and its elements, one Word64 each
-  hashSize _ = 808
+  -- @8 + 100 * 8@: size of the list, and its elements, one 'Word64' each
+  type HashSize (TestBlockWith ptype) = 808
   toRawHash _ (TestHash h)
     | len > 100 = error "hash too long"
     | otherwise = BL.toStrict . Put.runPut $ do
@@ -991,7 +991,7 @@ instance ConvertRawHash (TestBlockWith ptype) where
         replicateM_ (100 - len) $ Put.putWord64le 0
    where
     len = length h
-  fromRawHash _ bs = flip Get.runGet (BL.fromStrict bs) $ do
+  unsafeFromRawHash _ bs = flip Get.runGet (BL.fromStrict bs) $ do
     len <- fromIntegral <$> Get.getWord64le
     (NE.nonEmpty -> Just h, rs) <-
       splitAt len <$> replicateM 100 Get.getWord64le

--- a/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Ledger/Block.hs
+++ b/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Ledger/Block.hs
@@ -86,6 +86,7 @@ import Data.Proxy
 import Data.Typeable
 import Data.Word
 import GHC.Generics (Generic)
+import GHC.TypeLits (KnownNat)
 import NoThunks.Class (NoThunks (..))
 import Ouroboros.Consensus.Block
 import Ouroboros.Consensus.Config
@@ -284,10 +285,13 @@ instance
   (SimpleCrypto c, Typeable ext, Typeable ext') =>
   StandardHash (SimpleBlock' c ext ext')
 
-instance SimpleCrypto c => ConvertRawHash (SimpleBlock' c ext ext') where
+instance
+  (KnownNat (Hash.HashSize (SimpleHash c)), SimpleCrypto c) =>
+  ConvertRawHash (SimpleBlock' c ext ext')
+  where
+  type HashSize (SimpleBlock' c ext ext') = Hash.HashSize (SimpleHash c)
   toShortRawHash _ = Hash.hashToBytesShort
-  fromShortRawHash _ = hashFromBytesShortE
-  hashSize _ = fromIntegral $ Hash.hashSize (Proxy @(SimpleHash c))
+  unsafeFromShortRawHash _ = hashFromBytesShortE
 
 {-------------------------------------------------------------------------------
   HasMockTxs instance

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ImmutableDB/Primary.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ImmutableDB/Primary.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
 {-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 #if __GLASGOW_HASKELL__ >= 908
@@ -150,9 +152,9 @@ data DummyBlock
 
 -- | Only 'hashSize' is used.
 instance ConvertRawHash DummyBlock where
-  hashSize _ = 32
+  type HashSize DummyBlock = 32
   toRawHash _ = error "not used in the tests"
-  fromRawHash _ = error "not used in the tests"
+  unsafeFromRawHash _ = error "not used in the tests"
 
 prop_reconstructPrimaryIndex :: TestPrimaryIndex -> Property
 prop_reconstructPrimaryIndex (TestPrimaryIndex chunkInfo chunk primaryIndex _slot) =


### PR DESCRIPTION
This PR introduces a specialization of `RealPoint` for blocks where the header hash is always 32 bytes long. 