### PR TITLE
Peras: Add asserts in the implForgeCert

### DIFF
--- a/changelog.d/20260619_172515_alexander.vershilov_assert_votes_size.md
+++ b/changelog.d/20260619_172515_alexander.vershilov_assert_votes_size.md
@@ -1,0 +1,24 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+<!--
+### Breaking
+
+- A bullet item for the Breaking category.
+
+-->
+### Non-Breaking
+
+- Extend `implForgeCert` with assertions that verify that ordering function
+  is compatible with the one used during certificates verification
+
+<!--
+### Patch
+
+- A bullet item for the Patch category.
+
+-->

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Committee/EveryoneVotes.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Committee/EveryoneVotes.hs
@@ -23,6 +23,7 @@ module Ouroboros.Consensus.Committee.EveryoneVotes
 
 import Cardano.Ledger.BaseTypes (NonZero)
 import Cardano.Ledger.BaseTypes.NonZero (NonZero (..), nonZero)
+import Control.Exception (assert)
 import Control.Monad.Zip (MonadZip (..))
 import qualified Data.Array as Array
 import Data.Bifunctor (Bifunctor (..))
@@ -251,19 +252,29 @@ implForgeCert ::
   Either
     (VotingCommitteeError crypto EveryoneVotes)
     (Cert crypto EveryoneVotes)
-implForgeCert votes = do
-  aggSig <-
-    bimap CryptoError id $ do
-      aggregateVoteSignatures
-        (Proxy @crypto)
-        voteSignatures
-  pure $
-    EveryoneVotesCert
-      (getElectionIdFromVotes votes)
-      (getVoteCandidateFromVotes votes)
-      (NESet.fromList voters)
-      aggSig
+implForgeCert votes =
+  assert allUniqueVoterSeats $ do
+    aggSig <-
+      bimap CryptoError id $ do
+        aggregateVoteSignatures
+          (Proxy @crypto)
+          voteSignatures
+
+    pure $
+      EveryoneVotesCert
+        (getElectionIdFromVotes votes)
+        (getVoteCandidateFromVotes votes)
+        voterMap
+        aggSig
  where
+  -- We want to fail fast in case if the number of votes is not the same
+  -- as voters representation in EveryoneVotes. This assumption may be
+  -- violated in case if implementation uses incorrect ordering function
+  -- in the `ensureUniqueVotesWithSameTarget`
+  allUniqueVoterSeats =
+    NESet.size voterMap == length voters
+      && NESet.size voterMap == length voteSignatures
+  voterMap = NESet.fromList voters
   (voters, voteSignatures) =
     munzip $ flip fmap votesInAscendingSeatIndexOrder $ \case
       EveryoneVotesVote seatIndex _ _ sig ->

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Committee/WFALS.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Committee/WFALS.hs
@@ -41,6 +41,7 @@ module Ouroboros.Consensus.Committee.WFALS
   ) where
 
 import Cardano.Ledger.BaseTypes (NonZero (..), Nonce, nonZero)
+import Control.Exception (assert)
 import Control.Monad (void)
 import Control.Monad.Zip (MonadZip (..))
 import qualified Data.Array as Array
@@ -438,19 +439,28 @@ implForgeCert ::
   Either
     (VotingCommitteeError crypto WFALS)
     (Cert crypto WFALS)
-implForgeCert votes = do
-  aggSig <-
-    bimap CryptoError id $
-      aggregateVoteSignatures
-        (Proxy @crypto)
-        voteSignatures
-  pure $
-    WFALSCert
-      (getElectionIdFromVotes votes)
-      (getVoteCandidateFromVotes votes)
-      (NEMap.fromAscList voters)
-      aggSig
+implForgeCert votes =
+  assert allUniqueVoterSeats $ do
+    aggSig <-
+      bimap CryptoError id $
+        aggregateVoteSignatures
+          (Proxy @crypto)
+          voteSignatures
+    pure $
+      WFALSCert
+        (getElectionIdFromVotes votes)
+        (getVoteCandidateFromVotes votes)
+        voterMap
+        aggSig
  where
+  -- We want to fail fast in case if the number of votes is not the same
+  -- as voters representation in WFALSCert. This assumption may be
+  -- violated in case if implementation uses incorrect ordering function
+  -- in the `ensureUniqueVotesWithSameTarget`
+  allUniqueVoterSeats =
+    NEMap.size voterMap == length voters
+      && NEMap.size voterMap == length voteSignatures
+  voterMap = NEMap.fromAscList voters
   (voters, voteSignatures) =
     munzip $ flip fmap votesInAscendingSeatIndexOrder $ \case
       WFALSPersistentVote seatIndex _ _ sig ->


### PR DESCRIPTION
There is a chance that incompatible ordering functions may be passed to the `verifyCert`. And we need to catch this problem sooner and prevent from building incorrect cert with mismatched amount of votes, so we add a check that the size of the deduplicated voters and certs is the same.

See https://github.com/tweag/cardano-peras/issues/240 for the deeper discussion.

# Description

Please include a meaningful description of the PR and link the relevant issues
this PR might resolve.

Also note that:

- New code should be properly tested (even if it does not add new features).
- The fix for a regression should include a test that reproduces said regression.

# WARNING

To update your feature branch if it's stale, please rebase it manually on top of `main`. Don't update your feature branch by merging `main` into it. Your pull request will not pass CI if you do.
