### PR TITLE
Db analyser analysis from snapshot

### DIFF
--- a/changelog.d/20260608_000000_javier.sagredo_remove_lgr_start_snapshot.md
+++ b/changelog.d/20260608_000000_javier.sagredo_remove_lgr_start_snapshot.md
@@ -1,0 +1,5 @@
+### Breaking
+
+- Removed `lgrStartSnapshot` from `LedgerDB.LedgerDbArgs`. It was only ever set to
+  `Nothing` and was meant for db-analyser, which now selects its starting snapshot
+  via the replay goal instead. `initialize` no longer takes a `Maybe DiskSnapshot`.

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Run.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Run.hs
@@ -13,6 +13,7 @@ import Cardano.Ledger.BaseTypes
 import Cardano.Tools.DBAnalyser.Analysis
 import Cardano.Tools.DBAnalyser.HasAnalysis
 import Cardano.Tools.DBAnalyser.Types
+import Control.Monad (unless)
 import Control.Monad.Trans.Class
 import Control.ResourceRegistry
 import Control.Tracer (Tracer (..), nullTracer)
@@ -35,10 +36,15 @@ import Ouroboros.Consensus.Node.ProtocolInfo (ProtocolInfo (..))
 import Ouroboros.Consensus.Protocol.Abstract
 import qualified Ouroboros.Consensus.Storage.ChainDB as ChainDB
 import qualified Ouroboros.Consensus.Storage.ChainDB.Impl.Args as ChainDB
+import Ouroboros.Consensus.Storage.Common (BlockComponent (..))
 import qualified Ouroboros.Consensus.Storage.ImmutableDB as ImmutableDB
 import qualified Ouroboros.Consensus.Storage.ImmutableDB.Stream as ImmutableDB
 import Ouroboros.Consensus.Storage.LedgerDB (TraceEvent (..))
 import qualified Ouroboros.Consensus.Storage.LedgerDB as LedgerDB
+import Ouroboros.Consensus.Storage.LedgerDB.Snapshots
+  ( DiskSnapshot (..)
+  , listSnapshots
+  )
 import qualified Ouroboros.Consensus.Storage.LedgerDB.V2 as LedgerDB.V2
 import qualified Ouroboros.Consensus.Storage.LedgerDB.V2.Backend as LedgerDB.V2
 import qualified Ouroboros.Consensus.Storage.LedgerDB.V2.InMemory as InMemory
@@ -63,12 +69,20 @@ openLedgerDB ::
   , HasHardForkHistory blk
   ) =>
   Complete LedgerDB.LedgerDbArgs IO blk ->
+  ImmutableDB.ImmutableDB IO blk ->
+  -- | The replay goal, i.e. the point up to which blocks from the ImmutableDB
+  -- are replayed on top of the chosen snapshot. The chosen snapshot is the
+  -- newest one that is not more recent than this point, and blocks are replayed
+  -- on top of it until the ledger state is exactly at this point. For
+  -- db-analyser this is the @--analyse-from@ point, so that an analysis
+  -- starting from a ledger state begins exactly there, regardless of which
+  -- snapshots happen to exist on disk.
   Point blk ->
   IO
     ( LedgerDB.LedgerDB' IO blk
     , LedgerDB.TestInternals' IO blk
     )
-openLedgerDB args replayGoal =
+openLedgerDB args immutableDB replayGoal =
   runWithTempRegistry $
     (,()) <$> do
       (ldb, od) <- case LedgerDB.lgrBackendArgs args of
@@ -93,11 +107,35 @@ openLedgerDB args replayGoal =
                   snapManager
                   (LedgerDB.praosGetVolatileSuffix $ LedgerDB.ledgerDbCfgSecParam $ LedgerDB.lgrConfig args)
                   res
-          lift $ LedgerDB.openDBInternal args initDb snapManager emptyStream replayGoal
+          lift $ do
+            warnUnlessSnapshotAtGoal snapManager
+            LedgerDB.openDBInternal args initDb snapManager replayStream replayGoal
       pure (ldb, od)
+ where
+  -- Stream blocks from the ImmutableDB, stopping as soon as we reach a block
+  -- that is more recent than the replay goal. As a result, the replay leaves
+  -- the ledger state exactly at the replay goal (the last block at or before
+  -- it), rather than streaming all the way to the ImmutableDB tip.
+  replayStream = ImmutableDB.streamAPI' shouldStop GetBlock immutableDB
+   where
+    shouldStop blk
+      | NotOrigin (blockSlot blk) > pointSlot replayGoal = pure ImmutableDB.NoMoreItems
+      | otherwise = pure $ ImmutableDB.NextItem blk
 
-emptyStream :: Applicative m => ImmutableDB.StreamAPI m blk a
-emptyStream = ImmutableDB.StreamAPI $ \_ k -> k $ Right $ pure ImmutableDB.NoMoreItems
+  -- Warn when there is no snapshot exactly at the requested replay goal. In
+  -- that case the LedgerDB is initialised from the newest older snapshot and
+  -- blocks are replayed up to the goal, which can be considerably slower than
+  -- starting from a snapshot that already sits at the requested slot.
+  warnUnlessSnapshotAtGoal snapManager =
+    case pointSlot replayGoal of
+      Origin -> pure ()
+      NotOrigin slot -> do
+        snapshots <- listSnapshots snapManager
+        unless (any ((== unSlotNo slot) . dsNumber) snapshots) $
+          hPutStrLn stderr $
+            "Warning: no ledger snapshot exists exactly at slot "
+              <> show (unSlotNo slot)
+              <> "; starting from the newest older snapshot and replaying blocks up to that slot."
 
 analyse ::
   forall blk.
@@ -170,20 +208,21 @@ analyse dbaConfig args =
       SomeAnalysis (Proxy :: Proxy startFrom) ana <- pure $ runAnalysis analysis
 
       let getPointForSlot :: SlotNo -> IO (Point blk)
-          getPointForSlot slot = ImmutableDB.getHashForSlot internal slot >>= \case
-            Just hash -> pure $ BlockPoint slot hash
-            Nothing -> fail $ "No block with given slot in the ImmutableDB: " <> show slot
+          getPointForSlot slot =
+            ImmutableDB.getHashForSlot internal slot >>= \case
+              Just hash -> pure $ BlockPoint slot hash
+              Nothing -> fail $ "No block with given slot in the ImmutableDB: " <> show slot
 
       startFrom <- case sing :: Sing startFrom of
         SStartFromPoint -> do
           FromPoint <$> case startSlot of
             Origin -> pure GenesisPoint
             NotOrigin slot -> getPointForSlot slot
-
         SStartFromLedgerState -> do
-          (ledgerDB, intLedgerDB) <- openLedgerDB ldbArgs =<< case startSlot of
-            Origin -> pure genesisPoint
-            NotOrigin slot -> getPointForSlot slot
+          (ledgerDB, intLedgerDB) <-
+            openLedgerDB ldbArgs immutableDB =<< case startSlot of
+              Origin -> pure genesisPoint
+              NotOrigin slot -> getPointForSlot slot
           -- This marker divides the "loading" phase of the program, where the
           -- system is principally occupied with reading snapshot data from
           -- disk, from the "processing" phase, where we are streaming blocks

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Run.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Run.hs
@@ -63,11 +63,12 @@ openLedgerDB ::
   , HasHardForkHistory blk
   ) =>
   Complete LedgerDB.LedgerDbArgs IO blk ->
+  Point blk ->
   IO
     ( LedgerDB.LedgerDB' IO blk
     , LedgerDB.TestInternals' IO blk
     )
-openLedgerDB args =
+openLedgerDB args replayGoal =
   runWithTempRegistry $
     (,()) <$> do
       (ldb, od) <- case LedgerDB.lgrBackendArgs args of
@@ -92,7 +93,7 @@ openLedgerDB args =
                   snapManager
                   (LedgerDB.praosGetVolatileSuffix $ LedgerDB.ledgerDbCfgSecParam $ LedgerDB.lgrConfig args)
                   res
-          lift $ LedgerDB.openDBInternal args initDb snapManager emptyStream genesisPoint
+          lift $ LedgerDB.openDBInternal args initDb snapManager emptyStream replayGoal
       pure (ldb, od)
 
 emptyStream :: Applicative m => ImmutableDB.StreamAPI m blk a
@@ -167,16 +168,22 @@ analyse dbaConfig args =
 
     withImmutableDB immutableDbArgs $ \(immutableDB, internal) -> do
       SomeAnalysis (Proxy :: Proxy startFrom) ana <- pure $ runAnalysis analysis
+
+      let getPointForSlot :: SlotNo -> IO (Point blk)
+          getPointForSlot slot = ImmutableDB.getHashForSlot internal slot >>= \case
+            Just hash -> pure $ BlockPoint slot hash
+            Nothing -> fail $ "No block with given slot in the ImmutableDB: " <> show slot
+
       startFrom <- case sing :: Sing startFrom of
-        SStartFromPoint ->
+        SStartFromPoint -> do
           FromPoint <$> case startSlot of
             Origin -> pure GenesisPoint
-            NotOrigin slot ->
-              ImmutableDB.getHashForSlot internal slot >>= \case
-                Just hash -> pure $ BlockPoint slot hash
-                Nothing -> fail $ "No block with given slot in the ImmutableDB: " <> show slot
+            NotOrigin slot -> getPointForSlot slot
+
         SStartFromLedgerState -> do
-          (ledgerDB, intLedgerDB) <- openLedgerDB ldbArgs
+          (ledgerDB, intLedgerDB) <- openLedgerDB ldbArgs =<< case startSlot of
+            Origin -> pure genesisPoint
+            NotOrigin slot -> getPointForSlot slot
           -- This marker divides the "loading" phase of the program, where the
           -- system is principally occupied with reading snapshot data from
           -- disk, from the "processing" phase, where we are streaming blocks

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB.hs
@@ -142,14 +142,12 @@ openDBInternal args@(LedgerDbArgs{lgrHasFS = SomeHasFS fs}) initDb snapManager s
       replayGoal
       initDb
       snapManager
-      lgrStartSnapshot
   (ledgerDb, internal) <- mkLedgerDb initDb db
   return (ledgerDb, internal)
  where
   LedgerDbArgs
     { lgrConfig
     , lgrTracer
-    , lgrStartSnapshot
     } = args
 
   replayTracer = LedgerReplayEvent >$< lgrTracer

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/API.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/API.hs
@@ -533,7 +533,6 @@ initialize ::
   Point blk ->
   InitDB db m blk ->
   SnapshotManager m blk st ->
-  Maybe DiskSnapshot ->
   m (InitLog blk, db)
 initialize
   replayTracer
@@ -542,11 +541,8 @@ initialize
   stream
   replayGoal
   dbIface
-  snapManager
-  fromSnapshot =
-    case fromSnapshot of
-      Nothing -> listSnapshots snapManager >>= tryNewestFirst id
-      Just snap -> tryNewestFirst id [snap]
+  snapManager =
+    listSnapshots snapManager >>= tryNewestFirst id
    where
     InitDB{initFromGenesis, initFromSnapshot} = dbIface
 

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/Args.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/Args.hs
@@ -58,10 +58,6 @@ data LedgerDbArgs f m blk = LedgerDbArgs
   , lgrTracer :: !(Tracer m (TraceEvent blk))
   , lgrBackendArgs :: LedgerDbBackendArgs m blk
   , lgrQueryBatchSize :: QueryBatchSize
-  , lgrStartSnapshot :: Maybe DiskSnapshot
-  -- ^ If provided, the ledgerdb will start using said snapshot and fallback
-  -- to genesis. It will ignore any other existing snapshots. Useful for
-  -- db-analyser.
   }
 
 -- | Default arguments
@@ -80,7 +76,6 @@ defaultArgs backendArgs =
     , -- This value is the closest thing to a pre-UTxO-HD node, and as such it
       -- will be the default for end-users.
       lgrBackendArgs = LedgerDbBackendArgsV2 backendArgs
-    , lgrStartSnapshot = Nothing
     }
 
 newtype LedgerDbBackendArgs m blk

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/ChainDB.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/ChainDB.hs
@@ -132,7 +132,6 @@ fromMinimalChainDbArgs MinimalChainDbArgs{..} =
           , lgrConfig = configLedgerDb mcdbTopLevelConfig OmitLedgerEvents
           , lgrBackendArgs = LedgerDbBackendArgsV2 $ V2.SomeBackendArgs InMemArgs
           , lgrQueryBatchSize = DefaultQueryBatchSize
-          , lgrStartSnapshot = Nothing
           }
     , cdbPerasCertDbArgs =
         PerasCertDbArgs

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/MiniProtocol/LocalStateQuery/Server.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/MiniProtocol/LocalStateQuery/Server.hs
@@ -248,7 +248,6 @@ initLedgerDB s c = do
           , lgrBackendArgs = LedgerDbBackendArgsV2 $ V2.SomeBackendArgs InMemArgs
           , lgrConfig = LedgerDB.configLedgerDb (testCfg s) OmitLedgerEvents
           , lgrQueryBatchSize = DefaultQueryBatchSize
-          , lgrStartSnapshot = Nothing
           }
   ldb <-
     runWithTempRegistry

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/LedgerDB/StateMachine.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/LedgerDB/StateMachine.hs
@@ -541,7 +541,6 @@ openLedgerDB flavArgs env cfg fs = do
           tracer
           flavArgs
           DefaultQueryBatchSize
-          Nothing
   (ldb, od) <-
     runWithTempRegistry $
       (\x -> (x, ())) <$> case lgrBackendArgs args of


### PR DESCRIPTION
Built on top of #2060 

# What changed

### 1. From #2060, Percolate the replay goal from `--analyse-from`

`openLedgerDB` previously hard-coded the replay goal to `genesisPoint`. Because
`initialize` rejects every snapshot whose slot is more recent than the replay
goal (`InitFailureTooRecent`), a genesis goal rejected *all* snapshots, so
db-analyser always restarted from genesis and silently ignored `--analyse-from`.

The replay goal is now derived from the `--analyse-from` argument (genesis when
it is omitted), so snapshot selection considers the on-disk snapshots and picks
the newest one that is not more recent than the requested slot.

### 2. Replay up to `--analyse-from` before analysing

With (1), the LedgerDB starts from the newest snapshot at or before
`--analyse-from`, but it was opened with an *empty* stream — no blocks were
replayed. When no snapshot existed exactly at the requested slot, the ledger
state (and therefore the analysis) silently began at the older snapshot's tip
rather than at `--analyse-from`.

`openLedgerDB` is now handed the ImmutableDB and replays blocks on top of the
chosen snapshot up to the replay goal, so the ledger state is exactly at
`--analyse-from` before the analysis begins. The replay stream stops at the
first block past the goal, mirroring the `StartFromPoint` behaviour where the
analyse-from block is the anchor and processing starts after it. When a snapshot
already sits exactly at the requested slot, the stream stops immediately and no
blocks are replayed.

If no snapshot exists exactly at the requested slot, db-analyser now emits a
warning (the replay from an older snapshot up to the goal can be slow), but
still proceeds.

### 3. Remove the unused `lgrStartSnapshot`

`LedgerDbArgs.lgrStartSnapshot :: Maybe DiskSnapshot` was introduced to let
db-analyser start from a specific snapshot, but it was only ever set to
`Nothing` and db-analyser never used it. Its purpose is now served by the
replay-goal-based snapshot selection above, so the field and the corresponding
`Maybe DiskSnapshot` argument of `initialize` are removed.

**Breaking change** for downstream consumers of `LedgerDB.LedgerDbArgs`. The
node only constructs `LedgerDbArgs` via `defaultArgs` and never set this field,
so it is unaffected. A changelog fragment is included.