### PR TITLE
Add Mithril predictable ledger state snapshot policy

### DIFF
--- a/changelog.d/20260609_175033_georgy.lukyanov_ledger_snaphot_param_revision.md
+++ b/changelog.d/20260609_175033_georgy.lukyanov_ledger_snaphot_param_revision.md
@@ -1,0 +1,24 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+<!--
+### Breaking
+
+- A bullet item for the Breaking category.
+
+-->
+
+### Non-Breaking
+
+- Add `mithrilSnapshotPolicyArgs`, which specifies when Mithril should take ledger state snapshots.
+
+<!--
+### Patch
+
+- A bullet item for the Patch category.
+
+-->

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/Snapshots.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/Snapshots.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE RankNTypes #-}
@@ -51,6 +52,7 @@ module Ouroboros.Consensus.Storage.LedgerDB.Snapshots
   , TablesCodecVersion (..)
   , NumOfDiskSnapshots (..)
   , defaultSnapshotPolicyArgs
+  , mithrilSnapshotPolicyArgs
 
     -- * Codec
   , readExtLedgerState
@@ -625,6 +627,33 @@ defaultSnapshotPolicyArgs =
   SnapshotPolicyArgs
     (SnapshotFrequency $ SnapshotFrequencyArgs UseDefault UseDefault UseDefault UseDefault)
     UseDefault
+
+-- | Snapshot Policy arguments to be used by Mithril
+--
+-- The snapshot interval is derived as follows:
+--   * The epoch in Shelley is 432,000 slots long.
+--
+-- The snapshot offset is derived as follows:
+--   * 21,600 slots per epoch in Byron
+--   * The Byron era was 208 epochs long
+--   * The Shelley era starts at 208 * 21,600 = 4,492,800 slots
+--   * Half of a Shelley epoch is 432,000 / 2 = 216,000
+--   * The resulting offset of the first snapshot in Shelley is 4,492,800 + 216,000 = 4,708,800
+--   * Finally, if we want to start taking snapshot while still syncing Byron,
+--     we must start at slot 4,708,800 % 432,000 = 388,800
+mithrilSnapshotPolicyArgs :: SnapshotPolicyArgs
+mithrilSnapshotPolicyArgs =
+  SnapshotPolicyArgs
+    { spaFrequency =
+        SnapshotFrequency $
+          SnapshotFrequencyArgs
+            { sfaInterval = Override (unsafeNonZero 432_000)
+            , sfaOffset = Override 388_800
+            , sfaRateLimit = UseDefault
+            , sfaDelaySnapshotRange = UseDefault
+            }
+    , spaNum = UseDefault
+    }
 
 -- | Default on-disk policy suitable to use with cardano-node
 defaultSnapshotPolicy ::


### PR DESCRIPTION
Add `mithrilSnapshotPolicyArgs` --- a policy for ledger state snapshots to be used by Mithril:
- Use the values provided by the Mithril team in https://github.com/input-output-hk/mithril/issues/3242#issuecomment-4420884552

