### PR TITLE
LeiosDb: avoid use after free + performance improvements
 

### DIFF
--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Forge.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Forge.hs
@@ -33,7 +33,7 @@ import qualified Data.Sequence.Strict as Seq
 import qualified Data.Typeable as Typeable
 import LeiosDemoDb
   ( LeiosDbConnection (..)
-  , leiosDbQueryCompletedEbByHash
+  , leiosDbLookupEbClosure
   )
 import LeiosDemoTypes
   ( EbAnnouncement (..)
@@ -183,7 +183,7 @@ forgeShelleyBlock hotKey cbl ForgeBlockArgs{..} = do
             -- TODO: Why exactly do we guard against this? Also, shouldn't we
             -- detect it the other way around: if we have a cert, but not
             -- downloaded it ourselves -> warning!
-            mClosure <- leiosDbQueryCompletedEbByHash fbLeiosDb (pointEbHash ebPoint)
+            mClosure <- leiosDbLookupEbClosure fbLeiosDb (pointEbHash ebPoint)
             case mClosure of
               Nothing -> do
                 traceWith fbLeiosTracer $

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Leios.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Leios.hs
@@ -30,7 +30,7 @@ import Data.Function ((&))
 import Data.Maybe.Strict (strictMaybeToMaybe)
 import Data.Proxy (Proxy (..))
 import qualified Data.Sequence.Strict as StrictSeq
-import LeiosDemoDb (leiosDbQueryCompletedEbByHash)
+import LeiosDemoDb (leiosDbLookupEbClosure)
 import LeiosDemoTypes (EbAnnouncement (..), LeiosPoint (..), RbHash (..))
 import Lens.Micro ((.~), (^.))
 import Ouroboros.Consensus.Block (ChainHash (..), blockPrevHash, toRawHash)
@@ -88,7 +88,7 @@ instance
   where
   resolveLeiosClosure leiosDb point _blk = do
     mAnnouncedEb <-
-      leiosDbQueryCompletedEbByHash
+      leiosDbLookupEbClosure
         leiosDb
         (pointEbHash point)
     case mAnnouncedEb of

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Leios.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Leios.hs
@@ -93,7 +93,24 @@ instance
         (pointEbHash point)
     case mAnnouncedEb of
       Nothing ->
-        pure []
+        -- FIXME(TEMP diagnostic): a missing closure here means we're
+        -- about to apply a cert-RB whose EB payload is not in this
+        -- node's LeiosDb. Under the intended parking design, chain-sel
+        -- would not have selected this block yet — it's supposed to
+        -- park pending closure acquisition. The previous behaviour
+        -- ('pure []') silently produced an empty tx list, letting the
+        -- cert-RB apply as if the EB carried no txs, which then
+        -- diverged the UTxO and caused downstream blocks to fail
+        -- validation ('ValueNotConservedUTxO' / 'BadInputsUTxO' on
+        -- txs consuming outputs the missing EB should have produced).
+        -- Erroring loudly here surfaces the exact block/EB pair that
+        -- exposed the parking gap, instead of silently corrupting the
+        -- ledger state.
+        error $
+          "resolveLeiosClosure: EB closure missing from LeiosDb for point "
+            <> show point
+            <> "; chain-sel selected a cert-RB without its EB closure. "
+            <> "Refusing to apply as empty (would diverge UTxO)."
       Just closureEntries ->
         pure $ mkShelleyTx . deserialiseLeiosTx . snd <$> closureEntries
 

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToNode.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToNode.hs
@@ -546,17 +546,26 @@ mkHandlers
           pure . leiosNotifyServerPeer $
             atomically $
               processEbNotification <|> processVote
-      , hLeiosFetchClient = \leiosConn _version controlMessageSTM peer peerVars ->
-          toLeiosFetchClientPeerPipelined $
-            leiosFetchClientPeerPipelined $
-              Leios.nextLeiosFetchClientCommand
-                (Node.leiosKernelTracer tracers)
-                (leiosPeerTracer peer)
-                ((== Terminate) <$> controlMessageSTM)
-                (getLeiosOutstanding, getLeiosReady)
-                leiosConn
-                (Leios.MkPeerId peer)
-                (Leios.requestsToSend peerVars)
+      , hLeiosFetchClient = \leiosConn _version controlMessageSTM peer peerVars -> toLeiosFetchClientPeerPipelined $ Effect $ do
+          let reqVar = Leios.requestsToSend peerVars
+          -- Queue for responses received by the pipelined-peer collector
+          -- thread. The collector enqueues here rather than touching the
+          -- 'LeiosDbConnection' directly; 'nextLeiosFetchClientCommand'
+          -- drains and processes on the main peer thread, keeping all DB
+          -- access single-threaded.
+          responseQ <- LazySTM.atomically LazySTM.newTQueue
+          pure $
+            ( leiosFetchClientPeerPipelined $
+                Leios.nextLeiosFetchClientCommand
+                  (Node.leiosKernelTracer tracers)
+                  (leiosPeerTracer peer)
+                  ((== Terminate) <$> controlMessageSTM)
+                  (getLeiosOutstanding, getLeiosReady)
+                  leiosConn
+                  (Leios.MkPeerId peer)
+                  reqVar
+                  responseQ
+            )
       , hLeiosFetchServer = \leiosConn _version peer -> Effect $ do
           leiosFetchContext <- Leios.newLeiosFetchContext leiosConn
           pure $

--- a/ouroboros-consensus-protocol/src/ouroboros-consensus-protocol/Ouroboros/Consensus/Protocol/Praos/Header.hs
+++ b/ouroboros-consensus-protocol/src/ouroboros-consensus-protocol/Ouroboros/Consensus/Protocol/Praos/Header.hs
@@ -123,6 +123,8 @@ data HeaderBody crypto = HeaderBody
   -- ^ protocol version
   , hbLeiosExt :: !(StrictMaybe HeaderLeiosExtension)
   -- ^ Whether the header / protocol is extended with Leios features.
+  -- TODO: This Maybe can be avoided by doing version-aware encoding/decoding
+  -- and this would then become an always extended Leios header
   }
   deriving Generic
 

--- a/ouroboros-consensus/bench/leios-db-bench/Main.hs
+++ b/ouroboros-consensus/bench/leios-db-bench/Main.hs
@@ -11,22 +11,14 @@
 --
 -- * __Fetch clients__ (configurable, default 3 threads): each inserts 20 fresh
 --   EBs via 'leiosDbInsertEbPoint' → 'leiosDbInsertEbBody' → 'leiosDbInsertTxs'.
---   Blind-write client role.
---
--- * __Fetch client RMW__ (configurable, default 2 threads): mirrors
---   @msgLeiosBlock@ — for each EB, 'leiosDbLookupEbPoint' first, then only
---   'leiosDbInsertEbPoint' if the point was not already present, then
---   'leiosDbInsertEbBody' and 'leiosDbInsertTxs'. Exercises the
---   read-then-write pattern that a shared writer/reader split has to
---   handle atomically.
 --
 -- * __Fetch servers__ (configurable, default 3 threads): each does 30
 --   'leiosDbLookupEbBody' + 10 'leiosDbBatchRetrieveTxs' calls cycling through
 --   the pre-populated EBs.
 --
 -- * __Chain-sel reader__ (1 thread): mimics the block-apply path via
---   'leiosDbQueryCompletedEbByHash' — the same read that
---   'resolveLeiosClosure' issues per Dijkstra-era CertRB.
+--   'leiosDbLookupEbClosure' — the same read that 'resolveLeiosClosure'
+--   issues per Dijkstra-era CertRB.
 --
 -- * __GC ticker__ (1 thread): periodic 'leiosDbGarbageCollect' calls (a
 --   handle-level operation that touches every table). Exercises
@@ -63,8 +55,7 @@ import LeiosDemoDb
   , leiosDbInsertEbPoint
   , leiosDbInsertTxs
   , leiosDbLookupEbBody
-  , leiosDbLookupEbPoint
-  , leiosDbQueryCompletedEbByHash
+  , leiosDbLookupEbClosure
   , newLeiosDBSQLite
   , withLeiosDb
   )
@@ -95,9 +86,8 @@ main = do
           <> show numFetchLogicRounds
           <> " rounds of filterMissingEbBodies (200+200) + filterMissingTxs (500+500)"
       , "  Fetch clients   (×" <> show numFetchClients <> "): 20 insertEbPoint/insertEbBody/insertTxs each"
-      , "  Fetch client RMW(×" <> show numRmwClients <> "): 20 lookup+conditional insert each (msgLeiosBlock shape)"
       , "  Fetch servers   (×" <> show numFetchServers <> "): 30 lookupEbBody + 10 batchRetrieveTxs each"
-      , "  Chain-sel reader(×1): " <> show numChainSelReads <> " queryCompletedEbByHash calls"
+      , "  Chain-sel reader(×1): " <> show numChainSelReads <> " lookupEbClosure calls"
       , "  GC ticker       (×1): " <> show numGcTicks <> " garbageCollect calls"
       , ""
       , "Runs: 1 warmup + " <> show numRuns <> " timed"
@@ -120,10 +110,6 @@ txsPerEb = 200
 -- | Number of fetch client threads (writers that insert fresh EBs).
 numFetchClients :: Int
 numFetchClients = 3
-
--- | Number of "msgLeiosBlock-shaped" clients that read before writing.
-numRmwClients :: Int
-numRmwClients = 2
 
 -- | Number of fetch server threads (readers serving downstream peers).
 numFetchServers :: Int
@@ -150,25 +136,22 @@ numRuns = 5
 -- | All production roles running concurrently against one DB handle.
 benchConcurrentAll :: BenchEnv -> IO ()
 benchConcurrentAll BenchEnv{beDb = db, bePoints = points, beWriterIdx = writerIdxRef} = do
-  -- Blind writers and RMW writers both claim fresh EB-index ranges so we
-  -- don't hit UNIQUE-violations across concurrent iterations.
-  startBlind <- atomicModifyIORef' writerIdxRef
-    (\n -> (n + numFetchClients * ebsPerClient, n))
-  startRmw <- atomicModifyIORef' writerIdxRef
-    (\n -> (n + numRmwClients * ebsPerClient, n))
-  fl      <- async (fetchLogic db points)
-  cs      <- async (chainSelReader db points)
-  gc      <- async (gcTicker db)
-  clients    <- forM (rangeFor startBlind numFetchClients) $ \r -> async (fetchClient db r)
-  rmwClients <- forM (rangeFor startRmw numRmwClients)     $ \r -> async (fetchClientRmw db r)
+  startIdx <-
+    atomicModifyIORef'
+      writerIdxRef
+      (\n -> (n + numFetchClients * ebsPerClient, n))
+  fl <- async (fetchLogic db points)
+  cs <- async (chainSelReader db points)
+  gc <- async (gcTicker db)
+  clients <- forM (clientRanges startIdx) $ \range -> async (fetchClient db range)
   mapConcurrently_ (fetchServer db points) [0 .. numFetchServers - 1]
   wait fl >> wait cs >> wait gc
-  forM_ (clients <> rmwClients) wait
+  forM_ clients wait
  where
   ebsPerClient = 20
-  rangeFor start n =
-    [ [start + i * ebsPerClient .. start + (i + 1) * ebsPerClient - 1]
-    | i <- [0 .. n - 1]
+  clientRanges startIdx =
+    [ [startIdx + i * ebsPerClient .. startIdx + (i + 1) * ebsPerClient - 1]
+    | i <- [0 .. numFetchClients - 1]
     ]
 
 -- | Mirrors the fetch logic loop: filters for missing EB bodies and TXs.
@@ -191,22 +174,13 @@ fetchClient db range =
   withLeiosDb db $ \c ->
     forM_ range (insertOneEb c)
 
--- | Mirrors 'msgLeiosBlock' on the fetch-client response path: look up the
--- EB point first, insert it only if missing, then insert the body and its
--- tx closure. This is the read-then-write shape that a shared
--- writer\/reader-split API has to keep atomic.
-fetchClientRmw :: LeiosDbHandle IO -> [Int] -> IO ()
-fetchClientRmw db range =
-  withLeiosDb db $ \c ->
-    forM_ range (insertOneEbRmw c)
-
 -- | Mirrors chain-selection's block-apply path: repeated
--- 'leiosDbQueryCompletedEbByHash' for the closure of the certified EB.
+-- 'leiosDbLookupEbClosure' for the tx closure of each certified EB.
 chainSelReader :: LeiosDbHandle IO -> [LeiosPoint] -> IO ()
 chainSelReader db points =
   withLeiosDb db $ \c ->
     forM_ (take numChainSelReads (cycle points)) $ \p ->
-      leiosDbQueryCompletedEbByHash c p.pointEbHash
+      leiosDbLookupEbClosure c p.pointEbHash
 
 -- | Fires periodic garbage-collect calls. Handle-level operation; touches
 -- every table when implemented (currently a no-op backend-side, but the
@@ -299,26 +273,6 @@ insertOneEb conn ebIdx = do
         , let h = genTxHash ebIdx txIdx
         ]
   leiosDbInsertEbPoint conn point (leiosEbBytesSize eb)
-  leiosDbInsertEbBody conn point eb
-  _ <- leiosDbInsertTxs conn txs
-  pure ()
-
--- | Read-modify-write insert: check whether the EB point is already
--- known and only insert it if not, then insert body + txs. Mirrors
--- 'msgLeiosBlock' on the fetch-client response path.
-insertOneEbRmw :: Monad m => LeiosDbConnection m -> Int -> m ()
-insertOneEbRmw conn ebIdx = do
-  let point = genPoint ebIdx
-      eb = genEb ebIdx
-      txs =
-        [ (h, genTx h)
-        | txIdx <- [0 .. txsPerEb - 1]
-        , let h = genTxHash ebIdx txIdx
-        ]
-  existing <- leiosDbLookupEbPoint conn point.pointEbHash
-  case existing of
-    Just _ -> pure ()
-    Nothing -> leiosDbInsertEbPoint conn point (leiosEbBytesSize eb)
   leiosDbInsertEbBody conn point eb
   _ <- leiosDbInsertTxs conn txs
   pure ()

--- a/ouroboros-consensus/bench/leios-db-bench/Main.hs
+++ b/ouroboros-consensus/bench/leios-db-bench/Main.hs
@@ -4,17 +4,33 @@
 
 -- | Concurrent benchmark for 'LeiosDemoDb' mirroring production access patterns.
 --
--- The following three roles run concurrently against the same SQLite handle:
+-- The following roles run concurrently against the same SQLite handle:
 --
 -- * __Fetch logic__ (1 thread): configurable rounds of
 --   'leiosDbFilterMissingEbBodies' + 'leiosDbFilterMissingTxs'.
 --
--- * __Fetch clients__ (configurable, default 2 threads): each inserts 20 fresh
+-- * __Fetch clients__ (configurable, default 3 threads): each inserts 20 fresh
 --   EBs via 'leiosDbInsertEbPoint' → 'leiosDbInsertEbBody' → 'leiosDbInsertTxs'.
+--   Blind-write client role.
 --
--- * __Fetch servers__ (configurable, default 8 threads): each does 30
+-- * __Fetch client RMW__ (configurable, default 2 threads): mirrors
+--   @msgLeiosBlock@ — for each EB, 'leiosDbLookupEbPoint' first, then only
+--   'leiosDbInsertEbPoint' if the point was not already present, then
+--   'leiosDbInsertEbBody' and 'leiosDbInsertTxs'. Exercises the
+--   read-then-write pattern that a shared writer/reader split has to
+--   handle atomically.
+--
+-- * __Fetch servers__ (configurable, default 3 threads): each does 30
 --   'leiosDbLookupEbBody' + 10 'leiosDbBatchRetrieveTxs' calls cycling through
 --   the pre-populated EBs.
+--
+-- * __Chain-sel reader__ (1 thread): mimics the block-apply path via
+--   'leiosDbQueryCompletedEbByHash' — the same read that
+--   'resolveLeiosClosure' issues per Dijkstra-era CertRB.
+--
+-- * __GC ticker__ (1 thread): periodic 'leiosDbGarbageCollect' calls (a
+--   handle-level operation that touches every table). Exercises
+--   contention with the concurrent readers/writers.
 --
 -- All data is deterministic (no QuickCheck generators), so runs are stable and
 -- comparable across refactors.
@@ -42,10 +58,13 @@ import LeiosDemoDb
   , leiosDbBatchRetrieveTxs
   , leiosDbFilterMissingEbBodies
   , leiosDbFilterMissingTxs
+  , leiosDbGarbageCollect
   , leiosDbInsertEbBody
   , leiosDbInsertEbPoint
   , leiosDbInsertTxs
   , leiosDbLookupEbBody
+  , leiosDbLookupEbPoint
+  , leiosDbQueryCompletedEbByHash
   , newLeiosDBSQLite
   , withLeiosDb
   )
@@ -72,11 +91,14 @@ main = do
       , "  Total TXs         : " <> show (numPrePopulatedEbs * txsPerEb)
       , ""
       , "Concurrent workload per iteration:"
-      , "  Fetch logic   (×1): "
+      , "  Fetch logic     (×1): "
           <> show numFetchLogicRounds
           <> " rounds of filterMissingEbBodies (200+200) + filterMissingTxs (500+500)"
-      , "  Fetch clients (×" <> show numFetchClients <> "): 20 insertEbPoint/insertEbBody/insertTxs each"
-      , "  Fetch servers (×" <> show numFetchServers <> "): 30 lookupEbBody + 10 batchRetrieveTxs each"
+      , "  Fetch clients   (×" <> show numFetchClients <> "): 20 insertEbPoint/insertEbBody/insertTxs each"
+      , "  Fetch client RMW(×" <> show numRmwClients <> "): 20 lookup+conditional insert each (msgLeiosBlock shape)"
+      , "  Fetch servers   (×" <> show numFetchServers <> "): 30 lookupEbBody + 10 batchRetrieveTxs each"
+      , "  Chain-sel reader(×1): " <> show numChainSelReads <> " queryCompletedEbByHash calls"
+      , "  GC ticker       (×1): " <> show numGcTicks <> " garbageCollect calls"
       , ""
       , "Runs: 1 warmup + " <> show numRuns <> " timed"
       , ""
@@ -99,6 +121,10 @@ txsPerEb = 200
 numFetchClients :: Int
 numFetchClients = 3
 
+-- | Number of "msgLeiosBlock-shaped" clients that read before writing.
+numRmwClients :: Int
+numRmwClients = 2
+
 -- | Number of fetch server threads (readers serving downstream peers).
 numFetchServers :: Int
 numFetchServers = 3
@@ -107,26 +133,42 @@ numFetchServers = 3
 numFetchLogicRounds :: Int
 numFetchLogicRounds = 100
 
+-- | Number of chain-sel-shaped reader calls per iteration.
+numChainSelReads :: Int
+numChainSelReads = 50
+
+-- | Number of GC ticks per iteration.
+numGcTicks :: Int
+numGcTicks = 3
+
 -- | Timed repetitions (plus one warmup).
 numRuns :: Int
 numRuns = 5
 
 -- * The benchmark
 
--- | All three production roles running concurrently against one DB handle.
+-- | All production roles running concurrently against one DB handle.
 benchConcurrentAll :: BenchEnv -> IO ()
 benchConcurrentAll BenchEnv{beDb = db, bePoints = points, beWriterIdx = writerIdxRef} = do
-  startIdx <- atomicModifyIORef' writerIdxRef (\n -> (n + numFetchClients * ebsPerClient, n))
-  fl <- async (fetchLogic db points)
-  clients <- forM (clientRanges startIdx) $ \range -> async (fetchClient db range)
+  -- Blind writers and RMW writers both claim fresh EB-index ranges so we
+  -- don't hit UNIQUE-violations across concurrent iterations.
+  startBlind <- atomicModifyIORef' writerIdxRef
+    (\n -> (n + numFetchClients * ebsPerClient, n))
+  startRmw <- atomicModifyIORef' writerIdxRef
+    (\n -> (n + numRmwClients * ebsPerClient, n))
+  fl      <- async (fetchLogic db points)
+  cs      <- async (chainSelReader db points)
+  gc      <- async (gcTicker db)
+  clients    <- forM (rangeFor startBlind numFetchClients) $ \r -> async (fetchClient db r)
+  rmwClients <- forM (rangeFor startRmw numRmwClients)     $ \r -> async (fetchClientRmw db r)
   mapConcurrently_ (fetchServer db points) [0 .. numFetchServers - 1]
-  wait fl
-  forM_ clients wait
+  wait fl >> wait cs >> wait gc
+  forM_ (clients <> rmwClients) wait
  where
   ebsPerClient = 20
-  clientRanges startIdx =
-    [ [startIdx + i * ebsPerClient .. startIdx + (i + 1) * ebsPerClient - 1]
-    | i <- [0 .. numFetchClients - 1]
+  rangeFor start n =
+    [ [start + i * ebsPerClient .. start + (i + 1) * ebsPerClient - 1]
+    | i <- [0 .. n - 1]
     ]
 
 -- | Mirrors the fetch logic loop: filters for missing EB bodies and TXs.
@@ -148,6 +190,31 @@ fetchClient :: LeiosDbHandle IO -> [Int] -> IO ()
 fetchClient db range =
   withLeiosDb db $ \c ->
     forM_ range (insertOneEb c)
+
+-- | Mirrors 'msgLeiosBlock' on the fetch-client response path: look up the
+-- EB point first, insert it only if missing, then insert the body and its
+-- tx closure. This is the read-then-write shape that a shared
+-- writer\/reader-split API has to keep atomic.
+fetchClientRmw :: LeiosDbHandle IO -> [Int] -> IO ()
+fetchClientRmw db range =
+  withLeiosDb db $ \c ->
+    forM_ range (insertOneEbRmw c)
+
+-- | Mirrors chain-selection's block-apply path: repeated
+-- 'leiosDbQueryCompletedEbByHash' for the closure of the certified EB.
+chainSelReader :: LeiosDbHandle IO -> [LeiosPoint] -> IO ()
+chainSelReader db points =
+  withLeiosDb db $ \c ->
+    forM_ (take numChainSelReads (cycle points)) $ \p ->
+      leiosDbQueryCompletedEbByHash c p.pointEbHash
+
+-- | Fires periodic garbage-collect calls. Handle-level operation; touches
+-- every table when implemented (currently a no-op backend-side, but the
+-- call path is realistic).
+gcTicker :: LeiosDbHandle IO -> IO ()
+gcTicker db =
+  forM_ [1 .. numGcTicks] $ \i ->
+    leiosDbGarbageCollect db (SlotNo (fromIntegral (i * 10)))
 
 -- | Mirrors a fetch server: looks up EB bodies and retrieves TX batches.
 fetchServer :: LeiosDbHandle IO -> [LeiosPoint] -> Int -> IO ()
@@ -232,6 +299,26 @@ insertOneEb conn ebIdx = do
         , let h = genTxHash ebIdx txIdx
         ]
   leiosDbInsertEbPoint conn point (leiosEbBytesSize eb)
+  leiosDbInsertEbBody conn point eb
+  _ <- leiosDbInsertTxs conn txs
+  pure ()
+
+-- | Read-modify-write insert: check whether the EB point is already
+-- known and only insert it if not, then insert body + txs. Mirrors
+-- 'msgLeiosBlock' on the fetch-client response path.
+insertOneEbRmw :: Monad m => LeiosDbConnection m -> Int -> m ()
+insertOneEbRmw conn ebIdx = do
+  let point = genPoint ebIdx
+      eb = genEb ebIdx
+      txs =
+        [ (h, genTx h)
+        | txIdx <- [0 .. txsPerEb - 1]
+        , let h = genTxHash ebIdx txIdx
+        ]
+  existing <- leiosDbLookupEbPoint conn point.pointEbHash
+  case existing of
+    Just _ -> pure ()
+    Nothing -> leiosDbInsertEbPoint conn point (leiosEbBytesSize eb)
   leiosDbInsertEbBody conn point eb
   _ <- leiosDbInsertTxs conn txs
   pure ()

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoDb.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoDb.hs
@@ -4,7 +4,6 @@ module LeiosDemoDb
   , LeiosDbHandle (..)
   , LeiosEbNotification (..)
   , LeiosDbConnection (..)
-  , LeiosFetchWork (..)
   , CompletedEbs
   , TraceLeiosDb (..)
 
@@ -30,7 +29,6 @@ import LeiosDemoDb.Common
   , LeiosDbConnection (..)
   , LeiosDbHandle (..)
   , LeiosEbNotification (..)
-  , LeiosFetchWork (..)
   , withLeiosDb
   )
 import LeiosDemoDb.InMemory

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoDb/Common.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoDb/Common.hs
@@ -6,14 +6,12 @@ module LeiosDemoDb.Common
   , LeiosDbHandle (..)
   , LeiosEbNotification (..)
   , LeiosDbConnection (..)
-  , LeiosFetchWork (..)
   , CompletedEbs
   ) where
 
 import Cardano.Slotting.Slot (SlotNo)
 import Control.Concurrent.Class.MonadSTM.Strict (StrictTChan)
 import Data.ByteString (ByteString)
-import Data.Map.Strict (Map)
 import GHC.Stack (HasCallStack)
 import LeiosDemoTypes
   ( BytesSize
@@ -90,21 +88,21 @@ data LeiosDbConnection m = LeiosDbConnection
   { close :: m ()
   -- ^ Close the connection and free up resources. After calling this, the connection may not be used anymore.
   , leiosDbScanEbPoints :: HasCallStack => m [(SlotNo, EbHash)]
-  , leiosDbLookupEbPoint :: HasCallStack => EbHash -> m (Maybe SlotNo)
-  -- ^ Check if an EB point exists in the database. Returns the slot if found.
   , leiosDbInsertEbPoint :: HasCallStack => LeiosPoint -> BytesSize -> m ()
-  -- ^ Insert an announced EB point with its expected size.
+  -- ^ Insert an announced EB point with its expected size. Called on
+  -- the announcement path (forge issuing an EB, peer receiving an
+  -- announcement). Idempotent — a second insert at the same point is
+  -- a no-op.
   , leiosDbLookupEbBody :: HasCallStack => EbHash -> m [(TxHash, BytesSize)]
-  , leiosDbQueryFetchWork :: HasCallStack => m LeiosFetchWork
-  -- ^ Query all work needed for the fetch logic (used at startup):
-  -- - Missing EB bodies: EBs in ebs with NULL missingTxCount
-  -- - Missing TXs: TXs in ebTxs without entries in txs
-  -- NOTE: This is O(n) and should only be used at startup for initialization.
-  , -- NOTE: yields a LeiosOfferBlock notification
-    leiosDbInsertEbBody :: HasCallStack => LeiosPoint -> LeiosEb -> m ()
-  , -- TODO: Take [LeiosTx] and hash on insert?
-    leiosDbInsertTxs :: HasCallStack => [(TxHash, ByteString)] -> m CompletedEbs
-  -- ^ Insert transactions into the global txs table (INSERT OR IGNORE).
+  -- ^ Read the EB "body": the ordered list of tx-hash + tx-byte-size
+  -- pairs that constitute this EB. No tx bytes are fetched; contrast
+  -- with 'leiosDbLookupEbClosure' which joins with the 'txs' table.
+  , leiosDbInsertEbBody :: HasCallStack => LeiosPoint -> LeiosEb -> m ()
+  -- ^ Persist an EB body. The point MUST already have been inserted
+  -- via 'leiosDbInsertEbPoint' (announcement path). Yields an
+  -- 'AcquiredEb' notification.
+  , leiosDbInsertTxs :: HasCallStack => [(TxHash, ByteString)] -> m CompletedEbs
+  -- ^ Insert transactions into the global 'txs' table (INSERT OR IGNORE).
   -- After inserting, checks which EBs referencing these txs are now complete
   -- and emits 'AcquiredEbTxs' notifications for each.
   --
@@ -113,13 +111,16 @@ data LeiosDbConnection m = LeiosDbConnection
   -- Consumers should handle notifications idempotently.
   --
   -- REVIEW: return type only used for tracing, necessary?
-  , -- TODO: Return LeiosTx?
-    leiosDbBatchRetrieveTxs :: HasCallStack => EbHash -> [Int] -> m [(Int, TxHash, Maybe ByteString)]
+  , leiosDbBatchRetrieveTxs :: HasCallStack => EbHash -> [Int] -> m [(Int, TxHash, Maybe ByteString)]
   , leiosDbFilterMissingEbBodies :: HasCallStack => [LeiosPoint] -> m [LeiosPoint]
   -- ^ Batch filter: returns the subset of input LeiosPoints whose EB bodies are missing.
   , leiosDbFilterMissingTxs :: HasCallStack => [TxHash] -> m [TxHash]
   -- ^ Batch filter: returns the subset of input TxHashes that we do NOT have.
-  , leiosDbQueryCompletedEbByHash :: HasCallStack => EbHash -> m (Maybe [(TxHash, ByteString)])
+  , leiosDbLookupEbClosure :: HasCallStack => EbHash -> m (Maybe [(TxHash, ByteString)])
+  -- ^ Read the EB "closure": the tx hashes AND their tx bytes. Contrast
+  -- with 'leiosDbLookupEbBody' which returns only hashes + sizes.
+  -- Used by chain-sel's 'resolveLeiosClosure' to splice the EB's txs
+  -- back into the CertRB before applying to the ledger.
   }
 
 instance NoThunks (LeiosDbHandle m) where
@@ -133,13 +134,3 @@ instance NoThunks (LeiosDbConnection m) where
   wNoThunks _ctx _a = return Nothing
 
 type CompletedEbs = [LeiosPoint]
-
--- | Result of querying the database for fetch work.
--- Contains all the information needed by the fetch logic to make decisions.
-data LeiosFetchWork = LeiosFetchWork
-  { missingEbBodies :: !(Map LeiosPoint BytesSize)
-  -- ^ EBs that have been announced but whose bodies haven't been downloaded yet
-  , missingEbTxs :: !(Map LeiosPoint [(Int, TxHash, BytesSize)])
-  -- ^ EBs whose bodies we have, but with missing TXs (offset, hash, size)
-  }
-  deriving (Eq, Show)

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoDb/InMemory.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoDb/InMemory.hs
@@ -36,7 +36,6 @@ import LeiosDemoDb.Common
   , LeiosDbConnection (..)
   , LeiosDbHandle (..)
   , LeiosEbNotification (..)
-  , LeiosFetchWork (..)
   )
 import LeiosDemoTypes
   ( BytesSize
@@ -125,7 +124,6 @@ newLeiosDBInMemoryWith stateVar = do
             LeiosDbConnection
               { close = pure ()
               , leiosDbScanEbPoints = imScanEbPoints stateVar
-              , leiosDbLookupEbPoint = imLookupEbPoint stateVar
               , leiosDbInsertEbPoint = imInsertEbPoint stateVar
               , leiosDbLookupEbBody = imLookupEbBody stateVar
               , leiosDbInsertEbBody = imInsertEbBody stateVar notificationChan
@@ -133,8 +131,7 @@ newLeiosDBInMemoryWith stateVar = do
               , leiosDbBatchRetrieveTxs = imBatchRetrieveTxs stateVar
               , leiosDbFilterMissingEbBodies = imFilterMissingEbBodies stateVar
               , leiosDbFilterMissingTxs = imFilterMissingTxs stateVar
-              , leiosDbQueryFetchWork = imQueryFetchWork stateVar
-              , leiosDbQueryCompletedEbByHash = imQueryCompletedEbByHash stateVar
+              , leiosDbLookupEbClosure = imLookupEbClosure stateVar
               }
       }
 
@@ -148,15 +145,8 @@ imScanEbPoints stateVar = atomically $ do
     | p <- Map.keys (imEbPoints state)
     ]
 
-imLookupEbPoint :: IOLike m => StrictTVar m InMemoryLeiosDb -> EbHash -> m (Maybe SlotNo)
-imLookupEbPoint stateVar ebHash = atomically $ do
-  state <- readTVar stateVar
-  pure $
-    listToMaybe
-      [p.pointSlotNo | p <- Map.keys (imEbPoints state), p.pointEbHash == ebHash]
-
--- | Insert a point. Subsequent calls at the same point are no-ops
--- (the first-seen size sticks; the body-downloaded set is untouched).
+-- | Insert an announced EB point. Idempotent: a second insert at the
+-- same point keeps the first-seen size.
 imInsertEbPoint :: IOLike m => StrictTVar m InMemoryLeiosDb -> LeiosPoint -> BytesSize -> m ()
 imInsertEbPoint stateVar point ebBytesSize = atomically $
   modifyTVar stateVar $ \s ->
@@ -182,6 +172,7 @@ imInsertEbBody ::
   m ()
 imInsertEbBody stateVar notificationChan point eb = do
   let items = leiosEbBodyItems eb
+      ebBytesSize = leiosEbBytesSize eb
   when (null items) $
     error "leiosDbInsertEbBody: empty EB body (programmer error)"
   atomically $ do
@@ -207,7 +198,7 @@ imInsertEbBody stateVar notificationChan point eb = do
           imEbBodiesDownloaded =
             Set.insert point (imEbBodiesDownloaded s)
         }
-    writeTChan notificationChan $ AcquiredEb point (leiosEbBytesSize eb)
+    writeTChan notificationChan $ AcquiredEb point ebBytesSize
 
 imInsertTxs ::
   IOLike m =>
@@ -304,32 +295,9 @@ imFilterMissingTxs stateVar txHashes = atomically $ do
   state <- readTVar stateVar
   pure [txHash | txHash <- txHashes, not $ Map.member txHash (imTxs state)]
 
-imQueryFetchWork :: IOLike m => StrictTVar m InMemoryLeiosDb -> m LeiosFetchWork
-imQueryFetchWork stateVar = atomically $ do
-  state <- readTVar stateVar
-  let missingEbBodies =
-        Map.fromList
-          [ (point, ebBytesSize)
-          | (point, ebBytesSize) <- Map.toList (imEbPoints state)
-          , not (Set.member point (imEbBodiesDownloaded state))
-          ]
-      missingEbTxs =
-        Map.fromList
-          [ (point, missing)
-          | point <- Set.toList (imEbBodiesDownloaded state)
-          , Just entries <- [Map.lookup (pointEbHash point) (imEbBodies state)]
-          , let missing =
-                  [ (offset, eteTxHash e, eteTxBytesSize e)
-                  | (offset, e) <- IntMap.toList entries
-                  , not (Map.member (eteTxHash e) (imTxs state))
-                  ]
-          , not (null missing)
-          ]
-  pure LeiosFetchWork{missingEbBodies, missingEbTxs}
-
-imQueryCompletedEbByHash ::
+imLookupEbClosure ::
   IOLike m => StrictTVar m InMemoryLeiosDb -> EbHash -> m (Maybe [(TxHash, ByteString)])
-imQueryCompletedEbByHash stateVar ebHash = atomically $ do
+imLookupEbClosure stateVar ebHash = atomically $ do
   state <- readTVar stateVar
   case Map.lookup ebHash (imEbBodies state) of
     Nothing -> pure Nothing

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoDb/InMemory.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoDb/InMemory.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedRecordDot #-}
 
 module LeiosDemoDb.InMemory
@@ -11,7 +10,7 @@ module LeiosDemoDb.InMemory
   , newLeiosDBInMemoryWith
   ) where
 
-import Cardano.Prelude (Generic, forM_, listToMaybe, maybeToList, when)
+import Cardano.Prelude (Generic, forM_, maybeToList, when)
 import Cardano.Slotting.Slot (SlotNo (..))
 import Control.Concurrent.Class.MonadSTM.Strict
   ( StrictTChan

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoDb/SQLite.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoDb/SQLite.hs
@@ -653,9 +653,6 @@ dbWithBEGIN db k =
       )
       (\() -> k)
 
-dbReset :: HasCallStack => DB.Statement -> IO ()
-dbReset stmt = withDieStmt stmt $ DB.reset stmt
-
 dbStep :: HasCallStack => DB.Statement -> IO DB.StepResult
 dbStep stmt = withDieStmt stmt $ DB.stepNoCB stmt
 

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoDb/SQLite.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoDb/SQLite.hs
@@ -52,7 +52,6 @@ import LeiosDemoDb.Common
   , LeiosDbConnection (..)
   , LeiosDbHandle (..)
   , LeiosEbNotification (..)
-  , LeiosFetchWork (..)
   )
 import LeiosDemoDb.Trace (TraceLeiosDb (..))
 import LeiosDemoException (LeiosDbException (..))
@@ -160,7 +159,6 @@ openSQLiteConnection tracer dbPath notificationChan = do
     LeiosDbConnection
       { close = check >> void (DB.close db)
       , leiosDbScanEbPoints = check >> sqlScanEbPoints db
-      , leiosDbLookupEbPoint = \h -> check >> sqlLookupEbPoint db h
       , leiosDbInsertEbPoint = \p sz -> check >> sqlInsertEbPoint db p sz
       , leiosDbLookupEbBody = \h -> check >> sqlLookupEbBody db h
       , leiosDbInsertEbBody = \p eb -> check >> sqlInsertEbBody tracer db notify p eb
@@ -168,8 +166,7 @@ openSQLiteConnection tracer dbPath notificationChan = do
       , leiosDbBatchRetrieveTxs = \h offs -> check >> sqlBatchRetrieveTxs tracer db h offs
       , leiosDbFilterMissingEbBodies = \ebs -> check >> sqlFilterMissingEbBodies tracer db ebs
       , leiosDbFilterMissingTxs = \hs -> check >> sqlFilterMissingTxs tracer db hs
-      , leiosDbQueryFetchWork = check >> sqlQueryFetchWork db
-      , leiosDbQueryCompletedEbByHash = \h -> check >> sqlQueryCompletedEbByHash db h
+      , leiosDbLookupEbClosure = \h -> check >> sqlLookupEbClosure db h
       }
 
 -- * Top-level implementations
@@ -198,24 +195,6 @@ sqlScanCompleteEbHashesSince db sinceSlot =
               loop (hash : acc)
     loop []
 
-sqlLookupEbPoint :: DB.Database -> EbHash -> IO (Maybe SlotNo)
-sqlLookupEbPoint db ebHash =
-  dbWithBEGIN db $ dbWithPrepare db (fromString sql_lookup_eb) $ \stmt -> do
-    dbBindBlob stmt 1 (let MkEbHash bytes = ebHash in bytes)
-    dbStep stmt >>= \case
-      DB.Done -> pure Nothing
-      DB.Row -> do
-        slot <- SlotNo . fromIntegral <$> DB.columnInt64 stmt 0
-        pure (Just slot)
-
-sqlInsertEbPoint :: DB.Database -> LeiosPoint -> BytesSize -> IO ()
-sqlInsertEbPoint db point ebBytesSize =
-  dbWithBEGIN db $ dbWithPrepare db (fromString sql_insert_eb) $ \stmt -> do
-    dbBindInt64 stmt 1 (fromIntegral $ unSlotNo point.pointSlotNo)
-    dbBindBlob stmt 2 point.pointEbHash.ebHashBytes
-    dbBindInt64 stmt 3 (fromIntegral ebBytesSize)
-    dbStep1 stmt
-
 sqlLookupEbBody :: DB.Database -> EbHash -> IO [(TxHash, BytesSize)]
 sqlLookupEbBody db ebHash =
   dbWithBEGIN db $ dbWithPrepare db (fromString sql_lookup_ebBodies) $ \stmt -> do
@@ -229,6 +208,16 @@ sqlLookupEbBody db ebHash =
               loop ((txHash, size) : acc)
     loop []
 
+sqlInsertEbPoint :: DB.Database -> LeiosPoint -> BytesSize -> IO ()
+sqlInsertEbPoint db point ebBytesSize =
+  dbWithBEGIN db $ dbWithPrepare db (fromString sql_insert_eb) $ \stmt -> do
+    dbBindInt64 stmt 1 (fromIntegral $ unSlotNo point.pointSlotNo)
+    dbBindBlob stmt 2 point.pointEbHash.ebHashBytes
+    dbBindInt64 stmt 3 (fromIntegral ebBytesSize)
+    dbStep1 stmt
+
+-- | Persist an EB body. The point MUST already be present (inserted
+-- via 'sqlInsertEbPoint' on the announcement path).
 sqlInsertEbBody ::
   Tracer IO TraceLeiosDb ->
   DB.Database ->
@@ -238,6 +227,7 @@ sqlInsertEbBody ::
   IO ()
 sqlInsertEbBody tracer db notify point eb = do
   let items = leiosEbBodyItems eb
+      ebBytesSize = leiosEbBytesSize eb
   when (null items) $
     error "leiosDbInsertEbBody: empty EB body (programmer error)"
   dbWithBEGIN db $ do
@@ -261,7 +251,7 @@ sqlInsertEbBody tracer db notify point eb = do
       dbBindBlob stmt 2 point.pointEbHash.ebHashBytes
       dbBindInt64 stmt 3 (fromIntegral $ unSlotNo point.pointSlotNo)
       dbStep1 stmt
-  notify $ AcquiredEb point (leiosEbBytesSize eb)
+  notify $ AcquiredEb point ebBytesSize
 
 sqlInsertTxs ::
   Tracer IO TraceLeiosDb ->
@@ -405,38 +395,9 @@ sqlFilterMissingTxs tracer db txHashes =
       dbStep1 stmtFlush
     pure result
 
-sqlQueryFetchWork :: DB.Database -> IO LeiosFetchWork
-sqlQueryFetchWork db =
-  dbWithBEGIN db $ do
-    -- Query missing EB bodies
-    missingEbBodies <- dbWithPrepare db (fromString sql_query_missing_eb_bodies) $ \stmt -> do
-      let loop acc =
-            dbStep stmt >>= \case
-              DB.Done -> pure (Map.fromList (reverse acc))
-              DB.Row -> do
-                slot <- SlotNo . fromIntegral <$> DB.columnInt64 stmt 0
-                ebHash <- MkEbHash <$> DB.columnBlob stmt 1
-                ebBytesSize <- fromIntegral <$> DB.columnInt64 stmt 2
-                loop ((MkLeiosPoint slot ebHash, ebBytesSize) : acc)
-      loop []
-    -- Query missing TXs, grouped by EB
-    missingEbTxs <- dbWithPrepare db (fromString sql_query_missing_eb_txs) $ \stmt -> do
-      let loop acc =
-            dbStep stmt >>= \case
-              DB.Done -> pure (Map.fromListWith (++) (reverse acc))
-              DB.Row -> do
-                slot <- SlotNo . fromIntegral <$> DB.columnInt64 stmt 0
-                ebHash <- MkEbHash <$> DB.columnBlob stmt 1
-                txOffset <- fromIntegral <$> DB.columnInt64 stmt 2
-                txHash <- MkTxHash <$> DB.columnBlob stmt 3
-                txBytesSize <- fromIntegral <$> DB.columnInt64 stmt 4
-                loop ((MkLeiosPoint slot ebHash, [(txOffset, txHash, txBytesSize)]) : acc)
-      loop []
-    pure LeiosFetchWork{missingEbBodies, missingEbTxs}
-
-sqlQueryCompletedEbByHash :: DB.Database -> EbHash -> IO (Maybe [(TxHash, ByteString)])
-sqlQueryCompletedEbByHash db ebHash =
-  dbWithBEGIN db $ dbWithPrepare db (fromString sqlQueryCompletedEbByPoint') $ \stmt -> do
+sqlLookupEbClosure :: DB.Database -> EbHash -> IO (Maybe [(TxHash, ByteString)])
+sqlLookupEbClosure db ebHash =
+  dbWithBEGIN db $ dbWithPrepare db (fromString sql_lookup_eb_closure) $ \stmt -> do
     dbBindBlob stmt 1 (ebHashBytes ebHash)
     -- FIXME(bladyjoker): This should have a SlotNo as the second part of the key
     let loop acc =
@@ -507,10 +468,6 @@ sql_scan_complete_ebs_since =
   \      (SELECT ebHashBytes FROM ebs WHERE missingTxCount IS NOT NULL AND missingTxCount <= 0)\n\
   \"
 
-sql_lookup_eb :: String
-sql_lookup_eb =
-  "SELECT ebSlot FROM ebs WHERE ebHashBytes = ?"
-
 sql_insert_eb :: String
 sql_insert_eb =
   "INSERT OR IGNORE INTO ebs (ebSlot, ebHashBytes, ebBytesSize) VALUES (?, ?, ?)"
@@ -530,28 +487,6 @@ sql_insert_ebBody =
 sql_insert_tx :: String
 sql_insert_tx =
   "INSERT INTO txs (txHashBytes, txBytes, txBytesSize) VALUES (?, ?, ?)\n\
-  \"
-
--- | Query for missing EB bodies: EBs announced but not yet downloaded.
--- Returns (ebSlot, ebHashBytes, ebBytesSize) for each missing body.
-sql_query_missing_eb_bodies :: String
-sql_query_missing_eb_bodies =
-  "SELECT ep.ebSlot, ep.ebHashBytes, ep.ebBytesSize\n\
-  \FROM ebs ep\n\
-  \WHERE missingTxCount IS NULL\n\
-  \ORDER BY ep.ebSlot DESC\n\
-  \"
-
--- | Query for missing TXs: TXs in ebTxs that don't have corresponding entries in txs.
--- Returns (ebSlot, ebHashBytes, txOffset, txHashBytes, txBytesSize) for each missing TX.
-sql_query_missing_eb_txs :: String
-sql_query_missing_eb_txs =
-  "SELECT ep.ebSlot, e.ebHashBytes, e.txOffset, e.txHashBytes, e.txBytesSize\n\
-  \FROM ebTxs e\n\
-  \JOIN ebs ep ON e.ebHashBytes = ep.ebHashBytes\n\
-  \LEFT JOIN txs t ON e.txHashBytes = t.txHashBytes\n\
-  \WHERE t.txHashBytes IS NULL\n\
-  \ORDER BY ep.ebSlot DESC, e.txOffset ASC\n\
   \"
 
 -- | Insert ebHashes into temp table for batch filtering
@@ -659,8 +594,8 @@ sql_attach_memTxPoints =
   \  ) WITHOUT ROWID;\n\
   \"
 
-sqlQueryCompletedEbByPoint' :: String
-sqlQueryCompletedEbByPoint' =
+sql_lookup_eb_closure :: String
+sql_lookup_eb_closure =
   unlines
     [ "SELECT ebTx.txHashBytes, tx.txBytes"
     , "FROM ebTxs as ebTx"

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoDb/SQLite.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoDb/SQLite.hs
@@ -47,6 +47,8 @@ import Database.SQLite3
   , open2
   )
 import qualified Database.SQLite3.Direct as DB
+import Foreign.Ptr (Ptr, WordPtr, castPtr)
+import Foreign.Storable (peekByteOff)
 import GHC.Stack (HasCallStack)
 import qualified GHC.Stack
 import LeiosDemoDb.Common
@@ -156,6 +158,7 @@ openSQLiteConnection tracer dbPath notificationChan = do
               <> show me
               <> " but opened on "
               <> show owner
+        checkSqliteIntegrity db
   pure $
     LeiosDbConnection
       { close = check >> void (DB.close db)
@@ -169,6 +172,43 @@ openSQLiteConnection tracer dbPath notificationChan = do
       , leiosDbFilterMissingTxs = \hs -> check >> sqlFilterMissingTxs tracer db hs
       , leiosDbLookupEbClosure = \h -> check >> sqlLookupEbClosure db h
       }
+
+-- | TEMP: sanity-check that the @sqlite3@ conn struct's @.mutex@ field
+-- still looks like a valid pointer.
+--
+-- Motivation: the proto-devnet crashes with a SIGSEGV inside
+-- @sqlite3_finalize@ where the sqlite3 struct's memory has been
+-- overwritten with small integer values (in one dump, @pVdbe = 0x11@
+-- and @mutex = 0x4b@). The safety net on 'LeiosDbConnection' only
+-- catches cross-thread facade entry, not corruption from further
+-- inside. This peek runs on every facade entry BEFORE we hand
+-- anything to SQLite, so we throw a Haskell exception with a stack
+-- trace instead of segfaulting.
+--
+-- Layout assumption (SQLite 3.45.0, our compile flags):
+--
+--   +0   sqlite3_vfs *pVfs
+--   +8   struct Vdbe *pVdbe
+--   +16  CollSeq *pDfltColl
+--   +24  sqlite3_mutex *mutex     ← we peek this
+--
+-- This offset is architecture- and compile-flag-dependent; we know
+-- it's correct on x86_64 Linux with our build flags because we
+-- pinned it from the coredump.
+--
+-- Under SERIALIZED threading mode (which our SQLite is compiled
+-- with, @THREADSAFE=1@) the @.mutex@ field is always a non-NULL
+-- pointer while the conn is alive. So @0@ or any small integer
+-- means the struct has been freed and reused.
+checkSqliteIntegrity :: HasCallStack => DB.Database -> IO ()
+checkSqliteIntegrity (DB.Database dbp) = do
+  mutex :: WordPtr <- peekByteOff (castPtr dbp :: Ptr ()) 24
+  when (fromIntegral mutex < (0x1000 :: Integer)) $
+    error $
+      "LeiosDbConnection: sqlite3 conn struct appears corrupted; "
+        <> "db->mutex = "
+        <> show mutex
+        <> " (expected a valid pointer). Refusing to proceed to avoid SIGSEGV."
 
 -- * Top-level implementations
 

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoDb/SQLite.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoDb/SQLite.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module LeiosDemoDb.SQLite
@@ -127,51 +128,82 @@ sqlScanCompleteEbClosuresSince dbPath sinceSlot = do
 
 -- * Connection management
 
-openSQLiteConnection ::
-  Tracer IO TraceLeiosDb ->
-  FilePath ->
-  StrictTChan IO LeiosEbNotification ->
-  IO (LeiosDbConnection IO)
-openSQLiteConnection tracer dbPath notificationChan = do
-  shouldInitSchema <- not <$> doesFileExist dbPath
-  db <- open2 (fromString dbPath) [SQLOpenReadWrite, SQLOpenCreate] SQLVFSDefault
-  traverse_ (dbExec db) $
-    [ "pragma journal_mode = WAL;"
-    , "pragma synchronous = normal;"
-    , "pragma page_size = 32768;"
-    , "pragma mmap_size = 268435500;"
-    ]
-  when shouldInitSchema $
-    dbExec db (fromString sql_schema)
-  let notify = atomically . writeTChan notificationChan
-  -- TEMP: safety net. 'LeiosDbConnection' is a direct-sqlite handle that is
-  -- not thread-safe (SQLite protects concurrent ops but not close-during-op).
-  -- Fail loudly with a call stack if any op runs on a different thread than
-  -- the opener. Remove once we have proven all callsites are single-threaded.
-  owner <- myThreadId
-  let check :: HasCallStack => IO ()
-      check = do
-        me <- myThreadId
-        when (me /= owner) $
-          error $
-            "LeiosDbConnection used from thread "
-              <> show me
-              <> " but opened on "
-              <> show owner
-        checkSqliteIntegrity db
-  pure $
-    LeiosDbConnection
-      { close = check >> void (DB.close db)
-      , leiosDbScanEbPoints = check >> sqlScanEbPoints db
-      , leiosDbInsertEbPoint = \p sz -> check >> sqlInsertEbPoint db p sz
-      , leiosDbLookupEbBody = \h -> check >> sqlLookupEbBody db h
-      , leiosDbInsertEbBody = \p eb -> check >> sqlInsertEbBody tracer db notify p eb
-      , leiosDbInsertTxs = \txs -> check >> sqlInsertTxs tracer db notify txs
-      , leiosDbBatchRetrieveTxs = \h offs -> check >> sqlBatchRetrieveTxs tracer db h offs
-      , leiosDbFilterMissingEbBodies = \ebs -> check >> sqlFilterMissingEbBodies tracer db ebs
-      , leiosDbFilterMissingTxs = \hs -> check >> sqlFilterMissingTxs tracer db hs
-      , leiosDbLookupEbClosure = \h -> check >> sqlLookupEbClosure db h
-      }
+-- | Every prepared statement the connection needs, prepared once at open
+-- time and finalised deterministically at 'close' time (before
+-- 'sqlite3_close_v2'). Reused across all calls on this connection via
+-- 'useStmt' (bind → step → reset).
+--
+-- Rationale: the previous per-call @dbWithPrepare@ pattern was safe under
+-- bracket unwind for its OWN scope, but under the load of the proto-devnet
+-- we hit a use-after-free of the @sqlite3@ conn struct (see coredump
+-- analysis in @analysis-runs/bench-baseline.txt@). Preparing once and
+-- finalising synchronously with close removes every code path that could
+-- call 'sqlite3_finalize' on a statement whose connection has been
+-- destroyed.
+data Stmts = Stmts
+  { stScanEbPoints :: !DB.Statement
+  , stInsertEbPoint :: !DB.Statement
+  , stLookupEbBody :: !DB.Statement
+  , stInsertEbTxsRow :: !DB.Statement
+  , stInitMissingCount :: !DB.Statement
+  , stInsertTx :: !DB.Statement
+  , stDecrMissingCount :: !DB.Statement
+  , stFindCompleteEbs :: !DB.Statement
+  , stMarkNotifiedEbs :: !DB.Statement
+  , stBatchRetrieveTxs :: !DB.Statement
+  , stFilterMissingEbBodies :: !DB.Statement
+  , stFilterMissingTxs :: !DB.Statement
+  , stLookupEbClosure :: !DB.Statement
+  }
+
+data Conn = Conn
+  { connDb :: !DB.Database
+  , connStmts :: !Stmts
+  }
+
+-- | Prepare every statement 'Stmts' names. Order is not observable.
+prepareStmts :: DB.Database -> IO Stmts
+prepareStmts db =
+  Stmts
+    <$> dbPrepare db (fromString sql_scan_ebs)
+    <*> dbPrepare db (fromString sql_insert_eb)
+    <*> dbPrepare db (fromString sql_lookup_ebBodies)
+    <*> dbPrepare db (fromString sql_insert_ebBody)
+    <*> dbPrepare db (fromString sql_init_missing_tx_count)
+    <*> dbPrepare db (fromString sql_insert_tx)
+    <*> dbPrepare db (fromString sql_decrement_missing_tx_count)
+    <*> dbPrepare db (fromString sql_find_complete_ebs)
+    <*> dbPrepare db (fromString sql_mark_notified_ebs)
+    <*> dbPrepare db (fromString sql_retrieve_from_ebTxs_json)
+    <*> dbPrepare db (fromString sql_filter_missing_eb_bodies_json)
+    <*> dbPrepare db (fromString sql_filter_missing_txs_json)
+    <*> dbPrepare db (fromString sql_lookup_eb_closure)
+
+-- | Finalise every statement in 'Stmts'. Called from 'close' immediately
+-- before 'sqlite3_close_v2', on the connection's owner thread.
+finalizeStmts :: Stmts -> IO ()
+finalizeStmts Stmts{..} = do
+  dbFinalize stScanEbPoints
+  dbFinalize stInsertEbPoint
+  dbFinalize stLookupEbBody
+  dbFinalize stInsertEbTxsRow
+  dbFinalize stInitMissingCount
+  dbFinalize stInsertTx
+  dbFinalize stDecrMissingCount
+  dbFinalize stFindCompleteEbs
+  dbFinalize stMarkNotifiedEbs
+  dbFinalize stBatchRetrieveTxs
+  dbFinalize stFilterMissingEbBodies
+  dbFinalize stFilterMissingTxs
+  dbFinalize stLookupEbClosure
+
+-- | Run an action on a pre-prepared statement and always @sqlite3_reset@
+-- it afterwards, regardless of outcome. Reset uses raw 'DB.reset' (no
+-- error re-throw) because SQLite reports the /previous/ step's error via
+-- reset; we let the original exception propagate instead.
+useStmt :: DB.Statement -> IO a -> IO a
+useStmt stmt action =
+  action `MonadThrow.finally` (void $ DB.reset stmt)
 
 -- | TEMP: sanity-check that the @sqlite3@ conn struct's @.mutex@ field
 -- still looks like a valid pointer.
@@ -210,11 +242,59 @@ checkSqliteIntegrity (DB.Database dbp) = do
         <> show mutex
         <> " (expected a valid pointer). Refusing to proceed to avoid SIGSEGV."
 
+openSQLiteConnection ::
+  Tracer IO TraceLeiosDb ->
+  FilePath ->
+  StrictTChan IO LeiosEbNotification ->
+  IO (LeiosDbConnection IO)
+openSQLiteConnection tracer dbPath notificationChan = do
+  shouldInitSchema <- not <$> doesFileExist dbPath
+  db <- open2 (fromString dbPath) [SQLOpenReadWrite, SQLOpenCreate] SQLVFSDefault
+  traverse_ (dbExec db) $
+    [ "pragma journal_mode = WAL;"
+    , "pragma synchronous = normal;"
+    , "pragma page_size = 32768;"
+    , "pragma mmap_size = 268435500;"
+    ]
+  when shouldInitSchema $
+    dbExec db (fromString sql_schema)
+  stmts <- prepareStmts db
+  let conn = Conn{connDb = db, connStmts = stmts}
+      notify = atomically . writeTChan notificationChan
+  -- TEMP: safety net. 'LeiosDbConnection' is a direct-sqlite handle that is
+  -- not thread-safe (SQLite protects concurrent ops but not close-during-op).
+  -- Fail loudly with a call stack if any op runs on a different thread than
+  -- the opener. Remove once we have proven all callsites are single-threaded.
+  owner <- myThreadId
+  let check :: HasCallStack => IO ()
+      check = do
+        me <- myThreadId
+        when (me /= owner) $
+          error $
+            "LeiosDbConnection used from thread "
+              <> show me
+              <> " but opened on "
+              <> show owner
+        checkSqliteIntegrity db
+  pure $
+    LeiosDbConnection
+      { close = check >> finalizeStmts stmts >> void (DB.close db)
+      , leiosDbScanEbPoints = check >> sqlScanEbPoints conn
+      , leiosDbInsertEbPoint = \p sz -> check >> sqlInsertEbPoint conn p sz
+      , leiosDbLookupEbBody = \h -> check >> sqlLookupEbBody conn h
+      , leiosDbInsertEbBody = \p eb -> check >> sqlInsertEbBody tracer conn notify p eb
+      , leiosDbInsertTxs = \txs -> check >> sqlInsertTxs tracer conn notify txs
+      , leiosDbBatchRetrieveTxs = \h offs -> check >> sqlBatchRetrieveTxs conn h offs
+      , leiosDbFilterMissingEbBodies = \ebs -> check >> sqlFilterMissingEbBodies conn ebs
+      , leiosDbFilterMissingTxs = \hs -> check >> sqlFilterMissingTxs conn hs
+      , leiosDbLookupEbClosure = \h -> check >> sqlLookupEbClosure conn h
+      }
+
 -- * Top-level implementations
 
-sqlScanEbPoints :: DB.Database -> IO [(SlotNo, EbHash)]
-sqlScanEbPoints db =
-  dbWithBEGIN db $ dbWithPrepare db (fromString sql_scan_ebs) $ \stmt -> do
+sqlScanEbPoints :: Conn -> IO [(SlotNo, EbHash)]
+sqlScanEbPoints Conn{connDb = db, connStmts = Stmts{stScanEbPoints = stmt}} =
+  dbWithBEGIN db $ useStmt stmt $ do
     let loop acc =
           dbStep stmt >>= \case
             DB.Done -> pure (reverse acc)
@@ -236,9 +316,9 @@ sqlScanCompleteEbHashesSince db sinceSlot =
               loop (hash : acc)
     loop []
 
-sqlLookupEbBody :: DB.Database -> EbHash -> IO [(TxHash, BytesSize)]
-sqlLookupEbBody db ebHash =
-  dbWithBEGIN db $ dbWithPrepare db (fromString sql_lookup_ebBodies) $ \stmt -> do
+sqlLookupEbBody :: Conn -> EbHash -> IO [(TxHash, BytesSize)]
+sqlLookupEbBody Conn{connDb = db, connStmts = Stmts{stLookupEbBody = stmt}} ebHash =
+  dbWithBEGIN db $ useStmt stmt $ do
     dbBindBlob stmt 1 (let MkEbHash bytes = ebHash in bytes)
     let loop acc =
           dbStep stmt >>= \case
@@ -249,9 +329,9 @@ sqlLookupEbBody db ebHash =
               loop ((txHash, size) : acc)
     loop []
 
-sqlInsertEbPoint :: DB.Database -> LeiosPoint -> BytesSize -> IO ()
-sqlInsertEbPoint db point ebBytesSize =
-  dbWithBEGIN db $ dbWithPrepare db (fromString sql_insert_eb) $ \stmt -> do
+sqlInsertEbPoint :: Conn -> LeiosPoint -> BytesSize -> IO ()
+sqlInsertEbPoint Conn{connDb = db, connStmts = Stmts{stInsertEbPoint = stmt}} point ebBytesSize =
+  dbWithBEGIN db $ useStmt stmt $ do
     dbBindInt64 stmt 1 (fromIntegral $ unSlotNo point.pointSlotNo)
     dbBindBlob stmt 2 point.pointEbHash.ebHashBytes
     dbBindInt64 stmt 3 (fromIntegral ebBytesSize)
@@ -261,87 +341,80 @@ sqlInsertEbPoint db point ebBytesSize =
 -- via 'sqlInsertEbPoint' on the announcement path).
 sqlInsertEbBody ::
   Tracer IO TraceLeiosDb ->
-  DB.Database ->
+  Conn ->
   (LeiosEbNotification -> IO ()) ->
   LeiosPoint ->
   LeiosEb ->
   IO ()
-sqlInsertEbBody tracer db notify point eb = do
+sqlInsertEbBody tracer Conn{connDb = db, connStmts = Stmts{stInsertEbTxsRow, stInitMissingCount}} notify point eb = do
   let items = leiosEbBodyItems eb
       ebBytesSize = leiosEbBytesSize eb
   when (null items) $
     error "leiosDbInsertEbBody: empty EB body (programmer error)"
   dbWithBEGIN db $ do
-    dbWithPrepare db (fromString sql_insert_ebBody) $ \stmt ->
-      mapM_
-        ( \(txOffset, txHash, txBytesSize) -> do
-            dbBindBlob stmt 1 point.pointEbHash.ebHashBytes
-            dbBindInt64 stmt 2 (fromIntegral txOffset)
-            dbBindBlob stmt 3 (let MkTxHash bytes = txHash in bytes)
-            dbBindInt64 stmt 4 (fromIntegral txBytesSize)
-            dbStepInsertOrTrace
-              tracer
-              "ebTxs"
-              (show point.pointEbHash <> "@" <> show txOffset)
-              stmt
-        )
-        items
+    forM_ items $ \(txOffset, txHash, txBytesSize) -> useStmt stInsertEbTxsRow $ do
+      dbBindBlob stInsertEbTxsRow 1 point.pointEbHash.ebHashBytes
+      dbBindInt64 stInsertEbTxsRow 2 (fromIntegral txOffset)
+      dbBindBlob stInsertEbTxsRow 3 (let MkTxHash bytes = txHash in bytes)
+      dbBindInt64 stInsertEbTxsRow 4 (fromIntegral txBytesSize)
+      dbStepInsertOrTrace
+        tracer
+        "ebTxs"
+        (show point.pointEbHash <> "@" <> show txOffset)
+        stInsertEbTxsRow
     -- Initialize missingTxCount (accounts for txs already in the DB)
-    dbWithPrepare db (fromString sql_init_missing_tx_count) $ \stmt -> do
-      dbBindBlob stmt 1 point.pointEbHash.ebHashBytes
-      dbBindBlob stmt 2 point.pointEbHash.ebHashBytes
-      dbBindInt64 stmt 3 (fromIntegral $ unSlotNo point.pointSlotNo)
-      dbStep1 stmt
+    useStmt stInitMissingCount $ do
+      dbBindBlob stInitMissingCount 1 point.pointEbHash.ebHashBytes
+      dbBindBlob stInitMissingCount 2 point.pointEbHash.ebHashBytes
+      dbBindInt64 stInitMissingCount 3 (fromIntegral $ unSlotNo point.pointSlotNo)
+      dbStep1 stInitMissingCount
   notify $ AcquiredEb point ebBytesSize
 
 sqlInsertTxs ::
   Tracer IO TraceLeiosDb ->
-  DB.Database ->
+  Conn ->
   (LeiosEbNotification -> IO ()) ->
   [(TxHash, ByteString)] ->
   IO CompletedEbs
-sqlInsertTxs tracer db notify txs = do
+sqlInsertTxs _tracer conn notify txs = do
   -- Skip txs already persisted in 'txs'. Under mempool backlog,
   -- successive forges (or overlapping peer EBs) re-present the same tx
   -- hashes; attempting the INSERT and catching a constraint violation
-  -- still pays the bind + PK-lookup + reset cost per row. Reuses the
-  -- existing 'mem.txHashes'-based filter (own read transaction, safe to
-  -- call before the write BEGIN below).
-  missing <- Set.fromList <$> sqlFilterMissingTxs tracer db (map fst txs)
+  -- still pays the bind + PK-lookup + reset cost per row.
+  missing <- Set.fromList <$> sqlFilterMissingTxs conn (map fst txs)
   let novel = filter (\(h, _) -> h `Set.member` missing) txs
-  completed <- dbWithBEGIN db $
+      Conn
+        { connDb = db
+        , connStmts = Stmts{stInsertTx, stDecrMissingCount, stFindCompleteEbs, stMarkNotifiedEbs}
+        } = conn
+  completed <- dbWithBEGIN db $ do
     -- 'dbStepInsert' still handles the rare race where a concurrent
     -- writer inserted the same hash between the filter above and the
     -- INSERT below.
-    dbWithPrepare db (fromString sql_insert_tx) $ \stmtInsert ->
-      dbWithPrepare db (fromString sql_decrement_missing_tx_count) $ \stmtDecr -> do
-        forM_ novel $ \(txHash, txBytes) -> do
-          let txBytesSize = fromIntegral $ BS.length txBytes
-              txHashBytes = let MkTxHash bytes = txHash in bytes
-          dbBindBlob stmtInsert 1 txHashBytes
-          dbBindBlob stmtInsert 2 txBytes
-          dbBindInt64 stmtInsert 3 txBytesSize
-          inserted <- dbStepInsert stmtInsert
-          -- Use raw reset: after ErrorConstraint, dbReset would re-throw the error
-          void $ DB.reset stmtInsert
-          when inserted $ do
-            dbBindBlob stmtDecr 1 txHashBytes
-            dbStep1 stmtDecr
-            dbReset stmtDecr
-        -- Find newly-complete EBs (missingTxCount reached 0)
-        completed <- dbWithPrepare db (fromString sql_find_complete_ebs) $ \stmt -> do
-          let loop acc =
-                dbStep stmt >>= \case
-                  DB.Done -> pure (reverse acc)
-                  DB.Row -> do
-                    ebHash <- MkEbHash <$> DB.columnBlob stmt 0
-                    slot <- SlotNo . fromIntegral <$> DB.columnInt64 stmt 1
-                    loop (MkLeiosPoint slot ebHash : acc)
-          loop []
-        -- Mark them as notified so they are not found again
-        dbWithPrepare db (fromString sql_mark_notified_ebs) $ \stmt ->
-          dbStep1 stmt
-        pure completed
+    forM_ novel $ \(txHash, txBytes) -> do
+      let txBytesSize = fromIntegral $ BS.length txBytes
+          txHashBytes = let MkTxHash bytes = txHash in bytes
+      inserted <- useStmt stInsertTx $ do
+        dbBindBlob stInsertTx 1 txHashBytes
+        dbBindBlob stInsertTx 2 txBytes
+        dbBindInt64 stInsertTx 3 txBytesSize
+        dbStepInsert stInsertTx
+      when inserted $ useStmt stDecrMissingCount $ do
+        dbBindBlob stDecrMissingCount 1 txHashBytes
+        dbStep1 stDecrMissingCount
+    -- Find newly-complete EBs (missingTxCount reached 0)
+    completed <- useStmt stFindCompleteEbs $ do
+      let loop acc =
+            dbStep stFindCompleteEbs >>= \case
+              DB.Done -> pure (reverse acc)
+              DB.Row -> do
+                ebHash <- MkEbHash <$> DB.columnBlob stFindCompleteEbs 0
+                slot <- SlotNo . fromIntegral <$> DB.columnInt64 stFindCompleteEbs 1
+                loop (MkLeiosPoint slot ebHash : acc)
+      loop []
+    -- Mark them as notified so they are not found again
+    useStmt stMarkNotifiedEbs $ dbStep1 stMarkNotifiedEbs
+    pure completed
   -- Emit a closure-completion notification for each completed EB
   forM_ completed $ \point -> notify (AcquiredEbTxs point)
   pure completed
@@ -353,63 +426,57 @@ sqlInsertTxs tracer db notify txs = do
 -- No temp tables, no attached databases, no per-item INSERT round-trips.
 -- Works on strictly read-only connections.
 sqlBatchRetrieveTxs ::
-  Tracer IO TraceLeiosDb ->
-  DB.Database ->
+  Conn ->
   EbHash ->
   [Int] ->
   IO [(Int, TxHash, Maybe ByteString)]
-sqlBatchRetrieveTxs _tracer db ebHash offsets =
-  dbWithBEGIN db $
-    dbWithPrepare db (fromString sql_retrieve_from_ebTxs_json) $ \stmt -> do
-      dbBindBlob stmt 1 (let MkEbHash bytes = ebHash in bytes)
-      dbBindUtf8 stmt 2 (jsonIntArray offsets)
-      let loop acc =
-            dbStep stmt >>= \case
-              DB.Done -> pure (reverse acc)
-              DB.Row -> do
-                offset <- fromIntegral <$> DB.columnInt64 stmt 0
-                txHash <- MkTxHash <$> DB.columnBlob stmt 1
-                -- Column 2 is from LEFT JOIN, NULL if tx not in txs table
-                txBytes <- DB.columnBlob stmt 2
-                let mbTxBytes = if txBytes == mempty then Nothing else Just txBytes
-                loop ((offset, txHash, mbTxBytes) : acc)
-      loop []
+sqlBatchRetrieveTxs Conn{connDb = db, connStmts = Stmts{stBatchRetrieveTxs = stmt}} ebHash offsets =
+  dbWithBEGIN db $ useStmt stmt $ do
+    dbBindBlob stmt 1 (let MkEbHash bytes = ebHash in bytes)
+    dbBindUtf8 stmt 2 (jsonIntArray offsets)
+    let loop acc =
+          dbStep stmt >>= \case
+            DB.Done -> pure (reverse acc)
+            DB.Row -> do
+              offset <- fromIntegral <$> DB.columnInt64 stmt 0
+              txHash <- MkTxHash <$> DB.columnBlob stmt 1
+              -- Column 2 is from LEFT JOIN, NULL if tx not in txs table
+              txBytes <- DB.columnBlob stmt 2
+              let mbTxBytes = if txBytes == mempty then Nothing else Just txBytes
+              loop ((offset, txHash, mbTxBytes) : acc)
+    loop []
 
 -- | Batch-filter EB points against @ebTxs@. Passes ebHashes as a JSON
 -- array of hex strings; SQL decodes with @unhex()@ so index lookups on
 -- @ebTxs.ebHashBytes@ still fire.
-sqlFilterMissingEbBodies ::
-  Tracer IO TraceLeiosDb -> DB.Database -> [LeiosPoint] -> IO [LeiosPoint]
-sqlFilterMissingEbBodies _tracer db points =
-  dbWithBEGIN db $
-    dbWithPrepare db (fromString sql_filter_missing_eb_bodies_json) $ \stmt -> do
-      let pointsByHash = Map.fromList [(p.pointEbHash, p) | p <- points]
-      dbBindUtf8 stmt 1 (jsonHexArray (map ebHashBytes (Map.keys pointsByHash)))
-      let loop acc =
-            dbStep stmt >>= \case
-              DB.Done -> pure (reverse acc)
-              DB.Row -> do
-                ebHash <- MkEbHash <$> DB.columnBlob stmt 0
-                case Map.lookup ebHash pointsByHash of
-                  Just p -> loop (p : acc)
-                  Nothing -> loop acc
-      loop []
+sqlFilterMissingEbBodies :: Conn -> [LeiosPoint] -> IO [LeiosPoint]
+sqlFilterMissingEbBodies Conn{connDb = db, connStmts = Stmts{stFilterMissingEbBodies = stmt}} points =
+  dbWithBEGIN db $ useStmt stmt $ do
+    let pointsByHash = Map.fromList [(p.pointEbHash, p) | p <- points]
+    dbBindUtf8 stmt 1 (jsonHexArray (map ebHashBytes (Map.keys pointsByHash)))
+    let loop acc =
+          dbStep stmt >>= \case
+            DB.Done -> pure (reverse acc)
+            DB.Row -> do
+              ebHash <- MkEbHash <$> DB.columnBlob stmt 0
+              case Map.lookup ebHash pointsByHash of
+                Just p -> loop (p : acc)
+                Nothing -> loop acc
+    loop []
 
 -- | Batch-filter tx hashes against @txs@. Same idiom as
 -- 'sqlFilterMissingEbBodies'.
-sqlFilterMissingTxs ::
-  Tracer IO TraceLeiosDb -> DB.Database -> [TxHash] -> IO [TxHash]
-sqlFilterMissingTxs _tracer db txHashes =
-  dbWithBEGIN db $
-    dbWithPrepare db (fromString sql_filter_missing_txs_json) $ \stmt -> do
-      dbBindUtf8 stmt 1 (jsonHexArray [b | MkTxHash b <- txHashes])
-      let loop acc =
-            dbStep stmt >>= \case
-              DB.Done -> pure (reverse acc)
-              DB.Row -> do
-                txHash <- MkTxHash <$> DB.columnBlob stmt 0
-                loop (txHash : acc)
-      loop []
+sqlFilterMissingTxs :: Conn -> [TxHash] -> IO [TxHash]
+sqlFilterMissingTxs Conn{connDb = db, connStmts = Stmts{stFilterMissingTxs = stmt}} txHashes =
+  dbWithBEGIN db $ useStmt stmt $ do
+    dbBindUtf8 stmt 1 (jsonHexArray [b | MkTxHash b <- txHashes])
+    let loop acc =
+          dbStep stmt >>= \case
+            DB.Done -> pure (reverse acc)
+            DB.Row -> do
+              txHash <- MkTxHash <$> DB.columnBlob stmt 0
+              loop (txHash : acc)
+    loop []
 
 -- | Build a JSON array of hex-encoded blobs: @["aabb...","1234...",...]@.
 -- Consumed on the SQL side via @json_each(?)@ + @unhex(je.value)@.
@@ -436,9 +503,9 @@ jsonIntArray xs =
   intersperseB _ [x] = [x]
   intersperseB s (x : rest) = x : s : intersperseB s rest
 
-sqlLookupEbClosure :: DB.Database -> EbHash -> IO (Maybe [(TxHash, ByteString)])
-sqlLookupEbClosure db ebHash =
-  dbWithBEGIN db $ dbWithPrepare db (fromString sql_lookup_eb_closure) $ \stmt -> do
+sqlLookupEbClosure :: Conn -> EbHash -> IO (Maybe [(TxHash, ByteString)])
+sqlLookupEbClosure Conn{connDb = db, connStmts = Stmts{stLookupEbClosure = stmt}} ebHash =
+  dbWithBEGIN db $ useStmt stmt $ do
     dbBindBlob stmt 1 (ebHashBytes ebHash)
     -- FIXME(bladyjoker): This should have a SlotNo as the second part of the key
     let loop acc =

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoDb/SQLite.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoDb/SQLite.hs
@@ -17,7 +17,7 @@ module LeiosDemoDb.SQLite
 
 import Cardano.Prelude (forM_, traverse_, when)
 import Cardano.Slotting.Slot (SlotNo (..))
-import Control.Concurrent (threadDelay)
+import Control.Concurrent (myThreadId, threadDelay)
 import Control.Concurrent.Class.MonadSTM.Strict
   ( StrictTChan
   , dupTChan
@@ -142,20 +142,34 @@ openSQLiteConnection tracer dbPath notificationChan = do
     dbExec db (fromString sql_schema)
   dbExec db (fromString sql_attach_memTxPoints)
   let notify = atomically . writeTChan notificationChan
+  -- TEMP: safety net. 'LeiosDbConnection' is a direct-sqlite handle that is
+  -- not thread-safe (SQLite protects concurrent ops but not close-during-op).
+  -- Fail loudly with a call stack if any op runs on a different thread than
+  -- the opener. Remove once we have proven all callsites are single-threaded.
+  owner <- myThreadId
+  let check :: HasCallStack => IO ()
+      check = do
+        me <- myThreadId
+        when (me /= owner) $
+          error $
+            "LeiosDbConnection used from thread "
+              <> show me
+              <> " but opened on "
+              <> show owner
   pure $
     LeiosDbConnection
-      { close = void $ DB.close db
-      , leiosDbScanEbPoints = sqlScanEbPoints db
-      , leiosDbLookupEbPoint = sqlLookupEbPoint db
-      , leiosDbInsertEbPoint = sqlInsertEbPoint db
-      , leiosDbLookupEbBody = sqlLookupEbBody db
-      , leiosDbInsertEbBody = sqlInsertEbBody tracer db notify
-      , leiosDbInsertTxs = sqlInsertTxs tracer db notify
-      , leiosDbBatchRetrieveTxs = sqlBatchRetrieveTxs tracer db
-      , leiosDbFilterMissingEbBodies = sqlFilterMissingEbBodies tracer db
-      , leiosDbFilterMissingTxs = sqlFilterMissingTxs tracer db
-      , leiosDbQueryFetchWork = sqlQueryFetchWork db
-      , leiosDbQueryCompletedEbByHash = sqlQueryCompletedEbByHash db
+      { close = check >> void (DB.close db)
+      , leiosDbScanEbPoints = check >> sqlScanEbPoints db
+      , leiosDbLookupEbPoint = \h -> check >> sqlLookupEbPoint db h
+      , leiosDbInsertEbPoint = \p sz -> check >> sqlInsertEbPoint db p sz
+      , leiosDbLookupEbBody = \h -> check >> sqlLookupEbBody db h
+      , leiosDbInsertEbBody = \p eb -> check >> sqlInsertEbBody tracer db notify p eb
+      , leiosDbInsertTxs = \txs -> check >> sqlInsertTxs tracer db notify txs
+      , leiosDbBatchRetrieveTxs = \h offs -> check >> sqlBatchRetrieveTxs tracer db h offs
+      , leiosDbFilterMissingEbBodies = \ebs -> check >> sqlFilterMissingEbBodies tracer db ebs
+      , leiosDbFilterMissingTxs = \hs -> check >> sqlFilterMissingTxs tracer db hs
+      , leiosDbQueryFetchWork = check >> sqlQueryFetchWork db
+      , leiosDbQueryCompletedEbByHash = \h -> check >> sqlQueryCompletedEbByHash db h
       }
 
 -- * Top-level implementations

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoDb/SQLite.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoDb/SQLite.hs
@@ -18,7 +18,7 @@ module LeiosDemoDb.SQLite
 
 import Cardano.Prelude (forM_, traverse_, when)
 import Cardano.Slotting.Slot (SlotNo (..))
-import Control.Concurrent (myThreadId, threadDelay)
+import Control.Concurrent (threadDelay)
 import Control.Concurrent.Class.MonadSTM.Strict
   ( StrictTChan
   , dupTChan
@@ -48,8 +48,6 @@ import Database.SQLite3
   , open2
   )
 import qualified Database.SQLite3.Direct as DB
-import Foreign.Ptr (Ptr, WordPtr, castPtr)
-import Foreign.Storable (peekByteOff)
 import GHC.Stack (HasCallStack)
 import qualified GHC.Stack
 import LeiosDemoDb.Common
@@ -205,43 +203,6 @@ useStmt :: DB.Statement -> IO a -> IO a
 useStmt stmt action =
   action `MonadThrow.finally` (void $ DB.reset stmt)
 
--- | TEMP: sanity-check that the @sqlite3@ conn struct's @.mutex@ field
--- still looks like a valid pointer.
---
--- Motivation: the proto-devnet crashes with a SIGSEGV inside
--- @sqlite3_finalize@ where the sqlite3 struct's memory has been
--- overwritten with small integer values (in one dump, @pVdbe = 0x11@
--- and @mutex = 0x4b@). The safety net on 'LeiosDbConnection' only
--- catches cross-thread facade entry, not corruption from further
--- inside. This peek runs on every facade entry BEFORE we hand
--- anything to SQLite, so we throw a Haskell exception with a stack
--- trace instead of segfaulting.
---
--- Layout assumption (SQLite 3.45.0, our compile flags):
---
---   +0   sqlite3_vfs *pVfs
---   +8   struct Vdbe *pVdbe
---   +16  CollSeq *pDfltColl
---   +24  sqlite3_mutex *mutex     ← we peek this
---
--- This offset is architecture- and compile-flag-dependent; we know
--- it's correct on x86_64 Linux with our build flags because we
--- pinned it from the coredump.
---
--- Under SERIALIZED threading mode (which our SQLite is compiled
--- with, @THREADSAFE=1@) the @.mutex@ field is always a non-NULL
--- pointer while the conn is alive. So @0@ or any small integer
--- means the struct has been freed and reused.
-checkSqliteIntegrity :: HasCallStack => DB.Database -> IO ()
-checkSqliteIntegrity (DB.Database dbp) = do
-  mutex :: WordPtr <- peekByteOff (castPtr dbp :: Ptr ()) 24
-  when (fromIntegral mutex < (0x1000 :: Integer)) $
-    error $
-      "LeiosDbConnection: sqlite3 conn struct appears corrupted; "
-        <> "db->mutex = "
-        <> show mutex
-        <> " (expected a valid pointer). Refusing to proceed to avoid SIGSEGV."
-
 openSQLiteConnection ::
   Tracer IO TraceLeiosDb ->
   FilePath ->
@@ -261,33 +222,18 @@ openSQLiteConnection tracer dbPath notificationChan = do
   stmts <- prepareStmts db
   let conn = Conn{connDb = db, connStmts = stmts}
       notify = atomically . writeTChan notificationChan
-  -- TEMP: safety net. 'LeiosDbConnection' is a direct-sqlite handle that is
-  -- not thread-safe (SQLite protects concurrent ops but not close-during-op).
-  -- Fail loudly with a call stack if any op runs on a different thread than
-  -- the opener. Remove once we have proven all callsites are single-threaded.
-  owner <- myThreadId
-  let check :: HasCallStack => IO ()
-      check = do
-        me <- myThreadId
-        when (me /= owner) $
-          error $
-            "LeiosDbConnection used from thread "
-              <> show me
-              <> " but opened on "
-              <> show owner
-        checkSqliteIntegrity db
   pure $
     LeiosDbConnection
-      { close = check >> finalizeStmts stmts >> void (DB.close db)
-      , leiosDbScanEbPoints = check >> sqlScanEbPoints conn
-      , leiosDbInsertEbPoint = \p sz -> check >> sqlInsertEbPoint conn p sz
-      , leiosDbLookupEbBody = \h -> check >> sqlLookupEbBody conn h
-      , leiosDbInsertEbBody = \p eb -> check >> sqlInsertEbBody tracer conn notify p eb
-      , leiosDbInsertTxs = \txs -> check >> sqlInsertTxs tracer conn notify txs
-      , leiosDbBatchRetrieveTxs = \h offs -> check >> sqlBatchRetrieveTxs conn h offs
-      , leiosDbFilterMissingEbBodies = \ebs -> check >> sqlFilterMissingEbBodies conn ebs
-      , leiosDbFilterMissingTxs = \hs -> check >> sqlFilterMissingTxs conn hs
-      , leiosDbLookupEbClosure = \h -> check >> sqlLookupEbClosure conn h
+      { close = finalizeStmts stmts >> void (DB.close db)
+      , leiosDbScanEbPoints = sqlScanEbPoints conn
+      , leiosDbInsertEbPoint = sqlInsertEbPoint conn
+      , leiosDbLookupEbBody = sqlLookupEbBody conn
+      , leiosDbInsertEbBody = sqlInsertEbBody tracer conn notify
+      , leiosDbInsertTxs = sqlInsertTxs tracer conn notify
+      , leiosDbBatchRetrieveTxs = sqlBatchRetrieveTxs conn
+      , leiosDbFilterMissingEbBodies = sqlFilterMissingEbBodies conn
+      , leiosDbFilterMissingTxs = sqlFilterMissingTxs conn
+      , leiosDbLookupEbClosure = sqlLookupEbClosure conn
       }
 
 -- * Top-level implementations

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoDb/SQLite.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoDb/SQLite.hs
@@ -269,41 +269,39 @@ sqlInsertTxs tracer db notify txs = do
   -- call before the write BEGIN below).
   missing <- Set.fromList <$> sqlFilterMissingTxs tracer db (map fst txs)
   let novel = filter (\(h, _) -> h `Set.member` missing) txs
-  completed <- dbWithBEGIN db $ do
-    stmtInsert <- dbPrepare db (fromString sql_insert_tx)
-    stmtDecr <- dbPrepare db (fromString sql_decrement_missing_tx_count)
+  completed <- dbWithBEGIN db $
     -- 'dbStepInsert' still handles the rare race where a concurrent
     -- writer inserted the same hash between the filter above and the
     -- INSERT below.
-    forM_ novel $ \(txHash, txBytes) -> do
-      let txBytesSize = fromIntegral $ BS.length txBytes
-          txHashBytes = let MkTxHash bytes = txHash in bytes
-      dbBindBlob stmtInsert 1 txHashBytes
-      dbBindBlob stmtInsert 2 txBytes
-      dbBindInt64 stmtInsert 3 txBytesSize
-      inserted <- dbStepInsert stmtInsert
-      -- Use raw reset: after ErrorConstraint, dbReset would re-throw the error
-      void $ DB.reset stmtInsert
-      when inserted $ do
-        dbBindBlob stmtDecr 1 txHashBytes
-        dbStep1 stmtDecr
-        dbReset stmtDecr
-    dbFinalize stmtInsert
-    dbFinalize stmtDecr
-    -- Find newly-complete EBs (missingTxCount reached 0)
-    completed <- dbWithPrepare db (fromString sql_find_complete_ebs) $ \stmt -> do
-      let loop acc =
-            dbStep stmt >>= \case
-              DB.Done -> pure (reverse acc)
-              DB.Row -> do
-                ebHash <- MkEbHash <$> DB.columnBlob stmt 0
-                slot <- SlotNo . fromIntegral <$> DB.columnInt64 stmt 1
-                loop (MkLeiosPoint slot ebHash : acc)
-      loop []
-    -- Mark them as notified so they are not found again
-    dbWithPrepare db (fromString sql_mark_notified_ebs) $ \stmt ->
-      dbStep1 stmt
-    pure completed
+    dbWithPrepare db (fromString sql_insert_tx) $ \stmtInsert ->
+      dbWithPrepare db (fromString sql_decrement_missing_tx_count) $ \stmtDecr -> do
+        forM_ novel $ \(txHash, txBytes) -> do
+          let txBytesSize = fromIntegral $ BS.length txBytes
+              txHashBytes = let MkTxHash bytes = txHash in bytes
+          dbBindBlob stmtInsert 1 txHashBytes
+          dbBindBlob stmtInsert 2 txBytes
+          dbBindInt64 stmtInsert 3 txBytesSize
+          inserted <- dbStepInsert stmtInsert
+          -- Use raw reset: after ErrorConstraint, dbReset would re-throw the error
+          void $ DB.reset stmtInsert
+          when inserted $ do
+            dbBindBlob stmtDecr 1 txHashBytes
+            dbStep1 stmtDecr
+            dbReset stmtDecr
+        -- Find newly-complete EBs (missingTxCount reached 0)
+        completed <- dbWithPrepare db (fromString sql_find_complete_ebs) $ \stmt -> do
+          let loop acc =
+                dbStep stmt >>= \case
+                  DB.Done -> pure (reverse acc)
+                  DB.Row -> do
+                    ebHash <- MkEbHash <$> DB.columnBlob stmt 0
+                    slot <- SlotNo . fromIntegral <$> DB.columnInt64 stmt 1
+                    loop (MkLeiosPoint slot ebHash : acc)
+          loop []
+        -- Mark them as notified so they are not found again
+        dbWithPrepare db (fromString sql_mark_notified_ebs) $ \stmt ->
+          dbStep1 stmt
+        pure completed
   -- Emit a closure-completion notification for each completed EB
   forM_ completed $ \point -> notify (AcquiredEbTxs point)
   pure completed

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoDb/SQLite.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoDb/SQLite.hs
@@ -35,6 +35,8 @@ import Control.Tracer (Tracer, traceWith)
 import Data.Bifunctor (first)
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
+import qualified Data.ByteString.Builder as BB
+import qualified Data.ByteString.Lazy as BSL
 import Data.Int (Int64)
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
@@ -139,7 +141,6 @@ openSQLiteConnection tracer dbPath notificationChan = do
     ]
   when shouldInitSchema $
     dbExec db (fromString sql_schema)
-  dbExec db (fromString sql_attach_memTxPoints)
   let notify = atomically . writeTChan notificationChan
   -- TEMP: safety net. 'LeiosDbConnection' is a direct-sqlite handle that is
   -- not thread-safe (SQLite protects concurrent ops but not close-during-op).
@@ -307,58 +308,45 @@ sqlInsertTxs tracer db notify txs = do
   forM_ completed $ \point -> notify (AcquiredEbTxs point)
   pure completed
 
+-- | Retrieve tx bytes for a batch of @(ebHash, txOffset)@ points. Passes
+-- the offsets list as a JSON int array bound to a single parameter;
+-- SQLite's 'json_each' virtual table joins it against 'ebTxs' + 'txs'.
+--
+-- No temp tables, no attached databases, no per-item INSERT round-trips.
+-- Works on strictly read-only connections.
 sqlBatchRetrieveTxs ::
   Tracer IO TraceLeiosDb ->
   DB.Database ->
   EbHash ->
   [Int] ->
   IO [(Int, TxHash, Maybe ByteString)]
-sqlBatchRetrieveTxs tracer db ebHash offsets =
-  dbWithBEGIN db $ do
-    -- First, insert offsets into temp table
-    dbWithPrepare db (fromString sql_insert_memTxPoints) $ \stmtInsert ->
-      mapM_
-        ( \offset -> do
-            dbBindBlob stmtInsert 1 (let MkEbHash bytes = ebHash in bytes)
-            dbBindInt64 stmtInsert 2 (fromIntegral offset)
-            dbStepInsertOrTrace
-              tracer
-              "mem.txPoints"
-              (show ebHash <> "@" <> show offset)
-              stmtInsert
-        )
-        offsets
-
-    -- Then retrieve from ebTxs LEFT JOIN txs
-    results <- dbWithPrepare db (fromString sql_retrieve_from_ebTxs) $ \stmtRetrieve -> do
+sqlBatchRetrieveTxs _tracer db ebHash offsets =
+  dbWithBEGIN db $
+    dbWithPrepare db (fromString sql_retrieve_from_ebTxs_json) $ \stmt -> do
+      dbBindBlob stmt 1 (let MkEbHash bytes = ebHash in bytes)
+      dbBindUtf8 stmt 2 (jsonIntArray offsets)
       let loop acc =
-            dbStep stmtRetrieve >>= \case
+            dbStep stmt >>= \case
               DB.Done -> pure (reverse acc)
               DB.Row -> do
-                offset <- fromIntegral <$> DB.columnInt64 stmtRetrieve 0
-                txHash <- MkTxHash <$> DB.columnBlob stmtRetrieve 1
+                offset <- fromIntegral <$> DB.columnInt64 stmt 0
+                txHash <- MkTxHash <$> DB.columnBlob stmt 1
                 -- Column 2 is from LEFT JOIN, NULL if tx not in txs table
-                txBytes <- DB.columnBlob stmtRetrieve 2
+                txBytes <- DB.columnBlob stmt 2
                 let mbTxBytes = if txBytes == mempty then Nothing else Just txBytes
                 loop ((offset, txHash, mbTxBytes) : acc)
       loop []
 
-    -- Flush temp table
-    dbWithPrepare db (fromString sql_flush_memTxPoints) $ \stmtFlush ->
-      dbStep1 stmtFlush
-    pure results
-
+-- | Batch-filter EB points against @ebTxs@. Passes ebHashes as a JSON
+-- array of hex strings; SQL decodes with @unhex()@ so index lookups on
+-- @ebTxs.ebHashBytes@ still fire.
 sqlFilterMissingEbBodies ::
   Tracer IO TraceLeiosDb -> DB.Database -> [LeiosPoint] -> IO [LeiosPoint]
-sqlFilterMissingEbBodies tracer db points =
-  -- TODO: Replace temp table approach with JSON1 extension for cleaner batch queries.
-  dbWithBEGIN db $ do
-    let pointsByHash = Map.fromList [(p.pointEbHash, p) | p <- points]
-    dbWithPrepare db (fromString sql_insert_memEbHashes) $ \stmtInsert ->
-      forM_ (Map.keys pointsByHash) $ \ebHash -> do
-        dbBindBlob stmtInsert 1 ebHash.ebHashBytes
-        dbStepInsertOrTrace tracer "mem.ebHashes" (show ebHash) stmtInsert
-    result <- dbWithPrepare db (fromString sql_filter_missing_eb_bodies) $ \stmt -> do
+sqlFilterMissingEbBodies _tracer db points =
+  dbWithBEGIN db $
+    dbWithPrepare db (fromString sql_filter_missing_eb_bodies_json) $ \stmt -> do
+      let pointsByHash = Map.fromList [(p.pointEbHash, p) | p <- points]
+      dbBindUtf8 stmt 1 (jsonHexArray (map ebHashBytes (Map.keys pointsByHash)))
       let loop acc =
             dbStep stmt >>= \case
               DB.Done -> pure (reverse acc)
@@ -368,22 +356,15 @@ sqlFilterMissingEbBodies tracer db points =
                   Just p -> loop (p : acc)
                   Nothing -> loop acc
       loop []
-    dbWithPrepare db (fromString sql_flush_memEbHashes) $ \stmtFlush ->
-      dbStep1 stmtFlush
-    pure result
 
+-- | Batch-filter tx hashes against @txs@. Same idiom as
+-- 'sqlFilterMissingEbBodies'.
 sqlFilterMissingTxs ::
   Tracer IO TraceLeiosDb -> DB.Database -> [TxHash] -> IO [TxHash]
-sqlFilterMissingTxs tracer db txHashes =
-  -- TODO: Replace temp table approach with JSON1 extension for cleaner batch queries:
-  --   WHERE t.txHashBytes IN (SELECT unhex(value) FROM json_each(?))
-  -- This would eliminate the need for mem.txHashes table and insert/flush overhead.
-  dbWithBEGIN db $ do
-    dbWithPrepare db (fromString sql_insert_memTxHashes) $ \stmtInsert ->
-      forM_ txHashes $ \txHash@(MkTxHash bytes) -> do
-        dbBindBlob stmtInsert 1 bytes
-        dbStepInsertOrTrace tracer "mem.txHashes" (show txHash) stmtInsert
-    result <- dbWithPrepare db (fromString sql_filter_missing_txs) $ \stmt -> do
+sqlFilterMissingTxs _tracer db txHashes =
+  dbWithBEGIN db $
+    dbWithPrepare db (fromString sql_filter_missing_txs_json) $ \stmt -> do
+      dbBindUtf8 stmt 1 (jsonHexArray [b | MkTxHash b <- txHashes])
       let loop acc =
             dbStep stmt >>= \case
               DB.Done -> pure (reverse acc)
@@ -391,9 +372,31 @@ sqlFilterMissingTxs tracer db txHashes =
                 txHash <- MkTxHash <$> DB.columnBlob stmt 0
                 loop (txHash : acc)
       loop []
-    dbWithPrepare db (fromString sql_flush_memTxHashes) $ \stmtFlush ->
-      dbStep1 stmtFlush
-    pure result
+
+-- | Build a JSON array of hex-encoded blobs: @["aabb...","1234...",...]@.
+-- Consumed on the SQL side via @json_each(?)@ + @unhex(je.value)@.
+jsonHexArray :: [ByteString] -> ByteString
+jsonHexArray xs =
+  BSL.toStrict . BB.toLazyByteString $
+    BB.char7 '[' <> commaSep (map hexElem xs) <> BB.char7 ']'
+ where
+  hexElem b = BB.char7 '"' <> BB.byteStringHex b <> BB.char7 '"'
+  commaSep = mconcat . intersperseB (BB.char7 ',')
+  intersperseB _ [] = []
+  intersperseB _ [x] = [x]
+  intersperseB s (x : rest) = x : s : intersperseB s rest
+
+-- | Build a JSON array of integers: @[1,2,3,...]@. Same consumer pattern
+-- as 'jsonHexArray' (values are already ints, so no decoding step).
+jsonIntArray :: [Int] -> ByteString
+jsonIntArray xs =
+  BSL.toStrict . BB.toLazyByteString $
+    BB.char7 '[' <> commaSep (map BB.intDec xs) <> BB.char7 ']'
+ where
+  commaSep = mconcat . intersperseB (BB.char7 ',')
+  intersperseB _ [] = []
+  intersperseB _ [x] = [x]
+  intersperseB s (x : rest) = x : s : intersperseB s rest
 
 sqlLookupEbClosure :: DB.Database -> EbHash -> IO (Maybe [(TxHash, ByteString)])
 sqlLookupEbClosure db ebHash =
@@ -489,39 +492,22 @@ sql_insert_tx =
   "INSERT INTO txs (txHashBytes, txBytes, txBytesSize) VALUES (?, ?, ?)\n\
   \"
 
--- | Insert ebHashes into temp table for batch filtering
-sql_insert_memEbHashes :: String
-sql_insert_memEbHashes =
-  "INSERT INTO mem.ebHashes (ebHashBytes) VALUES (?)"
-
--- | Filter: return ebHashes from temp table that do NOT have bodies in ebTxs
-sql_filter_missing_eb_bodies :: String
-sql_filter_missing_eb_bodies =
-  "SELECT m.ebHashBytes FROM mem.ebHashes m\n\
-  \WHERE NOT EXISTS (SELECT 1 FROM ebTxs e WHERE e.ebHashBytes = m.ebHashBytes)\n\
+-- | Batch-filter ebHashes via JSON1. Parameter is a JSON array of hex
+-- strings; 'unhex(je.value)' decodes back into a BLOB comparable against
+-- the indexed @ebTxs.ebHashBytes@ column.
+sql_filter_missing_eb_bodies_json :: String
+sql_filter_missing_eb_bodies_json =
+  "SELECT unhex(je.value) FROM json_each(?) je\n\
+  \WHERE NOT EXISTS (SELECT 1 FROM ebTxs e WHERE e.ebHashBytes = unhex(je.value))\n\
   \"
 
--- | Flush the temp ebHashes table
-sql_flush_memEbHashes :: String
-sql_flush_memEbHashes =
-  "DELETE FROM mem.ebHashes"
-
--- | Insert txHashes into temp table for batch filtering
-sql_insert_memTxHashes :: String
-sql_insert_memTxHashes =
-  "INSERT INTO mem.txHashes (txHashBytes) VALUES (?)"
-
--- | Filter: return txHashes from temp table that do NOT exist in txs
-sql_filter_missing_txs :: String
-sql_filter_missing_txs =
-  "SELECT m.txHashBytes FROM mem.txHashes m\n\
-  \WHERE NOT EXISTS (SELECT 1 FROM txs t WHERE t.txHashBytes = m.txHashBytes)\n\
+-- | Batch-filter txHashes via JSON1. Same shape as
+-- 'sql_filter_missing_eb_bodies_json'.
+sql_filter_missing_txs_json :: String
+sql_filter_missing_txs_json =
+  "SELECT unhex(je.value) FROM json_each(?) je\n\
+  \WHERE NOT EXISTS (SELECT 1 FROM txs t WHERE t.txHashBytes = unhex(je.value))\n\
   \"
-
--- | Flush the temp txHashes table
-sql_flush_memTxHashes :: String
-sql_flush_memTxHashes =
-  "DELETE FROM mem.txHashes"
 
 -- | Find EBs that are now complete (missingTxCount reached 0).
 sql_find_complete_ebs :: String
@@ -554,44 +540,17 @@ sql_init_missing_tx_count =
   \) WHERE ebHashBytes = ? AND ebSlot = ?\n\
   \"
 
-sql_insert_memTxPoints :: String
-sql_insert_memTxPoints =
-  "INSERT INTO mem.txPoints (ebHashBytes, txOffset) VALUES (?, ?)\n\
-  \"
-
-sql_retrieve_from_ebTxs :: String
-sql_retrieve_from_ebTxs =
-  "SELECT e.txOffset, e.txHashBytes, t.txBytes\n\
-  \FROM ebTxs e\n\
+-- | Batch retrieve of tx bytes for a batch of @(ebHash, offset)@ points.
+-- @?1@ is the ebHash blob (all offsets belong to the same EB); @?2@ is a
+-- JSON int array of offsets. The join uses ebTxs' PK
+-- @(ebHashBytes, txOffset)@, so index lookups still fire.
+sql_retrieve_from_ebTxs_json :: String
+sql_retrieve_from_ebTxs_json =
+  "SELECT je.value, e.txHashBytes, t.txBytes\n\
+  \FROM json_each(?2) je\n\
+  \JOIN ebTxs e ON e.ebHashBytes = ?1 AND e.txOffset = je.value\n\
   \LEFT JOIN txs t ON e.txHashBytes = t.txHashBytes\n\
-  \WHERE (e.ebHashBytes, e.txOffset) IN (SELECT ebHashBytes, txOffset FROM mem.txPoints)\n\
-  \ORDER BY e.txOffset ASC\n\
-  \"
-
-sql_flush_memTxPoints :: String
-sql_flush_memTxPoints =
-  "DELETE FROM mem.txPoints\n\
-  \"
-
-sql_attach_memTxPoints :: String
-sql_attach_memTxPoints =
-  "ATTACH DATABASE ':memory:' AS mem;\n\
-  \\n\
-  \CREATE TABLE mem.txPoints (\n\
-  \    ebHashBytes INTEGER NOT NULL\n\
-  \  ,\n\
-  \    txOffset INTEGER NOT NULL\n\
-  \  ,\n\
-  \    PRIMARY KEY (ebHashBytes ASC, txOffset ASC)\n\
-  \  ) WITHOUT ROWID;\n\
-  \\n\
-  \CREATE TABLE mem.txHashes (\n\
-  \    txHashBytes BLOB NOT NULL PRIMARY KEY\n\
-  \  ) WITHOUT ROWID;\n\
-  \\n\
-  \CREATE TABLE mem.ebHashes (\n\
-  \    ebHashBytes BLOB NOT NULL PRIMARY KEY\n\
-  \  ) WITHOUT ROWID;\n\
+  \ORDER BY je.value ASC\n\
   \"
 
 sql_lookup_eb_closure :: String
@@ -608,6 +567,11 @@ sql_lookup_eb_closure =
 
 dbBindBlob :: HasCallStack => DB.Statement -> DB.ParamIndex -> ByteString -> IO ()
 dbBindBlob q p v = withDieStmt q $ DB.bindBlob q p v
+
+-- | Bind as TEXT. Needed for JSON1 payloads: 'json_each' interprets BLOB
+-- arguments as JSONB (SQLite ≥ 3.45), our payload is ASCII JSON.
+dbBindUtf8 :: HasCallStack => DB.Statement -> DB.ParamIndex -> ByteString -> IO ()
+dbBindUtf8 q p v = withDieStmt q $ DB.bindText q p (DB.Utf8 v)
 
 dbBindInt64 :: HasCallStack => DB.Statement -> DB.ParamIndex -> Int64 -> IO ()
 dbBindInt64 q p v = withDieStmt q $ DB.bindInt64 q p v

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic.hs
@@ -46,7 +46,6 @@ import LeiosDemoDb
   , leiosDbInsertEbPoint
   , leiosDbInsertTxs
   , leiosDbLookupEbBody
-  , leiosDbLookupEbPoint
   )
 import qualified LeiosDemoOnlyTestFetch as LF
 import LeiosDemoTypes
@@ -555,33 +554,37 @@ nextLeiosFetchClientCommand ktracer tracer stopSTM kernelVars db peerId reqsVar 
   checkOrPeek =
     stopSTM >>= \case
       True -> pure $ Right $ Left ()
-      False -> StrictSTM.readTVar reqsVar >>= \case
-        req Seq.:<| reqs -> do
-          StrictSTM.writeTVar reqsVar reqs
-          pure $ Right $ Right $ g req
-        Seq.Empty -> pure $ Left ()
+      False ->
+        StrictSTM.readTVar reqsVar >>= \case
+          req Seq.:<| reqs -> do
+            StrictSTM.writeTVar reqsVar reqs
+            pure $ Right $ Right $ g req
+          Seq.Empty -> pure $ Left ()
 
   -- Blocking path. Wake on stop, new request, or a response arriving
   -- (peek doesn't consume; caller re-drains). Ensures responses get
   -- processed even when there are no requests to send.
   blockingLoop :: m (Either () (LF.SomeLeiosFetchJob LeiosPoint LeiosEb LeiosTx m))
   blockingLoop = do
-    step <- StrictSTM.atomically $
-      (Right <$> awaitStopOrRequest) `LazySTM.orElse`
-      (Left () <$ LazySTM.peekTQueue responseQ)
+    step <-
+      StrictSTM.atomically $
+        (Right <$> awaitStopOrRequest)
+          `LazySTM.orElse` (Left () <$ LazySTM.peekTQueue responseQ)
     case step of
       Right result -> pure result
       Left () -> drainResponses *> blockingLoop
 
   awaitStopOrRequest ::
     StrictSTM.STM m (Either () (LF.SomeLeiosFetchJob LeiosPoint LeiosEb LeiosTx m))
-  awaitStopOrRequest = stopSTM >>= \case
-    True -> pure $ Left ()
-    False -> StrictSTM.readTVar reqsVar >>= \case
-      req Seq.:<| reqs -> do
-        StrictSTM.writeTVar reqsVar reqs
-        pure $ Right $ g req
-      Seq.Empty -> StrictSTM.retry
+  awaitStopOrRequest =
+    stopSTM >>= \case
+      True -> pure $ Left ()
+      False ->
+        StrictSTM.readTVar reqsVar >>= \case
+          req Seq.:<| reqs -> do
+            StrictSTM.writeTVar reqsVar reqs
+            pure $ Right $ g req
+          Seq.Empty -> StrictSTM.retry
 
   g = \case
     LeiosBlockRequest req@(MkLeiosBlockRequest p _ebBytesSize) ->
@@ -640,26 +643,13 @@ msgLeiosBlock ktracer tracer (outstandingVar, readyVar) db peerId req eb = do
     when novel $ do
       -- TODO don't hold the outstanding mvar during this IO
       traceException tracer TraceLeiosPeerDbException $ do
-        -- NOTE: The point should already be in the table because of the
-        -- announcement handling. The fetching logic should have only decided to
-        -- download announced (or otherwise known) EBs. However, this is an
-        -- interesting situation where a node offers an EB we have not seen via an
-        -- announcement before. We check if the point exists and trace a warning
-        -- if not, then insert as safety net. We should remove this once we are
-        -- confident the fetching logic handles this correctly.
-        leiosDbLookupEbPoint db ebHash >>= \case
-          Just _ -> pure () -- Point already exists (expected from announcement)
-          Nothing -> do
-            -- Unexpected: we're receiving an EB body without having seen the announcement first
-            traceWith ktracer $ TraceLeiosBlockPointMissing point
-            leiosDbInsertEbPoint db point ebBytesSize
-        -- FIXME: getting a LeiosDb: ErrorConstraint exception here When forging
-        -- a leios EB, another peer offers us the block we already produced and
-        -- the fetching logic does download it. This results in a duplicate
-        -- insert here. We can of course make the database ignore the
-        -- duplicates, but we should have not even fetched it.
-        -- REVIEW: ^^^^ this should be resolved
-        -- TODO: This was encountered again, but likely because of a race on two fetches.
+        -- FIXME: Once proper EB announcements are wired in, the point
+        -- MUST already be present here (announcement handling inserts
+        -- it) and this should become an assertion. Today we still tolerate
+        -- receiving an EB body without a prior announcement, so we insert
+        -- the point idempotently as a stop-gap and trace a warning.
+        traceWith ktracer $ TraceLeiosBlockPointMissing point
+        leiosDbInsertEbPoint db point ebBytesSize
         leiosDbInsertEbBody db point eb
         traceWith ktracer $ TraceLeiosBlockAcquired point
     -- update NodeKernel state

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic.hs
@@ -12,6 +12,7 @@ module LeiosDemoLogic (module LeiosDemoLogic) where
 import Cardano.Slotting.Slot (SlotNo (..))
 import Control.Concurrent.Class.MonadMVar (MVar)
 import qualified Control.Concurrent.Class.MonadMVar as MVar
+import qualified Control.Concurrent.Class.MonadSTM as LazySTM
 import Control.Concurrent.Class.MonadSTM.Strict (StrictTVar)
 import qualified Control.Concurrent.Class.MonadSTM.Strict as StrictSTM
 import Control.Monad (forM_, when)
@@ -500,6 +501,13 @@ packRequests env =
 
 -----
 
+-- | A response received by the pipelined-peer collector thread, deferred
+-- for processing on the main peer thread. The collector must not touch
+-- the 'LeiosDbConnection' — it belongs to the main peer thread.
+data PendingResponse
+  = PendingBlockResponse !LeiosBlockRequest !LeiosEb
+  | PendingBlockTxsResponse !LeiosBlockTxsRequest !(V.Vector LeiosTx)
+
 nextLeiosFetchClientCommand ::
   forall pid m.
   ( Ord pid
@@ -514,42 +522,81 @@ nextLeiosFetchClientCommand ::
   LeiosDbConnection m ->
   PeerId pid ->
   StrictTVar m (Seq LeiosFetchRequest) ->
+  -- | Queue of responses received by the pipelined collector thread.
+  -- The collector enqueues; this function (on the main peer thread)
+  -- drains and processes, keeping all 'LeiosDbConnection' access on
+  -- the main thread.
+  LazySTM.TQueue m PendingResponse ->
   m
     ( Either
         (m (Either () (LF.SomeLeiosFetchJob LeiosPoint LeiosEb LeiosTx m)))
         (Either () (LF.SomeLeiosFetchJob LeiosPoint LeiosEb LeiosTx m))
     )
-nextLeiosFetchClientCommand ktracer tracer stopSTM kernelVars db peerId reqsVar = do
-  f (pure Nothing) (pure . Just) >>= \case
-    Just x -> pure $ Right x
-    Nothing -> pure $ Left $ f StrictSTM.retry pure
+nextLeiosFetchClientCommand ktracer tracer stopSTM kernelVars db peerId reqsVar responseQ = do
+  drainResponses
+  StrictSTM.atomically checkOrPeek >>= \case
+    Right result -> pure $ Right result
+    Left () -> pure $ Left blockingLoop
  where
-  f ::
-    StrictSTM.STM m r ->
-    (Either () (LF.SomeLeiosFetchJob LeiosPoint LeiosEb LeiosTx m) -> StrictSTM.STM m r) ->
-    m r
-  f retry_ pure_ = StrictSTM.atomically $ do
+  -- Drain everything currently in the response queue and process on this thread.
+  drainResponses :: m ()
+  drainResponses = do
+    pending <- StrictSTM.atomically $ LazySTM.flushTQueue responseQ
+    forM_ pending $ \case
+      PendingBlockResponse req eb ->
+        msgLeiosBlock ktracer tracer kernelVars db peerId req eb
+      PendingBlockTxsResponse req txs ->
+        msgLeiosBlockTxs ktracer tracer kernelVars db peerId req txs
+
+  -- Non-blocking: return 'Right result' if stop or a request is available,
+  -- or 'Left ()' if we'd have to block (caller returns Left blockingLoop).
+  checkOrPeek ::
+    StrictSTM.STM m (Either () (Either () (LF.SomeLeiosFetchJob LeiosPoint LeiosEb LeiosTx m)))
+  checkOrPeek =
     stopSTM >>= \case
-      True -> pure_ $ Left ()
-      False ->
-        StrictSTM.readTVar reqsVar >>= \case
-          Seq.Empty -> retry_
-          req Seq.:<| reqs -> do
-            StrictSTM.writeTVar reqsVar reqs
-            pure_ $ Right $ g req
+      True -> pure $ Right $ Left ()
+      False -> StrictSTM.readTVar reqsVar >>= \case
+        req Seq.:<| reqs -> do
+          StrictSTM.writeTVar reqsVar reqs
+          pure $ Right $ Right $ g req
+        Seq.Empty -> pure $ Left ()
+
+  -- Blocking path. Wake on stop, new request, or a response arriving
+  -- (peek doesn't consume; caller re-drains). Ensures responses get
+  -- processed even when there are no requests to send.
+  blockingLoop :: m (Either () (LF.SomeLeiosFetchJob LeiosPoint LeiosEb LeiosTx m))
+  blockingLoop = do
+    step <- StrictSTM.atomically $
+      (Right <$> awaitStopOrRequest) `LazySTM.orElse`
+      (Left () <$ LazySTM.peekTQueue responseQ)
+    case step of
+      Right result -> pure result
+      Left () -> drainResponses *> blockingLoop
+
+  awaitStopOrRequest ::
+    StrictSTM.STM m (Either () (LF.SomeLeiosFetchJob LeiosPoint LeiosEb LeiosTx m))
+  awaitStopOrRequest = stopSTM >>= \case
+    True -> pure $ Left ()
+    False -> StrictSTM.readTVar reqsVar >>= \case
+      req Seq.:<| reqs -> do
+        StrictSTM.writeTVar reqsVar reqs
+        pure $ Right $ g req
+      Seq.Empty -> StrictSTM.retry
 
   g = \case
     LeiosBlockRequest req@(MkLeiosBlockRequest p _ebBytesSize) ->
       LF.MkSomeLeiosFetchJob
         (LF.MsgLeiosBlockRequest p)
         ( pure $ \(LF.MsgLeiosBlock eb) ->
-            msgLeiosBlock ktracer tracer kernelVars db peerId req eb
+            StrictSTM.atomically $
+              LazySTM.writeTQueue responseQ (PendingBlockResponse req eb)
         )
     LeiosBlockTxsRequest req@(MkLeiosBlockTxsRequest p bitmaps _txHashes) ->
       LF.MkSomeLeiosFetchJob
         (LF.MsgLeiosBlockTxsRequest p bitmaps)
-        ( pure $ \(LF.MsgLeiosBlockTxs _ _ txs) -> do
-            msgLeiosBlockTxs ktracer tracer kernelVars db peerId req txs
+        ( pure $ \(LF.MsgLeiosBlockTxs _ _ txs) ->
+            StrictSTM.atomically $
+              LazySTM.writeTQueue responseQ (PendingBlockTxsResponse req txs)
         )
 
 -----

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/V1.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/V1.hs
@@ -28,7 +28,7 @@ import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.Word
 import GHC.Generics (Generic)
-import LeiosDemoDb (LeiosDbConnection, LeiosDbHandle (open))
+import LeiosDemoDb (LeiosDbHandle, withLeiosDb)
 import LeiosDemoTypes (HasLeiosVoting)
 import Ouroboros.Consensus.Block
 import Ouroboros.Consensus.Config
@@ -88,10 +88,14 @@ mkInitDb ::
   GetVolatileSuffix m blk ->
   m (InitDB (DbChangelog' blk, BackingStore' m blk) m blk)
 mkInitDb args bss getBlock snapManager getVolatileSuffix = do
-  -- Open the LeiosDb connection once, up front, and share it between the
-  -- immutable-DB replay path ('initReapplyBlock') and the post-replay
-  -- 'LedgerDBEnv'. See V2.mkInitDb for the longer rationale.
-  ldbLeiosDb <- open lgrLeiosDb
+  -- 'lgrLeiosDb' is a 'LeiosDbHandle' — a factory for per-thread
+  -- 'LeiosDbConnection's. We do NOT open a connection here to share
+  -- across threads: 'direct-sqlite' handles are single-thread and
+  -- were segfaulting when the shared connection was used from a
+  -- different worker (see the thread-check safety net in
+  -- LeiosDemoDb.SQLite). Every consumer opens its own via
+  -- 'withLeiosDb' on its own thread instead.
+  let ldbLeiosDb = lgrLeiosDb
   pure $
     InitDB
       { initFromGenesis = do
@@ -110,7 +114,8 @@ mkInitDb args bss getBlock snapManager getVolatileSuffix = do
                 ds
             )
       , initReapplyBlock = \cfg blk (chlog, bstore) -> do
-          !chlog' <- reapplyThenPushLeios ldbLeiosDb cfg blk (readKeySets bstore) chlog
+          !chlog' <- withLeiosDb ldbLeiosDb $ \leiosConn ->
+            reapplyThenPushLeios leiosConn cfg blk (readKeySets bstore) chlog
           -- It's OK to flush without a lock here, since the `LedgerDB` has not
           -- finished initializing, only this thread has access to the backing
           -- store.
@@ -287,22 +292,28 @@ implValidate ::
   SuccessForkerAction m l ->
   m (ValidateResult l blk)
 implValidate h ldbEnv tr cache rollbacks hdrs onSuccess =
-  validate (ledgerDbCfgComputeLedgerEvents $ ldbCfg ldbEnv) $
-    ValidateArgs
-      (ldbResolveBlock ldbEnv)
-      (ledgerDbCfg $ ldbCfg ldbEnv)
-      ( \l -> do
-          prev <- readTVar (ldbPrevApplied ldbEnv)
-          writeTVar (ldbPrevApplied ldbEnv) (Foldable.foldl' (flip Set.insert) prev l)
-      )
-      (readTVar (ldbPrevApplied ldbEnv))
-      (withForkerByRollback h)
-      onSuccess
-      tr
-      cache
-      rollbacks
-      hdrs
-      (ldbLeiosDb ldbEnv)
+  -- Open a connection scoped to this call: the 'LeiosDbConnection'
+  -- must be owned by the thread calling 'validate', which for
+  -- 'validateFork' is the ChainSel/block-adder thread. Storing a
+  -- shared connection in 'ldbEnv' was crashing SQLite when a
+  -- non-owner thread invoked this path.
+  withLeiosDb (ldbLeiosDb ldbEnv) $ \leiosConn ->
+    validate (ledgerDbCfgComputeLedgerEvents $ ldbCfg ldbEnv) $
+      ValidateArgs
+        (ldbResolveBlock ldbEnv)
+        (ledgerDbCfg $ ldbCfg ldbEnv)
+        ( \l -> do
+            prev <- readTVar (ldbPrevApplied ldbEnv)
+            writeTVar (ldbPrevApplied ldbEnv) (Foldable.foldl' (flip Set.insert) prev l)
+        )
+        (readTVar (ldbPrevApplied ldbEnv))
+        (withForkerByRollback h)
+        onSuccess
+        tr
+        cache
+        rollbacks
+        hdrs
+        leiosConn
 
 implGetPrevApplied :: MonadSTM m => LedgerDBEnv m l blk -> STM m (Set (RealPoint blk))
 implGetPrevApplied env = readTVar (ldbPrevApplied env)
@@ -465,7 +476,8 @@ implIntReapplyThenPush ::
 implIntReapplyThenPush env blk = do
   chlog <- readTVarIO $ ldbChangelog env
   chlog' <-
-    reapplyThenPushLeios (ldbLeiosDb env) (ldbCfg env) blk (readKeySets (ldbBackingStore env)) chlog
+    withLeiosDb (ldbLeiosDb env) $ \leiosConn ->
+      reapplyThenPushLeios leiosConn (ldbCfg env) blk (readKeySets (ldbBackingStore env)) chlog
   atomically $ writeTVar (ldbChangelog env) chlog'
 
 {-------------------------------------------------------------------------------
@@ -570,7 +582,10 @@ data LedgerDBEnv m l blk = LedgerDBEnv
   , ldbQueryBatchSize :: !QueryBatchSize
   , ldbResolveBlock :: !(ResolveBlock m blk)
   , ldbGetVolatileSuffix :: !(GetVolatileSuffix m blk)
-  , ldbLeiosDb :: !(LeiosDbConnection m)
+  , ldbLeiosDb :: !(LeiosDbHandle m)
+  -- ^ 'LeiosDbHandle', not a live connection: every consumer opens its
+  -- own per-thread connection via 'withLeiosDb' at use time (a
+  -- 'direct-sqlite' handle is single-thread).
   }
   deriving Generic
 

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/V2.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/V2.hs
@@ -30,7 +30,7 @@ import Data.Traversable (for)
 import Data.Tuple (Solo (..))
 import Data.Word
 import GHC.Generics
-import LeiosDemoDb (LeiosDbConnection, LeiosDbHandle (open))
+import LeiosDemoDb (LeiosDbHandle, withLeiosDb)
 import LeiosDemoTypes (HasLeiosVoting)
 import NoThunks.Class
 import Ouroboros.Consensus.Block
@@ -83,15 +83,13 @@ mkInitDb ::
   Resources m backend ->
   m (InitDB (LedgerSeq' m blk) m blk)
 mkInitDb args getBlock snapManager getVolatileSuffix res = do
-  -- Open the LeiosDb connection once, up front, and share it between
-  -- the immutable-DB replay path ('initReapplyBlock') and the
-  -- post-replay 'LedgerDB' env ('ldbLeiosDb'). The replay path needs
-  -- the connection so 'reapplyThenPush' can splice EB bodies into
-  -- CertRBs via 'resolveLeiosBlock' — without it, replayed CertRBs
-  -- would be applied with empty wire bodies and the resulting ledger
-  -- state would diverge from the one produced by the original fresh
-  -- sync (missing every EB-tx output).
-  ldbLeiosDb <- open lgrLeiosDb
+  -- 'lgrLeiosDb' is a 'LeiosDbHandle' — a factory for per-thread
+  -- 'LeiosDbConnection's. We do NOT open a shared connection here:
+  -- a direct-sqlite handle must be used from the thread that opened
+  -- it, and every consumer (initial replay, ChainSel validate,
+  -- reapplyThenPushNOW, ...) runs on a different thread. Each opens
+  -- its own via 'withLeiosDb' at use time instead.
+  let ldbLeiosDb = lgrLeiosDb
   pure $
     InitDB
       { initFromGenesis = do
@@ -108,7 +106,9 @@ mkInitDb args getBlock snapManager getVolatileSuffix res = do
                   res
                   ds
             )
-      , initReapplyBlock = reapplyThenPush ldbLeiosDb
+      , initReapplyBlock = \cfg ap db ->
+          withLeiosDb ldbLeiosDb $ \leiosConn ->
+            reapplyThenPush leiosConn cfg ap db
       , currentTip = ledgerState . current
       , mkLedgerDb = \lseq -> do
           varDB <- newTVarIO lseq
@@ -219,7 +219,8 @@ mkInternals ldb h snapManager =
           ( \frk -> do
               st <- atomically $ forkerGetLedgerState frk
               let cds = headerStateChainDep (headerState st)
-              blk' <- resolveLeiosBlock (ldbLeiosDb env) cds blk
+              blk' <- withLeiosDb (ldbLeiosDb env) $ \leiosConn ->
+                resolveLeiosBlock leiosConn cds blk
               tables <- forkerReadTables frk (getBlockKeySets blk')
               let st' =
                     tickThenReapply
@@ -318,22 +319,24 @@ implValidate ::
   SuccessForkerAction m l ->
   m (ValidateResult l blk)
 implValidate h ldbEnv tr cache rollbacks hdrs onSuccess =
-  validate (ledgerDbCfgComputeLedgerEvents $ ldbCfg ldbEnv) $
-    ValidateArgs
-      (ldbResolveBlock ldbEnv)
-      (ledgerDbCfg $ ldbCfg ldbEnv)
-      ( \l -> do
-          prev <- readTVar (ldbPrevApplied ldbEnv)
-          writeTVar (ldbPrevApplied ldbEnv) (Foldable.foldl' (flip Set.insert) prev l)
-      )
-      (readTVar (ldbPrevApplied ldbEnv))
-      (withForkerByRollback h)
-      onSuccess
-      tr
-      cache
-      rollbacks
-      hdrs
-      (ldbLeiosDb ldbEnv)
+  -- See V1.implValidate for the rationale on opening per-call.
+  withLeiosDb (ldbLeiosDb ldbEnv) $ \leiosConn ->
+    validate (ledgerDbCfgComputeLedgerEvents $ ldbCfg ldbEnv) $
+      ValidateArgs
+        (ldbResolveBlock ldbEnv)
+        (ledgerDbCfg $ ldbCfg ldbEnv)
+        ( \l -> do
+            prev <- readTVar (ldbPrevApplied ldbEnv)
+            writeTVar (ldbPrevApplied ldbEnv) (Foldable.foldl' (flip Set.insert) prev l)
+        )
+        (readTVar (ldbPrevApplied ldbEnv))
+        (withForkerByRollback h)
+        onSuccess
+        tr
+        cache
+        rollbacks
+        hdrs
+        leiosConn
 
 implGetPrevApplied :: MonadSTM m => LedgerDBEnv m l blk -> STM m (Set (RealPoint blk))
 implGetPrevApplied env = readTVar (ldbPrevApplied env)
@@ -447,8 +450,10 @@ data LedgerDBEnv m l blk = LedgerDBEnv
   -- in tests can release such resources. These are the resource keys for the
   -- LSM session and the resource key for the BlockIO interface.
   , ldbGetVolatileSuffix :: !(GetVolatileSuffix m blk)
-  , ldbLeiosDb :: !(LeiosDbConnection m)
-  -- ^ Connection to the Leios demo DB.
+  , ldbLeiosDb :: !(LeiosDbHandle m)
+  -- ^ 'LeiosDbHandle', not a live connection: every consumer opens
+  -- its own per-thread connection via 'withLeiosDb' at use time (a
+  -- 'direct-sqlite' handle is single-thread).
   }
   deriving Generic
 

--- a/ouroboros-consensus/test/consensus-test/Test/LeiosDemoDb.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/LeiosDemoDb.hs
@@ -25,7 +25,6 @@ import qualified Data.Vector.Strict as V
 import LeiosDemoDb
   ( LeiosDbHandle (..)
   , LeiosEbNotification (..)
-  , LeiosFetchWork (..)
   , leiosDbBatchRetrieveTxs
   , leiosDbFilterMissingEbBodies
   , leiosDbFilterMissingTxs
@@ -33,9 +32,7 @@ import LeiosDemoDb
   , leiosDbInsertEbPoint
   , leiosDbInsertTxs
   , leiosDbLookupEbBody
-  , leiosDbLookupEbPoint
-  , leiosDbQueryCompletedEbByHash
-  , leiosDbQueryFetchWork
+  , leiosDbLookupEbClosure
   , leiosDbScanEbPoints
   , newLeiosDBInMemory
   , newLeiosDBSQLite
@@ -111,8 +108,6 @@ mkTestGroups impl =
   [ testGroup
       "points"
       [ testProperty "insert then scan" $ prop_pointsInsertThenScan impl
-      , testProperty "insert then lookup" $ prop_pointsInsertThenLookup impl
-      , testProperty "lookup missing returns Nothing" $ prop_pointsLookupMissing impl
       , testProperty "multiple inserts accumulate" $ prop_pointsAccumulate impl
       ]
   , testGroup
@@ -141,13 +136,6 @@ mkTestGroups impl =
           withFreshDb impl test_multipleSlotsSameHash
       ]
   , testGroup
-      "queryFetchWork"
-      [ testProperty "empty db returns empty work" $ prop_fetchWorkEmpty impl
-      , testProperty "missing bodies reported" $ prop_fetchWorkMissingBodies impl
-      , testProperty "missing txs reported" $ prop_fetchWorkMissingTxs impl
-      , testProperty "complete eb has no missing txs" $ prop_fetchWorkCompleteTxs impl
-      ]
-  , testGroup
       "filterMissingEbBodies"
       [ testProperty "empty input returns empty" $ prop_filterEbBodiesEmpty impl
       , testProperty "returns only missing EBs" $ prop_filterEbBodiesCorrect impl
@@ -158,7 +146,7 @@ mkTestGroups impl =
       , testProperty "returns only missing TXs" $ prop_filterTxsCorrect impl
       ]
   , testGroup
-      "queryCompletedEbByPoint"
+      "lookupEbClosure"
       [ testProperty "complete EB returns Just with tx data" $ prop_completedEbComplete impl
       , testProperty "no txs returns Nothing" $ prop_completedEbMissingTxs impl
       , testProperty "partial txs returns Nothing" $ prop_completedEbPartialTxs impl
@@ -302,28 +290,6 @@ prop_pointsInsertThenScan impl =
         (point.pointSlotNo, point.pointEbHash) `elem` points
           & tabulate "insertEbPoint" [timeBucket insertTime]
           & tabulate "scanEbPoints" [timeBucket scanTime]
-
--- | Property: inserting a point and then looking it up returns the slot.
-prop_pointsInsertThenLookup :: DbImpl -> Property
-prop_pointsInsertThenLookup impl =
-  forAll genPoint $ \point ->
-    ioProperty $ withFreshDb impl $ \db -> withLeiosDb db $ \con -> do
-      (_, insertTime) <- timed $ leiosDbInsertEbPoint con point 1000
-      (result, lookupTime) <- timed $ leiosDbLookupEbPoint con point.pointEbHash
-      pure $
-        result === Just point.pointSlotNo
-          & tabulate "insertEbPoint" [timeBucket insertTime]
-          & tabulate "lookupEbPoint" [timeBucket lookupTime]
-
--- | Property: looking up a non-existent point returns Nothing.
-prop_pointsLookupMissing :: DbImpl -> Property
-prop_pointsLookupMissing impl =
-  forAll genEbHash $ \missingHash ->
-    ioProperty $ withFreshDb impl $ \db -> withLeiosDb db $ \con -> do
-      (result, lookupTime) <- timed $ leiosDbLookupEbPoint con missingHash
-      pure $
-        result === Nothing
-          & tabulate "lookupEbPoint (missing)" [timeBucket lookupTime]
 
 -- | Property: multiple inserted points all appear in scan results.
 prop_pointsAccumulate :: DbImpl -> Property
@@ -701,103 +667,6 @@ test_multipleSlotsSameHash db = do
  where
   setEquals xs ys = Map.fromList [(p, ()) | p <- xs] @?= Map.fromList [(p, ()) | p <- ys]
 
--- * Property tests for queryFetchWork
-
--- | Property: empty database returns empty fetch work.
-prop_fetchWorkEmpty :: DbImpl -> Property
-prop_fetchWorkEmpty impl =
-  ioProperty $ withFreshDb impl $ \db -> withLeiosDb db $ \con -> do
-    (work, queryTime) <- timed $ leiosDbQueryFetchWork con
-    pure $
-      conjoin
-        [ missingEbBodies work === Map.empty
-            & counterexample "Expected no missing EB bodies"
-        , missingEbTxs work === Map.empty
-            & counterexample "Expected no missing TXs"
-        ]
-        & tabulate "queryFetchWork (empty)" [timeBucket queryTime]
-
--- | Property: EBs with points but no bodies are reported as missing.
-prop_fetchWorkMissingBodies :: DbImpl -> Property
-prop_fetchWorkMissingBodies impl =
-  forAllShrinkShow (chooseInt (1, 10)) shrink show $ \count ->
-    forAll (replicateM count genPoint) $ \points ->
-      ioProperty $
-        withFreshDb impl $ \db ->
-          withLeiosDb db $ \con -> do
-            -- Insert points without bodies
-            forM_ points $ \p -> leiosDbInsertEbPoint con p 1000
-            (work, queryTime) <- timed $ leiosDbQueryFetchWork con
-            let expectedMap = Map.fromList [(p, 1000) | p <- points]
-            pure $
-              missingEbBodies work === expectedMap
-                & counterexample ("Expected: " ++ show expectedMap)
-                & counterexample ("Got: " ++ show (missingEbBodies work))
-                & tabulate "queryFetchWork (missing bodies)" [timeBucket queryTime]
-                & tabulate "numPoints" [magnitudeBucket count]
-
--- | Property: EBs with bodies but missing TXs are reported.
-prop_fetchWorkMissingTxs :: DbImpl -> Property
-prop_fetchWorkMissingTxs impl =
-  forAllShrinkShow (chooseInt (1, 20)) shrink show $ \numTxs ->
-    forAll (genPointAndEb numTxs) $ \(point, eb) ->
-      ioProperty $
-        withFreshDb impl $ \db ->
-          withLeiosDb db $ \con -> do
-            -- Insert point and body, but no txs
-            leiosDbInsertEbPoint con point (leiosEbBytesSize eb)
-            leiosDbInsertEbBody con point eb
-            (work, queryTime) <- timed $ leiosDbQueryFetchWork con
-            let expectedTxCount = numTxs
-            pure $
-              conjoin
-                [ -- Should have no missing bodies (we inserted the body)
-                  missingEbBodies work === Map.empty
-                    & counterexample "Should have no missing bodies"
-                , -- Should have the EB with missing TXs
-                  Map.size (missingEbTxs work) === 1
-                    & counterexample ("Expected 1 EB with missing TXs, got: " ++ show (Map.size $ missingEbTxs work))
-                , -- The missing TX count should match
-                  case Map.toList (missingEbTxs work) of
-                    [(_, txs)] ->
-                      length txs === expectedTxCount
-                        & counterexample ("Expected " ++ show expectedTxCount ++ " missing TXs, got: " ++ show (length txs))
-                    _ -> False & counterexample "Unexpected missing TXs structure"
-                ]
-                & tabulate "queryFetchWork (missing txs)" [timeBucket queryTime]
-                & tabulate "numTxs" [magnitudeBucket numTxs]
-
--- | Property: EBs with all TXs present have no missing TXs.
-prop_fetchWorkCompleteTxs :: DbImpl -> Property
-prop_fetchWorkCompleteTxs impl =
-  forAllShrinkShow (chooseInt (1, 20)) shrink show $ \numTxs ->
-    forAll (genPointAndEb numTxs) $ \(point, eb) ->
-      forAllBlind genTxBytes $ \baseTxBytes ->
-        ioProperty $
-          withFreshDb impl $ \db ->
-            withLeiosDb db $ \con -> do
-              -- Insert point, body, and all txs
-              leiosDbInsertEbPoint con point (leiosEbBytesSize eb)
-              leiosDbInsertEbBody con point eb
-              let ebTxList = V.toList (leiosEbTxs eb)
-                  txsToInsert =
-                    [ (txHash, baseTxBytes)
-                    | (txHash, _size) <- ebTxList
-                    ]
-              _ <- leiosDbInsertTxs con txsToInsert
-              (work, queryTime) <- timed $ leiosDbQueryFetchWork con
-              pure $
-                conjoin
-                  [ -- Should have no missing bodies
-                    missingEbBodies work === Map.empty
-                      & counterexample "Should have no missing bodies"
-                  , -- Should have no missing TXs
-                    missingEbTxs work === Map.empty
-                      & counterexample ("Should have no missing TXs, got: " ++ show (missingEbTxs work))
-                  ]
-                  & tabulate "queryFetchWork (complete)" [timeBucket queryTime]
-                  & tabulate "numTxs" [magnitudeBucket numTxs]
-
 -- * Test utilities
 
 -- | Assert that a notification is AcquiredEb with the expected point.
@@ -886,7 +755,7 @@ prop_filterTxsCorrect impl =
               & tabulate "filterMissingTxs" [timeBucket filterTime]
               & tabulate "numTxs" [magnitudeBucket numTxs]
 
--- * Property tests for queryCompletedEbByPoint
+-- * Property tests for lookupEbClosure
 
 -- | Property: complete EB (all txs inserted) returns Just with correct tx data.
 prop_completedEbComplete :: DbImpl -> Property
@@ -900,7 +769,7 @@ prop_completedEbComplete impl =
           let ebTxList = V.toList (leiosEbTxs eb)
               txsToInsert = [(txHash, txBytes) | (txHash, _size) <- ebTxList]
           _ <- leiosDbInsertTxs con txsToInsert
-          (result, queryTime) <- timed $ leiosDbQueryCompletedEbByHash con (pointEbHash point)
+          (result, queryTime) <- timed $ leiosDbLookupEbClosure con (pointEbHash point)
           let expectedHashes = map fst txsToInsert
               check = case result of
                 Nothing ->
@@ -916,7 +785,7 @@ prop_completedEbComplete impl =
                     ]
           pure $
             check
-              & tabulate "queryCompletedEbByPoint (complete)" [timeBucket queryTime]
+              & tabulate "lookupEbClosure (complete)" [timeBucket queryTime]
               & tabulate "numTxs" [magnitudeBucket numTxs]
 
 -- | Property: EB with body but no txs returns Nothing.
@@ -927,11 +796,11 @@ prop_completedEbMissingTxs impl =
       ioProperty $ withFreshDb impl $ \db -> withLeiosDb db $ \con -> do
         leiosDbInsertEbPoint con point (leiosEbBytesSize eb)
         leiosDbInsertEbBody con point eb
-        (result, queryTime) <- timed $ leiosDbQueryCompletedEbByHash con (pointEbHash point)
+        (result, queryTime) <- timed $ leiosDbLookupEbClosure con (pointEbHash point)
         pure $
           result === Nothing
             & counterexample "Expected Nothing when no txs are present"
-            & tabulate "queryCompletedEbByPoint (no txs)" [timeBucket queryTime]
+            & tabulate "lookupEbClosure (no txs)" [timeBucket queryTime]
             & tabulate "numTxs" [magnitudeBucket numTxs]
 
 -- | Property: EB with partial txs (at least one missing) returns Nothing.
@@ -948,7 +817,7 @@ prop_completedEbPartialTxs impl =
               partialTxs = take (numTxs `div` 2) ebTxList
               txsToInsert = [(txHash, txBytes) | (txHash, _size) <- partialTxs]
           _ <- leiosDbInsertTxs con txsToInsert
-          (result, queryTime) <- timed $ leiosDbQueryCompletedEbByHash con (pointEbHash point)
+          (result, queryTime) <- timed $ leiosDbLookupEbClosure con (pointEbHash point)
           pure $
             result === Nothing
               & counterexample
@@ -958,7 +827,7 @@ prop_completedEbPartialTxs impl =
                     ++ show numTxs
                     ++ " txs present"
                 )
-              & tabulate "queryCompletedEbByPoint (partial txs)" [timeBucket queryTime]
+              & tabulate "lookupEbClosure (partial txs)" [timeBucket queryTime]
               & tabulate "numTxs" [magnitudeBucket numTxs]
 
 -- | Property: EB with only a point announced (no body) returns Nothing.
@@ -967,8 +836,8 @@ prop_completedEbNoBody impl =
   forAll genPoint $ \point ->
     ioProperty $ withFreshDb impl $ \db -> withLeiosDb db $ \con -> do
       leiosDbInsertEbPoint con point 1000
-      (result, queryTime) <- timed $ leiosDbQueryCompletedEbByHash con (pointEbHash point)
+      (result, queryTime) <- timed $ leiosDbLookupEbClosure con (pointEbHash point)
       pure $
         result === Nothing
           & counterexample "Expected Nothing for EB with no body inserted"
-          & tabulate "queryCompletedEbByPoint (no body)" [timeBucket queryTime]
+          & tabulate "lookupEbClosure (no body)" [timeBucket queryTime]


### PR DESCRIPTION
We saw segfaults since we added more strict bracketing on the sqlite connections. Notentirely pin pointed, but preparing statements once and having sqlite clean it up on connection close seems to help. See also commit history foe things attempted.

This is also improving performance on the queries that used temp in-mem tables by some **30%** using JSON1 queries.