### PR TITLE
Rename `Test.Consensus.Node` to `Test.Consensus.DBLock`

### DIFF
--- a/ouroboros-consensus-diffusion/test/consensus-test/Main.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Main.hs
@@ -1,11 +1,11 @@
 module Main (main) where
 
 import qualified Test.Consensus.BlockTree.Tests (tests)
+import qualified Test.Consensus.DBLock (tests)
 import qualified Test.Consensus.GSM (tests)
 import qualified Test.Consensus.Genesis.TestSuite.SmallKey.Tests (tests)
 import qualified Test.Consensus.Genesis.Tests (tests)
 import qualified Test.Consensus.HardFork.Combinator (tests)
-import qualified Test.Consensus.Node (tests)
 import qualified Test.Consensus.PeerSimulator.Tests (tests)
 import qualified Test.Consensus.PointSchedule.Shrinking.Tests (tests)
 import qualified Test.Consensus.PointSchedule.Tests (tests)
@@ -22,7 +22,7 @@ tests :: TestTree
 tests =
   testGroup
     "ouroboros-consensus"
-    [ Test.Consensus.Node.tests
+    [ Test.Consensus.DBLock.tests
     , testGroup
         "HardFork"
         [ testGroup

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/DBLock.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/DBLock.hs
@@ -17,7 +17,7 @@
 --
 -- This module contains a bunch of unit tests to make sure that these locks and
 -- markers are created correctly and behave as expected.
-module Test.Consensus.Node (tests) where
+module Test.Consensus.DBLock (tests) where
 
 import Control.Monad.Class.MonadTimer.SI (MonadTimer)
 import Control.Monad.IOSim (runSimOrThrow)
@@ -46,7 +46,7 @@ import Test.Util.QuickCheck (ge)
 tests :: TestTree
 tests =
   testGroup
-    "Node"
+    "DBLock"
     [ testGroup
         "checkDbMarker"
         [ testCase "match" test_checkNetworkMagic_match

--- a/ouroboros-consensus.cabal
+++ b/ouroboros-consensus.cabal
@@ -1183,6 +1183,7 @@ test-suite consensus-diffusion-test
   other-modules:
     Test.Consensus.BlockTree
     Test.Consensus.BlockTree.Tests
+    Test.Consensus.DBLock
     Test.Consensus.Genesis.Setup
     Test.Consensus.Genesis.Setup.Classifiers
     Test.Consensus.Genesis.Setup.GenChains
@@ -1202,7 +1203,6 @@ test-suite consensus-diffusion-test
     Test.Consensus.HardFork.Combinator.A
     Test.Consensus.HardFork.Combinator.B
     Test.Consensus.Network.AnchoredFragment.Extras
-    Test.Consensus.Node
     Test.Consensus.PeerSimulator.BlockFetch
     Test.Consensus.PeerSimulator.ChainSync
     Test.Consensus.PeerSimulator.Config


### PR DESCRIPTION
Fix https://github.com/IntersectMBO/ouroboros-network/issues/4304

# Description

Renames the `Test.Consensus.Node` to `Test.Consensus.DBLock`

Tested:
```sh
cabal build all
cabal test ouroboros-consensus:test:consensus-test
cabal test ouroboros-consensus:test:consensus-diffusion-test
```
