### PR TITLE
[Peras 30]  Tweak generic voting committee interface and implementations 

### DIFF
--- a/changelog.d/20260717_115054_agustin.mista_tweak_voting_committee_types.md
+++ b/changelog.d/20260717_115054_agustin.mista_tweak_voting_committee_types.md
@@ -1,0 +1,27 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+<!--
+### Breaking
+
+- A bullet item for the Breaking category.
+
+-->
+### Non-Breaking
+
+- Move the `VotingCommittee` data family out of the `CryptoSupportsVotingCommittee` class
+- Move the `voteTarget` and `compareVotesById` helpers into the `CryptoSupportsVotingCommittee` class.
+- Change `VoteWeight` to represent the relative (normalised) voting power of a voter w.r.t. the rest of the committee.
+- Derive `FromCBOR`, `ToCBOR`, `NoThunks`, `Generic` and `Exception` for the voting committee types, keys and errors.
+- Implement orphan `FromCBOR`/`ToCBOR` instances for `Nonce`, as well as `NoThunks` for `Array`.
+
+<!--
+### Patch
+
+- A bullet item for the Patch category.
+
+-->

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Committee/Class.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Committee/Class.hs
@@ -7,7 +7,8 @@
 -- | Generic interface used by implementations of voting committees.
 module Ouroboros.Consensus.Committee.Class
   ( -- * Voting committee interface
-    CryptoSupportsVotingCommittee (..)
+    VotingCommittee
+  , CryptoSupportsVotingCommittee (..)
 
     -- * Votes with same target
   , UniqueVotesWithSameTarget
@@ -35,6 +36,15 @@ import Ouroboros.Consensus.Committee.Crypto
   )
 import Ouroboros.Consensus.Committee.Types (PoolId, VoteWeight)
 
+-- | Structure storing the voting committee context
+--
+-- NOTE: This data family is defined outside of the
+-- 'CryptoSupportsVotingCommittee' class so that it can be instantiated for the
+-- HFC block without having to provide an instance of the whole class (because
+-- for HFC, we dispatch to a concrete era first so none of the methods/types of
+-- the class would actually be used).
+data family VotingCommittee crypto committee :: Type
+
 -- * Voting committee interface
 
 -- | Interface for voting committee schemes.
@@ -46,9 +56,6 @@ class
   CryptoSupportsVoteSigning crypto =>
   CryptoSupportsVotingCommittee crypto committee
   where
-  -- | Structure storing the voting committee context
-  data VotingCommittee crypto committee :: Type
-
   -- | Input information needed to construct a voting committee
   data VotingCommitteeInput crypto committee :: Type
 
@@ -66,6 +73,19 @@ class
 
   -- | Abstract certificate attesting the winner of a given election
   data Cert crypto committee :: Type
+
+  -- | Project the target (election and candidate) from an abstract vote
+  voteTarget ::
+    Vote crypto committee ->
+    (ElectionId crypto, VoteCandidate crypto)
+
+  -- | Compare votes by ID, where EQ means that two votes have the same
+  -- ID and are either total duplicates, or are equivocating (i.e., they have
+  -- the same ID but a different target)
+  compareVotesById ::
+    Vote crypto committee ->
+    Vote crypto committee ->
+    Ordering
 
   -- | Construct a voting committee
   mkVotingCommittee ::
@@ -100,7 +120,20 @@ class
       (VotingCommitteeError crypto committee)
       (EligibilityWitness crypto committee)
 
-  -- | Compute the voting weight of a eligibile party
+  -- | Compute the (relative) voting power of an eligibile party
+  --
+  -- WARNING: there is a key difference between the "Ledger stake" and the "Vote
+  -- weight" of a given voter. On one hand, the ledger stake is the stake as
+  -- reflected directly by the ledger stake distribution under consideration
+  -- (in its corresponding absolute unit). On the other hand, the "Vote weight"
+  -- refers to the relative (i.e. normalised) voting power of that voter w.r.t.
+  -- the rest of the committee.
+  --
+  -- It is up to the implementation of the voting committee to decide how to
+  -- compute this value, but it should be implemented so that detecting a
+  -- quorum can be done by comparing the total vote weight of the votes received
+  -- against a fixed threshold, e.g., "a quorum is reached if the total weight
+  -- of the votes received exceeds 75% or 0.75 (of the total voting stake)".
   eligiblePartyVoteWeight ::
     VotingCommittee crypto committee ->
     EligibilityWitness crypto committee ->
@@ -213,25 +246,20 @@ ensureUniqueVotesWithSameTarget getTarget cmpVotes votes =
 -- guarantee that the input votes satisfy the contract.
 unsafeUniqueVotesWithSameTarget ::
   forall crypto committee.
-  ( Eq (ElectionId crypto)
+  ( CryptoSupportsVotingCommittee crypto committee
+  , Eq (ElectionId crypto)
   , Eq (VoteCandidate crypto)
   ) =>
-  -- | How to project the target from an abstract vote
-  (Vote crypto committee -> (ElectionId crypto, VoteCandidate crypto)) ->
-  -- | How to compare votes by ID, where EQ means that two votes have the same
-  -- ID and are either total duplicates, or are equivocating (i.e., they have
-  -- the same ID but a different target)
-  (Vote crypto committee -> Vote crypto committee -> Ordering) ->
   -- | Collection of votes to check
   NE [Vote crypto committee] ->
   UniqueVotesWithSameTarget crypto committee
-unsafeUniqueVotesWithSameTarget getTarget cmpVotes votes =
+unsafeUniqueVotesWithSameTarget votes =
   assert
     ( isRight
         ( checkUniqueVotesWithSameTarget
             (Proxy @crypto)
-            getTarget
-            cmpVotes
+            voteTarget
+            compareVotesById
             votes
         )
     )
@@ -241,7 +269,7 @@ unsafeUniqueVotesWithSameTarget getTarget cmpVotes votes =
       (firstVote :| nextVotes)
  where
   firstVote :| nextVotes = votes
-  (electionId, candidate) = getTarget firstVote
+  (electionId, candidate) = voteTarget firstVote
 
 -- | Validate that a non-empty collection of votes is well-formed for
 -- certificate forging: all votes target the same election and candidate

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Committee/Crypto/BLS.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Committee/Crypto/BLS.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -15,12 +17,12 @@ module Ouroboros.Consensus.Committee.Crypto.BLS
   ( -- * BLS crypto helpers to instantiate voting committees
     KeyRole (..)
   , KeyScope
-  , PrivateKey
+  , PrivateKey (privateKeyScope)
   , rawDeserialisePrivateKey
   , rawSerialisePrivateKey
   , coercePrivateKey
   , derivePublicKey
-  , PublicKey
+  , PublicKey (publicKeyScope)
   , rawDeserialisePublicKey
   , rawSerialisePublicKey
   , coercePublicKey
@@ -69,7 +71,9 @@ import Data.Kind (Type)
 import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.List.NonEmpty as NonEmpty
 import Data.Proxy (Proxy (..))
+import GHC.Generics (Generic)
 import GHC.Natural (Natural)
+import NoThunks.Class (NoThunks)
 import Ouroboros.Consensus.Committee.Crypto (NormalizedVRFOutput (..))
 
 -- * BLS crypto helpers to instantiate voting committees
@@ -92,7 +96,8 @@ data PrivateKey r = PrivateKey
   { unPrivateKey :: !(SignKeyDSIGN BLS12381MinSigDSIGN)
   , privateKeyScope :: !KeyScope
   }
-  deriving stock (Eq, Show)
+  deriving stock (Eq, Show, Generic)
+  deriving anyclass NoThunks
 
 rawDeserialisePrivateKey ::
   KeyScope ->
@@ -131,9 +136,10 @@ derivePublicKey sk =
 type PublicKey :: KeyRole -> Type
 data PublicKey r = PublicKey
   { unPublicKey :: !(VerKeyDSIGN BLS12381MinSigDSIGN)
-  , publicKeyScope :: !(KeyScope)
+  , publicKeyScope :: !KeyScope
   }
-  deriving stock (Eq, Show)
+  deriving stock (Eq, Show, Generic)
+  deriving anyclass NoThunks
 
 rawDeserialisePublicKey ::
   KeyScope ->
@@ -164,8 +170,9 @@ type Signature :: KeyRole -> Type
 newtype Signature r = Signature
   { unSignature :: SigDSIGN BLS12381MinSigDSIGN
   }
-  deriving stock (Eq, Show)
+  deriving stock (Show, Eq, Generic)
   deriving newtype (FromCBOR, ToCBOR)
+  deriving anyclass NoThunks
 
 -- | BLS proof of possession type
 newtype ProofOfPossession = ProofOfPossession

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Committee/EveryoneVotes.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Committee/EveryoneVotes.hs
@@ -1,9 +1,16 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 -- | A simple voting committee where pools with positive stake can vote.
 module Ouroboros.Consensus.Committee.EveryoneVotes
@@ -21,9 +28,15 @@ module Ouroboros.Consensus.Committee.EveryoneVotes
   , numActiveVoters
   ) where
 
+import Cardano.Binary
+  ( FromCBOR (..)
+  , ToCBOR (..)
+  , decodeListLenOf
+  , encodeListLen
+  )
 import Cardano.Ledger.BaseTypes (NonZero)
 import Cardano.Ledger.BaseTypes.NonZero (NonZero (..), nonZero)
-import Control.Exception (assert)
+import Control.Exception (Exception, assert)
 import Control.Monad.Zip (MonadZip (..))
 import qualified Data.Array as Array
 import Data.Bifunctor (Bifunctor (..))
@@ -34,9 +47,13 @@ import qualified Data.Map.Strict as Map
 import Data.Proxy (Proxy (..))
 import Data.Set (Set)
 import qualified Data.Set.NonEmpty as NESet
+import Data.Typeable (Typeable)
+import GHC.Generics (Generic)
+import NoThunks.Class (NoThunks)
 import Ouroboros.Consensus.Committee.Class
   ( CryptoSupportsVotingCommittee (..)
   , UniqueVotesWithSameTarget
+  , VotingCommittee
   , getElectionIdFromVotes
   , getRawVotes
   , getVoteCandidateFromVotes
@@ -50,7 +67,8 @@ import Ouroboros.Consensus.Committee.Crypto
   , VoteCandidate
   )
 import Ouroboros.Consensus.Committee.Types
-  ( LedgerStake (..)
+  ( Cumulative (..)
+  , LedgerStake (..)
   , PoolId
   , VoteWeight (..)
   )
@@ -58,6 +76,7 @@ import Ouroboros.Consensus.Committee.WFA
   ( ExtWFAStakeDistr (..)
   , NumPoolsWithPositiveStake (..)
   , SeatIndex
+  , TotalStake (..)
   , WFAError
   , getCandidateIfSeatWithinBounds
   , unsafeGetCandidateInSeat
@@ -66,20 +85,61 @@ import Ouroboros.Consensus.Committee.WFA
 -- | Tag for a simple voting committee where pools with positive stake can vote.
 data EveryoneVotes
 
+data instance VotingCommittee crypto EveryoneVotes
+  = EveryoneVotesVotingCommittee
+  { -- Preaccumulated stake distribution used to compute committee composition
+    extWFAStakeDistr :: !(ExtWFAStakeDistr (PublicKey crypto))
+  , -- Index of a given candidate in the cumulative stake distribution
+    candidateSeats :: !(Map PoolId SeatIndex)
+  , -- Number of active voters (i.e., those with non-zero stake)
+    numActiveVoters :: !NumPoolsWithPositiveStake
+  , -- Total stake of all voters (i.e., the sum of the stakes)
+    totalActiveStake :: !TotalStake
+  }
+
 instance
-  CryptoSupportsAggregateVoteSigning crypto =>
+  ( Typeable crypto
+  , FromCBOR (PublicKey crypto)
+  ) =>
+  FromCBOR (VotingCommittee crypto EveryoneVotes)
+  where
+  fromCBOR = do
+    decodeListLenOf 4
+    extWFAStakeDistr <- fromCBOR
+    candidateSeats <- fromCBOR
+    numActiveVoters <- fromCBOR
+    totalActiveStake <- fromCBOR
+    pure $
+      EveryoneVotesVotingCommittee
+        { extWFAStakeDistr
+        , candidateSeats
+        , numActiveVoters
+        , totalActiveStake
+        }
+
+instance
+  ( Typeable crypto
+  , ToCBOR (PublicKey crypto)
+  ) =>
+  ToCBOR (VotingCommittee crypto EveryoneVotes)
+  where
+  toCBOR
+    EveryoneVotesVotingCommittee
+      { extWFAStakeDistr
+      , candidateSeats
+      , numActiveVoters
+      , totalActiveStake
+      } =
+      encodeListLen 4
+        <> toCBOR extWFAStakeDistr
+        <> toCBOR candidateSeats
+        <> toCBOR numActiveVoters
+        <> toCBOR totalActiveStake
+
+instance
+  (Ord (ElectionId crypto), CryptoSupportsAggregateVoteSigning crypto) =>
   CryptoSupportsVotingCommittee crypto EveryoneVotes
   where
-  data VotingCommittee crypto EveryoneVotes
-    = EveryoneVotesVotingCommittee
-    { -- Preaccumulated stake distribution used to compute committee composition
-      extWFAStakeDistr :: !(ExtWFAStakeDistr (PublicKey crypto))
-    , -- Index of a given candidate in the cumulative stake distribution
-      candidateSeats :: !(Map PoolId SeatIndex)
-    , -- Number of active voters (i.e., those with non-zero stake)
-      numActiveVoters :: !NumPoolsWithPositiveStake
-    }
-
   data VotingCommitteeInput crypto EveryoneVotes
     = EveryoneVotesVotingCommitteeInput
         -- Extended cumulative stake distribution of the potential voters
@@ -100,7 +160,6 @@ instance
       InvalidCertSignature String
     | -- We triggered an unexpected cryptographic error
       CryptoError String
-    deriving (Show, Eq)
 
   data EligibilityWitness crypto EveryoneVotes
     = EveryoneVotesMember
@@ -129,6 +188,47 @@ instance
   forgeCert = implForgeCert
   verifyCert = implVerifyCert
 
+  voteTarget (EveryoneVotesVote _ electionId candidate _) =
+    (electionId, candidate)
+  compareVotesById
+    (EveryoneVotesVote seatIndex1 electionId1 _ _)
+    (EveryoneVotesVote seatIndex2 electionId2 _ _) =
+      compare (electionId1, seatIndex1) (electionId2, seatIndex2)
+
+deriving instance
+  Show (PublicKey crypto) =>
+  Show (VotingCommittee crypto EveryoneVotes)
+deriving instance
+  Eq (PublicKey crypto) =>
+  Eq (VotingCommittee crypto EveryoneVotes)
+deriving instance
+  NoThunks (PublicKey crypto) =>
+  NoThunks (VotingCommittee crypto EveryoneVotes)
+deriving instance Generic (VotingCommittee crypto EveryoneVotes)
+
+deriving instance
+  Show (PublicKey crypto) =>
+  Show (VotingCommitteeInput crypto EveryoneVotes)
+deriving instance
+  Eq (PublicKey crypto) =>
+  Eq (VotingCommitteeInput crypto EveryoneVotes)
+deriving instance
+  NoThunks (PublicKey crypto) =>
+  NoThunks (VotingCommitteeInput crypto EveryoneVotes)
+deriving instance Generic (VotingCommitteeInput crypto EveryoneVotes)
+
+deriving instance
+  Show (VotingCommitteeError crypto EveryoneVotes)
+deriving instance
+  Eq (VotingCommitteeError crypto EveryoneVotes)
+deriving instance
+  NoThunks (VotingCommitteeError crypto EveryoneVotes)
+deriving instance
+  Generic (VotingCommitteeError crypto EveryoneVotes)
+deriving instance
+  Typeable crypto =>
+  Exception (VotingCommitteeError crypto EveryoneVotes)
+
 -- | Construct a 'EveryoneVotesVotingCommittee' for a given epoch
 mkEveryoneVotesVotingCommittee ::
   VotingCommitteeInput crypto EveryoneVotes ->
@@ -151,6 +251,7 @@ mkEveryoneVotesVotingCommittee
         { extWFAStakeDistr = stakeDistr
         , candidateSeats = seats
         , numActiveVoters = numPoolsWithPositiveStake stakeDistr
+        , totalActiveStake = totalStake stakeDistr
         }
 
 -- | Check whether we should vote in a given election
@@ -234,15 +335,23 @@ implVerifyVote committee = \case
 -- | Compute the voting power of an eligible committee member.
 --
 -- In this simple voting committee, the vote weight of a member is equal to
--- their ledger stake, as long as it is positive.
+-- their (normalised) ledger stake, as long as it is positive.
 implEligiblePartyVoteWeight ::
   VotingCommittee crypto EveryoneVotes ->
   EligibilityWitness crypto EveryoneVotes ->
   VoteWeight
-implEligiblePartyVoteWeight _committee member =
-  VoteWeight (unLedgerStake (unNonZero voterStake))
+implEligiblePartyVoteWeight committee = \case
+  EveryoneVotesMember _ nonZeroStake ->
+    mkVoteWeight
+      . unLedgerStake
+      . unNonZero
+      $ nonZeroStake
  where
-  EveryoneVotesMember _ voterStake = member
+  TotalStake (Cumulative (LedgerStake activeStake)) =
+    totalActiveStake committee
+
+  mkVoteWeight absoluteStake =
+    VoteWeight (absoluteStake / activeStake)
 
 -- | Forge a certificate attesting the winner of a given election
 implForgeCert ::

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Committee/Types.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Committee/Types.hs
@@ -12,42 +12,66 @@ module Ouroboros.Consensus.Committee.Types
   , Cumulative (..)
   ) where
 
+import Cardano.Binary (FromCBOR (..), ToCBOR (..))
+import qualified Cardano.Crypto.Hash as Hash
 import Cardano.Ledger.BaseTypes (HasZero)
-import Cardano.Ledger.Core (KeyHash, KeyRole (..))
-import Codec.Serialise (Serialise)
+import Cardano.Ledger.Core (KeyHash (..), KeyRole (..))
+import Cardano.Prelude (Generic)
+import Control.DeepSeq (NFData)
+import Data.Semigroup (Sum (..))
 import Data.Word (Word64)
-import GHC.Generics (Generic)
 import NoThunks.Class (NoThunks)
 
 -- | Identifier of a given voter in the committee selection scheme
 newtype PoolId = PoolId
   { unPoolId :: KeyHash StakePool
   }
-  deriving (Show, Eq, Ord)
+  deriving stock (Show, Eq, Ord, Generic)
+  deriving anyclass NoThunks
+
+instance FromCBOR PoolId where
+  fromCBOR = do
+    bytes <- fromCBOR
+    case Hash.hashFromBytes bytes of
+      Just hash ->
+        return (PoolId (KeyHash hash))
+      Nothing ->
+        fail ("failed to decode PoolId, invalid hash bytes: " <> show bytes)
+
+instance ToCBOR PoolId where
+  toCBOR (PoolId hash) =
+    toCBOR (Hash.hashToBytes (unKeyHash hash))
 
 -- | Stake of a voter as reflected by the ledger state
 newtype LedgerStake = LedgerStake
   { unLedgerStake :: Rational
   }
-  deriving (Show, Eq)
-  deriving newtype (Num, HasZero)
+  deriving stock (Show, Eq, Ord, Generic)
+  deriving newtype (Num, HasZero, FromCBOR, ToCBOR)
+  deriving anyclass NoThunks
 
--- | Voting power of a voter in the committee selection scheme
+-- | Relative voting power of a voter in the committee selection scheme
 newtype VoteWeight = VoteWeight
   { unVoteWeight :: Rational
   }
-  deriving (Show, Eq)
+  deriving stock (Show, Eq, Ord, Generic)
+  deriving newtype (Num, Fractional, NFData, FromCBOR, ToCBOR)
+  deriving anyclass NoThunks
+  deriving Semigroup via Sum Rational
+  deriving Monoid via Sum Rational
 
 -- | Target committee size
 newtype TargetCommitteeSize = TargetCommitteeSize
   { unTargetCommitteeSize :: Word64
   }
   deriving stock (Show, Eq, Generic)
-  deriving newtype Serialise
+  deriving newtype (FromCBOR, ToCBOR)
   deriving anyclass NoThunks
 
 -- | Wrapper to tag accumulated resources
 newtype Cumulative a = Cumulative
   { unCumulative :: a
   }
-  deriving (Show, Eq)
+  deriving stock (Show, Eq, Generic)
+  deriving newtype (FromCBOR, ToCBOR)
+  deriving anyclass NoThunks

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Committee/WFA.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Committee/WFA.hs
@@ -1,4 +1,10 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE TypeApplications #-}
 
 -- | Deterministic portion of the Weighted Fait-Accompli committee selection scheme
 module Ouroboros.Consensus.Committee.WFA
@@ -13,6 +19,7 @@ module Ouroboros.Consensus.Committee.WFA
     -- * Cumulative stake distributions
   , SeatIndex (..)
   , NumPoolsWithPositiveStake (..)
+  , TotalStake (..)
   , WFAError (..)
   , WFATiebreaker (..)
   , wFATiebreakerWithEpochNonce
@@ -25,12 +32,20 @@ module Ouroboros.Consensus.Committee.WFA
 -- NOTE: DSIGN/BLS imports are needed to implement the fair 'WFATiebreaker'
 -- using epoch nonces. If we move away from BLS in the future of Peras/Leios, we
 -- might want to revisit its implementation to use a different hash function.
+
+import Cardano.Binary
+  ( FromCBOR (..)
+  , ToCBOR (..)
+  , decodeListLen
+  , decodeListLenOf
+  , encodeListLen
+  )
 import Cardano.Crypto.DSIGN (BLS12381MinSigDSIGN, DSIGNAlgorithm (SigDSIGN))
 import qualified Cardano.Crypto.Hash as Hash
 import Cardano.Ledger.BaseTypes (Nonce (NeutralNonce, Nonce))
 import Cardano.Ledger.Binary (runByteBuilder)
 import Cardano.Ledger.Core (HASH, Hash, KeyHash (unKeyHash))
-import Control.Exception (assert)
+import Control.Exception (Exception, assert)
 import Data.Array (Array, Ix, listArray)
 import qualified Data.Array as Array
 import qualified Data.ByteString.Builder.Extra as BS
@@ -38,7 +53,9 @@ import Data.Function (on)
 import qualified Data.List as List
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import Data.Word (Word64)
+import Data.Word (Word64, Word8)
+import GHC.Generics (Generic)
+import NoThunks.Class (NoThunks)
 import Ouroboros.Consensus.Committee.Types
   ( Cumulative (..)
   , LedgerStake (..)
@@ -46,6 +63,7 @@ import Ouroboros.Consensus.Committee.Types
   , TargetCommitteeSize (..)
   , unPoolId
   )
+import Ouroboros.Consensus.Util.Orphans ()
 
 -- * Weighted Fait-Accompli committee selection scheme
 
@@ -54,28 +72,36 @@ newtype PersistentCommitteeSize
   = PersistentCommitteeSize
   { unPersistentCommitteeSize :: Word64
   }
-  deriving (Show, Eq)
+  deriving stock (Show, Eq, Generic)
+  deriving newtype (FromCBOR, ToCBOR)
+  deriving anyclass NoThunks
 
 -- | Non-persistent committee size
 newtype NonPersistentCommitteeSize
   = NonPersistentCommitteeSize
   { unNonPersistentCommitteeSize :: Word64
   }
-  deriving (Show, Eq)
+  deriving stock (Show, Eq, Generic)
+  deriving newtype (FromCBOR, ToCBOR)
+  deriving anyclass NoThunks
 
 -- | Total persistent stake
 newtype TotalPersistentStake
   = TotalPersistentStake
   { unTotalPersistentStake :: Cumulative LedgerStake
   }
-  deriving (Show, Eq)
+  deriving stock (Show, Eq, Generic)
+  deriving newtype (FromCBOR, ToCBOR)
+  deriving anyclass NoThunks
 
 -- | Total non-persistent stake
 newtype TotalNonPersistentStake
   = TotalNonPersistentStake
   { unTotalNonPersistentStake :: Cumulative LedgerStake
   }
-  deriving (Show, Eq)
+  deriving stock (Show, Eq, Generic)
+  deriving newtype (FromCBOR, ToCBOR)
+  deriving anyclass NoThunks
 
 -- | Errors that can occur when trying to split the stake distribution into
 -- persistent and seats via weighted Fait-Accompli.
@@ -88,7 +114,27 @@ data WFAError
     NotEnoughPoolsWithPositiveStake
       TargetCommitteeSize
       NumPoolsWithPositiveStake
-  deriving (Show, Eq)
+  deriving stock (Show, Eq, Generic)
+  deriving anyclass (NoThunks, Exception)
+
+instance FromCBOR WFAError where
+  fromCBOR = do
+    len <- decodeListLen
+    tag <- fromCBOR @Word8
+    case (len, tag) of
+      (1, 0) -> pure EmptyStakeDistribution
+      (3, 1) -> NotEnoughPoolsWithPositiveStake <$> fromCBOR <*> fromCBOR
+      _ -> fail $ "Invalid WFAError length/tag: " <> show (len, tag)
+
+instance ToCBOR WFAError where
+  toCBOR EmptyStakeDistribution =
+    encodeListLen 1
+      <> toCBOR (0 :: Word8)
+  toCBOR (NotEnoughPoolsWithPositiveStake totalSeats numPools) =
+    encodeListLen 3
+      <> toCBOR (1 :: Word8)
+      <> toCBOR totalSeats
+      <> toCBOR numPools
 
 -- | Split a stake distrubution into persistent and non-persistent committee
 -- seats according to the weighted Fait-Accompli scheme.
@@ -231,14 +277,27 @@ newtype SeatIndex
   = SeatIndex
   { unSeatIndex :: Word64
   }
-  deriving (Show, Eq, Ord, Enum, Ix)
+  deriving stock (Show, Eq, Ord, Ix, Generic)
+  deriving newtype (Enum, FromCBOR, ToCBOR)
+  deriving anyclass NoThunks
 
 -- | Number of pools with positive stake in the underlying stake distribution
 newtype NumPoolsWithPositiveStake
   = NumPoolsWithPositiveStake
   { unNumPoolsWithPositiveStake :: Word64
   }
-  deriving (Show, Eq)
+  deriving stock (Show, Eq, Generic)
+  deriving newtype (FromCBOR, ToCBOR)
+  deriving anyclass NoThunks
+
+-- | Total stake in the underlying stake distribution
+newtype TotalStake
+  = TotalStake
+  { unTotalStake :: Cumulative LedgerStake
+  }
+  deriving stock (Show, Eq, Generic)
+  deriving newtype (FromCBOR, ToCBOR)
+  deriving anyclass NoThunks
 
 -- | Tiebreaker for voters with the same stake in the cumulative stake.
 --
@@ -356,8 +415,47 @@ data ExtWFAStakeDistr a
   -- weighted Fait-Accompli instantiations with a target committee size larger
   -- than the number of pools with positive stake, which would lead to incorrect
   -- results (e.g. granting persistent seats to voters with zero stake).
+  , totalStake :: TotalStake
+  -- ^ Total stake in the underlying stake distribution. This is also
+  -- precomputed at the beginning of each epoch to allow for quick
+  -- transformations between absolute and relative stakes.
   }
-  deriving Show
+  deriving stock (Show, Eq, Generic)
+  deriving anyclass NoThunks
+
+instance FromCBOR a => FromCBOR (ExtWFAStakeDistr a) where
+  fromCBOR = do
+    decodeListLenOf 3
+    unExtWFAStakeDistr <- decodeArray
+    numPoolsWithPositiveStake <- fromCBOR
+    totalStake <- fromCBOR
+    pure
+      ExtWFAStakeDistr
+        { unExtWFAStakeDistr
+        , numPoolsWithPositiveStake
+        , totalStake
+        }
+   where
+    decodeArray = do
+      xs <- fromCBOR
+      let bounds = (SeatIndex 0, SeatIndex (fromIntegral (length xs - 1)))
+      pure (Array.listArray bounds xs)
+
+instance ToCBOR a => ToCBOR (ExtWFAStakeDistr a) where
+  toCBOR
+    ExtWFAStakeDistr
+      { unExtWFAStakeDistr
+      , numPoolsWithPositiveStake
+      , totalStake
+      } =
+      encodeListLen 3
+        <> encodeArray unExtWFAStakeDistr
+        <> toCBOR numPoolsWithPositiveStake
+        <> toCBOR totalStake
+     where
+      encodeArray arr = do
+        let xs = Array.elems arr
+        toCBOR xs
 
 -- | Construct an extended cumulative stake distribution.
 --
@@ -375,6 +473,7 @@ mkExtWFAStakeDistr tiebreaker pools
         ExtWFAStakeDistr
           { unExtWFAStakeDistr = stakeDistrArray
           , numPoolsWithPositiveStake = numPoolsWithPositiveStakeAcc
+          , totalStake = TotalStake totalStakeAcc
           }
  where
   stakeDistrArray =
@@ -388,7 +487,7 @@ mkExtWFAStakeDistr tiebreaker pools
   --   * seat 0's cumulative stake == total stake, and
   --   * last seat's cumulative stake = its own stake.
   -- In addition, count the number of pools with positive stake in the same pass.
-  ((_totalStake, numPoolsWithPositiveStakeAcc), cumulativeStakeAndPools) =
+  ((totalStakeAcc, numPoolsWithPositiveStakeAcc), cumulativeStakeAndPools) =
     List.mapAccumR
       accumStakeAndCountPoolsWithPositiveStake
       ( Cumulative (LedgerStake 0)

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Committee/WFALS.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Committee/WFALS.hs
@@ -1,9 +1,17 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE EmptyDataDeriving #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 -- | Weighted Fait-Accompli with Local Sortition (wFA^LS) committee selection.
 --
@@ -40,8 +48,14 @@ module Ouroboros.Consensus.Committee.WFALS
   , totalNonPersistentStake
   ) where
 
+import Cardano.Binary
+  ( FromCBOR (..)
+  , ToCBOR (..)
+  , decodeListLenOf
+  , encodeListLen
+  )
 import Cardano.Ledger.BaseTypes (NonZero (..), Nonce, nonZero)
-import Control.Exception (assert)
+import Control.Exception (Exception, assert)
 import Control.Monad (void)
 import Control.Monad.Zip (MonadZip (..))
 import qualified Data.Array as Array
@@ -54,9 +68,13 @@ import qualified Data.Map.NonEmpty as NEMap
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Maybe (catMaybes)
+import Data.Typeable (Typeable)
+import GHC.Generics (Generic)
+import NoThunks.Class (NoThunks)
 import Ouroboros.Consensus.Committee.Class
   ( CryptoSupportsVotingCommittee (..)
   , UniqueVotesWithSameTarget
+  , VotingCommittee
   , getElectionIdFromVotes
   , getRawVotes
   , getVoteCandidateFromVotes
@@ -89,7 +107,7 @@ import Ouroboros.Consensus.Committee.WFA
   , PersistentCommitteeSize (..)
   , SeatIndex (..)
   , TotalNonPersistentStake (..)
-  , TotalPersistentStake
+  , TotalPersistentStake (..)
   , WFAError
   , getCandidateIfSeatWithinBounds
   , unsafeGetCandidateInSeat
@@ -98,42 +116,95 @@ import Ouroboros.Consensus.Committee.WFA
 
 -- | Tag for weighted Fait-Accompli with Local Sortition (wFA^LS)
 data WFALS
+  deriving (Show, Eq, Generic, NoThunks)
+
+-- According to the weighted Fait-Accompli committee selection scheme, voting
+-- committees are composed of two parts:
+--  1. a deterministic set of "persistent" members that are assigned at the
+--   beginning of the epoch according to the weighted Fait-Accompli scheme, and
+--  2. a non-deterministic set of "non-persistent" members that are selected on
+--   each election within such epoch via local sortition among the candidates
+--   that were not granted a persistent seat.
+--
+-- Due to 1., this interface is temporarily anchored to a given epoch, allowing
+-- us partially apply much of the relevant information about the committee
+-- composition at the beginning of such epoch.
+data instance VotingCommittee crypto WFALS
+  = WFALSVotingCommittee
+  { -- Preaccumulated stake distribution used to compute committee composition
+    extWFAStakeDistr :: !(ExtWFAStakeDistr (PublicKey crypto))
+  , -- Index of a given candidate in the cumulative stake distribution
+    candidateSeats :: !(Map PoolId SeatIndex)
+  , -- Number of persistent seats granted by the weighted Fait-Accompli scheme
+    persistentCommitteeSize :: !PersistentCommitteeSize
+  , -- Expected number of non-persistent voters
+    nonPersistentCommitteeSize :: !NonPersistentCommitteeSize
+  , -- Total stake of persistent voters
+    totalPersistentStake :: !TotalPersistentStake
+  , -- Total stake of non-persistent voters
+    totalNonPersistentStake :: !TotalNonPersistentStake
+  , --  Epoch nonce of the epoch where this committee selection takes place
+    epochNonce :: !Nonce
+  }
+
+instance
+  ( Typeable crypto
+  , FromCBOR (PublicKey crypto)
+  ) =>
+  FromCBOR (VotingCommittee crypto WFALS)
+  where
+  fromCBOR = do
+    decodeListLenOf 7
+    extWFAStakeDistr <- fromCBOR
+    candidateSeats <- fromCBOR
+    persistentCommitteeSize <- fromCBOR
+    nonPersistentCommitteeSize <- fromCBOR
+    totalPersistentStake <- fromCBOR
+    totalNonPersistentStake <- fromCBOR
+    epochNonce <- fromCBOR
+    pure
+      WFALSVotingCommittee
+        { extWFAStakeDistr
+        , candidateSeats
+        , persistentCommitteeSize
+        , nonPersistentCommitteeSize
+        , totalPersistentStake
+        , totalNonPersistentStake
+        , epochNonce
+        }
+
+instance
+  ( Typeable crypto
+  , ToCBOR (PublicKey crypto)
+  ) =>
+  ToCBOR (VotingCommittee crypto WFALS)
+  where
+  toCBOR
+    WFALSVotingCommittee
+      { extWFAStakeDistr
+      , candidateSeats
+      , persistentCommitteeSize
+      , nonPersistentCommitteeSize
+      , totalPersistentStake
+      , totalNonPersistentStake
+      , epochNonce
+      } =
+      encodeListLen 7
+        <> toCBOR extWFAStakeDistr
+        <> toCBOR candidateSeats
+        <> toCBOR persistentCommitteeSize
+        <> toCBOR nonPersistentCommitteeSize
+        <> toCBOR totalPersistentStake
+        <> toCBOR totalNonPersistentStake
+        <> toCBOR epochNonce
 
 instance
   ( CryptoSupportsAggregateVoteSigning crypto
   , CryptoSupportsBatchVRFVerification crypto
+  , Ord (ElectionId crypto)
   ) =>
   CryptoSupportsVotingCommittee crypto WFALS
   where
-  -- According to the weighted Fait-Accompli committee selection scheme, voting
-  -- committees are composed of two parts:
-  --  1. a deterministic set of "persistent" members that are assigned at the
-  --   beginning of the epoch according to the weighted Fait-Accompli scheme, and
-  --  2. a non-deterministic set of "non-persistent" members that are selected on
-  --   each election within such epoch via local sortition among the candidates
-  --   that were not granted a persistent seat.
-  --
-  -- Due to 1., this interface is temporarily anchored to a given epoch, allowing
-  -- us partially apply much of the relevant information about the committee
-  -- composition at the beginning of such epoch.
-  data VotingCommittee crypto WFALS
-    = WFALSVotingCommittee
-    { -- Preaccumulated stake distribution used to compute committee composition
-      extWFAStakeDistr :: !(ExtWFAStakeDistr (PublicKey crypto))
-    , -- Index of a given candidate in the cumulative stake distribution
-      candidateSeats :: !(Map PoolId SeatIndex)
-    , -- Number of persistent seats granted by the weighted Fait-Accompli scheme
-      persistentCommitteeSize :: !PersistentCommitteeSize
-    , -- Expected number of non-persistent voters
-      nonPersistentCommitteeSize :: !NonPersistentCommitteeSize
-    , --  Total stake of persistent voters
-      totalPersistentStake :: !TotalPersistentStake
-    , -- Total stake of non-persistent voters
-      totalNonPersistentStake :: !TotalNonPersistentStake
-    , --  Epoch nonce of the epoch where this committee selection takes place
-      epochNonce :: !Nonce
-    }
-
   data VotingCommitteeInput crypto WFALS
     = WFALSVotingCommitteeInput
         -- Epoch nonce for the epoch where this voting committee takes place
@@ -162,7 +233,6 @@ instance
       InvalidCertSignature String
     | -- We triggered an unexpected cryptographic error
       CryptoError String
-    deriving (Show, Eq)
 
   data EligibilityWitness crypto WFALS
     = -- A persistent member of the voting committee
@@ -203,6 +273,55 @@ instance
   eligiblePartyVoteWeight = implEligiblePartyVoteWeight
   forgeCert = implForgeCert
   verifyCert = implVerifyCert
+
+  voteTarget = \case
+    WFALSPersistentVote _ electionId candidate _ ->
+      (electionId, candidate)
+    WFALSNonPersistentVote _ electionId candidate _ _ ->
+      (electionId, candidate)
+  compareVotesById vote1 vote2 = compare (getVoteId vote1) (getVoteId vote2)
+   where
+    getVoteId = \case
+      WFALSPersistentVote seatIndex electionId _ _ ->
+        (seatIndex, electionId)
+      WFALSNonPersistentVote seatIndex electionId _ _ _ ->
+        (seatIndex, electionId)
+
+deriving instance
+  Show (PublicKey crypto) =>
+  Show (VotingCommittee crypto WFALS)
+deriving instance
+  Eq (PublicKey crypto) =>
+  Eq (VotingCommittee crypto WFALS)
+deriving instance
+  NoThunks (PublicKey crypto) =>
+  NoThunks (VotingCommittee crypto WFALS)
+deriving instance
+  Generic (VotingCommittee crypto WFALS)
+
+deriving instance
+  Show (PublicKey crypto) =>
+  Show (VotingCommitteeInput crypto WFALS)
+deriving instance
+  Eq (PublicKey crypto) =>
+  Eq (VotingCommitteeInput crypto WFALS)
+deriving instance
+  NoThunks (PublicKey crypto) =>
+  NoThunks (VotingCommitteeInput crypto WFALS)
+deriving instance
+  Generic (VotingCommitteeInput crypto WFALS)
+
+deriving instance
+  Show (VotingCommitteeError crypto WFALS)
+deriving instance
+  Eq (VotingCommitteeError crypto WFALS)
+deriving instance
+  NoThunks (VotingCommitteeError crypto WFALS)
+deriving instance
+  Generic (VotingCommitteeError crypto WFALS)
+deriving instance
+  Typeable crypto =>
+  Exception (VotingCommitteeError crypto WFALS)
 
 -- | Construct a 'WFALSVotingCommittee' for a given epoch
 mkWFALSVotingCommittee ::
@@ -393,18 +512,15 @@ implVerifyVote committee = \case
 
 -- | Compute the voting power of an eligible committee member
 --
--- NOTE: there is a subtle difference between the "Ledger stake" and the "Vote
--- weight" of a given voter. On one hand, the ledger stake is the stake as
--- reflected directly by the ledger stake distribution under consideration. On
--- the other hand, the "Vote" weight refers to the voting power of that voter,
--- i.e., the stake that a voter can effectively contribute to an election,
--- which might be different from their ledger stake depending on their committee
+-- In this voting committee scheme, the vote weight of a member depends on their
 -- membership type:
 --   * for a persistent committee member, their vote weight is equal to their
---     ledger stake throughout their entire tenure in the committee, whereas
---   * for a non-persistent committee member, their vote weight (provided that
---     they are actually selected to vote via local sortition) is equal to their
---     ledger stake normalized by the total non-persistent stake.
+--     (normalised) ledger stake throughout their entire tenure in the
+--     committee, whereas
+--   * for a non-persistent committee member, their vote weight is equal to
+--     their (normalised) non-persistent vote weight. This is computed as the
+--     number of seats granted to them by local sortition, scaled by their
+--     relative non-persistent stake w.r.t. other non-persistent voters.
 implEligiblePartyVoteWeight ::
   VotingCommittee crypto WFALS ->
   EligibilityWitness crypto WFALS ->
@@ -414,7 +530,7 @@ implEligiblePartyVoteWeight committee = \case
   WFALSPersistentMember
     _seatIndex
     (LedgerStake stake) ->
-      VoteWeight stake
+      mkVoteWeight stake
   -- Non-persistent members have their voting power proportional to their
   -- number of seats granted by local sortition and their stake (normalized
   -- by the total non-persistent stake)
@@ -423,13 +539,18 @@ implEligiblePartyVoteWeight committee = \case
     (LedgerStake stake)
     _vrfOutput
     numSeats ->
-      VoteWeight $
+      mkVoteWeight $
         fromIntegral (unLocalSortitionNumSeats (unNonZero numSeats))
           * stake
           / nonPersistentStake
-     where
-      TotalNonPersistentStake (Cumulative (LedgerStake nonPersistentStake)) =
-        totalNonPersistentStake committee
+ where
+  TotalPersistentStake (Cumulative (LedgerStake persistentStake)) =
+    totalPersistentStake committee
+  TotalNonPersistentStake (Cumulative (LedgerStake nonPersistentStake)) =
+    totalNonPersistentStake committee
+
+  mkVoteWeight absoluteStake =
+    VoteWeight (absoluteStake / (persistentStake + nonPersistentStake))
 
 -- | Forge a certificate attesting the winner of a given election
 implForgeCert ::

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Util/Orphans.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Util/Orphans.hs
@@ -9,15 +9,24 @@
 
 module Ouroboros.Consensus.Util.Orphans () where
 
-import Cardano.Binary (fromCBOR, toCBOR)
+import Cardano.Binary (FromCBOR (..), ToCBOR (..))
 import Cardano.Binary.FixedSizeCodec (decodeFixedSized, encodeFixedSized)
 import Cardano.Crypto.DSIGN.Class
 import Cardano.Crypto.DSIGN.Mock (MockDSIGN)
 import Cardano.Crypto.Hash (Hash, HashAlgorithm)
+import Cardano.Ledger.BaseTypes (Nonce, shelleyProtVer)
+import Cardano.Ledger.Binary
+  ( DecCBOR (..)
+  , EncCBOR (..)
+  , toPlainDecoder
+  , toPlainEncoding
+  )
 import Cardano.Ledger.Genesis (NoGenesis (..))
 import Codec.CBOR.Decoding (Decoder)
 import Codec.Serialise (Serialise (..))
 import Control.Tracer (Tracer)
+import Data.Array (Array)
+import qualified Data.Array as Array
 import Data.IntPSQ (IntPSQ)
 import qualified Data.IntPSQ as PSQ
 import Data.MultiSet (MultiSet)
@@ -49,6 +58,16 @@ instance (HashAlgorithm h, Typeable a) => Serialise (Hash h a) where
 instance Serialise (VerKeyDSIGN MockDSIGN) where
   encode = encodeFixedSized
   decode = decodeFixedSized
+
+{-------------------------------------------------------------------------------
+  FromCBOR / ToCBOR
+-------------------------------------------------------------------------------}
+
+instance FromCBOR Nonce where
+  fromCBOR = toPlainDecoder Nothing shelleyProtVer decCBOR
+
+instance ToCBOR Nonce where
+  toCBOR = toPlainEncoding shelleyProtVer . encCBOR
 
 {-------------------------------------------------------------------------------
   NoThunks
@@ -88,6 +107,10 @@ instance NoThunks a => NoThunks (K a b) where
 instance NoThunks a => NoThunks (MultiSet a) where
   showTypeOf _ = "MultiSet"
   wNoThunks ctxt = wNoThunks ctxt . MultiSet.toMap
+
+instance NoThunks a => NoThunks (Array i a) where
+  showTypeOf _ = "Array"
+  wNoThunks ctxt = wNoThunks ctxt . Array.elems
 
 instance NoThunks StdGen where
   showTypeOf _ = "StdGen"

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/Committee/EveryoneVotes/Tests.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/Committee/EveryoneVotes/Tests.hs
@@ -15,6 +15,7 @@ import Data.Map (Map)
 import qualified Data.Map.Strict as Map
 import Ouroboros.Consensus.Committee.Class
   ( CryptoSupportsVotingCommittee (..)
+  , VotingCommittee
   , ensureUniqueVotesWithSameTarget
   )
 import Ouroboros.Consensus.Committee.Crypto

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/Committee/WFALS/Tests.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/Committee/WFALS/Tests.hs
@@ -16,6 +16,7 @@ import qualified Data.Map.Strict as Map
 import Data.Proxy (Proxy (..))
 import Ouroboros.Consensus.Committee.Class
   ( CryptoSupportsVotingCommittee (..)
+  , VotingCommittee
   , ensureUniqueVotesWithSameTarget
   )
 import Ouroboros.Consensus.Committee.Crypto


### PR DESCRIPTION
This PR brings more groundwork needed in anticipation of the upcoming integration of Peras with the rest of the codebase:

- Refactors the generic voting-committee interface:
  + Moving the `VotingCommittee` data family out of the `CryptoSupportsVotingCommittee` class (simplifies future HFC instance).
  + Adding voteTarget / compareVotesById methods so vote projection and comparison are part of the class rather than passed around as functions

- Establishes a clear boundary between absolute and relative stakes: `VoteWeight` now represents a voter's stake relative to the total committee stake, enabling quorum detection against a fixed threshold (bounded between 0 and 1).

- Adds all necessary instances across committee types: `Serialise`, `NoThunks`, `Generic`, `Exception`, etc., including some orphan ones for `Array` and `Nonce`, among others.