### PR TITLE
leios-prototype: prevent leaking LeiosFetch budget on disconnects

### DIFF
--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToNode.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToNode.hs
@@ -435,10 +435,13 @@ mkHandlers
           let tracer = leiosPeerTracer peer
               kernelTracer = Node.leiosKernelTracer tracers
               LeiosVoteState{addVote} = leiosVoteState
-          MVar.modifyMVar_ getLeiosPeersVars $ \leiosPeersVars -> do
-            x <- Leios.newLeiosPeerVars
-            let !leiosPeersVars' = Map.insert (Leios.MkPeerId peer) x leiosPeersVars
-            pure leiosPeersVars'
+          -- Allocate this peer's vars once and keep them in scope; the message
+          -- handlers below can write to 'peerVars' directly. The map insertion
+          -- exists only to publish them to the LeiosFetch client and the fetch
+          -- decision logic.
+          peerVars <- Leios.newLeiosPeerVars
+          MVar.modifyMVar_ getLeiosPeersVars $
+            pure . Map.insert (Leios.MkPeerId peer) peerVars
           pure $
             leiosNotifyClientPeerPipelined
               ( atomically controlMessageSTM <&> \case
@@ -478,11 +481,6 @@ mkHandlers
                               { Leios.missingEbBodies =
                                   Map.insert point ebBytesSize (Leios.missingEbBodies outstanding)
                               }
-                    peerVars <- do
-                      peersVars <- MVar.readMVar getLeiosPeersVars
-                      case Map.lookup (Leios.MkPeerId peer) peersVars of
-                        Nothing -> error "impossible!"
-                        Just x -> pure x
                     MVar.modifyMVar_ (Leios.offerings peerVars) $ \(offers1, offers2) -> do
                       let !offers1' = Set.insert ebHash offers1
                       pure (offers1', offers2)
@@ -490,11 +488,6 @@ mkHandlers
                   MsgLeiosBlockTxsOffer p -> do
                     traceWith tracer $ MkTraceLeiosPeer $ "MsgLeiosBlockTxsOffer " <> Leios.prettyLeiosPoint p
                     let MkLeiosPoint{pointEbHash = ebHash} = p
-                    peerVars <- do
-                      peersVars <- MVar.readMVar getLeiosPeersVars
-                      case Map.lookup (Leios.MkPeerId peer) peersVars of
-                        Nothing -> error "impossible!"
-                        Just x -> pure x
                     MVar.modifyMVar_ (Leios.offerings peerVars) $ \(offers1, offers2) -> do
                       let !offers2' = Set.insert ebHash offers2
                       pure (offers1, offers2')

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToNode.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToNode.hs
@@ -69,6 +69,7 @@ import Data.Functor ((<&>))
 import Data.Hashable (Hashable)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
+import qualified Data.Sequence as Seq
 import qualified Data.Set as Set
 import Data.Void (Void)
 import LeiosDemoDb
@@ -533,13 +534,23 @@ mkHandlers
               processEbNotification <|> processVote
       , hLeiosFetchClient = \_version controlMessageSTM peer -> toLeiosFetchClientPeerPipelined $ Effect $ do
           reqVar <-
+            -- Wait for the LeiosNotify client to publish this peer's vars. We
+            -- also watch 'controlMessageSTM': if the peer is being disconnected
+            -- from before the entry ever appears, it never will, and this loop
+            -- would otherwise spin forever. On 'Terminate' we hand back an empty
+            -- queue, so 'nextLeiosFetchClientCommand' observes 'stopSTM' on its
+            -- first transaction and terminates the client immediately.
             let loop = do
-                  leiosPeersVars <- MVar.readMVar getLeiosPeersVars
-                  case Map.lookup (Leios.MkPeerId peer) leiosPeersVars of
-                    Just x -> pure $ Leios.requestsToSend x
-                    Nothing -> do
-                      threadDelay (0.010 :: DiffTime)
-                      loop
+                  terminating <- atomically $ (== Terminate) <$> controlMessageSTM
+                  if terminating
+                    then TVar.Unchecked.newTVarIO Seq.empty
+                    else do
+                      leiosPeersVars <- MVar.readMVar getLeiosPeersVars
+                      case Map.lookup (Leios.MkPeerId peer) leiosPeersVars of
+                        Just x -> pure $ Leios.requestsToSend x
+                        Nothing -> do
+                          threadDelay (0.010 :: DiffTime)
+                          loop
              in loop
           leiosConn <- LeiosDb.open leiosDB
           pure $

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToNode.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToNode.hs
@@ -312,6 +312,7 @@ data Handlers m addr blk = Handlers
       NodeToNodeVersion ->
       ControlMessageSTM m ->
       ConnectionId addr ->
+      Leios.LeiosPeerVars m ->
       LeiosNotifyClientPeerPipelined LeiosPoint () LeiosVote m ()
   , hLeiosNotifyServer ::
       NodeToNodeVersion ->
@@ -432,17 +433,10 @@ mkHandlers
       , hKeepAliveServer = \_version _peer -> keepAliveServer
       , hPeerSharingClient = \_version controlMessageSTM _peer -> peerSharingClient controlMessageSTM
       , hPeerSharingServer = \_version _peer -> peerSharingServer getPeerSharingAPI
-      , hLeiosNotifyClient = \_version controlMessageSTM peer -> toLeiosNotifyClientPeerPipelined $ Effect $ do
+      , hLeiosNotifyClient = \_version controlMessageSTM peer peerVars -> toLeiosNotifyClientPeerPipelined $ Effect $ do
           let tracer = leiosPeerTracer peer
               kernelTracer = Node.leiosKernelTracer tracers
               LeiosVoteState{addVote} = leiosVoteState
-          -- Allocate this peer's vars once and keep them in scope; the message
-          -- handlers below can write to 'peerVars' directly. The map insertion
-          -- exists only to publish them to the LeiosFetch client and the fetch
-          -- decision logic.
-          peerVars <- Leios.newLeiosPeerVars
-          MVar.modifyMVar_ getLeiosPeersVars $
-            pure . Map.insert (Leios.MkPeerId peer) peerVars
           pure $
             leiosNotifyClientPeerPipelined
               ( atomically controlMessageSTM <&> \case
@@ -1244,6 +1238,43 @@ mkApps kernel rng Tracers{..} mkCodecs ByteLimits{..} chainSyncTimeouts lopBucke
       $ peerSharingServerPeer
       $ hPeerSharingServer version them
 
+  -- | Owns the per-peer 'LeiosPeerVars' entry in 'getLeiosPeersVars': allocates
+  -- and registers it on connect and, on every exit path, unregisters it and
+  -- refunds that peer's outstanding fetch requests. Modelled on
+  -- 'bracketFetchClient'. This bracket is the sole writer of the
+  -- 'getLeiosPeersVars' map itself; the LeiosNotify client (which fills in the
+  -- entry's 'offerings') runs inside it, while the LeiosFetch client and the
+  -- fetch decision loop read the entry and write its 'requestsToSend'.
+  --
+  -- The unregister's 'removePeerFromOutstanding' (which takes
+  -- 'getLeiosOutstanding') is safe against the fetch decision loop: that loop
+  -- re-reads the live peers *inside* its own 'getLeiosOutstanding' critical
+  -- section and only increments those, so the refund is serialised with the
+  -- increment. Since this unregister deletes the 'getLeiosPeersVars' entry
+  -- before refunding, the loop either still sees the peer (and the refund runs
+  -- afterwards, cancelling the increment) or no longer sees it (and never
+  -- increments it) -- so it cannot re-insert a departed peer's accounting after
+  -- teardown has refunded it.
+  bracketLeiosPeer ::
+    ConnectionId addrNTN ->
+    (Leios.LeiosPeerVars m -> m a) ->
+    m a
+  bracketLeiosPeer them =
+    bracket
+      ( do
+          peerVars <- Leios.newLeiosPeerVars
+          MVar.modifyMVar_ (getLeiosPeersVars kernel) $
+            pure . Map.insert pid peerVars
+          pure peerVars
+      )
+      ( \_peerVars -> do
+          MVar.modifyMVar_ (getLeiosPeersVars kernel) $ pure . Map.delete pid
+          MVar.modifyMVar_ (getLeiosOutstanding kernel) $
+            pure . Leios.removePeerFromOutstanding pid
+      )
+   where
+    pid = Leios.MkPeerId them
+
   aLeiosNotifyClient ::
     NodeToNodeVersion ->
     ExpandedInitiatorContext addrNTN PeerTrustable m ->
@@ -1257,15 +1288,16 @@ mkApps kernel rng Tracers{..} mkCodecs ByteLimits{..} chainSyncTimeouts lopBucke
       }
     channel = do
       labelThisThread "LeiosNotifyClient"
-      ((), trailing) <-
-        runPipelinedPeerWithLimits
-          (TraceLabelPeer them `contramap` tLeiosNotifyTracer)
-          (cLeiosNotifyCodec (mkCodecs version))
-          blLeiosNotify
-          timeLimitsLeiosNotify
-          channel
-          $ hLeiosNotifyClient version controlMessageSTM them
-      pure (NoInitiatorResult, trailing)
+      bracketLeiosPeer them $ \peerVars -> do
+        ((), trailing) <-
+          runPipelinedPeerWithLimits
+            (TraceLabelPeer them `contramap` tLeiosNotifyTracer)
+            (cLeiosNotifyCodec (mkCodecs version))
+            blLeiosNotify
+            timeLimitsLeiosNotify
+            channel
+            $ hLeiosNotifyClient version controlMessageSTM them peerVars
+        pure (NoInitiatorResult, trailing)
 
   aLeiosNotifyServer ::
     NodeToNodeVersion ->

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToNode.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToNode.hs
@@ -1238,7 +1238,7 @@ mkApps kernel rng Tracers{..} mkCodecs ByteLimits{..} chainSyncTimeouts lopBucke
       $ peerSharingServerPeer
       $ hPeerSharingServer version them
 
-  -- | Owns the per-peer 'LeiosPeerVars' entry in 'getLeiosPeersVars': allocates
+  -- \| Owns the per-peer 'LeiosPeerVars' entry in 'getLeiosPeersVars': allocates
   -- and registers it on connect and, on every exit path, unregisters it and
   -- refunds that peer's outstanding fetch requests. Modelled on
   -- 'bracketFetchClient'. This bracket is the sole writer of the

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
@@ -536,6 +536,14 @@ initNodeKernel
                   offerings
                   synthOfferings
           newDecisions <- MVar.modifyMVar getLeiosOutstanding $ \outstanding -> do
+            -- Re-read the live peers while holding the -- 'getLeiosOutstanding'
+            -- lock. This is used to avoid losing an update to
+            -- 'getLeiosOutstanding' that 'removePeerFromOutstanding' may have
+            -- made (due to a 'bracketLeiosPeer' exiting) after the peers were
+            -- read just above. Basically: don't assign new requests to a peer
+            -- that just disconnected, since the replies would never arrive /AND/
+            -- those requests would then remain in 'getLeiosOutstanding' forever.
+            stillLivePeers <- MVar.readMVar getLeiosPeersVars
             -- Short-circuit synth-add for EBs whose body is already in
             -- 'acquiredEbBodies' (analogous to MsgLeiosBlockOffer's
             -- check at 'NodeToNode.hs'). Avoids per-tick "synth re-adds,
@@ -577,7 +585,7 @@ initNodeKernel
             let (!outstanding', decisions) =
                   Leios.leiosFetchLogicIteration
                     Leios.demoLeiosFetchStaticEnv
-                    augmentedOfferings
+                    (Map.restrictKeys augmentedOfferings (Map.keysSet stillLivePeers))
                     filteredOutstanding
             pure (outstanding', decisions)
           traceWith leiosTr $ MkTraceLeiosKernel "leiosFetchLogic: decided"

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic.hs
@@ -609,59 +609,41 @@ msgLeiosBlock ktracer tracer (outstandingVar, readyVar) db peerId req eb = do
         leiosDbInsertEbBody db point eb
         traceWith ktracer $ TraceLeiosBlockAcquired point
     -- update NodeKernel state
+    --
+    -- 'refundEbRequest' reverses this peer's per-request accounting (but skips
+    -- it if the peer has already been cancelled in bulk by a disconnect); the
+    -- global acquisition state below is updated unconditionally, since we did
+    -- receive the EB.
     let !outstanding' =
-          if not novel
-            then
-              outstanding
-                { Leios.requestedBytesSize = Leios.requestedBytesSize outstanding - ebBytesSize
-                , Leios.requestedBytesSizePerPeer =
-                    Map.alter
-                      ( \case
-                          Nothing -> error "impossible!"
-                          Just x -> delIf (== 0) $ x - ebBytesSize
-                      )
-                      peerId
-                      (Leios.requestedBytesSizePerPeer outstanding)
-                , Leios.requestedEbPeers =
-                    Map.update (delIf Set.null . Set.delete peerId) ebHash (Leios.requestedEbPeers outstanding)
-                }
-            else
-              outstanding
-                { Leios.acquiredEbBodies = Set.insert ebHash (Leios.acquiredEbBodies outstanding)
-                , Leios.missingEbBodies = Map.delete point (Leios.missingEbBodies outstanding)
-                , Leios.blockingPerEb =
-                    Map.insert
-                      point
-                      (let MkLeiosEb v = eb in V.length v)
-                      (Leios.blockingPerEb outstanding)
-                , Leios.missingEbTxs =
-                    Map.insert
-                      point
-                      ( V.ifoldl
-                          (\acc i x -> IntMap.insert i x acc)
-                          IntMap.empty
-                          (let MkLeiosEb v = eb in v)
-                      )
-                      (Leios.missingEbTxs outstanding)
-                , Leios.reverseEbIndexByTx =
-                    V.ifoldl
-                      ( \acc i (txHash, txBytesSize) ->
-                          Map.insertWith Map.union txHash (Map.singleton ebHash (i, txBytesSize)) acc
-                      )
-                      (Leios.reverseEbIndexByTx outstanding)
-                      (let MkLeiosEb v = eb in v)
-                , Leios.requestedBytesSize = Leios.requestedBytesSize outstanding - ebBytesSize
-                , Leios.requestedBytesSizePerPeer =
-                    Map.alter
-                      ( \case
-                          Nothing -> error "impossible!"
-                          Just x -> delIf (== 0) $ x - ebBytesSize
-                      )
-                      peerId
-                      (Leios.requestedBytesSizePerPeer outstanding)
-                , Leios.requestedEbPeers =
-                    Map.update (delIf Set.null . Set.delete peerId) ebHash (Leios.requestedEbPeers outstanding)
-                }
+          refundEbRequest peerId ebHash ebBytesSize $
+            if novel
+              then
+                outstanding
+                  { Leios.acquiredEbBodies = Set.insert ebHash (Leios.acquiredEbBodies outstanding)
+                  , Leios.missingEbBodies = Map.delete point (Leios.missingEbBodies outstanding)
+                  , Leios.blockingPerEb =
+                      Map.insert
+                        point
+                        (let MkLeiosEb v = eb in V.length v)
+                        (Leios.blockingPerEb outstanding)
+                  , Leios.missingEbTxs =
+                      Map.insert
+                        point
+                        ( V.ifoldl
+                            (\acc i x -> IntMap.insert i x acc)
+                            IntMap.empty
+                            (let MkLeiosEb v = eb in v)
+                        )
+                        (Leios.missingEbTxs outstanding)
+                  , Leios.reverseEbIndexByTx =
+                      V.ifoldl
+                        ( \acc i (txHash, txBytesSize) ->
+                            Map.insertWith Map.union txHash (Map.singleton ebHash (i, txBytesSize)) acc
+                        )
+                        (Leios.reverseEbIndexByTx outstanding)
+                        (let MkLeiosEb v = eb in v)
+                  }
+              else outstanding
     pure outstanding'
   void $ MVar.tryPutMVar readyVar ()
   traceWith tracer $ MkTraceLeiosPeer $ "[done] MsgLeiosBlock " <> Leios.prettyLeiosPoint point
@@ -670,6 +652,59 @@ msgLeiosBlock ktracer tracer (outstandingVar, readyVar) db peerId req eb = do
 
 delIf :: (a -> Bool) -> a -> Maybe a
 delIf predicate x = if predicate x then Nothing else Just x
+
+-----
+
+-- | Reverse this peer's per-request accounting for a received EB body, but only
+-- if the peer is still tracked.
+--
+-- If the peer has already been cancelled in bulk (e.g. it disconnected and its
+-- requests were refunded en masse via its 'requestedBytesSizePerPeer' total),
+-- that entry is gone; re-applying the per-request refund here would
+-- double-subtract 'requestedBytesSize' and underflow. So we gate on the peer
+-- still being present. The membership check, the refund, and the bulk
+-- cancellation all run within the same 'outstandingVar' critical section, so
+-- whichever happens first claims the refund and the other no-ops.
+refundEbRequest ::
+  Ord pid =>
+  PeerId pid ->
+  EbHash ->
+  BytesSize ->
+  LeiosOutstanding pid ->
+  LeiosOutstanding pid
+refundEbRequest peerId ebHash ebBytesSize o
+  | Map.member peerId (Leios.requestedBytesSizePerPeer o) =
+      o
+        { Leios.requestedBytesSize = Leios.requestedBytesSize o - ebBytesSize
+        , Leios.requestedBytesSizePerPeer =
+            Map.update (\x -> delIf (== 0) (x - ebBytesSize)) peerId (Leios.requestedBytesSizePerPeer o)
+        , Leios.requestedEbPeers =
+            Map.update (delIf Set.null . Set.delete peerId) ebHash (Leios.requestedEbPeers o)
+        }
+  | otherwise = o
+
+-----
+
+-- | Like 'refundEbRequest', but for a received batch of EB txs: installs the
+-- already-computed 'requestedTxPeers'' (this peer removed from each requested
+-- tx) and refunds the bytes, gated on the peer still being tracked (see
+-- 'refundEbRequest').
+refundTxRequest ::
+  Ord pid =>
+  PeerId pid ->
+  Map TxHash (Set (PeerId pid)) ->
+  BytesSize ->
+  LeiosOutstanding pid ->
+  LeiosOutstanding pid
+refundTxRequest peerId requestedTxPeers' txsBytesSize o
+  | Map.member peerId (Leios.requestedBytesSizePerPeer o) =
+      o
+        { Leios.requestedBytesSize = Leios.requestedBytesSize o - txsBytesSize
+        , Leios.requestedBytesSizePerPeer =
+            Map.update (\x -> delIf (== 0) (x - txsBytesSize)) peerId (Leios.requestedBytesSizePerPeer o)
+        , Leios.requestedTxPeers = requestedTxPeers'
+        }
+  | otherwise = o
 
 -----
 
@@ -737,37 +772,31 @@ msgLeiosBlockTxs ktracer tracer (outstandingVar, readyVar) db peerId req txs = d
         beatOtherPeers =
           (`IntMap.restrictKeys` offsetsSet) $
             Map.findWithDefault IntMap.empty point (Leios.missingEbTxs outstanding)
+    -- 'refundTxRequest' reverses this peer's per-request accounting (but skips
+    -- it if the peer has already been cancelled in bulk by a disconnect); the
+    -- global state below is updated unconditionally, since we did receive the
+    -- txs.
     let !outstanding' =
-          outstanding
-            { Leios.missingEbTxs =
-                Map.update
-                  (delIf IntMap.null . (`IntMap.withoutKeys` offsetsSet))
-                  point
-                  (Leios.missingEbTxs outstanding)
-            , Leios.reverseEbIndexByTx = reverseEbIndexByTx'
-            , Leios.blockingPerEb =
-                if IntMap.null beatOtherPeers
-                  then Leios.blockingPerEb outstanding
-                  else
-                    Map.alter
-                      ( \case
-                          Nothing -> Nothing
-                          Just x -> delIf (== 0) $ x - IntMap.size beatOtherPeers
-                      )
-                      point
-                      (Leios.blockingPerEb outstanding)
-            , Leios.requestedBytesSize =
-                Leios.requestedBytesSize outstanding - fromIntegral txsBytesSize
-            , Leios.requestedBytesSizePerPeer =
-                Map.alter
-                  ( \case
-                      Nothing -> error "impossible!"
-                      Just x -> delIf (== 0) $ x - fromIntegral txsBytesSize
-                  )
-                  peerId
-                  (Leios.requestedBytesSizePerPeer outstanding)
-            , Leios.requestedTxPeers = requestedTxPeers'
-            }
+          refundTxRequest peerId requestedTxPeers' (fromIntegral txsBytesSize) $
+            outstanding
+              { Leios.missingEbTxs =
+                  Map.update
+                    (delIf IntMap.null . (`IntMap.withoutKeys` offsetsSet))
+                    point
+                    (Leios.missingEbTxs outstanding)
+              , Leios.reverseEbIndexByTx = reverseEbIndexByTx'
+              , Leios.blockingPerEb =
+                  if IntMap.null beatOtherPeers
+                    then Leios.blockingPerEb outstanding
+                    else
+                      Map.alter
+                        ( \case
+                            Nothing -> Nothing
+                            Just x -> delIf (== 0) $ x - IntMap.size beatOtherPeers
+                        )
+                        point
+                        (Leios.blockingPerEb outstanding)
+              }
     pure outstanding'
   void $ MVar.tryPutMVar readyVar ()
   traceWith tracer $ MkTraceLeiosPeer $ "[done] " ++ Leios.prettyLeiosBlockTxsRequest req

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic.hs
@@ -655,6 +655,31 @@ delIf predicate x = if predicate x then Nothing else Just x
 
 -----
 
+-- | Cancel all of a peer's outstanding fetch requests in bulk, e.g. when it
+-- disconnects: refund its share of the request budget and drop it from the
+-- per-EB/per-tx request sets, so those items can be re-requested from other
+-- peers.
+--
+-- Note this is O(size of the request maps): it scans 'requestedEbPeers' /
+-- 'requestedTxPeers' for the peer rather than knowing its keys directly. A
+-- future optimisation would track a per-peer in-flight set to make this
+-- O(that peer's outstanding requests).
+removePeerFromOutstanding ::
+  Ord pid =>
+  PeerId pid ->
+  LeiosOutstanding pid ->
+  LeiosOutstanding pid
+removePeerFromOutstanding peerId o =
+  o
+    { Leios.requestedBytesSize =
+        Leios.requestedBytesSize o - Map.findWithDefault 0 peerId (Leios.requestedBytesSizePerPeer o)
+    , Leios.requestedBytesSizePerPeer = Map.delete peerId (Leios.requestedBytesSizePerPeer o)
+    , Leios.requestedEbPeers = Map.mapMaybe (delIf Set.null . Set.delete peerId) (Leios.requestedEbPeers o)
+    , Leios.requestedTxPeers = Map.mapMaybe (delIf Set.null . Set.delete peerId) (Leios.requestedTxPeers o)
+    }
+
+-----
+
 -- | Reverse this peer's per-request accounting for a received EB body, but only
 -- if the peer is still tracked.
 --

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic.hs
@@ -674,8 +674,10 @@ removePeerFromOutstanding peerId o =
     { Leios.requestedBytesSize =
         Leios.requestedBytesSize o - Map.findWithDefault 0 peerId (Leios.requestedBytesSizePerPeer o)
     , Leios.requestedBytesSizePerPeer = Map.delete peerId (Leios.requestedBytesSizePerPeer o)
-    , Leios.requestedEbPeers = Map.mapMaybe (delIf Set.null . Set.delete peerId) (Leios.requestedEbPeers o)
-    , Leios.requestedTxPeers = Map.mapMaybe (delIf Set.null . Set.delete peerId) (Leios.requestedTxPeers o)
+    , Leios.requestedEbPeers =
+        Map.mapMaybe (delIf Set.null . Set.delete peerId) (Leios.requestedEbPeers o)
+    , Leios.requestedTxPeers =
+        Map.mapMaybe (delIf Set.null . Set.delete peerId) (Leios.requestedTxPeers o)
     }
 
 -----

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoTypes.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoTypes.hs
@@ -311,6 +311,17 @@ data LeiosOutstanding pid = MkLeiosOutstanding
   --
   -- * 'blockingPerEb' is only decremented when txs are actually inserted
   --   into the DB (via @MsgLeiosBlockTxs@ handling).
+  --
+  -- TODO: 'blockingPerEb' can go permanently stale for txs shared across EBs.
+  -- 'msgLeiosBlockTxs' only decrements the entry for the EB it was requesting;
+  -- a tx that also belongs to another EB B is then in the DB, so 'filterMissingWork'
+  -- drops it from B's missing set and B never fetches it itself -- so B's
+  -- 'blockingPerEb' is never decremented for that tx and stays > 0. This is
+  -- currently harmless only because nothing reads 'blockingPerEb' as a gate: the
+  -- downstream @MsgLeiosBlockTxsOffer@ is actually driven by the DB emitting
+  -- 'AcquiredEbTxs' for every EB its @completed@ computation finds finished
+  -- (cross-EB aware), not by this field. Before using 'blockingPerEb' to gate
+  -- anything, reconcile it against shared-tx arrivals (or derive it from the DB).
   }
 
 emptyLeiosOutstanding :: LeiosOutstanding pid


### PR DESCRIPTION
We've seen a some forks on the testnet recently, and this PR fixes a bug that is a plausible cause.

- The testnet is seeing "spurious" disconnects (for other reasons)---unsurprising on a _testnet_.
- It's possible those disconnects are correlated with Leios fetch requests (since they are bursts of work, and the disconnects we've seen are from the Mempool hard timeout, which CPU starvation could cause).
- If so, then the bug fixed in this PR might explain the testnet forks.

The bug was: this testnet prototype evolved from a much narrower demo, in which disconnects were irrelevant. As such, it didn't handle them at all. In particular, if some requests were in-flight for the peer during the disconnect, then the LeiosFetch logic was never given the bad news that those requests' replies would never arrive. The unfortunate side-effect was that those outstanding requests still consumed some of the LeiosFetch budget. If that were to happen often enough, then the entire budget would be consumed by zombie requests, and so LeiosFetch would stop requesting anything. And that might lead to a testnet node not being able to follow the other testnet node's chain(s).

----

This PR updates the LeiosFetch logic (and related mini protocol spawning/tear down) to react properly when a peer disconnects. In particular, its outstanding requests (both assigned-but-not-yet-sent and also sent-but-not-yet-replied-to) are removed from the central state tracking outstanding requests.

The yak-shaving beyond that specific change is necessary to preventing write-conflicts:

- The `msgLeiosBlock` and `msgLeiosBlockTxs` handlers might race with the budget-flush, which could have resulted in them _also_ decreasing the budget when one of the replies arrived around the same time of the disconnect.

- The LeiosFetch logic snapshots the current peers and then makes its decisions and updates under a `modifyMVar outstandingVar ...`. Which means if a peer disconnects in between those two, there's a risk that the LeiosFetch logic would update `outstandingVar` by assigning new requests to the disconnected peer---which would still risk the same leak (just probably smaller and much less often).

The first we fix by making those handlers slightly smarter: skip the update to `outstanding` if the peer isn't still present in the current `outstanding`. The second we fix by re-snapshotting the live peer set inside of the `modifyMVar outstandingVar` that decides on new requests.