### PR TITLE
LSM: Rework snapshot-converter into a command tree

### DIFF
--- a/changelog.d/20260610_134116_javier.sagredo_lsm_salt_argument.md
+++ b/changelog.d/20260610_134116_javier.sagredo_lsm_salt_argument.md
@@ -1,0 +1,25 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+<!--
+### Breaking
+
+- A bullet item for the Breaking category.
+
+-->
+<!--
+### Non-Breaking
+
+- A bullet item for the Non-Breaking category.
+
+-->
+<!--
+### Patch
+
+- A bullet item for the Patch category.
+
+-->

--- a/ouroboros-consensus-cardano/app/snapshot-converter.hs
+++ b/ouroboros-consensus-cardano/app/snapshot-converter.hs
@@ -1,245 +1,338 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE ViewPatterns #-}
-#if __GLASGOW_HASKELL__ >= 912
-{-# LANGUAGE MultilineStrings #-}
-#endif
 
 module Main (main) where
 
 import Cardano.Crypto.Init (cryptoInit)
 import Cardano.Tools.DBAnalyser.HasAnalysis (mkProtocolInfo)
-import Control.Concurrent
+import Control.Concurrent (threadDelay)
+import Control.Exception (SomeException, displayException, try)
 import Control.Monad (forever, void)
-import Control.Monad.Except
-import DBAnalyser.Parsers
+import Control.Monad.Except (runExceptT)
+import DBAnalyser.Parsers (CardanoBlockArgs, parseCardanoArgs)
 import qualified Data.List as L
-#if __GLASGOW_HASKELL__ < 912
-import qualified Data.Text as T
-#endif
 import Main.Utf8
 import Options.Applicative
-import Options.Applicative.Help (Doc)
-#if __GLASGOW_HASKELL__ < 912
-import Options.Applicative.Help.Pretty (Pretty (pretty))
-#endif
 import Ouroboros.Consensus.Cardano.SnapshotConversion
 import Ouroboros.Consensus.Storage.LedgerDB.Snapshots
+import Ouroboros.Consensus.Storage.LedgerDB.V2.LSM
+  ( lsmDbExportSnapshot
+  , lsmDbImportSnapshot
+  )
 import System.Exit
 import System.FSNotify
-import System.FilePath
+import System.FilePath (splitDirectories, splitFileName, (</>))
 
-data Config
-  = -- | Run in daemon mode
-    DaemonConfig
-      -- | Where the input snapshot will be in
-      SnapshotsDirectoryWithFormat
-      -- | Where to put the converted snapshots
-      SnapshotsDirectory
-  | -- | Run in normal mode
-    NoDaemonConfig
-      -- | Where and in which format the input snapshot is in
-      Snapshot'
-      -- | Where and in which format the output snapshot must be in
-      Snapshot'
+{-------------------------------------------------------------------------------
+  Commands
+-------------------------------------------------------------------------------}
 
--- | Helper for parsing a directory that contains both the snapshots directory
--- and the particular snapshot.
-data Snapshot'
-  = StandaloneSnapshot' FilePath StandaloneFormat
-  | LSMSnapshot' FilePath LSMDatabaseFilePath
+-- | The various ways in which the tool can be invoked.
+--
+-- 'Daemon' and 'Convert' operate purely on /standalone (exported) LSM
+-- snapshots/ and Mem snapshots; they never touch a live LSM database, and so
+-- carry the 'CardanoBlockArgs' needed to decode ledger states.
+--
+-- 'LsmExport' and 'LsmImport' operate directly on a (offline) LSM database; no
+-- ledger decoding is involved, hence no 'CardanoBlockArgs'.
+data Command
+  = Daemon DaemonOpts CardanoBlockArgs
+  | Convert ConvertOpts CardanoBlockArgs
+  | LsmExport LsmDbOpts
+  | LsmImport LsmDbOpts
 
-snapshot'ToSnapshot :: Snapshot' -> Snapshot
-snapshot'ToSnapshot (LSMSnapshot' s lsmfp) =
-  let (snapFp, snapName) = splitFileName s
-   in case snapshotFromPath snapName of
-        Just snap -> Snapshot (LSMSnapshot (SnapshotsDirectory snapFp) lsmfp) snap
-        Nothing -> error $ "Malformed input, last fragment of the input \"" <> s <> "\"is not a snapshot name"
-snapshot'ToSnapshot (StandaloneSnapshot' s fmt) =
-  let (snapFp, snapName) = splitFileName s
-   in case snapshotFromPath snapName of
-        Just snap -> Snapshot (StandaloneSnapshot (SnapshotsDirectory snapFp) fmt) snap
-        Nothing -> error $ "Malformed input, last fragment of the input \"" <> s <> "\"is not a snapshot name"
+-- | Options for the daemon: watch a directory for completed snapshots and
+-- convert each exported LSM snapshot into a Mem snapshot.
+data DaemonOpts = DaemonOpts
+  { daemonMonitorMetaDir :: FilePath
+  -- ^ The directory holding the @state@/@meta@ files of the snapshots produced
+  -- by the node (watched for completed snapshots).
+  , daemonLsmSnapshotsExportDir :: FilePath
+  -- ^ The directory into which the node exports its LSM snapshots. The exported
+  -- snapshot for a snapshot named @N@ is expected at @<this>/N@.
+  , daemonMemSnapshotDir :: FilePath
+  -- ^ The directory into which to write the converted Mem snapshots.
+  }
+
+-- | Options for a one-shot conversion between an exported LSM snapshot and a Mem
+-- snapshot (in either direction).
+data ConvertOpts = ConvertOpts
+  { convertSnapshotInDir :: FilePath
+  -- ^ The input snapshot (a directory named after the slot, holding at least the
+  -- @state@/@meta@ files).
+  , convertImportInDir :: Maybe FilePath
+  -- ^ If set, the input is an exported LSM snapshot whose tables live at
+  -- @<this>/<input snapshot name>@; otherwise the input is a Mem snapshot.
+  , convertSnapshotOutDir :: FilePath
+  -- ^ The output snapshot (a directory named after the slot).
+  , convertExportOutDir :: Maybe FilePath
+  -- ^ If set, the output is an exported LSM snapshot whose tables are written to
+  -- @<this>/<output snapshot name>@; otherwise the output is a Mem snapshot.
+  }
+
+-- | Options for the @lsm export@/@lsm import@ commands.
+data LsmDbOpts = LsmDbOpts
+  { lsmDbDir :: FilePath
+  -- ^ The LSM database (session) directory.
+  , lsmRootDir :: FilePath
+  -- ^ The export-to (for @export@) or import-from (for @import@) root directory.
+  -- The exported snapshot named @N@ lives at @<this>/N@.
+  , lsmSnapName :: String
+  -- ^ The snapshot name, e.g. @163470034@ or @163470034_my-suffix@.
+  }
 
 main :: IO ()
 main = withStdTerminalHandles $ do
   cryptoInit
-  (conf, args) <- getCommandLineConfig
+  cmd <- execParser opts
+  case cmd of
+    Daemon o args -> runDaemon o args
+    Convert o args -> runConvert o args
+    LsmExport o -> runLsmDb o lsmDbExportSnapshot
+    LsmImport o -> runLsmDb o lsmDbImportSnapshot
+
+{-------------------------------------------------------------------------------
+  Running the commands
+-------------------------------------------------------------------------------}
+
+runConvert :: ConvertOpts -> CardanoBlockArgs -> IO ()
+runConvert o args = do
   pInfo <- mkProtocolInfo args
-  case conf of
-    NoDaemonConfig (snapshot'ToSnapshot -> f) (snapshot'ToSnapshot -> t) -> do
-      eRes <- runExceptT (convertSnapshot True pInfo f t)
-      case eRes of
-        Left err -> do
-          putStrLn $ show err
-          exitFailure
-        Right () -> exitSuccess
-    DaemonConfig from@(getSnapshotDir . snapshotDirectory -> ledgerDbPath) to -> do
-      withManager $ \manager -> do
-        putStrLn $ "Watching " <> show ledgerDbPath
-        void $
-          watchTree
-            manager
-            ledgerDbPath
-            ( \case
-                CloseWrite ep _ IsFile -> "meta" `L.isSuffixOf` ep
-                _ -> False
-            )
-            ( \case
-                CloseWrite ep _ IsFile -> do
-                  case reverse $ splitDirectories ep of
-                    (_ : snapName@(snapshotFromPath -> Just ds) : _) -> do
-                      putStrLn $ "Converting snapshot " <> ep <> " to " <> (getSnapshotDir to </> snapName)
-                      res <-
-                        runExceptT $
-                          convertSnapshot
-                            False
-                            pInfo
-                            (Snapshot from ds)
-                            (Snapshot (StandaloneSnapshot to Mem) ds)
-                      case res of
-                        Left err ->
-                          putStrLn $ show err
-                        Right () ->
-                          putStrLn "Done"
-                    _ -> pure ()
+  from <- mkSnapshot (convertSnapshotInDir o) (convertImportInDir o)
+  to <- mkSnapshot (convertSnapshotOutDir o) (convertExportOutDir o)
+  eRes <- runExceptT (convertSnapshot True pInfo from to)
+  case eRes of
+    Left err -> putStrLn (show err) >> exitFailure
+    Right () -> exitSuccess
+
+runDaemon :: DaemonOpts -> CardanoBlockArgs -> IO ()
+runDaemon o args = do
+  pInfo <- mkProtocolInfo args
+  let monitorDir = daemonMonitorMetaDir o
+  withManager $ \manager -> do
+    putStrLn $ "Watching " <> show monitorDir
+    void $
+      watchTree
+        manager
+        monitorDir
+        ( \case
+            CloseWrite ep _ IsFile -> "meta" `L.isSuffixOf` ep
+            _ -> False
+        )
+        ( \case
+            CloseWrite ep _ IsFile ->
+              case reverse $ splitDirectories ep of
+                (_ : name@(snapshotFromPath -> Just ds) : _) -> do
+                  let exportedDir = daemonLsmSnapshotsExportDir o </> name
+                      from =
+                        Snapshot
+                          ( ExportedLSMSnapshot
+                              (SnapshotsDirectory monitorDir)
+                              (ExportedSnapshotPath exportedDir)
+                          )
+                          ds
+                      to =
+                        Snapshot
+                          (StandaloneSnapshot (SnapshotsDirectory (daemonMemSnapshotDir o)) Mem)
+                          ds
+                  putStrLn $
+                    "Converting snapshot " <> ep <> " to " <> (daemonMemSnapshotDir o </> name)
+                  res <- runExceptT (convertSnapshot False pInfo from to)
+                  case res of
+                    Left err -> putStrLn $ show err
+                    Right () -> putStrLn "Done"
                 _ -> pure ()
-            )
-        forever $ threadDelay 1000000
+            _ -> pure ()
+        )
+    forever $ threadDelay 1000000
+
+-- | Validate the snapshot name and run an LSM database operation (export or
+-- import) on the snapshot directory @<root>/<name>@, reporting the result.
+runLsmDb :: LsmDbOpts -> (FilePath -> String -> FilePath -> IO ()) -> IO ()
+runLsmDb o op = do
+  void $ requireSnapshotName name
+  res <- try $ op (lsmDbDir o) name (lsmRootDir o </> name)
+  case res of
+    Left (e :: SomeException) -> putStrLn (displayException e) >> exitFailure
+    Right () -> putStrLn "Done" >> exitSuccess
+ where
+  name = lsmSnapName o
+
+-- | Parse a snapshot name, exiting with a helpful message if it is malformed.
+requireSnapshotName :: String -> IO DiskSnapshot
+requireSnapshotName name =
+  case snapshotFromPath name of
+    Just ds -> pure ds
+    Nothing -> do
+      putStrLn $
+        "\""
+          <> name
+          <> "\" is not a valid snapshot name. It should be named after the slot"
+          <> " number of the contained state and an optional suffix, such as"
+          <> " `163470034` or `163470034_my-suffix`."
+      exitFailure
+
+-- | Interpret a snapshot path plus an optional exported-LSM root directory as a
+-- 'Snapshot'. When the root is given, the snapshot is an exported LSM snapshot
+-- whose tables live at @<root>/<snapshot name>@; otherwise it is a Mem snapshot.
+mkSnapshot :: FilePath -> Maybe FilePath -> IO Snapshot
+mkSnapshot snapPath mExportRoot = do
+  let (parent, name) = splitFileName snapPath
+  ds <- requireSnapshotName name
+  pure $
+    Snapshot
+      ( case mExportRoot of
+          Just root ->
+            ExportedLSMSnapshot
+              (SnapshotsDirectory parent)
+              (ExportedSnapshotPath (root </> name))
+          Nothing -> StandaloneSnapshot (SnapshotsDirectory parent) Mem
+      )
+      ds
 
 {-------------------------------------------------------------------------------
   Optparse-applicative
 -------------------------------------------------------------------------------}
 
-getCommandLineConfig :: IO (Config, CardanoBlockArgs)
-getCommandLineConfig =
-  execParser $
-    info
-      ( (,)
-          <$> parseConfig
-          <*> parseCardanoArgs <**> helper
-      )
-      ( fullDesc
-          <> header "Utility for converting snapshots among the different snapshot formats used by cardano-node."
-          <> progDescDoc programDescription
-      )
-
-parseConfig :: Parser Config
-parseConfig =
-  ( DaemonConfig
-      <$> ( LSMSnapshot
-              <$> (SnapshotsDirectory <$> strOption (long "monitor-lsm-snapshots-in"))
-              <*> (LSMDatabaseFilePath <$> strOption (long "lsm-database"))
+opts :: ParserInfo Command
+opts =
+  info
+    (commandParser <**> helper)
+    ( fullDesc
+        <> header
+          "Utility for managing and converting the ledger snapshots used by cardano-node."
+        <> progDesc
+          ( "Conversions operate on Mem snapshots and standalone (exported) LSM"
+              <> " snapshots, never on live LSM databases. Use the `lsm` commands to"
+              <> " export snapshots out of, or import snapshots into, an offline LSM"
+              <> " database."
           )
-      <*> (SnapshotsDirectory <$> strOption (long "output-mem-snapshots-in"))
-  )
-    <|> ( NoDaemonConfig
-            <$> ( ( LSMSnapshot'
-                      <$> (strOption (long "input-lsm-snapshot"))
-                      <*> (LSMDatabaseFilePath <$> strOption (long "input-lsm-database"))
-                  )
-                    <|> ( StandaloneSnapshot'
-                            <$> strOption (long "input-mem")
-                            <*> pure Mem
-                        )
-                )
-            <*> ( ( LSMSnapshot'
-                      <$> (strOption (long "output-lsm-snapshot"))
-                      <*> (LSMDatabaseFilePath <$> strOption (long "output-lsm-database"))
-                  )
-                    <|> ( StandaloneSnapshot'
-                            <$> strOption (long "output-mem")
-                            <*> pure Mem
-                        )
-                )
+    )
+
+commandParser :: Parser Command
+commandParser =
+  hsubparser
+    ( command
+        "daemon"
+        ( info
+            daemonCmd
+            ( progDesc $
+                "Watch a directory for completed snapshots and convert each exported"
+                  <> " LSM snapshot into a Mem snapshot as it is produced. Meaningful"
+                  <> " only for a node producing LSM snapshots."
+            )
         )
+        <> command
+          "convert"
+          ( info
+              convertCmd
+              ( progDesc $
+                  "Convert a single snapshot between an exported LSM snapshot and a Mem"
+                    <> " snapshot. The input/output paths must be named after the slot"
+                    <> " number of the contained state (e.g. `100` or `100_my-suffix`)."
+              )
+          )
+        <> command
+          "lsm"
+          ( info
+              lsmCmd
+              (progDesc "Export snapshots out of / import snapshots into an offline LSM database.")
+          )
+    )
 
-#if __GLASGOW_HASKELL__ >= 912
-programDescription :: Maybe Doc
-programDescription =
-  Just
-    """
-    # Running in oneshot mode
+daemonCmd :: Parser Command
+daemonCmd =
+  Daemon
+    <$> ( DaemonOpts
+            <$> strOption
+              ( long "monitor-snapshots-in"
+                  <> metavar "DIR"
+                  <> help "Directory with the node's snapshots (state/meta), watched for completion."
+              )
+            <*> strOption
+              ( long "lsm-exported-path"
+                  <> metavar "DIR"
+                  <> help "Directory into which the node exports its LSM snapshots."
+              )
+            <*> strOption
+              ( long "output-snapshots-in"
+                  <> metavar "DIR"
+                  <> help "Directory into which to write the converted Mem snapshots."
+              )
+        )
+    <*> parseCardanoArgs
 
-        `snapshot-converter` can be invoked to convert a single snapshot to a different
-        format. The two formats supported at the moment are: Mem and LSM.
+convertCmd :: Parser Command
+convertCmd =
+  Convert
+    <$> ( ConvertOpts
+            <$> strOption
+              ( long "snapshot-in"
+                  <> metavar "PATH"
+                  <> help "The input snapshot (directory named after the slot)."
+              )
+            <*> optional
+              ( strOption
+                  ( long "lsm-import-from"
+                      <> metavar "DIR"
+                      <> help "If set, the input is an exported LSM snapshot rooted here."
+                  )
+              )
+            <*> strOption
+              ( long "snapshot-out"
+                  <> metavar "PATH"
+                  <> help "The output snapshot (directory named after the slot)."
+              )
+            <*> optional
+              ( strOption
+                  ( long "lsm-export-to"
+                      <> metavar "DIR"
+                      <> help "If set, the output is an exported LSM snapshot rooted here."
+                  )
+              )
+        )
+    <*> parseCardanoArgs
 
-        As snapshots in Mem are fully contained in one directory, providing
-        that one is enough. On the other hand, converting an LSM snapshot requires a
-        reference to the snapshot directory as well as the LSM database directory.
+lsmCmd :: Parser Command
+lsmCmd =
+  hsubparser
+    ( command
+        "export"
+        ( info
+            ( LsmExport
+                <$> lsmDbOpts "lsm-export-to" "Root directory to export the snapshot into (as <DIR>/<snapshot>)."
+            )
+            (progDesc "Export a snapshot out of an offline LSM database into a standalone directory.")
+        )
+        <> command
+          "import"
+          ( info
+              ( LsmImport
+                  <$> lsmDbOpts "lsm-import-from" "Root directory holding the exported snapshot (at <DIR>/<snapshot>)."
+              )
+              ( progDesc
+                  "Import an exported snapshot into a new (offline) LSM database."
+              )
+          )
+    )
 
-        To run in oneshot mode, you have to provide input and output parameters as in:
-        ```
-        # mem to lsm
-        $ snapshot-converter --input-mem <PATH> --output-lsm-snapshot <PATH> --output-lsm-database <PATH> --config <PATH>
-
-        # lsm to mem
-        $ snapshot-converter --input-lsm-snapshot <PATH> --input-lsm-database <PATH> --output-mem <PATH> --config <PATH>
-        ```
-
-        Note that the input and output paths need to be named after the slot number
-        of the contained ledger state, this means for example that a snapshot for
-        slot 100 has to be contained in a directory `100[_suffix]` and has to be
-        written to a directory `100[_some_other_suffix]`. Providing a wrong slot
-        number will throw an error.
-
-        This naming convention is the same expected by `cardano-node`.
-
-    # Running in daemon mode
-
-        `snapshot-converter` can be invoked as a daemon to monitor and convert
-        snapshots produced by a `cardano-node` into Mem format as they are
-        written by the node. This is only meaningful to run if your node
-        produces LSM snapshots:
-        ```
-        # lsm to mem
-        $ snapshot-converter --monitor-lsm-snapshots-in <PATH> --lsm-database <PATH> --output-mem-snapshots-in <PATH> --config <PATH>
-        ```
-    """
-#else
-programDescription :: Maybe Doc
-programDescription =
-  Just
-   . pretty
-   . T.pack
-   $ unlines
-     [ "# Running in oneshot mode"
-     , ""
-     , "    `snapshot-converter` can be invoked to convert a single snapshot to a different"
-     , "    format. The two formats supported at the moment are: Mem and LSM."
-     , ""
-     , "    As snapshots in Mem are fully contained in one directory, providing"
-     , "    that one is enough. On the other hand, converting an LSM snapshot requires a"
-     , "    reference to the snapshot directory as well as the LSM database directory."
-     , ""
-     , "    To run in oneshot mode, you have to provide input and output parameters as in:"
-     , "    ```"
-     , "    # mem to lsm"
-     , "    $ snapshot-converter --input-mem <PATH> --output-lsm-snapshot <PATH> --output-lsm-database <PATH> --config <PATH>"
-     , ""
-     , "    # lsm to mem"
-     , "    $ snapshot-converter --input-lsm-snapshot <PATH> --input-lsm-database <PATH> --output-mem <PATH> --config <PATH>"
-     , "    ```"
-     , ""
-     , "    Note that the input and output paths need to be named after the slot number"
-     , "    of the contained ledger state, this means for example that a snapshot for"
-     , "    slot 100 has to be contained in a directory `100[_suffix]` and has to be"
-     , "    written to a directory `100[_some_other_suffix]`. Providing a wrong slot"
-     , "    number will throw an error."
-     , ""
-     , "    This naming convention is the same expected by `cardano-node`."
-     , ""
-     , "# Running in daemon mode"
-     , ""
-     , "    `snapshot-converter` can be invoked as a daemon to monitor and convert"
-     , "    snapshots produced by a `cardano-node` into Mem format as they are"
-     , "    written by the node. This is only meaningful to run if your node"
-     , "    produces LSM snapshots:"
-     , ""
-     , "    ```"
-     , "    # lsm to mem"
-     , "    $ snapshot-converter --monitor-lsm-snapshots-in <PATH> --lsm-database <PATH> --output-mem-snapshots-in <PATH> --config <PATH>"
-     , "    ```"
-     ]
-#endif
+lsmDbOpts :: String -> String -> Parser LsmDbOpts
+lsmDbOpts dirFlag dirHelp =
+  LsmDbOpts
+    <$> strOption
+      ( long "lsm-database"
+          <> metavar "DIR"
+          <> help "The LSM database (session) directory."
+      )
+    <*> strOption
+      ( long dirFlag
+          <> metavar "DIR"
+          <> help dirHelp
+      )
+    <*> strOption
+      ( long "snapshot"
+          <> metavar "NAME"
+          <> help "The snapshot name, e.g. 163470034 or 163470034_my-suffix."
+      )

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Block/Cardano.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Block/Cardano.hs
@@ -179,6 +179,17 @@ instance HasProtocolInfo (CardanoBlock StandardCrypto) where
         initialNonce
         (cfgHardForkTriggers cc)
 
+  mkLSMConfig CardanoBlockArgs{configFile} = do
+    -- The export path is interpreted relative to the LedgerDB filesystem root,
+    -- not the config file, so we read the config without adjusting file paths.
+    cc :: CardanoConfig <-
+      either (error . show) return
+        =<< Aeson.eitherDecodeFileStrict' configFile
+    pure
+      LSMConfig
+        { lsmConfigExportPath = lsmLedgerDBExportPath cc
+        }
+
 -- | An empty Dijkstra genesis to be provided when none is specified in the config.
 emptyDijkstraGenesis :: SL.DijkstraGenesis
 emptyDijkstraGenesis =
@@ -210,6 +221,10 @@ data CardanoConfig = CardanoConfig
   -- ^ @DijkstraGenesisFile@ field
   , cfgHardForkTriggers :: CardanoHardForkTriggers
   -- ^ @Test*HardForkAtEpoch@ for each Shelley era
+  , lsmLedgerDBExportPath :: Maybe FilePath
+  -- ^ @LedgerDB.LSMExportPath@ field: the directory (relative to the LSM-trees
+  -- LedgerDB filesystem root) into which the LSM backend exports snapshots as it
+  -- takes them. Only meaningful for the LSM backend.
   }
 
 instance AdjustFilePaths CardanoConfig where
@@ -252,6 +267,13 @@ instance Aeson.FromJSON CardanoConfig where
 
     dijkstraGenesisPath <- v Aeson..:? "DijkstraGenesisFile"
 
+    -- The LSM settings live in the @LedgerDB@ object (the rest of which is
+    -- parsed by the node, not here). @LSMExportPath@ is a directory path.
+    lsmLedgerDBExportPath <-
+      v Aeson..:? "LedgerDB" >>= \case
+        Nothing -> pure Nothing
+        Just ledgerDB -> ledgerDB Aeson..:? "LSMExportPath"
+
     triggers <- do
       let parseTrigger ::
             forall blk era.
@@ -290,6 +312,7 @@ instance Aeson.FromJSON CardanoConfig where
         , conwayGenesisPath = conwayGenesisPath
         , dijkstraGenesisPath = dijkstraGenesisPath
         , cfgHardForkTriggers = CardanoHardForkTriggers triggers
+        , lsmLedgerDBExportPath = lsmLedgerDBExportPath
         }
 
 instance HasAnalysis (CardanoBlock StandardCrypto) where

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/HasAnalysis.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/HasAnalysis.hs
@@ -4,6 +4,7 @@
 module Cardano.Tools.DBAnalyser.HasAnalysis
   ( HasAnalysis (..)
   , HasProtocolInfo (..)
+  , LSMConfig (..)
   , SizeInBytes
   , WithLedgerState (..)
   ) where
@@ -62,3 +63,18 @@ class (HasAnnTip blk, GetPrevHash blk, Condense (HeaderHash blk)) => HasAnalysis
 class HasProtocolInfo blk where
   data Args blk
   mkProtocolInfo :: Args blk -> IO (ProtocolInfo blk)
+
+  -- | The LSM-trees configuration to use when the LedgerDB runs on the LSM
+  -- backend. Defaults to no configuration (no snapshot exporting); only the
+  -- Cardano instance overrides this, reading the values from the node
+  -- configuration file.
+  mkLSMConfig :: Args blk -> IO LSMConfig
+  mkLSMConfig _ = pure (LSMConfig Nothing)
+
+-- | LSM-trees configuration relevant to db-analyser.
+data LSMConfig = LSMConfig
+  { lsmConfigExportPath :: Maybe FilePath
+  -- ^ The directory (relative to the LedgerDB filesystem root) into which the
+  -- LSM backend exports snapshots as it takes them. When 'Nothing', snapshots
+  -- are not exported.
+  }

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Run.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Run.hs
@@ -54,6 +54,7 @@ import Ouroboros.Consensus.Util.IOLike
 import Ouroboros.Consensus.Util.Orphans ()
 import Ouroboros.Network.Block (genesisPoint)
 import System.FS.API
+import System.FilePath (splitDirectories)
 import System.IO
 import System.Random (genWord64, newStdGen)
 import Text.Printf (printf)
@@ -160,6 +161,7 @@ analyse dbaConfig args =
     lock <- newMVar ()
     chainDBTracer <- mkTracer lock verbose
     analysisTracer <- mkTracer lock True
+    LSMConfig{lsmConfigExportPath} <- mkLSMConfig args
     lsmSalt <- fst . genWord64 <$> newStdGen
     ProtocolInfo{pInfoInitLedger = genesisLedger, pInfoConfig = cfg} <-
       mkProtocolInfo args
@@ -173,7 +175,11 @@ analyse dbaConfig args =
           V2LSM ->
             LedgerDB.LedgerDbBackendArgsV2 $
               LedgerDB.V2.SomeBackendArgs $
-                LSM.LSMArgs (mkFsPath ["lsm"]) Nothing lsmSalt (LSM.stdMkBlockIOFS dbDir)
+                LSM.LSMArgs
+                  (mkFsPath ["lsm"])
+                  (mkFsPath . splitDirectories <$> lsmConfigExportPath)
+                  lsmSalt
+                  (LSM.stdMkBlockIOFS dbDir)
 
         args' =
           ChainDB.completeChainDbArgs

--- a/ouroboros-consensus-cardano/src/unstable-snapshot-conversion/Ouroboros/Consensus/Cardano/SnapshotConversion.hs
+++ b/ouroboros-consensus-cardano/src/unstable-snapshot-conversion/Ouroboros/Consensus/Cardano/SnapshotConversion.hs
@@ -11,7 +11,7 @@
 -- executable.
 module Ouroboros.Consensus.Cardano.SnapshotConversion
   ( SnapshotsDirectory (..)
-  , LSMDatabaseFilePath (..)
+  , ExportedSnapshotPath (..)
   , Snapshot (..)
   , SnapshotsDirectoryWithFormat (..)
   , snapshotDirectory
@@ -52,14 +52,23 @@ import System.Random
 
 data SnapshotsDirectory = SnapshotsDirectory {getSnapshotDir :: FilePath}
 
-data LSMDatabaseFilePath = LSMDatabaseFilePath {getLSMDatabaseDir :: FilePath}
+-- | The directory holding a standalone (exported) LSM snapshot, i.e. the LSM
+-- ledger tables exported out of a session via @lsm-tree@'s @exportSnapshot@.
+--
+-- This is paired with a 'SnapshotsDirectory' that holds the @state@/@meta@
+-- files, just like the parts of an LSM snapshot inside a running node are split
+-- between the ChainDB @ledger@ directory and the LSM session directory.
+data ExportedSnapshotPath = ExportedSnapshotPath {getExportedSnapshotPath :: FilePath}
 
 data StandaloneFormat
   = Mem
 
 data SnapshotsDirectoryWithFormat
   = StandaloneSnapshot SnapshotsDirectory StandaloneFormat
-  | LSMSnapshot SnapshotsDirectory LSMDatabaseFilePath
+  | -- | A standalone (exported) LSM snapshot. Conversions never operate on a
+    -- live LSM database; they only ever read from or write to exported
+    -- snapshots (see 'ExportedSnapshotPath').
+    ExportedLSMSnapshot SnapshotsDirectory ExportedSnapshotPath
 
 data Snapshot = Snapshot
   { snapshotSnapShotDir :: SnapshotsDirectoryWithFormat
@@ -68,7 +77,7 @@ data Snapshot = Snapshot
 
 snapshotDirectory :: SnapshotsDirectoryWithFormat -> SnapshotsDirectory
 snapshotDirectory (StandaloneSnapshot fp _) = fp
-snapshotDirectory (LSMSnapshot fp _) = fp
+snapshotDirectory (ExportedLSMSnapshot fp _) = fp
 
 {-------------------------------------------------------------------------------
  Errors
@@ -148,8 +157,6 @@ data InEnv backend = InEnv
 data OutEnv backend = OutEnv
   { outStream :: IO (SomeBackend SinkArgs)
   -- ^ Sink arguments for consuming a stream of TxOuts
-  , outDeleteExtra :: Maybe FilePath
-  -- ^ In case some other directory needs to be wiped out
   , outProgressMsg :: String
   -- ^ A progress message (just for displaying)
   , outBackend :: SnapshotBackend
@@ -174,9 +181,9 @@ convertSnapshot ::
 convertSnapshot interactive (configCodec . pInfoConfig -> ccfg) from to = do
   InEnv{..} <- getInEnv
 
-  o@OutEnv{..} <- getOutEnv inState
+  OutEnv{..} <- getOutEnv inState
 
-  wipeOutputPaths o
+  wipePath interactive (getSnapshotDir outSnapDir F.</> snapshotToDirName outSnap)
 
   when interactive $ lift $ putStr "Copying state file..." >> hFlush stdout
   inStateFile <- lift $ unsafeToFilePath inHasFS (snapshotToStatePath inSnap)
@@ -231,13 +238,6 @@ convertSnapshot interactive (configCodec . pInfoConfig -> ccfg) from to = do
   inSomeHasFS, outSomeHasFS :: SomeHasFS IO
   inSomeHasFS = SomeHasFS inHasFS
   outSomeHasFS = SomeHasFS outHasFS
-
-  wipeOutputPaths OutEnv{..} = do
-    wipePath interactive (getSnapshotDir outSnapDir F.</> snapshotToDirName outSnap)
-    maybe
-      (pure ())
-      (wipePath interactive)
-      outDeleteExtra
 
   getState ::
     DiskSnapshot ->
@@ -311,15 +311,15 @@ convertSnapshot interactive (configCodec . pInfoConfig -> ccfg) from to = do
           ("InMemory@[" <> snapshotToDirName inSnap <> "]")
           c
           metadataCrc
-    Snapshot (LSMSnapshot _ (getLSMDatabaseDir -> lsmDbPath)) _ -> do
+    Snapshot (ExportedLSMSnapshot _ (getExportedSnapshotPath -> exportDir)) _ -> do
       metadataCrc <- getMetadata inSnap UTxOHDLSMSnapshot
       (st, c) <- getState inSnap
       checkSnapSlot st inSnap
       pure $
         InEnv
           st
-          (SomeBackend <$> mkLSMYieldArgs lsmDbPath inSnap stdMkBlockIOFS newStdGen)
-          ("LSM@[" <> lsmDbPath <> "]")
+          (SomeBackend <$> mkExportedLSMYieldArgs exportDir inSnap stdMkBlockIOFS newStdGen)
+          ("LSM (exported)@[" <> exportDir <> "]")
           c
           metadataCrc
 
@@ -333,23 +333,21 @@ convertSnapshot interactive (configCodec . pInfoConfig -> ccfg) from to = do
       pure $
         OutEnv
           (pure $ SomeBackend $ mkInMemSinkArgs outSomeHasFS outSnap st)
-          Nothing
           ("InMemory@[" <> snapshotToDirName outSnap <> "]")
           UTxOHDMemSnapshot
-    Snapshot (LSMSnapshot _ (LSMDatabaseFilePath lsmDbPath)) _ -> do
+    Snapshot (ExportedLSMSnapshot _ (ExportedSnapshotPath exportDir)) _ -> do
       checkSnapSlot st outSnap
       pure $
         OutEnv
           ( SomeBackend
-              <$> mkLSMSinkArgs
-                lsmDbPath
+              <$> mkExportedLSMSinkArgs
+                exportDir
                 outSnap
                 outSomeHasFS
                 stdMkBlockIOFS
                 newStdGen
           )
-          (Just lsmDbPath)
-          ("LSM@[" <> lsmDbPath <> "]")
+          ("LSM (exported)@[" <> exportDir <> "]")
           UTxOHDLSMSnapshot
 
   stream ::

--- a/ouroboros-consensus.cabal
+++ b/ouroboros-consensus.cabal
@@ -417,6 +417,7 @@ library lsm
     bytestring,
     containers,
     contra-tracer,
+    directory,
     filepath,
     fs-api,
     io-classes:mtl,
@@ -1923,12 +1924,9 @@ executable snapshot-converter
     fsnotify,
     mtl,
     optparse-applicative,
-    ouroboros-consensus:{cardano, ouroboros-consensus, unstable-cardano-tools, unstable-snapshot-conversion},
+    ouroboros-consensus:{cardano, lsm, ouroboros-consensus, unstable-cardano-tools, unstable-snapshot-conversion},
     with-utf8,
 
-  if impl(ghc <9.12)
-    build-depends:
-      text
   other-modules:
     DBAnalyser.Parsers
 

--- a/ouroboros-consensus/src/ouroboros-consensus-lsm/Ouroboros/Consensus/Storage/LedgerDB/V2/LSM.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus-lsm/Ouroboros/Consensus/Storage/LedgerDB/V2/LSM.hs
@@ -35,8 +35,14 @@ module Ouroboros.Consensus.Storage.LedgerDB.V2.LSM
     -- * Streaming
   , YieldArgs (YieldLSM)
   , mkLSMYieldArgs
+  , mkExportedLSMYieldArgs
   , SinkArgs (SinkLSM)
   , mkLSMSinkArgs
+  , mkExportedLSMSinkArgs
+
+    -- * Standalone (exported) snapshots
+  , lsmDbExportSnapshot
+  , lsmDbImportSnapshot
 
     -- * Exported for tests
   , LSM.Salt
@@ -94,11 +100,18 @@ import Ouroboros.Consensus.Util.IOLike
 import Ouroboros.Consensus.Util.IndexedMemPack
 import qualified Streaming as S
 import qualified Streaming.Prelude as S
+import qualified System.Directory as D
 import System.FS.API
 import System.FS.API.Lazy (hGetAll, hPutAll)
 import qualified System.FS.BlockIO.API as BIO
 import System.FS.BlockIO.IO
-import System.FilePath (splitDirectories, splitFileName)
+import System.FilePath
+  ( makeRelative
+  , splitDirectories
+  , splitFileName
+  , takeDirectory
+  , takeFileName
+  )
 import System.Random
 import Prelude hiding (read)
 
@@ -721,6 +734,11 @@ instance
         (Session m)
         -- \| Only to be closed by 'releaseYieldArgs'
         (SomeHasFSAndBlockIO m)
+        -- \| Cleanup hook run by 'releaseYieldArgs' /after/ the session has been
+        -- closed. Used to remove the temporary scratch session created when
+        -- yielding from a standalone (exported) snapshot. 'pure ()' for a plain
+        -- database yield.
+        (m ())
 
   data SinkArgs m LSM l blk
     = SinkLSM
@@ -733,19 +751,32 @@ instance
         -- \| DiskSnapshot
         DiskSnapshot
         (Session m)
+        -- \| \"After save\" hook, run by 'sink' /while the session is still
+        -- open/, right after the snapshot has been saved into it. Used to
+        -- export the freshly saved snapshot to a standalone directory. 'pure ()'
+        -- for a plain database sink.
+        (m ())
+        -- \| Cleanup hook run by 'releaseSinkArgs' /after/ the session has been
+        -- closed. Used to remove the temporary scratch session created when
+        -- sinking to a standalone (exported) snapshot. 'pure ()' for a plain
+        -- database sink.
+        (m ())
 
-  releaseYieldArgs (YieldLSM _ hdl session (SomeHasFSAndBlockIO _ bio)) = do
+  releaseYieldArgs (YieldLSM _ hdl session (SomeHasFSAndBlockIO _ bio) cleanup) = do
     close hdl
     LSM.closeSession session
+    cleanup
     BIO.close bio
 
-  releaseSinkArgs (SinkLSM _ _ (SomeHasFSAndBlockIO _ bio) _ session) = do
+  releaseSinkArgs (SinkLSM _ _ (SomeHasFSAndBlockIO _ bio) _ session _afterSave cleanup) = do
     LSM.closeSession session
+    cleanup
     BIO.close bio
 
-  yield _ (YieldLSM chunkSize hdl _ _) = yieldLsmS chunkSize hdl
+  yield _ (YieldLSM chunkSize hdl _ _ _) = yieldLsmS chunkSize hdl
 
-  sink _ (SinkLSM chunkSize shfs _ ds session) = sinkLsmS chunkSize shfs ds session
+  sink _ (SinkLSM chunkSize shfs _ ds session afterSave _cleanup) =
+    sinkLsmS chunkSize shfs ds session afterSave
 
 data SomeHasFSAndBlockIO m where
   SomeHasFSAndBlockIO ::
@@ -789,8 +820,11 @@ sinkLsmS ::
   SomeHasFS m ->
   DiskSnapshot ->
   Session m ->
+  -- | \"After save\" hook, run while the session is still open, right after the
+  -- snapshot has been saved into it.
+  m () ->
   Sink m l blk
-sinkLsmS writeChunkSize (SomeHasFS hfs) ds session st stream = do
+sinkLsmS writeChunkSize (SomeHasFS hfs) ds session afterSave st stream = do
   r <-
     bracket
       (lift $ LSM.newTable session)
@@ -803,6 +837,7 @@ sinkLsmS writeChunkSize (SomeHasFS hfs) ds session st stream = do
               (LSM.SnapshotLabel $ T.pack "UTxO table")
               lsmTable
           lift $ writeUTxOSizeFile hfs (snapshotToUTxOSizeFilePath ds) utxosSize
+          lift afterSave
           pure r
       )
   pure (fmap (,Nothing) r)
@@ -852,7 +887,185 @@ mkLSMYieldArgs lsmDbPath ds mkFS mkGen = do
       (LSM.toSnapshotName (snapshotToDirName ds))
       (LSM.SnapshotLabel $ T.pack "UTxO table")
   h <- newLSMLedgerTablesHandle nullTracer (const (pure ())) 0 tb
-  pure $ YieldLSM 1000 h session shfsbio
+  pure $ YieldLSM 1000 h session shfsbio (pure ())
+
+-- | Create Yield arguments for a standalone (exported) LSM snapshot.
+--
+-- Unlike 'mkLSMYieldArgs', which reads a snapshot out of a live LSM database,
+-- this opens a /temporary/ scratch session next to the exported snapshot,
+-- imports the exported snapshot into it, and then streams it as usual. The
+-- scratch session is removed by 'releaseYieldArgs'.
+--
+-- The scratch session is created in the parent directory of the exported
+-- snapshot, so that it lives on the same volume (a requirement of importing).
+mkExportedLSMYieldArgs ::
+  ( IOLike m
+  , LSMConstraints l blk
+  ) =>
+  -- | The directory containing the exported snapshot. Must not have a trailing
+  -- slash!
+  FilePath ->
+  -- | The complete name of the snapshot, so @<slotno>[_<suffix>]@.
+  DiskSnapshot ->
+  -- | Usually 'stdMkBlockIOFS'
+  (FilePath -> WithTempRegistry () m (SomeHasFSAndBlockIO m)) ->
+  -- | Usually 'newStdGen'
+  (m StdGen) ->
+  m (YieldArgs m LSM l blk)
+mkExportedLSMYieldArgs exportDir ds mkFS mkGen = do
+  shfsbio@(SomeHasFSAndBlockIO hasFS blockIO) <-
+    runWithTempRegistry $ (\x -> (x, ())) <$> mkFS (takeDirectory exportDir)
+  nonce <- fst . genWord64 <$> mkGen
+  let scratch = scratchSessionPath nonce
+  freshDirectory hasFS scratch
+  let snapName = LSM.toSnapshotName (snapshotToDirName ds)
+  session <-
+    LSM.newSession
+      nullTracer
+      hasFS
+      blockIO
+      nonce
+      scratch
+  LSM.importSnapshot
+    session
+    snapName
+    (mkFsPath [takeFileName exportDir])
+  tb <-
+    LSM.openTableFromSnapshot
+      session
+      snapName
+      (LSM.SnapshotLabel $ T.pack "UTxO table")
+  -- A scratch session used only for reading; it never exports snapshots.
+  h <- newLSMLedgerTablesHandle nullTracer (const (pure ())) 0 tb
+  pure $ YieldLSM 1000 h session shfsbio (removeDirectoryRecursive hasFS scratch)
+
+-- | Create Sink arguments for a standalone (exported) LSM snapshot.
+--
+-- Unlike 'mkLSMSinkArgs', which sinks into a live LSM database, this sinks into
+-- a /temporary/ scratch session next to the destination directory, and then
+-- exports the resulting snapshot to that directory (see 'LSM.exportSnapshot').
+-- The scratch session is removed by 'releaseSinkArgs'.
+--
+-- The scratch session is created in the parent directory of the destination, so
+-- that it lives on the same volume (a requirement of 'LSM.exportSnapshot').
+mkExportedLSMSinkArgs ::
+  IOLike m =>
+  -- | The destination directory for the exported snapshot. It will be
+  -- (re)created, and must not have a trailing slash!
+  FilePath ->
+  -- | The complete name of the snapshot, so @<slotno>[_<suffix>]@.
+  DiskSnapshot ->
+  -- | Usually 'ioHasFS', for the LedgerDB snapshot (@state@/@meta@) files.
+  SomeHasFS m ->
+  -- | Usually 'stdMkBlockIOFS'
+  (FilePath -> WithTempRegistry () m (SomeHasFSAndBlockIO m)) ->
+  -- | Usually 'newStdGen'
+  (m StdGen) ->
+  m (SinkArgs m LSM l blk)
+mkExportedLSMSinkArgs exportDir ds snapFs mkBlockIOFS mkGen = do
+  shfsbio@(SomeHasFSAndBlockIO hasFS blockIO) <-
+    runWithTempRegistry $ (\x -> (x, ())) <$> mkBlockIOFS (takeDirectory exportDir)
+  (nonce, gen') <- genWord64 <$> mkGen
+  let salt = fst $ genWord64 gen'
+      scratch = scratchSessionPath nonce
+      exportFsPath = mkFsPath [takeFileName exportDir]
+  freshDirectory hasFS scratch
+  -- 'LSM.exportSnapshot' requires the destination directory to not exist.
+  whenM (doesDirectoryExist hasFS exportFsPath) $
+    removeDirectoryRecursive hasFS exportFsPath
+  session <- LSM.newSession nullTracer hasFS blockIO salt scratch
+  let afterSave =
+        LSM.exportSnapshot session (LSM.toSnapshotName (snapshotToDirName ds)) exportFsPath
+  pure (SinkLSM 1000 snapFs shfsbio ds session afterSave (removeDirectoryRecursive hasFS scratch))
+
+-- | Export a snapshot out of a (offline) LSM database into a standalone
+-- directory, which must not exist yet.
+--
+-- The database session and the destination must live on the same volume.
+lsmDbExportSnapshot ::
+  -- | The LSM database (session) directory.
+  FilePath ->
+  -- | The name of the snapshot to export, so @<slotno>[_<suffix>]@.
+  String ->
+  -- | The destination directory, which must not exist yet.
+  FilePath ->
+  IO ()
+lsmDbExportSnapshot dbPath snapName exportDir = do
+  salt <- fst . genWord64 <$> newStdGen
+  withRootFS $ \hasFS blockIO -> do
+    sessionDir <- toRootFsPath dbPath
+    exportFs <- toRootFsPath exportDir
+    bracket
+      (LSM.openSession nullTracer hasFS blockIO salt sessionDir)
+      LSM.closeSession
+      (\session -> LSM.exportSnapshot session (LSM.toSnapshotName snapName) exportFs)
+
+-- | Import a snapshot from a standalone directory into a new (offline) LSM
+-- database, created at the given (empty or absent) directory.
+--
+-- The database session and the source must live on the same volume.
+lsmDbImportSnapshot ::
+  -- | The LSM database (session) directory. Created if it does not exist; must
+  -- be empty otherwise.
+  FilePath ->
+  -- | The name to give the imported snapshot, so @<slotno>[_<suffix>]@.
+  String ->
+  -- | The source directory containing the exported snapshot.
+  FilePath ->
+  IO ()
+lsmDbImportSnapshot dbPath snapName srcDir =
+  withRootFS $ \hasFS blockIO -> do
+    sessionDir <- toRootFsPath dbPath
+    srcFs <- toRootFsPath srcDir
+    createDirectoryIfMissing hasFS True sessionDir
+    salt <- fst . genWord64 <$> newStdGen
+    bracket
+      ( LSM.newSession
+          nullTracer
+          hasFS
+          blockIO
+          salt
+          sessionDir
+      )
+      LSM.closeSession
+      (\s -> LSM.importSnapshot s (LSM.toSnapshotName snapName) srcFs)
+
+-- | Mount the filesystem at the root, run an action with the resulting handles,
+-- and close the underlying block IO afterwards.
+--
+-- Mounting at the root means that any 'FsPath' (the session directory itself,
+-- as well as the import/export directories) can be expressed relative to a
+-- single mount point, even when they live in unrelated parts of the filesystem
+-- (as long as they are on the same volume, which the caller must guarantee).
+withRootFS ::
+  (forall h. (Eq h, Typeable h) => HasFS IO h -> BIO.HasBlockIO IO h -> IO a) ->
+  IO a
+withRootFS act = do
+  SomeHasFSAndBlockIO hasFS blockIO <-
+    runWithTempRegistry $ (\x -> (x, ())) <$> stdMkBlockIOFS "/"
+  act hasFS blockIO
+    `finally` BIO.close blockIO
+
+-- | A 'FsPath' (relative to the filesystem root) for a temporary scratch
+-- session directory, named after a nonce to make collisions unlikely.
+scratchSessionPath :: Word64 -> FsPath
+scratchSessionPath nonce = mkFsPath ["lsm-convert-scratch-" <> show nonce]
+
+-- | Interpret a (possibly relative) 'FilePath' as a 'FsPath' relative to the
+-- filesystem root, so that it can be used with a session mounted at the root.
+toRootFsPath :: FilePath -> IO FsPath
+toRootFsPath p = do
+  absPath <- D.makeAbsolute p
+  pure $ mkFsPath $ splitDirectories $ makeRelative "/" absPath
+
+-- | Ensure a directory exists and is empty.
+freshDirectory :: Monad m => HasFS m h -> FsPath -> m ()
+freshDirectory hasFS p = do
+  whenM (doesDirectoryExist hasFS p) $ removeDirectoryRecursive hasFS p
+  createDirectoryIfMissing hasFS True p
+
+whenM :: Monad m => m Bool -> m () -> m ()
+whenM mb act = mb >>= \b -> Monad.when b act
 
 -- | Create Sink arguments for LSM
 mkLSMSinkArgs ::
@@ -879,4 +1092,4 @@ mkLSMSinkArgs (splitFileName -> (lsmDbParentPath, lsmDbPath)) ds snapFs mkBlockI
   createDirectory hasFS lsmDbPath'
   salt <- fst . genWord64 <$> mkGen
   session <- LSM.newSession nullTracer hasFS blockIO salt lsmDbPath'
-  pure (SinkLSM 1000 snapFs shfsbio ds session)
+  pure (SinkLSM 1000 snapFs shfsbio ds session (pure ()) (pure ()))


### PR DESCRIPTION
Rework the snapshot-converter into a command tree:

  - daemon:  watch a node's snapshot directory and convert each exported LSM
             snapshot into a Mem snapshot as it is produced
  - convert: one-shot conversion between an exported LSM snapshot and a Mem
             snapshot, in either direction
  - lsm export / lsm import: move snapshots out of / into an offline LSM
             database

Conversions operate only on standalone (exported) LSM snapshots and Mem
snapshots, never on a live database.

db-analyser surfaces the LSM snapshot export directory via a new 'mkLSMConfig'
method on 'HasProtocolInfo' (read from the node config's
'LedgerDB.LSMExportPath'); it keeps using a random salt, as it builds a
throwaway ledger database whose exported snapshots record their own salt.