### PR TITLE
Fix typo in roundtrip tests

### DIFF
--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/Serialisation/Roundtrip.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/Serialisation/Roundtrip.hs
@@ -174,7 +174,7 @@ roundtripAnd check enc dec checkCddlValid a =
         case mkA' bs of
           Left err -> Left (showByteString bsRem err)
           Right a' ->
-            a == a' ?! pShowNeq a a
+            a == a' ?! pShowNeq a a'
       cddlValid =
         monadicIO $
           run (checkCddlValid $ Lazy.toStrict bs) >>= \case


### PR DESCRIPTION
`pShowNeq` was given the same value twice so failures in rountrip tests are very confusing

