### PR TITLE
Leios: hot fix CertRB staging area + emergency fetch + resolve CertRBs in immutable chain

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -55,12 +55,13 @@ source-repository-package
     cardano-diffusion
     network-mux
 
--- Points to ouroboros-ledger/ch1bo/leios-staging-area
+
+-- Points to ouroboros-ledger/leios-prototype
 source-repository-package
   type: git
   location: https://github.com/IntersectMBO/cardano-ledger
-  tag: dff221b6915bd694f1b0a740d010b13e436bbe06
-  --sha256: sha256-QAk7lH9cKNxWxCMtwMGjvX2bW5tdT+cAdWkibLy6VOE=
+  tag: c47305fcf47bd77437b837d0dfb9cb4181bfbc77
+  --sha256: sha256-U9luV5wuSytDg4zbXZnyQo29Jn4fZ10GKI8Q/QTrYrU=
   subdir:
     libs/cardano-ledger-core
     eras/dijkstra/impl

--- a/cabal.project
+++ b/cabal.project
@@ -55,12 +55,12 @@ source-repository-package
     cardano-diffusion
     network-mux
 
--- Points to ouroboros-ledger/leios-prototype-remake
+-- Points to ouroboros-ledger/ch1bo/leios-staging-area
 source-repository-package
   type: git
   location: https://github.com/IntersectMBO/cardano-ledger
-  tag: c47305fcf47bd77437b837d0dfb9cb4181bfbc77
-  --sha256: 1db2xc2gs44g5035srqzgqkbv3a2yacmvnwchd1jnjrfkibnxnak
+  tag: dff221b6915bd694f1b0a740d010b13e436bbe06
+  --sha256: sha256-QAk7lH9cKNxWxCMtwMGjvX2bW5tdT+cAdWkibLy6VOE=
   subdir:
     libs/cardano-ledger-core
     eras/dijkstra/impl

--- a/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/Block.hs
+++ b/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/Block.hs
@@ -1541,10 +1541,9 @@ instance
       fmap BlockDijkstra <$> resolveLeiosBlockHdr db prevAnn dijkstraBlk
     _ -> pure Nothing
 
-  checkLeiosBlockResolvable db blk = case blk of
-    BlockDijkstra dijkstraBlk ->
-      checkLeiosBlockResolvable db dijkstraBlk
-    _ -> pure Nothing
+  blockHasLeiosCert blk = case blk of
+    BlockDijkstra dijkstraBlk -> blockHasLeiosCert dijkstraBlk
+    _ -> False
 
   headerLeiosAnnouncement hdr = case hdr of
     HeaderDijkstra dHdr -> headerLeiosAnnouncement dHdr

--- a/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/Block.hs
+++ b/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/Block.hs
@@ -1541,6 +1541,11 @@ instance
       fmap BlockDijkstra <$> resolveLeiosBlockHdr db prevAnn dijkstraBlk
     _ -> pure Nothing
 
+  checkLeiosBlockResolvable db blk = case blk of
+    BlockDijkstra dijkstraBlk ->
+      checkLeiosBlockResolvable db dijkstraBlk
+    _ -> pure Nothing
+
   headerLeiosAnnouncement hdr = case hdr of
     HeaderDijkstra dHdr -> headerLeiosAnnouncement dHdr
     _ -> Nothing

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Forge.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Forge.hs
@@ -38,7 +38,7 @@ import LeiosDemoTypes
   , ForgedLeiosEb (..)
   , LeiosPoint (..)
   , TraceLeiosKernel (..)
-  , encodeLeiosCertPoint
+  , encodeLeiosCertInfo
   , forgeLeiosEb
   , leiosEbBytesSize
   , minCertificationGap
@@ -159,6 +159,7 @@ forgeShelleyBlock hotKey cbl ForgeBlockArgs{..} = do
                     { pointSlotNo = prevSlotNo
                     , pointEbHash = ebAnnouncementHash ann
                     }
+                ebSize = ebAnnouncementSize ann
             mClosure <- leiosDbQueryCompletedEbByPoint fbLeiosDb ebPoint
             case mClosure of
               Nothing -> do
@@ -181,7 +182,7 @@ forgeShelleyBlock hotKey cbl ForgeBlockArgs{..} = do
                     pure
                       ( SJust
                           ( LeiosCert
-                              (encodeLeiosCertPoint ebPoint)
+                              (encodeLeiosCertInfo ebPoint ebSize)
                           )
                       )
 

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Forge.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Forge.hs
@@ -38,6 +38,7 @@ import LeiosDemoTypes
   , ForgedLeiosEb (..)
   , LeiosPoint (..)
   , TraceLeiosKernel (..)
+  , encodeLeiosCertPoint
   , forgeLeiosEb
   , leiosEbBytesSize
   , minCertificationGap
@@ -177,7 +178,12 @@ forgeShelleyBlock hotKey cbl ForgeBlockArgs{..} = do
                     traceWith fbLeiosTracer $
                       MkTraceLeiosKernel $
                         "Certifying EB at " <> show ebPoint
-                    pure (SJust LeiosCert)
+                    pure
+                      ( SJust
+                          ( LeiosCert
+                              (encodeLeiosCertPoint ebPoint)
+                          )
+                      )
 
   -- Produce an EB from fbEbTxs, store it into fbLeiosDb, and return the
   -- announcement to embed in the header. An honest forger only emits an

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Forge.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Forge.hs
@@ -38,7 +38,6 @@ import LeiosDemoTypes
   , ForgedLeiosEb (..)
   , LeiosPoint (..)
   , TraceLeiosKernel (..)
-  , encodeLeiosCertInfo
   , forgeLeiosEb
   , leiosEbBytesSize
   , minCertificationGap
@@ -159,7 +158,6 @@ forgeShelleyBlock hotKey cbl ForgeBlockArgs{..} = do
                     { pointSlotNo = prevSlotNo
                     , pointEbHash = ebAnnouncementHash ann
                     }
-                ebSize = ebAnnouncementSize ann
             mClosure <- leiosDbQueryCompletedEbByPoint fbLeiosDb ebPoint
             case mClosure of
               Nothing -> do
@@ -179,12 +177,7 @@ forgeShelleyBlock hotKey cbl ForgeBlockArgs{..} = do
                     traceWith fbLeiosTracer $
                       MkTraceLeiosKernel $
                         "Certifying EB at " <> show ebPoint
-                    pure
-                      ( SJust
-                          ( LeiosCert
-                              (encodeLeiosCertInfo ebPoint ebSize)
-                          )
-                      )
+                    pure (SJust LeiosCert)
 
   -- Produce an EB from fbEbTxs, store it into fbLeiosDb, and return the
   -- announcement to embed in the header. An honest forger only emits an

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Ledger.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Ledger.hs
@@ -119,6 +119,7 @@ import LeiosDemoTypes
   ( EbAnnouncement (..)
   , LeiosPoint (..)
   , TxHash
+  , decodeLeiosCertPoint
   )
 import Lens.Micro
 import Lens.Micro.Extras (view)
@@ -1004,10 +1005,15 @@ instance
                   , pointEbHash = ebAnnouncementHash ann
                   }
             case mAnnouncedEb of
-              Nothing ->
-                error $
-                  "FIXME(bladyjoker): What exactly does this mean? Announced EB is being certified by the current chain but it's not available?"
-                    <> show cert
+              -- Issue #890: closure missing locally. Instead of
+              -- crashing, leave the body unchanged (empty txs) so the
+              -- chain can advance. The block's txs effectively don't
+              -- apply, but the node stays operational. The CertRB
+              -- staging area (wrapChainDbViewForLeiosStaging) is the
+              -- intended primary defence; this branch is the in-apply
+              -- safety net for the fork / racy-ChainSel cases the gate
+              -- can't catch.
+              Nothing -> pure blk
               Just announcedEb ->
                 pure $
                   blk{shelleyBlockRaw = Core.Block hdr body'}
@@ -1031,6 +1037,23 @@ instance
             body' = body & Core.txSeqBlockBodyL .~ txSeq
    where
     Core.Block hdr body = shelleyBlockRaw blk
+
+  checkLeiosBlockResolvable leiosDb blk =
+    case body ^. leiosCertBlockBodyL of
+      SNothing -> pure Nothing
+      SJust cert ->
+        case decodeLeiosCertPoint cert of
+          Left err ->
+            error $
+              "checkLeiosBlockResolvable: malformed LeiosCert payload: "
+                <> show err
+          Right point -> do
+            mAnnouncedEb <- leiosDbQueryCompletedEbByPoint leiosDb point
+            pure $ case mAnnouncedEb of
+              Nothing -> Just point
+              Just _ -> Nothing
+   where
+    Core.Block _ body = shelleyBlockRaw blk
 
   headerLeiosAnnouncement hdr =
     case hbLeiosEbAnnouncement annBody of

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Ledger.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Ledger.hs
@@ -119,7 +119,6 @@ import LeiosDemoTypes
   ( EbAnnouncement (..)
   , LeiosPoint (..)
   , TxHash
-  , decodeLeiosCertInfo
   )
 import Lens.Micro
 import Lens.Micro.Extras (view)
@@ -1011,7 +1010,7 @@ instance
                     <> show ann
                     <> " at last-slot "
                     <> show (praosStateLastSlot praosSt)
-                    <> " absent. Cert payload bytes: "
+                    <> " absent; cert: "
                     <> show cert
               Just announcedEb ->
                 pure $
@@ -1037,20 +1036,9 @@ instance
    where
     Core.Block hdr body = shelleyBlockRaw blk
 
-  checkLeiosBlockResolvable leiosDb blk =
-    case body ^. leiosCertBlockBodyL of
-      SNothing -> pure Nothing
-      SJust cert ->
-        case decodeLeiosCertInfo cert of
-          Left err ->
-            error $
-              "checkLeiosBlockResolvable: malformed LeiosCert payload: "
-                <> show err
-          Right (point, size) -> do
-            mAnnouncedEb <- leiosDbQueryCompletedEbByPoint leiosDb point
-            pure $ case mAnnouncedEb of
-              Nothing -> Just (point, size)
-              Just _ -> Nothing
+  blockHasLeiosCert blk = case body ^. leiosCertBlockBodyL of
+    SNothing -> False
+    SJust _ -> True
    where
     Core.Block _ body = shelleyBlockRaw blk
 
@@ -1059,10 +1047,12 @@ instance
       SNothing -> Nothing
       SJust ann ->
         Just
-          MkLeiosPoint
-            { pointSlotNo = hbSlotNo annBody
-            , pointEbHash = ebAnnouncementHash ann
-            }
+          ( MkLeiosPoint
+              { pointSlotNo = hbSlotNo annBody
+              , pointEbHash = ebAnnouncementHash ann
+              }
+          , ebAnnouncementSize ann
+          )
    where
     annBody :: HeaderBody c
     Header{headerBody = annBody} = shelleyHeaderRaw hdr

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Ledger.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Ledger.hs
@@ -119,7 +119,7 @@ import LeiosDemoTypes
   ( EbAnnouncement (..)
   , LeiosPoint (..)
   , TxHash
-  , decodeLeiosCertPoint
+  , decodeLeiosCertInfo
   )
 import Lens.Micro
 import Lens.Micro.Extras (view)
@@ -1005,15 +1005,14 @@ instance
                   , pointEbHash = ebAnnouncementHash ann
                   }
             case mAnnouncedEb of
-              -- Issue #890: closure missing locally. Instead of
-              -- crashing, leave the body unchanged (empty txs) so the
-              -- chain can advance. The block's txs effectively don't
-              -- apply, but the node stays operational. The CertRB
-              -- staging area (wrapChainDbViewForLeiosStaging) is the
-              -- intended primary defence; this branch is the in-apply
-              -- safety net for the fork / racy-ChainSel cases the gate
-              -- can't catch.
-              Nothing -> pure blk
+              Nothing ->
+                error $
+                  "Issue #890 gate missed: apply-time resolve found EB "
+                    <> show ann
+                    <> " at last-slot "
+                    <> show (praosStateLastSlot praosSt)
+                    <> " absent. Cert payload bytes: "
+                    <> show cert
               Just announcedEb ->
                 pure $
                   blk{shelleyBlockRaw = Core.Block hdr body'}
@@ -1042,15 +1041,15 @@ instance
     case body ^. leiosCertBlockBodyL of
       SNothing -> pure Nothing
       SJust cert ->
-        case decodeLeiosCertPoint cert of
+        case decodeLeiosCertInfo cert of
           Left err ->
             error $
               "checkLeiosBlockResolvable: malformed LeiosCert payload: "
                 <> show err
-          Right point -> do
+          Right (point, size) -> do
             mAnnouncedEb <- leiosDbQueryCompletedEbByPoint leiosDb point
             pure $ case mAnnouncedEb of
-              Nothing -> Just point
+              Nothing -> Just (point, size)
               Just _ -> Nothing
    where
     Core.Block _ body = shelleyBlockRaw blk

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Run.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Run.hs
@@ -81,16 +81,17 @@ openLedgerDB args =
   runWithTempRegistry $
     (,()) <$> do
       (ldb, _, od) <- case LedgerDB.lgrBackendArgs args of
-        LedgerDB.LedgerDbBackendArgsV1 bss ->
+        LedgerDB.LedgerDbBackendArgsV1 bss -> do
           let snapManager = LedgerDB.V1.snapshotManager args
-              initDb =
-                LedgerDB.V1.mkInitDb
-                  args
-                  bss
-                  (\_ -> pure (error "no stream"))
-                  snapManager
-                  (LedgerDB.praosGetVolatileSuffix $ LedgerDB.ledgerDbCfgSecParam $ LedgerDB.lgrConfig args)
-           in lift $ LedgerDB.openDBInternal args initDb snapManager emptyStream genesisPoint
+          initDb <-
+            lift $
+              LedgerDB.V1.mkInitDb
+                args
+                bss
+                (\_ -> pure (error "no stream"))
+                snapManager
+                (LedgerDB.praosGetVolatileSuffix $ LedgerDB.ledgerDbCfgSecParam $ LedgerDB.lgrConfig args)
+          lift $ LedgerDB.openDBInternal args initDb snapManager emptyStream genesisPoint
         LedgerDB.LedgerDbBackendArgsV2 (LedgerDB.V2.SomeBackendArgs bArgs) -> do
           res <-
             LedgerDB.V2.mkResources
@@ -105,13 +106,14 @@ openLedgerDB args =
                   (configCodec . getExtLedgerCfg . LedgerDB.ledgerDbCfg $ LedgerDB.lgrConfig args)
                   (LedgerDBSnapshotEvent >$< LedgerDB.lgrTracer args)
                   (LedgerDB.lgrHasFS args)
-          let initDb =
-                LedgerDB.V2.mkInitDb
-                  args
-                  (\_ -> pure (error "no stream"))
-                  snapManager
-                  (LedgerDB.praosGetVolatileSuffix $ LedgerDB.ledgerDbCfgSecParam $ LedgerDB.lgrConfig args)
-                  res
+          initDb <-
+            lift $
+              LedgerDB.V2.mkInitDb
+                args
+                (\_ -> pure (error "no stream"))
+                snapManager
+                (LedgerDB.praosGetVolatileSuffix $ LedgerDB.ledgerDbCfgSecParam $ LedgerDB.lgrConfig args)
+                res
           lift $ LedgerDB.openDBInternal args initDb snapManager emptyStream genesisPoint
       pure (ldb, od)
 

--- a/ouroboros-consensus-cardano/test/cardano-test/Test/ThreadNet/Leios.hs
+++ b/ouroboros-consensus-cardano/test/cardano-test/Test/ThreadNet/Leios.hs
@@ -407,7 +407,7 @@ prop_leios_late_join seed =
               counterexample ("threw: " <> show e) False
           Right _ -> property True
  where
-  numSlots = 60 :: Word64 -- TODO restore to 200 once perf is fixed
+  numSlots = 200 :: Word64
 
 -- | Independently compute cumulative tx bytes by resolving each block in the
 -- chain (filling in EB closures from the LeiosDB) and summing individual

--- a/ouroboros-consensus-cardano/test/cardano-test/Test/ThreadNet/Leios.hs
+++ b/ouroboros-consensus-cardano/test/cardano-test/Test/ThreadNet/Leios.hs
@@ -384,16 +384,15 @@ prop_leios_late_join seed =
         r <- try @SomeException $ evaluate testOutput
         pure $ case r of
           Left e ->
+            -- DEBUG: try to grab traces too. If forcing the traces
+            -- also throws (because they share the failing chunk of
+            -- IOSim output), wrap in another 'try' and degrade
+            -- gracefully.
             counterexample ("late join slot: " <> show lateJoinSlot) $
               counterexample ("threw: " <> show e) False
           Right _ -> property True
  where
-  -- Shorter than 'prop_leios' (200 slots): staging causes node 3's chain
-  -- to stall, which makes downstream diffusion (LoP, fragment growth,
-  -- BlockFetch retries) do O(numSlots × backlog) work per slot until
-  -- Phase 2 (emergency EB fetch, issue #890) lands. Once Phase 2 is in,
-  -- restore to 200.
-  numSlots = 50 :: Word64
+  numSlots = 60 :: Word64 -- TODO restore to 200 once perf is fixed
 
 -- | Independently compute cumulative tx bytes by resolving each block in the
 -- chain (filling in EB closures from the LeiosDB) and summing individual

--- a/ouroboros-consensus-cardano/test/cardano-test/Test/ThreadNet/Leios.hs
+++ b/ouroboros-consensus-cardano/test/cardano-test/Test/ThreadNet/Leios.hs
@@ -41,6 +41,7 @@ import Cardano.Protocol.TPraos.OCert (KESPeriod (..))
 import Cardano.Slotting.Time (SlotLength, slotLengthFromSec)
 import qualified Control.Concurrent.Class.MonadSTM.Strict.TVar as StrictTVar
 import Control.DeepSeq (force)
+import Control.Exception (SomeException, evaluate, try)
 import Control.Monad (foldM, replicateM)
 import Control.Monad.IOSim (runSimOrThrow)
 import qualified Control.Tracer as Tracer
@@ -107,8 +108,12 @@ import Test.Consensus.Cardano.ProtocolInfo (Era (Dijkstra), hardForkInto)
 import Test.QuickCheck
   ( Property
   , Testable
+  , choose
   , conjoin
   , counterexample
+  , forAll
+  , ioProperty
+  , property
   , tabulate
   , (.&&.)
   , (.||.)
@@ -144,7 +149,7 @@ import Test.ThreadNet.Network
   , TraceThreadNetNode (FromLeios, FromLeiosPeer, FromMempool)
   )
 import Test.ThreadNet.TxGen.Cardano (CardanoTxGenExtra (..))
-import Test.ThreadNet.Util.NodeJoinPlan (trivialNodeJoinPlan)
+import Test.ThreadNet.Util.NodeJoinPlan (NodeJoinPlan (..), trivialNodeJoinPlan)
 import Test.ThreadNet.Util.NodeRestarts (noRestarts)
 import Test.ThreadNet.Util.NodeToNodeVersion (newestVersion)
 import Test.ThreadNet.Util.NodeTopology (meshNodeTopology)
@@ -159,6 +164,8 @@ tests =
     "Leios ThreadNet"
     [ adjustQuickCheckTests (`div` 10) $
         testProperty "basic functionality" prop_leios
+    , adjustQuickCheckTests (`div` 10) $
+        testProperty "late join" prop_leios_late_join
     ]
 
 -- | Verify a suite of basic Leios ThreadNet invariants in a single run:
@@ -190,7 +197,9 @@ prop_leios seed =
   numSlots = 200 :: Word64
 
   (testOutput, ProtocolInfo{pInfoConfig, pInfoInitLedger}) =
-    runThreadNet seed (NumSlots numSlots) (NumCoreNodes $ fromIntegral numNodes)
+    runThreadNet seed (NumSlots numSlots) numCoreNodes (trivialNodeJoinPlan numCoreNodes)
+
+  numCoreNodes = NumCoreNodes $ fromIntegral numNodes
 
   traces = testOutput.allTraces
 
@@ -343,6 +352,49 @@ prop_leios seed =
       | (s1, s2) <- zip certifyingBlocks (drop 1 certifyingBlocks)
       ]
 
+-- | A late-joining node must not crash on a CertRB whose certified EB
+-- closure it never observed live.
+--
+-- 4 nodes, 200 slots. Nodes 0–2 join at slot 0; node 3 joins at a random
+-- slot in @[1, numSlots - 1]@, after at least some CertRBs may already
+-- have been produced.
+prop_leios_late_join :: Seed -> Property
+prop_leios_late_join seed =
+  forAll (choose (1, fromIntegral numSlots - 1)) $ \lateJoinSlot ->
+    let
+      joinPlan =
+        NodeJoinPlan $
+          Map.fromList
+            [ (CoreNodeId 0, SlotNo 0)
+            , (CoreNodeId 1, SlotNo 0)
+            , (CoreNodeId 2, SlotNo 0)
+            , (CoreNodeId 3, SlotNo $ fromIntegral (lateJoinSlot :: Int))
+            ]
+
+      numCoreNodes = NumCoreNodes 4
+
+      (testOutput, _) =
+        runThreadNet seed (NumSlots numSlots) numCoreNodes joinPlan
+     in
+      -- 'runThreadNet' rethrows simulation exceptions when its result is
+      -- forced. Catch them here so the property reports a failure with the
+      -- 'lateJoinSlot' counterexample rather than letting the exception
+      -- propagate.
+      ioProperty $ do
+        r <- try @SomeException $ evaluate testOutput
+        pure $ case r of
+          Left e ->
+            counterexample ("late join slot: " <> show lateJoinSlot) $
+              counterexample ("threw: " <> show e) False
+          Right _ -> property True
+ where
+  -- Shorter than 'prop_leios' (200 slots): staging causes node 3's chain
+  -- to stall, which makes downstream diffusion (LoP, fragment growth,
+  -- BlockFetch retries) do O(numSlots × backlog) work per slot until
+  -- Phase 2 (emergency EB fetch, issue #890) lands. Once Phase 2 is in,
+  -- restore to 200.
+  numSlots = 50 :: Word64
+
 -- | Independently compute cumulative tx bytes by resolving each block in the
 -- chain (filling in EB closures from the LeiosDB) and summing individual
 -- 'sizeTxF' values per transaction.
@@ -427,8 +479,9 @@ runThreadNet ::
   Seed ->
   NumSlots ->
   NumCoreNodes ->
+  NodeJoinPlan ->
   (TestOutput (CardanoBlock StandardCrypto), ProtocolInfo (CardanoBlock StandardCrypto))
-runThreadNet initSeed numSlots numCoreNodes =
+runThreadNet initSeed numSlots numCoreNodes joinPlan =
   ( runTestNetwork
       testConfig
       testConfigB
@@ -514,7 +567,7 @@ runThreadNet initSeed numSlots numCoreNodes =
       { forgeEbbEnv = Nothing
       , future = EraFinal slotLength shelleyGenesis.sgEpochLength
       , messageDelay = noCalcMessageDelay
-      , nodeJoinPlan = trivialNodeJoinPlan numCoreNodes
+      , nodeJoinPlan = joinPlan
       , nodeRestarts = noRestarts
       , txGenExtra =
           CardanoTxGenExtra

--- a/ouroboros-consensus-cardano/test/cardano-test/Test/ThreadNet/Leios.hs
+++ b/ouroboros-consensus-cardano/test/cardano-test/Test/ThreadNet/Leios.hs
@@ -303,6 +303,21 @@ prop_leios seed =
       & tabulate "Certifying blocks" [show $ length certifyingBlocks]
       & tabulate "Effective throughput" [show throughput]
 
+  -- FIXME: This only exercises the in-memory replay via
+  -- 'foldWithResolution' (essentially the volatile-range
+  -- 'Forker.applyBlock' code path). It does NOT cover the
+  -- immutable-DB replay path used at node startup
+  -- ('replayStartingWith' → V1/V2 'reapplyBlock'). Bug
+  -- discovered on the staging-branch testnet: that replay path
+  -- was silently bypassing 'resolveLeiosBlock', causing CertRB
+  -- bodies to be re-applied as empty (no EB-txs spliced in),
+  -- which left the post-restart ledger state missing every
+  -- EB-tx output and triggered 'BadInputsUTxO' on the first
+  -- volatile block that spent one of those outputs. A
+  -- ThreadNet variant that snapshots one node mid-run, kills
+  -- it, and restarts from disk would catch this — see the
+  -- proto-devnet kill-and-restart drill in
+  -- ouroboros-leios/demo/proto-devnet for the manual analogue.
   ebCertificateInclusion =
     let expectedLedger = nodeOutputFinalLedger someNode
         foldedLedger = replayNodeChain pInfoConfig pInfoInitLedger someNode

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
@@ -63,6 +63,7 @@ import Data.Maybe (isJust)
 import qualified Data.Measure
 import Data.Proxy
 import Data.Set (Set)
+import qualified Data.Set as Set
 import qualified Data.Text as Text
 import Data.Void (Void)
 import LeiosDemoDb
@@ -76,13 +77,16 @@ import qualified LeiosDemoLogic as Leios
 import LeiosDemoTypes
   ( LeiosOutstanding
   , LeiosPeerVars
+  , LeiosPoint
   , LeiosVote (..)
   , TraceLeiosKernel (..)
   , VoterId (MkVoterId)
+  , pointEbHash
   )
 import qualified LeiosDemoTypes as Leios
 import LeiosStagingArea
   ( LeiosStagingArea (..)
+  , StagedCertRB (..)
   , newLeiosStagingArea
   , runStagingAreaDrain
   )
@@ -478,14 +482,67 @@ initNodeKernel
           iterationStart <- getMonotonicTime
           leiosPeersVars <- MVar.readMVar getLeiosPeersVars
           offerings <- mapM (MVar.readMVar . Leios.offerings) leiosPeersVars
+          -- Synthesise inputs from the CertRB staging area (issue #890).
+          -- The fetch logic doesn't know about staging directly; we
+          -- expose staged entries to it as "this EB body is missing"
+          -- (synthMissing) and "these peers offered it" (synthOfferings).
+          -- Re-derived each tick from the staging snapshot + current
+          -- ChainSync candidates, so peers that connect after staging
+          -- still become eligible.
+          stagedNow <- atomically $ stagedSnapshot leiosCertRbStaging
+          candidates <- atomically $ do
+            handlesNow <- cschcMap varChainSyncHandles
+            -- Re-key by 'PeerId' so the map lines up with how the
+            -- staging area and the offerings map identify peers.
+            traverse
+              (fmap csCandidate . readTVar . cschState)
+              (Map.mapKeys Leios.MkPeerId handlesNow)
+          let stagedAugmented =
+                augmentStagedPeers candidates stagedNow
+              synthMissing =
+                Map.map stagedSize stagedAugmented
+              synthOfferings =
+                Map.fromListWith
+                  (\(a, b) (c, d) -> (a <> c, b <> d))
+                  [ ( peer
+                    , (Set.singleton (pointEbHash point), Set.empty)
+                    )
+                  | (point, entry) <- Map.toList stagedAugmented
+                  , peer <- Set.toList (stagedPeers entry)
+                  ]
+              augmentedOfferings =
+                Map.unionWith
+                  (\(a, b) (c, d) -> (a <> c, b <> d))
+                  offerings
+                  synthOfferings
           newDecisions <- MVar.modifyMVar getLeiosOutstanding $ \outstanding -> do
-            filteredOutstanding <- Leios.filterMissingWork leiosConn outstanding
+            let realMissingKeys = Map.keysSet (Leios.missingEbBodies outstanding)
+                synthOnlyKeys =
+                  Map.keysSet synthMissing `Set.difference` realMissingKeys
+                augmentedOutstanding =
+                  outstanding
+                    { Leios.missingEbBodies =
+                        Map.union (Leios.missingEbBodies outstanding) synthMissing
+                    }
+            filteredOutstanding <-
+              Leios.filterMissingWork leiosConn augmentedOutstanding
             traceWith leiosTr $ MkTraceLeiosKernel "leiosFetchLogic: filtered"
-            let (!outstanding', decisions) =
+            let (!outstanding'', decisions) =
                   Leios.leiosFetchLogicIteration
                     Leios.demoLeiosFetchStaticEnv
-                    offerings
+                    augmentedOfferings
                     filteredOutstanding
+                -- Strip the synthetic-only missingEbBodies entries
+                -- before persisting; the rest (requestedEbPeers,
+                -- requestedBytesSize, ...) is real and must be kept
+                -- so the eventual MsgLeiosBlock response is accepted.
+                outstanding' =
+                  outstanding''
+                    { Leios.missingEbBodies =
+                        Map.withoutKeys
+                          (Leios.missingEbBodies outstanding'')
+                          synthOnlyKeys
+                    }
             pure (outstanding', decisions)
           traceWith leiosTr $ MkTraceLeiosKernel "leiosFetchLogic: decided"
           let newRequests =
@@ -636,7 +693,8 @@ data InternalState m addrNTN addrNTC blk = IS
       MVar.MVar m (Map.Map (Leios.PeerId (ConnectionId addrNTN)) (LeiosPeerVars m))
   , leiosVoteStateIS :: LeiosVoteState m
   , -- | CertRBs whose EB closure isn't locally available yet (issue #890).
-    leiosCertRbStaging :: LeiosStagingArea m blk
+    leiosCertRbStaging ::
+      LeiosStagingArea m (Leios.PeerId (ConnectionId addrNTN)) blk
   }
 
 initInternalState ::
@@ -708,7 +766,7 @@ initInternalState
             chainDB
             leiosDB
             leiosCertRbStaging
-            leiosOutstanding
+            varChainSyncHandles
             leiosReady
             (BlockFetchClientInterface.defaultChainDbView chainDB)
         blockFetchInterface ::
@@ -744,17 +802,21 @@ toConsensusMode = \case
 -- 'getIsFetched' is also widened so the BlockFetch decision logic doesn't
 -- keep refetching the same block while it's staged.
 wrapChainDbViewForLeiosStaging ::
-  forall m blk peer.
+  forall m blk addrNTN.
   ( IOLike m
   , HasHeader blk
+  , HasHeader (Header blk)
+  , Ord addrNTN
   , ResolveLeiosBlock blk
   ) =>
   Tracer m TraceLeiosKernel ->
   ChainDB m blk ->
   LeiosDbHandle m ->
-  LeiosStagingArea m blk ->
-  MVar.MVar m (LeiosOutstanding peer) ->
+  LeiosStagingArea m (Leios.PeerId (ConnectionId addrNTN)) blk ->
+  ChainSyncClientHandleCollection (ConnectionId addrNTN) m blk ->
   MVar.MVar m () ->
+  -- ^ 'getLeiosReady' — pinged after a stage so the fetch loop wakes
+  -- promptly and can synthesise the new entry into its next iteration.
   BlockFetchClientInterface.ChainDbView m blk ->
   BlockFetchClientInterface.ChainDbView m blk
 wrapChainDbViewForLeiosStaging
@@ -762,7 +824,7 @@ wrapChainDbViewForLeiosStaging
   chainDB
   leiosDbHandle
   stagingArea
-  outstandingMVar
+  varChainSyncHandles
   readyMVar
   defView =
     defView
@@ -773,6 +835,7 @@ wrapChainDbViewForLeiosStaging
           pure $ \p -> baseFetched p || staged p
       }
    where
+    _ = chainDB
     stagingAwareAddBlock punish blk = do
       mMissing <-
         withLeiosDb leiosDbHandle $ \conn ->
@@ -780,24 +843,18 @@ wrapChainDbViewForLeiosStaging
       case mMissing of
         Nothing ->
           BlockFetchClientInterface.addBlockAsync defView punish blk
-        Just point -> do
+        Just (point, size) -> do
+          peers <- atomically $ peersThatKnowBlock varChainSyncHandles blk
           traceWith tracer $
             MkTraceLeiosKernel $
               "CertRB staging: parking block "
                 ++ show (Block.blockPoint blk)
                 ++ "; missing EB "
                 ++ show point
-          atomically $ stageCertRB stagingArea point blk
-          MVar.modifyMVar_ outstandingMVar $ \o ->
-            pure
-              o
-                { Leios.missingEbBodies =
-                    Map.insertWith
-                      (\_new old -> old)
-                      point
-                      0
-                      (Leios.missingEbBodies o)
-                }
+                ++ "; known to "
+                ++ show (Set.size peers)
+                ++ " peer(s)"
+          atomically $ stageCertRB stagingArea point size peers blk
           _ <- MVar.tryPutMVar readyMVar ()
           -- Deferred promise: claim "written" so BlockFetch logic
           -- doesn't immediately refetch; report processed as failed
@@ -810,6 +867,56 @@ wrapChainDbViewForLeiosStaging
                     FailedToAddBlock
                       "CertRB staged, awaiting EB closure"
               }
+
+-- | Re-derive each staged entry's peer set by unioning in any peer
+-- whose *current* ChainSync candidate contains the staged block.
+-- Handles peers that connect (or extend their candidate through this
+-- block) after staging.
+augmentStagedPeers ::
+  (HasHeader blk, HasHeader (Header blk), Ord peer) =>
+  Map.Map peer (AF.AnchoredFragment (HeaderWithTime blk)) ->
+  Map.Map LeiosPoint (StagedCertRB peer blk) ->
+  Map.Map LeiosPoint (StagedCertRB peer blk)
+augmentStagedPeers candidates staged =
+  Map.map go staged
+ where
+  go entry =
+    let extra =
+          Set.fromList
+            [ peer
+            | (peer, frag) <- Map.toList candidates
+            , any
+                ((== Block.blockHash (stagedBlock entry)) . Block.blockHash)
+                (AF.toOldestFirst frag)
+            ]
+     in entry{stagedPeers = stagedPeers entry `Set.union` extra}
+
+-- | Scan all ChainSync candidates for ones whose fragment contains a
+-- header with the same hash as @blk@. Those peers' chains have admitted
+-- this block, so they almost certainly hold (or can quickly obtain) the
+-- certified EB closure.
+peersThatKnowBlock ::
+  ( IOLike m
+  , HasHeader blk
+  , HasHeader (Header blk)
+  , Ord peer
+  ) =>
+  ChainSyncClientHandleCollection peer m blk ->
+  blk ->
+  STM m (Set.Set (Leios.PeerId peer))
+peersThatKnowBlock varChainSyncHandles blk = do
+  handles <- cschcMap varChainSyncHandles
+  let hsh = Block.blockHash blk
+  fmap (Set.fromList . Map.elems) $
+    flip Map.traverseMaybeWithKey handles $ \peer h -> do
+      st <- readTVar (cschState h)
+      let frag = csCandidate st
+      pure $
+        if any
+          ((== hsh) . Block.blockHash)
+          (AF.toOldestFirst frag)
+          then Just (Leios.MkPeerId peer)
+          else Nothing
 
 forkBlockForging ::
   forall m addrNTN addrNTC blk.

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
@@ -38,6 +38,7 @@ import Cardano.Network.PeerSelection.Bootstrap (UseBootstrapPeers)
 import Cardano.Network.PeerSelection.LocalRootPeers
   ( OutboundConnectionsState (..)
   )
+import Control.Applicative ((<|>))
 import qualified Control.Concurrent.Class.MonadMVar as MVar
 import qualified Control.Concurrent.Class.MonadSTM as LazySTM
 import Control.Concurrent.Class.MonadSTM.Strict (readTChan)
@@ -56,6 +57,7 @@ import Data.Foldable (traverse_)
 import Data.Function (on)
 import Data.Functor ((<&>))
 import Data.Hashable (Hashable)
+import Data.List (find)
 import Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as Map
@@ -67,7 +69,7 @@ import qualified Data.Set as Set
 import qualified Data.Text as Text
 import Data.Void (Void)
 import LeiosDemoDb
-  ( LeiosDbConnection
+  ( LeiosDbConnection (..)
   , LeiosDbHandle (subscribeEbNotifications)
   , LeiosEbNotification (..)
   , withLeiosDb
@@ -75,7 +77,8 @@ import LeiosDemoDb
 import qualified LeiosDemoDb as LeiosDb
 import qualified LeiosDemoLogic as Leios
 import LeiosDemoTypes
-  ( LeiosOutstanding
+  ( BytesSize
+  , LeiosOutstanding
   , LeiosPeerVars
   , LeiosPoint
   , LeiosVote (..)
@@ -765,7 +768,6 @@ initInternalState
         chainDbView =
           wrapChainDbViewForLeiosStaging
             (leiosKernelTracer tracers)
-            chainDB
             leiosDB
             leiosCertRbStaging
             varChainSyncHandles
@@ -806,13 +808,11 @@ toConsensusMode = \case
 wrapChainDbViewForLeiosStaging ::
   forall m blk addrNTN.
   ( IOLike m
-  , HasHeader blk
-  , HasHeader (Header blk)
+  , GetPrevHash blk
   , Ord addrNTN
   , ResolveLeiosBlock blk
   ) =>
   Tracer m TraceLeiosKernel ->
-  ChainDB m blk ->
   LeiosDbHandle m ->
   LeiosStagingArea m (Leios.PeerId (ConnectionId addrNTN)) blk ->
   ChainSyncClientHandleCollection (ConnectionId addrNTN) m blk ->
@@ -823,7 +823,6 @@ wrapChainDbViewForLeiosStaging ::
   BlockFetchClientInterface.ChainDbView m blk
 wrapChainDbViewForLeiosStaging
   tracer
-  chainDB
   leiosDbHandle
   stagingArea
   varChainSyncHandles
@@ -837,35 +836,81 @@ wrapChainDbViewForLeiosStaging
           pure $ \p -> baseFetched p || staged p
       }
    where
-    _ = chainDB
-    stagingAwareAddBlock punish blk = do
-      mMissing <-
-        withLeiosDb leiosDbHandle $ \conn ->
-          checkLeiosBlockResolvable conn blk
-      case mMissing of
-        Nothing ->
+    stagingAwareAddBlock punish blk
+      | not (blockHasLeiosCert blk) =
           BlockFetchClientInterface.addBlockAsync defView punish blk
-        Just (point, size) -> do
-          peers <- atomically $ peersThatKnowBlock varChainSyncHandles blk
-          traceWith tracer
-            TraceCertRBStaged
-              { stagedBlockPoint = show (Block.blockPoint blk)
-              , stagedEbPoint = point
-              , stagedKnownPeers = Set.size peers
-              }
-          atomically $ stageCertRB stagingArea point size peers blk
-          _ <- MVar.tryPutMVar readyMVar ()
-          -- Deferred promise: claim "written" so BlockFetch logic
-          -- doesn't immediately refetch; report processed as failed
-          -- (the staged block is not yet on the chain).
-          pure
-            AddBlockPromise
-              { blockWrittenToDisk = pure True
-              , blockProcessed =
-                  pure $
-                    FailedToAddBlock
-                      "CertRB staged, awaiting EB closure"
-              }
+      | otherwise = do
+          mAnn <- atomically $ do
+            candidates <- candidateFragments
+            currentChain <- BlockFetchClientInterface.getCurrentChain defView
+            pure $
+              findParentAnnouncement
+                (Block.blockPrevHash blk)
+                currentChain
+                candidates
+          case mAnn of
+            -- Parent isn't visible on the current chain or any
+            -- ChainSync candidate, or didn't announce. Can't determine
+            -- the EB. Admit and let ChainSel / apply-time error
+            -- decide. Fork-time / out-of-order arrivals blind spot:
+            -- see issue #890 PR description.
+            Nothing ->
+              BlockFetchClientInterface.addBlockAsync defView punish blk
+            Just (point, size) -> do
+              mEb <- withLeiosDb leiosDbHandle $ \conn ->
+                leiosDbQueryCompletedEbByPoint conn point
+              case mEb of
+                Just _ ->
+                  BlockFetchClientInterface.addBlockAsync defView punish blk
+                Nothing -> stage point size punish blk
+
+    candidateFragments = do
+      handles <- cschcMap varChainSyncHandles
+      traverse (fmap csCandidate . readTVar . cschState) handles
+
+    stage point size _punish blk = do
+      peers <- atomically $ peersThatKnowBlock varChainSyncHandles blk
+      traceWith tracer
+        TraceCertRBStaged
+          { stagedBlockPoint = show (Block.blockPoint blk)
+          , stagedEbPoint = point
+          , stagedKnownPeers = Set.size peers
+          }
+      atomically $ stageCertRB stagingArea point size peers blk
+      _ <- MVar.tryPutMVar readyMVar ()
+      -- Deferred promise: claim "written" so BlockFetch logic
+      -- doesn't immediately refetch; report processed as failed
+      -- (the staged block is not yet on the chain).
+      pure
+        AddBlockPromise
+          { blockWrittenToDisk = pure True
+          , blockProcessed =
+              pure $
+                FailedToAddBlock
+                  "CertRB staged, awaiting EB closure"
+          }
+
+-- | Find the parent header in the current chain or any ChainSync
+-- candidate fragment, and read its 'headerLeiosAnnouncement'.
+-- Candidates are scanned because the parent may not yet be on the
+-- selected chain (BlockFetch can deliver a child before its parent
+-- reaches ChainSel).
+findParentAnnouncement ::
+  forall blk peer.
+  (HasHeader (Header blk), ResolveLeiosBlock blk) =>
+  ChainHash blk ->
+  AF.AnchoredFragment (Header blk) ->
+  Map.Map peer (AF.AnchoredFragment (HeaderWithTime blk)) ->
+  Maybe (LeiosPoint, BytesSize)
+findParentAnnouncement prev currentChain candidates = case prev of
+  GenesisHash -> Nothing
+  BlockHash h ->
+    let onChain =
+          find (\hdr -> Block.blockHash hdr == h) (AF.toNewestFirst currentChain)
+        onCandidate =
+          find (\hdr -> Block.blockHash hdr == h) $
+            concatMap (fmap hwtHeader . AF.toNewestFirst) (Map.elems candidates)
+     in (onChain <|> onCandidate) >>= headerLeiosAnnouncement
 
 -- | Re-derive each staged entry's peer set by unioning in any peer
 -- whose *current* ChainSync candidate contains the staged block.

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
@@ -60,6 +60,7 @@ import Data.Hashable (Hashable)
 import Data.List (find)
 import Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NE
+import qualified Data.IntMap.Strict as IntMap
 import qualified Data.Map.Strict as Map
 import Data.Maybe (isJust)
 import qualified Data.Measure
@@ -78,11 +79,13 @@ import qualified LeiosDemoDb as LeiosDb
 import qualified LeiosDemoLogic as Leios
 import LeiosDemoTypes
   ( BytesSize
+  , EbHash
   , LeiosOutstanding
   , LeiosPeerVars
   , LeiosPoint
   , LeiosVote (..)
   , TraceLeiosKernel (..)
+  , TxHash
   , VoterId (MkVoterId)
   , pointEbHash
   )
@@ -500,11 +503,30 @@ initNodeKernel
             traverse
               (fmap csCandidate . readTVar . cschState)
               (Map.mapKeys Leios.MkPeerId handlesNow)
+          -- DB-derived view of what's still missing. We use this to
+          -- synthesise 'missingEbTxs' entries for staged points whose
+          -- body has arrived but whose tx closure is incomplete —
+          -- needed at least on restart (no fresh 'MsgLeiosBlock' will
+          -- arrive to populate the in-memory state via the natural
+          -- novel=True path) and as a safety net for the rare race
+          -- where body arrival fires outside the MVar window that
+          -- normally populates 'missingEbTxs'.
+          fetchWork <- LeiosDb.leiosDbQueryFetchWork leiosConn
           let stagedAugmented =
                 augmentStagedPeers candidates stagedNow
+              livePeers = Map.keysSet leiosPeersVars
+              stagedPoints = Map.keysSet stagedAugmented
               synthMissing =
                 Map.map stagedSize stagedAugmented
+              -- Only synth offerings for peers we can actually send to
+              -- (in 'leiosPeersVars'). Otherwise the decision logic
+              -- would target peers whose request slot is missing from
+              -- the eventual 'Map.intersectionWith' send step → silent
+              -- drop, while 'requestedEbPeers' / 'requestedTxPeers' is
+              -- already updated, locking the EB out from future
+              -- retries.
               synthOfferings =
+                (`Map.restrictKeys` livePeers) $
                 Map.fromListWith
                   (\(a, b) (c, d) -> (a <> c, b <> d))
                   -- Peers that know the staged CertRB have applied it on
@@ -519,19 +541,65 @@ initNodeKernel
                   | (point, entry) <- Map.toList stagedAugmented
                   , peer <- Set.toList (stagedPeers entry)
                   ]
+              -- Synthetic missingEbTxs for staged points whose body is
+              -- already in leios.db (per fetchWork: ebTxs rows exist
+              -- but txs aren't all in). One entry per (offset, txHash,
+              -- size) tuple.
+              synthMissingTxs ::
+                Map.Map LeiosPoint (IntMap.IntMap (TxHash, BytesSize))
+              synthMissingTxs =
+                Map.map
+                  ( IntMap.fromList
+                      . map (\(i, txHash, bs) -> (i, (txHash, bs)))
+                  )
+                  ( LeiosDb.missingEbTxs fetchWork
+                      `Map.restrictKeys` stagedPoints
+                  )
+              -- Inverse index for the synth-added txs: choosePeerTx
+              -- consults 'reverseEbIndexByTx[txHash]' and errors with
+              -- "impossible!" if it's missing. Mirror the population
+              -- the natural body-arrival path does.
+              synthReverseEbIndexByTx ::
+                Map.Map TxHash (Map.Map EbHash (Int, BytesSize))
+              synthReverseEbIndexByTx =
+                Map.fromListWith
+                  Map.union
+                  [ (txHash, Map.singleton (pointEbHash point) (i, bs))
+                  | (point, txs) <- Map.toList synthMissingTxs
+                  , (i, (txHash, bs)) <- IntMap.toList txs
+                  ]
               augmentedOfferings =
                 Map.unionWith
                   (\(a, b) (c, d) -> (a <> c, b <> d))
                   offerings
                   synthOfferings
           newDecisions <- MVar.modifyMVar getLeiosOutstanding $ \outstanding -> do
-            let realMissingKeys = Map.keysSet (Leios.missingEbBodies outstanding)
-                synthOnlyKeys =
-                  Map.keysSet synthMissing `Set.difference` realMissingKeys
+            let realMissingBodyKeys = Map.keysSet (Leios.missingEbBodies outstanding)
+                synthOnlyBodyKeys =
+                  Map.keysSet synthMissing `Set.difference` realMissingBodyKeys
+                realMissingTxKeys = Map.keysSet (Leios.missingEbTxs outstanding)
+                synthOnlyTxKeys =
+                  Map.keysSet synthMissingTxs `Set.difference` realMissingTxKeys
+                realReverseKeys = Map.keysSet (Leios.reverseEbIndexByTx outstanding)
+                synthOnlyReverseKeys =
+                  Map.keysSet synthReverseEbIndexByTx `Set.difference` realReverseKeys
                 augmentedOutstanding =
                   outstanding
                     { Leios.missingEbBodies =
-                        Map.union (Leios.missingEbBodies outstanding) synthMissing
+                        -- Left-biased: keep real entry (carries in-flight
+                        -- request state) over the synth's bare size.
+                        Map.union
+                          (Leios.missingEbBodies outstanding)
+                          synthMissing
+                    , Leios.missingEbTxs =
+                        Map.union
+                          (Leios.missingEbTxs outstanding)
+                          synthMissingTxs
+                    , Leios.reverseEbIndexByTx =
+                        Map.unionWith
+                          Map.union
+                          (Leios.reverseEbIndexByTx outstanding)
+                          synthReverseEbIndexByTx
                     }
             filteredOutstanding <-
               Leios.filterMissingWork leiosConn augmentedOutstanding
@@ -541,26 +609,55 @@ initNodeKernel
                     Leios.demoLeiosFetchStaticEnv
                     augmentedOfferings
                     filteredOutstanding
-                -- Strip the synthetic-only missingEbBodies entries
-                -- before persisting; the rest (requestedEbPeers,
-                -- requestedBytesSize, ...) is real and must be kept
-                -- so the eventual MsgLeiosBlock response is accepted.
+                -- Strip synthetic-only entries before persisting; the
+                -- rest of 'outstanding''' (requestedEbPeers,
+                -- requestedTxPeers, requestedBytesSize, …) is real and
+                -- must be kept so the eventual responses are accepted.
                 outstanding' =
                   outstanding''
                     { Leios.missingEbBodies =
                         Map.withoutKeys
                           (Leios.missingEbBodies outstanding'')
-                          synthOnlyKeys
+                          synthOnlyBodyKeys
+                    , Leios.missingEbTxs =
+                        Map.withoutKeys
+                          (Leios.missingEbTxs outstanding'')
+                          synthOnlyTxKeys
+                    , Leios.reverseEbIndexByTx =
+                        Map.withoutKeys
+                          (Leios.reverseEbIndexByTx outstanding'')
+                          synthOnlyReverseKeys
                     }
             pure (outstanding', decisions)
           traceWith leiosTr $ MkTraceLeiosKernel "leiosFetchLogic: decided"
           let newRequests =
                 Leios.packRequests Leios.demoLeiosFetchStaticEnv newDecisions
+              numStaged = Map.size stagedNow
+              numLiveStagedPeers =
+                sum [ Set.size (stagedPeers e)
+                    | e <- Map.elems stagedAugmented ]
+              decisionsTargetedKeys = Map.keysSet newRequests
+              droppableKeys =
+                decisionsTargetedKeys `Set.difference` livePeers
           traceWith leiosTr $
             MkTraceLeiosKernel $
               "leiosFetchLogic: "
                 ++ show (sum (fmap length newRequests))
                 ++ " new reqs"
+          traceWith leiosTr $
+            MkTraceLeiosKernel $
+              "leiosFetchLogic: staged="
+                ++ show numStaged
+                ++ " liveStagedPeerLinks="
+                ++ show numLiveStagedPeers
+                ++ " synthTxsEntries="
+                ++ show (Map.size synthMissingTxs)
+          unless (Set.null droppableKeys) $
+            traceWith leiosTr $
+              MkTraceLeiosKernel $
+                "leiosFetchLogic: WARNING dropping "
+                  ++ show (Set.size droppableKeys)
+                  ++ " peer-targeted decisions because target not in leiosPeersVars"
           (\f -> sequence_ $ Map.intersectionWith f leiosPeersVars newRequests) $ \vars reqs ->
             atomically $
               StrictSTM.modifyTVar (Leios.requestsToSend vars) (<> reqs)
@@ -697,9 +794,9 @@ data InternalState m addrNTN addrNTC blk = IS
   , leiosPeersVars ::
       MVar.MVar m (Map.Map (Leios.PeerId (ConnectionId addrNTN)) (LeiosPeerVars m))
   , leiosVoteStateIS :: LeiosVoteState m
-  , -- | CertRBs whose EB closure isn't locally available yet (issue #890).
-    leiosCertRbStaging ::
+  , leiosCertRbStaging ::
       LeiosStagingArea m (Leios.PeerId (ConnectionId addrNTN)) blk
+  -- ^ CertRBs whose EB closure isn't locally available yet (issue #890).
   }
 
 initInternalState ::
@@ -816,9 +913,9 @@ wrapChainDbViewForLeiosStaging ::
   LeiosDbHandle m ->
   LeiosStagingArea m (Leios.PeerId (ConnectionId addrNTN)) blk ->
   ChainSyncClientHandleCollection (ConnectionId addrNTN) m blk ->
-  MVar.MVar m () ->
-  -- ^ 'getLeiosReady' — pinged after a stage so the fetch loop wakes
+  -- | 'getLeiosReady' — pinged after a stage so the fetch loop wakes
   -- promptly and can synthesise the new entry into its next iteration.
+  MVar.MVar m () ->
   BlockFetchClientInterface.ChainDbView m blk ->
   BlockFetchClientInterface.ChainDbView m blk
 wrapChainDbViewForLeiosStaging
@@ -870,7 +967,8 @@ wrapChainDbViewForLeiosStaging
 
     stage point size _punish blk = do
       peers <- atomically $ peersThatKnowBlock varChainSyncHandles blk
-      traceWith tracer
+      traceWith
+        tracer
         TraceCertRBStaged
           { stagedBlockPoint = show (Block.blockPoint blk)
           , stagedEbPoint = point
@@ -916,6 +1014,14 @@ findParentAnnouncement prev currentChain candidates = case prev of
 -- whose *current* ChainSync candidate contains the staged block.
 -- Handles peers that connect (or extend their candidate through this
 -- block) after staging.
+-- | Recompute each staged entry's peer set from the current ChainSync
+-- candidates: any peer whose candidate fragment still contains the
+-- staged block. We REPLACE the persisted 'stagedPeers' (rather than
+-- union with it) so that peers which have since disconnected — and
+-- whose handles are therefore no longer in 'candidates' — drop out.
+-- Otherwise the fetch synth would keep aiming requests at peers that
+-- aren't in 'leiosPeersVars' anymore, and 'Map.intersectionWith' in
+-- the fetch loop would silently drop them.
 augmentStagedPeers ::
   (HasHeader blk, HasHeader (Header blk), Ord peer) =>
   Map.Map peer (AF.AnchoredFragment (HeaderWithTime blk)) ->
@@ -925,7 +1031,7 @@ augmentStagedPeers candidates staged =
   Map.map go staged
  where
   go entry =
-    let extra =
+    let live =
           Set.fromList
             [ peer
             | (peer, frag) <- Map.toList candidates
@@ -933,7 +1039,7 @@ augmentStagedPeers candidates staged =
                 ((== Block.blockHash (stagedBlock entry)) . Block.blockHash)
                 (AF.toOldestFirst frag)
             ]
-     in entry{stagedPeers = stagedPeers entry `Set.union` extra}
+     in entry{stagedPeers = live}
 
 -- | Scan all ChainSync candidates for ones whose fragment contains a
 -- header with the same hash as @blk@. Those peers' chains have admitted

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
@@ -69,6 +69,7 @@ import LeiosDemoDb
   ( LeiosDbConnection
   , LeiosDbHandle (subscribeEbNotifications)
   , LeiosEbNotification (..)
+  , withLeiosDb
   )
 import qualified LeiosDemoDb as LeiosDb
 import qualified LeiosDemoLogic as Leios
@@ -80,6 +81,11 @@ import LeiosDemoTypes
   , VoterId (MkVoterId)
   )
 import qualified LeiosDemoTypes as Leios
+import LeiosStagingArea
+  ( LeiosStagingArea (..)
+  , newLeiosStagingArea
+  , runStagingAreaDrain
+  )
 import LeiosVoteState (LeiosVoteState (..), newLeiosVoteState)
 import Ouroboros.Consensus.Block hiding (blockMatchesHeader)
 import qualified Ouroboros.Consensus.Block as Block
@@ -120,7 +126,8 @@ import Ouroboros.Consensus.Node.Run
 import Ouroboros.Consensus.Node.Tracers
 import Ouroboros.Consensus.Protocol.Abstract
 import Ouroboros.Consensus.Storage.ChainDB.API
-  ( AddBlockResult (..)
+  ( AddBlockPromise (..)
+  , AddBlockResult (..)
   , ChainDB
   )
 import qualified Ouroboros.Consensus.Storage.ChainDB.API as ChainDB
@@ -291,6 +298,7 @@ initNodeKernel ::
   ( IOLike m
   , SI.MonadTimer m
   , RunNode blk
+  , ResolveLeiosBlock blk
   , Ord addrNTN
   , Hashable addrNTN
   , Typeable addrNTN
@@ -327,6 +335,11 @@ initNodeKernel
           , peerSharingRegistry
           , varChainSyncHandles
           , varGsmState
+          , leiosOutstanding = getLeiosOutstanding
+          , leiosReady = getLeiosReady
+          , leiosPeersVars = getLeiosPeersVars
+          , leiosVoteStateIS = leiosVoteState
+          , leiosCertRbStaging
           } = st
 
     varOutboundConnectionsState <- newTVarIO UntrustedState
@@ -444,11 +457,10 @@ initNodeKernel
           txChannelsVar
           sharedTxStateVar
 
-    -- Leios fetch-logic state.
-    leiosVoteState <- newLeiosVoteState
-    getLeiosPeersVars <- MVar.newMVar Map.empty
-    getLeiosOutstanding <- MVar.newMVar Leios.emptyLeiosOutstanding
-    getLeiosReady <- MVar.newEmptyMVar
+    -- Leios fetch-logic state is created up-front in 'initInternalState'
+    -- because the wrapped 'ChainDbView' (issue #890 CertRB staging) needs
+    -- to register fetch work and wake the fetch loop. We just destructure
+    -- the IS-level vars above.
 
     -- The Leios fetch logic: 0.5s loop that takes 'getLeiosReady', reads
     -- the peers' offerings, runs 'leiosFetchLogicIteration' to decide what
@@ -493,6 +505,26 @@ initNodeKernel
             MkTraceLeiosKernel $
               "leiosFetchLogic: duration " ++ show duration
           SI.threadDelay $ loopInterval - duration
+
+    -- CertRB staging drain (issue #890): on every EB closure arrival,
+    -- check whether a staged CertRB was waiting for it; if so, hand it to
+    -- 'ChainDB.addBlockAsync' so ChainSel can finally consider it.
+    void $
+      forkLinkedThread registry "NodeKernel.leiosCertRbDrain" $ do
+        let drainTr = leiosKernelTracer tracers
+        chan <- subscribeEbNotifications leiosDB
+        runStagingAreaDrain leiosCertRbStaging chan $ \point blk -> do
+          traceWith drainTr $
+            MkTraceLeiosKernel $
+              "CertRB staging: EB closure arrived, releasing "
+                ++ "block staged on "
+                ++ show point
+          _ <-
+            ChainDB.addBlockAsync
+              chainDB
+              InvalidBlockPunishment.noPunishment
+              blk
+          pure ()
 
     -- The Leios voting thread: when this node has a voting key, subscribe
     -- to local "EB closure acquired" notifications and emit a vote for
@@ -596,6 +628,15 @@ data InternalState m addrNTN addrNTC blk = IS
   , mempool :: Mempool m blk
   , peerSharingRegistry :: PeerSharingRegistry addrNTN m
   , leiosDB :: LeiosDbHandle m
+  , -- Leios state created here so the wrapped 'ChainDbView' (issue #890
+    -- CertRB staging) can register fetch work; consumed in 'initNodeKernel'.
+    leiosOutstanding :: MVar.MVar m (LeiosOutstanding (ConnectionId addrNTN))
+  , leiosReady :: MVar.MVar m ()
+  , leiosPeersVars ::
+      MVar.MVar m (Map.Map (Leios.PeerId (ConnectionId addrNTN)) (LeiosPeerVars m))
+  , leiosVoteStateIS :: LeiosVoteState m
+  , -- | CertRBs whose EB closure isn't locally available yet (issue #890).
+    leiosCertRbStaging :: LeiosStagingArea m blk
   }
 
 initInternalState ::
@@ -605,6 +646,7 @@ initInternalState ::
   , Ord addrNTN
   , Typeable addrNTN
   , RunNode blk
+  , ResolveLeiosBlock blk
   ) =>
   NodeKernelArgs m addrNTN addrNTC blk ->
   m (InternalState m addrNTN addrNTC blk)
@@ -645,6 +687,14 @@ initInternalState
 
     fetchClientRegistry <- newFetchClientRegistry
 
+    -- Leios state created up front so the wrapped 'ChainDbView' below can
+    -- register fetch work / wake the fetch loop without forward references.
+    leiosVoteStateIS <- newLeiosVoteState
+    leiosPeersVars <- MVar.newMVar Map.empty
+    leiosOutstanding <- MVar.newMVar Leios.emptyLeiosOutstanding
+    leiosReady <- MVar.newEmptyMVar
+    leiosCertRbStaging <- newLeiosStagingArea
+
     let readFetchMode =
           BlockFetchClientInterface.readFetchModeDefault
             (toConsensusMode $ gnkaLoEAndGDDArgs genesisArgs)
@@ -652,13 +702,22 @@ initInternalState
             (ChainDB.getCurrentChain chainDB)
             getUseBootstrapPeers
             (GSM.gsmStateToLedgerJudgement <$> readTVar varGsmState)
+        chainDbView =
+          wrapChainDbViewForLeiosStaging
+            (leiosKernelTracer tracers)
+            chainDB
+            leiosDB
+            leiosCertRbStaging
+            leiosOutstanding
+            leiosReady
+            (BlockFetchClientInterface.defaultChainDbView chainDB)
         blockFetchInterface ::
           BlockFetchConsensusInterface (ConnectionId addrNTN) (HeaderWithTime blk) blk m
         blockFetchInterface =
           BlockFetchClientInterface.mkBlockFetchConsensusInterface
             (dbfTracer tracers)
             (configBlock cfg)
-            (BlockFetchClientInterface.defaultChainDbView chainDB)
+            chainDbView
             varChainSyncHandles
             blockFetchSize
             readFetchMode
@@ -672,6 +731,85 @@ toConsensusMode :: forall a. LoEAndGDDConfig a -> ConsensusMode
 toConsensusMode = \case
   LoEAndGDDDisabled -> PraosMode
   LoEAndGDDEnabled _ -> GenesisMode
+
+-- | CertRB staging gate for issue #890.
+--
+-- Wraps a 'ChainDbView' so that incoming CertRBs whose announced EB closure
+-- is not yet in the local LeiosDb are *not* handed to ChainSel — they're
+-- parked in 'stagingTVar' and the missing EB is registered as Leios fetch
+-- work. Once the EB closure arrives, a separate drain thread (forked in
+-- 'initNodeKernel') re-submits the parked block via the unwrapped
+-- 'ChainDB.addBlockAsync'.
+--
+-- 'getIsFetched' is also widened so the BlockFetch decision logic doesn't
+-- keep refetching the same block while it's staged.
+wrapChainDbViewForLeiosStaging ::
+  forall m blk peer.
+  ( IOLike m
+  , HasHeader blk
+  , ResolveLeiosBlock blk
+  ) =>
+  Tracer m TraceLeiosKernel ->
+  ChainDB m blk ->
+  LeiosDbHandle m ->
+  LeiosStagingArea m blk ->
+  MVar.MVar m (LeiosOutstanding peer) ->
+  MVar.MVar m () ->
+  BlockFetchClientInterface.ChainDbView m blk ->
+  BlockFetchClientInterface.ChainDbView m blk
+wrapChainDbViewForLeiosStaging
+  tracer
+  chainDB
+  leiosDbHandle
+  stagingArea
+  outstandingMVar
+  readyMVar
+  defView =
+    defView
+      { BlockFetchClientInterface.addBlockAsync = stagingAwareAddBlock
+      , BlockFetchClientInterface.getIsFetched = do
+          baseFetched <- BlockFetchClientInterface.getIsFetched defView
+          staged <- isStagedBlock stagingArea
+          pure $ \p -> baseFetched p || staged p
+      }
+   where
+    stagingAwareAddBlock punish blk = do
+      mMissing <-
+        withLeiosDb leiosDbHandle $ \conn ->
+          checkLeiosBlockResolvable conn blk
+      case mMissing of
+        Nothing ->
+          BlockFetchClientInterface.addBlockAsync defView punish blk
+        Just point -> do
+          traceWith tracer $
+            MkTraceLeiosKernel $
+              "CertRB staging: parking block "
+                ++ show (Block.blockPoint blk)
+                ++ "; missing EB "
+                ++ show point
+          atomically $ stageCertRB stagingArea point blk
+          MVar.modifyMVar_ outstandingMVar $ \o ->
+            pure
+              o
+                { Leios.missingEbBodies =
+                    Map.insertWith
+                      (\_new old -> old)
+                      point
+                      0
+                      (Leios.missingEbBodies o)
+                }
+          _ <- MVar.tryPutMVar readyMVar ()
+          -- Deferred promise: claim "written" so BlockFetch logic
+          -- doesn't immediately refetch; report processed as failed
+          -- (the staged block is not yet on the chain).
+          pure
+            AddBlockPromise
+              { blockWrittenToDisk = pure True
+              , blockProcessed =
+                  pure $
+                    FailedToAddBlock
+                      "CertRB staged, awaiting EB closure"
+              }
 
 forkBlockForging ::
   forall m addrNTN addrNTC blk.

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
@@ -60,7 +60,6 @@ import Data.Hashable (Hashable)
 import Data.List (find)
 import Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NE
-import qualified Data.IntMap.Strict as IntMap
 import qualified Data.Map.Strict as Map
 import Data.Maybe (isJust)
 import qualified Data.Measure
@@ -79,13 +78,11 @@ import qualified LeiosDemoDb as LeiosDb
 import qualified LeiosDemoLogic as Leios
 import LeiosDemoTypes
   ( BytesSize
-  , EbHash
   , LeiosOutstanding
   , LeiosPeerVars
   , LeiosPoint
   , LeiosVote (..)
   , TraceLeiosKernel (..)
-  , TxHash
   , VoterId (MkVoterId)
   , pointEbHash
   )
@@ -488,154 +485,114 @@ initNodeKernel
           iterationStart <- getMonotonicTime
           leiosPeersVars <- MVar.readMVar getLeiosPeersVars
           offerings <- mapM (MVar.readMVar . Leios.offerings) leiosPeersVars
+          let livePeers = Map.keysSet leiosPeersVars
           -- Synthesise inputs from the CertRB staging area (issue #890).
-          -- The fetch logic doesn't know about staging directly; we
-          -- expose staged entries to it as "this EB body is missing"
-          -- (synthMissing) and "these peers offered it" (synthOfferings).
+          -- Each currently-staged CertRB becomes a high-priority body
+          -- to fetch ('synthMissing') plus an offer-by-each-staged-peer
+          -- ('synthOfferings'). The EB hash goes into *both* halves of
+          -- the per-peer offer pair, since a peer that has the CertRB
+          -- applied locally holds the full closure (body AND txs), so
+          -- 'choosePeerEb' (body) and 'choosePeerTx' (closure) both
+          -- pick them up.
+          --
+          -- We deliberately do *not* synthesise 'missingEbTxs' /
+          -- 'reverseEbIndexByTx' here. Once the body arrives,
+          -- 'msgLeiosBlock' populates those from the body's tx list;
+          -- until then there's nothing to fetch. The previous per-tick
+          -- 'leiosDbQueryFetchWork' was an O(|leios.db|) workaround for
+          -- the restart case (body in DB, tx closure partial). Restart
+          -- recovery is deferred to a follow-up startup-bootstrap of
+          -- 'LeiosOutstanding'; until that lands, an interrupted
+          -- closure fetch is not resumed across restart.
+          --
           -- Re-derived each tick from the staging snapshot + current
           -- ChainSync candidates, so peers that connect after staging
           -- still become eligible.
           stagedNow <- atomically $ stagedSnapshot leiosCertRbStaging
-          candidates <- atomically $ do
-            handlesNow <- cschcMap varChainSyncHandles
-            -- Re-key by 'PeerId' so the map lines up with how the
-            -- staging area and the offerings map identify peers.
-            traverse
-              (fmap csCandidate . readTVar . cschState)
-              (Map.mapKeys Leios.MkPeerId handlesNow)
-          -- DB-derived view of what's still missing. We use this to
-          -- synthesise 'missingEbTxs' entries for staged points whose
-          -- body has arrived but whose tx closure is incomplete —
-          -- needed at least on restart (no fresh 'MsgLeiosBlock' will
-          -- arrive to populate the in-memory state via the natural
-          -- novel=True path) and as a safety net for the rare race
-          -- where body arrival fires outside the MVar window that
-          -- normally populates 'missingEbTxs'.
-          fetchWork <- LeiosDb.leiosDbQueryFetchWork leiosConn
-          let stagedAugmented =
-                augmentStagedPeers candidates stagedNow
-              livePeers = Map.keysSet leiosPeersVars
-              stagedPoints = Map.keysSet stagedAugmented
-              synthMissing =
-                Map.map stagedSize stagedAugmented
-              -- Only synth offerings for peers we can actually send to
-              -- (in 'leiosPeersVars'). Otherwise the decision logic
-              -- would target peers whose request slot is missing from
-              -- the eventual 'Map.intersectionWith' send step → silent
-              -- drop, while 'requestedEbPeers' / 'requestedTxPeers' is
-              -- already updated, locking the EB out from future
-              -- retries.
-              synthOfferings =
-                (`Map.restrictKeys` livePeers) $
-                Map.fromListWith
-                  (\(a, b) (c, d) -> (a <> c, b <> d))
-                  -- Peers that know the staged CertRB have applied it on
-                  -- their chain, so they hold the full closure — EB body
-                  -- AND tx closure. Synthesise the EB hash into both
-                  -- sets so 'choosePeerEb' (body) and 'choosePeerTx'
-                  -- (txs) both pick them up.
-                  [ ( peer
-                    , let ebs = Set.singleton (pointEbHash point)
-                       in (ebs, ebs)
-                    )
-                  | (point, entry) <- Map.toList stagedAugmented
-                  , peer <- Set.toList (stagedPeers entry)
-                  ]
-              -- Synthetic missingEbTxs for staged points whose body is
-              -- already in leios.db (per fetchWork: ebTxs rows exist
-              -- but txs aren't all in). One entry per (offset, txHash,
-              -- size) tuple.
-              synthMissingTxs ::
-                Map.Map LeiosPoint (IntMap.IntMap (TxHash, BytesSize))
-              synthMissingTxs =
-                Map.map
-                  ( IntMap.fromList
-                      . map (\(i, txHash, bs) -> (i, (txHash, bs)))
-                  )
-                  ( LeiosDb.missingEbTxs fetchWork
-                      `Map.restrictKeys` stagedPoints
-                  )
-              -- Inverse index for the synth-added txs: choosePeerTx
-              -- consults 'reverseEbIndexByTx[txHash]' and errors with
-              -- "impossible!" if it's missing. Mirror the population
-              -- the natural body-arrival path does.
-              synthReverseEbIndexByTx ::
-                Map.Map TxHash (Map.Map EbHash (Int, BytesSize))
-              synthReverseEbIndexByTx =
-                Map.fromListWith
-                  Map.union
-                  [ (txHash, Map.singleton (pointEbHash point) (i, bs))
-                  | (point, txs) <- Map.toList synthMissingTxs
-                  , (i, (txHash, bs)) <- IntMap.toList txs
-                  ]
-              augmentedOfferings =
+          (stagedAugmented, synthMissing, synthOfferings) <-
+            if Map.null stagedNow
+              then pure (Map.empty, Map.empty, Map.empty)
+              else do
+                candidates <- atomically $ do
+                  handlesNow <- cschcMap varChainSyncHandles
+                  -- Re-key by 'PeerId' so the map lines up with how the
+                  -- staging area and the offerings map identify peers.
+                  traverse
+                    (fmap csCandidate . readTVar . cschState)
+                    (Map.mapKeys Leios.MkPeerId handlesNow)
+                let augmented = augmentStagedPeers candidates stagedNow
+                    -- Only synth offerings for peers we can actually
+                    -- send to (in 'leiosPeersVars'). Otherwise the
+                    -- decision logic would target peers whose request
+                    -- slot is missing from the eventual
+                    -- 'Map.intersectionWith' send step → silent drop,
+                    -- while 'requestedEbPeers' / 'requestedTxPeers' is
+                    -- already updated, locking the EB out from future
+                    -- retries.
+                    offers =
+                      (`Map.restrictKeys` livePeers) $
+                        Map.fromListWith
+                          (\(a, b) (c, d) -> (a <> c, b <> d))
+                          [ ( peer
+                            , let ebs = Set.singleton (pointEbHash point)
+                               in (ebs, ebs)
+                            )
+                          | (point, entry) <- Map.toList augmented
+                          , peer <- Set.toList (stagedPeers entry)
+                          ]
+                pure (augmented, Map.map stagedSize augmented, offers)
+          let augmentedOfferings =
                 Map.unionWith
                   (\(a, b) (c, d) -> (a <> c, b <> d))
                   offerings
                   synthOfferings
           newDecisions <- MVar.modifyMVar getLeiosOutstanding $ \outstanding -> do
-            let realMissingBodyKeys = Map.keysSet (Leios.missingEbBodies outstanding)
-                synthOnlyBodyKeys =
-                  Map.keysSet synthMissing `Set.difference` realMissingBodyKeys
-                realMissingTxKeys = Map.keysSet (Leios.missingEbTxs outstanding)
-                synthOnlyTxKeys =
-                  Map.keysSet synthMissingTxs `Set.difference` realMissingTxKeys
-                realReverseKeys = Map.keysSet (Leios.reverseEbIndexByTx outstanding)
-                synthOnlyReverseKeys =
-                  Map.keysSet synthReverseEbIndexByTx `Set.difference` realReverseKeys
+            -- Short-circuit synth-add for EBs whose body is already in
+            -- 'acquiredEbBodies' (analogous to MsgLeiosBlockOffer's
+            -- check at 'NodeToNode.hs'). Avoids per-tick "synth re-adds,
+            -- filterMissingWork removes" round-trips during the
+            -- post-body, pre-closure-complete window.
+            let synthMissing' =
+                  Map.filterWithKey
+                    ( \point _ ->
+                        Set.notMember
+                          (pointEbHash point)
+                          (Leios.acquiredEbBodies outstanding)
+                    )
+                    synthMissing
+                -- Persist the synth-added body entries directly. The
+                -- natural cleanup paths handle them: 'msgLeiosBlock'
+                -- deletes from 'missingEbBodies' on body arrival;
+                -- 'filterMissingWork' moves the entry to
+                -- 'acquiredEbBodies' if the body was already in DB
+                -- (e.g. from forging or a prior session). Left-biased
+                -- so the real entry's in-flight-request bookkeeping is
+                -- preserved.
                 augmentedOutstanding =
                   outstanding
                     { Leios.missingEbBodies =
-                        -- Left-biased: keep real entry (carries in-flight
-                        -- request state) over the synth's bare size.
                         Map.union
                           (Leios.missingEbBodies outstanding)
-                          synthMissing
-                    , Leios.missingEbTxs =
-                        Map.union
-                          (Leios.missingEbTxs outstanding)
-                          synthMissingTxs
-                    , Leios.reverseEbIndexByTx =
-                        Map.unionWith
-                          Map.union
-                          (Leios.reverseEbIndexByTx outstanding)
-                          synthReverseEbIndexByTx
+                          synthMissing'
                     }
             filteredOutstanding <-
               Leios.filterMissingWork leiosConn augmentedOutstanding
             traceWith leiosTr $ MkTraceLeiosKernel "leiosFetchLogic: filtered"
-            let (!outstanding'', decisions) =
+            let (!outstanding', decisions) =
                   Leios.leiosFetchLogicIteration
                     Leios.demoLeiosFetchStaticEnv
                     augmentedOfferings
                     filteredOutstanding
-                -- Strip synthetic-only entries before persisting; the
-                -- rest of 'outstanding''' (requestedEbPeers,
-                -- requestedTxPeers, requestedBytesSize, …) is real and
-                -- must be kept so the eventual responses are accepted.
-                outstanding' =
-                  outstanding''
-                    { Leios.missingEbBodies =
-                        Map.withoutKeys
-                          (Leios.missingEbBodies outstanding'')
-                          synthOnlyBodyKeys
-                    , Leios.missingEbTxs =
-                        Map.withoutKeys
-                          (Leios.missingEbTxs outstanding'')
-                          synthOnlyTxKeys
-                    , Leios.reverseEbIndexByTx =
-                        Map.withoutKeys
-                          (Leios.reverseEbIndexByTx outstanding'')
-                          synthOnlyReverseKeys
-                    }
             pure (outstanding', decisions)
           traceWith leiosTr $ MkTraceLeiosKernel "leiosFetchLogic: decided"
           let newRequests =
                 Leios.packRequests Leios.demoLeiosFetchStaticEnv newDecisions
               numStaged = Map.size stagedNow
               numLiveStagedPeers =
-                sum [ Set.size (stagedPeers e)
-                    | e <- Map.elems stagedAugmented ]
+                sum
+                  [ Set.size (stagedPeers e)
+                  | e <- Map.elems stagedAugmented
+                  ]
               decisionsTargetedKeys = Map.keysSet newRequests
               droppableKeys =
                 decisionsTargetedKeys `Set.difference` livePeers
@@ -644,14 +601,13 @@ initNodeKernel
               "leiosFetchLogic: "
                 ++ show (sum (fmap length newRequests))
                 ++ " new reqs"
-          traceWith leiosTr $
-            MkTraceLeiosKernel $
-              "leiosFetchLogic: staged="
-                ++ show numStaged
-                ++ " liveStagedPeerLinks="
-                ++ show numLiveStagedPeers
-                ++ " synthTxsEntries="
-                ++ show (Map.size synthMissingTxs)
+          unless (Map.null stagedNow) $
+            traceWith leiosTr $
+              MkTraceLeiosKernel $
+                "leiosFetchLogic: staged="
+                  ++ show numStaged
+                  ++ " liveStagedPeerLinks="
+                  ++ show numLiveStagedPeers
           unless (Set.null droppableKeys) $
             traceWith leiosTr $
               MkTraceLeiosKernel $
@@ -976,16 +932,40 @@ wrapChainDbViewForLeiosStaging
           }
       atomically $ stageCertRB stagingArea point size peers blk
       _ <- MVar.tryPutMVar readyMVar ()
-      -- Deferred promise: claim "written" so BlockFetch logic
-      -- doesn't immediately refetch; report processed as failed
-      -- (the staged block is not yet on the chain).
+      -- Block this BlockFetch client thread until the staging
+      -- drain releases this entry (closure arrived; block was
+      -- admitted to ChainDB via the unwrapped 'addBlockAsync' on
+      -- the drain side). This stops the BlockFetch decision
+      -- module from re-fetching the same CertRB in a tight loop
+      -- during the staging window — the previous "lie about
+      -- 'blockWrittenToDisk = pure True'" approach plus the
+      -- 'getIsFetched' widening together don't suppress refetch
+      -- in the steady-state late-join scenario, and the resulting
+      -- decision-loop spin is the dominant retainer of iosim
+      -- 'SimTrace' state (PR open point #3).
+      --
+      -- Cost: head-of-line blocking on this peer's BlockFetch
+      -- pipeline. The closure fetch runs on a separate
+      -- LeiosFetch channel of the same connection, so progress
+      -- is not deadlocked. CPU cost is zero — STM 'retry'.
+      --
+      -- Caveat: if the closure never arrives (all peers offering
+      -- it disconnect), this STM blocks forever and the client
+      -- thread leaks. Tracked alongside PR open point #4 (no GC
+      -- of staged entries); the GC pass will need to also wake
+      -- parked threads with a 'FailedToAddBlock' verdict before
+      -- evicting an entry.
+      atomically $ do
+        snapshot <- stagedSnapshot stagingArea
+        when (Map.member point snapshot) retry
+      -- Drain has admitted the block via the unwrapped
+      -- 'addBlockAsync'; surface success so the BlockFetch
+      -- client counts it as fetched and moves on.
       pure
         AddBlockPromise
           { blockWrittenToDisk = pure True
           , blockProcessed =
-              pure $
-                FailedToAddBlock
-                  "CertRB staged, awaiting EB closure"
+              pure $ SuccesfullyAddedBlock (Block.blockPoint blk)
           }
 
 -- | Find the parent header in the current chain or any ChainSync

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
@@ -504,8 +504,14 @@ initNodeKernel
               synthOfferings =
                 Map.fromListWith
                   (\(a, b) (c, d) -> (a <> c, b <> d))
+                  -- Peers that know the staged CertRB have applied it on
+                  -- their chain, so they hold the full closure — EB body
+                  -- AND tx closure. Synthesise the EB hash into both
+                  -- sets so 'choosePeerEb' (body) and 'choosePeerTx'
+                  -- (txs) both pick them up.
                   [ ( peer
-                    , (Set.singleton (pointEbHash point), Set.empty)
+                    , let ebs = Set.singleton (pointEbHash point)
+                       in (ebs, ebs)
                     )
                   | (point, entry) <- Map.toList stagedAugmented
                   , peer <- Set.toList (stagedPeers entry)
@@ -571,11 +577,7 @@ initNodeKernel
         let drainTr = leiosKernelTracer tracers
         chan <- subscribeEbNotifications leiosDB
         runStagingAreaDrain leiosCertRbStaging chan $ \point blk -> do
-          traceWith drainTr $
-            MkTraceLeiosKernel $
-              "CertRB staging: EB closure arrived, releasing "
-                ++ "block staged on "
-                ++ show point
+          traceWith drainTr TraceCertRBReleased{releasedEbPoint = point}
           _ <-
             ChainDB.addBlockAsync
               chainDB
@@ -845,15 +847,12 @@ wrapChainDbViewForLeiosStaging
           BlockFetchClientInterface.addBlockAsync defView punish blk
         Just (point, size) -> do
           peers <- atomically $ peersThatKnowBlock varChainSyncHandles blk
-          traceWith tracer $
-            MkTraceLeiosKernel $
-              "CertRB staging: parking block "
-                ++ show (Block.blockPoint blk)
-                ++ "; missing EB "
-                ++ show point
-                ++ "; known to "
-                ++ show (Set.size peers)
-                ++ " peer(s)"
+          traceWith tracer
+            TraceCertRBStaged
+              { stagedBlockPoint = show (Block.blockPoint blk)
+              , stagedEbPoint = point
+              , stagedKnownPeers = Set.size peers
+              }
           atomically $ stageCertRB stagingArea point size peers blk
           _ <- MVar.tryPutMVar readyMVar ()
           -- Deferred promise: claim "written" so BlockFetch logic

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
@@ -1014,14 +1014,17 @@ findParentAnnouncement prev currentChain candidates = case prev of
 -- whose *current* ChainSync candidate contains the staged block.
 -- Handles peers that connect (or extend their candidate through this
 -- block) after staging.
--- | Recompute each staged entry's peer set from the current ChainSync
--- candidates: any peer whose candidate fragment still contains the
--- staged block. We REPLACE the persisted 'stagedPeers' (rather than
--- union with it) so that peers which have since disconnected — and
--- whose handles are therefore no longer in 'candidates' — drop out.
--- Otherwise the fetch synth would keep aiming requests at peers that
--- aren't in 'leiosPeersVars' anymore, and 'Map.intersectionWith' in
--- the fetch loop would silently drop them.
+-- | Re-derive each staged entry's peer set by unioning in any peer
+-- whose *current* ChainSync candidate contains the staged block —
+-- handles peers that connect (or extend through this block) after
+-- staging. We deliberately UNION (rather than replace) so that
+-- original attesters who were known to have the block at stage time
+-- stay in the set even if their candidate fragment has since rolled
+-- past it (the block is in their immutable DB and they can still
+-- serve it via LeiosFetch). The 'Map.restrictKeys livePeers' filter
+-- in 'leiosFetchLogic's synth step drops any peers that have
+-- disconnected from 'leiosPeersVars' so 'Map.intersectionWith' won't
+-- silently drop their requests.
 augmentStagedPeers ::
   (HasHeader blk, HasHeader (Header blk), Ord peer) =>
   Map.Map peer (AF.AnchoredFragment (HeaderWithTime blk)) ->
@@ -1031,7 +1034,7 @@ augmentStagedPeers candidates staged =
   Map.map go staged
  where
   go entry =
-    let live =
+    let extra =
           Set.fromList
             [ peer
             | (peer, frag) <- Map.toList candidates
@@ -1039,7 +1042,7 @@ augmentStagedPeers candidates staged =
                 ((== Block.blockHash (stagedBlock entry)) . Block.blockHash)
                 (AF.toOldestFirst frag)
             ]
-     in entry{stagedPeers = live}
+     in entry{stagedPeers = stagedPeers entry `Set.union` extra}
 
 -- | Scan all ChainSync candidates for ones whose fragment contains a
 -- header with the same hash as @blk@. Those peers' chains have admitted

--- a/ouroboros-consensus.cabal
+++ b/ouroboros-consensus.cabal
@@ -106,6 +106,7 @@ library
     LeiosDemoOnlyTestFetch
     LeiosDemoOnlyTestNotify
     LeiosDemoTypes
+    LeiosStagingArea
     LeiosVoteState
     Ouroboros.Consensus.Block
     Ouroboros.Consensus.Block.Abstract

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoTypes.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoTypes.hs
@@ -19,6 +19,7 @@ module LeiosDemoTypes (module LeiosDemoTypes) where
 
 import Cardano.Binary (FromCBOR (fromCBOR), ToCBOR, enforceSize, serialize', toCBOR)
 import qualified Cardano.Crypto.Hash as Hash
+import qualified Cardano.Ledger.BaseTypes
 import Cardano.Ledger.Binary (DecCBOR, EncCBOR)
 import Cardano.Ledger.Core (EraTx, Tx, TxLevel (TopTx))
 import Cardano.Prelude (NFData, NonEmpty, toList, toString, (&))
@@ -27,7 +28,9 @@ import Codec.CBOR.Decoding (Decoder)
 import qualified Codec.CBOR.Decoding as CBOR
 import Codec.CBOR.Encoding (Encoding)
 import qualified Codec.CBOR.Encoding as CBOR
-import Codec.Serialise (Serialise, decode, encode)
+import qualified Codec.CBOR.Read as CBOR
+import qualified Codec.CBOR.Write as CBOR
+import Codec.Serialise (DeserialiseFailure, Serialise, decode, encode)
 import Control.Concurrent.Class.MonadMVar (MVar)
 import qualified Control.Concurrent.Class.MonadMVar as MVar
 import Control.Concurrent.Class.MonadSTM.Strict (StrictTVar)
@@ -39,6 +42,7 @@ import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Base16 as BS16
 import qualified Data.ByteString.Char8 as BS8
+import qualified Data.ByteString.Lazy as BSL
 import Data.IntMap (IntMap)
 import qualified Data.IntMap as IntMap
 import Data.Map (Map)
@@ -127,6 +131,25 @@ decodeLeiosPoint :: Decoder s LeiosPoint
 decodeLeiosPoint = do
   enforceSize (fromString "LeiosPoint") 2
   MkLeiosPoint <$> decode <*> decodeEbHash
+
+-- | Encode a 'LeiosPoint' as the CBOR payload to embed in a
+-- 'Cardano.Ledger.BaseTypes.LeiosCert'. Consensus uses this when
+-- forging a CertRB; the receiver decodes it via 'decodeLeiosCertPoint'
+-- to learn which EB closure to fetch / splice.
+encodeLeiosCertPoint :: LeiosPoint -> BS.ByteString
+encodeLeiosCertPoint = CBOR.toStrictByteString . encodeLeiosPoint
+
+-- | Inverse of 'encodeLeiosCertPoint': decode the 'LeiosPoint' embedded
+-- in a 'LeiosCert.leiosCertPayload'. Returns 'Left' with the
+-- deserialise error on a malformed payload.
+decodeLeiosCertPoint ::
+  Cardano.Ledger.BaseTypes.LeiosCert ->
+  Either DeserialiseFailure LeiosPoint
+decodeLeiosCertPoint cert =
+  case CBOR.deserialiseFromBytes decodeLeiosPoint $
+    BSL.fromStrict (Cardano.Ledger.BaseTypes.leiosCertPayload cert) of
+    Left err -> Left err
+    Right (_, point) -> Right point
 
 -- | Types used in Praos headers
 data EbAnnouncement = EbAnnouncement

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoTypes.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoTypes.hs
@@ -19,7 +19,6 @@ module LeiosDemoTypes (module LeiosDemoTypes) where
 
 import Cardano.Binary (FromCBOR (fromCBOR), ToCBOR, enforceSize, serialize', toCBOR)
 import qualified Cardano.Crypto.Hash as Hash
-import qualified Cardano.Ledger.BaseTypes
 import Cardano.Ledger.Binary (DecCBOR, EncCBOR)
 import Cardano.Ledger.Core (EraTx, Tx, TxLevel (TopTx))
 import Cardano.Prelude (NFData, NonEmpty, toList, toString, (&))
@@ -146,14 +145,18 @@ encodeLeiosCertInfo point bytesSize =
       <> encode bytesSize
 
 -- | Inverse of 'encodeLeiosCertInfo': decode the @(LeiosPoint,
--- BytesSize)@ pair embedded in a 'LeiosCert.leiosCertPayload'. Returns
--- 'Left' with the deserialise error on a malformed payload.
+-- BytesSize)@ pair from a raw CBOR payload. Returns 'Left' with the
+-- deserialise error on malformed bytes.
+--
+-- (The deployed 'Cardano.Ledger.BaseTypes.LeiosCert' is the empty
+-- placeholder, so this isn't used by the hot-fix path; the (en|de)coder
+-- pair is kept as a utility for a follow-up that wants to ship the
+-- (point, size) on-chain.)
 decodeLeiosCertInfo ::
-  Cardano.Ledger.BaseTypes.LeiosCert ->
+  BS.ByteString ->
   Either DeserialiseFailure (LeiosPoint, BytesSize)
-decodeLeiosCertInfo cert =
-  case CBOR.deserialiseFromBytes go $
-    BSL.fromStrict (Cardano.Ledger.BaseTypes.leiosCertPayload cert) of
+decodeLeiosCertInfo bs =
+  case CBOR.deserialiseFromBytes go (BSL.fromStrict bs) of
     Left err -> Left err
     Right (_, x) -> Right x
  where

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoTypes.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoTypes.hs
@@ -132,24 +132,34 @@ decodeLeiosPoint = do
   enforceSize (fromString "LeiosPoint") 2
   MkLeiosPoint <$> decode <*> decodeEbHash
 
--- | Encode a 'LeiosPoint' as the CBOR payload to embed in a
+-- | Encode the (point, size) pair as the CBOR payload to embed in a
 -- 'Cardano.Ledger.BaseTypes.LeiosCert'. Consensus uses this when
--- forging a CertRB; the receiver decodes it via 'decodeLeiosCertPoint'
--- to learn which EB closure to fetch / splice.
-encodeLeiosCertPoint :: LeiosPoint -> BS.ByteString
-encodeLeiosCertPoint = CBOR.toStrictByteString . encodeLeiosPoint
+-- forging a CertRB; the receiver decodes it via 'decodeLeiosCertInfo'
+-- to learn which EB closure to fetch / splice and what its expected
+-- on-the-wire size is (needed for the fetch logic's
+-- 'msgLeiosBlock' response validation).
+encodeLeiosCertInfo :: LeiosPoint -> BytesSize -> BS.ByteString
+encodeLeiosCertInfo point bytesSize =
+  CBOR.toStrictByteString $
+    CBOR.encodeListLen 2
+      <> encodeLeiosPoint point
+      <> encode bytesSize
 
--- | Inverse of 'encodeLeiosCertPoint': decode the 'LeiosPoint' embedded
--- in a 'LeiosCert.leiosCertPayload'. Returns 'Left' with the
--- deserialise error on a malformed payload.
-decodeLeiosCertPoint ::
+-- | Inverse of 'encodeLeiosCertInfo': decode the @(LeiosPoint,
+-- BytesSize)@ pair embedded in a 'LeiosCert.leiosCertPayload'. Returns
+-- 'Left' with the deserialise error on a malformed payload.
+decodeLeiosCertInfo ::
   Cardano.Ledger.BaseTypes.LeiosCert ->
-  Either DeserialiseFailure LeiosPoint
-decodeLeiosCertPoint cert =
-  case CBOR.deserialiseFromBytes decodeLeiosPoint $
+  Either DeserialiseFailure (LeiosPoint, BytesSize)
+decodeLeiosCertInfo cert =
+  case CBOR.deserialiseFromBytes go $
     BSL.fromStrict (Cardano.Ledger.BaseTypes.leiosCertPayload cert) of
     Left err -> Left err
-    Right (_, point) -> Right point
+    Right (_, x) -> Right x
+ where
+  go = do
+    enforceSize (fromString "LeiosCertInfo") 2
+    (,) <$> decodeLeiosPoint <*> decode
 
 -- | Types used in Praos headers
 data EbAnnouncement = EbAnnouncement

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoTypes.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoTypes.hs
@@ -691,6 +691,22 @@ data TraceLeiosKernel
   | TraceLeiosVoted {vote :: LeiosVote}
   | TraceLeiosVoteAcquired {vote :: LeiosVote}
   | TraceLeiosDbException LeiosDbException
+  | -- | A CertRB was admitted to the staging area because its certified
+    -- EB closure isn't locally available. This is a critical event: it
+    -- means the node would have crashed in 'resolveLeiosBlock' (issue
+    -- #890) and the staging-area / Phase-2 emergency-fetch path is
+    -- compensating. Carries the staged block's point, the missing EB
+    -- point, and the number of peers whose ChainSync candidate
+    -- contained the block (they're treated as implicit offerers of the
+    -- EB by the fetch loop).
+    TraceCertRBStaged
+      { stagedBlockPoint :: String
+      , stagedEbPoint :: LeiosPoint
+      , stagedKnownPeers :: Int
+      }
+  | -- | A staged CertRB has been released back into ChainSel because
+    -- the EB closure (body + txs) is now locally available.
+    TraceCertRBReleased {releasedEbPoint :: LeiosPoint}
 
 deriving instance Show TraceLeiosKernel
 
@@ -747,6 +763,22 @@ traceLeiosKernelToObject = \case
       ]
   TraceLeiosDbException e ->
     jsonLeiosDbException e
+  TraceCertRBStaged{stagedBlockPoint, stagedEbPoint, stagedKnownPeers} ->
+    let MkLeiosPoint (SlotNo ebSlot) ebHash = stagedEbPoint
+     in mconcat
+          [ "kind" .= Aeson.String "CertRBStaged"
+          , "blockPoint" .= stagedBlockPoint
+          , "ebHash" .= prettyEbHash ebHash
+          , "ebSlot" .= ebSlot
+          , "knownPeers" .= stagedKnownPeers
+          ]
+  TraceCertRBReleased{releasedEbPoint} ->
+    let MkLeiosPoint (SlotNo ebSlot) ebHash = releasedEbPoint
+     in mconcat
+          [ "kind" .= Aeson.String "CertRBReleased"
+          , "ebHash" .= prettyEbHash ebHash
+          , "ebSlot" .= ebSlot
+          ]
 
 data TraceLeiosPeer
   = MkTraceLeiosPeer String

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosStagingArea.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosStagingArea.hs
@@ -1,11 +1,29 @@
 -- | CertRB staging area for issue #890.
 --
--- A small in-memory buffer of CertRBs whose announced EB closure isn't
+-- An in-memory buffer of CertRBs whose announced EB closure isn't
 -- locally available yet. The BlockFetch client stages such blocks here
 -- instead of handing them to ChainSel (which would crash inside
 -- 'resolveLeiosBlock'); a drain loop ('runStagingAreaDrain') releases
 -- them once the corresponding EB closure arrives via LeiosFetch
 -- notifications.
+--
+-- Each staged entry remembers:
+--
+-- * the block itself,
+-- * the announced EB body's expected on-the-wire size (the fetch logic
+--   needs it to validate the response in 'msgLeiosBlock'), and
+-- * the set of peers known — at staging time — to have this block on
+--   their ChainSync candidate fragment, so the fetch logic can pretend
+--   those peers offered the EB (Phase 2 emergency fetch).
+--
+-- The staging area is the source of truth: the fetch logic 'reads'
+-- 'stagedSnapshot' each tick and synthesises augmented inputs from it
+-- transiently, never writing back here.
+--
+-- TODO(issue #890, Phase 2 follow-up): garbage-collect staged entries
+-- whose peer set is empty AND have aged out (no current candidate
+-- contains them anymore). For now, entries live until the drain
+-- releases them.
 module LeiosStagingArea (module LeiosStagingArea) where
 
 import Control.Concurrent.Class.MonadSTM.Strict
@@ -20,50 +38,81 @@ import Control.Concurrent.Class.MonadSTM.Strict
   , writeTVar
   )
 import Control.Monad (forever)
+import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 import Data.Void (Void)
 import LeiosDemoDb.Common (LeiosEbNotification (..))
-import LeiosDemoTypes (LeiosPoint)
+import LeiosDemoTypes (BytesSize, LeiosPoint)
 import Ouroboros.Consensus.Block (HasHeader, Point, blockPoint)
 
+-- | A single staged CertRB.
+data StagedCertRB peer blk = MkStagedCertRB
+  { stagedBlock :: !blk
+  , stagedSize :: !BytesSize
+  , stagedPeers :: !(Set.Set peer)
+  -- ^ Peers known to have this block on their candidate at staging
+  -- time. The fetch logic uses this set as the pool of peers it can
+  -- pretend offered the certified EB.
+  }
+
 -- | Staging area for CertRBs awaiting their EB closure.
---
--- The TVar is encapsulated; callers use the record fields to stage,
--- release, or query staged blocks.
-data LeiosStagingArea m blk = LeiosStagingArea
-  { stageCertRB :: LeiosPoint -> blk -> STM m ()
-  -- ^ Stage @blk@ at the missing EB @LeiosPoint@. Replaces any prior
-  -- entry for the same point.
+data LeiosStagingArea m peer blk = LeiosStagingArea
+  { stageCertRB ::
+      LeiosPoint ->
+      BytesSize ->
+      Set.Set peer ->
+      blk ->
+      STM m ()
+  -- ^ Stage @blk@ at the certified-EB @LeiosPoint@. If an entry
+  -- already exists for the same point, its peer set is unioned with
+  -- the new one (later peers can add themselves) and size is preserved.
   , releaseCertRB :: LeiosPoint -> STM m (Maybe blk)
   -- ^ Remove and return the block staged at @point@, if any. Called by
   -- the drain loop once the corresponding EB closure arrives.
   , isStagedBlock :: STM m (Point blk -> Bool)
   -- ^ A predicate over block points that returns 'True' for blocks
   -- currently in the staging area. Used to widen the BlockFetch
-  -- client's view of fetched blocks so it doesn't keep refetching them.
+  -- client's view of fetched blocks so it doesn't keep refetching.
+  , stagedSnapshot :: STM m (Map LeiosPoint (StagedCertRB peer blk))
+  -- ^ Read-only snapshot of the staging area, consumed by the fetch
+  -- logic each tick to synthesise augmented inputs (missing-EB
+  -- entries + peer offerings).
   }
 
 newLeiosStagingArea ::
-  (MonadSTM m, HasHeader blk) => m (LeiosStagingArea m blk)
+  (MonadSTM m, HasHeader blk, Ord peer) =>
+  m (LeiosStagingArea m peer blk)
 newLeiosStagingArea = do
   tvar <- atomically $ newTVar Map.empty
   pure
     LeiosStagingArea
-      { stageCertRB = \point blk ->
-          modifyTVar tvar (Map.insert point blk)
+      { stageCertRB = \point size peers blk ->
+          modifyTVar tvar $
+            Map.insertWith
+              ( \new old ->
+                  old{stagedPeers = stagedPeers old `Set.union` stagedPeers new}
+              )
+              point
+              MkStagedCertRB
+                { stagedBlock = blk
+                , stagedSize = size
+                , stagedPeers = peers
+                }
       , releaseCertRB = \point -> do
           m <- readTVar tvar
           case Map.lookup point m of
             Nothing -> pure Nothing
-            Just blk -> do
+            Just entry -> do
               writeTVar tvar (Map.delete point m)
-              pure (Just blk)
+              pure (Just (stagedBlock entry))
       , isStagedBlock = do
           staged <- readTVar tvar
           let points =
-                Set.fromList [blockPoint b | b <- Map.elems staged]
+                Set.fromList
+                  [blockPoint (stagedBlock e) | e <- Map.elems staged]
           pure (`Set.member` points)
+      , stagedSnapshot = readTVar tvar
       }
 
 -- | Drain loop: every EB-closure notification removes any block staged
@@ -75,16 +124,22 @@ newLeiosStagingArea = do
 -- 'LeiosDbHandle' type.
 runStagingAreaDrain ::
   MonadSTM m =>
-  LeiosStagingArea m blk ->
+  LeiosStagingArea m peer blk ->
   StrictTChan m LeiosEbNotification ->
   (LeiosPoint -> blk -> m ()) ->
   m Void
 runStagingAreaDrain area chan onReleased = forever $ do
   ev <- atomically (readTChan chan)
-  let point = case ev of
-        AcquiredEb p _ -> p
-        AcquiredEbTxs p -> p
-  mStaged <- atomically $ releaseCertRB area point
-  case mStaged of
-    Nothing -> pure ()
-    Just blk -> onReleased point blk
+  case ev of
+    AcquiredEb{} ->
+      -- Only the EB body arrived; the tx closure isn't complete yet.
+      -- 'resolveLeiosBlock' queries 'leiosDbQueryCompletedEbByPoint',
+      -- which still returns 'Nothing' here. Releasing now would
+      -- re-submit the staged block before its txs land and crash at
+      -- apply time. Wait for 'AcquiredEbTxs'.
+      pure ()
+    AcquiredEbTxs point -> do
+      mStaged <- atomically $ releaseCertRB area point
+      case mStaged of
+        Nothing -> pure ()
+        Just blk -> onReleased point blk

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosStagingArea.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosStagingArea.hs
@@ -1,0 +1,90 @@
+-- | CertRB staging area for issue #890.
+--
+-- A small in-memory buffer of CertRBs whose announced EB closure isn't
+-- locally available yet. The BlockFetch client stages such blocks here
+-- instead of handing them to ChainSel (which would crash inside
+-- 'resolveLeiosBlock'); a drain loop ('runStagingAreaDrain') releases
+-- them once the corresponding EB closure arrives via LeiosFetch
+-- notifications.
+module LeiosStagingArea (module LeiosStagingArea) where
+
+import Control.Concurrent.Class.MonadSTM.Strict
+  ( MonadSTM
+  , STM
+  , StrictTChan
+  , atomically
+  , modifyTVar
+  , newTVar
+  , readTChan
+  , readTVar
+  , writeTVar
+  )
+import Control.Monad (forever)
+import qualified Data.Map.Strict as Map
+import qualified Data.Set as Set
+import Data.Void (Void)
+import LeiosDemoDb.Common (LeiosEbNotification (..))
+import LeiosDemoTypes (LeiosPoint)
+import Ouroboros.Consensus.Block (HasHeader, Point, blockPoint)
+
+-- | Staging area for CertRBs awaiting their EB closure.
+--
+-- The TVar is encapsulated; callers use the record fields to stage,
+-- release, or query staged blocks.
+data LeiosStagingArea m blk = LeiosStagingArea
+  { stageCertRB :: LeiosPoint -> blk -> STM m ()
+  -- ^ Stage @blk@ at the missing EB @LeiosPoint@. Replaces any prior
+  -- entry for the same point.
+  , releaseCertRB :: LeiosPoint -> STM m (Maybe blk)
+  -- ^ Remove and return the block staged at @point@, if any. Called by
+  -- the drain loop once the corresponding EB closure arrives.
+  , isStagedBlock :: STM m (Point blk -> Bool)
+  -- ^ A predicate over block points that returns 'True' for blocks
+  -- currently in the staging area. Used to widen the BlockFetch
+  -- client's view of fetched blocks so it doesn't keep refetching them.
+  }
+
+newLeiosStagingArea ::
+  (MonadSTM m, HasHeader blk) => m (LeiosStagingArea m blk)
+newLeiosStagingArea = do
+  tvar <- atomically $ newTVar Map.empty
+  pure
+    LeiosStagingArea
+      { stageCertRB = \point blk ->
+          modifyTVar tvar (Map.insert point blk)
+      , releaseCertRB = \point -> do
+          m <- readTVar tvar
+          case Map.lookup point m of
+            Nothing -> pure Nothing
+            Just blk -> do
+              writeTVar tvar (Map.delete point m)
+              pure (Just blk)
+      , isStagedBlock = do
+          staged <- readTVar tvar
+          let points =
+                Set.fromList [blockPoint b | b <- Map.elems staged]
+          pure (`Set.member` points)
+      }
+
+-- | Drain loop: every EB-closure notification removes any block staged
+-- on that point and hands it to @onReleased@ (typically
+-- 'ChainDB.addBlockAsync').
+--
+-- The caller supplies the notification channel (obtained via
+-- 'subscribeEbNotifications') so this module need not depend on the
+-- 'LeiosDbHandle' type.
+runStagingAreaDrain ::
+  MonadSTM m =>
+  LeiosStagingArea m blk ->
+  StrictTChan m LeiosEbNotification ->
+  (LeiosPoint -> blk -> m ()) ->
+  m Void
+runStagingAreaDrain area chan onReleased = forever $ do
+  ev <- atomically (readTChan chan)
+  let point = case ev of
+        AcquiredEb p _ -> p
+        AcquiredEbTxs p -> p
+  mStaged <- atomically $ releaseCertRB area point
+  case mStaged of
+    Nothing -> pure ()
+    Just blk -> onReleased point blk

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ChainSync/Server.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ChainSync/Server.hs
@@ -159,7 +159,7 @@ chainSyncBlocksServer tracer chainDB ccfg version leiosDb flr = ChainSyncServer 
       m (WithPoint blk (Serialised blk))
     resolve (WithPoint (hdr, sblk) pt) = do
       mPrevAnn <- readTVarIO prevAnnVar
-      atomically $ writeTVar prevAnnVar (headerLeiosAnnouncement hdr)
+      atomically $ writeTVar prevAnnVar (fst <$> headerLeiosAnnouncement hdr)
       sblk' <- case mPrevAnn of
         Nothing -> pure sblk
         Just prevAnn -> case decode sblk of
@@ -176,7 +176,7 @@ chainSyncBlocksServer tracer chainDB ccfg version leiosDb flr = ChainSyncServer 
       Origin -> atomically $ writeTVar prevAnnVar Nothing
       NotOrigin rp -> do
         mHdr <- ChainDB.getBlockComponent chainDB GetHeader rp
-        atomically $ writeTVar prevAnnVar (mHdr >>= headerLeiosAnnouncement)
+        atomically $ writeTVar prevAnnVar (fst <$> (mHdr >>= headerLeiosAnnouncement))
 
     decode :: Serialised blk -> Either CBOR.Read.DeserialiseFailure blk
     decode (Serialised bs) =

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB.hs
@@ -80,16 +80,17 @@ openDB
   getBlock
   getVolatileSuffix =
     case lgrBackendArgs args of
-      LedgerDbBackendArgsV1 bss ->
+      LedgerDbBackendArgsV1 bss -> do
         let snapManager = V1.snapshotManager args
-            initDb =
-              V1.mkInitDb
-                args
-                bss
-                getBlock
-                snapManager
-                getVolatileSuffix
-         in lift $ doOpenDB args initDb snapManager stream replayGoal
+        initDb <-
+          lift $
+            V1.mkInitDb
+              args
+              bss
+              getBlock
+              snapManager
+              getVolatileSuffix
+        lift $ doOpenDB args initDb snapManager stream replayGoal
       LedgerDbBackendArgsV2 (SomeBackendArgs bArgs) -> do
         -- Note this is the only step that cares about the temporary
         -- registry. Note also that the final state is an polymorphic and
@@ -108,7 +109,7 @@ openDB
                 (configCodec . getExtLedgerCfg . ledgerDbCfg $ lgrConfig args)
                 snapTracer
                 (lgrHasFS args)
-        let initDb = V2.mkInitDb args getBlock snapManager getVolatileSuffix res
+        initDb <- lift $ V2.mkInitDb args getBlock snapManager getVolatileSuffix res
         lift $ doOpenDB args initDb snapManager stream replayGoal
        where
         !tr = lgrTracer args

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/Forker.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/Forker.hs
@@ -569,33 +569,19 @@ class ResolveLeiosBlock blk where
     Monad m => LeiosDbConnection m -> LeiosPoint -> blk -> m (Maybe blk)
   resolveLeiosBlockHdr _ _ _ = return Nothing
 
-  -- | Closure-availability check for the CertRB staging area (issue #890).
+  -- | Whether this block's body carries a 'LeiosCert' (a CertRB).
   --
-  -- The Leios cert in the block body carries the certified EB point and
-  -- its expected on-the-wire body size as a CBOR payload (see
-  -- 'LeiosCert.leiosCertPayload' / 'encodeLeiosCertInfo'); this method
-  -- decodes them and asks the local 'LeiosDb' whether the closure is
-  -- present.
-  --
-  -- Returns @Just (point, size)@ when the block carries a Leios cert
-  -- and the referenced EB closure is *not* in the local 'LeiosDb' —
-  -- the caller can then park the CertRB (along with the size, which
-  -- the fetch logic needs to validate the eventual response) in a
-  -- staging area. Returns 'Nothing' when the block has no Leios cert,
-  -- or when the closure is already present (so the block is safe to
-  -- admit to ChainSel).
-  checkLeiosBlockResolvable ::
-    Monad m =>
-    LeiosDbConnection m ->
-    blk ->
-    m (Maybe (LeiosPoint, BytesSize))
-  checkLeiosBlockResolvable _ _ = return Nothing
+  -- The CertRB staging area gate inspects this cheaply before going on
+  -- to compute the announced EB point and querying the 'LeiosDb'.
+  blockHasLeiosCert :: blk -> Bool
+  blockHasLeiosCert _ = False
 
-  -- | The EB point announced by this header, if any. 'Nothing' for headers
-  -- in eras that don't carry Leios announcements. Lets the chain-sync
-  -- server hold only the minimum needed to splice the next cert block, and
-  -- skip decoding entirely when the announcer didn't announce.
-  headerLeiosAnnouncement :: Header blk -> Maybe LeiosPoint
+  -- | The EB announcement carried by this header (point + on-the-wire
+  -- body size), if any. 'Nothing' for headers in eras that don't carry
+  -- Leios announcements. The CertRB staging gate reads this off the
+  -- parent header on the current chain to learn which EB the new
+  -- block's cert refers to.
+  headerLeiosAnnouncement :: Header blk -> Maybe (LeiosPoint, BytesSize)
   headerLeiosAnnouncement _ = Nothing
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/Forker.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/Forker.hs
@@ -569,6 +569,25 @@ class ResolveLeiosBlock blk where
     Monad m => LeiosDbConnection m -> LeiosPoint -> blk -> m (Maybe blk)
   resolveLeiosBlockHdr _ _ _ = return Nothing
 
+  -- | Closure-availability check for the CertRB staging area (issue #890).
+  --
+  -- The Leios cert in the block body carries the certified EB point as
+  -- a CBOR payload ('LeiosCert.leiosCertPayload'); this method decodes
+  -- it and asks the local 'LeiosDb' whether the closure is present.
+  --
+  -- Returns @Just point@ when the block carries a Leios cert and the
+  -- referenced EB closure is *not* in the local 'LeiosDb' — the caller
+  -- can then park the CertRB in a staging area and add @point@ to the
+  -- fetch work set. Returns 'Nothing' when the block has no Leios cert,
+  -- or when the closure is already present (so the block is safe to
+  -- admit to ChainSel).
+  checkLeiosBlockResolvable ::
+    Monad m =>
+    LeiosDbConnection m ->
+    blk ->
+    m (Maybe LeiosPoint)
+  checkLeiosBlockResolvable _ _ = return Nothing
+
   -- | The EB point announced by this header, if any. 'Nothing' for headers
   -- in eras that don't carry Leios announcements. Lets the chain-sync
   -- server hold only the minimum needed to splice the next cert block, and

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/Forker.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/Forker.hs
@@ -70,7 +70,7 @@ import qualified Data.Set as Set
 import Data.Word
 import GHC.Generics
 import LeiosDemoDb (LeiosDbConnection)
-import LeiosDemoTypes (LeiosPoint)
+import LeiosDemoTypes (BytesSize, LeiosPoint)
 import NoThunks.Class
 import Ouroboros.Consensus.Block
 import Ouroboros.Consensus.HeaderValidation (headerStateChainDep)
@@ -571,21 +571,24 @@ class ResolveLeiosBlock blk where
 
   -- | Closure-availability check for the CertRB staging area (issue #890).
   --
-  -- The Leios cert in the block body carries the certified EB point as
-  -- a CBOR payload ('LeiosCert.leiosCertPayload'); this method decodes
-  -- it and asks the local 'LeiosDb' whether the closure is present.
+  -- The Leios cert in the block body carries the certified EB point and
+  -- its expected on-the-wire body size as a CBOR payload (see
+  -- 'LeiosCert.leiosCertPayload' / 'encodeLeiosCertInfo'); this method
+  -- decodes them and asks the local 'LeiosDb' whether the closure is
+  -- present.
   --
-  -- Returns @Just point@ when the block carries a Leios cert and the
-  -- referenced EB closure is *not* in the local 'LeiosDb' — the caller
-  -- can then park the CertRB in a staging area and add @point@ to the
-  -- fetch work set. Returns 'Nothing' when the block has no Leios cert,
+  -- Returns @Just (point, size)@ when the block carries a Leios cert
+  -- and the referenced EB closure is *not* in the local 'LeiosDb' —
+  -- the caller can then park the CertRB (along with the size, which
+  -- the fetch logic needs to validate the eventual response) in a
+  -- staging area. Returns 'Nothing' when the block has no Leios cert,
   -- or when the closure is already present (so the block is safe to
   -- admit to ChainSel).
   checkLeiosBlockResolvable ::
     Monad m =>
     LeiosDbConnection m ->
     blk ->
-    m (Maybe LeiosPoint)
+    m (Maybe (LeiosPoint, BytesSize))
   checkLeiosBlockResolvable _ _ = return Nothing
 
   -- | The EB point announced by this header, if any. 'Nothing' for headers

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/V1.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/V1.hs
@@ -85,65 +85,69 @@ mkInitDb ::
   ResolveBlock m blk ->
   SnapshotManagerV1 m blk ->
   GetVolatileSuffix m blk ->
-  InitDB (DbChangelog' blk, BackingStore' m blk) m blk
-mkInitDb args bss getBlock snapManager getVolatileSuffix =
-  InitDB
-    { initFromGenesis = do
-        st <- lgrGenesis
-        let genesis = forgetLedgerTables st
-            chlog = DbCh.empty genesis
-        backingStore <- newBackingStore bsTracer baArgs lgrHasFS' genesis (projectLedgerTables st)
-        pure (chlog, backingStore)
-    , initFromSnapshot = \ds ->
-        runExceptT
-          ( loadSnapshot
-              bsTracer
-              baArgs
-              (configCodec . getExtLedgerCfg . ledgerDbCfg $ lgrConfig)
-              lgrHasFS'
-              ds
-          )
-    , initReapplyBlock = \cfg blk (chlog, bstore) -> do
-        !chlog' <- reapplyThenPush cfg blk (readKeySets bstore) chlog
-        -- It's OK to flush without a lock here, since the `LedgerDB` has not
-        -- finished initializing, only this thread has access to the backing
-        -- store.
-        chlog'' <-
-          unsafeIgnoreWriteLock $
-            if shouldFlush flushFreq (flushableLength chlog')
-              then do
-                let (toFlush, toKeep) = splitForFlushing chlog'
-                mapM_ (flushIntoBackingStore bstore) toFlush
-                pure toKeep
-              else pure chlog'
-        pure (chlog'', bstore)
-    , currentTip = \(ch, _) -> ledgerState . current $ ch
-    , mkLedgerDb = \(db, ldbBackingStore) -> do
-        (varDB, prevApplied) <-
-          (,) <$> newTVarIO db <*> newTVarIO Set.empty
-        flushLock <- mkLedgerDBLock
-        nextForkerKey <- newTVarIO (ForkerKey 0)
-        ldbLeiosDb <- open lgrLeiosDb
-        let env =
-              LedgerDBEnv
-                { ldbChangelog = varDB
-                , ldbBackingStore = ldbBackingStore
-                , ldbLock = flushLock
-                , ldbPrevApplied = prevApplied
-                , ldbNextForkerKey = nextForkerKey
-                , ldbSnapshotPolicy = defaultSnapshotPolicy (ledgerDbCfgSecParam lgrConfig) lgrSnapshotPolicyArgs
-                , ldbTracer = lgrTracer
-                , ldbCfg = lgrConfig
-                , ldbHasFS = lgrHasFS'
-                , ldbShouldFlush = shouldFlush flushFreq
-                , ldbQueryBatchSize = lgrQueryBatchSize
-                , ldbResolveBlock = getBlock
-                , ldbGetVolatileSuffix = getVolatileSuffix
-                , ldbLeiosDb
-                }
-        h <- LDBHandle <$> newTVarIO (LedgerDBOpen env)
-        pure $ implMkLedgerDb h snapManager
-    }
+  m (InitDB (DbChangelog' blk, BackingStore' m blk) m blk)
+mkInitDb args bss getBlock snapManager getVolatileSuffix = do
+  -- Open the LeiosDb connection once, up front, and share it between the
+  -- immutable-DB replay path ('initReapplyBlock') and the post-replay
+  -- 'LedgerDBEnv'. See V2.mkInitDb for the longer rationale.
+  ldbLeiosDb <- open lgrLeiosDb
+  pure $
+    InitDB
+      { initFromGenesis = do
+          st <- lgrGenesis
+          let genesis = forgetLedgerTables st
+              chlog = DbCh.empty genesis
+          backingStore <- newBackingStore bsTracer baArgs lgrHasFS' genesis (projectLedgerTables st)
+          pure (chlog, backingStore)
+      , initFromSnapshot = \ds ->
+          runExceptT
+            ( loadSnapshot
+                bsTracer
+                baArgs
+                (configCodec . getExtLedgerCfg . ledgerDbCfg $ lgrConfig)
+                lgrHasFS'
+                ds
+            )
+      , initReapplyBlock = \cfg blk (chlog, bstore) -> do
+          !chlog' <- reapplyThenPushLeios ldbLeiosDb cfg blk (readKeySets bstore) chlog
+          -- It's OK to flush without a lock here, since the `LedgerDB` has not
+          -- finished initializing, only this thread has access to the backing
+          -- store.
+          chlog'' <-
+            unsafeIgnoreWriteLock $
+              if shouldFlush flushFreq (flushableLength chlog')
+                then do
+                  let (toFlush, toKeep) = splitForFlushing chlog'
+                  mapM_ (flushIntoBackingStore bstore) toFlush
+                  pure toKeep
+                else pure chlog'
+          pure (chlog'', bstore)
+      , currentTip = \(ch, _) -> ledgerState . current $ ch
+      , mkLedgerDb = \(db, ldbBackingStore) -> do
+          (varDB, prevApplied) <-
+            (,) <$> newTVarIO db <*> newTVarIO Set.empty
+          flushLock <- mkLedgerDBLock
+          nextForkerKey <- newTVarIO (ForkerKey 0)
+          let env =
+                LedgerDBEnv
+                  { ldbChangelog = varDB
+                  , ldbBackingStore = ldbBackingStore
+                  , ldbLock = flushLock
+                  , ldbPrevApplied = prevApplied
+                  , ldbNextForkerKey = nextForkerKey
+                  , ldbSnapshotPolicy = defaultSnapshotPolicy (ledgerDbCfgSecParam lgrConfig) lgrSnapshotPolicyArgs
+                  , ldbTracer = lgrTracer
+                  , ldbCfg = lgrConfig
+                  , ldbHasFS = lgrHasFS'
+                  , ldbShouldFlush = shouldFlush flushFreq
+                  , ldbQueryBatchSize = lgrQueryBatchSize
+                  , ldbResolveBlock = getBlock
+                  , ldbGetVolatileSuffix = getVolatileSuffix
+                  , ldbLeiosDb
+                  }
+          h <- LDBHandle <$> newTVarIO (LedgerDBOpen env)
+          pure $ implMkLedgerDb h snapManager
+      }
  where
   !bsTracer = LedgerDBFlavorImplEvent . FlavorImplSpecificTraceV1 >$< tr
   !tr = lgrTracer
@@ -380,6 +384,7 @@ mkInternals ::
   ( IOLike m
   , LedgerDbSerialiseConstraints blk
   , LedgerSupportsProtocol blk
+  , ResolveLeiosBlock blk
   ) =>
   LedgerDBHandle m (ExtLedgerState blk) blk ->
   SnapshotManagerV1 m blk ->
@@ -450,12 +455,14 @@ implIntPush env st = do
 implIntReapplyThenPush ::
   ( IOLike m
   , ApplyBlock l blk
+  , ResolveLeiosBlock blk
   , l ~ ExtLedgerState blk
   ) =>
   LedgerDBEnv m l blk -> blk -> m ()
 implIntReapplyThenPush env blk = do
   chlog <- readTVarIO $ ldbChangelog env
-  chlog' <- reapplyThenPush (ldbCfg env) blk (readKeySets (ldbBackingStore env)) chlog
+  chlog' <-
+    reapplyThenPushLeios (ldbLeiosDb env) (ldbCfg env) blk (readKeySets (ldbBackingStore env)) chlog
   atomically $ writeTVar (ldbChangelog env) chlog'
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/V1/DbChangelog.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/V1/DbChangelog.hs
@@ -123,6 +123,7 @@ module Ouroboros.Consensus.Storage.LedgerDB.V1.DbChangelog
     -- the ledger state](#g:hydratingTheLedgerState) and then finally call the
     -- ledger, which might throw errors.
   , reapplyThenPush
+  , reapplyThenPushLeios
 
     -- *** Hydrating the ledger state #hydratingTheLedgerState#
 
@@ -196,8 +197,10 @@ import Data.SOP (K, unK)
 import Data.SOP.Functors
 import Data.Word
 import GHC.Generics (Generic)
+import LeiosDemoDb (LeiosDbConnection)
 import Ouroboros.Consensus.Block
 import Ouroboros.Consensus.Config
+import Ouroboros.Consensus.HeaderValidation (headerStateChainDep)
 import Ouroboros.Consensus.Ledger.Abstract
 import Ouroboros.Consensus.Ledger.Extended
 import Ouroboros.Consensus.Ledger.Tables.Utils
@@ -361,6 +364,38 @@ reapplyThenPush ::
 reapplyThenPush cfg ap ksReader db =
   (\current' -> pruneToImmTipOnly $ extend current' db)
     <$> reapplyBlock (ledgerDbCfgComputeLedgerEvents cfg) (ledgerDbCfg cfg) ap ksReader db
+
+-- | Leios-aware variant of 'reapplyThenPush' used by the production
+-- code path.
+--
+-- For Leios CertRBs the wire-encoded body carries only a 'LeiosCert'
+-- (no txs); the actual transactions live in the EB closure. Mirroring
+-- 'Forker.applyBlock', we splice the EB body back in via
+-- 'resolveLeiosBlock' before ticking the ledger — otherwise the
+-- immutable-DB replay path would apply CertRBs as empty bodies,
+-- leaving the ledger state missing every EB-tx output that was
+-- created during the original fresh sync.
+--
+-- The non-Leios 'reapplyThenPush' is retained because the V1
+-- DbChangelog test suite operates on bare 'LedgerState' (not
+-- 'ExtLedgerState') and so cannot satisfy the 'l ~ ExtLedgerState blk'
+-- constraint that 'headerStateChainDep' requires.
+reapplyThenPushLeios ::
+  ( Monad m
+  , ApplyBlock l blk
+  , ResolveLeiosBlock blk
+  , l ~ ExtLedgerState blk
+  ) =>
+  LeiosDbConnection m ->
+  LedgerDbCfg l ->
+  blk ->
+  KeySetsReader m l ->
+  DbChangelog l ->
+  m (DbChangelog l)
+reapplyThenPushLeios leiosDb cfg b ksReader db = do
+  let cds = headerStateChainDep (headerState (current db))
+  b' <- resolveLeiosBlock leiosDb cds b
+  reapplyThenPush cfg b' ksReader db
 
 -- | Prune oldest ledger states according to the given 'LedgerDbPrune' strategy.
 --

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/V2.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/V2.hs
@@ -80,50 +80,59 @@ mkInitDb ::
   SnapshotManagerV2 m blk ->
   GetVolatileSuffix m blk ->
   Resources m backend ->
-  InitDB (LedgerSeq' m blk) m blk
+  m (InitDB (LedgerSeq' m blk) m blk)
 mkInitDb args getBlock snapManager getVolatileSuffix res = do
-  InitDB
-    { initFromGenesis = do
-        genesis <- lgrGenesis
-        sr <- createAndPopulateStateRefFromGenesis v2Tracer res genesis
-        pure $ LedgerSeq . AS.Empty $ sr
-    , initFromSnapshot = \ds ->
-        runExceptT
-          ( first (LedgerSeq . AS.Empty)
-              <$> openStateRefFromSnapshot
-                v2Tracer
-                (configCodec . getExtLedgerCfg . ledgerDbCfg $ lgrConfig)
-                lgrHasFS
-                res
-                ds
-          )
-    , initReapplyBlock = reapplyThenPush
-    , currentTip = ledgerState . current
-    , mkLedgerDb = \lseq -> do
-        varDB <- newTVarIO lseq
-        prevApplied <- newTVarIO Set.empty
-        lock <- RAWLock.new ()
-        nextForkerKey <- newTVarIO (ForkerKey 0)
-        ldbLeiosDb <- open lgrLeiosDb
-        let env =
-              LedgerDBEnv
-                { ldbSeq = varDB
-                , ldbPrevApplied = prevApplied
-                , ldbNextForkerKey = nextForkerKey
-                , ldbSnapshotPolicy = defaultSnapshotPolicy (ledgerDbCfgSecParam lgrConfig) lgrSnapshotPolicyArgs
-                , ldbTracer = tr
-                , ldbCfg = lgrConfig
-                , ldbHasFS = lgrHasFS
-                , ldbResolveBlock = getBlock
-                , ldbQueryBatchSize = lgrQueryBatchSize
-                , ldbOpenHandlesLock = lock
-                , ldbGetVolatileSuffix = getVolatileSuffix
-                , ldbBackendResources = SomeResources res
-                , ldbLeiosDb
-                }
-        h <- LDBHandle <$> newTVarIO (LedgerDBOpen env)
-        pure $ implMkLedgerDb h snapManager
-    }
+  -- Open the LeiosDb connection once, up front, and share it between
+  -- the immutable-DB replay path ('initReapplyBlock') and the
+  -- post-replay 'LedgerDB' env ('ldbLeiosDb'). The replay path needs
+  -- the connection so 'reapplyThenPush' can splice EB bodies into
+  -- CertRBs via 'resolveLeiosBlock' — without it, replayed CertRBs
+  -- would be applied with empty wire bodies and the resulting ledger
+  -- state would diverge from the one produced by the original fresh
+  -- sync (missing every EB-tx output).
+  ldbLeiosDb <- open lgrLeiosDb
+  pure $
+    InitDB
+      { initFromGenesis = do
+          genesis <- lgrGenesis
+          sr <- createAndPopulateStateRefFromGenesis v2Tracer res genesis
+          pure $ LedgerSeq . AS.Empty $ sr
+      , initFromSnapshot = \ds ->
+          runExceptT
+            ( first (LedgerSeq . AS.Empty)
+                <$> openStateRefFromSnapshot
+                  v2Tracer
+                  (configCodec . getExtLedgerCfg . ledgerDbCfg $ lgrConfig)
+                  lgrHasFS
+                  res
+                  ds
+            )
+      , initReapplyBlock = reapplyThenPush ldbLeiosDb
+      , currentTip = ledgerState . current
+      , mkLedgerDb = \lseq -> do
+          varDB <- newTVarIO lseq
+          prevApplied <- newTVarIO Set.empty
+          lock <- RAWLock.new ()
+          nextForkerKey <- newTVarIO (ForkerKey 0)
+          let env =
+                LedgerDBEnv
+                  { ldbSeq = varDB
+                  , ldbPrevApplied = prevApplied
+                  , ldbNextForkerKey = nextForkerKey
+                  , ldbSnapshotPolicy = defaultSnapshotPolicy (ledgerDbCfgSecParam lgrConfig) lgrSnapshotPolicyArgs
+                  , ldbTracer = tr
+                  , ldbCfg = lgrConfig
+                  , ldbHasFS = lgrHasFS
+                  , ldbResolveBlock = getBlock
+                  , ldbQueryBatchSize = lgrQueryBatchSize
+                  , ldbOpenHandlesLock = lock
+                  , ldbGetVolatileSuffix = getVolatileSuffix
+                  , ldbBackendResources = SomeResources res
+                  , ldbLeiosDb
+                  }
+          h <- LDBHandle <$> newTVarIO (LedgerDBOpen env)
+          pure $ implMkLedgerDb h snapManager
+      }
  where
   LedgerDbArgs
     { lgrConfig
@@ -174,6 +183,8 @@ mkInternals ::
   forall m l blk.
   ( IOLike m
   , ApplyBlock l blk
+  , ResolveLeiosBlock blk
+  , l ~ ExtLedgerState blk
   ) =>
   LedgerDB m l blk ->
   LedgerDBHandle m l blk ->
@@ -205,12 +216,14 @@ mkInternals ldb h snapManager =
           ldb
           ( \frk -> do
               st <- atomically $ forkerGetLedgerState frk
-              tables <- forkerReadTables frk (getBlockKeySets blk)
+              let cds = headerStateChainDep (headerState st)
+              blk' <- resolveLeiosBlock (ldbLeiosDb env) cds blk
+              tables <- forkerReadTables frk (getBlockKeySets blk')
               let st' =
                     tickThenReapply
                       (ledgerDbCfgComputeLedgerEvents (ldbCfg env))
                       (ledgerDbCfg $ ldbCfg env)
-                      blk
+                      blk'
                       (st `withLedgerTables` tables)
               forkerPush frk st' >> Monad.join (atomically (forkerCommit frk))
               pruneLedgerSeq env

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/V2/LedgerSeq.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/V2/LedgerSeq.hs
@@ -57,13 +57,16 @@ import Cardano.Ledger.BaseTypes
 import Data.Function (on)
 import Data.Word
 import GHC.Generics
+import LeiosDemoDb (LeiosDbConnection)
 import NoThunks.Class
 import Ouroboros.Consensus.Block
 import Ouroboros.Consensus.Config.SecurityParam
+import Ouroboros.Consensus.HeaderValidation (headerStateChainDep)
 import Ouroboros.Consensus.Ledger.Abstract
 import Ouroboros.Consensus.Ledger.Extended
 import Ouroboros.Consensus.Ledger.Tables.Utils
 import Ouroboros.Consensus.Storage.LedgerDB.API
+import Ouroboros.Consensus.Storage.LedgerDB.Forker (ResolveLeiosBlock (..))
 import Ouroboros.Consensus.Util.IOLike
 import Ouroboros.Network.AnchoredSeq hiding
   ( anchor
@@ -237,30 +240,46 @@ closeLedgerSeq (LedgerSeq l) =
 --
 -- The @fst@ component of the result should be run to close the pruned states.
 reapplyThenPush ::
-  (IOLike m, ApplyBlock l blk) =>
+  (IOLike m, ApplyBlock l blk, ResolveLeiosBlock blk, l ~ ExtLedgerState blk) =>
+  LeiosDbConnection m ->
   LedgerDbCfg l ->
   blk ->
   LedgerSeq m l ->
   m (LedgerSeq m l)
-reapplyThenPush cfg ap db = do
-  newSt <- reapplyBlock (ledgerDbCfgComputeLedgerEvents cfg) (ledgerDbCfg cfg) ap db
+reapplyThenPush leiosDb cfg ap db = do
+  newSt <- reapplyBlock leiosDb (ledgerDbCfgComputeLedgerEvents cfg) (ledgerDbCfg cfg) ap db
   let (m, db') = pruneToImmTipOnly $ extend newSt db
   m
   pure db'
 
+-- | Reapply a block to the tip of the 'LedgerSeq'.
+--
+-- For Leios CertRBs, the wire-encoded body carries only a 'LeiosCert' (no
+-- txs); the actual transactions live in the EB closure. Mirroring
+-- 'Forker.applyBlock', we splice the EB body back in via 'resolveLeiosBlock'
+-- before ticking the ledger — otherwise the immutable-DB replay path would
+-- apply CertRBs as empty bodies, leaving the ledger state missing every
+-- EB-tx output that was created during the original fresh sync.
 reapplyBlock ::
   forall m l blk.
-  (ApplyBlock l blk, IOLike m) =>
+  ( ApplyBlock l blk
+  , IOLike m
+  , ResolveLeiosBlock blk
+  , l ~ ExtLedgerState blk
+  ) =>
+  LeiosDbConnection m ->
   ComputeLedgerEvents ->
   LedgerCfg l ->
   blk ->
   LedgerSeq m l ->
   m (StateRef m l)
-reapplyBlock evs cfg b db = do
-  let ks = getBlockKeySets b
-      StateRef st tbs = currentHandle db
+reapplyBlock leiosDb evs cfg b db = do
+  let StateRef st tbs = currentHandle db
+      cds = headerStateChainDep (headerState st)
+  b' <- resolveLeiosBlock leiosDb cds b
+  let ks = getBlockKeySets b'
   vals <- read tbs st ks
-  let st' = tickThenReapply evs cfg b (st `withLedgerTables` vals)
+  let st' = tickThenReapply evs cfg b' (st `withLedgerTables` vals)
       newst = forgetLedgerTables st'
 
   newtbs <- duplicateWithDiffs tbs st st'

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/LedgerDB/StateMachine.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/LedgerDB/StateMachine.hs
@@ -596,16 +596,17 @@ openLedgerDB flavArgs env cfg fs = do
   (ldb, _, od) <-
     runWithTempRegistry $
       (\x -> (x, ())) <$> case lgrBackendArgs args of
-        LedgerDbBackendArgsV1 bss ->
+        LedgerDbBackendArgsV1 bss -> do
           let snapManager = V1.snapshotManager args
-              initDb =
-                V1.mkInitDb
-                  args
-                  bss
-                  getBlock
-                  snapManager
-                  (praosGetVolatileSuffix $ ledgerDbCfgSecParam cfg)
-           in lift $ openDBInternal args initDb snapManager stream replayGoal
+          initDb <-
+            lift $
+              V1.mkInitDb
+                args
+                bss
+                getBlock
+                snapManager
+                (praosGetVolatileSuffix $ ledgerDbCfgSecParam cfg)
+          lift $ openDBInternal args initDb snapManager stream replayGoal
         LedgerDbBackendArgsV2 (V2.SomeBackendArgs bArgs) -> do
           res <-
             mkResources
@@ -620,7 +621,9 @@ openLedgerDB flavArgs env cfg fs = do
                   (configCodec . getExtLedgerCfg . ledgerDbCfg $ lgrConfig args)
                   (LedgerDBSnapshotEvent >$< lgrTracer args)
                   (lgrHasFS args)
-          let initDb = V2.mkInitDb args getBlock snapManager (praosGetVolatileSuffix $ ledgerDbCfgSecParam cfg) res
+          initDb <-
+            lift $
+              V2.mkInitDb args getBlock snapManager (praosGetVolatileSuffix $ ledgerDbCfgSecParam cfg) res
           lift $ openDBInternal args initDb snapManager stream replayGoal
   case NE.nonEmpty volBlocks of
     Nothing -> pure ()


### PR DESCRIPTION
Fixes the crash in `resolveLeiosBlock` (*"FIXME(bladyjoker): … Announced EB is being certified by the current chain but it's not available?"*) that hits late-joining or briefly-disconnected nodes when a CertRB arrives before its certified EB closure has been streamed locally.

This follows the design idea of a "staging area" as outlined in https://github.com/input-output-hk/ouroboros-leios/issues/890

### Notes on the design

- **Cert carries `(LeiosPoint, BytesSize)` payload.** Forge encodes; receiver decodes. No predecessor lookup, no chain-dep state at the gate. Requires the paired `cardano-ledger` change (`LeiosCert` becomes `newtype LeiosCert { leiosCertPayload :: ByteString }`).
- **Gate at `addBlockAsync`** (`wrapChainDbViewForLeiosStaging` in `NodeKernel.hs`). When a CertRB arrives with a missing closure, the gate parks `(blk, size, peers-from-ChainSync-candidates)` in `LeiosStagingArea` instead of admitting to ChainSel. New `checkLeiosBlockResolvable` class method does the decode + LeiosDb lookup.
- **Gate blocks the BlockFetch client thread** until the staged entry releases (closure arrived and drain admitted the block via the unwrapped `addBlockAsync`). The previous "lie via `blockWrittenToDisk = pure True`" approach plus the `getIsFetched` widening did not suppress BlockFetch's redecision; the resulting refetch spin was the dominant retainer of iosim `SimTrace` state and made `prop_leios_late_join` OOM at `numSlots=200`. Cost: head-of-line blocking on this peer's BlockFetch pipeline for the closure-fetch duration; LeiosFetch runs on a separate channel so progress is not deadlocked. Caveat tied to open point #4 below.
- **Fetch loop synthesises augmented inputs each tick** from `stagedSnapshot` — adds synthetic `missingEbBodies` entries and per-peer `offerings` (both halves so `choosePeerEb` and `choosePeerTx` both see the staged peers). Synth is gated on `not (Map.null stagedNow)` and the body-add is short-circuited against `acquiredEbBodies` to avoid the per-tick re-add+filter round-trip. The per-tick `leiosDbQueryFetchWork` (whose own API doc declared it startup-only) is gone; tx-closure synth is dropped — once the body arrives, the natural `msgLeiosBlock` handler populates `missingEbTxs`. Restart recovery of partial tx closures (the case the per-tick DB query was working around) is deferred to a follow-up that primes `LeiosOutstanding` from the DB once at MVar creation.
- **Drain releases on `AcquiredEbTxs` only** (not `AcquiredEb`) — `leiosDbQueryCompletedEbByPoint` only returns `Just` once the full closure is in.

### Orthogonal fix included: EB resolution on immutable-DB replay

Commit fbaa872 is a separate, narrowly-scoped fix shipped here for convenience. The immutable-DB replay path (`replayStartingWith` → V1/V2 `reapplyBlock`) was bypassing `resolveLeiosBlock` entirely. On every restart, CertRBs in the immutable range were re-applied with their empty wire body, leaving the post-replay ledger state missing every EB-tx output. The first volatile block to spend one of those outputs failed with `BadInputsUTxO`. Fix: thread `LeiosDbConnection` into `reapplyBlock` (V1: new `reapplyThenPushLeios` wrapper; V2: in-place) and call `resolveLeiosBlock` before `tickThenReapply`. Verified on `proto-devnet` (k=5 restart) and on the Leios testnet (~530k immutable blocks replayed cleanly, no `BadInputsUTxO`). This subsumes the always-failing-restart half of open point #2 below; the closure-goes-missing edge case is unchanged.

### Validation

- [x] Threadnet test `prop_leios_late_join` (cherry-picked from `origin/leios-late-join-v2`) passes at `numSlots=200`. Existing `prop_leios` still passes.
- [x] iosim perf: `prop_leios_late_join` @ `numSlots=200`, 1 iter, `+RTS -M4G -s`: ~52 s wall, **134 MB peak residency**, 95.6 % productivity (was 119 s, OOM @ 4 GB, 49.6 % productivity before blocking the BlockFetch client). For comparison, `prop_leios` @ same scope: 49 s, 88 MB peak. Cardano simple convergence baseline (numSlots ≈266): 7 s, 278 MB.
- [x] Manually ran `ouroboros-leios/demo/proto-devnet`, killed and restarted one of the nodes: node 3 missed 3 EB certs while down → on restart logged 3 distinct `CertRBStaged` → Phase 2 fetched the EBs from peers → 3 `CertRBReleased` → all three nodes converged on the same tip.
- [x] Leios testnet catchup: caught up to current tip from genesis, then restarted; `OpenedDB` reported `immtip=535588`, `tip=544039` (~530k blocks replayed via the patched path, 0 `InvalidBlock` / `BadInputsUTxO`). Runnable setup at `ouroboros-leios/testnet/` https://github.com/input-output-hk/ouroboros-leios/pull/930

### Open points (not fixed by this PR)

1. **Gate is best-effort for fork blocks.** The wrapper looks up the parent on the current chain *and* the active ChainSync candidate fragments. That covers chain-extension (catch-up) and BlockFetch out-of-order delivery, but not a fork whose parent is unknown to all live candidates. In that case the lookup returns `Nothing` ⇒ we admit ⇒ if ChainSel later switches to that fork and the CertRB's closure isn't local, `resolveLeiosBlock` crashes as before. Proper fix in the long run: make ChainSel itself aware of missing-cert-closure state and resolve at adoption time. The staging area is a deliberate stop-gap; the more surgical ChainSel-level design subsumes it.
2. **InitChainSel bypasses the staging gate.** The orthogonal fix above makes immutable-replay apply CertRBs correctly when the LeiosDb closure is present (the common case on every restart). What's still uncovered: if the closure later goes missing (LeiosDb wipe, crash between ChainSel adopt and LeiosDb flush, file corruption), restart's InitChainSel hits the original error because the wrap sits on `addBlockAsync` and is skipped at startup. Same long-run fix subsumes this — gating in the apply path / via ChainSel.
3. **Fetch-loop bootstrap from DB.** The synth pipeline now relies entirely on the in-memory `LeiosOutstanding` plus the staging snapshot. The case that's lost is restart recovery when a previous run had received an EB body but not its full tx closure: the natural `msgLeiosBlock` handler won't re-fire on restart, so `missingEbTxs` stays empty for that EB and the closure never finishes. Follow-up: prime `LeiosOutstanding` from `LeiosDb.leiosDbQueryFetchWork` once at MVar creation in `initNodeKernel` — exactly the use the API doc reserves it for. Sketch in this branch's `leios-fetch-loop-sketch.md` (local).
4. **No GC of staged entries** whose peer-set has emptied (all peers disconnected before EB arrived). TODO in `LeiosStagingArea`. With the new BlockFetch-blocking semantics this also leaks parked client threads in that scenario — the GC pass needs to wake parked threads with a `FailedToAddBlock` verdict before evicting an entry.

### Traces

- `Consensus.LeiosKernel.TraceLeiosKernel` with `kind:"CertRBStaged"` (`blockPoint`, `ebHash`, `ebSlot`, `knownPeers`) and `kind:"CertRBReleased"` (`ebHash`, `ebSlot`).
