### PR TITLE
Don't miss EB certification opportunities in the forging loop

### DIFF
--- a/cabal/newer-ghcs.cabal
+++ b/cabal/newer-ghcs.cabal
@@ -11,6 +11,8 @@ if impl (ghc >= 9.14)
     , aeson:containers
     , aeson:template-haskell
     , aeson:time
+    , aeson-pretty:aeson
+    , base64-bytestring-type:aeson
     , bin:QuickCheck
     , bin:base
     , binary-orphans:base
@@ -21,6 +23,7 @@ if impl (ghc >= 9.14)
     , canonical-json:containers
     , cborg:base
     , cborg:containers
+    , cborg-json:aeson
     , cborg-json:base
     , compact:base
     , config-ini:containers
@@ -32,6 +35,7 @@ if impl (ghc >= 9.14)
     , dec:base
     , dependent-map:constraints-extras
     , dependent-map:containers
+    , deriving-aeson:aeson
     , dictionary-sharing:containers
     , diff-containers:base
     , fin:QuickCheck
@@ -39,13 +43,16 @@ if impl (ghc >= 9.14)
     , fin:universe-base
     , fingertree-rm:base
     , fs-api:unix-bytestring
+    , fs-sim:QuickCheck
     , hedgehog-quickcheck:QuickCheck
     , http-api-data:base
     , http-api-data:containers
+    , http-api-data:text-iso8601
     , hspec-core:QuickCheck
     , indexed-traversable:base
     , indexed-traversable:containers
     , indexed-traversable-instances:base
+    , json-stream:aeson
     , kes-agent:base
     , kes-agent-crypto:base
     , latex-svg-image:base
@@ -54,6 +61,7 @@ if impl (ghc >= 9.14)
     , microstache:aeson
     , microstache:base
     , microstache:containers
+    , monoidal-containers:aeson
     , nonempty-vector:base
     , ordered-containers:containers
     , plutus-core:dependent-map
@@ -81,6 +89,7 @@ if impl (ghc >= 9.14)
     , serialise:base
     , serialise:containers
     , serialise:time
+    , tdigest:base
     , these:base
     , time-compat:time
     , transformers:base

--- a/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/Block.hs
+++ b/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/Block.hs
@@ -1540,10 +1540,9 @@ instance
   ) =>
   ResolveLeiosBlock (HardForkBlock (CardanoEras c))
   where
-  resolveLeiosClosure db point blk = case blk of
-    BlockDijkstra dijkstraBlk ->
-      fmap GenTxDijkstra <$> resolveLeiosClosure db point dijkstraBlk
-    _ -> pure []
+  resolveLeiosClosure db point =
+    fmap GenTxDijkstra
+      <$> resolveLeiosClosure db point
 
   inlineLeiosClosure blk txs = case blk of
     BlockDijkstra dijkstraBlk ->

--- a/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/Block.hs
+++ b/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/Block.hs
@@ -1540,9 +1540,9 @@ instance
   ) =>
   ResolveLeiosBlock (HardForkBlock (CardanoEras c))
   where
-  resolveLeiosClosure db point =
+  resolveLeiosClosure db ebHash =
     fmap GenTxDijkstra
-      <$> resolveLeiosClosure db point
+      <$> resolveLeiosClosure db ebHash
 
   inlineLeiosClosure blk txs = case blk of
     BlockDijkstra dijkstraBlk ->

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Forge.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Forge.hs
@@ -24,7 +24,7 @@ import qualified Cardano.Ledger.Shelley.API as SL (Block (..), extractTx)
 import Cardano.Prelude (nonEmpty)
 import qualified Cardano.Protocol.TPraos.BHeader as SL
 import Control.Exception
-import Control.Monad (void)
+import Control.Monad (void, when)
 import Control.Tracer (traceWith)
 import Data.ByteString.Short (fromShort)
 import Data.Maybe (isJust)
@@ -36,6 +36,7 @@ import LeiosDemoTypes
   ( EbAnnouncement (..)
   , ForgedLeiosEb (..)
   , LeiosPoint (..)
+  , RbHash (..)
   , TraceLeiosKernel (..)
   , forgeLeiosEb
   , hashLeiosEb
@@ -110,14 +111,18 @@ forgeShelleyBlock hotKey cbl ForgeBlockArgs{..} = do
   let blk = mkShelleyBlock $ SL.Block hdr rbBody
   case fst <$> mayEbAnn of
     Just (forgedEb :: ForgedLeiosEb) -> do
+      let announcingRbHashBytes =
+            fromShort
+              . toShortRawHash (Proxy @(ShelleyBlock proto era))
+              $ blk.shelleyBlockHeaderHash
       traceWith fbLeiosTracer $
         TraceLeiosBlockAnnounced
-          { announcingRbHashBytes =
-              fromShort
-                . toShortRawHash (Proxy @(ShelleyBlock proto era))
-                $ blk.shelleyBlockHeaderHash
+          { announcingRbHashBytes = announcingRbHashBytes
           , announcedEbPoint = forgedEb.point
           }
+      when (isJust mayLeiosCert) $
+        traceWith fbLeiosTracer $
+          TraceLeiosCertifiedAndAnnounced{atSlot = fbCurrentSlotNo, rbHash = MkRbHash announcingRbHashBytes}
     Nothing -> pure ()
   return $
     assert (verifyBlockIntegrity (configSlotsPerKESPeriod $ configConsensus fbConfig) blk) $

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Forge.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Forge.hs
@@ -28,6 +28,7 @@ import Control.Monad (void)
 import Control.Tracer (traceWith)
 import Data.ByteString.Short (fromShort)
 import Data.Maybe (isJust)
+import Data.Maybe.Strict (StrictMaybe (..), maybeToStrictMaybe)
 import qualified Data.Sequence.Strict as Seq
 import qualified Data.Typeable as Typeable
 import LeiosDemoDb (LeiosDbConnection (..))
@@ -73,14 +74,19 @@ forgeShelleyBlock ::
   ForgeBlockArgs m (ShelleyBlock proto era) ->
   m (ShelleyBlock proto era)
 forgeShelleyBlock hotKey cbl ForgeBlockArgs{..} = do
-  -- For the Dijkstra era only: either certify a previously-announced EB
-  -- (and embed a Leios certificate in the block body), or — if no
-  -- previous announcement is ready to be certified — possibly forge a
-  -- new EB and announce it on this block's header. Other eras do
-  -- neither.
+  -- Forge an RB and attempt to announce an EB and/or certify a previously announced one:
+  --
+  --  * Certify: if the forge loop decided to certify a previously-announced
+  --    EB ('fbMayLeiosCert' is a 'Just'), embed the certificate in the block body.
+  --
+  --  * Announce: forge and store a new EB from 'fbEbTxs' and announce it on this RB's header.
+  --    When we are also certifying, 'fbEbTxs' contains transactions from the mempool that has already
+  --    been rebased onto the post-certificate ledger state.
   (mayEbAnn, mayLeiosCert) <-
     case Typeable.eqT @era @DijkstraEra of
-      Just Refl -> decideLeios
+      Just Refl -> do
+        mayEbAnn <- mkAndStoreEb
+        pure (mayEbAnn, fbMayLeiosCert)
       Nothing -> pure (Nothing, Nothing)
   let rbBody = mkBody mayLeiosCert
       actualRbBodySize = SL.blockBodySize protocolVersion rbBody
@@ -144,24 +150,6 @@ forgeShelleyBlock hotKey cbl ForgeBlockArgs{..} = do
       . castHash
       . getTipHash
       $ fbCurrentTickedLedgerState
-
-  -- Dijkstra-only: if the forge loop decided to certify a
-  -- previously-announced EB ('fbMayLeiosCert'), embed the certificate and
-  -- suppress this block's own EB announcement. Otherwise fall back to
-  -- forging a new EB (when the mempool has txs for one). Mirrors the
-  -- prototype's 'decideForgeType'.
-  --
-  -- The certification /decision/ (announced + downloaded + gap elapsed +
-  -- certificate available) is made upstream in
-  -- 'Ouroboros.Consensus.NodeKernel.decideLeiosCertify' so it can run before
-  -- the mempool snapshot; here we only act on its result.
-  decideLeios :: m (Maybe (ForgedLeiosEb, EbAnnouncement), Maybe LeiosCert)
-  decideLeios =
-    case fbMayLeiosCert of
-      cert@(Just _) -> pure (Nothing, cert)
-      Nothing -> do
-        ann <- mkAndStoreEb
-        pure (ann, Nothing)
 
   -- Produce an EB from fbEbTxs, store it into fbLeiosDb, and return the
   -- announcement to embed in the header. An honest forger only emits an

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Forge.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Forge.hs
@@ -83,13 +83,11 @@ forgeShelleyBlock hotKey cbl ForgeBlockArgs{..} = do
   --  * Announce: forge and store a new EB from 'fbEbTxs' and announce it on this RB's header.
   --    When we are also certifying, 'fbEbTxs' contains transactions from the mempool that has already
   --    been rebased onto the post-certificate ledger state.
-  (mayEbAnn, mayLeiosCert) <-
+  mayEbAnn <-
     case Typeable.eqT @era @DijkstraEra of
-      Just Refl -> do
-        mayEbAnn <- mkAndStoreEb
-        pure (mayEbAnn, fbMayLeiosCert)
-      Nothing -> pure (Nothing, Nothing)
-  let rbBody = mkBody mayLeiosCert
+      Just Refl -> mkAndStoreEb
+      Nothing -> pure Nothing
+  let rbBody = mkBody fbMayLeiosCert
       actualRbBodySize = SL.blockBodySize protocolVersion rbBody
   hdr <-
     mkHeader @_ @(ProtoCrypto proto)
@@ -104,7 +102,7 @@ forgeShelleyBlock hotKey cbl ForgeBlockArgs{..} = do
       protocolVersion
       $ SJust
         HeaderLeiosExtension
-          { containsCert = isJust mayLeiosCert
+          { containsCert = isJust fbMayLeiosCert
           , ebAnnouncement = maybeToStrictMaybe $ snd <$> mayEbAnn
           }
 
@@ -120,7 +118,7 @@ forgeShelleyBlock hotKey cbl ForgeBlockArgs{..} = do
           { announcingRbHashBytes = announcingRbHashBytes
           , announcedEbPoint = forgedEb.point
           }
-      when (isJust mayLeiosCert) $
+      when (isJust fbMayLeiosCert) $
         traceWith fbLeiosTracer $
           TraceLeiosCertifiedAndAnnounced{atSlot = fbCurrentSlotNo, rbHash = MkRbHash announcingRbHashBytes}
     Nothing -> pure ()

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Forge.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Forge.hs
@@ -11,7 +11,6 @@
 module Ouroboros.Consensus.Shelley.Ledger.Forge (forgeShelleyBlock) where
 
 import Cardano.Crypto.Leios (LeiosCert)
-import Cardano.Ledger.BaseTypes (StrictMaybe (SJust), maybeToStrictMaybe)
 import qualified Cardano.Ledger.Core as Core (TopTx, Tx)
 import qualified Cardano.Ledger.Core as SL
   ( BlockBody
@@ -31,22 +30,16 @@ import Data.ByteString.Short (fromShort)
 import Data.Maybe (isJust)
 import qualified Data.Sequence.Strict as Seq
 import qualified Data.Typeable as Typeable
-import LeiosDemoDb
-  ( LeiosDbConnection (..)
-  , leiosDbLookupEbClosure
-  )
+import LeiosDemoDb (LeiosDbConnection (..))
 import LeiosDemoTypes
   ( EbAnnouncement (..)
   , ForgedLeiosEb (..)
   , LeiosPoint (..)
-  , RbHash (..)
   , TraceLeiosKernel (..)
   , forgeLeiosEb
   , hashLeiosEb
   , leiosEbBytesSize
-  , minCertificationGap
   )
-import LeiosVoteState (LeiosVoteState (queryCert))
 import Lens.Micro ((&), (.~))
 import Ouroboros.Consensus.Block
 import Ouroboros.Consensus.Config
@@ -64,7 +57,7 @@ import Ouroboros.Consensus.Shelley.Ledger.Integrity
 import Ouroboros.Consensus.Shelley.Ledger.Mempool
 import Ouroboros.Consensus.Shelley.Protocol.Abstract
   ( ProtoCrypto
-  , ProtocolHeaderSupportsKES (configSlotsPerKESPeriod, protocolStateLeiosInfo)
+  , ProtocolHeaderSupportsKES (configSlotsPerKESPeriod)
   , mkHeader
   )
 
@@ -152,64 +145,23 @@ forgeShelleyBlock hotKey cbl ForgeBlockArgs{..} = do
       . getTipHash
       $ fbCurrentTickedLedgerState
 
-  -- Dijkstra-only: certify a previously-announced EB on this chain if
-  -- one is ready (announced + downloaded + gap > minCertificationGap +
-  -- certificate available in LeiosDb), suppressing this block's own EB
-  -- announcement. Otherwise fall back to forging a new EB (when the
-  -- mempool has txs for one). Mirrors the prototype's 'decideForgeType'.
+  -- Dijkstra-only: if the forge loop decided to certify a
+  -- previously-announced EB ('fbMayLeiosCert'), embed the certificate and
+  -- suppress this block's own EB announcement. Otherwise fall back to
+  -- forging a new EB (when the mempool has txs for one). Mirrors the
+  -- prototype's 'decideForgeType'.
+  --
+  -- The certification /decision/ (announced + downloaded + gap elapsed +
+  -- certificate available) is made upstream in
+  -- 'Ouroboros.Consensus.NodeKernel.decideLeiosCertify' so it can run before
+  -- the mempool snapshot; here we only act on its result.
   decideLeios :: m (Maybe (ForgedLeiosEb, EbAnnouncement), Maybe LeiosCert)
-  decideLeios = do
-    cert <- decideCertify
-    case cert of
-      Just _ -> pure (Nothing, cert)
+  decideLeios =
+    case fbMayLeiosCert of
+      cert@(Just _) -> pure (Nothing, cert)
       Nothing -> do
         ann <- mkAndStoreEb
         pure (ann, Nothing)
-
-  decideCertify :: m (Maybe LeiosCert)
-  decideCertify =
-    case fbChainDepState >>= protocolStateLeiosInfo (Proxy @proto) of
-      Nothing -> pure Nothing
-      Just (_, Origin) -> pure Nothing
-      Just (ann, NotOrigin prevSlotNo)
-        | unSlotNo fbCurrentSlotNo - unSlotNo prevSlotNo <= minCertificationGap ->
-            pure Nothing
-        | otherwise -> do
-            let ebPoint =
-                  MkLeiosPoint
-                    { pointSlotNo = prevSlotNo
-                    , pointEbHash = ebAnnouncementHash ann
-                    }
-            -- TODO: Why exactly do we guard against this? Also, shouldn't we
-            -- detect it the other way around: if we have a cert, but not
-            -- downloaded it ourselves -> warning!
-            mClosure <- leiosDbLookupEbClosure fbLeiosDb (pointEbHash ebPoint)
-            case mClosure of
-              Nothing -> do
-                traceWith fbLeiosTracer $
-                  MkTraceLeiosKernel $
-                    "EB not yet downloaded: " <> show ebPoint
-                pure Nothing
-              Just _ -> do
-                -- we get the hash of the previous block header because eb certification must
-                -- happen withing one block (this is the linear aspect of linear leios).
-                let announcingRbHash = case getTipHash fbCurrentTickedLedgerState of
-                      BlockHash h -> MkRbHash (toRawHash (Proxy @(ShelleyBlock proto era)) h)
-                      GenesisHash -> error "decideCertify: cannot certify on top of genesis"
-                mCert <- queryCert fbLeiosVoteState announcingRbHash
-                case mCert of
-                  Nothing -> do
-                    traceWith fbLeiosTracer $
-                      MkTraceLeiosKernel $
-                        "EB downloaded but no certificate: " <> show ebPoint
-                    pure Nothing
-                  Just cert -> do
-                    traceWith fbLeiosTracer $
-                      TraceLeiosBlockCertified
-                        { atSlot = fbCurrentSlotNo
-                        , certifiedPoint = ebPoint
-                        }
-                    pure (Just cert)
 
   -- Produce an EB from fbEbTxs, store it into fbLeiosDb, and return the
   -- announcement to embed in the header. An honest forger only emits an

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Leios.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Leios.hs
@@ -86,7 +86,7 @@ instance
   (PraosCrypto c, ShelleyCompatible (Praos c) DijkstraEra) =>
   ResolveLeiosBlock (ShelleyBlock (Praos c) DijkstraEra)
   where
-  resolveLeiosClosure leiosDb point _blk = do
+  resolveLeiosClosure leiosDb point = do
     mAnnouncedEb <-
       leiosDbLookupEbClosure
         leiosDb

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Leios.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Leios.hs
@@ -86,11 +86,11 @@ instance
   (PraosCrypto c, ShelleyCompatible (Praos c) DijkstraEra) =>
   ResolveLeiosBlock (ShelleyBlock (Praos c) DijkstraEra)
   where
-  resolveLeiosClosure leiosDb point = do
+  resolveLeiosClosure leiosDb ebHash = do
     mAnnouncedEb <-
       leiosDbLookupEbClosure
         leiosDb
-        (pointEbHash point)
+        ebHash
     case mAnnouncedEb of
       Nothing ->
         -- FIXME(TEMP diagnostic): a missing closure here means we're
@@ -108,7 +108,7 @@ instance
         -- ledger state.
         error $
           "resolveLeiosClosure: EB closure missing from LeiosDb for point "
-            <> show point
+            <> show ebHash
             <> "; chain-sel selected a cert-RB without its EB closure. "
             <> "Refusing to apply as empty (would diverge UTxO)."
       Just closureEntries ->

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBSynthesizer/Forging.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBSynthesizer/Forging.hs
@@ -249,6 +249,7 @@ runForge epochSize_ nextSlot opts chainDB blockForging cfg genTxs leiosDb = do
             , fbLeiosDb = leiosDb
             , fbLeiosTracer = Trace.nullTracer
             , fbLeiosVoteState = leiosVoteState
+            , fbMayLeiosCert = Nothing
             }
 
     -- Add the block to the chain DB (synchronously) and verify adoption

--- a/ouroboros-consensus-cardano/test/cardano-test/Test/ThreadNet/Leios.hs
+++ b/ouroboros-consensus-cardano/test/cardano-test/Test/ThreadNet/Leios.hs
@@ -59,7 +59,7 @@ import Data.Function ((&))
 import Data.Functor.Identity (runIdentity)
 import Data.Map (Map)
 import qualified Data.Map.Strict as Map
-import Data.Maybe (isNothing, mapMaybe)
+import Data.Maybe (isJust, isNothing, mapMaybe)
 import Data.Proxy (Proxy (..))
 import Data.Sequence.Strict ((|>))
 import qualified Data.Set as Set
@@ -219,6 +219,8 @@ prop_leios seed =
         & counterexample "[failed] propVoting"
     , propCertifying
         & counterexample "[failed] propCertifying"
+    , propCertifyAndAnnounce
+        & counterexample "[failed] propCertifyAndAnnounce"
     ]
  where
   numNodes = 3 :: Int
@@ -303,6 +305,18 @@ prop_leios seed =
     FromNode nid (FromLeios TraceLeiosVoteAcquired{vote}) -> Just (nid, vote)
     _ -> Nothing
 
+  -- Certifying an EB and announcing a new one are no longer mutually exclusive, so
+  -- an RB can finalise the previous EB (via a cert) while announcing the
+  -- next one. With continuous tx flow, a certifying block rebases the
+  -- mempool onto the post-certified-EB ledger state and announces a fresh EB
+  -- from the survivors. Unless the run produced no certifying blocks at all,
+  -- at least one should exercise the combined path.
+  propCertifyAndAnnounce =
+    (not (null announcedAndCertifiedSlots))
+      & counterexample "no block both certified and announced"
+      & counterexample ("certifying block slots: " <> show certificateBlocks)
+      & counterexample ("certify-and-announce block slots: " <> show certifyAndAnnounceBlocks)
+
   propCertifying =
     conjoin
       [ length reachedQuorumPoints > 0
@@ -341,6 +355,19 @@ prop_leios seed =
       , SJust _ <- [body ^. leiosCertBlockBodyL]
       ]
 
+  -- Slots of blocks that /both/ certify a previous EB (cert in the body)
+  -- and announce a fresh one (announcement in the header);
+  -- this set being non-empty is the direct evidence that we can certify an EB
+  -- and announce a new one in the same RB.
+  certifyAndAnnounceBlocks =
+    toList . Set.fromList $
+      [ blockSlot blk
+      | blk@(BlockDijkstra dijkstraBlk) <- concat nodeChains
+      , let SL.Block _ body = shelleyBlockRaw dijkstraBlk
+      , SJust _ <- [body ^. leiosCertBlockBodyL]
+      , isJust (headerLeiosAnnouncement (getHeader blk))
+      ]
+
   throughput = fromIntegral (sum includedTxCounts) / fromIntegral numSlots :: Double
 
   -- Pick any node — all nodes should converge to the same chain.
@@ -370,6 +397,7 @@ prop_leios seed =
       & tabulate "Praos blocks forged" [show $ length forgedBlocks]
       & tabulate "Leios blocks forged" [show $ length forgedEBs]
       & tabulate "Certifying blocks" [show $ length certificateBlocks]
+      & tabulate "Certify-and-announce blocks" [show $ length certifyAndAnnounceBlocks]
       & tabulate "Effective throughput" [show throughput]
 
   -- FIXME: This only exercises the in-memory replay via

--- a/ouroboros-consensus-cardano/test/cardano-test/Test/ThreadNet/Leios.hs
+++ b/ouroboros-consensus-cardano/test/cardano-test/Test/ThreadNet/Leios.hs
@@ -553,7 +553,8 @@ sumChainTxBytes _topConfig _initLedger node = runSimOrThrow $ do
   foldChain leiosDb prevAnn !total (blk : rest) = do
     blk' <- case (blockLeiosCert blk, prevAnn) of
       (Just _, Just point) ->
-        inlineLeiosClosure blk <$> resolveLeiosClosure leiosDb point blk
+        inlineLeiosClosure blk
+          <$> resolveLeiosClosure leiosDb point
       _ -> pure blk
     let nextAnn = fst <$> headerLeiosAnnouncement (getHeader blk)
     foldChain leiosDb nextAnn (total + blockTxSizeSum blk') rest
@@ -618,7 +619,7 @@ foldWithResolution leiosDb cfg blks initState =
         Nothing ->
           error "foldWithResolution: CertRB but no announcement on parent chain-dep state"
         Just (point, _) -> do
-          closureTxs <- resolveLeiosClosure leiosDb point blk
+          closureTxs <- resolveLeiosClosure leiosDb point
           let ls = ledgerState state
               lcfg = configLedger (getExtLedgerCfg cfg)
           case applyLeiosClosure lcfg closureTxs ls of

--- a/ouroboros-consensus-cardano/test/cardano-test/Test/ThreadNet/Leios.hs
+++ b/ouroboros-consensus-cardano/test/cardano-test/Test/ThreadNet/Leios.hs
@@ -59,7 +59,7 @@ import Data.Function ((&))
 import Data.Functor.Identity (runIdentity)
 import Data.Map (Map)
 import qualified Data.Map.Strict as Map
-import Data.Maybe (isJust, isNothing, mapMaybe)
+import Data.Maybe (isNothing, mapMaybe)
 import Data.Proxy (Proxy (..))
 import Data.Sequence.Strict ((|>))
 import qualified Data.Set as Set
@@ -315,7 +315,7 @@ prop_leios seed =
     (not (null announcedAndCertifiedSlots))
       & counterexample "no block both certified and announced"
       & counterexample ("certifying block slots: " <> show certificateBlocks)
-      & counterexample ("certify-and-announce block slots: " <> show certifyAndAnnounceBlocks)
+      & counterexample ("announced-and-certified slots: " <> show announcedAndCertifiedSlots)
 
   propCertifying =
     conjoin
@@ -355,18 +355,13 @@ prop_leios seed =
       , SJust _ <- [body ^. leiosCertBlockBodyL]
       ]
 
-  -- Slots of blocks that /both/ certify a previous EB (cert in the body)
-  -- and announce a fresh one (announcement in the header);
-  -- this set being non-empty is the direct evidence that we can certify an EB
-  -- and announce a new one in the same RB.
-  certifyAndAnnounceBlocks =
-    toList . Set.fromList $
-      [ blockSlot blk
-      | blk@(BlockDijkstra dijkstraBlk) <- concat nodeChains
-      , let SL.Block _ body = shelleyBlockRaw dijkstraBlk
-      , SJust _ <- [body ^. leiosCertBlockBodyL]
-      , isJust (headerLeiosAnnouncement (getHeader blk))
-      ]
+  -- Slots at which a single forging opportunity both certified the
+  -- previously-announced EB and announced a fresh one.
+  announcedAndCertifiedSlots :: [SlotNo]
+  announcedAndCertifiedSlots =
+    toList . Set.fromList $ flip mapMaybe leiosTraces $ \case
+      TraceLeiosCertifiedAndAnnounced{atSlot} -> Just atSlot
+      _ -> Nothing
 
   throughput = fromIntegral (sum includedTxCounts) / fromIntegral numSlots :: Double
 
@@ -397,7 +392,7 @@ prop_leios seed =
       & tabulate "Praos blocks forged" [show $ length forgedBlocks]
       & tabulate "Leios blocks forged" [show $ length forgedEBs]
       & tabulate "Certifying blocks" [show $ length certificateBlocks]
-      & tabulate "Certify-and-announce blocks" [show $ length certifyAndAnnounceBlocks]
+      & tabulate "Certify-and-announce blocks" [show $ length announcedAndCertifiedSlots]
       & tabulate "Effective throughput" [show throughput]
 
   -- FIXME: This only exercises the in-memory replay via

--- a/ouroboros-consensus-cardano/test/cardano-test/Test/ThreadNet/Leios.hs
+++ b/ouroboros-consensus-cardano/test/cardano-test/Test/ThreadNet/Leios.hs
@@ -577,7 +577,7 @@ sumChainTxBytes _topConfig _initLedger node = runSimOrThrow $ do
     blk' <- case (blockLeiosCert blk, prevAnn) of
       (Just _, Just point) ->
         inlineLeiosClosure blk
-          <$> resolveLeiosClosure leiosDb point
+          <$> resolveLeiosClosure leiosDb (pointEbHash point)
       _ -> pure blk
     let nextAnn = fst <$> headerLeiosAnnouncement (getHeader blk)
     foldChain leiosDb nextAnn (total + blockTxSizeSum blk') rest
@@ -642,7 +642,7 @@ foldWithResolution leiosDb cfg blks initState =
         Nothing ->
           error "foldWithResolution: CertRB but no announcement on parent chain-dep state"
         Just (point, _) -> do
-          closureTxs <- resolveLeiosClosure leiosDb point
+          closureTxs <- resolveLeiosClosure leiosDb (pointEbHash point)
           let ls = ledgerState state
               lcfg = configLedger (getExtLedgerCfg cfg)
           case applyLeiosClosure lcfg closureTxs ls of

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
@@ -749,7 +749,7 @@ decideLeiosCertify ::
   SlotNo ->
   -- | The state of the header we are extending.
   HeaderState blk ->
-  m (Maybe (LeiosCert, Leios.LeiosPoint))
+  m (Maybe (LeiosCert, Leios.EbHash))
 decideLeiosCertify leiosDb voteState tracer currentSlot headerState =
   case protocolStateLeiosAnnouncement @blk (headerStateChainDep headerState) of
     Nothing -> pure Nothing
@@ -790,7 +790,7 @@ decideLeiosCertify leiosDb voteState tracer currentSlot headerState =
                           { atSlot = currentSlot
                           , certifiedPoint = ebPoint
                           }
-                      pure (Just (cert, ebPoint))
+                      pure (Just (cert, Leios.pointEbHash ebPoint))
 
 forkBlockForging ::
   forall m addrNTN addrNTC blk.

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
@@ -57,7 +57,7 @@ import Data.Hashable (Hashable)
 import Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as Map
-import Data.Maybe (isJust)
+import Data.Maybe (fromMaybe, isJust)
 import qualified Data.Measure
 import Data.Proxy
 import Data.Set (Set)
@@ -91,7 +91,12 @@ import Ouroboros.Consensus.Ledger.Extended
 import Ouroboros.Consensus.Ledger.SupportsMempool
 import Ouroboros.Consensus.Ledger.SupportsPeerSelection
 import Ouroboros.Consensus.Ledger.SupportsProtocol
-import Ouroboros.Consensus.Ledger.Tables.Utils (forgetLedgerTables)
+import Ouroboros.Consensus.Ledger.Tables.Utils
+  ( calculateDifference
+  , forgetLedgerTables
+  , prependDiffs
+  , trackingToDiffs
+  )
 import Ouroboros.Consensus.Mempool
 import qualified Ouroboros.Consensus.MiniProtocol.BlockFetch.ClientInterface as BlockFetchClientInterface
 import Ouroboros.Consensus.MiniProtocol.ChainSync.Client
@@ -162,6 +167,7 @@ import Ouroboros.Network.PeerSharing
   , ps_POLICY_PEER_SHARE_MAX_PEERS
   , ps_POLICY_PEER_SHARE_STICKY_TIME
   )
+import Ouroboros.Network.Point (WithOrigin (..))
 import Ouroboros.Network.Protocol.LocalStateQuery.Type (Target (..))
 import Ouroboros.Network.TxSubmission.Inbound.V1
   ( TxSubmissionInitDelay
@@ -964,24 +970,67 @@ forkBlockForging IS{..} (MkBlockForging blockForgingM) =
                 (headerStateChainDep (headerState unticked))
                 (pointHash bcPrevPoint)
 
-          mempoolSnapshot <-
-            lift $
-              getSnapshotFor
-                mempool
-                currentSlot
-                tickedLedgerState
-                readTables
-
           let rbCap = blockCapacityTxMeasure (configLedger cfg) tickedLedgerState
-              mayEbCap = ebCapacityTxMeasure (configLedger cfg) tickedLedgerState
-              (rbTxs, txssz) = snapshotTake mempoolSnapshot rbCap
-              ebTxs = case mayEbCap of
-                Nothing -> []
-                Just ebCap ->
-                  let (allTxs, _) = snapshotTake mempoolSnapshot (Data.Measure.plus rbCap ebCap)
-                   in drop (length rbTxs) allTxs
-          -- NB respect the capacity of the ledger state we're extending,
-          -- which is /not/ 'snapshotLedgerState'
+              ebCap = fromMaybe Data.Measure.zero $ ebCapacityTxMeasure (configLedger cfg) tickedLedgerState
+          (rbTxs, ebTxs, txssz, mempoolSnapshot) <-
+            lift $ case mayLeiosCertAndAnnouncement of
+              Nothing -> do
+                -- We don't have a Leios certificate: take transactions for an RB and
+                -- an EB to be announced.
+                snap <- getSnapshotFor mempool currentSlot tickedLedgerState readTables
+                let (rbTxs', txssz') = snapshotTake snap rbCap
+                    ebTxs' =
+                      let (allTxs, _) = snapshotTake snap (Data.Measure.plus rbCap ebCap)
+                       in drop (length rbTxs') allTxs
+                pure (rbTxs', ebTxs', txssz', snap)
+              Just (_cert, announcedPoint) -> do
+                -- We have a Leios certificate: only take transactions for a new EB, as the RB will
+                -- carry the certificate and must not carry additional txs.
+                case protocolStateLeiosAnnouncement @blk (headerStateChainDep (headerState unticked)) of
+                  Nothing ->
+                    -- This case is impossible, as 'decideLeiosCertify' already checks exactly this and
+                    -- only builds a certificate if there is a matching announcement.
+                    error "forkBlockForging: impossible! no matching announcement for the certificate."
+                  Just (announcedPoint, _) -> do
+                    ebClosureTxs <- resolveLeiosClosure leiosConn announcedPoint (Proxy @blk)
+                    vals <- readTables (foldMap leiosClosureTxKeySets ebClosureTxs)
+                    let lsBeforeEB = ledgerState unticked `withLedgerTables` vals
+                    case applyLeiosClosure (configLedger cfg) ebClosureTxs lsBeforeEB of
+                      Left err -> do
+                        -- Should not happen: each closure tx was validated
+                        -- when inserted into the LeiosDb. Degrade safely by
+                        -- certifying but announcing no new EB, rather than
+                        -- announcing txs we could not revalidate.
+                        traceWith (leiosKernelTracer tracers) $
+                          MkTraceLeiosKernel $
+                            "forge rebase: applyLeiosClosure failed, announcing no EB: "
+                              <> show err
+                        -- as EB application failed, return the mempool based on top of
+                        -- the unmodified ledger state
+                        snap <- getSnapshotFor mempool currentSlot tickedLedgerState readTables
+                        pure ([], [], Data.Measure.zero, snap)
+                      Right lsAfterEB -> do
+                        -- Compose the EB closure diff (relative to the unticked
+                        -- parent) with the tick diff (relative to the
+                        -- state with the EB closure applied), so the snapshot is revalidated
+                        -- against parent + closure + tick. 'readTables' reads
+                        -- values at the unticked parent, matching that base.
+                        -- TODO(geo2a): I'm still not sure if this is correct
+                        let ebClosureDiff =
+                              trackingToDiffs (calculateDifference lsBeforeEB lsAfterEB)
+                            tickedLsAfterEB =
+                              applyChainTick
+                                OmitLedgerEvents
+                                (configLedger cfg)
+                                currentSlot
+                                (forgetLedgerTables lsAfterEB)
+                            rebasedTicked = prependDiffs ebClosureDiff tickedLsAfterEB
+                        snap <-
+                          getSnapshotForNoCache mempool currentSlot rebasedTicked readTables
+                        let ebTxs' = case mayEbCap of
+                              Nothing -> []
+                              Just ebCap -> fst (snapshotTake snap ebCap)
+                        pure ([], ebTxs', Data.Measure.zero, snap)
 
           -- force the mempool's computation before the tracer event
           _ <- evaluate (length rbTxs)

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
@@ -740,19 +740,18 @@ decideLeiosCertify ::
   ( Monad m
   , ResolveLeiosBlock blk
   , ConvertRawHash blk
+  , HasAnnTip blk
   ) =>
   LeiosDbConnection m ->
   LeiosVoteState m ->
   Tracer m TraceLeiosKernel ->
   -- | The slot we are forging for.
   SlotNo ->
-  -- | The (unticked) chain dep state we are extending.
-  ChainDepState (BlockProtocol blk) ->
-  -- | The hash of the block we are forging on top of (the announcing RB).
-  ChainHash blk ->
+  -- | The state of the header we are extending.
+  HeaderState blk ->
   m (Maybe (LeiosCert, Leios.LeiosPoint))
-decideLeiosCertify leiosDb voteState tracer currentSlot cds tipHash =
-  case protocolStateLeiosAnnouncement @blk cds of
+decideLeiosCertify leiosDb voteState tracer currentSlot headerState =
+  case protocolStateLeiosAnnouncement @blk (headerStateChainDep headerState) of
     Nothing -> pure Nothing
     Just (ebPoint, _ebSize)
       | unSlotNo currentSlot - unSlotNo (Leios.pointSlotNo ebPoint) <= Leios.minCertificationGap ->
@@ -772,11 +771,12 @@ decideLeiosCertify leiosDb voteState tracer currentSlot cds tipHash =
               -- The announcing RB is the block we're forging on top of;
               -- EB certification must happen within one block (this is the
               -- linear aspect of linear Leios).
-              case tipHash of
-                GenesisHash ->
-                  error "decideLeiosCertify: cannot certify on top of genesis"
-                BlockHash h -> do
-                  let announcingRb = Leios.MkRbHash (toRawHash (Proxy @blk) h)
+              case headerStateTip headerState of
+                Origin -> error "decideLeiosCertify: cannot certify on top of genesis"
+                At tip -> do
+                  -- the hash of the block we will be forging on top of (the announcing RB).
+                  let tipHash = annTipHash tip
+                      announcingRb = Leios.MkRbHash (toRawHash (Proxy @blk) tipHash)
                   mCert <- queryCert voteState announcingRb
                   case mCert of
                     Nothing -> do
@@ -966,8 +966,7 @@ forkBlockForging IS{..} (MkBlockForging blockForgingM) =
                 leiosVoteState
                 (leiosKernelTracer tracers)
                 currentSlot
-                (headerStateChainDep (headerState unticked))
-                (pointHash bcPrevPoint)
+                (headerState unticked)
 
           let rbCap = blockCapacityTxMeasure (configLedger cfg) tickedLedgerState
               ebCap = fromMaybe Data.Measure.zero $ ebCapacityTxMeasure (configLedger cfg) tickedLedgerState

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
@@ -92,10 +92,9 @@ import Ouroboros.Consensus.Ledger.SupportsMempool
 import Ouroboros.Consensus.Ledger.SupportsPeerSelection
 import Ouroboros.Consensus.Ledger.SupportsProtocol
 import Ouroboros.Consensus.Ledger.Tables.Utils
-  ( calculateDifference
+  ( emptyLedgerTables
   , forgetLedgerTables
   , prependDiffs
-  , trackingToDiffs
   )
 import Ouroboros.Consensus.Mempool
 import qualified Ouroboros.Consensus.MiniProtocol.BlockFetch.ClientInterface as BlockFetchClientInterface
@@ -986,51 +985,37 @@ forkBlockForging IS{..} (MkBlockForging blockForgingM) =
               Just (_cert, announcedPoint) -> do
                 -- We have a Leios certificate: only take transactions for a new EB, as the RB will
                 -- carry the certificate and must not carry additional txs.
-                case protocolStateLeiosAnnouncement @blk (headerStateChainDep (headerState unticked)) of
-                  Nothing ->
-                    -- This case is impossible, as 'decideLeiosCertify' already checks exactly this and
-                    -- only builds a certificate if there is a matching announcement.
-                    error "forkBlockForging: impossible! no matching announcement for the certificate."
-                  Just (announcedPoint, _) -> do
-                    ebClosureTxs <- resolveLeiosClosure leiosConn announcedPoint (Proxy @blk)
-                    vals <- readTables (foldMap leiosClosureTxKeySets ebClosureTxs)
-                    let lsBeforeEB = ledgerState unticked `withLedgerTables` vals
-                    case applyLeiosClosure (configLedger cfg) ebClosureTxs lsBeforeEB of
-                      Left err -> do
-                        -- Should not happen: each closure tx was validated
-                        -- when inserted into the LeiosDb. Degrade safely by
-                        -- certifying but announcing no new EB, rather than
-                        -- announcing txs we could not revalidate.
-                        traceWith (leiosKernelTracer tracers) $
-                          MkTraceLeiosKernel $
-                            "forge rebase: applyLeiosClosure failed, announcing no EB: "
-                              <> show err
-                        -- as EB application failed, return the mempool based on top of
-                        -- the unmodified ledger state
-                        snap <- getSnapshotFor mempool currentSlot tickedLedgerState readTables
-                        pure ([], [], Data.Measure.zero, snap)
-                      Right lsAfterEB -> do
-                        -- Compose the EB closure diff (relative to the unticked
-                        -- parent) with the tick diff (relative to the
-                        -- state with the EB closure applied), so the snapshot is revalidated
-                        -- against parent + closure + tick. 'readTables' reads
-                        -- values at the unticked parent, matching that base.
-                        -- TODO(geo2a): I'm still not sure if this is correct
-                        let ebClosureDiff =
-                              trackingToDiffs (calculateDifference lsBeforeEB lsAfterEB)
-                            tickedLsAfterEB =
-                              applyChainTick
-                                OmitLedgerEvents
-                                (configLedger cfg)
-                                currentSlot
-                                (forgetLedgerTables lsAfterEB)
-                            rebasedTicked = prependDiffs ebClosureDiff tickedLsAfterEB
-                        snap <-
-                          getSnapshotForNoCache mempool currentSlot rebasedTicked readTables
-                        let ebTxs' = case mayEbCap of
-                              Nothing -> []
-                              Just ebCap -> fst (snapshotTake snap ebCap)
-                        pure ([], ebTxs', Data.Measure.zero, snap)
+
+                -- Apply the EB's transactions onto the ledger state
+                res <-
+                  resolveAndApplyLeiosClosure
+                    leiosConn
+                    (configLedger cfg)
+                    announcedPoint
+                    readTables
+                    emptyLedgerTables
+                    (ledgerState unticked)
+                case res of
+                  Left err ->
+                    -- Should not happen: each closure tx was validated
+                    -- when inserted into the LeiosDb. Fail loudly.
+                    error $ "forkBlockForging: applyLeiosClosure failed, announcing no EB. " <> show err
+                  Right LeiosClosureApplied{lcaStateAfterEB, lcaClosureDiff} -> do
+                    -- Compose the EB closure diff (relative to the unticked
+                    -- parent) with the tick diff (relative to the
+                    -- state with the EB closure applied), so the mempool snapshot is revalidated
+                    -- against parent + closure + tick.
+                    let tickedLsAfterEB =
+                          lcaClosureDiff
+                            `prependDiffs` applyChainTick
+                              OmitLedgerEvents
+                              (configLedger cfg)
+                              currentSlot
+                              (forgetLedgerTables lcaStateAfterEB)
+                    snap <-
+                      getSnapshotForNoCache mempool currentSlot tickedLsAfterEB readTables
+                    let ebTxs' = fst (snapshotTake snap ebCap)
+                    pure ([], ebTxs', Data.Measure.zero, snap)
 
           -- force the mempool's computation before the tracer event
           _ <- evaluate (length rbTxs)

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
@@ -71,7 +71,8 @@ import LeiosDemoDb
 import qualified LeiosDemoDb as LeiosDb
 import qualified LeiosDemoLogic as Leios
 import LeiosDemoTypes
-  ( LeiosOutstanding
+  ( LeiosCert
+  , LeiosOutstanding
   , LeiosPeerVars
   , TraceLeiosKernel (..)
   )
@@ -717,6 +718,75 @@ toConsensusMode = \case
   LoEAndGDDDisabled -> PraosMode
   LoEAndGDDEnabled _ -> GenesisMode
 
+-- | Decide whether the block we're about to forge should certify a
+-- previously-announced EB on this chain, returning the assembled
+-- certificate and the 'LeiosPoint' at which the EB was announced.
+--
+-- An EB is certifiable when:
+--
+--   * it was announced on this chain ('protocolStateLeiosAnnouncement' is a 'Just');
+--   * enough slots ('minCertificationGap') have elapsed since the announcement;
+--   * we have downloaded its closure into the 'LeiosDb', and
+--   * we have assembled a certificate for the announcing RB.
+--
+-- Returns 'Nothing' for non-Leios eras and whenever any of the above is not yet satisfied.
+decideLeiosCertify ::
+  forall blk m.
+  ( Monad m
+  , ResolveLeiosBlock blk
+  , ConvertRawHash blk
+  ) =>
+  LeiosDbConnection m ->
+  LeiosVoteState m ->
+  Tracer m TraceLeiosKernel ->
+  -- | The slot we are forging for.
+  SlotNo ->
+  -- | The (unticked) chain dep state we are extending.
+  ChainDepState (BlockProtocol blk) ->
+  -- | The hash of the block we are forging on top of (the announcing RB).
+  ChainHash blk ->
+  m (Maybe (LeiosCert, Leios.LeiosPoint))
+decideLeiosCertify leiosDb voteState tracer currentSlot cds tipHash =
+  case protocolStateLeiosAnnouncement @blk cds of
+    Nothing -> pure Nothing
+    Just (ebPoint, _ebSize)
+      | unSlotNo currentSlot - unSlotNo (Leios.pointSlotNo ebPoint) <= Leios.minCertificationGap ->
+          pure Nothing
+      | otherwise -> do
+          -- TODO: Why exactly do we guard against this? Also, shouldn't we
+          -- detect it the other way around: if we have a cert, but not
+          -- downloaded it ourselves -> warning!
+          mClosure <- leiosDbLookupEbClosure leiosDb (Leios.pointEbHash ebPoint)
+          case mClosure of
+            Nothing -> do
+              traceWith tracer $
+                MkTraceLeiosKernel $
+                  "EB not yet downloaded: " <> show ebPoint
+              pure Nothing
+            Just _ ->
+              -- The announcing RB is the block we're forging on top of;
+              -- EB certification must happen within one block (this is the
+              -- linear aspect of linear Leios).
+              case tipHash of
+                GenesisHash ->
+                  error "decideLeiosCertify: cannot certify on top of genesis"
+                BlockHash h -> do
+                  let announcingRb = Leios.MkRbHash (toRawHash (Proxy @blk) h)
+                  mCert <- queryCert voteState announcingRb
+                  case mCert of
+                    Nothing -> do
+                      traceWith tracer $
+                        MkTraceLeiosKernel $
+                          "EB downloaded but no certificate: " <> show ebPoint
+                      pure Nothing
+                    Just cert -> do
+                      traceWith tracer $
+                        TraceLeiosBlockCertified
+                          { atSlot = currentSlot
+                          , certifiedPoint = ebPoint
+                          }
+                      pure (Just (cert, ebPoint))
+
 forkBlockForging ::
   forall m addrNTN addrNTC blk.
   (IOLike m, RunNode blk) =>
@@ -776,7 +846,16 @@ forkBlockForging IS{..} (MkBlockForging blockForgingM) =
     -- 'ChainDB.withReadOnlyForkerAtPoint', we switched to a fork where 'bcPrevPoint'
     -- is no longer on our chain. When that happens, we simply give up on the
     -- chance to produce a block.
-    (rbTxs, ebTxs, txssz, proof, snapSize, tickedLedgerState, forgingOnTopOf, untickedChainDepState) <-
+    ( rbTxs
+      , ebTxs
+      , txssz
+      , proof
+      , snapSize
+      , tickedLedgerState
+      , forgingOnTopOf
+      , untickedChainDepState
+      , mayLeiosCert
+      ) <-
       ChainDB.withReadOnlyForkerAtPoint chainDB (SpecificPoint bcPrevPoint) $ \case
         Left _ -> do
           trace blockForging $ TraceNoLedgerState currentSlot bcPrevPoint
@@ -874,6 +953,17 @@ forkBlockForging IS{..} (MkBlockForging blockForgingM) =
 
           let readTables = fmap castLedgerTables . roforkerReadTables forker . castLedgerTables
 
+          -- Decide whether this block certifies a previously-announced EB
+          mayLeiosCertAndAnnouncement <-
+            lift $
+              decideLeiosCertify @blk
+                leiosConn
+                leiosVoteState
+                (leiosKernelTracer tracers)
+                currentSlot
+                (headerStateChainDep (headerState unticked))
+                (pointHash bcPrevPoint)
+
           mempoolSnapshot <-
             lift $
               getSnapshotFor
@@ -909,6 +999,7 @@ forkBlockForging IS{..} (MkBlockForging blockForgingM) =
             , forgetLedgerTables tickedLedgerState
             , ledgerTipPoint (ledgerState unticked)
             , headerStateChainDep (headerState unticked)
+            , fst <$> mayLeiosCertAndAnnouncement
             )
 
     -- Actually produce the block
@@ -925,6 +1016,7 @@ forkBlockForging IS{..} (MkBlockForging blockForgingM) =
             , Block.fbEbTxs = ebTxs
             , Block.fbIsLeader = proof
             , Block.fbChainDepState = Just untickedChainDepState
+            , Block.fbMayLeiosCert = mayLeiosCert
             , Block.fbLeiosDb = leiosConn
             , Block.fbLeiosTracer = leiosKernelTracer tracers
             , Block.fbLeiosVoteState = leiosVoteState

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoTypes.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoTypes.hs
@@ -883,6 +883,8 @@ data TraceLeiosKernel
     TraceLeiosNotVoted {ebPoint :: LeiosPoint, reason :: LeiosNotVotedReason}
   | TraceLeiosDbException LeiosDbException
   | TraceLeiosDb TraceLeiosDb
+  | -- | A forged RB both certifies an EB and announce a new one
+    TraceLeiosCertifiedAndAnnounced {atSlot :: SlotNo, rbHash :: RbHash}
 
 -- | Reasons 'runLeiosVoting' may decline to cast a vote after acquiring an
 -- EB closure. See 'TraceLeiosNotVoted'.
@@ -987,6 +989,12 @@ traceLeiosKernelToObject = \case
       [ "kind" .= Aeson.String "LeiosDbInsertCollision"
       , "table" .= table
       , "key" .= key
+      ]
+  TraceLeiosCertifiedAndAnnounced slotNo rbHash ->
+    mconcat
+      [ "kind" .= Aeson.String "LeiosCertifiedAndAnnounced"
+      , "slotNo" .= slotNo
+      , "rbHash" .= prettyRbHash rbHash
       ]
 
 notVotedReasonText :: LeiosNotVotedReason -> Aeson.Value

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Block/Forging.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Block/Forging.hs
@@ -30,7 +30,7 @@ import Data.Kind (Type)
 import Data.Text (Text)
 import GHC.Stack
 import LeiosDemoDb (LeiosDbConnection)
-import LeiosDemoTypes (TraceLeiosKernel)
+import LeiosDemoTypes (LeiosCert, TraceLeiosKernel)
 import LeiosVoteState (LeiosVoteState)
 import Ouroboros.Consensus.Block.Abstract
 import Ouroboros.Consensus.Config
@@ -262,6 +262,10 @@ data ForgeBlockArgs m blk = ForgeBlockArgs
   , fbEbTxs :: [Validated (GenTx blk)]
   , fbIsLeader :: IsLeader (BlockProtocol blk)
   , fbChainDepState :: Maybe (ChainDepState (BlockProtocol blk))
+  , fbMayLeiosCert :: Maybe LeiosCert
+  -- ^ The Leios certificate this block should embed, if it certifies a
+  -- previously-announced EB. 'Nothing' for non-Leios eras and for
+  -- blocks that don't certify anything.
   , fbLeiosDb :: LeiosDbConnection m
   , fbLeiosTracer :: Tracer m TraceLeiosKernel
   , fbLeiosVoteState :: LeiosVoteState m

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Embed/Unary.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Embed/Unary.hs
@@ -472,6 +472,7 @@ instance Functor m => Isomorphic (BlockForging m) where
                 , fbLeiosDb = fbLeiosDb fbArgs
                 , fbLeiosTracer = fbLeiosTracer fbArgs
                 , fbLeiosVoteState = fbLeiosVoteState fbArgs
+                , fbMayLeiosCert = fbMayLeiosCert fbArgs
                 }
       }
    where
@@ -527,6 +528,7 @@ instance Functor m => Isomorphic (BlockForging m) where
                 , fbLeiosDb = fbLeiosDb fbArgs
                 , fbLeiosTracer = fbLeiosTracer fbArgs
                 , fbLeiosVoteState = fbLeiosVoteState fbArgs
+                , fbMayLeiosCert = fbMayLeiosCert fbArgs
                 }
       }
    where

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Forging.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Forging.hs
@@ -326,6 +326,7 @@ hardForkForgeBlock
     , fbLeiosDb
     , fbLeiosTracer
     , fbLeiosVoteState
+    , fbMayLeiosCert
     } =
     fmap (HardForkBlock . OneEraBlock)
       $ hsequence
@@ -441,4 +442,5 @@ hardForkForgeBlock
             , fbLeiosDb
             , fbLeiosTracer
             , fbLeiosVoteState
+            , fbMayLeiosCert
             }

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/API.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/API.hs
@@ -263,7 +263,7 @@ data Mempool m blk = Mempool
   --
   -- n.b. in our current implementation, when one opens a mempool, we
   -- spawn a thread which performs this action whenever the 'ChainDB' tip
-  -- point changes.
+  -- point changes. See 'forkSyncStateOnTipPointChange'.
   }
 
 -- | This configuration data controls a lightweight "defensive programming"

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/API.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/API.hs
@@ -202,6 +202,20 @@ data Mempool m blk = Mempool
   -- - The ledger state ticked to the given slot number (with the diffs from ticking)
   --
   -- - A function that reads values for keys at the unticked ledger state.
+  , getSnapshotForNoCache ::
+      SlotNo ->
+      TickedLedgerState blk DiffMK ->
+      (LedgerTables (LedgerState blk) KeysMK -> m (LedgerTables (LedgerState blk) ValuesMK)) ->
+      m (MempoolSnapshot blk)
+  -- ^ Like 'getSnapshotFor', but always revalidates against the supplied
+  -- ledger state instead of possibly returning the cached snapshot.
+  --
+  -- Needed by the Leios forge path, which rebases the mempool onto the
+  -- ledger state /after/ a to-be-certified EB is applied (whose tip and
+  -- slot match the cached mempool state, so 'getSnapshotFor' would return
+  -- the stale pre-rebase snapshot). Values are read at the unticked parent,
+  -- so the caller's @ticked@ diffs (closure ⊕ tick) must be relative to that
+  -- same state. See input-output-hk/ouroboros-leios#838.
   , getCapacity :: STM m (TxMeasure blk)
   -- ^ Get the mempool's capacity
   --

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Init.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Init.hs
@@ -115,6 +115,7 @@ mkMempool mpEnv =
     , removeTxsEvenIfValid = implRemoveTxsEvenIfValid mpEnv
     , getSnapshot = snapshotFromIS <$> readTMVar istate
     , getSnapshotFor = implGetSnapshotFor mpEnv
+    , getSnapshotForNoCache = implGetSnapshotForNoCache mpEnv
     , getCapacity = isCapacity <$> readTMVar istate
     , testSyncWithLedger = implSyncWithLedger snapshotFromIS mpEnv
     , testTryAddTx = implAddTx mpEnv . TestingAddTx

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Query.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Query.hs
@@ -1,7 +1,10 @@
 {-# LANGUAGE FlexibleContexts #-}
 
 -- | Queries to the mempool
-module Ouroboros.Consensus.Mempool.Query (implGetSnapshotFor) where
+module Ouroboros.Consensus.Mempool.Query
+  ( implGetSnapshotFor
+  , implGetSnapshotForNoCache
+  ) where
 
 import Ouroboros.Consensus.Block.Abstract
 import Ouroboros.Consensus.Ledger.Abstract
@@ -10,6 +13,21 @@ import Ouroboros.Consensus.Mempool.API
 import Ouroboros.Consensus.Mempool.Impl.Common
 import qualified Ouroboros.Consensus.Mempool.TxSeq as TxSeq
 import Ouroboros.Consensus.Util.IOLike
+
+-- | Whether the mempool snapshot may be served from the cached internal or needs re-computation.
+--
+-- 'UseCache' is the normal case:
+
+-- — a state rebased onto a to-be-certified EB's closure so a freshly-announced
+-- EB only carries txs valid /after/ that EB is applied
+-- (input-output-hk/ouroboros-leios#838). There the cache must be bypassed, or
+-- we would return the stale pre-rebase snapshot and silently drop the rebase.
+data SnapshotCachePolicy
+  = -- | same tip hash => same ledger state, so the cached snapshot is reusable.
+    UseCache
+  | -- | for the Leios EB certifiation+announcement path, where the tip and
+    -- slot coincide with the cached mempool state but the ledger state differs.
+    AlwaysRevalidate
 
 implGetSnapshotFor ::
   ( IOLike m
@@ -26,17 +44,58 @@ implGetSnapshotFor ::
   -- the unticked ledger state.
   (LedgerTables (LedgerState blk) KeysMK -> m (LedgerTables (LedgerState blk) ValuesMK)) ->
   m (MempoolSnapshot blk)
-implGetSnapshotFor mpEnv slot ticked readUntickedTables = do
+implGetSnapshotFor = getSnapshotUsingPolicyFor UseCache
+
+-- | Like 'implGetSnapshotFor', but never short-circuits to the cached
+-- internal snapshot: it always revalidates the mempool against the supplied
+-- ledger state. See 'AlwaysRevalidate'.
+--
+-- Values are read at the unticked parent, so the caller's @ticked@ diffs
+-- (closure ⊕ tick) must be relative to that same state.
+implGetSnapshotForNoCache ::
+  ( IOLike m
+  , LedgerSupportsMempool blk
+  , HasTxId (GenTx blk)
+  ) =>
+  MempoolEnv m blk ->
+  -- | Get snapshot for this slot number (usually the current slot)
+  SlotNo ->
+  -- | The ledger state at which we want the snapshot, ticked to @slot@.
+  TickedLedgerState blk DiffMK ->
+  -- | A function that returns values corresponding to the given keys for
+  -- the unticked ledger state.
+  (LedgerTables (LedgerState blk) KeysMK -> m (LedgerTables (LedgerState blk) ValuesMK)) ->
+  m (MempoolSnapshot blk)
+implGetSnapshotForNoCache = getSnapshotUsingPolicyFor AlwaysRevalidate
+
+-- | Shared implementation of 'implGetSnapshotFor' and 'implGetSnapshotForNoCache'.
+getSnapshotUsingPolicyFor ::
+  ( IOLike m
+  , LedgerSupportsMempool blk
+  , HasTxId (GenTx blk)
+  ) =>
+  SnapshotCachePolicy ->
+  MempoolEnv m blk ->
+  SlotNo ->
+  TickedLedgerState blk DiffMK ->
+  (LedgerTables (LedgerState blk) KeysMK -> m (LedgerTables (LedgerState blk) ValuesMK)) ->
+  m (MempoolSnapshot blk)
+getSnapshotUsingPolicyFor policy mpEnv slot ticked readUntickedTables = do
   is <- atomically $ readTMVar istate
-  if pointHash (isTip is) == castHash (getTipHash ticked)
-    && isSlotNo is == slot
+  -- Whether we may trust the cached tables/snapshot: only when the tip
+  -- coincides /and/ the policy permits it (the rebase path forbids it even
+  -- though the tip coincides, since its ledger tables differ).
+  let canUseCache = case policy of
+        UseCache -> pointHash (isTip is) == castHash (getTipHash ticked)
+        AlwaysRevalidate -> False
+  if canUseCache && isSlotNo is == slot
     then
       -- We are looking for a snapshot exactly for the ledger state we already
       -- have cached, then just return it.
       pure $ snapshotFromIS is
     else do
       values <-
-        if pointHash (isTip is) == castHash (getTipHash ticked)
+        if canUseCache
           -- We are looking for a snapshot at the same state ticked
           -- to a different slot, so we can reuse the cached values
           then pure (isTxValues is)

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Update.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Update.hs
@@ -514,7 +514,8 @@ pureRemoveTxs capacityOverride lcfg slot lstate values tkt txs txIds =
   Sync with ledger
 -------------------------------------------------------------------------------}
 
--- | See 'Ouroboros.Consensus.Mempool.API.syncWithLedger'.
+-- | See 'Ouroboros.Consensus.Mempool.API.testSyncWithLedger' and
+-- and 'Ouroboros.Consensus.Mempool.Init.forkSyncStateOnTipPointChange'.
 implSyncWithLedger ::
   ( IOLike m
   , LedgerSupportsMempool blk

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ChainSync/Server.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ChainSync/Server.hs
@@ -28,7 +28,7 @@ import Control.Tracer
 import qualified Data.ByteString.Lazy as Lazy
 import Data.Functor ((<&>))
 import LeiosDemoDb (LeiosDbConnection)
-import LeiosDemoTypes (LeiosPoint)
+import LeiosDemoTypes (LeiosPoint (..))
 import Ouroboros.Consensus.Block
 import Ouroboros.Consensus.Storage.ChainDB.API
   ( BlockComponent (GetHeader, GetRawBlock)
@@ -168,7 +168,7 @@ chainSyncBlocksServer tracer chainDB ccfg leiosDb flr = ChainSyncServer $ do
         Just prevAnn | headerContainsLeiosCert hdr -> case decodeRaw sblk of
           Left _ -> pure sblk
           Right blk -> do
-            resolveLeiosClosure leiosDb prevAnn
+            resolveLeiosClosure leiosDb (pointEbHash prevAnn)
               <&> inlineLeiosClosure blk
               <&> encode
         _ -> pure sblk

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ChainSync/Server.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ChainSync/Server.hs
@@ -168,7 +168,7 @@ chainSyncBlocksServer tracer chainDB ccfg leiosDb flr = ChainSyncServer $ do
         Just prevAnn | headerContainsLeiosCert hdr -> case decodeRaw sblk of
           Left _ -> pure sblk
           Right blk -> do
-            resolveLeiosClosure leiosDb prevAnn blk
+            resolveLeiosClosure leiosDb prevAnn
               <&> inlineLeiosClosure blk
               <&> encode
         _ -> pure sblk

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/Forker.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/Forker.hs
@@ -47,7 +47,9 @@ module Ouroboros.Consensus.Storage.LedgerDB.Forker
   , AnnLedgerError (..)
   , AnnLedgerError'
   , ResolveBlock
+  , LeiosClosureApplied (..)
   , ResolveLeiosBlock (..)
+  , resolveAndApplyLeiosClosure
   , resolveLeiosBlock
   , SuccessForkerAction (..)
   , ValidateArgs (..)
@@ -339,6 +341,7 @@ validate ::
   , ApplyBlock l blk
   , ResolveLeiosBlock blk
   , HasLeiosVoting blk
+  , HasLedgerTables (LedgerState blk)
   , l ~ ExtLedgerState blk
   ) =>
   ComputeLedgerEvents ->
@@ -413,6 +416,7 @@ switch ::
   , MonadSTM m
   , ResolveLeiosBlock blk
   , HasLeiosVoting blk
+  , HasLedgerTables (LedgerState blk)
   , l ~ ExtLedgerState blk
   ) =>
   LeiosDbConnection m ->
@@ -475,6 +479,7 @@ applyBlock ::
   , MonadSTM m
   , ResolveLeiosBlock blk
   , HasLeiosVoting blk
+  , HasLedgerTables (LedgerState blk)
   , l ~ ExtLedgerState blk
   ) =>
   LeiosDbConnection m ->
@@ -499,26 +504,31 @@ applyBlock leiosDb evs cfg ap fo doResolveBlock = case ap of
           Nothing ->
             error $ "applyBlock ReapplyVal: nothing announced!?"
           Just (announcedPoint, _) -> do
-            closureTxs <- resolveLeiosClosure leiosDb announcedPoint b
-            let blkKeys = getBlockKeySets b
-                closureKeys = foldMap (castLedgerTables . leiosClosureTxKeySets) closureTxs
-            lsBeforeEB <- withLedgerTables extSt <$> forkerReadTables fo (closureKeys <> blkKeys)
-            let lcfg = configLedger (getExtLedgerCfg cfg)
-            case applyLeiosClosure lcfg closureTxs (ledgerState lsBeforeEB) of
+            let bKeys = castLedgerTables (getBlockKeySets b :: LedgerTables l KeysMK)
+                readTables = fmap castLedgerTables . forkerReadTables fo . castLedgerTables
+            res <-
+              resolveAndApplyLeiosClosure
+                leiosDb
+                (configLedger (getExtLedgerCfg cfg))
+                announcedPoint
+                readTables
+                bKeys
+                (ledgerState extSt)
+            let tip = castPoint $ getTip extSt
+            case res of
               Left lerr ->
                 pure
                   ( Left
                       ( AnnLedgerError
-                          (let tip = castPoint $ getTip lsBeforeEB in tip)
+                          tip
                           (blockRealPoint b)
                           (ExtValidationErrorLedger lerr)
                       )
                   )
-              Right newLst ->
-                let lsAfterEB = lsBeforeEB{ledgerState = newLst}
+              Right LeiosClosureApplied{lcaStateAfterEB, lcaClosureDiff} ->
+                let lsAfterEB = extSt{ledgerState = lcaStateAfterEB}
                     blockDiff = tickThenReapply evs cfg b lsAfterEB
-                    closureDiff = trackingToDiffs (calculateDifference lsBeforeEB lsAfterEB)
-                 in pure (Right (prependDiffs closureDiff blockDiff))
+                 in pure (Right (prependDiffs lcaClosureDiff blockDiff))
   ApplyVal b -> do
     extSt <- atomically (forkerGetLedgerState fo)
     let cds = headerStateChainDep (headerState extSt)
@@ -534,12 +544,13 @@ applyBlock leiosDb evs cfg ap fo doResolveBlock = case ap of
         -- carries only the Leios certificate, not the EB's txs). The
         -- sequence:
         --
+        -- TODO(geo2a): rewrite this comment to account for using 'reasolveAndApplyLeiosClosure'
         --   1. 'verifyLeiosCert' against the current committee and the
         --      announced (expected signed) EB.
         --   2. 'resolveLeiosClosure' to fetch the EB's txs from the
         --      LeiosDB.
         --   3. Load utxos (ledger tables) for the closure txs.
-        --   4. 'applyLeiosClosure' folds those txs onto the /unticked/
+        --   4. 'reasolveAndApplyLeiosClosure' folds those txs onto the /unticked/
         --      parent ledger via the per-era ledger 'ApplyTx' class
         --      with 'ValidateNone' (txs were validated upstream when
         --      inserted into the LeiosDb).
@@ -573,17 +584,20 @@ applyBlock leiosDb evs cfg ap fo doResolveBlock = case ap of
                 -- TODO: make this less fatal. This is like a ledger error.
                 error $ "applyBlock: invalid Leios cert: " <> show invalid
               Right _weight -> do
-                -- Load EB txs from disk
-                closureTxs <- resolveLeiosClosure leiosDb announcedPoint (Proxy @blk)
-                -- UTXO-HD of the whole closure
-                let blkKeys = getBlockKeySets b
-                    closureKeys = foldMap (castLedgerTables . leiosClosureTxKeySets) closureTxs
-                lsBeforeEB <- withLedgerTables extSt <$> forkerReadTables fo (closureKeys <> blkKeys)
-                let tip = castPoint $ getTip lsBeforeEB
-                case applyLeiosClosure
-                  (configLedger (getExtLedgerCfg cfg))
-                  closureTxs
-                  (ledgerState lsBeforeEB) of
+                -- get the UTXO-HD keys of the RB we are applying the cert onto
+                let bKeys = castLedgerTables (getBlockKeySets b :: LedgerTables l KeysMK)
+                let readTables = fmap castLedgerTables . forkerReadTables fo . castLedgerTables
+                -- Resolve the EB closure from disk and apply it onto the ledger state.
+                res <-
+                  resolveAndApplyLeiosClosure
+                    leiosDb
+                    (configLedger (getExtLedgerCfg cfg))
+                    announcedPoint
+                    readTables
+                    bKeys
+                    (ledgerState extSt)
+                let tip = castPoint $ getTip extSt
+                case res of
                   Left lerr ->
                     -- REVIEW: Better annotation than CertRB point possible?
                     --
@@ -597,25 +611,13 @@ applyBlock leiosDb evs cfg ap fo doResolveBlock = case ap of
                               (ExtValidationErrorLedger lerr)
                           )
                       )
-                  Right newLst ->
-                    let lsAfterEB = lsBeforeEB{ledgerState = newLst}
+                  Right LeiosClosureApplied{lcaStateAfterEB, lcaClosureDiff} ->
+                    let lsAfterEB = extSt{ledgerState = lcaStateAfterEB}
                      in case runExcept $ tickThenApply evs cfg b lsAfterEB of
                           Left lerr ->
                             pure (Left (AnnLedgerError tip (blockRealPoint b) lerr))
                           Right blockDiff ->
-                            -- The closure's table modifications happened
-                            -- between 'lsBeforeEB' and 'lsAfterEB' and are
-                            -- /not/ in 'blockDiff' (which is a diff relative
-                            -- to 'lsAfterEB'). 'forkerPush' interprets the
-                            -- pushed diff as being on top of 'extSt' (the
-                            -- LedgerDB anchor), so without composition the
-                            -- closure inputs/outputs would be silently
-                            -- dropped from the changelog and unavailable to
-                            -- the next block's 'forkerReadTables'.
-                            let closureDiff =
-                                  trackingToDiffs
-                                    (calculateDifference lsBeforeEB lsAfterEB)
-                             in pure (Right (prependDiffs closureDiff blockDiff))
+                            pure (Right (prependDiffs lcaClosureDiff blockDiff))
   ReapplyRef r -> do
     b <- doResolveBlock r
     applyBlock leiosDb evs cfg (ReapplyVal b) fo doResolveBlock
@@ -639,6 +641,7 @@ applyThenPush ::
   , MonadSTM m
   , ResolveLeiosBlock blk
   , HasLeiosVoting blk
+  , HasLedgerTables (LedgerState blk)
   , l ~ ExtLedgerState blk
   ) =>
   LeiosDbConnection m ->
@@ -660,6 +663,7 @@ applyThenPushMany ::
   , MonadSTM m
   , ResolveLeiosBlock blk
   , HasLeiosVoting blk
+  , HasLedgerTables (LedgerState blk)
   , l ~ ExtLedgerState blk
   ) =>
   LeiosDbConnection m ->
@@ -809,6 +813,48 @@ resolveLeiosBlock leiosDb cds b =
       -- NOTE: This produces a block that would fail full validation.
       resolveLeiosClosure leiosDb announcedPoint
         <&> inlineLeiosClosure b
+
+-- | The result of resolving an announced EB's closure and applying it a ledger state.
+data LeiosClosureApplied blk = LeiosClosureApplied
+  { lcaStateAfterEB :: LedgerState blk ValuesMK
+  -- ^ The ledger state with the EB's transactions applied.
+  , lcaClosureDiff :: LedgerState blk DiffMK
+  -- ^ The closure diff relative to the parent. Callers must 'prependDiffs'
+  -- this onto whatever diff they produce on top of 'lcaStateAfterEB'.
+  }
+
+-- | Resolve the closure of the EB announced at the given 'LeiosPoint' and
+-- apply it onto the given ledger state.
+resolveAndApplyLeiosClosure ::
+  forall m blk.
+  ( Monad m
+  , ResolveLeiosBlock blk
+  , HasLedgerTables (LedgerState blk)
+  ) =>
+  LeiosDbConnection m ->
+  LedgerCfg (LedgerState blk) ->
+  LeiosPoint ->
+  -- | The function to read the ledger tables given the keys of the EB closure's transactions.
+  (LedgerTables (LedgerState blk) KeysMK -> m (LedgerTables (LedgerState blk) ValuesMK)) ->
+  -- | Additional keys to be read, for example the UTxOs from an RB.
+  LedgerTables (LedgerState blk) KeysMK ->
+  -- | The base ledger state to apply the EB on top of.
+  LedgerState blk EmptyMK ->
+  m (Either (LedgerErr (LedgerState blk)) (LeiosClosureApplied blk))
+reasolveAndApplyLeiosClosure leiosDb lcfg announcedPoint readValues extraKeys lsBase = do
+  -- Load EB txs from disk
+  closureTxs <- resolveLeiosClosure leiosDb announcedPoint
+  -- UTXO-HD of the whole closure
+  let closureKeys = foldMap leiosClosureTxKeySets closureTxs <> extraKeys
+  closureVals <- readValues closureKeys
+  let lsBeforeEB = lsBase `withLedgerTables` closureVals
+  -- apply the closure and return the result in case there was not errors
+  pure $
+    applyLeiosClosure lcfg closureTxs lsBeforeEB <&> \lsAfterEB ->
+      LeiosClosureApplied
+        { lcaStateAfterEB = lsAfterEB
+        , lcaClosureDiff = trackingToDiffs (calculateDifference lsBeforeEB lsAfterEB)
+        }
 
 {-------------------------------------------------------------------------------
   Validation

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/Forker.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/Forker.hs
@@ -78,9 +78,10 @@ import GHC.Generics
 import LeiosDemoDb (LeiosDbConnection)
 import LeiosDemoTypes
   ( BytesSize
+  , EbHash
   , HasLeiosVoting (..)
   , LeiosCert
-  , LeiosPoint
+  , LeiosPoint (..)
   , RbHash
   , minCertificationThreshold
   , verifyLeiosCert
@@ -510,7 +511,7 @@ applyBlock leiosDb evs cfg ap fo doResolveBlock = case ap of
               resolveAndApplyLeiosClosure
                 leiosDb
                 (configLedger (getExtLedgerCfg cfg))
-                announcedPoint
+                (pointEbHash announcedPoint)
                 readTables
                 bKeys
                 (ledgerState extSt)
@@ -592,7 +593,7 @@ applyBlock leiosDb evs cfg ap fo doResolveBlock = case ap of
                   resolveAndApplyLeiosClosure
                     leiosDb
                     (configLedger (getExtLedgerCfg cfg))
-                    announcedPoint
+                    (pointEbHash announcedPoint)
                     readTables
                     bKeys
                     (ledgerState extSt)
@@ -723,7 +724,7 @@ class ResolveLeiosBlock blk where
   resolveLeiosClosure ::
     Monad m =>
     LeiosDbConnection m ->
-    LeiosPoint ->
+    EbHash ->
     m [GenTx blk]
   resolveLeiosClosure _ _ = pure []
 
@@ -811,7 +812,7 @@ resolveLeiosBlock leiosDb cds b =
     Nothing -> pure b
     Just (announcedPoint, _) ->
       -- NOTE: This produces a block that would fail full validation.
-      resolveLeiosClosure leiosDb announcedPoint
+      resolveLeiosClosure leiosDb (pointEbHash announcedPoint)
         <&> inlineLeiosClosure b
 
 -- | The result of resolving an announced EB's closure and applying it a ledger state.
@@ -823,7 +824,7 @@ data LeiosClosureApplied blk = LeiosClosureApplied
   -- this onto whatever diff they produce on top of 'lcaStateAfterEB'.
   }
 
--- | Resolve the closure of the EB announced at the given 'LeiosPoint' and
+-- | Resolve the closure of an EB identified by its 'EbHash' and
 -- apply it onto the given ledger state.
 resolveAndApplyLeiosClosure ::
   forall m blk.
@@ -833,7 +834,8 @@ resolveAndApplyLeiosClosure ::
   ) =>
   LeiosDbConnection m ->
   LedgerCfg (LedgerState blk) ->
-  LeiosPoint ->
+  -- | The EB to resolve
+  EbHash ->
   -- | The function to read the ledger tables given the keys of the EB closure's transactions.
   (LedgerTables (LedgerState blk) KeysMK -> m (LedgerTables (LedgerState blk) ValuesMK)) ->
   -- | Additional keys to be read, for example the UTxOs from an RB.
@@ -841,9 +843,9 @@ resolveAndApplyLeiosClosure ::
   -- | The base ledger state to apply the EB on top of.
   LedgerState blk EmptyMK ->
   m (Either (LedgerErr (LedgerState blk)) (LeiosClosureApplied blk))
-reasolveAndApplyLeiosClosure leiosDb lcfg announcedPoint readValues extraKeys lsBase = do
+resolveAndApplyLeiosClosure leiosDb lcfg ebHash readValues extraKeys lsBase = do
   -- Load EB txs from disk
-  closureTxs <- resolveLeiosClosure leiosDb announcedPoint
+  closureTxs <- resolveLeiosClosure leiosDb ebHash
   -- UTXO-HD of the whole closure
   let closureKeys = foldMap leiosClosureTxKeySets closureTxs <> extraKeys
   closureVals <- readValues closureKeys

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/Forker.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/Forker.hs
@@ -574,7 +574,7 @@ applyBlock leiosDb evs cfg ap fo doResolveBlock = case ap of
                 error $ "applyBlock: invalid Leios cert: " <> show invalid
               Right _weight -> do
                 -- Load EB txs from disk
-                closureTxs <- resolveLeiosClosure leiosDb announcedPoint b
+                closureTxs <- resolveLeiosClosure leiosDb announcedPoint (Proxy @blk)
                 -- UTXO-HD of the whole closure
                 let blkKeys = getBlockKeySets b
                     closureKeys = foldMap (castLedgerTables . leiosClosureTxKeySets) closureTxs
@@ -720,9 +720,8 @@ class ResolveLeiosBlock blk where
     Monad m =>
     LeiosDbConnection m ->
     LeiosPoint ->
-    blk ->
     m [GenTx blk]
-  resolveLeiosClosure _ _ _ = pure []
+  resolveLeiosClosure _ _ = pure []
 
   -- | The ledger keys read by a closure tx — what 'forkerReadTables' needs
   -- to load before 'applyLeiosClosure' can run. Leios-enabled instances
@@ -808,7 +807,7 @@ resolveLeiosBlock leiosDb cds b =
     Nothing -> pure b
     Just (announcedPoint, _) ->
       -- NOTE: This produces a block that would fail full validation.
-      resolveLeiosClosure leiosDb announcedPoint b
+      resolveLeiosClosure leiosDb announcedPoint
         <&> inlineLeiosClosure b
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/V2/LedgerSeq.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/V2/LedgerSeq.hs
@@ -68,7 +68,11 @@ import Ouroboros.Consensus.Ledger.Abstract
 import Ouroboros.Consensus.Ledger.Extended
 import Ouroboros.Consensus.Ledger.Tables.Utils
 import Ouroboros.Consensus.Storage.LedgerDB.API
-import Ouroboros.Consensus.Storage.LedgerDB.Forker (ResolveLeiosBlock (..))
+import Ouroboros.Consensus.Storage.LedgerDB.Forker
+  ( LeiosClosureApplied (..)
+  , ResolveLeiosBlock (..)
+  , resolveAndApplyLeiosClosure
+  )
 import Ouroboros.Consensus.Util.IOLike
 import Ouroboros.Network.AnchoredSeq hiding
   ( anchor
@@ -242,7 +246,12 @@ closeLedgerSeq (LedgerSeq l) =
 --
 -- The @fst@ component of the result should be run to close the pruned states.
 reapplyThenPush ::
-  (IOLike m, ApplyBlock l blk, ResolveLeiosBlock blk, l ~ ExtLedgerState blk) =>
+  ( IOLike m
+  , ApplyBlock l blk
+  , ResolveLeiosBlock blk
+  , HasLedgerTables (LedgerState blk)
+  , l ~ ExtLedgerState blk
+  ) =>
   LeiosDbConnection m ->
   LedgerDbCfg l ->
   blk ->
@@ -262,6 +271,7 @@ reapplyBlock ::
   ( ApplyBlock l blk
   , IOLike m
   , ResolveLeiosBlock blk
+  , HasLedgerTables (LedgerState blk)
   , l ~ ExtLedgerState blk
   ) =>
   LeiosDbConnection m ->
@@ -282,18 +292,22 @@ reapplyBlock leiosDb evs cfg b db = do
       case protocolStateLeiosAnnouncement @blk cds of
         Nothing -> error "V2.LedgerSeq.reapplyBlock: nothing announced!?"
         Just (announcedPoint, _) -> do
-          closureTxs <- resolveLeiosClosure leiosDb announcedPoint b
-          let blkKeys = getBlockKeySets b
-              closureKeys = foldMap (castLedgerTables . leiosClosureTxKeySets) closureTxs
-          vals <- read tbs st (closureKeys <> blkKeys)
-          let lsBeforeEB = st `withLedgerTables` vals
-          case applyLeiosClosure (configLedger (getExtLedgerCfg cfg)) closureTxs (ledgerState lsBeforeEB) of
+          let bKeys = castLedgerTables (getBlockKeySets b :: LedgerTables l KeysMK)
+              readTables = fmap castLedgerTables . read tbs st . castLedgerTables
+          res <-
+            resolveAndApplyLeiosClosure
+              leiosDb
+              (configLedger (getExtLedgerCfg cfg))
+              announcedPoint
+              readTables
+              bKeys
+              (ledgerState st)
+          case res of
             Left{} -> error "V2.LedgerSeq.reapplyBlock: applyLeiosClosure failed!"
-            Right newLst ->
-              let lsAfterEB = lsBeforeEB{ledgerState = newLst}
+            Right lca ->
+              let lsAfterEB = st{ledgerState = lcaStateAfterEB lca}
                   blockDiff = tickThenReapply evs cfg b lsAfterEB
-                  closureDiff = trackingToDiffs (calculateDifference lsBeforeEB lsAfterEB)
-               in pure (prependDiffs closureDiff blockDiff)
+               in pure (prependDiffs (lcaClosureDiff lca) blockDiff)
   let newst = forgetLedgerTables st'
   newtbs <- duplicateWithDiffs tbs st st'
   pure (StateRef newst newtbs)

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/V2/LedgerSeq.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/V2/LedgerSeq.hs
@@ -59,6 +59,7 @@ import Data.Function (on)
 import Data.Word
 import GHC.Generics
 import LeiosDemoDb (LeiosDbConnection)
+import LeiosDemoTypes (LeiosPoint (..))
 import NoThunks.Class
 import Ouroboros.Consensus.Block
 import Ouroboros.Consensus.Config (configLedger)
@@ -298,7 +299,7 @@ reapplyBlock leiosDb evs cfg b db = do
             resolveAndApplyLeiosClosure
               leiosDb
               (configLedger (getExtLedgerCfg cfg))
-              announcedPoint
+              (pointEbHash announcedPoint)
               readTables
               bKeys
               (ledgerState st)


### PR DESCRIPTION
Fixes https://github.com/input-output-hk/ouroboros-leios/issues/838

This PR allows the node to use the same forging opportunity to both apply a Endorser Block certificate to its ledger state and forge an announce a new EB. The resulting Ranking Block will:
- embed the EB certificate
- embed a new EB announcement
- not carry any additional transactions

This leads to significantly higher amount of EB announcement and certification events in the devnet (see the section below for additional details).

Unfortunately, I have not noticed any significant difference in throughput as reported by the Graphana dashboard. This may be due to mempool filling up to 5MB instead of the expected 25MB (see https://github.com/input-output-hk/ouroboros-leios/issues/987).

## Validation

I've made two 20 minute (around 1200 slots) runs of `proto-devnet`, with and without my changes.

The following plots display the data on EB announcements and certifications from one of the three nodes in the devnet. Things worth noting about these plots:
- the announcements are placed on the x-axis by the slot they were made, and the certifications by the slot they were applied.
- Since there are only 3 nodes in the network, sometimes a node will be elected the leader in two consecutive slots. I've set the bin width to 5 slots to minimise conflating the announcements and certifications in the `leios-prototype` plot, but it still does happen.

The data from the `leios-prototype` branch shows fewer total certifications and announcements, and they never happen at the same slot (the conflated ones are within 5 slots):
<img width="1800" height="600" alt="leios-prototype-plot-5" src="https://github.com/user-attachments/assets/c2e8b5ec-c850-4088-be63-4def2768e4f9" />

The data from this PR's branch shows more announcements and certifications, many of which happen at the same slot:
<img width="1800" height="600" alt="certify-and-announce-5" src="https://github.com/user-attachments/assets/df28fd96-2ebd-4090-95c7-7b1c932e2e1b" />


The seconds plot (with the changes from this PR) shows significantly more certifications and announcements, and many of the two fall into the same forging opportunity (trust me, I've looked at the logs).