### PR TITLE
Stop applying uncertified EBs from the ImmDB on startup (and increase LeiosNotify pipelining depth)

### DIFF
--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToNode.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToNode.hs
@@ -453,7 +453,7 @@ mkHandlers
             leiosNotifyClientPeerPipelined
               ( atomically controlMessageSTM <&> \case
                   Terminate -> Left ()
-                  _ -> Right 10 {- TODO magic number -}
+                  _ -> Right 100 {- TODO magic number -}
               )
               ( pure $ \case
                   MsgLeiosBlockAnnouncement{} -> error "Demo does not send EB announcements!"

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoDb/Common.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoDb/Common.hs
@@ -35,18 +35,17 @@ data LeiosDbHandle m = LeiosDbHandle
   -- TODO: make return type more descriptive (e.g. Subscription { getNext :: STM m LeiosEbNotification })
   , open :: m (LeiosDbConnection m)
   -- ^ Open a new connection to the LeiosDb.
-  , leiosDbScanCompleteEbClosuresNotOlderThanSlot :: HasCallStack => SlotNo -> m [LeiosPoint]
-  -- ^ Scan the EBs whose tx closure is already complete and that were announced
-  -- by an RB no older than the given slot. The ChainDB calls this once at
-  -- startup -- passing the immutable tip slot -- to seed the acquired-EB
-  -- closures set it owns (see @cdbAcquiredLeiosEbs@); thereafter it learns of
-  -- newly-completed closures from 'subscribeEbNotifications' ('AcquiredEbTxs').
-  --
-  -- The slot is a plain query bound, not retained state: the LeiosDb does not
-  -- know about (nor track) the immutable tip; it just answers the query. The
-  -- acquired set itself -- the @complete ∩ announced-no-older-than-tip@
-  -- projection that ChainSel consults -- is owned by the ChainDB, since its
-  -- definition depends on the immutable tip, which is a ChainDB concept.
+
+  -- NOTE: 'subscribeEbNotifications' and 'open' should be the _only_
+  -- methods of this handle. If you're thinking about adding another,
+  -- strongly consider adding it to 'LeiosDbConnection' instead. (See
+  -- https://github.com/input-output-hk/ouroboros-leios/issues/983 for
+  -- example motivation.)
+
+  -- TODO The two methods below are intentionally merely stubs for
+  -- now, but as part of implementing them, we should relocate them to
+  -- 'LeiosDbConnection'.
+
   , leiosDbGarbageCollect :: HasCallStack => SlotNo -> m ()
   -- ^ Evict LeiosDb data that is no longer needed now that everything up to the
   -- given slot is immutable. The ChainDB drives this from its GC scheduler,
@@ -88,6 +87,13 @@ data LeiosDbConnection m = LeiosDbConnection
   { close :: m ()
   -- ^ Close the connection and free up resources. After calling this, the connection may not be used anymore.
   , leiosDbScanEbPoints :: HasCallStack => m [(SlotNo, EbHash)]
+  , leiosDbScanCompleteEbClosuresNotOlderThanSlot :: HasCallStack => SlotNo -> m [LeiosPoint]
+  -- ^ Scan the EBs whose tx closure is complete and whose announcer is no older
+  -- than the given slot. The ChainDB opens a transient connection at startup --
+  -- passing the immutable tip slot -- to seed the acquired-EB-closures set it
+  -- owns (see @cdbAcquiredLeiosEbs@); thereafter it learns of newly-completed
+  -- closures from 'subscribeEbNotifications' ('AcquiredEbTxs'). The slot is a
+  -- plain query bound, not retained state.
   , leiosDbInsertEbPoint :: HasCallStack => LeiosPoint -> BytesSize -> m ()
   -- ^ Insert an announced EB point with its expected size. Called on
   -- the announcement path (forge issuing an EB, peer receiving an

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoDb/InMemory.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoDb/InMemory.hs
@@ -104,16 +104,6 @@ newLeiosDBInMemoryWith stateVar = do
     LeiosDbHandle
       { subscribeEbNotifications =
           atomically (dupTChan notificationChan)
-      , -- This is consulted only once, at ChainDB open, before any mini-protocol
-        -- runs (see 'Ouroboros.Consensus.Storage.ChainDB.Impl.openDBInternal').
-        -- An in-memory DB has no on-disk persistence, so for a fresh process it
-        -- is empty at that point and this could simply be @pure []@. We keep the
-        -- real scan because the ThreadNet harness persists the 'stateVar' across
-        -- simulated node restarts (it lives in the per-node 'NodeInfo' alongside
-        -- the MockFS DBs; see @Test.ThreadNet.Network@), so on a restart the
-        -- ChainDB reopens against a non-empty DB and this seeds the restored
-        -- acquired-EB-closures set — the restart-recovery path.
-        leiosDbScanCompleteEbClosuresNotOlderThanSlot = imScanCompleteEbClosuresSince stateVar
       , -- No-op for now; see 'leiosDbGarbageCollect'.
         leiosDbGarbageCollect = \_slotNo -> pure ()
       , -- No-op for now; see 'leiosDbPromoteToImmutable'.
@@ -123,6 +113,9 @@ newLeiosDBInMemoryWith stateVar = do
             LeiosDbConnection
               { close = pure ()
               , leiosDbScanEbPoints = imScanEbPoints stateVar
+              , -- ThreadNet persists 'stateVar' across simulated restarts, so on
+                -- restart this seeds the restored acquired-EB-closures set.
+                leiosDbScanCompleteEbClosuresNotOlderThanSlot = imScanCompleteEbClosuresSince stateVar
               , leiosDbInsertEbPoint = imInsertEbPoint stateVar
               , leiosDbLookupEbBody = imLookupEbBody stateVar
               , leiosDbInsertEbBody = imInsertEbBody stateVar notificationChan

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoDb/SQLite.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoDb/SQLite.hs
@@ -97,32 +97,14 @@ newLeiosDBSQLite tracer dbPath = do
     LeiosDbHandle
       { subscribeEbNotifications =
           atomically (dupTChan notificationChan)
-      , leiosDbScanCompleteEbClosuresNotOlderThanSlot = sqlScanCompleteEbClosuresSince dbPath
       , -- No-op for now; see 'leiosDbGarbageCollect'. A real implementation
-        -- would open a transient connection (like 'sqlScanCompleteEbClosuresSince')
-        -- and evict the no-longer-needed rows.
+        -- would open a transient connection and evict the no-longer-needed rows.
         leiosDbGarbageCollect = \_slotNo -> pure ()
       , -- No-op for now; see 'leiosDbPromoteToImmutable'. A real implementation
         -- would copy the EB's body and closure rows into immutable storage.
         leiosDbPromoteToImmutable = \_point -> pure ()
       , open = openSQLiteConnection tracer dbPath notificationChan
       }
-
--- | Implements 'leiosDbScanCompleteEbClosuresNotOlderThanSlot': the complete-closure EBs
--- announced no older than the given slot. Opens its own transient read-only
--- connection. Only an existing DB can hold complete closures: a
--- fresh DB file is created lazily by the first 'open', so when the file does
--- not exist there is nothing to scan.
-sqlScanCompleteEbClosuresSince :: FilePath -> SlotNo -> IO [LeiosPoint]
-sqlScanCompleteEbClosuresSince dbPath sinceSlot = do
-  dbExists <- doesFileExist dbPath
-  if not dbExists
-    then pure []
-    else do
-      db <- open2 (fromString dbPath) [SQLOpenReadWrite] SQLVFSDefault
-      points <- sqlScanCompleteEbPointsSince db sinceSlot
-      void $ DB.close db
-      pure points
 
 -- * Connection management
 
@@ -226,6 +208,7 @@ openSQLiteConnection tracer dbPath notificationChan = do
     LeiosDbConnection
       { close = finalizeStmts stmts >> void (DB.close db)
       , leiosDbScanEbPoints = sqlScanEbPoints conn
+      , leiosDbScanCompleteEbClosuresNotOlderThanSlot = sqlScanCompleteEbPointsSince db
       , leiosDbInsertEbPoint = sqlInsertEbPoint conn
       , leiosDbLookupEbBody = sqlLookupEbBody conn
       , leiosDbInsertEbBody = sqlInsertEbBody tracer conn notify
@@ -505,7 +488,7 @@ sql_scan_ebs =
   \ORDER BY ebSlot ASC\n\
   \"
 
--- | For 'sqlScanCompleteEbClosuresSince'
+-- | For 'sqlScanCompleteEbPointsSince'
 --
 -- The two conditions are decoupled across rows: the same EB hash can have
 -- several @(ebSlot, ebHashBytes)@ rows (one per announcer slot), and

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl.hs
@@ -51,7 +51,7 @@ import Data.Functor ((<&>))
 import qualified Data.Map.Strict as Map
 import Data.Maybe.Strict (StrictMaybe (..))
 import GHC.Stack (HasCallStack)
-import LeiosDemoDb.Common (leiosDbScanCompleteEbClosuresNotOlderThanSlot)
+import LeiosDemoDb.Common (leiosDbScanCompleteEbClosuresNotOlderThanSlot, withLeiosDb)
 import LeiosDemoTypes
   ( HasLeiosVoting
   , acquiredLeiosEbHashes
@@ -223,9 +223,10 @@ openDBInternal args launchBgTasks = runWithTempRegistry $ do
     -- tip. 'Background.leiosAcquiredEbsRunner' grows it thereafter from LeiosDb
     -- closure-completion notifications.
     initialAcquiredLeiosEbs <-
-      leiosDbScanCompleteEbClosuresNotOlderThanSlot
-        (Args.cdbsLeiosDb cdbSpecificArgs)
-        (fromWithOrigin (SlotNo 0) (pointSlot immutableDbTipPoint))
+      withLeiosDb (Args.cdbsLeiosDb cdbSpecificArgs) $ \leiosConn ->
+        leiosDbScanCompleteEbClosuresNotOlderThanSlot
+          leiosConn
+          (fromWithOrigin (SlotNo 0) (pointSlot immutableDbTipPoint))
     varAcquiredLeiosEbs <-
       newTVarIO (acquiredLeiosEbsFromList initialAcquiredLeiosEbs)
     chain <-

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/Forker.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/Forker.hs
@@ -493,6 +493,12 @@ applyBlock leiosDb evs cfg ap fo doResolveBlock = case ap of
     extSt <- atomically (forkerGetLedgerState fo)
     let cds = headerStateChainDep (headerState extSt)
     case blockLeiosCert b of
+      Nothing ->
+        -- Not a CertRB: ordinary Praos block
+        withValues b $ \v ->
+          case runExcept $ tickThenApply evs cfg b v of
+            Left lerr -> pure (Left (AnnLedgerError (castPoint $ getTip v) (blockRealPoint b) lerr))
+            Right st -> pure (Right st)
       Just cert -> do
         -- CertRB apply path. The block's body on the wire is empty (it
         -- carries only the Leios certificate, not the EB's txs). The
@@ -517,7 +523,7 @@ applyBlock leiosDb evs cfg ap fo doResolveBlock = case ap of
         case protocolStateLeiosAnnouncement @blk cds of
           Nothing ->
             -- TODO: make this less fatal or impossible to reach
-            error $ "applyBlock: nothing announced!?"
+            error $ "applyBlock applyVal: nothing announced!?"
           Just (announcedPoint, _) -> do
             cm <- case getLeiosCommittee (ledgerState extSt) of
               Just c -> pure c
@@ -550,6 +556,9 @@ applyBlock leiosDb evs cfg ap fo doResolveBlock = case ap of
                   (ledgerState lsBeforeEB) of
                   Left lerr ->
                     -- REVIEW: Better annotation than CertRB point possible?
+                    --
+                    -- TODO this should be unreachable, at least from
+                    -- ChainSel (maybe LeiosVoting calls it?)
                     pure
                       ( Left
                           ( AnnLedgerError
@@ -577,12 +586,6 @@ applyBlock leiosDb evs cfg ap fo doResolveBlock = case ap of
                                   trackingToDiffs
                                     (calculateDifference lsBeforeEB lsAfterEB)
                              in pure (Right (prependDiffs closureDiff blockDiff))
-      Nothing ->
-        -- Not a CertRB: ordinary Praos block
-        withValues b $ \v ->
-          case runExcept $ tickThenApply evs cfg b v of
-            Left lerr -> pure (Left (AnnLedgerError (castPoint $ getTip v) (blockRealPoint b) lerr))
-            Right st -> pure (Right st)
   ReapplyRef r -> do
     b <- doResolveBlock r
     applyBlock leiosDb evs cfg (ReapplyVal b) fo doResolveBlock

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/Forker.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/Forker.hs
@@ -486,9 +486,39 @@ applyBlock ::
   m (Either (AnnLedgerError l blk) (l DiffMK))
 applyBlock leiosDb evs cfg ap fo doResolveBlock = case ap of
   ReapplyVal b -> do
-    cds <- headerStateChainDep . headerState <$> atomically (forkerGetLedgerState fo)
-    b' <- resolveLeiosBlock leiosDb cds b
-    withValues b' (return . Right . tickThenReapply evs cfg b')
+    case blockLeiosCert b of
+      Nothing ->
+        -- Not a CertRB: ordinary Praos block
+        withValues b (return . Right . tickThenReapply evs cfg b)
+      Just{} -> do
+        -- Exactly the same as ApplyVal below, except skipping checks
+        -- where possible, since this is /reapplication/.
+        extSt <- atomically (forkerGetLedgerState fo)
+        let cds = headerStateChainDep (headerState extSt)
+        case protocolStateLeiosAnnouncement @blk cds of
+          Nothing ->
+            error $ "applyBlock ReapplyVal: nothing announced!?"
+          Just (announcedPoint, _) -> do
+            closureTxs <- resolveLeiosClosure leiosDb announcedPoint b
+            let blkKeys = getBlockKeySets b
+                closureKeys = foldMap (castLedgerTables . leiosClosureTxKeySets) closureTxs
+            lsBeforeEB <- withLedgerTables extSt <$> forkerReadTables fo (closureKeys <> blkKeys)
+            let lcfg = configLedger (getExtLedgerCfg cfg)
+            case applyLeiosClosure lcfg closureTxs (ledgerState lsBeforeEB) of
+              Left lerr ->
+                pure
+                  ( Left
+                      ( AnnLedgerError
+                          (let tip = castPoint $ getTip lsBeforeEB in tip)
+                          (blockRealPoint b)
+                          (ExtValidationErrorLedger lerr)
+                      )
+                  )
+              Right newLst ->
+                let lsAfterEB = lsBeforeEB{ledgerState = newLst}
+                    blockDiff = tickThenReapply evs cfg b lsAfterEB
+                    closureDiff = trackingToDiffs (calculateDifference lsBeforeEB lsAfterEB)
+                in pure (Right (prependDiffs closureDiff blockDiff))
   ApplyVal b -> do
     extSt <- atomically (forkerGetLedgerState fo)
     let cds = headerStateChainDep (headerState extSt)

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/V1/DbChangelog.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/V1/DbChangelog.hs
@@ -394,7 +394,7 @@ reapplyThenPushLeios ::
   m (DbChangelog l)
 reapplyThenPushLeios leiosDb cfg b ksReader db = do
   let cds = headerStateChainDep (headerState (current db))
-  b' <- resolveLeiosBlock leiosDb cds b
+  b' <- resolveLeiosBlock leiosDb cds b   -- TODO resolveLeiosBlock is the wrong function to call here
   reapplyThenPush cfg b' ksReader db
 
 -- | Prune oldest ledger states according to the given 'LedgerDbPrune' strategy.

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/V2.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/V2.hs
@@ -220,7 +220,7 @@ mkInternals ldb h snapManager =
               st <- atomically $ forkerGetLedgerState frk
               let cds = headerStateChainDep (headerState st)
               blk' <- withLeiosDb (ldbLeiosDb env) $ \leiosConn ->
-                resolveLeiosBlock leiosConn cds blk
+                resolveLeiosBlock leiosConn cds blk   -- TODO resolveLeiosBlock is the wrong function to call here
               tables <- forkerReadTables frk (getBlockKeySets blk')
               let st' =
                     tickThenReapply

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/V2/LedgerSeq.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/V2/LedgerSeq.hs
@@ -12,6 +12,7 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -60,13 +61,14 @@ import GHC.Generics
 import LeiosDemoDb (LeiosDbConnection)
 import NoThunks.Class
 import Ouroboros.Consensus.Block
+import Ouroboros.Consensus.Config (configLedger)
 import Ouroboros.Consensus.Config.SecurityParam
 import Ouroboros.Consensus.HeaderValidation (headerStateChainDep)
 import Ouroboros.Consensus.Ledger.Abstract
 import Ouroboros.Consensus.Ledger.Extended
 import Ouroboros.Consensus.Ledger.Tables.Utils
 import Ouroboros.Consensus.Storage.LedgerDB.API
-import Ouroboros.Consensus.Storage.LedgerDB.Forker (ResolveLeiosBlock (..), resolveLeiosBlock)
+import Ouroboros.Consensus.Storage.LedgerDB.Forker (ResolveLeiosBlock (..))
 import Ouroboros.Consensus.Util.IOLike
 import Ouroboros.Network.AnchoredSeq hiding
   ( anchor
@@ -254,12 +256,7 @@ reapplyThenPush leiosDb cfg ap db = do
 
 -- | Reapply a block to the tip of the 'LedgerSeq'.
 --
--- For Leios CertRBs, the wire-encoded body carries only a 'LeiosCert' (no
--- txs); the actual transactions live in the EB closure. Mirroring
--- 'Forker.applyBlock', we splice the EB body back in via 'resolveLeiosBlock'
--- before ticking the ledger — otherwise the immutable-DB replay path would
--- apply CertRBs as empty bodies, leaving the ledger state missing every
--- EB-tx output that was created during the original fresh sync.
+-- Mirrors the CertRB handling in 'Forker.applyBlock', minus validation.
 reapplyBlock ::
   forall m l blk.
   ( ApplyBlock l blk
@@ -276,12 +273,28 @@ reapplyBlock ::
 reapplyBlock leiosDb evs cfg b db = do
   let StateRef st tbs = currentHandle db
       cds = headerStateChainDep (headerState st)
-  b' <- resolveLeiosBlock leiosDb cds b
-  let ks = getBlockKeySets b'
-  vals <- read tbs st ks
-  let st' = tickThenReapply evs cfg b' (st `withLedgerTables` vals)
-      newst = forgetLedgerTables st'
-
+  st' <- case blockLeiosCert b of
+    Nothing -> do
+      -- Not a CertRB: ordinary Praos block
+      vals <- read tbs st (getBlockKeySets b)
+      pure $ tickThenReapply evs cfg b (st `withLedgerTables` vals)
+    Just{} ->
+      case protocolStateLeiosAnnouncement @blk cds of
+        Nothing -> error "V2.LedgerSeq.reapplyBlock: nothing announced!?"
+        Just (announcedPoint, _) -> do
+          closureTxs <- resolveLeiosClosure leiosDb announcedPoint b
+          let blkKeys = getBlockKeySets b
+              closureKeys = foldMap (castLedgerTables . leiosClosureTxKeySets) closureTxs
+          vals <- read tbs st (closureKeys <> blkKeys)
+          let lsBeforeEB = st `withLedgerTables` vals
+          case applyLeiosClosure (configLedger (getExtLedgerCfg cfg)) closureTxs (ledgerState lsBeforeEB) of
+            Left{} -> error "V2.LedgerSeq.reapplyBlock: applyLeiosClosure failed!"
+            Right newLst ->
+              let lsAfterEB = lsBeforeEB{ledgerState = newLst}
+                  blockDiff = tickThenReapply evs cfg b lsAfterEB
+                  closureDiff = trackingToDiffs (calculateDifference lsBeforeEB lsAfterEB)
+               in pure (prependDiffs closureDiff blockDiff)
+  let newst = forgetLedgerTables st'
   newtbs <- duplicateWithDiffs tbs st st'
   pure (StateRef newst newtbs)
 


### PR DESCRIPTION
Another bug I discovered during my time with the Leios testnet in the past couple days.