### PR TITLE
Make OneEraGenTxId Eq/Ord allocation-free (#2003)

### DIFF
--- a/changelog.d/20260715_122032_damian.nadales_txid_eq_ord_alloc.md
+++ b/changelog.d/20260715_122032_damian.nadales_txid_eq_ord_alloc.md
@@ -1,0 +1,29 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+### Breaking
+
+- Added `hardForkEqGenTxId` and `hardForkCompareGenTxId` to the `CanHardFork`
+  class. The `Eq` and `Ord` instances for `OneEraGenTxId` (and hence for
+  `TxId (GenTx (HardForkBlock xs))`) now delegate to them, so each hard fork
+  chooses how to compare its transaction ids. The methods have no default, so
+  existing `CanHardFork` instances must supply them; the exported `rawHashNS`
+  is the raw-hash implementation the non-optimizing instances reuse.
+
+<!--
+### Non-Breaking
+
+- A bullet item for the Non-Breaking category.
+
+-->
+
+### Patch
+
+- Made those `Eq`/`Ord` comparisons allocation-free for the Cardano eras, on
+  every comparison rather than only same-era ones. The Cardano instance reads
+  the transaction id hash as four machine words and compares them in registers,
+  instead of serialising both ids to their raw hash. The ordering is unchanged.

--- a/ouroboros-consensus-cardano/bench/txid-eq-ord-instances-bench/Main.hs
+++ b/ouroboros-consensus-cardano/bench/txid-eq-ord-instances-bench/Main.hs
@@ -1,0 +1,96 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE TypeApplications #-}
+-- The NFData instance for 'OneEraGenTxId' below is a bench-local orphan.
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Main (main) where
+
+import Cardano.Protocol.Crypto (StandardCrypto)
+import Control.DeepSeq (NFData (..))
+import Data.ByteString.Short (ShortByteString)
+import qualified Data.ByteString.Short as SBS
+import Data.SOP (All, Proxy (..), lengthSList)
+import Data.Word (Word8)
+import Ouroboros.Consensus.Cardano.Block (CardanoEras)
+import Ouroboros.Consensus.Cardano.Node ()
+import Ouroboros.Consensus.HardFork.Combinator.AcrossEras (OneEraGenTxId)
+import Ouroboros.Consensus.Shelley.HFEras ()
+import Ouroboros.Consensus.Shelley.Ledger.SupportsProtocol ()
+import Test.Consensus.Cardano.GenTxIdBuilders (BuildGenTxId, oneEraGenTxIds)
+import Test.Tasty.Bench (Benchmark, bench, bgroup, defaultMain, env, whnf)
+
+-- | 'OneEraGenTxId' has no 'NFData' instance, and a real one would need the
+-- raw-hash walk (or a copy of it) here, which we want to avoid. A deep force is
+-- not needed regardless: operands are built once and shared, and 'compare' and
+-- '==' re-walk each operand on every call, so their construction never enters
+-- the per-iteration figure (confirmed in the generated Core). WHNF suffices.
+instance NFData (OneEraGenTxId xs) where
+  rnf x = x `seq` ()
+
+main :: IO ()
+main =
+  defaultMain
+    [ -- 'env' builds the benchmark tree before running 'mkOperands', so the
+      -- operands are not available yet at that point. The irrefutable pattern
+      -- (@~@) avoids forcing the tuple while the tree is built; the operands are
+      -- touched only inside the 'bench' bodies, which run after 'mkOperands'.
+      env (mkOperands @(CardanoEras StandardCrypto)) $ \ ~(lhs, equalRhs, unequalRhs) ->
+        bgroup
+          "txid-eq-ord"
+          [ operationGroup "compare" compare lhs equalRhs unequalRhs
+          , operationGroup "==" (==) lhs equalRhs unequalRhs
+          ]
+    ]
+
+-- | One operation (@compare@ or @==@), laid out as @equal@ + @unequal@ cells
+-- over the era grid.
+operationGroup ::
+  String ->
+  (a -> a -> b) ->
+  [a] ->
+  [a] ->
+  [a] ->
+  Benchmark
+operationGroup name op lhs equalRhs unequalRhs =
+  bgroup
+    name
+    [ bgroup
+        "equal"
+        [ bench (show i) $ whnf (uncurry op) (lhs !! i, equalRhs !! i)
+        | i <- eras
+        ]
+    , bgroup
+        "unequal"
+        [ bench (show i ++ "-vs-" ++ show j) $ whnf (uncurry op) (lhs !! i, unequalRhs !! j)
+        | i <- eras
+        , j <- eras
+        ]
+    ]
+
+-- | Number of eras to benchmark, read from the era list type. It must come from
+-- the type, not the operand lists: the benchmark tree shape cannot depend on the
+-- runtime operands produced by 'env'.
+numEras :: Int
+numEras = lengthSList (Proxy @(CardanoEras StandardCrypto))
+
+eras :: [Int]
+eras = [0 .. numEras - 1]
+
+-- | A 32-byte hash, zero except for the given first byte. Two such hashes are
+-- equal iff that first byte matches.
+hashWithFirstByte :: Word8 -> ShortByteString
+hashWithFirstByte b = SBS.pack (b : replicate 31 0)
+
+-- | The three operand lists. @lhs@ and @equalRhs@ share a hash (first byte 0),
+-- so they compare equal; @unequalRhs@ has first byte 1, so it never does.
+mkOperands ::
+  All BuildGenTxId xs =>
+  IO ([OneEraGenTxId xs], [OneEraGenTxId xs], [OneEraGenTxId xs])
+mkOperands = pure (operandsFor 0, operandsFor 0, operandsFor 1)
+
+--                  lhs            equalRhs        unequalRhs
+
+-- | One operand per era (list index = era position) built from the given first
+-- byte.
+operandsFor :: All BuildGenTxId xs => Word8 -> [OneEraGenTxId xs]
+operandsFor b = oneEraGenTxIds (hashWithFirstByte b)

--- a/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/CanHardFork.hs
+++ b/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/CanHardFork.hs
@@ -62,6 +62,9 @@ import Ouroboros.Consensus.Byron.ByronHFC ()
 import Ouroboros.Consensus.Byron.Ledger
 import Ouroboros.Consensus.Byron.Node ()
 import Ouroboros.Consensus.Cardano.Block
+import Ouroboros.Consensus.Cardano.CanHardFork.OptimizedTxIdComparison
+  ( compareCardanoGenTxId
+  )
 import Ouroboros.Consensus.Forecast
 import Ouroboros.Consensus.HardFork.Combinator
 import Ouroboros.Consensus.HardFork.Combinator.State.Types
@@ -230,6 +233,16 @@ instance CardanoHardForkConstraints c => CanHardFork (CardanoEras c) where
 
     fromTrivial :: TrivialTxMeasurePhase2 -> RefScriptSize
     fromTrivial TrivialTxMeasurePhase2 = mempty
+
+  -- Both ids are ordered by their txid hash, ignoring the era. Equality reuses
+  -- 'compare' rather than a separate path: 'hardForkEqGenTxId' is
+  -- 'compareCardanoGenTxId' returning 'EQ'. This allocates no heap: all three
+  -- 'Ordering' constructors take zero arguments, so they are never allocated on
+  -- the dynamic heap; every 'Ordering' pointer is to one of three statically
+  -- allocated addresses. 'compareCardanoGenTxId' keeps the comparison itself
+  -- allocation-free.
+  hardForkCompareGenTxId = compareCardanoGenTxId
+  hardForkEqGenTxId l r = compareCardanoGenTxId l r == EQ
 
 class TiebreakerView (BlockProtocol blk) ~ PraosTiebreakerView c => HasPraosTiebreakerView c blk
 instance TiebreakerView (BlockProtocol blk) ~ PraosTiebreakerView c => HasPraosTiebreakerView c blk

--- a/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/CanHardFork/OptimizedTxIdComparison.hs
+++ b/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/CanHardFork/OptimizedTxIdComparison.hs
@@ -1,0 +1,133 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE UnboxedTuples #-}
+
+-- | Allocation-free cross-era comparison of Cardano transaction ids.
+--
+-- Both 'Ouroboros.Consensus.HardFork.Combinator.AcrossEras.OneEraGenTxId'
+-- instances order by the txid hash, ignoring the era. We read each id's 32-byte
+-- hash (Blake2b-256) as four big-endian 'Word64#' and compare those in
+-- registers. The words are unboxed, so no hash is boxed on the heap on any
+-- era's path:
+--
+--   * Shelley-based eras store the hash as 'PackedBytes32' (four words
+--     already); we unbox its fields.
+--   * Byron stores it as a 'ShortByteString'; we read four big-endian words
+--     out.
+--
+-- The extraction walks the era sum with a single dictionary used on every
+-- branch, so it is strict in the dictionary and allocates no per-level thunk.
+module Ouroboros.Consensus.Cardano.CanHardFork.OptimizedTxIdComparison
+  ( ToTxIdWords (..)
+  , compareCardanoGenTxId
+  ) where
+
+import Cardano.Crypto (abstractHashToShort)
+import qualified Cardano.Crypto.Hash as Hash
+import Cardano.Crypto.Hash.Class (PackedBytes (PackedBytes32))
+import Cardano.Crypto.PackedBytes (unpackBytes)
+import qualified Cardano.Ledger.Core as SL
+import qualified Cardano.Ledger.Shelley.API as SL
+import Data.Bits (unsafeShiftL, (.|.))
+import Data.ByteString.Short (ShortByteString)
+import qualified Data.ByteString.Short as SBS
+import Data.SOP.Constraint (All)
+import qualified Data.SOP.Strict as SOP
+import GHC.Exts (Word64#, gtWord64#, ltWord64#)
+import GHC.Word (Word64 (W64#))
+import Ouroboros.Consensus.Byron.Ledger
+import Ouroboros.Consensus.Ledger.SupportsMempool (GenTxId)
+import Ouroboros.Consensus.Shelley.Ledger
+import Ouroboros.Consensus.TypeFamilyWrappers (WrapGenTxId, unwrapGenTxId)
+
+-- | Order two Cardano transaction ids by their txid hash, ignoring the era.
+--
+-- 'txIdWords' reads each hash as four unboxed words and 'compareW64' orders
+-- them in registers. Two requirements keep this allocation-free:
+--
+-- * Both branches of 'txIdWords' force the @All ToTxIdWords ys@ dictionary
+--   ('Z' reads its head, 'S' its tail), so GHC compiles the tail-dictionary
+--   read as a strict field access rather than a per-step thunk.
+--
+-- * The compared words are unboxed ('Word64#'), so no hash is boxed on the
+--   heap.
+compareCardanoGenTxId ::
+  All ToTxIdWords xs =>
+  SOP.NS WrapGenTxId xs -> SOP.NS WrapGenTxId xs -> Ordering
+compareCardanoGenTxId l r =
+  case txIdWords l of
+    (# a0, a1, a2, a3 #) -> case txIdWords r of
+      (# b0, b1, b2, b3 #) ->
+        compareW64 a0 b0 <> compareW64 a1 b1 <> compareW64 a2 b2 <> compareW64 a3 b3
+
+-- | The four big-endian 64-bit words of an era's 32-byte txid hash
+-- (Blake2b-256), unboxed so no hash is materialised on the heap. An era whose
+-- txid hash is not four words is rejected by the 'Shelley' instance's
+-- 'PackedBytes32' match rather than miscompared.
+class ToTxIdWords blk where
+  toTxIdWords :: GenTxId blk -> (# Word64#, Word64#, Word64#, Word64# #)
+
+instance ToTxIdWords ByronBlock where
+  toTxIdWords (ByronTxId i) = sbsWords (abstractHashToShort i)
+  toTxIdWords (ByronDlgId i) = sbsWords (abstractHashToShort i)
+  toTxIdWords (ByronUpdateProposalId i) = sbsWords (abstractHashToShort i)
+  toTxIdWords (ByronUpdateVoteId i) = sbsWords (abstractHashToShort i)
+
+instance ShelleyBasedEra era => ToTxIdWords (ShelleyBlock proto era) where
+  toTxIdWords (ShelleyTxId i) =
+    case Hash.hashToPackedBytes (SL.extractHash (SL.unTxId i)) of
+      PackedBytes32 (W64# w0) (W64# w1) (W64# w2) (W64# w3) -> (# w0, w1, w2, w3 #)
+      -- The ledger hash is Blake2b-256, always 'PackedBytes32'; this arm is
+      -- unreachable and pays a copy only if it ever runs.
+      pb -> sbsWords (unpackBytes pb)
+
+-- | The four big-endian 'Word64#' of a 32-byte 'ShortByteString', assembled by
+-- shifting its bytes. Portable (no byte swap) and allocation-free: the words go
+-- straight into an unboxed tuple. This is the byte order the raw-hash reference
+-- compares by, so it agrees with the oracle (checked by the property test across
+-- word boundaries).
+sbsWords :: ShortByteString -> (# Word64#, Word64#, Word64#, Word64# #)
+sbsWords sbs =
+  (#
+    unbox (word64BigEndianAt 0)
+    , unbox (word64BigEndianAt 8)
+    , unbox (word64BigEndianAt 16)
+    , unbox (word64BigEndianAt 24)
+  #)
+ where
+  -- Inline so the four calls don't share one heap-allocated closure.
+  {-# INLINE word64BigEndianAt #-}
+  word64BigEndianAt byteOffset =
+    -- with bytes b0 b1 … b7 starting at 'byteOffset' the result looks like:
+    --    (b0 << 56) | (b1 << 48) | (b2 << 40) | (b3 << 32)
+    --  | (b4 << 24) | (b5 << 16) | (b6 << 8)  | b7
+    (byte (byteOffset + 0) `unsafeShiftL` 56)
+      .|. (byte (byteOffset + 1) `unsafeShiftL` 48)
+      .|. (byte (byteOffset + 2) `unsafeShiftL` 40)
+      .|. (byte (byteOffset + 3) `unsafeShiftL` 32)
+      .|. (byte (byteOffset + 4) `unsafeShiftL` 24)
+      .|. (byte (byteOffset + 5) `unsafeShiftL` 16)
+      .|. (byte (byteOffset + 6) `unsafeShiftL` 8)
+      .|. byte (byteOffset + 7)
+  byte k = fromIntegral (SBS.index sbs k) :: Word64
+  unbox (W64# w) = w
+
+-- | The txid hash of whichever era the id sits in, as four big-endian 'Word64#'.
+-- Direct recursion down the sum, building no intermediate 'NS'. Uses its single
+-- dictionary on every branch, so it is strict in it and allocates no per-level
+-- thunk.
+txIdWords ::
+  All ToTxIdWords ys =>
+  SOP.NS WrapGenTxId ys -> (# Word64#, Word64#, Word64#, Word64# #)
+txIdWords (SOP.Z x) = toTxIdWords (unwrapGenTxId x)
+txIdWords (SOP.S y) = txIdWords y
+
+-- | Order two 64-bit words as unsigned, in registers.
+compareW64 :: Word64# -> Word64# -> Ordering
+compareW64 a b = case a `ltWord64#` b of
+  1# -> LT
+  _ -> case a `gtWord64#` b of
+    1# -> GT
+    _ -> EQ

--- a/ouroboros-consensus-cardano/src/unstable-cardano-testlib/Test/Consensus/Cardano/GenTxIdBuilders.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-testlib/Test/Consensus/Cardano/GenTxIdBuilders.hs
@@ -1,0 +1,56 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE TypeApplications #-}
+
+-- | Build Cardano 'OneEraGenTxId' values from raw hash bytes, one per era.
+--
+-- Shared by the txid @Eq@\/@Ord@ benchmark and the txid @Eq@\/@Ord@
+-- equivalence test: both need to place a chosen 32-byte hash at a chosen era
+-- position, without going through the network or the ledger.
+module Test.Consensus.Cardano.GenTxIdBuilders
+  ( BuildGenTxId (..)
+  , apInjs
+  , buildNP
+  , oneEraGenTxIds
+  ) where
+
+import Cardano.Crypto.Hashing (unsafeAbstractHashFromShort)
+import Cardano.Ledger.Hashes (unsafeMakeSafeHash)
+import qualified Cardano.Ledger.Shelley.API as SL
+import Data.ByteString.Short (ShortByteString)
+import Data.SOP (All, Proxy (..), SListI)
+import Data.SOP.Strict (NP, NS, hap, hcollapse, hcpure, injections)
+import Ouroboros.Consensus.Byron.Ledger.Block (ByronBlock)
+import Ouroboros.Consensus.Byron.Ledger.Mempool (TxId (ByronTxId))
+import Ouroboros.Consensus.HardFork.Combinator.AcrossEras
+  ( OneEraGenTxId (..)
+  )
+import Ouroboros.Consensus.Ledger.SupportsMempool (GenTxId)
+import Ouroboros.Consensus.Shelley.Ledger.Block (ShelleyBlock)
+import Ouroboros.Consensus.Shelley.Ledger.Mempool (TxId (ShelleyTxId))
+import Ouroboros.Consensus.TypeFamilyWrappers (WrapGenTxId (..))
+import Ouroboros.Consensus.Util (hashFromBytesShortE)
+
+-- | Build a transaction id for one era from raw hash bytes. Each era wraps its
+-- hash differently, hence one instance per era shape.
+class BuildGenTxId blk where
+  buildGenTxId :: ShortByteString -> GenTxId blk
+
+instance BuildGenTxId (ShelleyBlock proto era) where
+  buildGenTxId bs = ShelleyTxId (SL.TxId (unsafeMakeSafeHash (hashFromBytesShortE bs)))
+
+instance BuildGenTxId ByronBlock where
+  buildGenTxId bs = ByronTxId (unsafeAbstractHashFromShort bs)
+
+-- | One leaf per era, every era sharing the given hash bytes.
+buildNP :: All BuildGenTxId xs => ShortByteString -> NP WrapGenTxId xs
+buildNP bs = hcpure (Proxy @BuildGenTxId) (WrapGenTxId (buildGenTxId bs))
+
+-- | Inject each leaf into the sum at its own era position. The strict 'NS' has
+-- no @apInjs_NP@, so we go through 'injections'.
+apInjs :: SListI xs => NP f xs -> [NS f xs]
+apInjs np = hcollapse (hap injections np)
+
+-- | One 'OneEraGenTxId' per era, list index equal to the era position, every
+-- entry carrying the given hash bytes.
+oneEraGenTxIds :: All BuildGenTxId xs => ShortByteString -> [OneEraGenTxId xs]
+oneEraGenTxIds bs = OneEraGenTxId <$> apInjs (buildNP bs)

--- a/ouroboros-consensus-cardano/src/unstable-cardano-testlib/Test/ThreadNet/Infra/ShelleyBasedHardFork.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-testlib/Test/ThreadNet/Infra/ShelleyBasedHardFork.hs
@@ -55,6 +55,7 @@ import Codec.CBOR.Decoding
 import Codec.CBOR.Encoding
 import qualified Control.Tracer as Tracer
 import Data.Coerce
+import Data.Function (on)
 import qualified Data.Map.Strict as Map
 import Data.MemPack
 import Data.Proxy
@@ -295,6 +296,11 @@ instance
   hardForkInjTxMeasurePhase2 = \case
     (Z (WrapTxMeasurePhase2 x)) -> translateTxMeasure x
     S (Z (WrapTxMeasurePhase2 x)) -> x
+
+  -- Test-only hard fork. For a test block the unoptimized raw-hash
+  -- comparison is fine.
+  hardForkEqGenTxId = (==) `on` rawHashNS
+  hardForkCompareGenTxId = compare `on` rawHashNS
 
 instance
   ShelleyBasedHardForkConstraints proto1 era1 proto2 era2 =>

--- a/ouroboros-consensus-cardano/test/cardano-test/Main.hs
+++ b/ouroboros-consensus-cardano/test/cardano-test/Main.hs
@@ -10,6 +10,7 @@ import qualified Test.Consensus.Cardano.Show ()
 import qualified Test.Consensus.Cardano.SupportedNetworkProtocolVersion
 import qualified Test.Consensus.Cardano.SupportsSanityCheck
 import qualified Test.Consensus.Cardano.Translation (tests)
+import qualified Test.Consensus.Cardano.TxId (tests)
 import Test.Tasty
 import qualified Test.ThreadNet.AllegraMary
 import qualified Test.ThreadNet.Cardano
@@ -44,4 +45,5 @@ tests =
     , Test.ThreadNet.ShelleyAllegra.tests
     , Test.Consensus.Cardano.MiniProtocol.LocalTxSubmission.Server.tests
     , Test.Consensus.Cardano.Translation.tests
+    , Test.Consensus.Cardano.TxId.tests
     ]

--- a/ouroboros-consensus-cardano/test/cardano-test/Test/Consensus/Cardano/TxId.hs
+++ b/ouroboros-consensus-cardano/test/cardano-test/Test/Consensus/Cardano/TxId.hs
@@ -1,0 +1,122 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE TypeApplications #-}
+
+-- | The allocation-free @Eq@\/@Ord@ instances for 'OneEraGenTxId' must agree
+-- with the raw-hash reference: order by hash bytes, ignore the era.
+--
+-- The comparison distinguishes four classes of input:
+--
+--   * same era, equal hashes
+--   * same era, unequal hashes
+--   * different eras, equal hashes
+--   * different eras, unequal hashes
+--
+-- For Cardano, same-era comparisons use the era's own Eq/Ord and cross-era
+-- comparisons go through PackedBytes; neither is the raw-hash reference, so
+-- every class is a real check. The cross-era cells in particular check that
+-- packed-word order agrees with raw-byte order across the Byron and Shelley
+-- representations.
+--
+-- The test builds a txid in every era for each probe hash, then compares every
+-- id with every other and checks the result against the reference. The probe
+-- hashes (see 'hashes') put a single 1 at each byte in turn, so a wrong byte
+-- order anywhere makes the era's 'Ord' disagree with the reference.
+module Test.Consensus.Cardano.TxId (tests) where
+
+import Cardano.Protocol.Crypto (StandardCrypto)
+import Data.ByteString.Short (ShortByteString)
+import qualified Data.ByteString.Short as SBS
+import Data.SOP (Proxy (..), lengthSList)
+import Data.Word (Word8)
+import Ouroboros.Consensus.Cardano.Block (CardanoEras)
+import Ouroboros.Consensus.Cardano.Node ()
+import Ouroboros.Consensus.HardFork.Combinator.Abstract (CanHardFork, rawHashNS)
+import Ouroboros.Consensus.HardFork.Combinator.AcrossEras (OneEraGenTxId (..))
+import Ouroboros.Consensus.Shelley.HFEras ()
+import Ouroboros.Consensus.Shelley.Ledger.SupportsProtocol ()
+import Test.Consensus.Cardano.GenTxIdBuilders (oneEraGenTxIds)
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (Assertion, assertEqual, testCase)
+import Test.Tasty.QuickCheck
+  ( Gen
+  , Property
+  , arbitrary
+  , chooseInt
+  , forAll
+  , frequency
+  , testProperty
+  , vectorOf
+  , (.&&.)
+  , (===)
+  )
+
+tests :: TestTree
+tests =
+  testGroup
+    "TxIdEqOrd"
+    [ testCase "Eq/Ord agree with the raw-hash reference" $
+        mapM_ check [(i, j, h1, h2) | i <- eras, j <- eras, h1 <- hashes, h2 <- hashes]
+    , testProperty
+        "Eq/Ord agree with the raw-hash reference on random hashes"
+        prop_agreeWithReference
+    ]
+
+-- | The reference semantics for the txid @Eq@\/@Ord@ instances: the raw hash
+-- bytes, era ignored. Imported from the combinator, not copied, so the test and
+-- the non-optimizing instances share one reference.
+refRawHash :: CanHardFork xs => OneEraGenTxId xs -> ShortByteString
+refRawHash = rawHashNS . getOneEraGenTxId
+
+-- | The txid built in era position @e@ from hash bytes @bs@.
+mkAt :: Int -> ShortByteString -> OneEraGenTxId (CardanoEras StandardCrypto)
+mkAt e bs = oneEraGenTxIds bs !! e
+
+-- | Check one era/hash combination against the reference, for @compare@ and
+-- @==@. The tuple is shown verbatim in the failure message.
+check :: (Int, Int, ShortByteString, ShortByteString) -> Assertion
+check c@(i, j, h1, h2) = do
+  assertEqual (show c ++ " [compare]") (compare (refRawHash a) (refRawHash b)) (compare a b)
+  assertEqual (show c ++ " [==]") (refRawHash a == refRawHash b) (a == b)
+ where
+  a = mkAt i h1
+  b = mkAt j h2
+
+-- | 'compare' and '==' on random era/hash pairs must agree with the raw-hash
+-- reference.
+prop_agreeWithReference :: Property
+prop_agreeWithReference =
+  forAll genEra $ \i ->
+    forAll genEra $ \j ->
+      forAll genHash $ \h1 ->
+        -- @h2@ equals @h1@ 1 time in 5; independent random hashes are almost
+        -- never equal, so otherwise '==' would never be tested against True.
+        forAll (frequency [(1, pure h1), (4, genHash)]) $ \h2 ->
+          let a = mkAt i h1
+              b = mkAt j h2
+           in compare a b === compare (refRawHash a) (refRawHash b)
+                .&&. (a == b) === (refRawHash a == refRawHash b)
+
+-- | A random 32-byte hash.
+genHash :: Gen ShortByteString
+genHash = SBS.pack <$> vectorOf 32 arbitrary
+
+-- | A random era position.
+genEra :: Gen Int
+genEra = chooseInt (0, lengthSList (Proxy @(CardanoEras StandardCrypto)) - 1)
+
+-- | The probe hashes: the all-zero hash, plus one hash per byte position, each
+-- 0 everywhere except a 1 at that byte. Probing every byte checks that a wrong
+-- byte order anywhere makes the era's 'Ord' disagree with the raw-byte
+-- reference.
+hashes :: [ShortByteString]
+hashes = zeros : [byteAt p 1 | p <- [0 .. 31]]
+
+eras :: [Int]
+eras = [0 .. lengthSList (Proxy @(CardanoEras StandardCrypto)) - 1]
+
+zeros :: ShortByteString
+zeros = SBS.pack (replicate 32 0)
+
+-- | 32 bytes, all zero except position @p@ set to @v@.
+byteAt :: Int -> Word8 -> ShortByteString
+byteAt p v = SBS.pack [if i == p then v else 0 | i <- [0 .. 31]]

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator.hs
@@ -16,6 +16,7 @@
 module Test.Consensus.HardFork.Combinator (tests) where
 
 import Cardano.Ledger.BaseTypes (nonZero, unNonZero)
+import Data.Function (on)
 import qualified Data.Map.Strict as Map
 import Data.MemPack
 import Data.SOP.BasicFunctors
@@ -451,6 +452,9 @@ instance CanHardFork '[BlockA, BlockB] where
   hardForkInjTxMeasurePhase2 = \case
     (Z (WrapTxMeasurePhase2 x)) -> x
     S (Z (WrapTxMeasurePhase2 x)) -> x
+
+  hardForkEqGenTxId = (==) `on` rawHashNS
+  hardForkCompareGenTxId = compare `on` rawHashNS
 
 versionN2N :: BlockNodeToNodeVersion TestBlock
 versionN2N =

--- a/ouroboros-consensus.cabal
+++ b/ouroboros-consensus.cabal
@@ -1327,6 +1327,7 @@ library cardano
     Ouroboros.Consensus.Cardano
     Ouroboros.Consensus.Cardano.Block
     Ouroboros.Consensus.Cardano.CanHardFork
+    Ouroboros.Consensus.Cardano.CanHardFork.OptimizedTxIdComparison
     Ouroboros.Consensus.Cardano.Condense
     Ouroboros.Consensus.Cardano.Ledger
     Ouroboros.Consensus.Cardano.Node

--- a/ouroboros-consensus.cabal
+++ b/ouroboros-consensus.cabal
@@ -1617,6 +1617,7 @@ library unstable-cardano-testlib
   exposed-modules:
     Test.Consensus.Cardano.Examples
     Test.Consensus.Cardano.Generators
+    Test.Consensus.Cardano.GenTxIdBuilders
     Test.Consensus.Cardano.MockCrypto
     Test.Consensus.Cardano.ProtocolInfo
     Test.ThreadNet.Infra.ShelleyBasedHardFork
@@ -1629,6 +1630,7 @@ library unstable-cardano-testlib
 
   build-depends:
     base,
+    bytestring,
     cardano-crypto-class,
     cardano-crypto-wrapper,
     cardano-ledger-alonzo:testlib,
@@ -1677,6 +1679,7 @@ test-suite cardano-test
     Test.Consensus.Cardano.SupportedNetworkProtocolVersion
     Test.Consensus.Cardano.SupportsSanityCheck
     Test.Consensus.Cardano.Translation
+    Test.Consensus.Cardano.TxId
     Test.ThreadNet.AllegraMary
     Test.ThreadNet.Cardano
     Test.ThreadNet.MaryAlonzo

--- a/ouroboros-consensus.cabal
+++ b/ouroboros-consensus.cabal
@@ -933,6 +933,25 @@ benchmark PerasCertDB-bench
     tasty-bench,
     unstable-consensus-testlib,
 
+benchmark txid-eq-ord-instances-bench
+  import: common-bench
+  type: exitcode-stdio-1.0
+  hs-source-dirs: ouroboros-consensus-cardano/bench/txid-eq-ord-instances-bench
+  main-is: Main.hs
+  ghc-options:
+    -with-rtsopts=-T
+
+  build-depends:
+    base,
+    bytestring,
+    cardano,
+    cardano-protocol-tpraos,
+    deepseq,
+    ouroboros-consensus,
+    sop-core,
+    tasty-bench,
+    unstable-cardano-testlib,
+
 test-suite doctest
   import: common-test
   main-is: doctest.hs

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Abstract/CanHardFork.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Abstract/CanHardFork.hs
@@ -10,9 +10,13 @@
 module Ouroboros.Consensus.HardFork.Combinator.Abstract.CanHardFork
   ( CanHardFork (..)
   , HashSizeOfHead
+  , rawHashNS
   ) where
 
+import Data.ByteString.Short (ShortByteString)
+import Data.Function (on)
 import Data.Measure (Measure)
+import Data.SOP.BasicFunctors (K (..))
 import Data.SOP.Constraint
 import Data.SOP.NonEmpty
 import qualified Data.SOP.Strict as SOP
@@ -92,6 +96,29 @@ class
 
   hardForkInjTxMeasurePhase2 :: SOP.NS WrapTxMeasurePhase2 xs -> HardForkTxMeasurePhase2 xs
 
+  -- | Whether two transaction ids of @xs@ are equal, ignoring which era each
+  -- sits in. Two txids in different eras can be equal; see the
+  -- 'Ouroboros.Consensus.HardFork.Combinator.AcrossEras.OneEraGenTxId' 'Eq'
+  -- instance.
+  --
+  -- Runs on every mempool lookup, so instances should avoid allocation.
+  -- 'rawHashNS' is the reference implementation and allocates; the Cardano
+  -- instance overrides it with an allocation-free walk. There is no class
+  -- default: every instance names its body explicitly.
+  hardForkEqGenTxId :: SOP.NS WrapGenTxId xs -> SOP.NS WrapGenTxId xs -> Bool
+
+  -- | Order two transaction ids of @xs@. See 'hardForkEqGenTxId'.
+  hardForkCompareGenTxId ::
+    SOP.NS WrapGenTxId xs -> SOP.NS WrapGenTxId xs -> Ordering
+
+-- | The raw hash of an era sum, era ignored.
+--
+-- The reference comparison for transaction ids. Non-optimizing 'CanHardFork'
+-- instances implement 'hardForkEqGenTxId'\/'hardForkCompareGenTxId' by comparing
+-- this hash. It serialises each id via 'toRawTxIdHash', which allocates.
+rawHashNS :: All SingleEraBlock xs => SOP.NS WrapGenTxId xs -> ShortByteString
+rawHashNS = SOP.hcollapse . SOP.hcmap proxySingle (K . toRawTxIdHash . unwrapGenTxId)
+
 instance SingleEraBlock blk => CanHardFork '[blk] where
   type HardForkTxMeasurePhase1 '[blk] = TxMeasurePhase1 blk
   type HardForkTxMeasurePhase2 '[blk] = TxMeasurePhase2 blk
@@ -101,3 +128,11 @@ instance SingleEraBlock blk => CanHardFork '[blk] where
 
   hardForkInjTxMeasurePhase1 (SOP.Z (WrapTxMeasurePhase1 x)) = x
   hardForkInjTxMeasurePhase2 (SOP.Z (WrapTxMeasurePhase2 x)) = x
+
+  -- No production code uses a single-era hard fork, so an allocating raw-hash
+  -- comparison is fine here.
+  --
+  -- NOTE: if some production code ever uses a single-era hard fork, it may
+  -- want an allocation-free comparator here, as the Cardano instance has.
+  hardForkEqGenTxId = (==) `on` rawHashNS
+  hardForkCompareGenTxId = compare `on` rawHashNS

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/AcrossEras.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/AcrossEras.hs
@@ -59,7 +59,6 @@ module Ouroboros.Consensus.HardFork.Combinator.AcrossEras
     -- * Utility
   , getSameValue
   , oneEraBlockHeader
-  , oneEraGenTxIdRawHash
   ) where
 
 import Cardano.Binary (FromCBOR (..), ToCBOR (..))
@@ -70,7 +69,6 @@ import qualified Data.ByteString.Base16 as B16
 import qualified Data.ByteString.Char8 as BSC
 import Data.ByteString.Short (ShortByteString)
 import qualified Data.ByteString.Short as Short
-import Data.Function (on)
 import Data.Proxy
 import Data.SOP.BasicFunctors
 import Data.SOP.Constraint
@@ -166,18 +164,21 @@ instance Condense (OneEraHash xs) where
   OneEraGenTxId
 -------------------------------------------------------------------------------}
 
--- | This instance compares the underlying raw hash ('toRawTxIdHash') of the
--- 'TxId'.
+-- | Compare 'OneEraGenTxId's by their transaction id, ignoring the era.
 --
--- Note that this means that transactions in different eras can have equal
--- 'TxId's. This should only be the case when the transaction format is
--- backwards compatible from one era to the next.
+-- Two transactions in different eras can therefore have equal 'TxId's. This
+-- should only happen when the transaction format is backwards compatible from
+-- one era to the next.
+--
+-- The comparison itself lives in the 'CanHardFork' instance for @xs@, as
+-- 'hardForkEqGenTxId'\/'hardForkCompareGenTxId'. The Cardano instance implements
+-- them without allocating; other instances use 'rawHashNS'.
 instance CanHardFork xs => Eq (OneEraGenTxId xs) where
-  (==) = (==) `on` oneEraGenTxIdRawHash
+  OneEraGenTxId l == OneEraGenTxId r = hardForkEqGenTxId l r
 
 -- | See the corresponding 'Eq' instance.
 instance CanHardFork xs => Ord (OneEraGenTxId xs) where
-  compare = compare `on` oneEraGenTxIdRawHash
+  compare (OneEraGenTxId l) (OneEraGenTxId r) = hardForkCompareGenTxId l r
 
 {-------------------------------------------------------------------------------
   Value for two /different/ eras
@@ -271,12 +272,6 @@ getSameValue values =
         return ()
     | otherwise =
         throwError "differing values across hard fork"
-
-oneEraGenTxIdRawHash :: CanHardFork xs => OneEraGenTxId xs -> ShortByteString
-oneEraGenTxIdRawHash =
-  hcollapse
-    . hcmap proxySingle (K . toRawTxIdHash . unwrapGenTxId)
-    . getOneEraGenTxId
 
 {-------------------------------------------------------------------------------
   NoThunks instances

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Mempool.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Mempool.hs
@@ -542,7 +542,7 @@ instance CanHardFork xs => HasTxId (GenTx (HardForkBlock xs)) where
 
 instance CanHardFork xs => HasRawTxId (TxId (GenTx (HardForkBlock xs))) where
   type RawTxId (TxId (GenTx (HardForkBlock xs))) = ShortByteString
-  getRawTxId = oneEraGenTxIdRawHash . getHardForkGenTxId
+  getRawTxId = rawHashNS . getOneEraGenTxId . getHardForkGenTxId
 
 {-------------------------------------------------------------------------------
   HasTxs


### PR DESCRIPTION
Makes the hard-fork transaction id `Eq`/`Ord` comparisons allocation-free (#2003).

On `main`, the `Eq`/`Ord` instances for `OneEraGenTxId` (and hence for `TxId (GenTx (HardForkBlock xs))`) compared through `oneEraGenTxIdRawHash`, which serialised each operand's hash to a fresh 32-byte `ShortByteString`.
That allocated on every comparison, on a path the mempool and local queries exercise heavily.

## The change

The comparison now goes through two new `CanHardFork` methods, `hardForkEqGenTxId` and `hardForkCompareGenTxId`.
The `Eq`/`Ord (OneEraGenTxId xs)` instances unwrap the newtype and delegate to them, so each hard fork decides how to compare its transaction ids.
The methods have no default, so every `CanHardFork` instance must supply them.
This is a breaking change to the class.

The Cardano instance implements them without allocating, on every comparison:

- it reads each id's 32-byte hash as four 64-bit words (`Word64#`) and compares them in registers, instead of serialising to a `ShortByteString`;
- Shelley-based eras return the four words they already store, and Byron reads them out of its hash bytes in place;
- this covers same-era and cross-era pairs alike, for every era including Byron.

The other `CanHardFork` instances (the single-era instance and the two test hard forks) implement the methods with `rawHashNS`, the shared raw-hash reference.
Those still allocate, but they are not the mempool traffic that #2003 targets.

The observable semantics are unchanged: order by the hash bytes, ignoring the era.
`oneEraGenTxIdRawHash` is removed; its walk survives as `rawHashNS`, now exported so the property test uses it directly instead of a copy.

## Testing

`Test.Consensus.Cardano.TxId` (in `cardano-test`) checks that the instances agree with `rawHashNS` over every era pair, against hashes that differ at the first and last byte of each 64-bit word.
Because the Cardano comparison is no longer the reference itself, these cross-era cells now genuinely check the packed comparison against the raw-hash order.
The era-txid builders live in `unstable-cardano-testlib`, shared by the test and the benchmark.

## Micro-benchmark

`compare`/`==` across the 8 Cardano eras: one distinct-hash pair for every ordered era pair (64 cells), plus one same-hash pair per era (8 cells).
"Before" is `main` (raw hash on every comparison), "after" is this branch.
`compare` and `==` combined (`tasty-bench`, `+RTS -T`):

| class | alloc before (B) | alloc after (B) | time before (ns) | time after (ns) |
|-----------|-----------------:|----------------:|-----------------:|----------------:|
| same era  | 2676 | 80 | 408 | 75 |
| cross era | 2676 | 80 | 398 | 74 |

Representative `compare` cells (era index = position in the Cardano era list, 0 = Byron, 7 = Dijkstra):

| cell | alloc before (B) | alloc after (B) | time before (ns) | time after (ns) |
|------------------------------|-----------------:|----------------:|-----------------:|----------------:|
| `equal 0` (Byron)            | 2480 | 80 | 419 | 48  |
| `equal 7` (Dijkstra)         | 2800 | 80 | 428 | 116 |
| `0-vs-1` (Byron, Shelley)    | 2544 | 80 | 387 | 47  |
| `1-vs-2` (Shelley, Allegra)  | 2624 | 80 | 397 | 51  |
| `7-vs-0` (Dijkstra, Byron)   | 2640 | 80 | 399 | 78  |
| `7-vs-7` (Dijkstra)          | 2800 | 80 | 434 | 118 |

The 80 B after is `tasty-bench`'s fixed per-measurement floor (`Copied=0`), so the comparison itself allocates nothing, on every cell.
The generated STG confirms it: no heap object on either path, Byron included.
Comparisons run about 5x faster.
