### PR TITLE
[Peras 28] Move PerasEnabled wrapper to O.C.Peras.Params

### DIFF
--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Committee/Types.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Committee/Types.hs
@@ -1,4 +1,6 @@
-{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 -- | Types common to any generic committee selection scheme
@@ -12,7 +14,10 @@ module Ouroboros.Consensus.Committee.Types
 
 import Cardano.Ledger.BaseTypes (HasZero)
 import Cardano.Ledger.Core (KeyHash, KeyRole (..))
+import Codec.Serialise (Serialise)
 import Data.Word (Word64)
+import GHC.Generics (Generic)
+import NoThunks.Class (NoThunks)
 
 -- | Identifier of a given voter in the committee selection scheme
 newtype PoolId = PoolId
@@ -37,7 +42,9 @@ newtype VoteWeight = VoteWeight
 newtype TargetCommitteeSize = TargetCommitteeSize
   { unTargetCommitteeSize :: Word64
   }
-  deriving (Show, Eq)
+  deriving stock (Show, Eq, Generic)
+  deriving newtype Serialise
+  deriving anyclass NoThunks
 
 -- | Wrapper to tag accumulated resources
 newtype Cumulative a = Cumulative

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/History/EraParams.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/History/EraParams.hs
@@ -1,9 +1,6 @@
-{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE GeneralisedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternSynonyms #-}
@@ -19,6 +16,7 @@ module Ouroboros.Consensus.HardFork.History.EraParams
   , pattern NoPerasEnabled
   , PerasEnabledT (..)
   , fromPerasEnabled
+  , perasEnabledToMaybe
 
     -- * Defaults
   , defaultEraParams
@@ -29,14 +27,14 @@ import Cardano.Ledger.BaseTypes (unNonZero)
 import Codec.CBOR.Decoding (Decoder, decodeListLen, decodeWord8)
 import Codec.CBOR.Encoding (Encoding, encodeListLen, encodeWord8)
 import Codec.Serialise (Serialise (..))
-import Control.Monad (ap, liftM, void)
-import Control.Monad.Trans.Class
+import Control.Monad (void)
 import Data.Word
 import GHC.Generics (Generic)
 import NoThunks.Class (NoThunks)
-import Ouroboros.Consensus.Block
+import Ouroboros.Consensus.Block.Abstract
 import Ouroboros.Consensus.BlockchainTime.WallClock.Types
 import Ouroboros.Consensus.Config.SecurityParam
+import Ouroboros.Consensus.Peras.Params
 
 {-------------------------------------------------------------------------------
   OVERVIEW
@@ -149,51 +147,6 @@ data EraParams = EraParams
   }
   deriving stock (Show, Eq, Generic)
   deriving anyclass NoThunks
-
--- | A marker for era parameters that are Peras-specific
---   and are not present in pre-Peras eras
-newtype PerasEnabled a = MkPerasEnabled (Maybe a)
-  deriving stock (Show, Eq, Ord, Generic)
-  deriving anyclass NoThunks
-  deriving newtype (Functor, Applicative, Monad)
-
-pattern PerasEnabled :: a -> PerasEnabled a
-pattern PerasEnabled x <- MkPerasEnabled (Just !x)
- where
-  PerasEnabled !x = MkPerasEnabled (Just x)
-
-pattern NoPerasEnabled :: PerasEnabled a
-pattern NoPerasEnabled = MkPerasEnabled Nothing
-
-{-# COMPLETE PerasEnabled, NoPerasEnabled #-}
-
--- | A 'fromMaybe'-like eliminator for 'PerasEnabled'
-fromPerasEnabled :: a -> PerasEnabled a -> a
-fromPerasEnabled defaultValue =
-  \case
-    NoPerasEnabled -> defaultValue
-    PerasEnabled value -> value
-
--- | A 'MaybeT'-like monad transformer.
---
---   Used solely for the Peras-related hard fork combinator queries,
---   see 'Ouroboros.Consensus.HardFork.History.Qry'.
-newtype PerasEnabledT m a = PerasEnabledT {runPerasEnabledT :: m (PerasEnabled a)}
-  deriving stock Functor
-
-instance (Functor m, Monad m) => Applicative (PerasEnabledT m) where
-  pure = PerasEnabledT . pure . PerasEnabled
-  (<*>) = ap
-
-instance Monad m => Monad (PerasEnabledT m) where
-  x >>= f = PerasEnabledT $ do
-    v <- runPerasEnabledT x
-    case v of
-      NoPerasEnabled -> pure NoPerasEnabled
-      PerasEnabled y -> runPerasEnabledT (f y)
-
-instance MonadTrans PerasEnabledT where
-  lift = PerasEnabledT . liftM PerasEnabled
 
 -- | Default 'EraParams'
 --

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Peras/Params.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Peras/Params.hs
@@ -1,7 +1,11 @@
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE StandaloneDeriving #-}
 
 -- | Peras protocol parameters
@@ -20,9 +24,23 @@ module Ouroboros.Consensus.Peras.Params
     -- * Protocol parameters bundle
   , PerasParams (..)
   , mkPerasParams
+
+    -- * 'PerasEnabled' wrapper
+  , PerasEnabled
+  , pattern PerasEnabled
+  , pattern NoPerasEnabled
+  , PerasEnabledT (..)
+  , fromPerasEnabled
+  , perasEnabledToMaybe
   )
 where
 
+import Cardano.Binary
+  ( FromCBOR (..)
+  , ToCBOR (..)
+  )
+import Control.Monad (ap, liftM)
+import Control.Monad.Trans.Class
 import Data.Semigroup (Sum (..))
 import Data.Word (Word64)
 import GHC.Generics (Generic)
@@ -30,9 +48,7 @@ import Ouroboros.Consensus.Util.Condense (Condense (..))
 import Ouroboros.Consensus.Util.IOLike (NoThunks)
 import Quiet (Quiet (..))
 
-{-------------------------------------------------------------------------------
-  Protocol parameters
--------------------------------------------------------------------------------}
+-- * Protocol parameters
 
 -- | Number of rounds for which to ignore certificates after entering a
 -- cooldown period.
@@ -40,7 +56,7 @@ newtype PerasIgnoranceRounds
   = PerasIgnoranceRounds {unPerasIgnoranceRounds :: Word64}
   deriving Show via Quiet PerasIgnoranceRounds
   deriving stock Generic
-  deriving newtype (Enum, Eq, Ord, NoThunks, Condense)
+  deriving newtype (Enum, Eq, Ord, NoThunks, Condense, FromCBOR, ToCBOR)
 
 -- | Minimum number of rounds to wait before voting again after a cooldown
 -- period starts.
@@ -97,7 +113,7 @@ newtype PerasQuorumStakeThreshold
   deriving stock Generic
   deriving newtype (Eq, Ord, NoThunks, Condense)
 
--- | Safety margin needed on top of the quorum stake threshold.
+-- | Safety margin needed on top of the quorum vote weight threshold.
 --
 -- NOTE: this is needed to account for an extremely unlikely local sortition
 -- where not enough honest non-persistent parties decide to vote in a round.
@@ -108,9 +124,7 @@ newtype PerasQuorumStakeThresholdSafetyMargin
   deriving stock Generic
   deriving newtype (Eq, Ord, NoThunks, Condense)
 
-{-------------------------------------------------------------------------------
-  Protocol parameters bundle
--------------------------------------------------------------------------------}
+-- * Protocol parameters bundle
 
 -- | Peras protocol parameters.
 --
@@ -175,3 +189,56 @@ mkPerasParams =
     , perasQuorumStakeThresholdSafetyMargin =
         PerasQuorumStakeThresholdSafetyMargin (2 / 100)
     }
+
+-- * 'PerasEnabled' wrapper
+
+-- | A marker for Peras-specific values that are not present in all eras
+newtype PerasEnabled a = MkPerasEnabled (Maybe a)
+  deriving stock (Show, Eq, Ord, Generic)
+  deriving anyclass NoThunks
+  deriving newtype (Functor, Applicative, Monad, FromCBOR, ToCBOR)
+
+pattern PerasEnabled :: a -> PerasEnabled a
+pattern PerasEnabled x <- MkPerasEnabled (Just !x)
+ where
+  PerasEnabled !x = MkPerasEnabled (Just x)
+
+pattern NoPerasEnabled :: PerasEnabled a
+pattern NoPerasEnabled = MkPerasEnabled Nothing
+
+{-# COMPLETE PerasEnabled, NoPerasEnabled #-}
+
+-- | A 'fromMaybe'-like eliminator for 'PerasEnabled'
+fromPerasEnabled :: a -> PerasEnabled a -> a
+fromPerasEnabled defaultValue = \case
+  NoPerasEnabled -> defaultValue
+  PerasEnabled value -> value
+
+-- | Return the underlying 'Maybe' of a 'PerasEnabled' value.
+perasEnabledToMaybe :: PerasEnabled a -> Maybe a
+perasEnabledToMaybe = \case
+  NoPerasEnabled -> Nothing
+  PerasEnabled value -> Just value
+
+-- | A 'MaybeT'-like monad transformer.
+--
+--   Used solely for the Peras-related hard fork combinator queries,
+--   see 'Ouroboros.Consensus.HardFork.History.Qry'.
+newtype PerasEnabledT m a = PerasEnabledT
+  { runPerasEnabledT :: m (PerasEnabled a)
+  }
+  deriving stock Functor
+
+instance (Functor m, Monad m) => Applicative (PerasEnabledT m) where
+  pure = PerasEnabledT . pure . PerasEnabled
+  (<*>) = ap
+
+instance Monad m => Monad (PerasEnabledT m) where
+  x >>= f = PerasEnabledT $ do
+    v <- runPerasEnabledT x
+    case v of
+      NoPerasEnabled -> pure NoPerasEnabled
+      PerasEnabled y -> runPerasEnabledT (f y)
+
+instance MonadTrans PerasEnabledT where
+  lift = PerasEnabledT . liftM PerasEnabled


### PR DESCRIPTION
This commit moves the `Maybe`-like `PerasEnabled` and `PerasEnabledT` wrappers into O.C.Peras.Params. This is in anticipation of the upcoming HFC plumbing that reuses these types outside of HFC history queries.