### PR TITLE
Fix genesis tests

### DIFF
--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LoP.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LoP.hs
@@ -12,9 +12,11 @@ module Test.Consensus.Genesis.Tests.LoP
   , testSuite
   ) where
 
+import Cardano.Ledger.BaseTypes.NonZero (unNonZero)
 import Data.Functor (($>))
 import Data.Ratio ((%))
-import Ouroboros.Consensus.Block.Abstract (Header)
+import Ouroboros.Consensus.Block.Abstract (Header, HeaderFields (..), unSlotNo)
+import Ouroboros.Consensus.Config.SecurityParam (SecurityParam (..))
 import qualified Ouroboros.Consensus.MiniProtocol.ChainSync.Client as CSClient
 import Ouroboros.Consensus.Util.IOLike
   ( DiffTime
@@ -26,7 +28,7 @@ import Ouroboros.Consensus.Util.LeakyBucket
   )
 import Ouroboros.Network.AnchoredFragment
   ( AnchoredFragment
-  , HasHeader
+  , HasHeader (..)
   )
 import qualified Ouroboros.Network.AnchoredFragment as AF
 import Test.Consensus.BlockTree (BlockTree (..), BlockTreeBranch (..))
@@ -49,6 +51,7 @@ import Test.Consensus.PointSchedule.SinglePeer
   , scheduleHeaderPoint
   , scheduleTipPoint
   )
+import Test.QuickCheck.Gen (suchThat)
 import Test.Util.Orphans.IOLike ()
 import Test.Util.PartialAccessors
 
@@ -216,7 +219,7 @@ testServe description mustTimeout =
     adjustTestCount
     adjustMaxSize
     ( do
-        gt@GenesisTest{gtBlockTree} <- genChains (pure 0)
+        gt@GenesisTest{gtBlockTree} <- genChains (pure 0) `suchThat` hasAtLeastOneBlockPerEpoch
         let lbpRate = borderlineRate (AF.length (btTrunk gtBlockTree))
             ps = makeSchedule (btTrunk gtBlockTree)
             gt' = gt{gtLoPBucketParams = LoPBucketParams{lbpCapacity, lbpRate}}
@@ -279,7 +282,7 @@ testDelayAttack description lopEnabled =
     adjustTestCount
     adjustMaxSize
     ( do
-        gt@GenesisTest{gtBlockTree} <- genChains (pure 1)
+        gt@GenesisTest{gtBlockTree} <- genChains (pure 1) `suchThat` hasAtLeastOneBlockPerEpoch
         let gt' = gt{gtLoPBucketParams = LoPBucketParams{lbpCapacity = 10, lbpRate = 1}}
             ps = delaySchedule gtBlockTree
         pure $ gt' $> ps
@@ -354,3 +357,22 @@ testDelayAttack description lopEnabled =
         -- Wait for LoP bucket to empty
         psMinEndTime = Time 11
      in PointSchedule{psSchedule, psStartOrder = [], psMinEndTime}
+
+-- \| Ensure that the block tree has at least one block per epoch on all branches.
+-- Otherwise, issues would arise when trying to update the ledger from era n to era n+2.
+hasAtLeastOneBlockPerEpoch :: HasHeader blk => GenesisTest blk schedule -> Bool
+hasAtLeastOneBlockPerEpoch GenesisTest{gtBlockTree, gtSecurityParam} =
+  all fragmentHasEnoughBlocks (btTrunk gtBlockTree : (btbFull <$> btBranches gtBlockTree))
+ where
+  k = unNonZero $ maxRollbacks gtSecurityParam
+  -- \| This value comes from `defaultErasParams`, which is way out of scope from here.
+  -- We should find a way to avoid repetition of this value, or at least centralize it.
+  epochSize = 10 * k
+  slotList frag = slotNo <$> AF.toOldestFirst frag
+  slotNo = unSlotNo . headerFieldSlot . getHeaderFields
+
+  fragmentHasEnoughBlocks frag =
+    all
+      (\(prev, next) -> next - prev <= epochSize)
+      -- \| Add 0 at the beginning to simulate Origin
+      (zip (0 : slotList frag) (slotList frag))

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Shrinking.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Shrinking.hs
@@ -90,7 +90,8 @@ shrinkPeerSchedules genesisTest@GenesisTest{gtBlockTree, gtSchedule} _stateView 
                     , psMinEndTime = simulationDuration
                     }
               }
-   in shrunkAdversarialPeers ++ shrunkHonestPeers
+      hasPeers GenesisTest{gtSchedule = PointSchedule{psSchedule = peers}} = not $ null peers
+   in filter hasPeers $ shrunkAdversarialPeers ++ shrunkHonestPeers
 
 -- | Shrink a 'PointSchedule' by removing adversaries. This does not affect
 -- the honest peers; and it does not remove ticks from the schedules of the

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Shrinking.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Shrinking.hs
@@ -20,6 +20,7 @@ import Control.Monad.Class.MonadTime.SI
   )
 import Data.Containers.ListUtils (nubOrd)
 import Data.Foldable (toList)
+import Data.Function ((&))
 import Data.Functor ((<&>))
 import qualified Data.Map.Strict as Map
 import Data.Maybe (catMaybes, mapMaybe)
@@ -125,9 +126,21 @@ duration PointSchedule{psSchedule, psMinEndTime} =
   maximum $ psMinEndTime : [t | sch <- toList psSchedule, (t, _) <- take 1 (reverse sch)]
 
 -- | Shrink a 'PeerSchedule' by removing ticks from it. The other ticks are kept
--- unchanged.
-shrinkAdversarialPeer :: PeerSchedule blk -> [PeerSchedule blk]
-shrinkAdversarialPeer = shrinkList (const [])
+-- unchanged. Preserve TP/HP/BP consistency, that is, at any time, TP >= HP and HP >= BP.
+shrinkAdversarialPeer :: Ord blk => PeerSchedule blk -> [PeerSchedule blk]
+shrinkAdversarialPeer = (filter preservesConsistency) . shrinkList (const [])
+ where
+  preservesConsistency sch =
+    foldr
+      ( \(_t, p) (tp, hp, acc) ->
+          case p of
+            ScheduleTipPoint newTp -> (newTp, hp, acc)
+            ScheduleHeaderPoint newHp -> (tp, newHp, acc && tp >= newHp)
+            ScheduleBlockPoint newBp -> (tp, hp, acc && hp >= newBp)
+      )
+      (Slot.Origin, Slot.Origin, True)
+      sch
+      & (\(_, _, x) -> x)
 
 -- | Shrink the 'others' field of a 'Peers' structure by attempting to remove
 -- peers or by shrinking their values using the given shrinking function.

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Shrinking.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Shrinking.hs
@@ -4,7 +4,8 @@
 
 module Test.Consensus.PointSchedule.Shrinking
   ( -- | Exported only for testing (that is, checking the properties of the function)
-    shrinkByRemovingAdversaries
+    shrinkAdversarialPeer
+  , shrinkByRemovingAdversaries
   , shrinkHonestPeer
   , shrinkHonestPeers
   , shrinkPeerSchedules

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Shrinking/Tests.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Shrinking/Tests.hs
@@ -4,8 +4,10 @@
 -- | Test properties of the shrinking functions
 module Test.Consensus.PointSchedule.Shrinking.Tests (tests) where
 
+import Cardano.Slotting.Slot (WithOrigin (..))
+import Control.Monad.Class.MonadTime.SI (Time (..))
 import Data.Foldable (toList)
-import Data.Map (keys)
+import Data.Map (elems, empty, keys, singleton)
 import Data.Maybe (mapMaybe)
 import Ouroboros.Consensus.Util (lastMaybe)
 import Test.Consensus.Genesis.Setup (genChains)
@@ -15,8 +17,8 @@ import Test.Consensus.PointSchedule
   , PointSchedule (..)
   , prettyPointSchedule
   )
-import Test.Consensus.PointSchedule.Peers (Peers (..))
-import Test.Consensus.PointSchedule.Shrinking (shrinkHonestPeers)
+import Test.Consensus.PointSchedule.Peers (PeerId (..), Peers (..))
+import Test.Consensus.PointSchedule.Shrinking (shrinkAdversarialPeer, shrinkHonestPeers)
 import Test.Consensus.PointSchedule.SinglePeer (SchedulePoint (..))
 import Test.QuickCheck (Property, conjoin, counterexample)
 import Test.Tasty
@@ -29,16 +31,23 @@ tests =
     "shrinking functions"
     [ testGroup
         "honest peer shrinking"
-        [ testProperty "actually shortens the schedule" prop_shortens
-        , testProperty "preserves the final state all peers" prop_preservesFinalStates
+        [ testProperty "actually shortens the schedule" prop_honShortens
+        , testProperty "preserves the final state all peers" prop_honPreservesFinalStates
+        ]
+    , testGroup
+        "adversarial peer shrinking"
+        [ testProperty "preserves consistency of TP/HP/BP" prop_advPreservesConsistency
         ]
     ]
 
-prop_shortens :: Property
-prop_shortens = checkShrinkProperty isShorterThan
+prop_honShortens :: Property
+prop_honShortens = checkHonShrinkProperty isShorterThan
 
-prop_preservesFinalStates :: Property
-prop_preservesFinalStates = checkShrinkProperty doesNotChangeFinalState
+prop_honPreservesFinalStates :: Property
+prop_honPreservesFinalStates = checkHonShrinkProperty doesNotChangeFinalState
+
+prop_advPreservesConsistency :: Property
+prop_advPreservesConsistency = checkAdvShrinkProperty preservesConsistency
 
 samePeers :: Peers (PeerSchedule blk) -> Peers (PeerSchedule blk) -> Bool
 samePeers sch1 sch2 =
@@ -79,9 +88,23 @@ doesNotChangeFinalState original shrunk =
   lastBP :: PeerSchedule blk -> Maybe (SchedulePoint blk)
   lastBP sch = lastMaybe $ mapMaybe (\case (_, p@(ScheduleBlockPoint _)) -> Just p; _ -> Nothing) sch
 
-checkShrinkProperty ::
+-- | Checks that the shrunk schedule still has the properties TP >= HP and HP >= BP at any time
+preservesConsistency :: Ord blk => PeerSchedule blk -> Bool
+preservesConsistency shrunk =
+  (\(_, _, x) -> x) $
+    foldr
+      ( \(_t, p) (tp, hp, acc) ->
+          case p of
+            ScheduleTipPoint newTp -> (newTp, hp, acc)
+            ScheduleHeaderPoint newHp -> (tp, newHp, acc && tp >= newHp)
+            ScheduleBlockPoint newBp -> (tp, hp, acc && hp >= newBp)
+      )
+      (Origin, Origin, True)
+      shrunk
+
+checkHonShrinkProperty ::
   (Peers (PeerSchedule TestBlock) -> Peers (PeerSchedule TestBlock) -> Bool) -> Property
-checkShrinkProperty prop =
+checkHonShrinkProperty prop =
   forAllBlind
     (genChains (choose (1, 4)) >>= genUniformSchedulePoints)
     ( \sch@PointSchedule{psSchedule, psStartOrder, psMinEndTime} ->
@@ -102,3 +125,40 @@ checkShrinkProperty prop =
             )
             (shrinkHonestPeers psSchedule)
     )
+
+checkAdvShrinkProperty :: (PeerSchedule TestBlock -> Bool) -> Property
+checkAdvShrinkProperty prop =
+  forAllBlind
+    ( do
+        chains <- genChains (choose (1, 4))
+        PointSchedule{psSchedule} <- genUniformSchedulePoints chains
+        -- \| We generated at least one honest peer schedule, and it can serve as adversarial
+        -- for the intent of this test.
+        case elems $ honestPeers psSchedule of
+          sch : _ -> pure sch
+          _ -> error "checkAdvShrinkProperty: no honest peer schedule generated"
+    )
+    ( \sch ->
+        conjoin $
+          map
+            ( \shrunk ->
+                counterexample
+                  ( "Original schedule:\n"
+                      ++ unlines (map ("    " ++) $ prettyPointSchedule $ mkAdvPointSchedule sch)
+                      ++ "\nShrunk schedule:\n"
+                      ++ unlines (map ("    " ++) $ prettyPointSchedule $ mkAdvPointSchedule shrunk)
+                  )
+                  (prop shrunk)
+            )
+            (shrinkAdversarialPeer sch)
+    )
+
+mkAdvPointSchedule :: PeerSchedule TestBlock -> PointSchedule TestBlock
+mkAdvPointSchedule sch =
+  PointSchedule
+    { psSchedule = Peers{honestPeers = empty, adversarialPeers = singleton 1 sch}
+    , psStartOrder = [AdversarialPeer 1]
+    , psMinEndTime = case lastMaybe sch of
+        Nothing -> Time 0
+        Just (t, _) -> t
+    }


### PR DESCRIPTION
This PR fixes a bunch of issues in the Genesis tests, that were unearthed during Peras development:

- Shrinking the peer schedule could remove all peers, thus breaking several downstream assumptions
- Shrinking the adversarial schedule could break the assumption that `TipPoint >= HeaderPoint >= BlockPoint`, thus potentially leading to unexpected (and uninteresting, in the context of Genesis tests) disconnections.
- While generating chains, we would sometimes generate less than one block per epoch, thus leading to errors when the ledger would try to update directly from epoch `n` to epoch `n+2`