### PR TITLE
Switch to GHC 9.14.1 for haddocks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,7 +207,7 @@ jobs:
       if: |
         github.event_name == 'push'
         && github.ref == 'refs/heads/main'
-        && matrix.ghc=='9.10.3'
+        && matrix.ghc=='9.14.1'
       run: |
         # need for latex, dvisvgm and standalone
         sudo apt install texlive-latex-extra texlive-latex-base
@@ -222,7 +222,7 @@ jobs:
       if: |
         github.event_name == 'push'
         && github.ref == 'refs/heads/main'
-        && matrix.ghc=='9.10.3'
+        && matrix.ghc=='9.14.1'
       uses: actions/upload-artifact@v7
       with:
         name: haddocks


### PR DESCRIPTION
GHC 9.10.3 keeps OOMing: https://github.com/IntersectMBO/ouroboros-consensus/actions/runs/29264882320/job/86867410113

So did GHC 9.12.4: https://github.com/IntersectMBO/ouroboros-consensus/actions/runs/29284973884/job/86935210471

GHC 9.14.1 succeeds: https://github.com/IntersectMBO/ouroboros-consensus/actions/runs/29292047246/job/86958343393