### PR TITLE
percolate replay goal from --analyse-from args instead of forcing genesis point in db-analyser.

### DIFF
--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Run.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Run.hs
@@ -63,11 +63,12 @@ openLedgerDB ::
   , HasHardForkHistory blk
   ) =>
   Complete LedgerDB.LedgerDbArgs IO blk ->
+  Point blk ->
   IO
     ( LedgerDB.LedgerDB' IO blk
     , LedgerDB.TestInternals' IO blk
     )
-openLedgerDB args =
+openLedgerDB args replayGoal =
   runWithTempRegistry $
     (,()) <$> do
       (ldb, od) <- case LedgerDB.lgrBackendArgs args of
@@ -92,7 +93,7 @@ openLedgerDB args =
                   snapManager
                   (LedgerDB.praosGetVolatileSuffix $ LedgerDB.ledgerDbCfgSecParam $ LedgerDB.lgrConfig args)
                   res
-          lift $ LedgerDB.openDBInternal args initDb snapManager emptyStream genesisPoint
+          lift $ LedgerDB.openDBInternal args initDb snapManager emptyStream replayGoal
       pure (ldb, od)
 
 emptyStream :: Applicative m => ImmutableDB.StreamAPI m blk a
@@ -167,16 +168,22 @@ analyse dbaConfig args =
 
     withImmutableDB immutableDbArgs $ \(immutableDB, internal) -> do
       SomeAnalysis (Proxy :: Proxy startFrom) ana <- pure $ runAnalysis analysis
+
+      let getPointForSlot :: SlotNo -> IO (Point blk)
+          getPointForSlot slot = ImmutableDB.getHashForSlot internal slot >>= \case
+            Just hash -> pure $ BlockPoint slot hash
+            Nothing -> fail $ "No block with given slot in the ImmutableDB: " <> show slot
+
       startFrom <- case sing :: Sing startFrom of
-        SStartFromPoint ->
+        SStartFromPoint -> do
           FromPoint <$> case startSlot of
             Origin -> pure GenesisPoint
-            NotOrigin slot ->
-              ImmutableDB.getHashForSlot internal slot >>= \case
-                Just hash -> pure $ BlockPoint slot hash
-                Nothing -> fail $ "No block with given slot in the ImmutableDB: " <> show slot
+            NotOrigin slot -> getPointForSlot slot
+
         SStartFromLedgerState -> do
-          (ledgerDB, intLedgerDB) <- openLedgerDB ldbArgs
+          (ledgerDB, intLedgerDB) <- openLedgerDB ldbArgs =<< case startSlot of
+            Origin -> pure genesisPoint
+            NotOrigin slot -> getPointForSlot slot
           -- This marker divides the "loading" phase of the program, where the
           -- system is principally occupied with reading snapshot data from
           -- disk, from the "processing" phase, where we are streaming blocks


### PR DESCRIPTION
# Description

We use db-analyser to produce ledger snapshots at specific points in time. However, the `--analyze-from` option is completely ignored and causes db-analyser to always revalidate the entire ledger state from genesis instead of using available ledger snapshots.

For example, I have a snapshot available at 119750386 and running db-analyser will cause a full replay from genesis.

```console
$ cabal run -- exe:db-analyser --db $DB --analyse-from 119750386 --store-ledger 120000000 --config $CONFIG --in-mem
[0.278506s] Started StoreLedgerStateAt (SlotNo 120000000) LedgerReapply
[0.279570s] BlockNo 0   SlotNo 0        9ad7ff320c9cf74e0f5ee78d22a85ce42bb0a487d0506bf60cfb5a91ea4497d2
[0.398745s] BlockNo 1000        SlotNo 105480   e5a041658fd5b598be34ee82df9b458fbc78f84d7ffd633dcf71a928db7a8f96
[0.516547s] BlockNo 2000        SlotNo 125480   08baff34f30d214c787d940b3021ce803e1bfbcbf353601a2bed0df0dba9280a
[0.634899s] BlockNo 3000        SlotNo 145480   58bdc464dcf8decff13cd2305cdb6a242e017d839e967efa00042671144031e5
[0.753513s] BlockNo 4000        SlotNo 165480   58e04c55e40878333d37c639d53abd3f8b40f0c782c1a1d9a8995b7ccd7c6d13
[0.868674s] BlockNo 5000        SlotNo 185480   d5338becd9078cad149bf97ed546e85201184e1f7a35058b1862f011bdd83f50
[0.984128s] BlockNo 6000        SlotNo 205480   b065f9b4068f1b34ea6d8d766a055892685735ee0fe8b8b6962fb97e36e3b859
[1.102843s] BlockNo 7000        SlotNo 225480   91f10478c9936bd8d4b585a7d012b30ec10c824d9f26b8483be2d6a0712a6c74
[1.217049s] BlockNo 8000        SlotNo 245480   44af1ffa3c5331c109bcb82cc1b53deae2c9efe8cb83be3e49aa10df5d1bdfb9
[1.330736s] BlockNo 9000        SlotNo 265480   2305cb6f0d239127bc94031350d287b55a74b8584f8e0ca4dff896f5d16d37de
[1.446582s] BlockNo 10000       SlotNo 285480   d75978ca0240979a4284cc0ab4fcf4801ab009a120e8395a4d7504c0f477cf2d
[1.562068s] BlockNo 11000       SlotNo 305480   f7b69af33d4e0f854b9e13db58f2ff5a22bb74118764e8ae0124c81cf208f272
^C
```

With this commit; the ledger db is now correctly _continuing_ from an available snapshot:

```console
$ cabal run -- exe:db-analyser --db $DB --analyse-from 119750386 --store-ledger 120000000 --config $CONFIG --in-mem
[6.781018s] Started StoreLedgerStateAt (SlotNo 120000000) LedgerReapply
[6.889151s] BlockNo 4581000     SlotNo 119759185        7c32159c8d5b6e6c34e335d67591ed4a30b7be7b96348ef4644a7494b895a69e
[7.116487s] BlockNo 4582000     SlotNo 119787105        ba07b0d8de03891d202cfad89117bd96bf457d528024dc3b3ae644bcef503ed5
[7.427753s] BlockNo 4583000     SlotNo 119813849        22bf8325c151f3ea0be95a03668e7649af855f19dbfc12d0b4faff06ea0406fa
[7.645774s] BlockNo 4584000     SlotNo 119841503        7b89c49befe4ec28d8080fe4788c2e1954b6049f8a9aa2cae42e8e60653cf83b
[7.982254s] BlockNo 4585000     SlotNo 119869016        4b437b5134e9a1fc189c923adf57e0d892842ec4fd23bf399cab9fbe26fb2b54
[8.243124s] BlockNo 4586000     SlotNo 119896173        607dcdf30397b947a36b6aeb5d4e1008f416f4683b529ae2ca2dddcf015d49e6
[8.464921s] BlockNo 4587000     SlotNo 119922554        2081dd623882e01add6c2c1ae23896a6acd6cf3f623f90fe17ba29b515fb1032
[8.721489s] BlockNo 4588000     SlotNo 119948875        8821b98f97600fca2a6b833adea0233068d7af13888fb03bb6cd770ed7d16a98
[9.040527s] BlockNo 4589000     SlotNo 119977533        192f0163a06845eee60eef16e2f5dc3a41b1f576cce7e066a131d608ffe2302c
[9.267010s] Snapshot was created at SlotNo 120000001 because there was no block forged at requested SlotNo 120000000
[9.267430s] Snapshot stored at SlotNo 120000001
[9.267525s] Done
ImmutableDB tip: Point (At (Block {blockPointSlot = SlotNo 124329598, blockPointHash = f298accb019eaa6659d8d7a17c988a647c5ca747f54dfac5da199b323cb73961}))
```

(cc @jasagredo as discussed in Porto; I believe this fixes the problem?)