### PR TITLE
Honor ExperimentalHardForksEnabled in db-synthesizer config parser

### DIFF
--- a/changelog.d/20260617_151209_damian.nadales_db_synth_experimental_hardforks.md
+++ b/changelog.d/20260617_151209_damian.nadales_db_synth_experimental_hardforks.md
@@ -1,0 +1,29 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+<!--
+### Breaking
+
+- A bullet item for the Breaking category.
+
+-->
+<!--
+### Non-Breaking
+
+- A bullet item for the Non-Breaking category.
+
+-->
+### Patch
+
+- `db-synthesizer`: honor the `ExperimentalHardForksEnabled` configuration key.
+  The parser previously read only the obsolete `TestEnableDevelopmentHardForkEras`
+  key (renamed in `cardano-node`), so configs using the current key left the
+  development-eras flag at its `False` default. That capped the node's max
+  protocol version below the era the same config scheduled, so every block was
+  rejected with `ObsoleteNode` and `db-synthesizer` forged nothing. The vendored
+  `NodeHardForkProtocolConfiguration` field is renamed to
+  `npcExperimentalHardForksEnabled` to match `cardano-node`.

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Node/Protocol/Cardano.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Node/Protocol/Cardano.hs
@@ -88,7 +88,7 @@ mkConsensusProtocolCardano
     }
   npcDijkstraProtocolConfig
   NodeHardForkProtocolConfiguration
-    { npcTestEnableDevelopmentHardForkEras
+    { npcExperimentalHardForksEnabled
     , -- During testing of the latest unreleased era, we conditionally
     -- declared that we knew about it. We do so only when a config option
     -- for testing development/unstable eras is used. This lets us include
@@ -256,7 +256,7 @@ mkConsensusProtocolCardano
         -- IMPORTANT: this Protver below has to be kept in sync with the values
         -- used in the node in cardano-node/src/Cardano/Node/Protocol/Cardano.hs
         -- in function mkSomeConsensusProtocolCardano.
-        ( if npcTestEnableDevelopmentHardForkEras
+        ( if npcExperimentalHardForksEnabled
             then ProtVer (natVersion @12) 0
             else ProtVer (natVersion @11) 0
         )

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Node/Types.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Node/Types.hs
@@ -182,7 +182,7 @@ data NodeDijkstraProtocolConfiguration
 -- | Configuration relating to a hard forks themselves, not the specific eras.
 data NodeHardForkProtocolConfiguration
   = NodeHardForkProtocolConfiguration
-  { npcTestEnableDevelopmentHardForkEras :: Bool
+  { npcExperimentalHardForksEnabled :: Bool
   -- ^ During the development and integration of new eras we wish to be
   -- able to test the hard fork transition into the new era, but we do not
   -- wish to generally have the node advertise that it understands the new

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBSynthesizer/Orphans.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBSynthesizer/Orphans.hs
@@ -20,6 +20,7 @@ import Data.Aeson as Aeson
   , (.:)
   , (.:?)
   )
+import Data.Maybe (fromMaybe, isJust)
 
 instance FromJSON NodeConfigStub where
   parseJSON val = withObject "NodeConfigStub" (parse' val) val
@@ -58,12 +59,17 @@ instance AdjustFilePaths NodeCredentials where
 -- DUPLICATE: mirroring parsers from cardano-node/src/Cardano/Node/Configuration/POM.hs
 
 instance FromJSON NodeHardForkProtocolConfiguration where
-  parseJSON = withObject "NodeHardForkProtocolConfiguration" $ \v ->
-    NodeHardForkProtocolConfiguration
-      <$> v
-        .:? "TestEnableDevelopmentHardForkEras"
-        .!= False
-      <*> v .:? "TestShelleyHardForkAtEpoch"
+  parseJSON = withObject "NodeHardForkProtocolConfiguration" $ \v -> do
+    -- Mirror cardano-node's POM.hs: 'ExperimentalHardForksEnabled' is the value
+    -- source. The former 'TestEnableDevelopmentHardForkEras' is accepted only as
+    -- a deprecation guard: if present it must agree with the new key, else fail.
+    mNew <- v .:? "ExperimentalHardForksEnabled"
+    mOld <- v .:? "TestEnableDevelopmentHardForkEras"
+    when (isJust mOld && mOld /= mNew) $
+      fail
+        "TestEnableDevelopmentHardForkEras has been renamed to ExperimentalHardForksEnabled in the configuration file"
+    NodeHardForkProtocolConfiguration (fromMaybe False mNew)
+      <$> v .:? "TestShelleyHardForkAtEpoch"
       <*> v .:? "TestAllegraHardForkAtEpoch"
       <*> v .:? "TestMaryHardForkAtEpoch"
       <*> v .:? "TestAlonzoHardForkAtEpoch"


### PR DESCRIPTION
`db-synthesizer` read the obsolete `TestEnableDevelopmentHardForkEras` key, which `cardano-node` renamed to `ExperimentalHardForksEnabled`. On a config that uses the current key, the development-eras flag defaulted to `False`. That capped the node's max protocol version at 11 while the same config scheduled Dijkstra (protocol version 12) at epoch 0, so every block was rejected as `ObsoleteNode` and db-synthesizer forged nothing.

Now we parse `ExperimentalHardForksEnabled`, keeping the old key as a deprecation guard that fails on inconsistent use, matching `cardano-node`'s POM.hs. Rename the vendored field `npcTestEnableDevelopmentHardForkEras` to `npcExperimentalHardForksEnabled`.

Fixes #2075
