### PR TITLE
Fold in leios testnet bugfixes from 20260708 stuck sync incident

### DIFF
--- a/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/Block.hs
+++ b/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/Block.hs
@@ -1597,6 +1597,10 @@ instance
     HeaderDijkstra dHdr -> headerLeiosAnnouncement dHdr
     _ -> Nothing
 
+  headerContainsLeiosCert hdr = case hdr of
+    HeaderDijkstra dHdr -> headerContainsLeiosCert dHdr
+    _ -> False
+
   protocolStateLeiosAnnouncement cds = case cds of
     ChainDepStateDijkstra praosSt ->
       protocolStateLeiosAnnouncement @(ShelleyBlock (Praos c) DijkstraEra) praosSt

--- a/ouroboros-consensus.cabal
+++ b/ouroboros-consensus.cabal
@@ -391,6 +391,7 @@ library
     mtl,
     multiset ^>=0.3,
     network-mux,
+    nonempty-containers,
     nothunks ^>=0.2 || ^>=0.3,
     ouroboros-network:{api, api-tests-lib, protocols} ^>=1.1,
     pretty-simple,

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoDb/Common.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoDb/Common.hs
@@ -37,7 +37,7 @@ data LeiosDbHandle m = LeiosDbHandle
   -- TODO: make return type more descriptive (e.g. Subscription { getNext :: STM m LeiosEbNotification })
   , open :: m (LeiosDbConnection m)
   -- ^ Open a new connection to the LeiosDb.
-  , leiosDbScanCompleteEbClosuresNotOlderThanSlot :: HasCallStack => SlotNo -> m [EbHash]
+  , leiosDbScanCompleteEbClosuresNotOlderThanSlot :: HasCallStack => SlotNo -> m [LeiosPoint]
   -- ^ Scan the EBs whose tx closure is already complete and that were announced
   -- by an RB no older than the given slot. The ChainDB calls this once at
   -- startup -- passing the immutable tip slot -- to seed the acquired-EB

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoDb/InMemory.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoDb/InMemory.hs
@@ -269,16 +269,14 @@ imInsertTxs stateVar notificationChan txs = atomically $ do
 -- @>= sinceSlot@, so we collect (and dedupe) the hashes of those points. This
 -- is precise across all of an EB's announcer slots, as in the SQLite backend.
 imScanCompleteEbClosuresSince ::
-  IOLike m => StrictTVar m InMemoryLeiosDb -> SlotNo -> m [EbHash]
+  IOLike m => StrictTVar m InMemoryLeiosDb -> SlotNo -> m [LeiosPoint]
 imScanCompleteEbClosuresSince stateVar sinceSlot = atomically $ do
   s <- readTVar stateVar
-  pure $
-    Set.toList $
-      Set.fromList
-        [ pointEbHash p
-        | p <- Set.toList (imCompletedEbs s)
-        , pointSlotNo p >= sinceSlot
-        ]
+  pure
+    [ p
+    | p <- Set.toList (imCompletedEbs s)
+    , pointSlotNo p >= sinceSlot
+    ]
 
 imBatchRetrieveTxs ::
   IOLike m => StrictTVar m InMemoryLeiosDb -> EbHash -> [Int] -> m [(Int, TxHash, Maybe ByteString)]

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoDb/SQLite.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoDb/SQLite.hs
@@ -111,16 +111,16 @@ newLeiosDBSQLite tracer dbPath = do
 -- connection. Only an existing DB can hold complete closures: a
 -- fresh DB file is created lazily by the first 'open', so when the file does
 -- not exist there is nothing to scan.
-sqlScanCompleteEbClosuresSince :: FilePath -> SlotNo -> IO [EbHash]
+sqlScanCompleteEbClosuresSince :: FilePath -> SlotNo -> IO [LeiosPoint]
 sqlScanCompleteEbClosuresSince dbPath sinceSlot = do
   dbExists <- doesFileExist dbPath
   if not dbExists
     then pure []
     else do
       db <- open2 (fromString dbPath) [SQLOpenReadWrite] SQLVFSDefault
-      hashes <- sqlScanCompleteEbHashesSince db sinceSlot
+      points <- sqlScanCompleteEbPointsSince db sinceSlot
       void $ DB.close db
-      pure hashes
+      pure points
 
 -- * Connection management
 
@@ -172,16 +172,17 @@ sqlScanEbPoints db =
               loop ((slot, hash) : acc)
     loop []
 
-sqlScanCompleteEbHashesSince :: DB.Database -> SlotNo -> IO [EbHash]
-sqlScanCompleteEbHashesSince db sinceSlot =
+sqlScanCompleteEbPointsSince :: DB.Database -> SlotNo -> IO [LeiosPoint]
+sqlScanCompleteEbPointsSince db sinceSlot =
   dbWithBEGIN db $ dbWithPrepare db (fromString sql_scan_complete_ebs_since) $ \stmt -> do
     dbBindInt64 stmt 1 (fromIntegral $ unSlotNo sinceSlot)
     let loop acc =
           dbStep stmt >>= \case
             DB.Done -> pure (reverse acc)
             DB.Row -> do
-              hash <- MkEbHash <$> DB.columnBlob stmt 0
-              loop (hash : acc)
+              slot <- SlotNo . fromIntegral <$> DB.columnInt64 stmt 0
+              hash <- MkEbHash <$> DB.columnBlob stmt 1
+              loop (MkLeiosPoint slot hash : acc)
     loop []
 
 sqlLookupEbPoint :: DB.Database -> EbHash -> IO (Maybe SlotNo)
@@ -487,10 +488,11 @@ sql_scan_ebs =
 -- /any/ complete row and /any/ row at @ebSlot >= ?@.
 sql_scan_complete_ebs_since :: String
 sql_scan_complete_ebs_since =
-  "SELECT DISTINCT ebHashBytes FROM ebs\n\
+  "SELECT MAX(ebSlot), ebHashBytes FROM ebs\n\
   \WHERE ebSlot >= ?\n\
   \  AND ebHashBytes IN\n\
   \      (SELECT ebHashBytes FROM ebs WHERE missingTxCount IS NOT NULL AND missingTxCount <= 0)\n\
+  \GROUP BY ebHashBytes\n\
   \"
 
 sql_lookup_eb :: String

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic.hs
@@ -872,8 +872,10 @@ leiosCertRbOffer (outstandingVar, readyVar) peerVars (point, ebBytesSize) = do
             }
   -- As if 'MsgLeiosBlockOffer' (body) and 'MsgLeiosBlockTxsOffer' (txs): record
   -- this peer as offering both.
-  MVar.modifyMVar_ (Leios.offerings peerVars) $ \(offers1, offers2) ->
-    pure (Set.insert ebHash offers1, Set.insert ebHash offers2)
+  MVar.modifyMVar_ (Leios.offerings peerVars) $ \(offers1, offers2) -> do
+    let !offers1' = Set.insert ebHash offers1
+        !offers2' = Set.insert ebHash offers2
+    pure (offers1', offers2')
   void $ MVar.tryPutMVar readyVar ()
 
 -----

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoOnlyTestFetch.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoOnlyTestFetch.hs
@@ -552,7 +552,7 @@ leiosFetchClientPeerPipelined tryNext =
         Succ m ->
           Collect
             (Just $ send stop n job)
-            (\MkC -> go1 stop m)
+            (\MkC -> send stop m job)
 
   send ::
     MutVar (PrimState m) WhetherDraining ->

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoTypes.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoTypes.hs
@@ -1,6 +1,9 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE GADTs #-}
@@ -57,7 +60,7 @@ import Cardano.Crypto.Leios
 import Cardano.Crypto.Util (SignableRepresentation (..))
 import Cardano.Ledger.Core (EraTx, Tx, TxLevel (TopTx))
 import Cardano.Prelude (NFData, NonEmpty, toList, toString, (&))
-import Cardano.Slotting.Slot (SlotNo (SlotNo))
+import Cardano.Slotting.Slot (SlotNo (SlotNo), WithOrigin, withOrigin)
 import Codec.Serialise (Serialise, decode, encode)
 import Control.Concurrent.Class.MonadMVar (MVar)
 import qualified Control.Concurrent.Class.MonadMVar as MVar
@@ -71,17 +74,20 @@ import qualified Data.ByteString as BS
 import qualified Data.ByteString.Base16 as BS16
 import qualified Data.ByteString.Char8 as BS8
 import Data.Fixed (Pico)
+import Data.Foldable (foldl')
 import Data.Function (on)
 import Data.IntMap (IntMap)
 import qualified Data.IntMap as IntMap
 import Data.List (nubBy, sortOn)
 import Data.Map (Map)
-import qualified Data.Map as Map
+import qualified Data.Map.Strict as Map
 import Data.Ratio ((%))
 import Data.Sequence (Seq)
 import qualified Data.Sequence as Seq
 import Data.Set (Set)
 import qualified Data.Set as Set
+import Data.Set.NonEmpty (NESet)
+import qualified Data.Set.NonEmpty as NESet
 import Data.String (fromString)
 import Data.Vector.Strict (Vector)
 import qualified Data.Vector.Strict as V
@@ -94,6 +100,7 @@ import LeiosDemoOnlyTestFetch (LeiosFetch, Message (..))
 import qualified LeiosDemoOnlyTestFetch as LeiosFetch
 import LeiosDemoOnlyTestNotify (LeiosNotify, Message (..))
 import qualified LeiosDemoOnlyTestNotify as LeiosNotify
+import NoThunks.Class (OnlyCheckWhnfNamed (..))
 import qualified Numeric
 import Ouroboros.Consensus.Ledger.Basics (EmptyMK, LedgerState)
 import Ouroboros.Consensus.Ledger.SupportsMempool
@@ -200,6 +207,80 @@ decodeLeiosPoint :: Decoder s LeiosPoint
 decodeLeiosPoint = do
   enforceSize (fromString "LeiosPoint") 2
   MkLeiosPoint <$> decode <*> decodeEbHash
+
+-- | Acquired EB tx closures, aged by the youngest announcement slot ever seen
+-- for each EB (tracked here, not derived from the VolatileDB).
+data AcquiredLeiosEbs = AcquiredLeiosEbs
+  { alebYoungestSlot :: !(Map EbHash SlotNo)
+  , alebBySlot :: !(Map SlotNo (NESet EbHash))
+    -- ^ INVARIANT: is merely reverse index of 'alebYoungestSlot'
+  }
+  deriving stock (Show, Generic)
+
+deriving via
+  OnlyCheckWhnfNamed "AcquiredLeiosEbs" AcquiredLeiosEbs
+  instance
+    NoThunks AcquiredLeiosEbs
+
+emptyAcquiredLeiosEbs :: AcquiredLeiosEbs
+emptyAcquiredLeiosEbs = AcquiredLeiosEbs Map.empty Map.empty
+
+-- | Use the 'Map' as a 'Set' without allocating the 'Set'.
+data AcquiredLeiosEbsSet =
+  forall x. MkAcquiredLeiosEbsSet !(Map EbHash x)
+
+acquiredLeiosEbHashes :: AcquiredLeiosEbs -> AcquiredLeiosEbsSet
+acquiredLeiosEbHashes = MkAcquiredLeiosEbsSet . alebYoungestSlot
+
+acquiredLeiosEbsSetMember :: EbHash -> AcquiredLeiosEbsSet -> Bool
+acquiredLeiosEbsSetMember eb (MkAcquiredLeiosEbsSet m) = Map.member eb m
+
+-- | NOT EXPORTED
+--
+-- An auxiliary for 'insertAcquiredLeiosEb'.
+newtype Alteration a b = MkAlteration (Maybe (a, b)) deriving (Functor)
+
+-- | 'Nothing' if unchanged; @'Just' (novel, st')@ otherwise, where @novel@ is
+-- 'True' iff the EB was not present before. Only bumps the slot when strictly
+-- greater than the one recorded.
+insertAcquiredLeiosEb ::
+  LeiosPoint -> AcquiredLeiosEbs -> Maybe (Bool, AcquiredLeiosEbs)
+insertAcquiredLeiosEb (MkLeiosPoint slot eb) (AcquiredLeiosEbs youngest bySlot) =
+  case mbAltered of
+      Nothing -> Nothing
+      Just ((novel, bySlot'), youngest') ->
+        Just (novel, AcquiredLeiosEbs youngest' bySlot')
+ where
+  MkAlteration mbAltered =
+    Map.alterF (fmap Just . MkAlteration . alteration) eb youngest
+  alteration = \case
+      Nothing -> Just ((True, insertBucket slot eb bySlot), slot)
+      Just prevSlot
+        | slot <= prevSlot -> Nothing
+        | otherwise ->
+          Just ((False, insertBucket slot eb $ deleteBucket prevSlot eb bySlot), slot)
+
+  insertBucket s e = Map.insertWith NESet.union s (NESet.singleton e)
+  deleteBucket s e = Map.update (NESet.nonEmptySet . NESet.delete e) s
+
+acquiredLeiosEbsFromList :: [LeiosPoint] -> AcquiredLeiosEbs
+acquiredLeiosEbsFromList =
+  foldl' (\st p -> maybe st snd (insertAcquiredLeiosEb p st)) emptyAcquiredLeiosEbs
+
+-- | Drop every EB whose youngest announcement slot is strictly older than the
+-- given (immutable tip) slot.
+pruneAcquiredLeiosEbs ::
+  WithOrigin SlotNo -> AcquiredLeiosEbs -> Maybe AcquiredLeiosEbs
+pruneAcquiredLeiosEbs immTip (AcquiredLeiosEbs youngest bySlot) =
+  withOrigin Nothing prune immTip
+ where
+  prune immTipSlot
+    | Map.null prunedSlots = Nothing
+    | otherwise = Just (AcquiredLeiosEbs youngest' bySlot')
+   where
+    (prunedSlots, bySlot') = Map.spanAntitone (< immTipSlot) bySlot
+    prunedEbHashes = foldMap NESet.toSet prunedSlots
+    youngest' = youngest `Map.withoutKeys` prunedEbHashes
 
 -- | Types used in Praos headers
 data EbAnnouncement = EbAnnouncement

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl.hs
@@ -50,10 +50,13 @@ import Control.Tracer
 import Data.Functor ((<&>))
 import qualified Data.Map.Strict as Map
 import Data.Maybe.Strict (StrictMaybe (..))
-import qualified Data.Set as Set
 import GHC.Stack (HasCallStack)
 import LeiosDemoDb.Common (leiosDbScanCompleteEbClosuresNotOlderThanSlot)
-import LeiosDemoTypes (HasLeiosVoting)
+import LeiosDemoTypes
+  ( HasLeiosVoting
+  , acquiredLeiosEbHashes
+  , acquiredLeiosEbsFromList
+  )
 import NoThunks.Class
 import Ouroboros.Consensus.Block
 import Ouroboros.Consensus.Config
@@ -224,7 +227,7 @@ openDBInternal args launchBgTasks = runWithTempRegistry $ do
         (Args.cdbsLeiosDb cdbSpecificArgs)
         (fromWithOrigin (SlotNo 0) (pointSlot immutableDbTipPoint))
     varAcquiredLeiosEbs <-
-      newTVarIO (Set.fromList initialAcquiredLeiosEbs)
+      newTVarIO (acquiredLeiosEbsFromList initialAcquiredLeiosEbs)
     chain <-
       ChainSel.initialChainSelection
         immutableDB
@@ -233,7 +236,7 @@ openDBInternal args launchBgTasks = runWithTempRegistry $ do
         initChainSelTracer
         (Args.cdbsTopLevelConfig cdbSpecificArgs)
         varInvalid
-        (readTVar varAcquiredLeiosEbs)
+        (acquiredLeiosEbHashes <$> readTVar varAcquiredLeiosEbs)
         (void initialLoE)
         (forgetFingerprint initialWeights)
     traceWith initChainSelTracer InitialChainSelected

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Background.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Background.hs
@@ -53,7 +53,6 @@ import qualified Data.Map.Strict as Map
 import Data.Maybe.Strict (strictMaybeToMaybe)
 import Data.Sequence.Strict (StrictSeq (..))
 import qualified Data.Sequence.Strict as Seq
-import qualified Data.Set as Set
 import Data.Time.Clock
 import Data.Void (Void)
 import Data.Word
@@ -66,6 +65,7 @@ import LeiosDemoDb.Common
   , subscribeEbNotifications
   )
 import LeiosDemoTypes (LeiosPoint, pointEbHash)
+import qualified LeiosDemoTypes
 import Ouroboros.Consensus.Block
 import Ouroboros.Consensus.HardFork.Abstract
 import Ouroboros.Consensus.Ledger.Inspect
@@ -167,15 +167,15 @@ leiosAcquiredEbsRunner CDB{..} = do
     atomically (readTChan chan) >>= \case
       AcquiredEb{} -> pure ()
       AcquiredEbTxs point -> do
-        let ebHash = pointEbHash point
-        novel <- atomically $ do
+        mNovel <- atomically $ do
           acquired <- readTVar cdbAcquiredLeiosEbs
-          if Set.member ebHash acquired
-            then pure False
-            else do
-              writeTVar cdbAcquiredLeiosEbs (Set.insert ebHash acquired)
-              pure True
-        when novel $ addReprocessLeiosEb ebHash cdbChainSelQueue
+          case LeiosDemoTypes.insertAcquiredLeiosEb point acquired of
+            Nothing -> pure Nothing
+            Just (novel, acquired') -> do
+              writeTVar cdbAcquiredLeiosEbs acquired'
+              pure (Just novel)
+        when (mNovel == Just True) $
+          addReprocessLeiosEb (pointEbHash point) cdbChainSelQueue
 
 {-------------------------------------------------------------------------------
   Copying blocks from the VolatileDB to the ImmutableDB
@@ -488,31 +488,16 @@ garbageCollectBlocks CDB{..} slotNo = do
   leiosDbGarbageCollect cdbLeiosDb slotNo
   traceWith cdbTracer $ TraceGCEvent $ PerformedGC slotNo
 
--- | Prune the acquired-EB set ('cdbAcquiredLeiosEbs') down to the EBs that
--- still have an announcer at or after the given (immutable tip) slot. An EB is
--- dropped only when /every/ announcer of it is /strictly/ older than the
--- immutable tip.
---
--- The strictness is essential: the announcement made by the immutable tip
--- itself is certified by the tip's /successor/, which is still in the volatile
--- suffix -- so a live RB may yet certify that EB, and it must be kept. Only when
--- an announcer is strictly older than the tip is its certifying successor (the
--- next block) necessarily at or before the tip, hence immutable; then the EB
--- can no longer be newly certified and ChainSel will never reconsider it.
---
--- Called as a VolatileDB GC is /scheduled/ (see 'copyToImmutableDBRunner'),
--- which is at least @cdbGcDelay@ before that GC -- and the LeiosDb closure
--- eviction it drives -- actually runs. So the acquired set stops advertising a
--- closure well before the closure itself can be evicted.
+-- | Prune the acquired-EB set by age as a VolatileDB GC is scheduled, dropping
+-- every EB whose youngest announcement slot is strictly older than the immutable
+-- tip (its certifying successor is then necessarily immutable).
 pruneAcquiredLeiosEbs ::
   IOLike m => ChainDbEnv m blk -> WithOrigin SlotNo -> m ()
 pruneAcquiredLeiosEbs CDB{..} immTip = atomically $ do
-  getAnnouncers <- VolatileDB.getLeiosAnnouncers cdbVolatileDB
-  let keep eb = any ((>= immTip) . pointSlot) (getAnnouncers eb)
   acquired <- readTVar cdbAcquiredLeiosEbs
-  let acquired' = Set.filter keep acquired
-  when (Set.size acquired' /= Set.size acquired) $
-    writeTVar cdbAcquiredLeiosEbs acquired'
+  mapM_
+    (writeTVar cdbAcquiredLeiosEbs)
+    (LeiosDemoTypes.pruneAcquiredLeiosEbs immTip acquired)
 
 {-------------------------------------------------------------------------------
   Scheduling garbage collections

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/ChainSel.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/ChainSel.hs
@@ -48,7 +48,12 @@ import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.Traversable (for)
 import GHC.Stack (HasCallStack)
-import LeiosDemoTypes (EbHash, pointEbHash)
+import LeiosDemoTypes
+  ( AcquiredLeiosEbsSet
+  , acquiredLeiosEbHashes
+  , acquiredLeiosEbsSetMember
+  , pointEbHash
+  )
 import Ouroboros.Consensus.Block
 import Ouroboros.Consensus.BlockchainTime.WallClock.Types (WithArrivalTime)
 import Ouroboros.Consensus.Config
@@ -128,7 +133,7 @@ initialChainSelection ::
   -- are skipped, exactly as in 'constructPreferableCandidates'; only the
   -- successor filter is needed here, since 'constructChains' only ever reaches a
   -- block as a successor of the immutable anchor (never as a standalone tip).
-  STM m (Set EbHash) ->
+  STM m AcquiredLeiosEbsSet ->
   LoE () ->
   PerasWeightSnapshot blk ->
   m (AnchoredFragment (Header blk))
@@ -749,7 +754,7 @@ constructPreferableCandidates CDB{..} weights curChain hdrCache p = do
     -- 'ignoreUnacquiredCertRBSuc'). This is a /transient/ exclusion (the EB may
     -- arrive later and make the block selectable) — unlike the permanent
     -- 'ignoreInvalid'/'ignoreInvalidSuc' exclusion of invalid blocks.
-    acquiredEbs <- readTVar cdbAcquiredLeiosEbs
+    acquiredEbs <- acquiredLeiosEbHashes <$> readTVar cdbAcquiredLeiosEbs
     rawSuccsOf <- VolatileDB.filterByPredecessor cdbVolatileDB
     rawLookupBlockInfo <- VolatileDB.getBlockInfo cdbVolatileDB
     let succsOf =
@@ -1471,7 +1476,7 @@ ignoreInvalidSuc _ invalid succsOf =
 -- that the predecessor's announcement is read regardless of any other
 -- filtering.
 isUnacquiredCertRB ::
-  Set EbHash ->
+  AcquiredLeiosEbsSet ->
   (HeaderHash blk -> Maybe (VolatileDB.BlockInfo blk)) ->
   HeaderHash blk ->
   Bool
@@ -1495,14 +1500,14 @@ isUnacquiredCertRB acquiredEbs lookupBlockInfo h = case lookupBlockInfo h of
             -- malformed and rejected by header validation (as above). Either
             -- way, report it unacquired.
             Nothing -> True
-            Just ebPt -> pointEbHash ebPt `Set.notMember` acquiredEbs
+            Just ebPt -> not (acquiredLeiosEbsSetMember (pointEbHash ebPt) acquiredEbs)
 
 -- | Wrap @getBlockInfo@ so that a cert-RB whose required EB closure has not been
 -- acquired ('isUnacquiredCertRB') is reported as absent — hiding it from chain
 -- selection both as a candidate tip and (with 'ignoreUnacquiredCertRBSuc') as a
 -- successor, so it is parked in the VolatileDB until its EB arrives.
 ignoreUnacquiredCertRB ::
-  Set EbHash ->
+  AcquiredLeiosEbsSet ->
   (HeaderHash blk -> Maybe (VolatileDB.BlockInfo blk)) ->
   (HeaderHash blk -> Maybe (VolatileDB.BlockInfo blk))
 ignoreUnacquiredCertRB acquiredEbs lookupBlockInfo h
@@ -1512,7 +1517,7 @@ ignoreUnacquiredCertRB acquiredEbs lookupBlockInfo h
 -- | Wrap a @successors@ function so that cert-RBs whose required EB closure has
 -- not been acquired are not returned as successors. See 'ignoreUnacquiredCertRB'.
 ignoreUnacquiredCertRBSuc ::
-  Set EbHash ->
+  AcquiredLeiosEbsSet ->
   (HeaderHash blk -> Maybe (VolatileDB.BlockInfo blk)) ->
   (ChainHash blk -> Set (HeaderHash blk)) ->
   (ChainHash blk -> Set (HeaderHash blk))

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Types.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Types.hs
@@ -92,13 +92,12 @@ import Data.Map.Strict (Map)
 import Data.Maybe.Strict (StrictMaybe (..))
 import Data.MultiSet (MultiSet)
 import qualified Data.MultiSet as MultiSet
-import Data.Set (Set)
 import Data.Typeable
 import Data.Void (Void)
 import Data.Word (Word64)
 import GHC.Generics (Generic)
 import LeiosDemoDb.Common (LeiosDbHandle)
-import LeiosDemoTypes (EbHash)
+import LeiosDemoTypes (AcquiredLeiosEbs, EbHash)
 import NoThunks.Class (OnlyCheckWhnfNamed (..))
 import Ouroboros.Consensus.Block
 import Ouroboros.Consensus.BlockchainTime.WallClock.Types (WithArrivalTime)
@@ -386,23 +385,13 @@ data ChainDbEnv m blk = CDB
   -- ^ Information on the last starvation of ChainSel, whether ongoing or
   -- ended recently.
   , cdbPerasCertDB :: !(PerasCertDB m blk)
-  , cdbAcquiredLeiosEbs :: !(StrictTVar m (Set EbHash))
-  -- ^ The set of Leios endorser blocks (EBs) whose tx closure has been
-  -- acquired and whose announcer is no older than the immutable tip. ChainSel
-  -- consults it (membership) to avoid selecting an RB that certifies an EB
-  -- whose closure is not yet available. Owned by the ChainDB: seeded at open
-  -- from the LeiosDb (via 'leiosDbScanCompleteEbClosuresNotOlderThanSlot', filtered by the
-  -- immutable tip), grown by 'leiosAcquiredEbsRunner' from LeiosDb
-  -- closure-completion notifications, and pruned by 'pruneAcquiredLeiosEbs' as
-  -- a GC is scheduled (dropping EBs no longer announced by a VolatileDB block
-  -- at or after the immutable tip). On growth, 'leiosAcquiredEbsRunner' also
-  -- enqueues a 'ChainSelReprocessLeiosEb' so the @addBlockRunner@ reprocesses
-  -- the parked cert-RBs in FIFO order. Empty (and never written) when Leios is
-  -- not in play.
-  --
-  -- TODO: the prune is an O(set) sweep of the VolatileDB announcer index each
-  -- time a GC is scheduled; it could be made incremental given a feed of EB
-  -- announcements to maintain a slot index from.
+  , cdbAcquiredLeiosEbs :: !(StrictTVar m AcquiredLeiosEbs)
+  -- ^ The Leios EBs whose tx closure has been acquired, aged by youngest
+  -- announcement slot. ChainSel consults it (membership) to avoid selecting an
+  -- RB that certifies an EB whose closure is not yet available. Seeded at open
+  -- from the LeiosDb, grown by 'leiosAcquiredEbsRunner' from closure-completion
+  -- notifications (which also enqueue a 'ChainSelReprocessLeiosEb'), and pruned
+  -- by age as a GC is scheduled.
   , cdbLeiosDb :: !(LeiosDbHandle m)
   -- ^ The LeiosDb handle. The LeiosDb is one of the stores the ChainDB owns and
   -- orchestrates -- alongside the ImmutableDB, VolatileDB, LedgerDB and


### PR DESCRIPTION
This PR fixes three bugs.

* We were accidentally using the default method `headerContainsLeiosCert` for the HFC, so we essentially never interepted MsgRollForward as an offer. I have no idea how the manual testing had done for that original PR didn't fail despite that.
* The pruning logic for the set of EBs acquired was incorrect: it was assuming that all the announcements were necessarily in the VolDB. But---somewhat counterintuitively---our syncing node is downloading the EB _before_ it even downloads the announcer's RB. So this pruning logic was instantly deleting the EB.
* There was a deeply fundamental one-line bug in the implementation of the pipelined LeiosFetch client: if some unprocessed responses had arrived, we would sometimes (at the very last possible moment) discard a request instead of actually sending it to the upstream peer. But the LeiosFetch decision logic's accounting wasn't informed, so it eventually concluded too many requests were outstanding (even though they were never actually sent) for it to be able to send any more.

This code has been running on the testnet for 12 hrs now, without exhibiting the stuck syncs (which has been perfectly reliable prior to these).