### PR TITLE
Discard snapshots if at same slot as the immutable db and is EBB

### DIFF
--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Run.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Run.hs
@@ -109,7 +109,10 @@ openLedgerDB args immutableDB replayGoal =
                   res
           lift $ do
             warnUnlessSnapshotAtGoal snapManager
-            LedgerDB.openDBInternal args initDb snapManager replayStream replayGoal
+            -- The replay goal is the @--analyse-from@ point, which is not
+            -- necessarily the ImmutableDB tip, so we do not know whether it
+            -- is an EBB. Assume it is not, like the vast majority of blocks.
+            LedgerDB.openDBInternal args initDb snapManager replayStream replayGoal IsNotEBB
       pure (ldb, od)
  where
   -- Stream blocks from the ImmutableDB, stopping as soon as we reach a block

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl.hs
@@ -146,7 +146,7 @@ openDBInternal ::
   m (ChainDB m blk, Internal m blk)
 openDBInternal args launchBgTasks = runWithTempRegistry $ do
   ( immutableDB
-    , immutableDbTipPoint
+    , immutableDbTip
     , volatileDB
     , ledgerDbGetVolatileSuffix
     , setGetCurrentChainForLedgerDB
@@ -154,8 +154,9 @@ openDBInternal args launchBgTasks = runWithTempRegistry $ do
     traceWith tracer $ TraceOpenEvent StartedOpeningDB
     traceWith tracer $ TraceOpenEvent StartedOpeningImmutableDB
     immutableDB <- ImmutableDB.openDB argsImmutableDb
-    immutableDbTipPoint <- atomically $ ImmutableDB.getTipPoint immutableDB
-    let immutableDbTipChunk =
+    immutableDbTip <- atomically $ ImmutableDB.getTip immutableDB
+    let immutableDbTipPoint = ImmutableDB.tipToPoint immutableDbTip
+        immutableDbTipChunk =
           chunkIndexOfPoint (ImmutableDB.immChunkInfo argsImmutableDb) immutableDbTipPoint
     traceWith tracer $
       TraceOpenEvent $
@@ -169,7 +170,7 @@ openDBInternal args launchBgTasks = runWithTempRegistry $ do
     (ledgerDbGetVolatileSuffix, setGetCurrentChainForLedgerDB) <- mkLedgerDbGetVolatileSuffix
     pure
       ( immutableDB
-      , immutableDbTipPoint
+      , immutableDbTip
       , volatileDB
       , ledgerDbGetVolatileSuffix
       , setGetCurrentChainForLedgerDB
@@ -184,7 +185,11 @@ openDBInternal args launchBgTasks = runWithTempRegistry $ do
     LedgerDB.openDB
       argsLgrDb
       (ImmutableDB.streamAPI immutableDB)
-      immutableDbTipPoint
+      (ImmutableDB.tipToPoint immutableDbTip)
+      ( case immutableDbTip of
+          Origin -> IsNotEBB
+          NotOrigin tip -> ImmutableDB.tipIsEBB tip
+      )
       (Query.getAnyKnownBlock immutableDB volatileDB)
       ledgerDbGetVolatileSuffix
 

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB.hs
@@ -63,6 +63,8 @@ openDB ::
   StreamAPI m blk blk ->
   -- | The Replay goal i.e. the tip of the stream of blocks.
   Point blk ->
+  -- | Whether the block at the replay goal is an EBB, see 'initialize'.
+  IsEBB ->
   -- | How to get blocks from the ChainDB
   ResolveBlock m blk ->
   GetVolatileSuffix m blk ->
@@ -71,6 +73,7 @@ openDB
   args
   stream
   replayGoal
+  replayGoalIsEBB
   getBlock
   getVolatileSuffix =
     case lgrBackendArgs args of
@@ -93,7 +96,7 @@ openDB
                 snapTracer
                 (lgrHasFS args)
         let initDb = V2.mkInitDb args getBlock snapManager getVolatileSuffix res
-        lift $ doOpenDB args initDb snapManager stream replayGoal
+        lift $ doOpenDB args initDb snapManager stream replayGoal replayGoalIsEBB
        where
         !tr = lgrTracer args
         !snapTracer = LedgerDBSnapshotEvent >$< tr
@@ -114,9 +117,10 @@ doOpenDB ::
   SnapshotManager m blk st ->
   StreamAPI m blk blk ->
   Point blk ->
+  IsEBB ->
   m (LedgerDB' m blk)
-doOpenDB args initDb snapManager stream replayGoal =
-  fst <$> openDBInternal args initDb snapManager stream replayGoal
+doOpenDB args initDb snapManager stream replayGoal replayGoalIsEBB =
+  fst <$> openDBInternal args initDb snapManager stream replayGoal replayGoalIsEBB
 
 -- | Open the ledger DB and expose internals for testing purposes
 openDBInternal ::
@@ -130,8 +134,9 @@ openDBInternal ::
   SnapshotManager m blk st ->
   StreamAPI m blk blk ->
   Point blk ->
+  IsEBB ->
   m (LedgerDB' m blk, TestInternals' m blk)
-openDBInternal args@(LedgerDbArgs{lgrHasFS = SomeHasFS fs}) initDb snapManager stream replayGoal = do
+openDBInternal args@(LedgerDbArgs{lgrHasFS = SomeHasFS fs}) initDb snapManager stream replayGoal replayGoalIsEBB = do
   createDirectoryIfMissing fs True (mkFsPath [])
   (_initLog, db) <-
     initialize
@@ -140,6 +145,7 @@ openDBInternal args@(LedgerDbArgs{lgrHasFS = SomeHasFS fs}) initDb snapManager s
       lgrConfig
       stream
       replayGoal
+      replayGoalIsEBB
       initDb
       snapManager
   (ledgerDb, internal) <- mkLedgerDb initDb db

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/API.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/API.hs
@@ -512,7 +512,9 @@ data InitDB db m blk = InitDB
 -- * We cannot deserialise them, or
 --
 -- * they are /ahead/ of the chain, they refer to a slot which is later than the
---     last slot in the immutable db.
+--     last slot in the immutable db (or the same slot, if the immutable db
+--     tip is an EBB, as the snapshot could then be for the EBB's same-slot
+--     successor block, which is not in the immutable db).
 --
 -- We do /not/ attempt to use multiple ledger states from disk to construct the
 -- ledger DB. Instead we load only a /single/ ledger state from disk, and
@@ -531,6 +533,9 @@ initialize ::
   LedgerDbCfg ExtLedgerState blk ->
   StreamAPI m blk blk ->
   Point blk ->
+  -- | Whether the block at the replay goal is an EBB. Used to decide whether
+  -- snapshots are ahead of the immutable db, see @snapshotTooRecent@.
+  IsEBB ->
   InitDB db m blk ->
   SnapshotManager m blk st ->
   m (InitLog blk, db)
@@ -540,11 +545,35 @@ initialize
   cfg
   stream
   replayGoal
+  replayGoalIsEBB
   dbIface
   snapManager =
     listSnapshots snapManager >>= tryNewestFirst id
    where
     InitDB{initFromGenesis, initFromSnapshot} = dbIface
+
+    -- \| Whether the given snapshot is ahead of the replay goal (the tip of
+    -- the immutable db), in which case it must be discarded, as replaying
+    -- from it would require blocks that are not in the immutable db.
+    --
+    -- Snapshots are named after the slot of the ledger state they contain,
+    -- so a snapshot named after a slot later than the replay goal is
+    -- necessarily too recent.
+    --
+    -- A snapshot named after the very slot of the replay goal is usually
+    -- fine (this is the common case for the most recent snapshot on a clean
+    -- restart), with one oddity: if the block at the replay goal is an EBB,
+    -- the snapshot could instead be for the EBB's successor block, which
+    -- shares its slot with the EBB but is not in the immutable db. The
+    -- snapshot name alone cannot distinguish the two cases, so we
+    -- conservatively discard such snapshots; EBBs are rare enough for this
+    -- not to matter.
+    snapshotTooRecent :: DiskSnapshot -> Bool
+    snapshotTooRecent s = case pointSlot replayGoal of
+      Origin -> True
+      At p -> case replayGoalIsEBB of
+        IsEBB -> dsNumber s >= unSlotNo p
+        IsNotEBB -> dsNumber s > unSlotNo p
 
     tryNewestFirst ::
       (InitLog blk -> InitLog blk) ->
@@ -568,10 +597,7 @@ initialize
           dbIface
       return (acc InitFromGenesis, db)
     tryNewestFirst acc (s : ss) = do
-      if ( case pointSlot replayGoal of
-             Origin -> True
-             At p -> dsNumber s > unSlotNo p
-         )
+      if snapshotTooRecent s
         then do
           deleteSnapshotIfTemporary snapManager s
           traceWith snapTracer . InvalidSnapshot s $ InitFailureTooRecent s replayGoal

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/MiniProtocol/LocalStateQuery/Server.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/MiniProtocol/LocalStateQuery/Server.hs
@@ -257,6 +257,8 @@ initLedgerDB s c = do
               args
               streamAPI
               (Chain.headPoint c)
+              -- These tests do not use EBBs.
+              IsNotEBB
               (\rpt -> pure $ fromMaybe (error "impossible") $ Chain.findBlock ((rpt ==) . blockRealPoint) c)
               (LedgerDB.praosGetVolatileSuffix s)
           pure (db, ())

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/LedgerDB/StateMachine.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/LedgerDB/StateMachine.hs
@@ -559,7 +559,8 @@ openLedgerDB flavArgs env cfg fs = do
                   (LedgerDBSnapshotEvent >$< lgrTracer args)
                   (lgrHasFS args)
           let initDb = V2.mkInitDb args getBlock snapManager (praosGetVolatileSuffix $ ledgerDbCfgSecParam cfg) res
-          lift $ openDBInternal args initDb snapManager stream replayGoal
+          -- These tests do not use EBBs.
+          lift $ openDBInternal args initDb snapManager stream replayGoal IsNotEBB
   case NE.nonEmpty volBlocks of
     Nothing -> pure ()
     Just volBlocks' -> do


### PR DESCRIPTION
This tackles a weird corner case in a test run, checkout the commit before this one and run `ChainDB q-s-m.sequential` with `--quickcheck-replay="(SMGen 15718721082101496336 1793087168948606521,99)"` to observe it.

In short, in the tests we don't copy blocks when we snapshot (which we do on production, see TODO(geo2a) in ChainDB.StateMachine). Normally we would be guarded by the fact that the snapshot would have a higher slot than the immutable db tip but when the tip is exactly at an EBB this is not the case and we reach the exception case.

With this fix, we instead discard the snapshot in this extremely rare situation.

# Description

Please include a meaningful description of the PR and link the relevant issues
this PR might resolve.

Also note that:

- New code should be properly tested (even if it does not add new features).
- The fix for a regression should include a test that reproduces said regression.

# WARNING

To update your feature branch if it's stale, please rebase it manually on top of `main`. Don't update your feature branch by merging `main` into it. Your pull request will not pass CI if you do.
