### PR TITLE
Improve snapshot-converter --help and --version

### DIFF
--- a/ouroboros-consensus-cardano/app/snapshot-converter.hs
+++ b/ouroboros-consensus-cardano/app/snapshot-converter.hs
@@ -7,23 +7,29 @@ module Main (main) where
 
 import Cardano.Crypto.Init (cryptoInit)
 import Cardano.Tools.DBAnalyser.HasAnalysis (mkProtocolInfo)
+import Cardano.Tools.GitRev (gitRev)
 import Control.Concurrent (threadDelay)
 import Control.Exception (SomeException, displayException, try)
 import Control.Monad (forever, void)
 import Control.Monad.Except (runExceptT)
 import DBAnalyser.Parsers (CardanoBlockArgs, parseCardanoArgs)
 import qualified Data.List as L
+import qualified Data.Text as T
+import Data.Version (showVersion)
 import Main.Utf8
 import Options.Applicative
+import Options.Applicative.Help.Pretty (Doc, pretty)
 import Ouroboros.Consensus.Cardano.SnapshotConversion
 import Ouroboros.Consensus.Storage.LedgerDB.Snapshots
 import Ouroboros.Consensus.Storage.LedgerDB.V2.LSM
   ( lsmDbExportSnapshot
   , lsmDbImportSnapshot
   )
+import Paths_ouroboros_consensus (version)
 import System.Exit
 import System.FSNotify
 import System.FilePath (splitDirectories, splitFileName, (</>))
+import System.Info (arch, compilerName, compilerVersion, os)
 
 {-------------------------------------------------------------------------------
   Commands
@@ -199,7 +205,7 @@ mkSnapshot snapPath mExportRoot = do
 opts :: ParserInfo Command
 opts =
   info
-    (commandParser <**> helper)
+    (commandParser <**> versionOption <**> helper)
     ( fullDesc
         <> header
           "Utility for managing and converting the ledger snapshots used by cardano-node."
@@ -209,7 +215,73 @@ opts =
               <> " export snapshots out of, or import snapshots into, an offline LSM"
               <> " database."
           )
+        <> footerDoc (Just examplesFooter)
     )
+
+-- | Report the tool version. The snapshot on-disk format is tied to the
+-- ouroboros-consensus code, so we report the ouroboros-consensus package
+-- version together with the exact git commit this tool was built from; that
+-- pair identifies which builds a given snapshot is compatible with. We also
+-- report the build platform and compiler, following the @cardano-cli
+-- --version@ format.
+versionOption :: Parser (a -> a)
+versionOption =
+  infoOption
+    versionString
+    ( long "version"
+        <> help "Show version, build platform and git commit, then exit."
+    )
+
+versionString :: String
+versionString =
+  "snapshot-converter, part of ouroboros-consensus "
+    <> showVersion version
+    <> " - "
+    <> os
+    <> "-"
+    <> arch
+    <> " - "
+    <> compilerName
+    <> "-"
+    <> showVersion compilerVersion
+    <> "\ngit rev "
+    <> T.unpack gitRev
+
+-- | Worked examples covering the expected flows, shown at the bottom of the
+-- top-level @--help@ output. The @convert@ examples require @--config@; the
+-- @lsm@ examples operate directly on an offline database and do not.
+examplesFooter :: Doc
+examplesFooter =
+  pretty $
+    L.intercalate
+      "\n"
+      [ "Typical flows (a snapshot is a directory named after its slot, e.g. `100`"
+      , "or `100_my-suffix`):"
+      , ""
+      , "  # Mem snapshot -> standalone (exported) LSM snapshot"
+      , "  snapshot-converter convert --config CONFIG \\"
+      , "    --snapshot-in  SNAPSHOTS/100 \\"
+      , "    --snapshot-out OUT/100 \\"
+      , "    --lsm-export-to EXPORTED"
+      , ""
+      , "  # standalone (exported) LSM snapshot -> Mem snapshot"
+      , "  snapshot-converter convert --config CONFIG \\"
+      , "    --snapshot-in    SNAPSHOTS/100 \\"
+      , "    --lsm-import-from EXPORTED \\"
+      , "    --snapshot-out   OUT/100"
+      , ""
+      , "  # import a standalone (exported) LSM snapshot into a new offline LSM database"
+      , "  snapshot-converter lsm import \\"
+      , "    --lsm-database    LSM_DB \\"
+      , "    --lsm-import-from EXPORTED \\"
+      , "    --snapshot        100"
+      , ""
+      , "  # export a snapshot out of an offline LSM database"
+      , "  snapshot-converter lsm export \\"
+      , "    --lsm-database  LSM_DB \\"
+      , "    --lsm-export-to EXPORTED \\"
+      , "    --snapshot      100"
+      ]
 
 commandParser :: Parser Command
 commandParser =

--- a/ouroboros-consensus.cabal
+++ b/ouroboros-consensus.cabal
@@ -1925,10 +1925,15 @@ executable snapshot-converter
     mtl,
     optparse-applicative,
     ouroboros-consensus:{cardano, lsm, ouroboros-consensus, unstable-cardano-tools, unstable-snapshot-conversion},
+    text,
     with-utf8,
 
   other-modules:
     DBAnalyser.Parsers
+    Paths_ouroboros_consensus
+
+  autogen-modules:
+    Paths_ouroboros_consensus
 
 test-suite tools-test
   import: common-test


### PR DESCRIPTION
```console
❯ cabal run snapshot-converter -- --version
snapshot-converter, part of ouroboros-consensus 3.0.1.0 - linux-x86_64 - ghc-9.14
git rev eb61e6021f398e7fbde34ce558fe92acf7f431d3-dirty
❯ cabal run snapshot-converter -- --help
Utility for managing and converting the ledger snapshots used by cardano-node.

Usage: snapshot-converter COMMAND [--version]

  Conversions operate on Mem snapshots and standalone (exported) LSM snapshots,
  never on live LSM databases. Use the `lsm` commands to export snapshots out
  of, or import snapshots into, an offline LSM database.

Available options:
  --version                Show version, build platform and git commit, then
                           exit.
  -h,--help                Show this help text

Available commands:
  daemon                   Watch a directory for completed snapshots and convert
                           each exported LSM snapshot into a Mem snapshot as it
                           is produced. Meaningful only for a node producing LSM
                           snapshots.
  convert                  Convert a single snapshot between an exported LSM
                           snapshot and a Mem snapshot. The input/output paths
                           must be named after the slot number of the contained
                           state (e.g. `100` or `100_my-suffix`).
  lsm                      Export snapshots out of / import snapshots into an
                           offline LSM database.

Typical flows (a snapshot is a directory named after its slot, e.g. `100`
or `100_my-suffix`):

  # Mem snapshot -> standalone (exported) LSM snapshot
  snapshot-converter convert --config CONFIG \
    --snapshot-in  SNAPSHOTS/100 \
    --snapshot-out OUT/100 \
    --lsm-export-to EXPORTED

  # standalone (exported) LSM snapshot -> Mem snapshot
  snapshot-converter convert --config CONFIG \
    --snapshot-in    SNAPSHOTS/100 \
    --lsm-import-from EXPORTED \
    --snapshot-out   OUT/100

  # import a standalone (exported) LSM snapshot into a new offline LSM database
  snapshot-converter lsm import \
    --lsm-database    LSM_DB \
    --lsm-import-from EXPORTED \
    --snapshot        100

  # export a snapshot out of an offline LSM database
  snapshot-converter lsm export \
    --lsm-database  LSM_DB \
    --lsm-export-to EXPORTED \
    --snapshot      100
```