### PR TITLE
[Peras 24, reopened] BLS crypto backend for voting committees

### DIFF
--- a/changelog.d/20260413_101837_agustin.mista_bls_crypto_for_voting_committees.md
+++ b/changelog.d/20260413_101837_agustin.mista_bls_crypto_for_voting_committees.md
@@ -1,0 +1,23 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+<!--
+### Breaking
+
+- A bullet item for the Breaking category.
+
+-->
+### Non-Breaking
+
+- Implemented BLS-based crypto helpers to instantiate voting committee implementations.
+
+<!--
+### Patch
+
+- A bullet item for the Patch category.
+
+-->

--- a/ouroboros-consensus.cabal
+++ b/ouroboros-consensus.cabal
@@ -118,6 +118,7 @@ library
     Ouroboros.Consensus.Committee.AcrossEpochs
     Ouroboros.Consensus.Committee.Class
     Ouroboros.Consensus.Committee.Crypto
+    Ouroboros.Consensus.Committee.Crypto.BLS
     Ouroboros.Consensus.Committee.EveryoneVotes
     Ouroboros.Consensus.Committee.LS
     Ouroboros.Consensus.Committee.Types

--- a/ouroboros-consensus.cabal
+++ b/ouroboros-consensus.cabal
@@ -643,6 +643,7 @@ test-suite consensus-test
   main-is: Main.hs
   other-modules:
     Test.Consensus.BlockchainTime.Simple
+    Test.Consensus.Committee.TestCrypto
     Test.Consensus.Committee.WFALS
     Test.Consensus.Committee.WFALS.Conformance
     Test.Consensus.Committee.WFALS.Model
@@ -678,9 +679,11 @@ test-suite consensus-test
     async,
     base,
     base-deriving-via,
+    bytestring,
     cardano-binary,
     cardano-crypto-class:{cardano-crypto-class, testlib},
     cardano-diffusion:api,
+    cardano-ledger-binary,
     cardano-ledger-core:{cardano-ledger-core, testlib},
     cardano-slotting:{cardano-slotting, testlib},
     cborg,
@@ -697,6 +700,7 @@ test-suite consensus-test
     measures,
     mtl,
     mwc-random,
+    nonempty-containers,
     nothunks,
     ouroboros-consensus,
     ouroboros-network:{api, api-tests-lib, ouroboros-network, protocols, protocols-tests-lib},

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Committee/Crypto/BLS.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Committee/Crypto/BLS.hs
@@ -1,0 +1,425 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneKindSignatures #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeData #-}
+{-# LANGUAGE TypeFamilies #-}
+
+-- | BLS crypto helpers to instantiate voting committees.
+--
+-- NOTE: this module is meant to be imported qualified.
+module Ouroboros.Consensus.Committee.Crypto.BLS
+  ( -- * BLS crypto helpers to instantiate voting committees
+    KeyRole (..)
+  , KeyScope
+  , PrivateKey
+  , rawDeserialisePrivateKey
+  , rawSerialisePrivateKey
+  , coercePrivateKey
+  , derivePublicKey
+  , PublicKey
+  , rawDeserialisePublicKey
+  , rawSerialisePublicKey
+  , coercePublicKey
+  , Signature
+  , ProofOfPossession
+  , HasBLSContext (..)
+  , signWithRole
+  , verifyWithRole
+  , createProofOfPossession
+  , verifyProofOfPossession
+
+    -- * Aggregate keys and signatures
+  , aggregatePublicKeys
+  , aggregateSignatures
+
+    -- * VRF signature manipulation
+  , signatureNatural
+  , signatureNaturalMax
+  , toNormalizedVRFOutput
+
+    -- * Linearized VRF output verification
+  , linearizeAndVerifyVRFs
+  ) where
+
+import Cardano.Binary (FromCBOR, ToCBOR)
+import Cardano.Crypto.DSIGN
+  ( BLS12381MinSigDSIGN
+  , BLS12381SignContext (..)
+  , DSIGNAggregatable (..)
+  , DSIGNAlgorithm (..)
+  , SigDSIGN (..)
+  , VerKeyDSIGN (..)
+  )
+import Cardano.Crypto.EllipticCurve.BLS12_381 (blsIsInf, blsMSM)
+import qualified Cardano.Crypto.Hash as Hash
+import Cardano.Crypto.Util (SignableRepresentation, bytesToNatural)
+import Cardano.Ledger.Hashes (HASH, KeyHash (..), StakePool)
+import Control.Monad (when)
+import Data.ByteString (ByteString)
+import Data.Coerce (coerce)
+import Data.Containers.NonEmpty (HasNonEmpty (..))
+import Data.Kind (Type)
+import Data.List.NonEmpty (NonEmpty (..))
+import qualified Data.List.NonEmpty as NonEmpty
+import Data.Proxy (Proxy (..))
+import GHC.Natural (Natural)
+import Ouroboros.Consensus.Committee.Crypto (NormalizedVRFOutput (..))
+
+-- * BLS crypto helpers to instantiate voting committees
+
+-- | Key roles
+type data KeyRole
+  = -- | Key role for signing votes
+    SIGN
+  | -- | Key role for local sortition in elections
+    VRF
+  | -- | Key role for Proof of Possession
+    POP
+
+-- | Key scope, later instantiated with usage and network id (e.g. PERAS/MAINNET)
+type KeyScope = ByteString
+
+-- | BLS private key type, parameterized by key role
+type PrivateKey :: KeyRole -> Type
+data PrivateKey r = PrivateKey
+  { unPrivateKey :: !(SignKeyDSIGN BLS12381MinSigDSIGN)
+  , privateKeyScope :: !KeyScope
+  }
+  deriving stock (Eq, Show)
+
+rawDeserialisePrivateKey ::
+  KeyScope ->
+  ByteString ->
+  Maybe (PrivateKey r)
+rawDeserialisePrivateKey scope bs = do
+  key <- rawDeserialiseSignKeyDSIGN bs
+  pure $
+    PrivateKey
+      { unPrivateKey = key
+      , privateKeyScope = scope
+      }
+
+rawSerialisePrivateKey ::
+  PrivateKey r ->
+  ByteString
+rawSerialisePrivateKey =
+  rawSerialiseSignKeyDSIGN . unPrivateKey
+
+coercePrivateKey ::
+  forall r2 r1.
+  PrivateKey r1 ->
+  PrivateKey r2
+coercePrivateKey = coerce
+
+derivePublicKey ::
+  PrivateKey r ->
+  PublicKey r
+derivePublicKey sk =
+  PublicKey
+    { unPublicKey = deriveVerKeyDSIGN (unPrivateKey sk)
+    , publicKeyScope = privateKeyScope sk
+    }
+
+-- | BLS public key type, parameterized by key role
+type PublicKey :: KeyRole -> Type
+data PublicKey r = PublicKey
+  { unPublicKey :: !(VerKeyDSIGN BLS12381MinSigDSIGN)
+  , publicKeyScope :: !(KeyScope)
+  }
+  deriving stock (Eq, Show)
+
+rawDeserialisePublicKey ::
+  KeyScope ->
+  ByteString ->
+  Maybe (PublicKey r)
+rawDeserialisePublicKey scope bs = do
+  key <- rawDeserialiseVerKeyDSIGN bs
+  pure $
+    PublicKey
+      { unPublicKey = key
+      , publicKeyScope = scope
+      }
+
+rawSerialisePublicKey ::
+  PublicKey r ->
+  ByteString
+rawSerialisePublicKey =
+  rawSerialiseVerKeyDSIGN . unPublicKey
+
+coercePublicKey ::
+  forall r2 r1.
+  PublicKey r1 ->
+  PublicKey r2
+coercePublicKey = coerce
+
+-- | BLS signature type, parameterized by key role
+type Signature :: KeyRole -> Type
+newtype Signature r = Signature
+  { unSignature :: SigDSIGN BLS12381MinSigDSIGN
+  }
+  deriving stock (Eq, Show)
+  deriving newtype (FromCBOR, ToCBOR)
+
+-- | BLS proof of possession type
+newtype ProofOfPossession = ProofOfPossession
+  { unProofOfPossession :: PossessionProofDSIGN BLS12381MinSigDSIGN
+  }
+  deriving stock (Eq, Show)
+  deriving newtype (FromCBOR, ToCBOR)
+
+-- TODO: get these contexts directly from @cardano-base@ after
+-- https://github.com/IntersectMBO/cardano-base/pull/635
+-- is merged.
+
+-- Basic over G1:
+-- https://www.ietf.org/archive/id/draft-irtf-cfrg-bls-signature-06.html#section-4.2.1-1
+minSigSignatureDST :: BLS12381SignContext
+minSigSignatureDST =
+  BLS12381SignContext
+    { blsSignContextDst = Just "BLS_SIG_BLS12381G1_XMD:SHA-256_SSWU_RO_NUL_"
+    , blsSignContextAug = Nothing
+    }
+
+-- PoP over G1:
+-- https://www.ietf.org/archive/id/draft-irtf-cfrg-bls-signature-06.html#section-4.2.3-1
+minSigPoPDST :: BLS12381SignContext
+minSigPoPDST =
+  BLS12381SignContext
+    { blsSignContextDst = Just "BLS_SIG_BLS12381G1_XMD:SHA-256_SSWU_RO_POP_"
+    , blsSignContextAug = Nothing
+    }
+
+-- | Role-separated BLS contexts for  signatures
+class HasBLSContext (r :: KeyRole) where
+  blsCtx :: Proxy r -> KeyScope -> BLS12381SignContext
+
+instance HasBLSContext SIGN where
+  blsCtx _ keyScope =
+    minSigSignatureDST
+      { blsSignContextAug =
+          Just ("VOTE:" <> keyScope <> ":V0")
+      }
+
+instance HasBLSContext VRF where
+  blsCtx _ keyScope =
+    minSigSignatureDST
+      { blsSignContextAug =
+          Just ("VRF:" <> keyScope <> ":V0")
+      }
+
+instance HasBLSContext POP where
+  blsCtx _ keyScope =
+    minSigPoPDST
+      { blsSignContextAug =
+          Just ("POP:" <> keyScope <> ":V0")
+      }
+
+-- | Sign a message with a  private key, producing a  signature
+signWithRole ::
+  forall r msg.
+  ( SignableRepresentation msg
+  , HasBLSContext r
+  ) =>
+  PrivateKey r ->
+  msg ->
+  Signature r
+signWithRole sk msg =
+  Signature
+    { unSignature =
+        signDSIGN
+          (blsCtx (Proxy @r) (privateKeyScope sk))
+          msg
+          (unPrivateKey sk)
+    }
+
+-- | Verify a  signature on a message with a  public key
+verifyWithRole ::
+  forall r msg.
+  ( SignableRepresentation msg
+  , HasBLSContext r
+  ) =>
+  PublicKey r ->
+  msg ->
+  Signature r ->
+  Either String ()
+verifyWithRole pk msg (Signature sig) =
+  verifyDSIGN
+    (blsCtx (Proxy @r) (publicKeyScope pk))
+    (unPublicKey pk)
+    msg
+    sig
+
+-- | Create a proof of possession signature for a  private key
+createProofOfPossession ::
+  PrivateKey POP ->
+  KeyHash StakePool ->
+  ProofOfPossession
+createProofOfPossession sk stakePoolHash =
+  ProofOfPossession
+    { unProofOfPossession =
+        createPossessionProofDSIGN
+          extCtx
+          (unPrivateKey sk)
+    }
+ where
+  poolBytes = Hash.hashToBytes (unKeyHash stakePoolHash)
+  baseCtx = blsCtx (Proxy @POP) (privateKeyScope sk)
+  extCtx = baseCtx{blsSignContextAug = blsSignContextAug baseCtx <> Just poolBytes}
+
+-- | Verify a proof of possession signature for a public key
+verifyProofOfPossession ::
+  PublicKey POP ->
+  KeyHash StakePool ->
+  ProofOfPossession ->
+  Either String ()
+verifyProofOfPossession pk stakePoolHash pop =
+  verifyPossessionProofDSIGN
+    extCtx
+    (unPublicKey pk)
+    (unProofOfPossession pop)
+ where
+  poolBytes = Hash.hashToBytes (unKeyHash stakePoolHash)
+  baseCtx = blsCtx (Proxy @POP) (publicKeyScope pk)
+  extCtx = baseCtx{blsSignContextAug = blsSignContextAug baseCtx <> Just poolBytes}
+
+-- * Aggregate keys and signatures
+
+-- | Aggregate multiple public keys into a single one.
+--
+-- PRECONDITION: all keys must have the same scope.
+--
+-- PRECONDITION: this assumes that proofs of possession have already been
+-- verified for all keys in advance.
+aggregatePublicKeys ::
+  NE [PublicKey r] ->
+  Either String (PublicKey r)
+aggregatePublicKeys keys@(firstKey :| restKeys) = do
+  -- Ensure all keys have the same scope before aggregation
+  when (any (/= publicKeyScope firstKey) (fmap publicKeyScope restKeys)) $
+    Left "Cannot aggregate public keys with different scopes"
+  aggKey <-
+    uncheckedAggregateVerKeysDSIGN
+      . fmap unPublicKey
+      . NonEmpty.toList
+      $ keys
+  pure $
+    PublicKey
+      { unPublicKey = aggKey
+      , publicKeyScope = publicKeyScope firstKey
+      }
+
+-- | Aggregate multiple signatures into a single one
+aggregateSignatures ::
+  NE [Signature r] ->
+  Either String (Signature r)
+aggregateSignatures sigs =
+  fmap Signature
+    . aggregateSigsDSIGN
+    . fmap unSignature
+    . NonEmpty.toList
+    $ sigs
+
+-- * VRF signature manipulation
+
+-- | Convert a BLS signature to a natural number for use in local sortition
+signatureNatural ::
+  Signature VRF ->
+  Natural
+signatureNatural sig =
+  bytesToNatural
+    . Hash.hashToBytes
+    . Hash.hashWith @HASH rawSerialiseSigDSIGN
+    . unSignature
+    $ sig
+
+-- | The maximum natural number that can be produced by a BLS signature
+signatureNaturalMax :: Natural
+signatureNaturalMax =
+  2 ^ ((8 :: Integer) * hashSize) - 1
+ where
+  hashSize =
+    fromIntegral (Hash.hashSize (Proxy :: Proxy HASH))
+
+-- | Create a normalized VRF output from a BLS signature
+toNormalizedVRFOutput ::
+  Signature VRF ->
+  NormalizedVRFOutput
+toNormalizedVRFOutput sig =
+  NormalizedVRFOutput $
+    fromIntegral (signatureNatural sig)
+      / fromIntegral signatureNaturalMax
+
+-- * Linearized VRF output verification
+
+-- | Verify a list of VRF outputs against on the same input using linearization.
+--
+-- The idea is to first aggregate all public keys and VRF outputs into a single
+-- aggregate ones. These can then be verified in one go, saving the (higher)
+-- cost of multiple signature verifications.
+--
+-- However, since we later derive a numeric value from each individual VRF
+-- output, verifying the aggregate signature alone is not sufficient. This is
+-- because an attacker could swap their (bad) VRF output with someone else's
+-- (better) one, and a naive signature aggregation and verification approach
+-- would still succeed.
+--
+-- Instead, each VRF output is first linearized using a scalar derived from the
+-- signature itself, and then aggregated together. This way, if an attacker
+-- tries to swap their VRF output with someone else's, the linearization will
+-- produce a different aggregate signature that will fail verification.
+--
+-- PRECONDITION: all keys must have the same scope.
+--
+-- PRECONDITION: the number of signatures must match the number of keys.
+linearizeAndVerifyVRFs ::
+  SignableRepresentation msg =>
+  NE [PublicKey VRF] ->
+  msg ->
+  NE [Signature VRF] ->
+  Either String ()
+linearizeAndVerifyVRFs keys@(firstKey :| restKeys) msg sigs = do
+  when (any (/= publicKeyScope firstKey) (fmap publicKeyScope restKeys)) $
+    Left "Cannot aggregate public keys with different scopes"
+
+  when (length sigs /= length keys) $
+    Left "Number of signatures must match number of public keys"
+
+  let scalars =
+        NonEmpty.map
+          (fromIntegral . signatureNatural)
+          sigs
+
+  let linearizedKeyPoint =
+        blsMSM
+          . NonEmpty.toList
+          . NonEmpty.zip scalars
+          . NonEmpty.map (\(PublicKey (VerKeyBLS12381 p) _) -> p)
+          $ keys
+
+  let linearizedSigPoint =
+        blsMSM
+          . NonEmpty.toList
+          . NonEmpty.zip scalars
+          . NonEmpty.map (\(Signature (SigBLS12381 p)) -> p)
+          $ sigs
+
+  when (blsIsInf linearizedKeyPoint) $
+    Left "Resulting key point is at infinity, cannot linearize"
+
+  when (blsIsInf linearizedSigPoint) $
+    Left "Resulting signature point is at infinity, cannot linearize"
+
+  let linearizedKey =
+        PublicKey
+          (VerKeyBLS12381 linearizedKeyPoint)
+          (publicKeyScope firstKey)
+
+  let linearizedSig =
+        Signature
+          (SigBLS12381 linearizedSigPoint)
+
+  verifyWithRole @VRF linearizedKey msg linearizedSig

--- a/ouroboros-consensus/test/consensus-test/Main.hs
+++ b/ouroboros-consensus/test/consensus-test/Main.hs
@@ -3,6 +3,7 @@
 module Main (main) where
 
 import qualified Test.Consensus.BlockchainTime.Simple (tests)
+import qualified Test.Consensus.Committee.TestCrypto (tests)
 import qualified Test.Consensus.Committee.WFALS (tests)
 import qualified Test.Consensus.HardFork.Forecast (tests)
 import qualified Test.Consensus.HardFork.History (tests)
@@ -39,7 +40,11 @@ tests =
   testGroup
     "ouroboros-consensus"
     [ Test.Consensus.BlockchainTime.Simple.tests
-    , Test.Consensus.Committee.WFALS.tests
+    , testGroup
+        "Committee"
+        [ Test.Consensus.Committee.WFALS.tests
+        , Test.Consensus.Committee.TestCrypto.tests
+        ]
     , Test.Consensus.HeaderValidation.tests
     , Test.Consensus.MiniProtocol.BlockFetch.Client.tests
     , Test.Consensus.MiniProtocol.ChainSync.CSJ.tests

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/Committee/TestCrypto.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/Committee/TestCrypto.hs
@@ -1,0 +1,552 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+-- | Test crypto for voting committee tests, based on BLS signatures.
+module Test.Consensus.Committee.TestCrypto
+  ( -- * Test crypto based on BLS signatures
+    TestCrypto
+  , VoteSignature (TestVoteSignature, unTestVoteSignature)
+  , VRFElectionInput (TestVRFElectionInput, unTestVRFElectionInput)
+  , VRFOutput (TestVRFOutput, unTestVRFOutput)
+
+    -- * QuickCheck helpers
+  , genElectionId
+  , genVoteCandidate
+  , genKeyPair
+
+    -- * Smoke test properties
+  , prop_SignAndVerifyVote
+  , prop_SignAndVerifyAggregateVote
+  , prop_EvalAndVerifyVRFOutput
+  , prop_EvalAndVerifyAggregateVRFOutput
+  , tests
+  ) where
+
+import Cardano.Crypto.DSIGN
+  ( BLS12381MinSigDSIGN
+  , DSIGNAlgorithm (..)
+  )
+import Cardano.Crypto.Hash (ByteString, Hash)
+import qualified Cardano.Crypto.Hash as Hash
+import Cardano.Ledger.BaseTypes (Nonce (..), mkNonceFromNumber)
+import Cardano.Ledger.Binary (runByteBuilder)
+import Cardano.Ledger.Hashes (HASH)
+import Control.Monad (when)
+import Control.Monad.Zip (MonadZip (..))
+import Data.Bifunctor (Bifunctor (..))
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Builder as BS
+import qualified Data.ByteString.Builder.Extra as BS
+import Data.Containers.NonEmpty (HasNonEmpty (..))
+import Data.Either (fromRight)
+import qualified Data.List.NonEmpty as NonEmpty
+import Data.Maybe (fromMaybe)
+import Data.Proxy (Proxy (..))
+import Data.Word (Word64)
+import GHC.Word (Word8)
+import Ouroboros.Consensus.Committee.Crypto
+  ( CryptoSupportsAggregateVoteSigning (..)
+  , CryptoSupportsBatchVRFVerification (..)
+  , CryptoSupportsVRF (..)
+  , CryptoSupportsVoteSigning (..)
+  , ElectionId
+  , PrivateKey
+  , PublicKey
+  , VRFPoolContext (..)
+  , VoteCandidate
+  )
+import Ouroboros.Consensus.Committee.Crypto.BLS (KeyRole (..))
+import qualified Ouroboros.Consensus.Committee.Crypto.BLS as BLS
+import Test.QuickCheck
+  ( Arbitrary (..)
+  , Gen
+  , Property
+  , Small (..)
+  , Testable (..)
+  , choose
+  , counterexample
+  , forAll
+  , frequency
+  , suchThat
+  , tabulate
+  , vectorOf
+  , (===)
+  )
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.QuickCheck (testProperty)
+import Test.Util.TestEnv (adjustQuickCheckTests)
+
+-- * Test crypto based on BLS signatures
+
+data TestCrypto
+
+type instance ElectionId TestCrypto = Word64
+type instance VoteCandidate TestCrypto = ByteString -- 32 bytes long
+
+type instance PrivateKey TestCrypto = (BLS.PrivateKey SIGN, BLS.PrivateKey VRF)
+type instance PublicKey TestCrypto = (BLS.PublicKey SIGN, BLS.PublicKey VRF)
+
+-- | Hash the message of a Peras vote
+--
+-- NOTE: this is inspired by the implementation used by the Praos VRF check in
+-- 'Ouroboros.Consensus.Protocol.Praos.VRF.mkInputVRF'.
+hashVoteSignature ::
+  ElectionId TestCrypto ->
+  VoteCandidate TestCrypto ->
+  Hash HASH (SigDSIGN BLS12381MinSigDSIGN)
+hashVoteSignature electionId candidate =
+  Hash.castHash
+    . Hash.hashWith id
+    . runByteBuilder (8 + 32)
+    $ electionIdBytes <> candidateBytes
+ where
+  electionIdBytes =
+    BS.word64BE electionId
+  candidateBytes =
+    BS.byteStringCopy candidate
+
+-- | Hash the input for the VRF used in Peras elections
+--
+-- NOTE: this is inspired by the implementation used by the Praos VRF check in
+-- 'Ouroboros.Consensus.Protocol.Praos.VRF.mkInputVRF'.
+hashVRFInput ::
+  ElectionId TestCrypto ->
+  Nonce ->
+  Hash HASH (SigDSIGN BLS12381MinSigDSIGN)
+hashVRFInput electionId epochNonce =
+  Hash.castHash
+    . Hash.hashWith id
+    . runByteBuilder (8 + 32)
+    $ electionIdBytes <> epochNonceBytes
+ where
+  electionIdBytes =
+    BS.word64BE electionId
+  epochNonceBytes =
+    case epochNonce of
+      NeutralNonce -> mempty
+      Nonce h -> BS.byteStringCopy (Hash.hashToBytes h)
+
+-- * Crypto instances
+
+instance CryptoSupportsVoteSigning TestCrypto where
+  type VoteSigningKey TestCrypto = BLS.PrivateKey SIGN
+  type VoteVerificationKey TestCrypto = BLS.PublicKey SIGN
+
+  newtype VoteSignature TestCrypto
+    = TestVoteSignature
+    { unTestVoteSignature :: BLS.Signature SIGN
+    }
+    deriving newtype (Show, Eq)
+
+  getVoteSigningKey _ = fst
+  getVoteVerificationKey _ = fst
+
+  signVote sk electionId candidate =
+    TestVoteSignature
+      . BLS.signWithRole @SIGN sk
+      $ hashVoteSignature electionId candidate
+
+  verifyVoteSignature pk electionId candidate (TestVoteSignature sig) =
+    BLS.verifyWithRole @SIGN
+      pk
+      (hashVoteSignature electionId candidate)
+      sig
+
+instance CryptoSupportsAggregateVoteSigning TestCrypto where
+  -- NOTE: in a real implementation, we would want to wrap these into newtypes
+  type AggregateVoteVerificationKey TestCrypto = VoteVerificationKey TestCrypto
+  type AggregateVoteSignature TestCrypto = VoteSignature TestCrypto
+
+  aggregateVoteVerificationKeys _ pks =
+    BLS.aggregatePublicKeys @SIGN pks
+
+  aggregateVoteSignatures _ sigs = do
+    aggSig <-
+      BLS.aggregateSignatures @SIGN
+        . fmap unTestVoteSignature
+        $ sigs
+    pure (TestVoteSignature aggSig)
+
+  verifyAggregateVoteSignature
+    _
+    aggPk
+    electionId
+    candidate
+    aggSig = do
+      BLS.verifyWithRole @SIGN
+        aggPk
+        (hashVoteSignature electionId candidate)
+        (unTestVoteSignature aggSig)
+
+instance CryptoSupportsVRF TestCrypto where
+  type VRFSigningKey TestCrypto = BLS.PrivateKey VRF
+  type VRFVerificationKey TestCrypto = BLS.PublicKey VRF
+
+  newtype VRFElectionInput TestCrypto
+    = TestVRFElectionInput
+    { unTestVRFElectionInput ::
+        Hash HASH (SigDSIGN BLS12381MinSigDSIGN)
+    }
+    deriving newtype (Show, Eq)
+
+  newtype VRFOutput TestCrypto
+    = TestVRFOutput
+    { unTestVRFOutput ::
+        BLS.Signature VRF
+    }
+    deriving newtype (Show, Eq)
+
+  getVRFSigningKey _ = snd
+  getVRFVerificationKey _ = snd
+
+  mkVRFElectionInput epochNonce electionId =
+    TestVRFElectionInput $
+      hashVRFInput electionId epochNonce
+
+  evalVRF context (TestVRFElectionInput input) =
+    case context of
+      VRFSignContext sk -> do
+        let sig = BLS.signWithRole @VRF sk input
+        pure $ TestVRFOutput sig
+      VRFVerifyContext pk (TestVRFOutput sig) -> do
+        BLS.verifyWithRole @VRF pk input sig
+        pure $ TestVRFOutput sig
+
+  normalizeVRFOutput (TestVRFOutput sig) =
+    BLS.toNormalizedVRFOutput sig
+
+instance CryptoSupportsBatchVRFVerification TestCrypto where
+  batchVerifyVRFOutputs
+    pks
+    (TestVRFElectionInput input)
+    sigs = do
+      BLS.linearizeAndVerifyVRFs
+        pks
+        input
+        . fmap unTestVRFOutput
+        $ sigs
+
+-- * QuickCheck helpers
+
+genEpochNonce :: Gen Nonce
+genEpochNonce =
+  frequency
+    [ (1, pure NeutralNonce)
+    , (9, mkNonceFromNumber <$> arbitrary)
+    ]
+
+genElectionId :: Gen (ElectionId TestCrypto)
+genElectionId =
+  getSmall <$> arbitrary
+
+genVoteCandidate :: Gen (VoteCandidate TestCrypto)
+genVoteCandidate =
+  BS.pack <$> vectorOf 32 (arbitrary @Word8)
+
+genKeyPair :: Gen (PrivateKey TestCrypto, PublicKey TestCrypto)
+genKeyPair = do
+  voteSigningKey <- genPrivateKey @SIGN
+  vrfSigningKey <- genPrivateKey @VRF
+  let voteVerificationKey = BLS.derivePublicKey voteSigningKey
+  let vrfVerificationKey = BLS.derivePublicKey vrfSigningKey
+  return
+    ( (voteSigningKey, vrfSigningKey)
+    , (voteVerificationKey, vrfVerificationKey)
+    )
+ where
+  genPrivateKey :: forall r. Gen (BLS.PrivateKey r)
+  genPrivateKey = do
+    fromMaybe (error "Failed to generate BLS private key")
+      . BLS.rawDeserialisePrivateKey @r "TEST"
+      . BS.pack
+      <$> vectorOf 32 (arbitrary @Word8)
+
+-- | Swap two distinct elements in a non-empty list.
+--
+-- PRECONDITION: the input list must have at least two elements.
+swapTwoElements :: NE [a] -> Gen (Int, Int, NE [a])
+swapTwoElements xs = do
+  let len = NonEmpty.length xs
+  when (len < 2) $
+    error "swapTwoElements requires a list with at least two elements"
+
+  i <- choose (0, len - 1)
+  j <- choose (0, len - 1) `suchThat` (/= i)
+  let maybeSwap k
+        | k == i = (NonEmpty.!!) xs j
+        | k == j = (NonEmpty.!!) xs i
+        | otherwise = (NonEmpty.!!) xs k
+  let xs' =
+        NonEmpty.fromList
+          [ maybeSwap k
+          | k <- [0 .. len - 1]
+          ]
+  return (i, j, xs')
+
+-- * Smoke test properties
+
+-- | Round trip test for vote signatures
+prop_SignAndVerifyVote :: Property
+prop_SignAndVerifyVote =
+  forAll genElectionId $ \electionId ->
+    forAll genVoteCandidate $ \candidate ->
+      forAll genKeyPair $ \(sk, pk) -> do
+        let voteSigningKey = getVoteSigningKey (Proxy @TestCrypto) sk
+        let voteVerificationKey = getVoteVerificationKey (Proxy @TestCrypto) pk
+        let sig = signVote @TestCrypto voteSigningKey electionId candidate
+        case ( verifyVoteSignature @TestCrypto
+                 voteVerificationKey
+                 electionId
+                 candidate
+                 sig
+             ) of
+          Left err ->
+            counterexample
+              ("Round trip verification failed: " <> err)
+              $ property False
+          Right () ->
+            property True
+
+-- | Round trip test for aggregate vote signatures
+prop_SignAndVerifyAggregateVote :: Property
+prop_SignAndVerifyAggregateVote =
+  forAll genElectionId $ \electionId ->
+    forAll genVoteCandidate $ \candidate ->
+      forAll (choose (1, 10)) $ \numSigners ->
+        forAll (vectorOf numSigners genKeyPair) $ \keyPairs -> do
+          let (voteSigningKeys, voteVerificationKeys) =
+                munzip
+                  . NonEmpty.fromList
+                  . fmap (first (getVoteSigningKey (Proxy @TestCrypto)))
+                  . fmap (second (getVoteVerificationKey (Proxy @TestCrypto)))
+                  $ keyPairs
+          let aggVoteSignature =
+                fromRight (error "Failed to aggregate vote signatures")
+                  . aggregateVoteSignatures (Proxy @TestCrypto)
+                  . fmap (\sk -> signVote @TestCrypto sk electionId candidate)
+                  $ voteSigningKeys
+          let aggVoteVerificationKey =
+                fromRight (error "Failed to aggregate vote verification keys")
+                  . aggregateVoteVerificationKeys (Proxy @TestCrypto)
+                  $ voteVerificationKeys
+          tabulate "Number of vote signers" [show numSigners] $
+            case ( verifyAggregateVoteSignature
+                     (Proxy @TestCrypto)
+                     aggVoteVerificationKey
+                     electionId
+                     candidate
+                     aggVoteSignature
+                 ) of
+              Left err ->
+                counterexample
+                  ("Aggregate vote verification failed: " <> err)
+                  $ property False
+              Right () ->
+                property True
+
+-- | Round trip test for VRF evaluation
+prop_EvalAndVerifyVRFOutput :: Property
+prop_EvalAndVerifyVRFOutput =
+  forAll genElectionId $ \electionId ->
+    forAll genEpochNonce $ \epochNonce ->
+      forAll genKeyPair $ \(sk, pk) -> do
+        let vrfSigningKey = getVRFSigningKey (Proxy @TestCrypto) sk
+        let vrfVerificationKey = getVRFVerificationKey (Proxy @TestCrypto) pk
+        let input = mkVRFElectionInput @TestCrypto epochNonce electionId
+        case ( evalVRF @TestCrypto
+                 (VRFSignContext vrfSigningKey)
+                 input
+             ) of
+          Left err ->
+            counterexample
+              ("VRF evaluation failed: " <> err)
+              $ property False
+          Right output ->
+            case ( evalVRF @TestCrypto
+                     (VRFVerifyContext vrfVerificationKey output)
+                     input
+                 ) of
+              Left err ->
+                counterexample
+                  ("VRF verification failed: " <> err)
+                  $ property False
+              Right output' ->
+                counterexample
+                  "VRF output mismatch"
+                  $ output === output'
+
+-- | Round trip test for aggregate VRF evaluation
+prop_EvalAndVerifyAggregateVRFOutput :: Property
+prop_EvalAndVerifyAggregateVRFOutput =
+  forAll genElectionId $ \electionId ->
+    forAll genEpochNonce $ \epochNonce ->
+      forAll (choose (1, 10)) $ \numSigners ->
+        forAll (vectorOf numSigners genKeyPair) $ \keyPairs -> do
+          let (vrfSigningKeys, vrfVerificationKeys) =
+                munzip
+                  . NonEmpty.fromList
+                  . fmap (first (getVRFSigningKey (Proxy @TestCrypto)))
+                  . fmap (second (getVRFVerificationKey (Proxy @TestCrypto)))
+                  $ keyPairs
+          let input = mkVRFElectionInput @TestCrypto epochNonce electionId
+          tabulate "Number of VRF signers" [show numSigners] $
+            case ( traverse
+                     (\sk -> evalVRF @TestCrypto (VRFSignContext sk) input)
+                     vrfSigningKeys
+                 ) of
+              Left err ->
+                counterexample
+                  ("VRF evaluation failed: " <> err)
+                  $ property False
+              Right vrfOutputs -> do
+                case ( batchVerifyVRFOutputs @TestCrypto
+                         vrfVerificationKeys
+                         input
+                         vrfOutputs
+                     ) of
+                  Left err ->
+                    counterexample
+                      ("Aggregate VRF verification failed: " <> err)
+                      $ property False
+                  Right () ->
+                    property True
+
+-- | Test resilience against swap attacks on aggregate VRF verification
+prop_SwapAttackOnAggregateVRF :: Property
+prop_SwapAttackOnAggregateVRF =
+  forAll genElectionId $ \electionId ->
+    forAll genEpochNonce $ \epochNonce ->
+      forAll (choose (2, 10)) $ \numSigners ->
+        forAll (vectorOf numSigners genKeyPair) $ \keyPairs -> do
+          let (vrfSigningKeys, vrfVerificationKeys) =
+                munzip
+                  . NonEmpty.fromList
+                  . fmap (first (getVRFSigningKey (Proxy @TestCrypto)))
+                  . fmap (second (getVRFVerificationKey (Proxy @TestCrypto)))
+                  $ keyPairs
+          let input = mkVRFElectionInput @TestCrypto epochNonce electionId
+          tabulate "Number of VRF signers" [show numSigners] $
+            case ( traverse
+                     (\sk -> evalVRF @TestCrypto (VRFSignContext sk) input)
+                     vrfSigningKeys
+                 ) of
+              Left err ->
+                counterexample
+                  ("VRF evaluation failed: " <> err)
+                  $ property False
+              Right vrfOutputs -> do
+                forAll (swapTwoElements vrfOutputs) $ \(i, j, swappedVRFOutputs) -> do
+                  case ( batchVerifyVRFOutputs @TestCrypto
+                           vrfVerificationKeys
+                           input
+                           swappedVRFOutputs
+                       ) of
+                    Left _ ->
+                      property True
+                    Right () ->
+                      counterexample
+                        ( "Aggregate VRF verification should have failed when "
+                            <> "swapping outputs at indices "
+                            <> show i
+                            <> " and "
+                            <> show j
+                        )
+                        $ property False
+
+-- | Associativity of aggregate vote verification keys.
+--
+-- NOTE: this is desirable if we want aggregate keys to be a closed Semigroup
+-- under real BLS aggregation (modulo rare aggregation failures). This means
+-- that we can either choose to collect all keys and aggregate them at once, or
+-- we can partially aggregate them as we go, keeping only a single aggregate key
+-- in memory at any time.
+prop_AssociativityOfAggregateKeys :: Property
+prop_AssociativityOfAggregateKeys =
+  forAll genKeyPair $ \(_, pk1) ->
+    forAll genKeyPair $ \(_, pk2) ->
+      forAll genKeyPair $ \(_, pk3) -> do
+        let toAggKey pk =
+              NonEmpty.singleton
+                . getVoteVerificationKey (Proxy @TestCrypto)
+                $ pk
+        let pk1' = toAggKey pk1
+        let pk2' = toAggKey pk2
+        let pk3' = toAggKey pk3
+        let lhs = do
+              pk12' <- NonEmpty.singleton <$> BLS.aggregatePublicKeys (pk1' <> pk2')
+              BLS.aggregatePublicKeys (pk12' <> pk3')
+        let rhs = do
+              pk23' <- NonEmpty.singleton <$> BLS.aggregatePublicKeys (pk2' <> pk3')
+              BLS.aggregatePublicKeys (pk1' <> pk23')
+        counterexample
+          "Aggregate vote verification keys should be associative"
+          $ lhs === rhs
+
+-- | Associativity of aggregate VRF verification keys.
+--
+-- NOTE: this is desirable if we want aggregate keys to be a closed Semigroup
+-- under real BLS aggregation (modulo rare aggregation failures). This means
+-- that we can either choose to collect all keys and aggregate them at once, or
+-- we can partially aggregate them as we go, keeping only a single aggregate key
+-- in memory at any time.
+prop_AssociativityOfAggregateVRFKeys :: Property
+prop_AssociativityOfAggregateVRFKeys =
+  forAll genKeyPair $ \(_, pk1) ->
+    forAll genKeyPair $ \(_, pk2) ->
+      forAll genKeyPair $ \(_, pk3) -> do
+        let toAggKey pk =
+              NonEmpty.singleton
+                . getVRFVerificationKey (Proxy @TestCrypto)
+                $ pk
+        let pk1' = toAggKey pk1
+        let pk2' = toAggKey pk2
+        let pk3' = toAggKey pk3
+        let lhs = do
+              pk12' <- NonEmpty.singleton <$> BLS.aggregatePublicKeys (pk1' <> pk2')
+              BLS.aggregatePublicKeys (pk12' <> pk3')
+        let rhs = do
+              pk23' <- NonEmpty.singleton <$> BLS.aggregatePublicKeys (pk2' <> pk3')
+              BLS.aggregatePublicKeys (pk1' <> pk23')
+        counterexample
+          "Aggregate VRF verification keys should be associative"
+          $ lhs === rhs
+
+tests :: TestTree
+tests =
+  testGroup
+    "TestCrypto properties"
+    [ adjustQuickCheckTests (* 10) $
+        testProperty
+          "prop_SignAndVerifyVote"
+          prop_SignAndVerifyVote
+    , adjustQuickCheckTests (* 10) $
+        testProperty
+          "prop_SignAndVerifyAggregateVote"
+          prop_SignAndVerifyAggregateVote
+    , adjustQuickCheckTests (* 10) $
+        testProperty
+          "prop_EvalAndVerifyVRFOutput"
+          prop_EvalAndVerifyVRFOutput
+    , adjustQuickCheckTests (* 10) $
+        testProperty
+          "prop_EvalAndVerifyAggregateVRFOutput"
+          prop_EvalAndVerifyAggregateVRFOutput
+    , adjustQuickCheckTests (* 10) $
+        testProperty
+          "prop_SwapAttackOnAggregateVRF"
+          prop_SwapAttackOnAggregateVRF
+    , adjustQuickCheckTests (* 10) $
+        testProperty
+          "prop_AssociativityOfAggregateKeys"
+          prop_AssociativityOfAggregateKeys
+    , adjustQuickCheckTests (* 10) $
+        testProperty
+          "prop_AssociativityOfAggregateVRFKeys"
+          prop_AssociativityOfAggregateVRFKeys
+    ]


### PR DESCRIPTION
This PR:

1. Implements crypto utilities needed instantiate concrete voting committee implementations with BLS crypto, and
2. a `TestCrypto` scheme defined around these utilities, with:
    + instances for all the type classes relevant to committee selection, and
    + property tests for round-trips and resilience to swap attacks

NOTES:

* #1977 instantiates both `WFALS` and `EveryoneVotes` with `TestCrypto` to define property tests.

* This is a reopened version of https://github.com/IntersectMBO/ouroboros-consensus/pull/1976, that got automatically closed (and locked) by GitHub after reordering two branches in this PR stack.