### PR TITLE
Switch Windows cross compilation to use GHC 9.12

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -46,9 +46,6 @@ if os (windows)
 
 constraints:
   tasty <1.5.4,
-  plutus-core ^>=1.61,
-  plutus-ledger-api ^>=1.61,
-  plutus-tx ^>=1.61
 
 -- ouroboros-network dependency after introducing `bracketKeepAlive` (PR#5371)
 source-repository-package

--- a/nix/ci.nix
+++ b/nix/ci.nix
@@ -50,7 +50,7 @@ let
     };
   } // lib.optionalAttrs (buildSystem == "x86_64-linux") {
     windows = {
-      haskell96 = mkHaskellJobsFor pkgs.hsPkgs.projectCross.ucrt64;
+      haskell912 = mkHaskellJobsFor pkgs.hsPkgs.projectVariants.ghc912.projectCross.ucrt64;
     };
   });
 


### PR DESCRIPTION
GHC 9.6.7 can't compile Plutus >1.61. We use 9.12 only for the Hydra cross compilation.