### PR TITLE
Leios: add EB announcement diffusion (but don't otherwise leverage them yet)

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -56,6 +56,15 @@ source-repository-package
     cardano-diffusion
     network-mux
 
+-- Points to nfrisby-antipipelining1 tag
+source-repository-package
+  type: git
+  location: https://github.com/IntersectMBO/typed-protocols
+  tag: 0ae7f499c54944a33aed9c55a38a092461be43ca
+  --sha256: sha256-ydJALGzd6FzJYE4zKCY6X5OKIcOZjcZDmuVgMsAswWA=
+  subdir:
+    typed-protocols
+
 -- Points to ouroboros-ledger/leios-prototype
 source-repository-package
   type: git

--- a/cabal.project
+++ b/cabal.project
@@ -56,12 +56,12 @@ source-repository-package
     cardano-diffusion
     network-mux
 
--- Points to nfrisby-antipipelining1 tag
+-- Points to nfrisby-pr93-lookahead-merge-commit tag
 source-repository-package
   type: git
   location: https://github.com/IntersectMBO/typed-protocols
-  tag: 0ae7f499c54944a33aed9c55a38a092461be43ca
-  --sha256: sha256-ydJALGzd6FzJYE4zKCY6X5OKIcOZjcZDmuVgMsAswWA=
+  tag: 9b4627221ae5d649f2303c6926a8dba3f9934658
+  --sha256: sha256-55skVYIR0WjXMwJEirLgF0HFHUpFLBppuV9gvTWqoOI=
   subdir:
     typed-protocols
 

--- a/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/Block.hs
+++ b/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/Block.hs
@@ -215,6 +215,7 @@ module Ouroboros.Consensus.Cardano.Block
   ) where
 
 import Data.Kind
+import Data.Proxy (Proxy (..))
 import Data.SOP.BasicFunctors
 import Data.SOP.Functors
 import Data.SOP.Index (Index (..))
@@ -1595,6 +1596,11 @@ instance
   headerLeiosAnnouncement hdr = case hdr of
     HeaderDijkstra dHdr -> headerLeiosAnnouncement dHdr
     _ -> Nothing
+
+  -- Compositional dispatch over the era stack (even though in practice only
+  -- Dijkstra carries an announcement, so only its instance is ever exercised).
+  headerElId (HardForkHeader (OneEraHeader ns)) =
+    hcollapse $ hcmap (Proxy @ResolveLeiosBlock) (K . headerElId) ns
 
   headerContainsLeiosCert hdr = case hdr of
     HeaderDijkstra dHdr -> headerContainsLeiosCert dHdr

--- a/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/Block.hs
+++ b/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/Block.hs
@@ -220,6 +220,7 @@ import Data.SOP.BasicFunctors
 import Data.SOP.Functors
 import Data.SOP.Index (Index (..))
 import Data.SOP.Strict
+import LeiosDemoTypes (AnnouncementDisposition (..))
 import Ouroboros.Consensus.Block (BlockProtocol)
 import Ouroboros.Consensus.Byron.Ledger.Block (ByronBlock)
 import Ouroboros.Consensus.HardFork.Combinator
@@ -1601,6 +1602,17 @@ instance
   -- Dijkstra carries an announcement, so only its instance is ever exercised).
   headerElId (HardForkHeader (OneEraHeader ns)) =
     hcollapse $ hcmap (Proxy @ResolveLeiosBlock) (K . headerElId) ns
+
+  classifyAnnouncementValidationErr err = case err of
+    HardForkValidationErrFromEra (OneEraValidationErr ns) ->
+      hcollapse $ hcmap (Proxy @ResolveLeiosBlock) classifyOne ns
+    HardForkValidationErrWrongEra{} -> DisconnectPeer
+   where
+    classifyOne ::
+      forall x.
+      ResolveLeiosBlock x =>
+      WrapValidationErr x -> K AnnouncementDisposition x
+    classifyOne (WrapValidationErr e) = K (classifyAnnouncementValidationErr @x e)
 
   headerContainsLeiosCert hdr = case hdr of
     HeaderDijkstra dHdr -> headerContainsLeiosCert dHdr

--- a/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/Block.hs
+++ b/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/Block.hs
@@ -1606,7 +1606,7 @@ instance
   classifyAnnouncementValidationErr err = case err of
     HardForkValidationErrFromEra (OneEraValidationErr ns) ->
       hcollapse $ hcmap (Proxy @ResolveLeiosBlock) classifyOne ns
-    HardForkValidationErrWrongEra{} -> DisconnectPeer
+    HardForkValidationErrWrongEra{} -> Reject
    where
     classifyOne ::
       forall x.

--- a/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/Block.hs
+++ b/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/Block.hs
@@ -5,12 +5,15 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneKindSignatures #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE ViewPatterns #-}
+
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Ouroboros.Consensus.Cardano.Block
@@ -214,14 +217,17 @@ module Ouroboros.Consensus.Cardano.Block
   , EraMismatch (..)
   ) where
 
+import Control.Monad.Except (throwError, withExcept)
 import Data.Kind
 import Data.Proxy (Proxy (..))
+import Data.Functor.Product (Product (..))
 import Data.SOP.BasicFunctors
+import Data.SOP.Constraint (All, SListI)
 import Data.SOP.Functors
-import Data.SOP.Index (Index (..))
+import Data.SOP.Index (Index (..), hcizipWith)
+import qualified Data.SOP.Match as Match
 import Data.SOP.Strict
-import LeiosDemoTypes (AnnouncementDisposition (..))
-import Ouroboros.Consensus.Block (BlockProtocol)
+import Ouroboros.Consensus.Block (BlockProtocol, SlotNo)
 import Ouroboros.Consensus.Byron.Ledger.Block (ByronBlock)
 import Ouroboros.Consensus.HardFork.Combinator
 import Ouroboros.Consensus.HardFork.Combinator.AcrossEras
@@ -247,6 +253,8 @@ import Ouroboros.Consensus.Shelley.Ledger.Ledger
   ( ShelleyPartialLedgerConfig (..)
   )
 import Ouroboros.Consensus.Shelley.Ledger.Leios ()
+import Ouroboros.Consensus.Shelley.Protocol.TPraos ()
+import Ouroboros.Consensus.Shelley.Protocol.Praos ()
 import Ouroboros.Consensus.Storage.LedgerDB (ResolveLeiosBlock (..))
 import Ouroboros.Consensus.TypeFamilyWrappers
 
@@ -1539,6 +1547,7 @@ instance
   , ShelleyCompatible (Praos c) DijkstraEra
   , HasCanonicalTxIn (CardanoEras c)
   , HasHardForkTxOut (CardanoEras c)
+  , CanHardFork (CardanoEras c)
   ) =>
   ResolveLeiosBlock (HardForkBlock (CardanoEras c))
   where
@@ -1603,16 +1612,7 @@ instance
   headerElId (HardForkHeader (OneEraHeader ns)) =
     hcollapse $ hcmap (Proxy @ResolveLeiosBlock) (K . headerElId) ns
 
-  classifyAnnouncementValidationErr err = case err of
-    HardForkValidationErrFromEra (OneEraValidationErr ns) ->
-      hcollapse $ hcmap (Proxy @ResolveLeiosBlock) classifyOne ns
-    HardForkValidationErrWrongEra{} -> Reject
-   where
-    classifyOne ::
-      forall x.
-      ResolveLeiosBlock x =>
-      WrapValidationErr x -> K AnnouncementDisposition x
-    classifyOne (WrapValidationErr e) = K (classifyAnnouncementValidationErr @x e)
+  validateAnnouncementChainDepState = update @(CardanoEras c)
 
   headerContainsLeiosCert hdr = case hdr of
     HeaderDijkstra dHdr -> headerContainsLeiosCert dHdr
@@ -1629,3 +1629,64 @@ instance
         (IS (IS (IS (IS (IS (IS (IS IZ)))))))
         (leiosClosureTxKeySets inner)
     _ -> emptyLedgerTables
+
+-----
+
+-- | We don't want to add the ResolveLeiosBlock sin-bin to SingleEraBlock, so we
+-- use this ad-hoc class instead.
+class    (SingleEraBlock blk, ResolveLeiosBlock blk) => AnnouncementEraBlock blk
+instance (SingleEraBlock blk, ResolveLeiosBlock blk) => AnnouncementEraBlock blk
+
+-- | Adapted from "Ouroboros.Consensus.HardFork.Combinator.Protocol.update"
+update ::
+  forall xs.
+  (CanHardFork xs, All AnnouncementEraBlock xs) =>
+  ConsensusConfig (HardForkProtocol xs) ->
+  OneEraValidateView xs ->
+  SlotNo ->
+  Ticked (HardForkChainDepState xs) ->
+  Except (HardForkValidationErr xs) ()
+update
+  HardForkConsensusConfig{..}
+  (OneEraValidateView view)
+  slot
+  (TickedHardForkChainDepState chainDepState ei) =
+    case State.match view chainDepState of
+      Left mismatch ->
+        throwError $
+          HardForkValidationErrWrongEra . MismatchEraInfo $
+            Match.bihcmap
+              proxySingle
+              singleEraInfo
+              (LedgerEraInfo . chainDepStateInfo . State.currentState)
+              mismatch
+      Right matched ->
+        hcollapse
+          . hcizipWith (Proxy :: Proxy AnnouncementEraBlock) (updateEra ei slot) cfgs
+          $ matched
+   where
+    cfgs = getPerEraConsensusConfig hardForkConsensusConfigPerEra
+
+-- | Adapted from "Ouroboros.Consensus.HardFork.Combinator.Protocol.updateEra"
+updateEra ::
+  forall xs blk.
+  (SListI xs, SingleEraBlock blk, ResolveLeiosBlock blk) =>
+  EpochInfo (Except PastHorizonException) ->
+  SlotNo ->
+  Index xs blk ->
+  WrapPartialConsensusConfig blk ->
+  Product WrapValidateView (Ticked :.: WrapChainDepState) blk ->
+  K (Except (HardForkValidationErr xs) ()) blk
+updateEra
+  ei
+  slot
+  index
+  cfg
+  (Pair view (Comp chainDepState)) =
+    K $
+      withExcept (injectValidationErr index) $
+          validateAnnouncementChainDepState @blk
+            (completeConsensusConfig' ei cfg)
+            (unwrapValidateView view)
+            slot
+            (unwrapTickedChainDepState chainDepState)

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Block.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Block.hs
@@ -210,7 +210,7 @@ data instance Header (ShelleyBlock proto era) = ShelleyHeader
   deriving Generic
 
 deriving instance ShelleyCompatible proto era => Show (Header (ShelleyBlock proto era))
-deriving instance ShelleyCompatible proto era => Eq (Header (ShelleyBlock proto era))
+deriving instance ShelleyCompatible proto era => Eq (Header (ShelleyBlock proto era))   -- TODO sound to use only 'shelleyHeaderHash'?
 deriving instance ShelleyCompatible proto era => NoThunks (Header (ShelleyBlock proto era))
 
 instance

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Leios.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Leios.hs
@@ -34,13 +34,23 @@ import Data.Proxy (Proxy (..))
 import qualified Data.Sequence.Strict as StrictSeq
 import LeiosDemoDb (leiosDbLookupEbClosure)
 import LeiosDemoLogic.Announcements.ElBimap (ElId (MkElId))
-import LeiosDemoTypes (EbAnnouncement (..), LeiosPoint (..), RbHash (..))
+import LeiosDemoTypes
+  ( AnnouncementDisposition (..)
+  , EbAnnouncement (..)
+  , LeiosPoint (..)
+  , RbHash (..)
+  )
 import Lens.Micro ((.~), (^.))
 import Ouroboros.Consensus.Block (ChainHash (..), blockPrevHash, toRawHash)
 import Ouroboros.Consensus.Ledger.Abstract (getTipSlot)
 import Ouroboros.Consensus.Ledger.SupportsMempool (getTransactionKeySets)
 import Ouroboros.Consensus.Ledger.Tables (stowLedgerTables, unstowLedgerTables)
-import Ouroboros.Consensus.Protocol.Praos (Praos, PraosCrypto, PraosState (..))
+import Ouroboros.Consensus.Protocol.Praos
+  ( Praos
+  , PraosCrypto
+  , PraosState (..)
+  , PraosValidationErr (..)
+  )
 import Ouroboros.Consensus.Protocol.Praos.Header
   ( Header (..)
   , HeaderBody (..)
@@ -204,6 +214,15 @@ instance
       (Crypto.hashToBytesShort . unKeyHash . SL.hashKey $ headerBody.hbVk)
    where
     Header{headerBody} = shelleyHeaderRaw hdr
+
+  classifyAnnouncementValidationErr err = case err of
+    -- A counter ahead of, or a pool absent from, our immutable tip's view can
+    -- be honest (our tip lags the announcement's chain), so skip these.
+    --
+    -- See the TODO on 'AnnouncementDisposition'
+    CounterOverIncrementedOCERT{} -> SkipAnnouncement
+    NoCounterForKeyHashOCERT{} -> SkipAnnouncement
+    _ -> DisconnectPeer
 
   protocolStateLeiosAnnouncement st = do
     ann <- strictMaybeToMaybe $ praosStateLeiosAnnouncement st

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Leios.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Leios.hs
@@ -11,12 +11,14 @@
 
 module Ouroboros.Consensus.Shelley.Ledger.Leios () where
 
+import qualified Cardano.Crypto.Hash as Crypto (hashToBytesShort)
 import Cardano.Ledger.Api (Tx)
 import Cardano.Ledger.Binary (decCBOR, decodeFullAnnotator)
 import qualified Cardano.Ledger.Block as Core
 import Cardano.Ledger.Core (TopTx, injectFailure)
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Dijkstra.BlockBody (leiosCertBlockBodyL)
+import Cardano.Ledger.Hashes (KeyHash (..))
 import qualified Cardano.Ledger.Shelley.API as SL
 import Cardano.Ledger.Shelley.Rules (ledgerPpL)
 import qualified Cardano.Ledger.Shelley.UTxO as SL
@@ -31,6 +33,7 @@ import Data.Maybe.Strict (strictMaybeToMaybe)
 import Data.Proxy (Proxy (..))
 import qualified Data.Sequence.Strict as StrictSeq
 import LeiosDemoDb (leiosDbLookupEbClosure)
+import LeiosDemoLogic.Announcements.ElBimap (ElId (MkElId))
 import LeiosDemoTypes (EbAnnouncement (..), LeiosPoint (..), RbHash (..))
 import Lens.Micro ((.~), (^.))
 import Ouroboros.Consensus.Block (ChainHash (..), blockPrevHash, toRawHash)
@@ -192,6 +195,13 @@ instance
           }
       , ann.ebAnnouncementSize
       )
+   where
+    Header{headerBody} = shelleyHeaderRaw hdr
+
+  headerElId hdr =
+    MkElId
+      headerBody.hbSlotNo
+      (Crypto.hashToBytesShort . unKeyHash . SL.hashKey $ headerBody.hbVk)
    where
     Header{headerBody} = shelleyHeaderRaw hdr
 

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Leios.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Leios.hs
@@ -217,12 +217,10 @@ instance
 
   classifyAnnouncementValidationErr err = case err of
     -- A counter ahead of, or a pool absent from, our immutable tip's view can
-    -- be honest (our tip lags the announcement's chain), so skip these.
-    --
-    -- See the TODO on 'AnnouncementDisposition'
-    CounterOverIncrementedOCERT{} -> SkipAnnouncement
-    NoCounterForKeyHashOCERT{} -> SkipAnnouncement
-    _ -> DisconnectPeer
+    -- be honest (our tip lags the announcement's chain), so tolerate these.
+    CounterOverIncrementedOCERT{} -> Tolerate
+    NoCounterForKeyHashOCERT{} -> Tolerate
+    _ -> Reject
 
   protocolStateLeiosAnnouncement st = do
     ann <- strictMaybeToMaybe $ praosStateLeiosAnnouncement st

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Leios.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Leios.hs
@@ -226,11 +226,13 @@ instance
   -- explained by that lag. The election proof (VRF) and the signature (KES +
   -- opcert, including the counter's revocation lower bound) are checked in full.
   validateAnnouncementChainDepState cfg hv _slot tcs = do
+    -- validate the claimed election
     doValidateVRFSignature
       (praosStateEpochNonce cs)
       pd
       (praosLeaderF prms)
       hv
+    -- authenticate the message
     doValidateKESSignatureWorker
       DoNotUpperBoundOCERT
       (praosMaxKESEvo prms)

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Leios.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Leios.hs
@@ -35,8 +35,7 @@ import qualified Data.Sequence.Strict as StrictSeq
 import LeiosDemoDb (leiosDbLookupEbClosure)
 import LeiosDemoLogic.Announcements.ElBimap (ElId (MkElId))
 import LeiosDemoTypes
-  ( AnnouncementDisposition (..)
-  , EbAnnouncement (..)
+  ( EbAnnouncement (..)
   , LeiosPoint (..)
   , RbHash (..)
   )
@@ -46,11 +45,17 @@ import Ouroboros.Consensus.Ledger.Abstract (getTipSlot)
 import Ouroboros.Consensus.Ledger.SupportsMempool (getTransactionKeySets)
 import Ouroboros.Consensus.Ledger.Tables (stowLedgerTables, unstowLedgerTables)
 import Ouroboros.Consensus.Protocol.Praos
-  ( Praos
+  ( ConsensusConfig (..)
+  , Praos
   , PraosCrypto
+  , PraosParams (..)
   , PraosState (..)
-  , PraosValidationErr (..)
+  , Ticked (..)
+  , WhetherToUpperBoundOCERT (..)
+  , doValidateKESSignatureWorker
+  , doValidateVRFSignature
   )
+import Ouroboros.Consensus.Protocol.Praos.Views (plvPoolDistr)
 import Ouroboros.Consensus.Protocol.Praos.Header
   ( Header (..)
   , HeaderBody (..)
@@ -215,12 +220,28 @@ instance
    where
     Header{headerBody} = shelleyHeaderRaw hdr
 
-  classifyAnnouncementValidationErr err = case err of
-    -- A counter ahead of, or a pool absent from, our immutable tip's view can
-    -- be honest (our tip lags the announcement's chain), so tolerate these.
-    CounterOverIncrementedOCERT{} -> Tolerate
-    NoCounterForKeyHashOCERT{} -> Tolerate
-    _ -> Reject
+  -- The announcement is validated out-of-context against a (possibly lagging)
+  -- immutable tip, so we skip the OCERT counter's upper bound
+  -- ('DoNotUpperBoundOCERT'): a counter ahead of our recorded view is honestly
+  -- explained by that lag. The election proof (VRF) and the signature (KES +
+  -- opcert, including the counter's revocation lower bound) are checked in full.
+  validateAnnouncementChainDepState cfg hv _slot tcs = do
+    doValidateVRFSignature
+      (praosStateEpochNonce cs)
+      pd
+      (praosLeaderF prms)
+      hv
+    doValidateKESSignatureWorker
+      DoNotUpperBoundOCERT
+      (praosMaxKESEvo prms)
+      (praosSlotsPerKESPeriod prms)
+      pd
+      (praosStateOCertCounters cs)
+      hv
+   where
+    prms = praosParams cfg
+    cs = tickedPraosStateChainDepState tcs
+    SL.PoolDistr pd _ = plvPoolDistr (tickedPraosStateLedgerView tcs)
 
   protocolStateLeiosAnnouncement st = do
     ann <- strictMaybeToMaybe $ praosStateLeiosAnnouncement st

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToNode.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToNode.hs
@@ -8,6 +8,7 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 -- | Intended for qualified import
@@ -63,6 +64,7 @@ import Control.DeepSeq (NFData)
 import Control.Monad (forM_, forever, void, when)
 import Control.Monad.Class.MonadTime.SI (MonadTime)
 import Control.Monad.Class.MonadTimer.SI (MonadTimer)
+import Control.Monad.Except (runExceptT)
 import Control.ResourceRegistry
 import Control.Tracer
 import Data.ByteString.Lazy (ByteString)
@@ -70,6 +72,7 @@ import Data.Functor ((<&>))
 import Data.Hashable (Hashable)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
+import qualified Data.Primitive.MutVar as Prim
 import qualified Data.Set as Set
 import Data.Void (Void)
 import LeiosDemoDb
@@ -79,6 +82,7 @@ import LeiosDemoDb
   , withLeiosDb
   )
 import qualified LeiosDemoLogic as Leios
+import qualified LeiosDemoLogic.Announcements as Announcements
 import LeiosDemoOnlyTestFetch
   ( LeiosFetch
   , LeiosFetchClientPeerPipelined
@@ -149,7 +153,11 @@ import Ouroboros.Consensus.Node.Serialisation
 import qualified Ouroboros.Consensus.Node.Tracers as Node
 import Ouroboros.Consensus.NodeKernel
 import qualified Ouroboros.Consensus.Storage.ChainDB.API as ChainDB
-import Ouroboros.Consensus.Storage.LedgerDB.Forker (ResolveLeiosBlock)
+import Ouroboros.Consensus.Storage.LedgerDB.Forker
+  ( ResolveLeiosBlock
+  , headerElId
+  , headerLeiosAnnouncement
+  )
 import Ouroboros.Consensus.Storage.Serialisation (SerialisedHeader)
 import Ouroboros.Consensus.Util (ShowProxy)
 import Ouroboros.Consensus.Util.IOLike
@@ -453,6 +461,10 @@ mkHandlers
           let tracer = leiosPeerTracer peer
               kernelTracer = Node.leiosKernelTracer tracers
               LeiosVoteState{addVote} = leiosVoteState
+          -- Per-upstream-peer announcement accountability (dedup and
+          -- equivocation counting). The pipelined-client handler is a stateless
+          -- callback, so this state lives in a (single-threaded) ref.
+          peerStateVar <- Prim.newMutVar Announcements.emptyPeerState
           pure $
             leiosNotifyClientPeerPipelined
               ( atomically controlMessageSTM <&> \case
@@ -461,13 +473,31 @@ mkHandlers
               )
               ( pure $ \case
                   MsgLeiosBlockAnnouncement hdr -> do
-                    immLedger <- atomically $ ChainDB.getImmutableLedger getChainDB
-                    Leios.onAnnouncement
-                      tracer
-                      getTopLevelConfig
-                      (getLeiosOutstanding, getLeiosReady)
-                      immLedger
-                      hdr
+                    st0 <- Prim.readMutVar peerStateVar
+                    res <-
+                      runExceptT $
+                        Announcements.onAnnouncement
+                          nullTracer
+                          (\(Leios.AncHeader h) -> headerElId h)
+                          ( \(Leios.AncHeader h) -> do
+                              immLedger <- atomically $ ChainDB.getImmutableLedger getChainDB
+                              pure $ Leios.announcementValidity getTopLevelConfig immLedger h
+                          )
+                          ( \(Leios.AncHeader h) -> forM_ (headerLeiosAnnouncement h) $ \pt@(point, _sz) -> do
+                              MVar.modifyMVar_ getLeiosOutstanding (pure . Leios.recordAnnouncedEb pt)
+                              traceWith tracer $
+                                MkTraceLeiosPeer $ "MsgLeiosBlockAnnouncement " <> Leios.prettyLeiosPoint point
+                              void $ MVar.tryPutMVar getLeiosReady ()
+                          )
+                          st0
+                          (Leios.AncHeader hdr)
+                    case res of
+                      Right st' -> Prim.writeMutVar peerStateVar st'
+                      Left err -> case Leios.reactToAnnouncementError @blk err of
+                        Leios.ReactSkip reason ->
+                          traceWith tracer $
+                            MkTraceLeiosPeer $ "MsgLeiosBlockAnnouncement skipped: " <> reason
+                        Leios.ReactDisconnect exn -> throwIO exn
                   MsgLeiosBlockOffer point ebBytesSize -> do
                     traceWith tracer $ MkTraceLeiosPeer $ "MsgLeiosBlockOffer " <> Leios.prettyLeiosPoint point
                     let MkLeiosPoint{pointEbHash = ebHash} = point

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToNode.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToNode.hs
@@ -498,11 +498,7 @@ mkHandlers
                           (Leios.AncHeader hdr)
                     case res of
                       Right st' -> Prim.writeMutVar peerStateVar st'
-                      Left err -> case Leios.reactToAnnouncementError @blk err of
-                        Leios.ReactSkipOpcertIssueNumberForgiven ->
-                          traceWith tracer $
-                            MkTraceLeiosPeer $ "MsgLeiosBlockAnnouncement skipped forgiven OpCert issue number"
-                        Leios.ReactDisconnect exn -> throwIO exn
+                      Left err -> throwIO (Leios.ReactToAnnouncementError err)
                   MsgLeiosBlockOffer point ebBytesSize -> do
                     traceWith tracer $ MkTraceLeiosPeer $ "MsgLeiosBlockOffer " <> Leios.prettyLeiosPoint point
                     let MkLeiosPoint{pointEbHash = ebHash} = point

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToNode.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToNode.hs
@@ -481,22 +481,27 @@ mkHandlers
                           (\(Leios.AncHeader h) -> headerElId h)
                           ( \(Leios.AncHeader h) -> do
                               immLedger <- atomically $ ChainDB.getImmutableLedger getChainDB
-                              pure $ Leios.announcementValidity getTopLevelConfig immLedger h
+                              Leios.announcementValidity
+                                chainSyncFutureCheck
+                                getTopLevelConfig
+                                immLedger
+                                h
                           )
-                          ( \(Leios.AncHeader h) -> forM_ (headerLeiosAnnouncement h) $ \pt@(point, _sz) -> do
-                              MVar.modifyMVar_ getLeiosOutstanding (pure . Leios.recordAnnouncedEb pt)
-                              traceWith tracer $
-                                MkTraceLeiosPeer $ "MsgLeiosBlockAnnouncement " <> Leios.prettyLeiosPoint point
-                              void $ MVar.tryPutMVar getLeiosReady ()
+                          ( \(Leios.AncHeader h) ->
+                              forM_ (headerLeiosAnnouncement h) $ \pt@(point, _sz) -> do
+                                MVar.modifyMVar_ getLeiosOutstanding (pure . Leios.recordAnnouncedEb pt)
+                                traceWith tracer $
+                                  MkTraceLeiosPeer $ "MsgLeiosBlockAnnouncement " <> Leios.prettyLeiosPoint point
+                                void $ MVar.tryPutMVar getLeiosReady ()
                           )
                           st0
                           (Leios.AncHeader hdr)
                     case res of
                       Right st' -> Prim.writeMutVar peerStateVar st'
                       Left err -> case Leios.reactToAnnouncementError @blk err of
-                        Leios.ReactSkip reason ->
+                        Leios.ReactSkipOpcertIssueNumberForgiven ->
                           traceWith tracer $
-                            MkTraceLeiosPeer $ "MsgLeiosBlockAnnouncement skipped: " <> reason
+                            MkTraceLeiosPeer $ "MsgLeiosBlockAnnouncement skipped forgiven OpCert issue number"
                         Leios.ReactDisconnect exn -> throwIO exn
                   MsgLeiosBlockOffer point ebBytesSize -> do
                     traceWith tracer $ MkTraceLeiosPeer $ "MsgLeiosBlockOffer " <> Leios.prettyLeiosPoint point

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToNode.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToNode.hs
@@ -465,7 +465,7 @@ mkHandlers
           -- Per-upstream-peer announcement accountability (dedup and
           -- equivocation counting). The pipelined-client handler is a stateless
           -- callback, so this state lives in a (single-threaded) ref.
-          peerStateVar <- Prim.newMutVar Announcements.emptyPeerState
+          peerStateVar <- Prim.newMutVar (SlotNo 0, Announcements.emptyPeerState)
           pure $
             leiosNotifyClientPeerPipelined
               ( atomically controlMessageSTM <&> \case
@@ -475,14 +475,14 @@ mkHandlers
               ( pure $ \case
                   MsgLeiosBlockAnnouncement hdr -> do
                     let getEl (Leios.AncHeader h) = headerElId h
-                    st0 <- Prim.readMutVar peerStateVar
+                    immLedger <- atomically $ ChainDB.getImmutableLedger getChainDB
+                    (latestPruneSlot, peerSt0) <- Prim.readMutVar peerStateVar
                     res <-
                       runExceptT $
                         Announcements.onAnnouncement
                           nullTracer
                           getEl
-                          ( \(Leios.AncHeader h) -> do
-                              immLedger <- atomically $ ChainDB.getImmutableLedger getChainDB
+                          ( \(Leios.AncHeader h) ->
                               Leios.announcementValidity
                                 systemTime
                                 chainSyncFutureCheck
@@ -502,33 +502,34 @@ mkHandlers
                                       Leios.recordAnnouncedEb (getLeiosOutstanding, getLeiosReady) anc'
                                   )
                                   cst
-                                  peer
+                                  (Just peer)
                                   shouldRelay
                                   ancHdr
                           )
-                          st0
+                          peerSt0
                           (Leios.AncHeader hdr)
-                    case res of
-                      Right st' -> Prim.writeMutVar peerStateVar st'
-                      Left err -> throwIO (Leios.ReactToAnnouncementError err)
+                    peerSt1 <- case res of
+                      Left err -> throwIO $ Leios.ReactToAnnouncementError err
+                      Right x -> pure x
+                    let (!latestPruneSlot', !peerSt2) =
+                          Leios.prunePeerStateToImmTip immLedger latestPruneSlot peerSt1
+                    Prim.writeMutVar peerStateVar (latestPruneSlot', peerSt2)
                   MsgLeiosBlockOffer point ebBytesSize -> do
                     traceWith tracer $ MkTraceLeiosPeer $ "MsgLeiosBlockOffer " <> Leios.prettyLeiosPoint point
                     let MkLeiosPoint{pointEbHash = ebHash} = point
-                    -- FIXME: EB announcements are not implemented. The
-                    -- fetch state is built entirely from peer offers,
-                    -- which is the wrong source of truth — the
-                    -- authoritative size lives in
-                    -- 'headerLeiosAnnouncement' on the parent RB
-                    -- header (signed by the forger). Until announcement
-                    -- handling lands, the sanitisation below is the
-                    -- best we can do against malformed offers:
-                    -- drop a zero-sized offer outright (no honest
-                    -- forger ever announces a 0-byte EB) and refuse to
-                    -- overwrite an existing entry that shares the same
-                    -- content hash, so the first-seen (slot, size)
-                    -- wins. The per-peer 'offerings' below is still
-                    -- updated so the peer remains a valid serving
-                    -- candidate.
+                    -- TODO: EB announcements now record the authoritative
+                    -- (forger-signed) size via 'recordAnnouncedEb', but this
+                    -- offer handler is not integrated with them yet: it still
+                    -- builds fetch state directly from peer offers, whose sizes
+                    -- are not authoritative (the authoritative one lives in
+                    -- 'headerLeiosAnnouncement' on the parent RB header). Until
+                    -- the two are reconciled, the sanitisation below is the best
+                    -- we can do against malformed offers: drop a zero-sized
+                    -- offer outright (no honest forger ever announces a 0-byte
+                    -- EB) and refuse to overwrite an existing entry that shares
+                    -- the same content hash, so the first-seen (slot, size)
+                    -- wins. The per-peer 'offerings' below is still updated so
+                    -- the peer remains a valid serving candidate.
                     MVar.modifyMVar_ getLeiosOutstanding $ \outstanding ->
                       pure $
                         if ebBytesSize == 0

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToNode.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToNode.hs
@@ -73,6 +73,7 @@ import Data.Hashable (Hashable)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import qualified Data.Primitive.MutVar as Prim
+import qualified Data.Sequence as Seq
 import qualified Data.Set as Set
 import Data.Void (Void)
 import LeiosDemoDb
@@ -371,6 +372,7 @@ mkHandlers
     , miniProtocolParameters
     , getDiffusionPipeliningSupport
     , txSubmissionInitDelay
+    , systemTime
     }
   nodeKernel@NodeKernel
     { getChainDB
@@ -482,13 +484,14 @@ mkHandlers
                           ( \(Leios.AncHeader h) -> do
                               immLedger <- atomically $ ChainDB.getImmutableLedger getChainDB
                               Leios.announcementValidity
+                                systemTime
                                 chainSyncFutureCheck
                                 getTopLevelConfig
                                 immLedger
                                 h
                           )
                           -- central part of the processing
-                          ( \ancHdr anc'@(p, _sz) -> do
+                          ( \ancHdr (shouldRelay, anc'@(p, _sz)) -> do
                               traceWith tracer $
                                 MkTraceLeiosPeer $ "MsgLeiosBlockAnnouncement new: " <> Leios.prettyLeiosPoint p
                               MVar.modifyMVar_ getLeiosCentralState $ \cst ->   -- TODO OK to hold this the whole time we're writing to the LeiosNotify queues (NB those enqeues never block)?
@@ -500,7 +503,7 @@ mkHandlers
                                   )
                                   cst
                                   peer
-                                  Announcements.DoRelay   -- TODO skip relay if "too old"
+                                  shouldRelay
                                   ancHdr
                           )
                           st0
@@ -564,21 +567,48 @@ mkHandlers
                           traceWith kernelTracer TraceLeiosCertified{rbHash = Leios.announcingRbHash vote}
                         _ -> pure ()
               )
-      , hLeiosNotifyServer = \_version _peer -> do
+      , hLeiosNotifyServer = \_version peer -> do
           chan <- subscribeEbNotifications leiosDB
           LeiosVoteSubscription{getNextVote} <- subscribeVotes leiosVoteState
 
-          -- This peer's outgoing LeiosNotify queue and its credit counter.
+          -- This peer's single outgoing LeiosNotify queue and its credit
+          -- counter, shared by all three sources (announcements, offers, votes)
+          -- and served strictly FIFO. The node-wide relay logic
+          -- ('onAnnouncementCentral') appends announcements through the
+          -- 'QueueAnnouncementView' we register below; offers and votes are
+          -- moved in by the 'pump'.
           --
           -- TODO the EB-offer and vote sources should eventually /register/
-          -- this peer with those components rather than the pump draining
-          -- fresh per-peer subscriptions; and the (not-yet-wired) EB
-          -- announcement source will be the highest-priority (leftmost)
-          -- branch of 'readNext'.
-          queue <- atomically LazySTM.newTQueue
-          credits <- LazySTM.newTVarIO (0 :: Int)
+          -- this peer with those components too, rather than the pump draining
+          -- fresh per-peer subscriptions.
+          credits <- TVar.Unchecked.newTVarIO (0 :: Int)
+          queue <- TVar.Unchecked.newTVarIO Seq.empty
 
-          let readNext ::
+          -- The view the central relay logic uses to enqueue announcements
+          let qav =
+                Announcements.MkQueueAnnouncementView
+                  credits
+                  (\q (Leios.AncHeader h) -> q Seq.|> MsgLeiosBlockAnnouncement h)
+                  queue
+
+          let -- 'incr' adds a credit per received request; 'next' hands the
+              -- sender thread the next queued message (FIFO across all three
+              -- sources); 'pump' moves offers/votes into the queue, dropping a
+              -- message when there are no free credits.
+              incr = atomically $ do
+                  n <- TVar.Unchecked.readTVar credits
+                  if n == Leios.lEIOSNOTIFYPIPELINEDEPTH then pure True else do
+                    TVar.Unchecked.writeTVar credits $! n + 1
+                    pure False
+              next = atomically $ do
+                  q <- TVar.Unchecked.readTVar queue
+                  case Seq.viewl q of
+                    Seq.EmptyL -> LazySTM.retry
+                    msg Seq.:< q' -> do
+                      TVar.Unchecked.writeTVar queue q'
+                      pure msg
+
+              pumpNext ::
                 STM
                   m
                   ( LeiosDemoOnlyTestNotify.Message
@@ -586,7 +616,7 @@ mkHandlers
                       LeiosDemoOnlyTestNotify.StBusy
                       LeiosDemoOnlyTestNotify.StIdle
                   )
-              readNext =
+              pumpNext =
                     ( readTChan chan >>= \case
                         AcquiredEb point ebSize ->
                           pure $ MsgLeiosBlockOffer point ebSize
@@ -595,22 +625,21 @@ mkHandlers
                     )
                   <|> (getNextVote <&> \vote -> MsgLeiosVotes [vote])
 
-              -- 'incr' adds a credit per received request; 'next' hands the
-              -- sender thread the next queued message; 'pump' drains the
-              -- sources into the queue, dropping a message when there are no
-              -- free credits.
-              incr = atomically $ do
-                  n <- LazySTM.readTVar credits
-                  if n == Leios.lEIOSNOTIFYPIPELINEDEPTH then pure True else do
-                    LazySTM.writeTVar credits $! n + 1
-                    pure False
-              next = atomically $ LazySTM.readTQueue queue
-              pump = forever $ atomically $ do
-                msg <- readNext
-                c <- LazySTM.readTVar credits
-                when (c > 0) $ do
-                  LazySTM.writeTVar credits (c - 1)
-                  LazySTM.writeTQueue queue msg
+              pump =
+                    ( do
+                        MVar.modifyMVar_ getLeiosCentralState $
+                          pure . Announcements.insertPeerCentral peer qav
+                        forever $ atomically $ do
+                          msg <- pumpNext
+                          c <- TVar.Unchecked.readTVar credits
+                          when (c > 0) $ do
+                            TVar.Unchecked.writeTVar credits $! c - 1
+                            q <- TVar.Unchecked.readTVar queue
+                            TVar.Unchecked.writeTVar queue (q Seq.|> msg)
+                    )
+                      `finally` ( MVar.modifyMVar_ getLeiosCentralState $
+                                    pure . Announcements.deletePeerCentral peer
+                                )
 
           pure (leiosNotifyServerPeerAntiPipelined incr next, pump)
       , hLeiosFetchClient = \leiosConn _version controlMessageSTM peer peerVars -> toLeiosFetchClientPeerPipelined $ Effect $ do

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToNode.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToNode.hs
@@ -156,7 +156,6 @@ import qualified Ouroboros.Consensus.Storage.ChainDB.API as ChainDB
 import Ouroboros.Consensus.Storage.LedgerDB.Forker
   ( ResolveLeiosBlock
   , headerElId
-  , headerLeiosAnnouncement
   )
 import Ouroboros.Consensus.Storage.Serialisation (SerialisedHeader)
 import Ouroboros.Consensus.Util (ShowProxy)
@@ -487,12 +486,10 @@ mkHandlers
                                 immLedger
                                 h
                           )
-                          ( \(Leios.AncHeader h) ->
-                              forM_ (headerLeiosAnnouncement h) $ \pt@(point, _sz) -> do
-                                MVar.modifyMVar_ getLeiosOutstanding (pure . Leios.recordAnnouncedEb pt)
-                                traceWith tracer $
-                                  MkTraceLeiosPeer $ "MsgLeiosBlockAnnouncement " <> Leios.prettyLeiosPoint point
-                                void $ MVar.tryPutMVar getLeiosReady ()
+                          ( \(Leios.AncHeader _h) anc'@(p, _sz) -> do
+                              traceWith tracer $
+                                MkTraceLeiosPeer $ "MsgLeiosBlockAnnouncement new: " <> Leios.prettyLeiosPoint p
+                              Leios.recordAnnouncedEb (getLeiosOutstanding, getLeiosReady) anc'
                           )
                           st0
                           (Leios.AncHeader hdr)

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToNode.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToNode.hs
@@ -156,7 +156,6 @@ import Ouroboros.Consensus.NodeKernel
 import qualified Ouroboros.Consensus.Storage.ChainDB.API as ChainDB
 import Ouroboros.Consensus.Storage.LedgerDB.Forker
   ( ResolveLeiosBlock
-  , headerElId
   )
 import Ouroboros.Consensus.Storage.Serialisation (SerialisedHeader)
 import Ouroboros.Consensus.Util (ShowProxy)
@@ -474,21 +473,25 @@ mkHandlers
               )
               ( pure $ \case
                   MsgLeiosBlockAnnouncement hdr -> do
-                    let getEl (Leios.AncHeader h) = headerElId h
+                    -- A header relayed as an announcement must carry one;
+                    -- disconnect the peer otherwise.
+                    anc <- case Leios.mkAnnouncingHeader hdr of
+                      Nothing -> throwIO Leios.ExnLeiosBlockAnnouncementMissing
+                      Just x -> pure x
                     immLedger <- atomically $ ChainDB.getImmutableLedger getChainDB
                     (latestPruneSlot, peerSt0) <- Prim.readMutVar peerStateVar
                     res <-
                       runExceptT $
                         Announcements.onAnnouncement
-                          nullTracer
-                          getEl
-                          ( \(Leios.AncHeader h) ->
+                          (contramap Leios.tracePeerAnnouncement tracer)
+                          Leios.ancElId
+                          ( \ancH ->
                               Leios.announcementValidity
                                 systemTime
                                 chainSyncFutureCheck
                                 getTopLevelConfig
                                 immLedger
-                                h
+                                (Leios.ancHeader ancH)
                           )
                           -- central part of the processing
                           ( \ancHdr (shouldRelay, anc'@(p, _sz)) -> do
@@ -496,8 +499,8 @@ mkHandlers
                                 MkTraceLeiosPeer $ "MsgLeiosBlockAnnouncement new: " <> Leios.prettyLeiosPoint p
                               MVar.modifyMVar_ getLeiosCentralState $ \cst ->   -- TODO OK to hold this the whole time we're writing to the LeiosNotify queues (NB those enqeues never block)?
                                 Announcements.onAnnouncementCentral
-                                  nullTracer
-                                  getEl
+                                  (contramap Leios.traceNewAnnouncement kernelTracer)
+                                  Leios.ancElId
                                   ( \_elSt ->
                                       Leios.recordAnnouncedEb (getLeiosOutstanding, getLeiosReady) anc'
                                   )
@@ -507,7 +510,7 @@ mkHandlers
                                   ancHdr
                           )
                           peerSt0
-                          (Leios.AncHeader hdr)
+                          anc
                     peerSt1 <- case res of
                       Left err -> throwIO $ Leios.ReactToAnnouncementError err
                       Right x -> pure x
@@ -589,7 +592,7 @@ mkHandlers
           let qav =
                 Announcements.MkQueueAnnouncementView
                   credits
-                  (\q (Leios.AncHeader h) -> q Seq.|> MsgLeiosBlockAnnouncement h)
+                  (\q anc -> q Seq.|> MsgLeiosBlockAnnouncement (Leios.ancHeader anc))
                   queue
 
           let -- 'incr' adds a credit per received request; 'next' hands the

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToNode.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToNode.hs
@@ -472,12 +472,13 @@ mkHandlers
               )
               ( pure $ \case
                   MsgLeiosBlockAnnouncement hdr -> do
+                    let getEl (Leios.AncHeader h) = headerElId h
                     st0 <- Prim.readMutVar peerStateVar
                     res <-
                       runExceptT $
                         Announcements.onAnnouncement
                           nullTracer
-                          (\(Leios.AncHeader h) -> headerElId h)
+                          getEl
                           ( \(Leios.AncHeader h) -> do
                               immLedger <- atomically $ ChainDB.getImmutableLedger getChainDB
                               Leios.announcementValidity
@@ -486,10 +487,21 @@ mkHandlers
                                 immLedger
                                 h
                           )
-                          ( \(Leios.AncHeader _h) anc'@(p, _sz) -> do
+                          -- central part of the processing
+                          ( \ancHdr anc'@(p, _sz) -> do
                               traceWith tracer $
                                 MkTraceLeiosPeer $ "MsgLeiosBlockAnnouncement new: " <> Leios.prettyLeiosPoint p
-                              Leios.recordAnnouncedEb (getLeiosOutstanding, getLeiosReady) anc'
+                              MVar.modifyMVar_ getLeiosCentralState $ \cst ->   -- TODO OK to hold this the whole time we're writing to the LeiosNotify queues (NB those enqeues never block)?
+                                Announcements.onAnnouncementCentral
+                                  nullTracer
+                                  getEl
+                                  ( \_elSt ->
+                                      Leios.recordAnnouncedEb (getLeiosOutstanding, getLeiosReady) anc'
+                                  )
+                                  cst
+                                  peer
+                                  Announcements.DoRelay   -- TODO skip relay if "too old"
+                                  ancHdr
                           )
                           st0
                           (Leios.AncHeader hdr)
@@ -633,6 +645,7 @@ mkHandlers
       , getLeiosVoteState = leiosVoteState
       , getLeiosOutstanding
       , getLeiosReady
+      , getLeiosCentralState
       } = nodeKernel
 
     leiosPeerTracer peer = TraceLabelPeer peer `contramap` Node.leiosPeerTracer tracers

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToNode.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToNode.hs
@@ -95,7 +95,7 @@ import LeiosDemoOnlyTestFetch
 import LeiosDemoOnlyTestNotify
   ( LeiosNotify
   , LeiosNotifyClientPeerPipelined
-  , LeiosNotifyServerPeer
+  , LeiosNotifyServerPeerAntiPipelined
   , Message
     ( MsgLeiosBlockAnnouncement
     , MsgLeiosBlockOffer
@@ -107,7 +107,8 @@ import LeiosDemoOnlyTestNotify
   , codecLeiosNotifyId
   , leiosNotifyClientPeerPipelined
   , leiosNotifyMiniProtocolNum
-  , leiosNotifyServerPeer
+  , leiosNotifyServerPeerAntiPipelined
+  , runAntiPipelinedPeerWithLimits
   , timeLimitsLeiosNotify
   , toLeiosNotifyClientPeerPipelined
   )
@@ -129,7 +130,7 @@ import LeiosVoteState
   )
 import qualified Network.Mux as Mux
 import Network.TypedProtocol.Codec
-import Network.TypedProtocol.Peer (Peer (Effect))
+import Network.TypedProtocol.Peer (Peer (Effect), PeerAntiPipelined (..))
 import Ouroboros.Consensus.Block
 import Ouroboros.Consensus.Config (DiffusionPipeliningSupport (..))
 import Ouroboros.Consensus.HeaderValidation (HeaderWithTime)
@@ -325,7 +326,7 @@ data Handlers m addr blk = Handlers
   , hLeiosNotifyServer ::
       NodeToNodeVersion ->
       ConnectionId addr ->
-      LeiosNotifyServerPeer LeiosPoint (Header blk) LeiosVote m ()
+      LeiosNotifyServerPeerAntiPipelined LeiosPoint (Header blk) LeiosVote m ()
   , hLeiosFetchClient ::
       LeiosDbConnection m ->
       NodeToNodeVersion ->
@@ -529,7 +530,7 @@ mkHandlers
                           traceWith kernelTracer TraceLeiosCertified{rbHash = Leios.announcingRbHash vote}
                         _ -> pure ()
               )
-      , hLeiosNotifyServer = \_version _peer -> Effect $ do
+      , hLeiosNotifyServer = \_version _peer -> PeerAntiPipelined $ Effect $ do
           chan <- subscribeEbNotifications leiosDB
           let processEbNotification ::
                 STM
@@ -559,9 +560,17 @@ mkHandlers
                 vote <- getNextVote
                 pure $ MsgLeiosVotes [vote]
 
-          pure . leiosNotifyServerPeer $
-            atomically $
-              processEbNotification <|> processVote
+          -- STUB: no announcement source or credit accounting yet.
+          -- TODO slot the announcement queue in as the highest-priority
+          -- (leftmost) branch of 'next' below, and make 'incr' bump this
+          -- peer's outstanding-request credit so the announcement logic can
+          -- bound what it enqueues.
+          let incr = pure ()
+              next =
+                atomically $
+                  processEbNotification <|> processVote
+          pure . runPeerAntiPipelined $
+            leiosNotifyServerPeerAntiPipelined incr next
       , hLeiosFetchClient = \leiosConn _version controlMessageSTM peer peerVars -> toLeiosFetchClientPeerPipelined $ Effect $ do
           let reqVar = Leios.requestsToSend peerVars
           -- Queue for responses received by the pipelined-peer collector
@@ -1342,7 +1351,7 @@ mkApps kernel rng Tracers{tTxLogicTracer = _, ..} mkCodecs ByteLimits{..} chainS
     m ((), Maybe bLN)
   aLeiosNotifyServer version ResponderContext{rcConnectionId = them} channel = do
     labelThisThread "LeiosNotifyServer"
-    runPeerWithLimits
+    runAntiPipelinedPeerWithLimits
       (TraceLabelPeer them `contramap` tLeiosNotifyTracer)
       (cLeiosNotifyCodec (mkCodecs version))
       blLeiosNotify

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToNode.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToNode.hs
@@ -461,7 +461,7 @@ mkHandlers
             leiosNotifyClientPeerPipelined
               ( atomically controlMessageSTM <&> \case
                   Terminate -> Left ()
-                  _ -> Right 100 {- TODO magic number -}
+                  _ -> Right Leios.lEIOSNOTIFYPIPELINEDEPTH
               )
               ( pure $ \case
                   MsgLeiosBlockAnnouncement hdr -> do
@@ -568,7 +568,11 @@ mkHandlers
               -- sender thread the next queued message; 'pump' drains the
               -- sources into the queue, dropping a message when there are no
               -- free credits.
-              incr = atomically $ LazySTM.modifyTVar' credits (+ 1)
+              incr = atomically $ do
+                  n <- LazySTM.readTVar credits
+                  if n == Leios.lEIOSNOTIFYPIPELINEDEPTH then pure True else do
+                    LazySTM.writeTVar credits $! n + 1
+                    pure False
               next = atomically $ LazySTM.readTQueue queue
               pump = forever $ atomically $ do
                 msg <- readNext

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToNode.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToNode.hs
@@ -149,11 +149,7 @@ import Ouroboros.Consensus.Node.Serialisation
 import qualified Ouroboros.Consensus.Node.Tracers as Node
 import Ouroboros.Consensus.NodeKernel
 import qualified Ouroboros.Consensus.Storage.ChainDB.API as ChainDB
-import Ouroboros.Consensus.Storage.LedgerDB.Forker
-  ( ResolveLeiosBlock
-  , headerContainsLeiosCert
-  , headerLeiosAnnouncement
-  )
+import Ouroboros.Consensus.Storage.LedgerDB.Forker (ResolveLeiosBlock)
 import Ouroboros.Consensus.Storage.Serialisation (SerialisedHeader)
 import Ouroboros.Consensus.Util (ShowProxy)
 import Ouroboros.Consensus.Util.IOLike
@@ -465,18 +461,13 @@ mkHandlers
               )
               ( pure $ \case
                   MsgLeiosBlockAnnouncement hdr -> do
-                    traceWith tracer $
-                      MkTraceLeiosPeer $
-                        unwords
-                          [ "MsgLeiosBlockAnnouncement"
-                          , "(ignored)"
-                          , show (headerPoint hdr)
-                          , "containsCert=" <> show (headerContainsLeiosCert hdr)
-                          , "announcedEb=" <> case headerLeiosAnnouncement hdr of
-                              Nothing -> "none"
-                              Just (ebPoint, ebSize) ->
-                                Leios.prettyEbHash (Leios.pointEbHash ebPoint) <> " size=" <> show ebSize
-                          ]
+                    immLedger <- atomically $ ChainDB.getImmutableLedger getChainDB
+                    Leios.onAnnouncement
+                      tracer
+                      getTopLevelConfig
+                      (getLeiosOutstanding, getLeiosReady)
+                      immLedger
+                      hdr
                   MsgLeiosBlockOffer point ebBytesSize -> do
                     traceWith tracer $ MkTraceLeiosPeer $ "MsgLeiosBlockOffer " <> Leios.prettyLeiosPoint point
                     let MkLeiosPoint{pointEbHash = ebHash} = point

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToNode.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToNode.hs
@@ -494,7 +494,7 @@ mkHandlers
                                 (Leios.ancHeader ancH)
                           )
                           -- central part of the processing
-                          ( \ancHdr (shouldRelay, anc'@(p, _sz)) -> do
+                          ( \ancHdr (shouldRelay, age, anc'@(p, _sz)) -> do
                               traceWith tracer $
                                 MkTraceLeiosPeer $ "MsgLeiosBlockAnnouncement new: " <> Leios.prettyLeiosPoint p
                               MVar.modifyMVar_ getLeiosCentralState $ \cst ->   -- TODO OK to hold this the whole time we're writing to the LeiosNotify queues (NB those enqeues never block)?
@@ -507,6 +507,7 @@ mkHandlers
                                   cst
                                   (Just peer)
                                   shouldRelay
+                                  (Just age)
                                   ancHdr
                           )
                           peerSt0

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToNode.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToNode.hs
@@ -60,7 +60,7 @@ import qualified Control.Concurrent.Class.MonadSTM as LazySTM
 import Control.Concurrent.Class.MonadSTM.Strict (readTChan)
 import qualified Control.Concurrent.Class.MonadSTM.Strict.TVar as TVar.Unchecked
 import Control.DeepSeq (NFData)
-import Control.Monad (forM_, void)
+import Control.Monad (forM_, forever, void, when)
 import Control.Monad.Class.MonadTime.SI (MonadTime)
 import Control.Monad.Class.MonadTimer.SI (MonadTimer)
 import Control.ResourceRegistry
@@ -130,7 +130,7 @@ import LeiosVoteState
   )
 import qualified Network.Mux as Mux
 import Network.TypedProtocol.Codec
-import Network.TypedProtocol.Peer (Peer (Effect), PeerAntiPipelined (..))
+import Network.TypedProtocol.Peer (Peer (Effect))
 import Ouroboros.Consensus.Block
 import Ouroboros.Consensus.Config (DiffusionPipeliningSupport (..))
 import Ouroboros.Consensus.HeaderValidation (HeaderWithTime)
@@ -326,7 +326,10 @@ data Handlers m addr blk = Handlers
   , hLeiosNotifyServer ::
       NodeToNodeVersion ->
       ConnectionId addr ->
-      LeiosNotifyServerPeerAntiPipelined LeiosPoint (Header blk) LeiosVote m ()
+      m
+        ( LeiosNotifyServerPeerAntiPipelined LeiosPoint (Header blk) LeiosVote m ()
+        , m Void
+        )
   , hLeiosFetchClient ::
       LeiosDbConnection m ->
       NodeToNodeVersion ->
@@ -530,25 +533,21 @@ mkHandlers
                           traceWith kernelTracer TraceLeiosCertified{rbHash = Leios.announcingRbHash vote}
                         _ -> pure ()
               )
-      , hLeiosNotifyServer = \_version _peer -> PeerAntiPipelined $ Effect $ do
+      , hLeiosNotifyServer = \_version _peer -> do
           chan <- subscribeEbNotifications leiosDB
-          let processEbNotification ::
-                STM
-                  m
-                  ( LeiosDemoOnlyTestNotify.Message
-                      (LeiosNotify LeiosPoint (Header blk) LeiosVote)
-                      LeiosDemoOnlyTestNotify.StBusy
-                      LeiosDemoOnlyTestNotify.StIdle
-                  )
-              processEbNotification =
-                readTChan chan >>= \case
-                  AcquiredEb point ebSize ->
-                    pure $ MsgLeiosBlockOffer point ebSize
-                  AcquiredEbTxs point ->
-                    pure $ MsgLeiosBlockTxsOffer point
-
           LeiosVoteSubscription{getNextVote} <- subscribeVotes leiosVoteState
-          let processVote ::
+
+          -- This peer's outgoing LeiosNotify queue and its credit counter.
+          --
+          -- TODO the EB-offer and vote sources should eventually /register/
+          -- this peer with those components rather than the pump draining
+          -- fresh per-peer subscriptions; and the (not-yet-wired) EB
+          -- announcement source will be the highest-priority (leftmost)
+          -- branch of 'readNext'.
+          queue <- atomically LazySTM.newTQueue
+          credits <- LazySTM.newTVarIO (0 :: Int)
+
+          let readNext ::
                 STM
                   m
                   ( LeiosDemoOnlyTestNotify.Message
@@ -556,21 +555,29 @@ mkHandlers
                       LeiosDemoOnlyTestNotify.StBusy
                       LeiosDemoOnlyTestNotify.StIdle
                   )
-              processVote = do
-                vote <- getNextVote
-                pure $ MsgLeiosVotes [vote]
+              readNext =
+                    ( readTChan chan >>= \case
+                        AcquiredEb point ebSize ->
+                          pure $ MsgLeiosBlockOffer point ebSize
+                        AcquiredEbTxs point ->
+                          pure $ MsgLeiosBlockTxsOffer point
+                    )
+                  <|> (getNextVote <&> \vote -> MsgLeiosVotes [vote])
 
-          -- STUB: no announcement source or credit accounting yet.
-          -- TODO slot the announcement queue in as the highest-priority
-          -- (leftmost) branch of 'next' below, and make 'incr' bump this
-          -- peer's outstanding-request credit so the announcement logic can
-          -- bound what it enqueues.
-          let incr = pure ()
-              next =
-                atomically $
-                  processEbNotification <|> processVote
-          pure . runPeerAntiPipelined $
-            leiosNotifyServerPeerAntiPipelined incr next
+              -- 'incr' adds a credit per received request; 'next' hands the
+              -- sender thread the next queued message; 'pump' drains the
+              -- sources into the queue, dropping a message when there are no
+              -- free credits.
+              incr = atomically $ LazySTM.modifyTVar' credits (+ 1)
+              next = atomically $ LazySTM.readTQueue queue
+              pump = forever $ atomically $ do
+                msg <- readNext
+                c <- LazySTM.readTVar credits
+                when (c > 0) $ do
+                  LazySTM.writeTVar credits (c - 1)
+                  LazySTM.writeTQueue queue msg
+
+          pure (leiosNotifyServerPeerAntiPipelined incr next, pump)
       , hLeiosFetchClient = \leiosConn _version controlMessageSTM peer peerVars -> toLeiosFetchClientPeerPipelined $ Effect $ do
           let reqVar = Leios.requestsToSend peerVars
           -- Queue for responses received by the pipelined-peer collector
@@ -1351,13 +1358,18 @@ mkApps kernel rng Tracers{tTxLogicTracer = _, ..} mkCodecs ByteLimits{..} chainS
     m ((), Maybe bLN)
   aLeiosNotifyServer version ResponderContext{rcConnectionId = them} channel = do
     labelThisThread "LeiosNotifyServer"
-    runAntiPipelinedPeerWithLimits
-      (TraceLabelPeer them `contramap` tLeiosNotifyTracer)
-      (cLeiosNotifyCodec (mkCodecs version))
-      blLeiosNotify
-      timeLimitsLeiosNotify
-      channel
-      $ hLeiosNotifyServer version them
+    (peer, pump) <- hLeiosNotifyServer version them
+    -- The pump lives exactly as long as the peer; 'link' surfaces a pump
+    -- crash instead of silently leaving the peer unable to send.
+    withAsync pump $ \pumpThread -> do
+      link pumpThread
+      runAntiPipelinedPeerWithLimits
+        (TraceLabelPeer them `contramap` tLeiosNotifyTracer)
+        (cLeiosNotifyCodec (mkCodecs version))
+        blLeiosNotify
+        timeLimitsLeiosNotify
+        channel
+        peer
 
   aLeiosFetchClient ::
     NodeToNodeVersion ->

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToNode.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToNode.hs
@@ -601,9 +601,11 @@ mkHandlers
               -- message when there are no free credits.
               incr = atomically $ do
                   n <- TVar.Unchecked.readTVar credits
-                  if n == Leios.lEIOSNOTIFYPIPELINEDEPTH then pure True else do
-                    TVar.Unchecked.writeTVar credits $! n + 1
-                    pure False
+                  if n == Leios.lEIOSNOTIFYPIPELINEDEPTH
+                    then pure LeiosDemoOnlyTestNotify.ExcessiveRequests
+                    else do
+                      TVar.Unchecked.writeTVar credits $! n + 1
+                      pure LeiosDemoOnlyTestNotify.NotExcessiveRequests
               next = atomically $ do
                   q <- TVar.Unchecked.readTVar queue
                   case Seq.viewl q of

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToNode.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToNode.hs
@@ -100,7 +100,7 @@ import LeiosDemoOnlyTestFetch
 import LeiosDemoOnlyTestNotify
   ( LeiosNotify
   , LeiosNotifyClientPeerPipelined
-  , LeiosNotifyServerPeerAntiPipelined
+  , LeiosNotifyServerPeerLookahead
   , Message
     ( MsgLeiosBlockAnnouncement
     , MsgLeiosBlockOffer
@@ -112,8 +112,8 @@ import LeiosDemoOnlyTestNotify
   , codecLeiosNotifyId
   , leiosNotifyClientPeerPipelined
   , leiosNotifyMiniProtocolNum
-  , leiosNotifyServerPeerAntiPipelined
-  , runAntiPipelinedPeerWithLimits
+  , leiosNotifyServerPeerLookahead
+  , runLookaheadFixedSenderPeerWithLimits
   , timeLimitsLeiosNotify
   , toLeiosNotifyClientPeerPipelined
   )
@@ -330,7 +330,7 @@ data Handlers m addr blk = Handlers
       NodeToNodeVersion ->
       ConnectionId addr ->
       m
-        ( LeiosNotifyServerPeerAntiPipelined LeiosPoint (Header blk) LeiosVote m ()
+        ( LeiosNotifyServerPeerLookahead LeiosPoint (Header blk) LeiosVote m ()
         , m Void
         )
   , hLeiosFetchClient ::
@@ -648,7 +648,7 @@ mkHandlers
                                     pure . Announcements.deletePeerCentral peer
                                 )
 
-          pure (leiosNotifyServerPeerAntiPipelined incr next, pump)
+          pure (leiosNotifyServerPeerLookahead incr next, pump)
       , hLeiosFetchClient = \leiosConn _version controlMessageSTM peer peerVars -> toLeiosFetchClientPeerPipelined $ Effect $ do
           let reqVar = Leios.requestsToSend peerVars
           -- Queue for responses received by the pipelined-peer collector
@@ -1435,7 +1435,7 @@ mkApps kernel rng Tracers{tTxLogicTracer = _, ..} mkCodecs ByteLimits{..} chainS
     -- crash instead of silently leaving the peer unable to send.
     withAsync pump $ \pumpThread -> do
       link pumpThread
-      runAntiPipelinedPeerWithLimits
+      runLookaheadFixedSenderPeerWithLimits
         (TraceLabelPeer them `contramap` tLeiosNotifyTracer)
         (cLeiosNotifyCodec (mkCodecs version))
         blLeiosNotify

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
@@ -118,9 +118,14 @@ import Ouroboros.Consensus.Storage.ChainDB.API
 import qualified Ouroboros.Consensus.Storage.ChainDB.API as ChainDB
 import Ouroboros.Consensus.Storage.ChainDB.Init (InitChainDB)
 import qualified Ouroboros.Consensus.Storage.ChainDB.Init as InitChainDB
+import Ouroboros.Consensus.Storage.LedgerDB.Forker
+  ( headerElId
+  , headerLeiosAnnouncement
+  )
 import Ouroboros.Consensus.Util.AnchoredFragment
   ( preferAnchoredCandidate
   )
+import Ouroboros.Consensus.Util (whenJust)
 import Ouroboros.Consensus.Util.EarlyExit hiding (callTraceSameThread)
 import Ouroboros.Consensus.Util.IOLike
 import Ouroboros.Consensus.Util.LeakyBucket
@@ -544,6 +549,19 @@ initNodeKernel
           leiosVoteState
           (topLevelConfigVotingKey cfg)
 
+    void $
+      forkLinkedWatcher registry "NodeKernel.leiosPruneAnnouncements" $
+        Watcher
+          { wFingerprint = id
+          , wInitial = Nothing
+          , wReader = getTipSlot . ledgerState <$> ChainDB.getImmutableLedger chainDB
+          , wNotify = \case
+              Origin -> pure ()
+              NotOrigin immTipSlot ->
+                MVar.modifyMVar_ getLeiosCentralState $
+                  pure . Announcements.pruneCentralState immTipSlot
+          }
+
     return
       NodeKernel
         { getChainDB = chainDB
@@ -575,6 +593,7 @@ initNodeKernel
         }
    where
     blockForgingController ::
+      Ord remotePeer =>
       InternalState m remotePeer localPeer blk ->
       STM m [MkBlockForging m blk] ->
       m Void
@@ -719,7 +738,7 @@ toConsensusMode = \case
 
 forkBlockForging ::
   forall m addrNTN addrNTC blk.
-  (IOLike m, RunNode blk) =>
+  (IOLike m, RunNode blk, Ord addrNTN) =>
   InternalState m addrNTN addrNTC blk ->
   MkBlockForging m blk ->
   m (Thread m Void)
@@ -741,20 +760,35 @@ forkBlockForging IS{..} (MkBlockForging blockForgingM) =
               rootCCtx
               "forge"
               currentSlot
-              $ \forgeCCtx ->
-                withEarlyExit_ $
-                  forge
-                    (forgeTracer tracers)
-                    (forgeStateInfoTracer tracers)
-                    (leiosKernelTracer tracers)
-                    forgeCCtx
-                    cfg
-                    chainDB
-                    mempool
-                    leiosVoteState
-                    bf
-                    leiosConn
-                    currentSlot
+              $ \forgeCCtx -> do
+                  mbForgedHeader <-
+                    withEarlyExit $
+                      forge
+                        (forgeTracer tracers)
+                        (forgeStateInfoTracer tracers)
+                        (leiosKernelTracer tracers)
+                        forgeCCtx
+                        cfg
+                        chainDB
+                        mempool
+                        leiosVoteState
+                        bf
+                        leiosConn
+                        currentSlot
+                  -- Relay this node's own freshly-forged EB announcement (if
+                  -- any) to downstream peers via LeiosNotify; 'forge' yields the
+                  -- header only when it forged and adopted a block.
+                  whenJust mbForgedHeader $ \forgedHeader ->
+                    whenJust (headerLeiosAnnouncement forgedHeader) $ \_ ->
+                      MVar.modifyMVar_ leiosCentralState $ \cst ->
+                        Announcements.onAnnouncementCentral
+                          nullTracer
+                          (\(Leios.AncHeader h) -> headerElId h)
+                          (\_elSt -> pure ()) -- we forged the EB; nothing to fetch locally
+                          cst
+                          Nothing -- the source is this node, not an upstream peer
+                          Announcements.DoRelay -- our newly forged block can't be too old
+                          (Leios.AncHeader forgedHeader)
     )
  where
   label :: String

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
@@ -756,40 +756,44 @@ forkBlockForging IS{..} (MkBlockForging blockForgingM) =
               rootCCtx
               "forge"
               currentSlot
-              $ \forgeCCtx -> do
-                  mbForgedHeader <-
-                    withEarlyExit $
-                      forge
-                        (forgeTracer tracers)
-                        (forgeStateInfoTracer tracers)
-                        (leiosKernelTracer tracers)
-                        forgeCCtx
-                        cfg
-                        chainDB
-                        mempool
-                        leiosVoteState
-                        bf
-                        leiosConn
-                        currentSlot
-                  -- Relay this node's own freshly-forged EB announcement (if
-                  -- any) to downstream peers via LeiosNotify; 'forge' yields the
-                  -- header only when it forged and adopted a block.
-                  whenJust mbForgedHeader $ \forgedHeader ->
-                    whenJust (Leios.mkAnnouncingHeader forgedHeader) $ \anc ->
-                      MVar.modifyMVar_ leiosCentralState $ \cst ->
-                        Announcements.onAnnouncementCentral
-                          (contramap Leios.traceNewAnnouncement (leiosKernelTracer tracers))
-                          Leios.ancElId
-                          (\_elSt -> pure ()) -- we forged the EB; nothing to fetch locally
-                          cst
-                          Nothing -- the source is this node, not an upstream peer
-                          Announcements.DoRelay -- our newly forged block can't be too old
-                          Nothing -- no wall-clock lateness for a locally-forged announcement
-                          anc
+              $ \forgeCCtx ->
+                withEarlyExit_ $
+                  forge
+                    (forgeTracer tracers)
+                    (forgeStateInfoTracer tracers)
+                    (leiosKernelTracer tracers)
+                    forgeCCtx
+                    cfg
+                    chainDB
+                    mempool
+                    leiosVoteState
+                    bf
+                    leiosConn
+                    announceForgedBlock
+                    currentSlot
     )
  where
   label :: String
   label = "NodeKernel.blockForging"
+
+  -- Concurrently (fire-and-forget) relay this node's own freshly-forged EB
+  -- announcement, if any, to downstream peers via LeiosNotify. 'forge' invokes
+  -- this right after forging and before adoption, so adoption never gates
+  -- getting the announcement onto the wire.
+  announceForgedBlock :: Header blk -> m ()
+  announceForgedBlock forgedHeader =
+    whenJust (Leios.mkAnnouncingHeader forgedHeader) $ \anc ->
+      void $ async $
+        MVar.modifyMVar_ leiosCentralState $ \cst ->
+          Announcements.onAnnouncementCentral
+            (contramap Leios.traceNewAnnouncement (leiosKernelTracer tracers))
+            Leios.ancElId
+            (\_elSt -> pure ()) -- we forged the EB; nothing to fetch locally
+            cst
+            Nothing -- the source is this node, not an upstream peer
+            Announcements.DoRelay -- our newly forged block can't be too old
+            Nothing -- no wall-clock lateness for a locally-forged announcement
+            anc
 
   -- 'LeiosDbConnection' is not thread-safe, so we open one per
   -- forge-credentials thread (and close it when the thread exits).

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
@@ -63,6 +63,7 @@ import LeiosDemoDb
   )
 import qualified LeiosDemoDb as LeiosDb
 import qualified LeiosDemoLogic as Leios
+import qualified LeiosDemoLogic.Announcements as Announcements
 import LeiosDemoTypes
   ( LeiosOutstanding
   , LeiosPeerVars
@@ -244,6 +245,9 @@ data NodeKernel m addrNTN addrNTC blk = NodeKernel
   , getLeiosReady :: MVar.MVar m ()
   -- ^ Filled by anyone who makes a change that might unblock a new
   -- fetch decision; the fetch logic 'MVar.takeMVar's before it runs.
+  , getLeiosCentralState ::
+      MVar.MVar m (Announcements.CentralState m (ConnectionId addrNTN) (Leios.AncHeader blk))
+  -- ^ Node-wide EB-announcement state
   }
 
 -- | Arguments required when initializing a node
@@ -325,6 +329,7 @@ initNodeKernel
           , varGsmState
           , leiosOutstanding = getLeiosOutstanding
           , leiosReady = getLeiosReady
+          , leiosCentralState = getLeiosCentralState
           , leiosPeersVars = getLeiosPeersVars
           , leiosVoteState
           } = st
@@ -566,6 +571,7 @@ initNodeKernel
         , getLeiosPeersVars = getLeiosPeersVars
         , getLeiosOutstanding = getLeiosOutstanding
         , getLeiosReady = getLeiosReady
+        , getLeiosCentralState = getLeiosCentralState
         }
    where
     blockForgingController ::
@@ -615,6 +621,8 @@ data InternalState m addrNTN addrNTC blk = IS
   , -- Leios fetch-logic state; consumed in 'initNodeKernel'.
     leiosOutstanding :: MVar.MVar m (LeiosOutstanding (ConnectionId addrNTN))
   , leiosReady :: MVar.MVar m ()
+  , leiosCentralState ::
+      MVar.MVar m (Announcements.CentralState m (ConnectionId addrNTN) (Leios.AncHeader blk))
   , leiosPeersVars ::
       LazySTM.TVar m (Map.Map (Leios.PeerId (ConnectionId addrNTN)) (LeiosPeerVars m))
   , leiosVoteState :: LeiosVoteState m
@@ -673,6 +681,7 @@ initInternalState
     leiosPeersVars <- LazySTM.newTVarIO Map.empty
     leiosOutstanding <- MVar.newMVar Leios.emptyLeiosOutstanding
     leiosReady <- MVar.newEmptyMVar
+    leiosCentralState <- MVar.newMVar Announcements.emptyCentralState
 
     let readFetchMode =
           BlockFetchClientInterface.readFetchModeDefault

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
@@ -784,6 +784,7 @@ forkBlockForging IS{..} (MkBlockForging blockForgingM) =
                           cst
                           Nothing -- the source is this node, not an upstream peer
                           Announcements.DoRelay -- our newly forged block can't be too old
+                          Nothing -- no wall-clock lateness for a locally-forged announcement
                           anc
     )
  where

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
@@ -118,10 +118,6 @@ import Ouroboros.Consensus.Storage.ChainDB.API
 import qualified Ouroboros.Consensus.Storage.ChainDB.API as ChainDB
 import Ouroboros.Consensus.Storage.ChainDB.Init (InitChainDB)
 import qualified Ouroboros.Consensus.Storage.ChainDB.Init as InitChainDB
-import Ouroboros.Consensus.Storage.LedgerDB.Forker
-  ( headerElId
-  , headerLeiosAnnouncement
-  )
 import Ouroboros.Consensus.Util.AnchoredFragment
   ( preferAnchoredCandidate
   )
@@ -251,7 +247,7 @@ data NodeKernel m addrNTN addrNTC blk = NodeKernel
   -- ^ Filled by anyone who makes a change that might unblock a new
   -- fetch decision; the fetch logic 'MVar.takeMVar's before it runs.
   , getLeiosCentralState ::
-      MVar.MVar m (Announcements.CentralState m (ConnectionId addrNTN) (Leios.AncHeader blk))
+      MVar.MVar m (Announcements.CentralState m (ConnectionId addrNTN) (Leios.AnnouncingHeader blk))
   -- ^ Node-wide EB-announcement state
   }
 
@@ -641,7 +637,7 @@ data InternalState m addrNTN addrNTC blk = IS
     leiosOutstanding :: MVar.MVar m (LeiosOutstanding (ConnectionId addrNTN))
   , leiosReady :: MVar.MVar m ()
   , leiosCentralState ::
-      MVar.MVar m (Announcements.CentralState m (ConnectionId addrNTN) (Leios.AncHeader blk))
+      MVar.MVar m (Announcements.CentralState m (ConnectionId addrNTN) (Leios.AnnouncingHeader blk))
   , leiosPeersVars ::
       LazySTM.TVar m (Map.Map (Leios.PeerId (ConnectionId addrNTN)) (LeiosPeerVars m))
   , leiosVoteState :: LeiosVoteState m
@@ -779,16 +775,16 @@ forkBlockForging IS{..} (MkBlockForging blockForgingM) =
                   -- any) to downstream peers via LeiosNotify; 'forge' yields the
                   -- header only when it forged and adopted a block.
                   whenJust mbForgedHeader $ \forgedHeader ->
-                    whenJust (headerLeiosAnnouncement forgedHeader) $ \_ ->
+                    whenJust (Leios.mkAnnouncingHeader forgedHeader) $ \anc ->
                       MVar.modifyMVar_ leiosCentralState $ \cst ->
                         Announcements.onAnnouncementCentral
-                          nullTracer
-                          (\(Leios.AncHeader h) -> headerElId h)
+                          (contramap Leios.traceNewAnnouncement (leiosKernelTracer tracers))
+                          Leios.ancElId
                           (\_elSt -> pure ()) -- we forged the EB; nothing to fetch locally
                           cst
                           Nothing -- the source is this node, not an upstream peer
                           Announcements.DoRelay -- our newly forged block can't be too old
-                          (Leios.AncHeader forgedHeader)
+                          anc
     )
  where
   label :: String

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel/Forge.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel/Forge.hs
@@ -97,9 +97,13 @@ forge ::
   LeiosVoteState m ->
   BlockForging m blk ->
   LeiosDbConnection m ->
+  -- | Invoked with the freshly-forged block's header, after forging and
+  -- /before/ adoption, so the caller can act on the new block (e.g. concurrently
+  -- announce its EB) without adoption gating it.
+  (Header blk -> m ()) ->
   SlotNo ->
-  WithEarlyExit m (Header blk)
-forge forgeEventTracer forgeStateInfoTracer leiosTracer forgeCCtx cfg chainDB mempool leiosVoteState blockForging leiosConn currentSlot = do
+  WithEarlyExit m ()
+forge forgeEventTracer forgeStateInfoTracer leiosTracer forgeCCtx cfg chainDB mempool leiosVoteState blockForging leiosConn afterForge currentSlot = do
   let trace :: TraceForgeEvent blk -> WithEarlyExit m ()
       trace =
         lift
@@ -256,6 +260,10 @@ forge forgeEventTracer forgeStateInfoTracer leiosTracer forgeCCtx cfg chainDB me
       newBlock
       snapSize
       rbTxsSize
+
+  -- Hand the freshly-forged block's header to the caller before adoption, so it
+  -- can act on it (e.g. concurrently announce its EB) without adoption gating it.
+  lift $ afterForge (getHeader newBlock)
 
   forgeTrace'Via
     (const ())
@@ -473,8 +481,7 @@ addBlockToChainDB ::
   [Validated (GenTx blk)] ->
   [Validated (GenTx blk)] ->
   blk ->
-  -- | The adopted block's header (only produced on the adopted path).
-  WithEarlyExit m (Header blk)
+  WithEarlyExit m ()
 addBlockToChainDB trace chainDB mempool currentSlot rbTxs ebTxs newBlock = do
   let noPunish = InvalidBlockPunishment.noPunishment -- no way to punish yourself
   -- Make sure that if an async exception is thrown while a block is
@@ -525,8 +532,6 @@ addBlockToChainDB trace chainDB mempool currentSlot rbTxs ebTxs newBlock = do
     -- block, i.e., the @HasTxs@ class, is not implementable by all blocks,
     -- e.g., @DualBlock@.
     trace $ TraceAdoptedBlock currentSlot newBlock rbTxs
-
-    pure (getHeader newBlock)
 
 -- | Obtain the ticked ledger view for 'currentSlot', required in order to
 -- construct the ticked 'ChainDepState'.

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel/Forge.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel/Forge.hs
@@ -98,7 +98,7 @@ forge ::
   BlockForging m blk ->
   LeiosDbConnection m ->
   SlotNo ->
-  WithEarlyExit m ()
+  WithEarlyExit m (Header blk)
 forge forgeEventTracer forgeStateInfoTracer leiosTracer forgeCCtx cfg chainDB mempool leiosVoteState blockForging leiosConn currentSlot = do
   let trace :: TraceForgeEvent blk -> WithEarlyExit m ()
       trace =
@@ -473,7 +473,8 @@ addBlockToChainDB ::
   [Validated (GenTx blk)] ->
   [Validated (GenTx blk)] ->
   blk ->
-  WithEarlyExit m ()
+  -- | The adopted block's header (only produced on the adopted path).
+  WithEarlyExit m (Header blk)
 addBlockToChainDB trace chainDB mempool currentSlot rbTxs ebTxs newBlock = do
   let noPunish = InvalidBlockPunishment.noPunishment -- no way to punish yourself
   -- Make sure that if an async exception is thrown while a block is
@@ -524,6 +525,8 @@ addBlockToChainDB trace chainDB mempool currentSlot rbTxs ebTxs newBlock = do
     -- block, i.e., the @HasTxs@ class, is not implementable by all blocks,
     -- e.g., @DualBlock@.
     trace $ TraceAdoptedBlock currentSlot newBlock rbTxs
+
+    pure (getHeader newBlock)
 
 -- | Obtain the ticked ledger view for 'currentSlot', required in order to
 -- construct the ticked 'ChainDepState'.

--- a/ouroboros-consensus-protocol/src/ouroboros-consensus-protocol/Ouroboros/Consensus/Protocol/Praos.hs
+++ b/ouroboros-consensus-protocol/src/ouroboros-consensus-protocol/Ouroboros/Consensus/Protocol/Praos.hs
@@ -31,6 +31,8 @@ module Ouroboros.Consensus.Protocol.Praos
 
     -- * For testing purposes
   , doValidateKESSignature
+  , doValidateKESSignatureWorker
+  , WhetherToUpperBoundOCERT (..)
   , doValidateVRFSignature
   ) where
 
@@ -672,6 +674,20 @@ validateKESSignature
   ocertCounters =
     doValidateKESSignature praosMaxKESEvo praosSlotsPerKESPeriod lvPoolDistr ocertCounters
 
+-- | Whether 'doValidateKESSignatureWorker' enforces the OCERT counter's /upper/
+-- bound, i.e. rejects (with 'CounterOverIncrementedOCERT') a counter more than
+-- one greater than the one we have recorded for this issuer.
+--
+-- Normal header validation enforces it ('UpperBoundOCERT'). Validating a
+-- relayed Leios announcement out-of-context against a (possibly lagging)
+-- immutable tip legitimately sees counters that have run ahead of our recorded
+-- view, so that path skips it ('DoNotUpperBoundOCERT'). The counter's /lower/
+-- bound ('CounterTooSmallOCERT', a revoked key) is enforced either way.
+data WhetherToUpperBoundOCERT
+  = UpperBoundOCERT
+  | DoNotUpperBoundOCERT
+  deriving (Eq, Show)
+
 -- NOTE: This function is much easier to test than 'validateKESSignature' because we don't need to
 -- construct a 'PraosConfig' nor 'LedgerView' to test it.
 doValidateKESSignature ::
@@ -682,7 +698,20 @@ doValidateKESSignature ::
   Map (KeyHash SL.BlockIssuer) Word64 ->
   Views.HeaderView c ->
   Except (PraosValidationErr c) ()
-doValidateKESSignature praosMaxKESEvo praosSlotsPerKESPeriod stakeDistribution ocertCounters b =
+doValidateKESSignature = doValidateKESSignatureWorker UpperBoundOCERT
+
+-- | The worker underlying 'doValidateKESSignature', parameterized by whether to
+-- enforce the OCERT counter's upper bound (see 'WhetherToUpperBoundOCERT').
+doValidateKESSignatureWorker ::
+  PraosCrypto c =>
+  WhetherToUpperBoundOCERT ->
+  Word64 ->
+  Word64 ->
+  Map (KeyHash SL.StakePool) SL.IndividualPoolStake ->
+  Map (KeyHash SL.BlockIssuer) Word64 ->
+  Views.HeaderView c ->
+  Except (PraosValidationErr c) ()
+doValidateKESSignatureWorker whetherToUpperBound praosMaxKESEvo praosSlotsPerKESPeriod stakeDistribution ocertCounters b =
   do
     c0 <= kp ?! KESBeforeStartOCERT c0 kp
     kp_ < c0_ + fromIntegral praosMaxKESEvo ?! KESAfterEndOCERT kp c0 praosMaxKESEvo
@@ -701,7 +730,9 @@ doValidateKESSignature praosMaxKESEvo praosSlotsPerKESPeriod stakeDistribution o
         throwError $ NoCounterForKeyHashOCERT hk
       Just m -> do
         m <= n ?! CounterTooSmallOCERT m n
-        n <= m + 1 ?! CounterOverIncrementedOCERT m n
+        case whetherToUpperBound of
+          UpperBoundOCERT -> n <= m + 1 ?! CounterOverIncrementedOCERT m n
+          DoNotUpperBoundOCERT -> pure ()
  where
   oc@(OCert vk_hot n c0@(KESPeriod c0_) tau) = Views.hvOCert b
   (VKey vkcold) = Views.hvVK b

--- a/ouroboros-consensus.cabal
+++ b/ouroboros-consensus.cabal
@@ -726,6 +726,7 @@ test-suite consensus-test
     Test.Consensus.Util.Versioned
     Test.LeiosDemoDb
     Test.LeiosDemoLogic
+    Test.LeiosDemoLogic.Announcements
     Test.LeiosDemoTypes
     Test.LeiosUtils.CallTrace
     Test.LeiosVoteState

--- a/ouroboros-consensus.cabal
+++ b/ouroboros-consensus.cabal
@@ -1147,6 +1147,7 @@ library diffusion
     network-mux ^>=0.10,
     ouroboros-consensus:{ouroboros-consensus, protocol},
     ouroboros-network:{api, framework, ouroboros-network, protocols},
+    primitive,
     random ^>=1.3,
     resource-registry,
     safe-wild-cards ^>=1.0,

--- a/ouroboros-consensus.cabal
+++ b/ouroboros-consensus.cabal
@@ -397,7 +397,7 @@ library
     network-mux,
     nonempty-containers,
     nothunks ^>=0.2 || ^>=0.3,
-    ouroboros-network:{api, api-tests-lib, protocols} ^>=1.1,
+    ouroboros-network:{api, api-tests-lib, framework, protocols} ^>=1.1,
     pretty-simple,
     primitive,
     psqueues ^>=0.2.3,

--- a/ouroboros-consensus.cabal
+++ b/ouroboros-consensus.cabal
@@ -108,6 +108,7 @@ library
     LeiosDemoLogic
     LeiosDemoLogic.Announcements
     LeiosDemoLogic.Announcements.ElBimap
+    LeiosDemoLogic.Announcements.Validate
     LeiosDemoOnlyTestFetch
     LeiosDemoOnlyTestNotify
     LeiosDemoTypes

--- a/ouroboros-consensus.cabal
+++ b/ouroboros-consensus.cabal
@@ -106,6 +106,8 @@ library
     LeiosDemoDb.Trace
     LeiosDemoException
     LeiosDemoLogic
+    LeiosDemoLogic.Announcements
+    LeiosDemoLogic.Announcements.ElBimap
     LeiosDemoOnlyTestFetch
     LeiosDemoOnlyTestNotify
     LeiosDemoTypes

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic.hs
@@ -1052,7 +1052,9 @@ instance Exception ExnLeiosBlockAnnouncementMissing
 --
 -- Returns the announcement's data and whether to relay it downstream (see
 -- 'Announcements.ShouldRelay' and 'maxAnnouncementAgeSend'), if the announcement
--- is valid.
+-- is valid. Per the 'Announcements.onAnnouncement' contract, 'Left Nothing'
+-- signals the too-old rejection (see 'maxAnnouncementAgeRecv') and 'Left Just'
+-- any other invalidity.
 announcementValidity ::
   (IOLike m, LedgerSupportsProtocol blk, ResolveLeiosBlock blk) =>
   SystemTime m ->
@@ -1062,7 +1064,7 @@ announcementValidity ::
   Header blk ->
   m
     ( Either
-        (AnnouncementInvalidity blk)
+        (Maybe (AnnouncementInvalidity blk))
         (Announcements.ShouldRelay, NominalDiffTime, (LeiosPoint, BytesSize))
     )
 announcementValidity systemTime futureCheck cfg immLedger hdr = do
@@ -1084,11 +1086,20 @@ announcementValidity systemTime futureCheck cfg immLedger hdr = do
   -- is non-negative.
   now <- systemTimeCurrent systemTime
   let age = diffRelTime now onset
-      shouldRelay =
-        if age <= maxAnnouncementAgeSend
-        then Announcements.DoRelay
-        else Announcements.DoNotRelay
-  pure $ (\v -> (shouldRelay, age, v)) <$> validateAnnouncementHeader cfg immLedger hdr
+  pure $
+    -- 'Left Nothing' signals the too-old rejection to 'Announcements.onAnnouncement'
+    -- (which raises 'Announcements.ErrTooOld'); only this function holds the wall
+    -- clock, so it owns that check.
+    if age > maxAnnouncementAgeRecv
+    then Left Nothing
+    else
+      let shouldRelay =
+            if age <= maxAnnouncementAgeSend
+            then Announcements.DoRelay
+            else Announcements.DoNotRelay
+       in case validateAnnouncementHeader cfg immLedger hdr of
+            Left inv -> Left (Just inv)
+            Right v -> Right (shouldRelay, age, v)
 
 -- | Record a validated, newly-announced EB body as missing, with its
 -- authoritative (forger-signed) size. First-seen wins: a no-op if the body is
@@ -1165,13 +1176,23 @@ lEIOSNOTIFYPIPELINEDEPTH = 100   -- TODO magic number
 -- | Do not relay (to downstream peers) an announcement whose slot's wall-clock
 -- onset is older than this. See 'Announcements.ShouldRelay'.
 --
--- Must be comfortably less than the minimum possible wall-clock age of the
--- immutable tip (the /average/ imm-tip age is @k \/ f@ slots behind the wall
--- clock, but we need the /never in a million years/ bound instead), so that a
--- downstream peer whose immutable tip is slightly ahead of ours by the time our
--- message arrives still accepts what we relay rather than disconnecting us for
--- a below-its-immutable-tip announcement.
+-- Must be comfortably less than 'maxAnnouncementAgeRecv', so that an
+-- announcement an honest node relays just before this bound still arrives at
+-- the downstream peer within that peer's larger receive bound, even after
+-- transmission time and clock skew.
 --
 -- TODO magic number; should be a config/RunNode option
 maxAnnouncementAgeSend :: NominalDiffTime
-maxAnnouncementAgeSend = 3600   -- 1 hour
+maxAnnouncementAgeSend = 300   -- 5 minutes
+
+-- | Disconnect an upstream peer that relays an announcement whose slot's
+-- wall-clock onset is older than this. See 'Announcements.ErrTooOld'.
+--
+-- Comfortably greater than 'maxAnnouncementAgeSend', so that an honest peer
+-- (which stops relaying at that smaller bound) is never disconnected on account
+-- of transmission time or clock skew.
+--
+-- TODO magic number; should be a config/RunNode option... or even a protocol
+-- parameter?
+maxAnnouncementAgeRecv :: NominalDiffTime
+maxAnnouncementAgeRecv = 600   -- 10 minutes

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic.hs
@@ -7,6 +7,7 @@
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -53,13 +54,12 @@ import LeiosDemoDb
   )
 import qualified LeiosDemoLogic.Announcements as Announcements
 import LeiosDemoLogic.Announcements.Validate
-  ( AnnouncementInvalidity (..)
+  ( AnnouncementInvalidity
   , validateAnnouncementHeader
   )
 import qualified LeiosDemoOnlyTestFetch as LF
 import LeiosDemoTypes
-  ( AnnouncementDisposition (..)
-  , BytesSize
+  ( BytesSize
   , EbHash (..)
   , LeiosBlockRequest (..)
   , LeiosBlockTxsRequest (..)
@@ -983,41 +983,16 @@ instance HasHeader (Header blk) => Eq (AncHeader blk) where
   AncHeader a == AncHeader b = headerHash a == headerHash b
 
 -- | Thrown when a peer misbehaves on the announcement protocol; the ensuing
--- thread death disconnects the peer.
+-- thread death disconnects the peer. It carries the
+-- 'Announcements.ErrAnnouncement' verbatim (the @blk@ is existential); every
+-- such error is a disconnect, since the only invalidities that used to be
+-- tolerated — opcert issue numbers ahead of the immutable tip — are now
+-- accepted outright by 'validateAnnouncementHeader'.
 data ExnInvalidLeiosAnnouncement =
-    -- | Re-sent an announcement it had already sent
-    ExnRepeatedAnnouncement
-  |
-    -- | Sent a third announcement for a single election
-    ExnThirdAnnouncement
-  |
-    -- | Sent a 'MsgLeiosBlockAnnouncement' whose header carries no announcement
-    ExnNoAnnouncement
-  |
-    -- | Sent an announcement whose header is invalid
-    ExnInvalidHeader
-  |
-    -- | Sent an announcement for a slot before our immutable tip (the forecast
-    -- anchor): stale for a caught-up node, and unvalidatable (a below-anchor
-    -- slot cannot be forecast).
-    --
-    -- TODO should we avoid /sending/ announcements that are near our tip?
-    -- Otherwise, an adversary could release their announcements right as the
-    -- network's imm tip is advancing across it, causing some frontier of honest
-    -- nodes to send announcements that their recipients punish
-    ExnBeforeImmutableTip
-  |
-    -- | Sent an announcement for a slot beyond our immutable tip's forecast
-    -- horizon. A fresh announcement is always within horizon for a caught-up
-    -- node, so this is either a bogus far-future slot or we're falling behind.
-    -- If we're falling behind, then either we're unhealthy or our honest peers
-    -- aren't serving us well (eg we have very bad connections), so disconnecting
-    -- from non-adversarial peers seems OK.
-    --
-    -- We cannot simply ignore in this case, because there's an unbounded amount
-    -- of bogus announcements in far-future slots.
-    ExnBeyondForecastHorizon
-  deriving Show
+  forall blk.
+    ReactToAnnouncementError (Announcements.ErrAnnouncement (AnnouncementInvalidity blk))
+
+deriving instance Show ExnInvalidLeiosAnnouncement
 
 instance Exception ExnInvalidLeiosAnnouncement
 
@@ -1072,36 +1047,6 @@ recordAnnouncedEb (point, ebBytesSize) outstanding =
   where
     MkLeiosPoint _ebSlot ebHash = point
 
--- | What the NodeToNode client should do with an 'Announcements.ErrAnnouncement'.
-data AnnouncementReaction =
-    -- | Do not relay, but do not disconnect
-    --
-    -- See TODO on 'AnnouncementDisposition', which applies here too.
-    ReactSkipOpcertIssueNumberForgiven
-  |
-    -- | Disconnect the peer by throwing the given exception.
-    ReactDisconnect !ExnInvalidLeiosAnnouncement
-
-reactToAnnouncementError ::
-  forall blk.
-  ResolveLeiosBlock blk =>
-  Announcements.ErrAnnouncement (AnnouncementInvalidity blk) ->
-  AnnouncementReaction
-reactToAnnouncementError = \case
-    Announcements.ErrRepeat -> ReactDisconnect ExnRepeatedAnnouncement
-    Announcements.ErrThird -> ReactDisconnect ExnThirdAnnouncement
-    Announcements.ErrInvalid invalidity -> case invalidity of
-        NoAnnouncement ->
-          ReactDisconnect ExnNoAnnouncement
-        SlotBeforeImmutableTip ->
-          ReactDisconnect ExnBeforeImmutableTip
-        OutsideHorizon _ ->
-          ReactDisconnect ExnBeyondForecastHorizon
-        HeaderInvalid err ->
-          case classifyAnnouncementValidationErr @blk err of
-            SkipAnnouncement ->
-              ReactSkipOpcertIssueNumberForgiven
-            DisconnectPeer -> ReactDisconnect ExnInvalidHeader
 
 lEIOSNOTIFYPIPELINEDEPTH :: Int
 lEIOSNOTIFYPIPELINEDEPTH = 100   -- TODO magic number

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic.hs
@@ -39,6 +39,7 @@ import Data.Sequence (Seq)
 import qualified Data.Sequence as Seq
 import Data.Set (Set)
 import qualified Data.Set as Set
+import Data.Time.Clock (NominalDiffTime)
 import qualified Data.Vector.Strict as V
 import qualified Data.Vector.Strict.Mutable as MV
 import Data.Word (Word16, Word64)
@@ -81,6 +82,11 @@ import LeiosDemoTypes
   )
 import qualified LeiosDemoTypes as Leios
 import Ouroboros.Consensus.Block (BlockProtocol, HasHeader, Header, headerHash)
+import Ouroboros.Consensus.BlockchainTime.WallClock.Types
+  ( SystemTime
+  , diffRelTime
+  , systemTimeCurrent
+  )
 import Ouroboros.Consensus.Config (TopLevelConfig, configLedger)
 import Ouroboros.Consensus.Ledger.Basics (EmptyMK)
 import Ouroboros.Consensus.Ledger.Extended (ExtLedgerState, ledgerState)
@@ -1005,16 +1011,23 @@ instance Exception ExnInvalidLeiosAnnouncement
 -- Chronos) — blocking the per-peer handler is acceptable, as a (near-)future
 -- announcement is the peer's fault.
 --
--- Returns the announcement's data, if the announcement is valid.
+-- Returns the announcement's data and whether to relay it downstream (see
+-- 'Announcements.ShouldRelay' and 'maxAnnouncementAgeSend'), if the announcement
+-- is valid.
 announcementValidity ::
   (IOLike m, LedgerSupportsProtocol blk, ResolveLeiosBlock blk) =>
+  SystemTime m ->
   InFutureCheck.SomeHeaderInFutureCheck m blk ->
   TopLevelConfig blk ->
   ExtLedgerState blk EmptyMK ->
   Header blk ->
-  m (Either (AnnouncementInvalidity blk) (LeiosPoint, BytesSize))
-announcementValidity futureCheck cfg immLedger hdr = do
-  case futureCheck of
+  m
+    ( Either
+        (AnnouncementInvalidity blk)
+        (Announcements.ShouldRelay, (LeiosPoint, BytesSize))
+    )
+announcementValidity systemTime futureCheck cfg immLedger hdr = do
+  onset <- case futureCheck of
     InFutureCheck.SomeHeaderInFutureCheck hifc -> do
       arrival <- InFutureCheck.recordHeaderArrival hifc hdr
       judgment <-
@@ -1026,8 +1039,16 @@ announcementValidity futureCheck cfg immLedger hdr = do
               (ledgerState immLedger)
               arrival
       arrivalResult <- InFutureCheck.handleHeaderArrival hifc judgment
-      either throwIO (\_onset -> pure ()) (runExcept arrivalResult)
-  pure $ validateAnnouncementHeader cfg immLedger hdr
+      either throwIO pure (runExcept arrivalResult)
+  -- The in-future check has delayed this thread until 'onset' if the
+  -- slot was near-future, so 'now' is at or after 'onset' and the age
+  -- is non-negative.
+  now <- systemTimeCurrent systemTime
+  let shouldRelay =
+        if diffRelTime now onset <= maxAnnouncementAgeSend
+        then Announcements.DoRelay
+        else Announcements.DoNotRelay
+  pure $ (,) shouldRelay <$> validateAnnouncementHeader cfg immLedger hdr
 
 -- | Record a validated, newly-announced EB body as missing, with its
 -- authoritative (forger-signed) size. First-seen wins: a no-op if the body is
@@ -1056,3 +1077,17 @@ recordAnnouncedEb (outstandingVar, readyVar) (point, ebBytesSize) = do
 
 lEIOSNOTIFYPIPELINEDEPTH :: Int
 lEIOSNOTIFYPIPELINEDEPTH = 100   -- TODO magic number
+
+-- | Do not relay (to downstream peers) an announcement whose slot's wall-clock
+-- onset is older than this. See 'Announcements.ShouldRelay'.
+--
+-- Must be comfortably less than the minimum possible wall-clock age of the
+-- immutable tip (the _average_ imm-tip age is @k \/ f@ slots behind the wall
+-- clock, but we need the _never in a million years_ bound instead), so that a
+-- downstream peer whose immutable tip is slightly ahead of ours by the time our
+-- message arrives still accepts what we relay rather than disconnecting us for
+-- a below-its-immutable-tip announcement.
+--
+-- TODO magic number; should be a config/RunNode option
+maxAnnouncementAgeSend :: NominalDiffTime
+maxAnnouncementAgeSend = 3600   -- 1 hour

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic.hs
@@ -951,3 +951,7 @@ leiosCertRbCallback kernelVars peerVars hdr cds =
   when (headerContainsLeiosCert hdr) $
     forM_ (protocolStateLeiosAnnouncement @blk cds) $ \announcement ->
       leiosCertRbOffer kernelVars peerVars announcement
+
+
+lEIOSNOTIFYPIPELINEDEPTH :: Int
+lEIOSNOTIFYPIPELINEDEPTH = 100   -- TODO magic number

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic.hs
@@ -1003,15 +1003,16 @@ instance Exception ExnInvalidLeiosAnnouncement
 -- a far-future slot raises 'InFutureCheck.HeaderArrivalException' (disconnecting
 -- the peer), a near-future slot blocks until the slot's onset (Ouroboros
 -- Chronos) — blocking the per-peer handler is acceptable, as a (near-)future
--- announcement is the peer's fault. Then return the announcement's invalidity,
--- if any.
+-- announcement is the peer's fault.
+--
+-- Returns the announcement's data, if the announcement is valid.
 announcementValidity ::
   (IOLike m, LedgerSupportsProtocol blk, ResolveLeiosBlock blk) =>
   InFutureCheck.SomeHeaderInFutureCheck m blk ->
   TopLevelConfig blk ->
   ExtLedgerState blk EmptyMK ->
   Header blk ->
-  m (Maybe (AnnouncementInvalidity blk))
+  m (Either (AnnouncementInvalidity blk) (LeiosPoint, BytesSize))
 announcementValidity futureCheck cfg immLedger hdr = do
   case futureCheck of
     InFutureCheck.SomeHeaderInFutureCheck hifc -> do
@@ -1026,27 +1027,32 @@ announcementValidity futureCheck cfg immLedger hdr = do
               arrival
       arrivalResult <- InFutureCheck.handleHeaderArrival hifc judgment
       either throwIO (\_onset -> pure ()) (runExcept arrivalResult)
-  pure $ either Just (const Nothing) (validateAnnouncementHeader cfg immLedger hdr)
+  pure $ validateAnnouncementHeader cfg immLedger hdr
 
 -- | Record a validated, newly-announced EB body as missing, with its
 -- authoritative (forger-signed) size. First-seen wins: a no-op if the body is
 -- already acquired or already recorded.
 recordAnnouncedEb ::
+  IOLike m =>
+  ( MVar m (LeiosOutstanding pid)
+  , MVar m ()
+  ) ->
   (LeiosPoint, BytesSize) ->
-  LeiosOutstanding pid ->
-  LeiosOutstanding pid
-recordAnnouncedEb (point, ebBytesSize) outstanding =
-    if Set.member ebHash (Leios.acquiredEbBodies outstanding)
+  m ()
+recordAnnouncedEb (outstandingVar, readyVar) (point, ebBytesSize) = do
+    changed <- MVar.modifyMVar outstandingVar (pure . upd)
+    when changed $ void $ MVar.tryPutMVar readyVar ()
+  where
+    MkLeiosPoint _ebSlot ebHash = point
+
+    upd outstanding = if Set.member ebHash (Leios.acquiredEbBodies outstanding)
        || any ((== ebHash) . pointEbHash) (Map.keys (Leios.missingEbBodies outstanding))
-      then outstanding
-      else
+      then (outstanding, False)
+      else flip (,) True $
         outstanding
           { Leios.missingEbBodies =
               Map.insert point ebBytesSize (Leios.missingEbBodies outstanding)
           }
-  where
-    MkLeiosPoint _ebSlot ebHash = point
-
 
 lEIOSNOTIFYPIPELINEDEPTH :: Int
 lEIOSNOTIFYPIPELINEDEPTH = 100   -- TODO magic number

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic.hs
@@ -1,11 +1,14 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 module LeiosDemoLogic (module LeiosDemoLogic) where
 
@@ -47,6 +50,7 @@ import LeiosDemoDb
   , leiosDbInsertTxs
   , leiosDbLookupEbBody
   )
+import qualified LeiosDemoLogic.Announcements as Announcements
 import LeiosDemoLogic.Announcements.Validate
   ( AnnouncementInvalidity (..)
   , validateAnnouncementHeader
@@ -75,7 +79,7 @@ import LeiosDemoTypes
   , maxTxsPerEb
   )
 import qualified LeiosDemoTypes as Leios
-import Ouroboros.Consensus.Block (BlockProtocol, Header)
+import Ouroboros.Consensus.Block (BlockProtocol, HasHeader, Header, headerHash)
 import Ouroboros.Consensus.Config (TopLevelConfig)
 import Ouroboros.Consensus.Ledger.Basics (EmptyMK)
 import Ouroboros.Consensus.Ledger.Extended (ExtLedgerState)
@@ -963,61 +967,102 @@ leiosCertRbCallback kernelVars peerVars hdr cds =
 
 -----
 
--- | Thrown when a peer relays a genuinely-invalid EB announcement; the ensuing
+-- The pure logic for handling an inbound 'MsgLeiosBlockAnnouncement'. The
+-- effectful glue (reading the immutable tip, the 'Announcements.PeerState' ref,
+-- 'MVar' updates, tracing, and 'throwIO') lives in the NodeToNode client, which
+-- invokes 'Announcements.onAnnouncement' with these pieces.
+
+-- | 'Header blk' as a relayed LeiosNotify announcement. The 'Eq' instance
+-- compares by header hash: that is the one identity used for announcement dedup
+-- and equivocation counting (see 'Announcements.onAnnouncement').
+newtype AncHeader blk = AncHeader (Header blk)
+
+instance HasHeader (Header blk) => Eq (AncHeader blk) where
+  AncHeader a == AncHeader b = headerHash a == headerHash b
+
+-- | Thrown when a peer misbehaves on the announcement protocol; the ensuing
 -- thread death disconnects the peer.
 data ExnInvalidLeiosAnnouncement =
+    -- | Re-sent an announcement it had already sent
+    ExnRepeatedAnnouncement
+  |
+    -- | Sent a third announcement for a single election
+    ExnThirdAnnouncement
+  |
+    -- | Sent a 'MsgLeiosBlockAnnouncement' whose header carries no announcement
     ExnNoAnnouncement
   |
+    -- | Sent an announcement whose header is invalid
     ExnInvalidHeader
+  |
+    -- | Sent an announcement for a slot beyond our immutable tip's forecast
+    -- horizon. A fresh announcement is always within horizon for a caught-up
+    -- node, so this is either a bogus far-future slot or we're falling behind.
+    -- If we're falling behind, then either we're unhealthy or our honest peers
+    -- aren't serving us well (eg we have very bad connections), so disconnecting
+    -- from non-adversarial peers seems OK.
+    --
+    -- We cannot simply ignore in this case, because there's an unbounded amount
+    -- of bogus announcements in far-future slots.
+    ExnBeyondForecastHorizon
   deriving Show
 
 instance Exception ExnInvalidLeiosAnnouncement
 
--- | Handle an inbound 'MsgLeiosBlockAnnouncement': validate the relayed RB
--- header (see 'validateAnnouncementHeader'), then record the EB body as missing
--- and wake the fetch logic, skip it, or disconnect the peer (see
--- 'AnnouncementDisposition').
-onAnnouncement ::
-  forall blk pid m.
-  (IOLike m, LedgerSupportsProtocol blk, ResolveLeiosBlock blk) =>
-  Tracer m TraceLeiosPeer ->
+-- | The @validate@ callback for 'Announcements.onAnnouncement': the
+-- announcement's invalidity, if any.
+announcementValidity ::
+  (LedgerSupportsProtocol blk, ResolveLeiosBlock blk) =>
   TopLevelConfig blk ->
-  ( MVar m (LeiosOutstanding pid)
-  , MVar m ()
-  ) ->
-  -- | The immutable tip's ledger state.
   ExtLedgerState blk EmptyMK ->
   Header blk ->
-  m ()
-onAnnouncement tracer cfg (outstandingVar, readyVar) immLedger hdr =
-  case validateAnnouncementHeader cfg immLedger hdr of
-    Right (point, ebBytesSize) -> do
-      traceWith tracer $
-        MkTraceLeiosPeer $ "MsgLeiosBlockAnnouncement " <> Leios.prettyLeiosPoint point
-      let MkLeiosPoint _ebSlot ebHash = point
-      MVar.modifyMVar_ outstandingVar $ \outstanding ->
-        pure $
-          if Set.member ebHash (Leios.acquiredEbBodies outstanding)
-            || any ((== ebHash) . pointEbHash) (Map.keys (Leios.missingEbBodies outstanding))
-            then outstanding
-            else
-              outstanding
-                { Leios.missingEbBodies =
-                    Map.insert point ebBytesSize (Leios.missingEbBodies outstanding)
-                }
-      void $ MVar.tryPutMVar readyVar ()
-    Left NoAnnouncement ->
-      throwIO ExnNoAnnouncement
-    Left (OutsideHorizon _) ->
-      traceWith tracer $
-        MkTraceLeiosPeer "MsgLeiosBlockAnnouncement skipped: announced slot beyond forecast horizon"
-    Left (HeaderInvalid err) ->
+  Maybe (AnnouncementInvalidity blk)
+announcementValidity cfg immLedger hdr =
+  either Just (const Nothing) (validateAnnouncementHeader cfg immLedger hdr)
+
+-- | Record a validated, newly-announced EB body as missing, with its
+-- authoritative (forger-signed) size. First-seen wins: a no-op if the body is
+-- already acquired or already recorded.
+recordAnnouncedEb ::
+  (LeiosPoint, BytesSize) ->
+  LeiosOutstanding pid ->
+  LeiosOutstanding pid
+recordAnnouncedEb (point, ebBytesSize) outstanding =
+    if Set.member ebHash (Leios.acquiredEbBodies outstanding)
+       || any ((== ebHash) . pointEbHash) (Map.keys (Leios.missingEbBodies outstanding))
+      then outstanding
+      else
+        outstanding
+          { Leios.missingEbBodies =
+              Map.insert point ebBytesSize (Leios.missingEbBodies outstanding)
+          }
+  where
+    MkLeiosPoint _ebSlot ebHash = point
+
+-- | What the NodeToNode client should do with an 'Announcements.ErrAnnouncement'.
+data AnnouncementReaction =
+    -- | Do not relay, but do not disconnect; trace the given reason.
+    ReactSkip !String
+  |
+    -- | Disconnect the peer by throwing the given exception.
+    ReactDisconnect !ExnInvalidLeiosAnnouncement
+
+reactToAnnouncementError ::
+  forall blk.
+  ResolveLeiosBlock blk =>
+  Announcements.ErrAnnouncement (AnnouncementInvalidity blk) ->
+  AnnouncementReaction
+reactToAnnouncementError = \case
+    Announcements.ErrRepeat -> ReactDisconnect ExnRepeatedAnnouncement
+    Announcements.ErrThird -> ReactDisconnect ExnThirdAnnouncement
+    Announcements.ErrInvalid NoAnnouncement -> ReactDisconnect ExnNoAnnouncement
+    Announcements.ErrInvalid (OutsideHorizon _) ->
+      ReactDisconnect ExnBeyondForecastHorizon
+    Announcements.ErrInvalid (HeaderInvalid err) ->
       case classifyAnnouncementValidationErr @blk err of
         SkipAnnouncement ->
-          traceWith tracer $
-            MkTraceLeiosPeer "MsgLeiosBlockAnnouncement skipped: opcert counter not verifiable against immutable tip"
-        DisconnectPeer ->
-          throwIO ExnInvalidHeader
+          ReactSkip "opcert counter not verifiable against immutable tip"
+        DisconnectPeer -> ReactDisconnect ExnInvalidHeader
 
 lEIOSNOTIFYPIPELINEDEPTH :: Int
 lEIOSNOTIFYPIPELINEDEPTH = 100   -- TODO magic number

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic.hs
@@ -28,7 +28,7 @@ import qualified Data.Bits as Bits
 import qualified Data.ByteString as BS
 import Data.DList (DList)
 import qualified Data.DList as DList
-import Data.Functor (void)
+import Data.Functor ((<&>), void)
 import Data.IntMap (IntMap)
 import qualified Data.IntMap as IntMap
 import qualified Data.IntSet as IntSet
@@ -54,13 +54,17 @@ import LeiosDemoDb
   , leiosDbLookupEbBody
   )
 import qualified LeiosDemoLogic.Announcements as Announcements
+import LeiosDemoLogic.Announcements.ElBimap (ElId)
 import LeiosDemoLogic.Announcements.Validate
   ( AnnouncementInvalidity
   , validateAnnouncementHeader
   )
 import qualified LeiosDemoOnlyTestFetch as LF
 import LeiosDemoTypes
-  ( BytesSize
+  ( AnnouncementEquivocation (..)
+  , AnnouncementFields (..)
+  , AnnouncementSource (..)
+  , BytesSize
   , EbHash (..)
   , LeiosBlockRequest (..)
   , LeiosBlockTxsRequest (..)
@@ -987,13 +991,33 @@ leiosCertRbCallback kernelVars peerVars hdr cds =
 -- 'MVar' updates, tracing, and 'throwIO') lives in the NodeToNode client, which
 -- invokes 'Announcements.onAnnouncement' with these pieces.
 
--- | 'Header blk' as a relayed LeiosNotify announcement. The 'Eq' instance
+-- | 'Header blk' as a relayed LeiosNotify announcement, paired with the
+-- announcement data parsed from it (see 'mkAnnouncingHeader'). The 'Eq' instance
 -- compares by header hash: that is the one identity used for announcement dedup
 -- and equivocation counting (see 'Announcements.onAnnouncement').
-newtype AncHeader blk = AncHeader (Header blk)
+data AnnouncingHeader blk =
+    -- | INVARIANT: 'ancHeader' includes an announcement whose fields are
+    -- 'ancAnnouncementFields'
+    UnsafeMkAnnouncingHeader {
+       ancHeader :: !(Header blk)
+     ,
+       ancAnnouncementFields :: !AnnouncementFields
+     }
 
-instance HasHeader (Header blk) => Eq (AncHeader blk) where
-  AncHeader a == AncHeader b = headerHash a == headerHash b
+instance HasHeader (Header blk) => Eq (AnnouncingHeader blk) where
+  a == b = headerHash (ancHeader a) == headerHash (ancHeader b)
+
+-- | Interpret a header as a relayed EB announcement, or 'Nothing' if it carries
+-- no announcement (so it should not have been relayed as one). Parsing the
+-- announcement once here keeps it total for all later consumers (e.g. tracing).
+mkAnnouncingHeader :: ResolveLeiosBlock blk => Header blk -> Maybe (AnnouncingHeader blk)
+mkAnnouncingHeader h =
+  headerLeiosAnnouncement h <&> \(MkLeiosPoint _ebSlot ebHash, ebBodySize) ->
+    UnsafeMkAnnouncingHeader h (MkAnnouncementFields (headerElId h) ebHash ebBodySize)
+
+-- | The election of an 'AnnouncingHeader'.
+ancElId :: AnnouncingHeader blk -> ElId
+ancElId = announcementElection . ancAnnouncementFields
 
 -- | Thrown when a peer misbehaves on the announcement protocol; the ensuing
 -- thread death disconnects the peer. It carries the
@@ -1008,6 +1032,14 @@ data ExnInvalidLeiosAnnouncement =
 deriving instance Show ExnInvalidLeiosAnnouncement
 
 instance Exception ExnInvalidLeiosAnnouncement
+
+-- | Thrown when a peer relays a 'MsgLeiosBlockAnnouncement' whose header carries
+-- no EB announcement (so 'mkAnnouncingHeader' returns 'Nothing'); the ensuing thread
+-- death disconnects the peer.
+data ExnLeiosBlockAnnouncementMissing = ExnLeiosBlockAnnouncementMissing
+  deriving Show
+
+instance Exception ExnLeiosBlockAnnouncementMissing
 
 -- | The @validate@ callback for 'Announcements.onAnnouncement'.
 --
@@ -1093,6 +1125,37 @@ prunePeerStateToImmTip immLedger latestPruneSlot peerSt =
     NotOrigin immTipSlot
       | latestPruneSlot < immTipSlot -> (immTipSlot, Announcements.prunePeerState immTipSlot peerSt)
     _ -> (latestPruneSlot, peerSt)
+
+-- | The just-counted announcement's fields, and whether it equivocates a prior
+-- header announcing the same election.
+announcementTraceFields ::
+  Announcements.ElState (AnnouncingHeader blk) ->
+  (AnnouncementEquivocation, AnnouncementFields)
+announcementTraceFields = \case
+  Announcements.OneAnnouncement a ->
+    (NoEquivocation, ancAnnouncementFields a)
+  Announcements.TwoAnnouncements _a1 a2 ->
+    (Equivocation, ancAnnouncementFields a2)
+
+-- | Render an 'Announcements' per-peer announcement event as a 'TraceLeiosPeer'.
+tracePeerAnnouncement ::
+  Announcements.TraceLeiosNotifyPeerEvent (AnnouncingHeader blk) ->
+  TraceLeiosPeer
+tracePeerAnnouncement (Announcements.TracePeerAnnouncement elSt) =
+  let (equivocation, fields) = announcementTraceFields elSt
+   in TraceLeiosPeerAnnouncement equivocation fields
+
+-- | Render an 'Announcements' node-wide announcement event as a
+-- 'TraceLeiosKernel'.
+traceNewAnnouncement ::
+  Announcements.TraceLeiosNotifyEvent peer (AnnouncingHeader blk) ->
+  TraceLeiosKernel
+traceNewAnnouncement (Announcements.TraceNewAnnouncement mbPeer _elId elSt) =
+  let (equivocation, fields) = announcementTraceFields elSt
+   in TraceLeiosAnnouncementAccepted
+        (maybe ForgedLocally (const ReceivedFromPeer) mbPeer)
+        equivocation
+        fields
 
 lEIOSNOTIFYPIPELINEDEPTH :: Int
 lEIOSNOTIFYPIPELINEDEPTH = 100   -- TODO magic number

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic.hs
@@ -20,6 +20,7 @@ import Control.Concurrent.Class.MonadSTM.Strict (StrictTVar)
 import qualified Control.Concurrent.Class.MonadSTM.Strict as StrictSTM
 import Control.Monad (forM_, when)
 import Control.Monad.Class.MonadThrow (Exception, catch, throwIO)
+import Control.Monad.Except (runExcept)
 import Control.Monad.Primitive (PrimMonad, PrimState)
 import Control.Tracer (Tracer, traceWith)
 import qualified Data.Bits as Bits
@@ -80,10 +81,11 @@ import LeiosDemoTypes
   )
 import qualified LeiosDemoTypes as Leios
 import Ouroboros.Consensus.Block (BlockProtocol, HasHeader, Header, headerHash)
-import Ouroboros.Consensus.Config (TopLevelConfig)
+import Ouroboros.Consensus.Config (TopLevelConfig, configLedger)
 import Ouroboros.Consensus.Ledger.Basics (EmptyMK)
-import Ouroboros.Consensus.Ledger.Extended (ExtLedgerState)
+import Ouroboros.Consensus.Ledger.Extended (ExtLedgerState, ledgerState)
 import Ouroboros.Consensus.Ledger.SupportsProtocol (LedgerSupportsProtocol)
+import qualified Ouroboros.Consensus.MiniProtocol.ChainSync.Client.InFutureCheck as InFutureCheck
 import Ouroboros.Consensus.Protocol.Abstract (ChainDepState)
 import Ouroboros.Consensus.Storage.LedgerDB.Forker (ResolveLeiosBlock (..))
 import Ouroboros.Consensus.Util.IOLike (IOLike)
@@ -995,6 +997,16 @@ data ExnInvalidLeiosAnnouncement =
     -- | Sent an announcement whose header is invalid
     ExnInvalidHeader
   |
+    -- | Sent an announcement for a slot before our immutable tip (the forecast
+    -- anchor): stale for a caught-up node, and unvalidatable (a below-anchor
+    -- slot cannot be forecast).
+    --
+    -- TODO should we avoid /sending/ announcements that are near our tip?
+    -- Otherwise, an adversary could release their announcements right as the
+    -- network's imm tip is advancing across it, causing some frontier of honest
+    -- nodes to send announcements that their recipients punish
+    ExnBeforeImmutableTip
+  |
     -- | Sent an announcement for a slot beyond our immutable tip's forecast
     -- horizon. A fresh announcement is always within horizon for a caught-up
     -- node, so this is either a bogus far-future slot or we're falling behind.
@@ -1009,16 +1021,37 @@ data ExnInvalidLeiosAnnouncement =
 
 instance Exception ExnInvalidLeiosAnnouncement
 
--- | The @validate@ callback for 'Announcements.onAnnouncement': the
--- announcement's invalidity, if any.
+-- | The @validate@ callback for 'Announcements.onAnnouncement'.
+--
+-- First apply ChainSync's in-future check to the announced slot's wall-clock
+-- onset (reusing the node's own 'InFutureCheck.SomeHeaderInFutureCheck'):
+-- a far-future slot raises 'InFutureCheck.HeaderArrivalException' (disconnecting
+-- the peer), a near-future slot blocks until the slot's onset (Ouroboros
+-- Chronos) — blocking the per-peer handler is acceptable, as a (near-)future
+-- announcement is the peer's fault. Then return the announcement's invalidity,
+-- if any.
 announcementValidity ::
-  (LedgerSupportsProtocol blk, ResolveLeiosBlock blk) =>
+  (IOLike m, LedgerSupportsProtocol blk, ResolveLeiosBlock blk) =>
+  InFutureCheck.SomeHeaderInFutureCheck m blk ->
   TopLevelConfig blk ->
   ExtLedgerState blk EmptyMK ->
   Header blk ->
-  Maybe (AnnouncementInvalidity blk)
-announcementValidity cfg immLedger hdr =
-  either Just (const Nothing) (validateAnnouncementHeader cfg immLedger hdr)
+  m (Maybe (AnnouncementInvalidity blk))
+announcementValidity futureCheck cfg immLedger hdr = do
+  case futureCheck of
+    InFutureCheck.SomeHeaderInFutureCheck hifc -> do
+      arrival <- InFutureCheck.recordHeaderArrival hifc hdr
+      judgment <-
+        either throwIO pure $
+          runExcept $
+            InFutureCheck.judgeHeaderArrival
+              hifc
+              (configLedger cfg)
+              (ledgerState immLedger)
+              arrival
+      arrivalResult <- InFutureCheck.handleHeaderArrival hifc judgment
+      either throwIO (\_onset -> pure ()) (runExcept arrivalResult)
+  pure $ either Just (const Nothing) (validateAnnouncementHeader cfg immLedger hdr)
 
 -- | Record a validated, newly-announced EB body as missing, with its
 -- authoritative (forger-signed) size. First-seen wins: a no-op if the body is
@@ -1041,8 +1074,10 @@ recordAnnouncedEb (point, ebBytesSize) outstanding =
 
 -- | What the NodeToNode client should do with an 'Announcements.ErrAnnouncement'.
 data AnnouncementReaction =
-    -- | Do not relay, but do not disconnect; trace the given reason.
-    ReactSkip !String
+    -- | Do not relay, but do not disconnect
+    --
+    -- See TODO on 'AnnouncementDisposition', which applies here too.
+    ReactSkipOpcertIssueNumberForgiven
   |
     -- | Disconnect the peer by throwing the given exception.
     ReactDisconnect !ExnInvalidLeiosAnnouncement
@@ -1055,14 +1090,18 @@ reactToAnnouncementError ::
 reactToAnnouncementError = \case
     Announcements.ErrRepeat -> ReactDisconnect ExnRepeatedAnnouncement
     Announcements.ErrThird -> ReactDisconnect ExnThirdAnnouncement
-    Announcements.ErrInvalid NoAnnouncement -> ReactDisconnect ExnNoAnnouncement
-    Announcements.ErrInvalid (OutsideHorizon _) ->
-      ReactDisconnect ExnBeyondForecastHorizon
-    Announcements.ErrInvalid (HeaderInvalid err) ->
-      case classifyAnnouncementValidationErr @blk err of
-        SkipAnnouncement ->
-          ReactSkip "opcert counter not verifiable against immutable tip"
-        DisconnectPeer -> ReactDisconnect ExnInvalidHeader
+    Announcements.ErrInvalid invalidity -> case invalidity of
+        NoAnnouncement ->
+          ReactDisconnect ExnNoAnnouncement
+        SlotBeforeImmutableTip ->
+          ReactDisconnect ExnBeforeImmutableTip
+        OutsideHorizon _ ->
+          ReactDisconnect ExnBeyondForecastHorizon
+        HeaderInvalid err ->
+          case classifyAnnouncementValidationErr @blk err of
+            SkipAnnouncement ->
+              ReactSkipOpcertIssueNumberForgiven
+            DisconnectPeer -> ReactDisconnect ExnInvalidHeader
 
 lEIOSNOTIFYPIPELINEDEPTH :: Int
 lEIOSNOTIFYPIPELINEDEPTH = 100   -- TODO magic number

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic.hs
@@ -81,13 +81,20 @@ import LeiosDemoTypes
   , maxTxsPerEb
   )
 import qualified LeiosDemoTypes as Leios
-import Ouroboros.Consensus.Block (BlockProtocol, HasHeader, Header, headerHash)
+import Ouroboros.Consensus.Block
+  ( BlockProtocol
+  , HasHeader
+  , Header
+  , WithOrigin (NotOrigin)
+  , headerHash
+  )
 import Ouroboros.Consensus.BlockchainTime.WallClock.Types
   ( SystemTime
   , diffRelTime
   , systemTimeCurrent
   )
 import Ouroboros.Consensus.Config (TopLevelConfig, configLedger)
+import Ouroboros.Consensus.Ledger.Abstract (getTipSlot)
 import Ouroboros.Consensus.Ledger.Basics (EmptyMK)
 import Ouroboros.Consensus.Ledger.Extended (ExtLedgerState, ledgerState)
 import Ouroboros.Consensus.Ledger.SupportsProtocol (LedgerSupportsProtocol)
@@ -1075,6 +1082,18 @@ recordAnnouncedEb (outstandingVar, readyVar) (point, ebBytesSize) = do
               Map.insert point ebBytesSize (Leios.missingEbBodies outstanding)
           }
 
+prunePeerStateToImmTip ::
+  LedgerSupportsProtocol blk =>
+  ExtLedgerState blk EmptyMK ->
+  SlotNo ->
+  Announcements.PeerState anc ->
+  (SlotNo, Announcements.PeerState anc)
+prunePeerStateToImmTip immLedger latestPruneSlot peerSt =
+  case getTipSlot (ledgerState immLedger) of
+    NotOrigin immTipSlot
+      | latestPruneSlot < immTipSlot -> (immTipSlot, Announcements.prunePeerState immTipSlot peerSt)
+    _ -> (latestPruneSlot, peerSt)
+
 lEIOSNOTIFYPIPELINEDEPTH :: Int
 lEIOSNOTIFYPIPELINEDEPTH = 100   -- TODO magic number
 
@@ -1082,8 +1101,8 @@ lEIOSNOTIFYPIPELINEDEPTH = 100   -- TODO magic number
 -- onset is older than this. See 'Announcements.ShouldRelay'.
 --
 -- Must be comfortably less than the minimum possible wall-clock age of the
--- immutable tip (the _average_ imm-tip age is @k \/ f@ slots behind the wall
--- clock, but we need the _never in a million years_ bound instead), so that a
+-- immutable tip (the /average/ imm-tip age is @k \/ f@ slots behind the wall
+-- clock, but we need the /never in a million years/ bound instead), so that a
 -- downstream peer whose immutable tip is slightly ahead of ours by the time our
 -- message arrives still accepts what we relay rather than disconnecting us for
 -- a below-its-immutable-tip announcement.

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic.hs
@@ -47,9 +47,14 @@ import LeiosDemoDb
   , leiosDbInsertTxs
   , leiosDbLookupEbBody
   )
+import LeiosDemoLogic.Announcements.Validate
+  ( AnnouncementInvalidity (..)
+  , validateAnnouncementHeader
+  )
 import qualified LeiosDemoOnlyTestFetch as LF
 import LeiosDemoTypes
-  ( BytesSize
+  ( AnnouncementDisposition (..)
+  , BytesSize
   , EbHash (..)
   , LeiosBlockRequest (..)
   , LeiosBlockTxsRequest (..)
@@ -71,6 +76,10 @@ import LeiosDemoTypes
   )
 import qualified LeiosDemoTypes as Leios
 import Ouroboros.Consensus.Block (BlockProtocol, Header)
+import Ouroboros.Consensus.Config (TopLevelConfig)
+import Ouroboros.Consensus.Ledger.Basics (EmptyMK)
+import Ouroboros.Consensus.Ledger.Extended (ExtLedgerState)
+import Ouroboros.Consensus.Ledger.SupportsProtocol (LedgerSupportsProtocol)
 import Ouroboros.Consensus.Protocol.Abstract (ChainDepState)
 import Ouroboros.Consensus.Storage.LedgerDB.Forker (ResolveLeiosBlock (..))
 import Ouroboros.Consensus.Util.IOLike (IOLike)
@@ -952,6 +961,63 @@ leiosCertRbCallback kernelVars peerVars hdr cds =
     forM_ (protocolStateLeiosAnnouncement @blk cds) $ \announcement ->
       leiosCertRbOffer kernelVars peerVars announcement
 
+-----
+
+-- | Thrown when a peer relays a genuinely-invalid EB announcement; the ensuing
+-- thread death disconnects the peer.
+data ExnInvalidLeiosAnnouncement =
+    ExnNoAnnouncement
+  |
+    ExnInvalidHeader
+  deriving Show
+
+instance Exception ExnInvalidLeiosAnnouncement
+
+-- | Handle an inbound 'MsgLeiosBlockAnnouncement': validate the relayed RB
+-- header (see 'validateAnnouncementHeader'), then record the EB body as missing
+-- and wake the fetch logic, skip it, or disconnect the peer (see
+-- 'AnnouncementDisposition').
+onAnnouncement ::
+  forall blk pid m.
+  (IOLike m, LedgerSupportsProtocol blk, ResolveLeiosBlock blk) =>
+  Tracer m TraceLeiosPeer ->
+  TopLevelConfig blk ->
+  ( MVar m (LeiosOutstanding pid)
+  , MVar m ()
+  ) ->
+  -- | The immutable tip's ledger state.
+  ExtLedgerState blk EmptyMK ->
+  Header blk ->
+  m ()
+onAnnouncement tracer cfg (outstandingVar, readyVar) immLedger hdr =
+  case validateAnnouncementHeader cfg immLedger hdr of
+    Right (point, ebBytesSize) -> do
+      traceWith tracer $
+        MkTraceLeiosPeer $ "MsgLeiosBlockAnnouncement " <> Leios.prettyLeiosPoint point
+      let MkLeiosPoint _ebSlot ebHash = point
+      MVar.modifyMVar_ outstandingVar $ \outstanding ->
+        pure $
+          if Set.member ebHash (Leios.acquiredEbBodies outstanding)
+            || any ((== ebHash) . pointEbHash) (Map.keys (Leios.missingEbBodies outstanding))
+            then outstanding
+            else
+              outstanding
+                { Leios.missingEbBodies =
+                    Map.insert point ebBytesSize (Leios.missingEbBodies outstanding)
+                }
+      void $ MVar.tryPutMVar readyVar ()
+    Left NoAnnouncement ->
+      throwIO ExnNoAnnouncement
+    Left (OutsideHorizon _) ->
+      traceWith tracer $
+        MkTraceLeiosPeer "MsgLeiosBlockAnnouncement skipped: announced slot beyond forecast horizon"
+    Left (HeaderInvalid err) ->
+      case classifyAnnouncementValidationErr @blk err of
+        SkipAnnouncement ->
+          traceWith tracer $
+            MkTraceLeiosPeer "MsgLeiosBlockAnnouncement skipped: opcert counter not verifiable against immutable tip"
+        DisconnectPeer ->
+          throwIO ExnInvalidHeader
 
 lEIOSNOTIFYPIPELINEDEPTH :: Int
 lEIOSNOTIFYPIPELINEDEPTH = 100   -- TODO magic number

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic.hs
@@ -1063,7 +1063,7 @@ announcementValidity ::
   m
     ( Either
         (AnnouncementInvalidity blk)
-        (Announcements.ShouldRelay, (LeiosPoint, BytesSize))
+        (Announcements.ShouldRelay, NominalDiffTime, (LeiosPoint, BytesSize))
     )
 announcementValidity systemTime futureCheck cfg immLedger hdr = do
   onset <- case futureCheck of
@@ -1083,11 +1083,12 @@ announcementValidity systemTime futureCheck cfg immLedger hdr = do
   -- slot was near-future, so 'now' is at or after 'onset' and the age
   -- is non-negative.
   now <- systemTimeCurrent systemTime
-  let shouldRelay =
-        if diffRelTime now onset <= maxAnnouncementAgeSend
+  let age = diffRelTime now onset
+      shouldRelay =
+        if age <= maxAnnouncementAgeSend
         then Announcements.DoRelay
         else Announcements.DoNotRelay
-  pure $ (,) shouldRelay <$> validateAnnouncementHeader cfg immLedger hdr
+  pure $ (\v -> (shouldRelay, age, v)) <$> validateAnnouncementHeader cfg immLedger hdr
 
 -- | Record a validated, newly-announced EB body as missing, with its
 -- authoritative (forger-signed) size. First-seen wins: a no-op if the body is
@@ -1150,12 +1151,13 @@ tracePeerAnnouncement (Announcements.TracePeerAnnouncement elSt) =
 traceNewAnnouncement ::
   Announcements.TraceLeiosNotifyEvent peer (AnnouncingHeader blk) ->
   TraceLeiosKernel
-traceNewAnnouncement (Announcements.TraceNewAnnouncement mbPeer _elId elSt) =
+traceNewAnnouncement (Announcements.TraceNewAnnouncement mbPeer _elId elSt age) =
   let (equivocation, fields) = announcementTraceFields elSt
    in TraceLeiosAnnouncementAccepted
         (maybe ForgedLocally (const ReceivedFromPeer) mbPeer)
         equivocation
         fields
+        age
 
 lEIOSNOTIFYPIPELINEDEPTH :: Int
 lEIOSNOTIFYPIPELINEDEPTH = 100   -- TODO magic number

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic/Announcements.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic/Announcements.hs
@@ -185,12 +185,12 @@ onAnnouncement ::
   (Eq anc, Monad m) =>
   Tracer m (TraceLeiosNotifyPeerEvent anc) ->
   (anc -> ElId) ->
-  (anc -> m (Maybe invalidity)) ->
+  (anc -> m (Either invalidity validated)) ->
   -- ^ How to validate the announcement
   --
   -- ASSUMPTION: this function will reject an announcement that is
   -- more than 60 seconds older than the local immutable tip.
-  (anc -> m ()) ->
+  (anc -> validated -> m ()) ->
   -- ^ How this central logic should react to a new announcement from
   -- this peer
   --
@@ -206,9 +206,11 @@ onAnnouncement tracer getEl validate process st anc = do
     lift $ traceWith tracer $ TracePeerAnnouncement elSt
     -- do the more expensive validation only after the trivial
     -- counting checks
-    lift (validate anc) >>= mapM_ (throwError . ErrInvalid)
-    lift $ process anc
-    pure st'
+    lift (validate anc) >>= \case
+        Left err -> throwError $ ErrInvalid err
+        Right x -> do
+            lift $ process anc x
+            pure st'
 
 -----
 -- The central logic for receiving a MsgLeiosAnnouncement

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic/Announcements.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic/Announcements.hs
@@ -104,6 +104,36 @@ prunePeerState immTipSlot st =
     -- NB strict comparison, so that the immtip's announcement remains
     tooOld (MkElId elSlot _poolId) = elSlot < immTipSlot
 
+-- | Behaviors of a LeiosNotify upstream peer's announcement stream
+-- that an honest node rejects
+--
+-- There is one surprising and notable absence: the
+-- MsgLeiosBlockAnnouncement handler /completely/ /ignores/
+-- operational certificate (aka opcert) issue numbers. In effect, this
+-- logic is assuming that all OCINs are controlled by the pool
+-- owner. That's patentedly contrary the intended purpose of OCINs, so
+-- it needs justification; hence this comment.
+--
+-- The crux is a Catch 22 if we consider different OCINs as different
+-- identities. We must either treat all of those identities
+-- _independently_ (ie as distinct elections) or _prioritize_ the
+-- greater OCINs (which seems intuitive). The problem is that the
+-- adversary can create arbitrarily many OCINs for its own pools. And
+-- then it can abuse either choice we make: either it gets to multiply
+-- the Leios load on the network per election, or it can cause
+-- arbitrary "partitions" of the network, with one clique certifying a
+-- lower OCIN's announcement but the other clique completely ignoring
+-- that announcement.
+--
+-- The current behavior is to accept (and relay!) any OCIN at least as
+-- great as the counter in our immutable tip's ledger state. The only
+-- downside to this is that an increment OCIN doesn't revoke the old
+-- opcert _for Leios_ until the increment is on the immutable tip
+-- (Praos is still immediate). So a leaked hot key means the attacker
+-- can equivocate all of the victim's announcements until the victim
+-- notices, lands a new opcert on chain, and then waits for that
+-- opcert to become immutable (~12 hr, <= ~36 hr). Not ideal, but
+-- tolerable.
 data ErrAnnouncement invalidity =
     -- | The peer had already sent this same announcement before
     ErrRepeat
@@ -113,6 +143,7 @@ data ErrAnnouncement invalidity =
   |
     -- | This announcement is invalid
     ErrInvalid !invalidity
+  deriving Show
 
 -- | Returns 'Nothing' if this election was already 'TwoAnnouncements' or if this
 -- announcement was already received
@@ -175,14 +206,6 @@ onAnnouncement tracer getEl validate process st anc = do
     lift $ traceWith tracer $ TracePeerAnnouncement elSt
     -- do the more expensive validation only after the trivial
     -- counting checks
-    --
-    -- TODO: BUG: FIXME: on a 'Just', this 'throwError' discards the
-    -- just-updated PeerState 'st''. That is correct for an invalidity
-    -- we disconnect on, but wrong for one the caller merely /skips/
-    -- (eg an opcert issue number greater than the immutable tip's
-    -- counter): the peer is still accountable, so the skipped
-    -- announcement must still be recorded in 'live' (keeping its
-    -- equivocation count). The skip path fails to do this.
     lift (validate anc) >>= mapM_ (throwError . ErrInvalid)
     lift $ process anc
     pure st'

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic/Announcements.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic/Announcements.hs
@@ -249,7 +249,7 @@ data QueueAnnouncementView m anc =
         !(StrictTVar m q)
 
 data TraceLeiosNotifyEvent peer anc =
-    TraceNewAnnouncement !peer !ElId !(ElState anc)
+    TraceNewAnnouncement !(Maybe peer) !ElId !(ElState anc)
 
 -- | Called whenever the ChainDB's immutable tip advances to a new slot
 --
@@ -306,8 +306,12 @@ data ShouldRelay = DoRelay | DoNotRelay
 
 -- | The nub of the callback argument to 'onAnnouncement'
 --
--- NOTE: Should also be called by the block forging thread when
--- issuing an announcement.
+-- NOTE: This is also called by the block forging thread when this node issues
+-- its own announcement (with 'Nothing' as the source peer).
+--
+-- TODO: headers arriving via the ChainSync 'MsgRollForward' carry announcements
+-- too, and so should also feed the 'CentralState' (for relay and dedup); they
+-- do not yet.
 onAnnouncementCentral ::
   forall m peer anc.
   (MonadSTM m, Ord peer, Eq anc) =>
@@ -322,7 +326,9 @@ onAnnouncementCentral ::
   -- Maybe also update a cache used to dedup header validation
   -- computations. Etc.
   CentralState m peer anc ->
-  peer ->
+  Maybe peer ->
+  -- ^ The upstream peer the announcement came from, or 'Nothing' if this node
+  -- is itself the source (e.g. its own block forging).
   ShouldRelay ->
   anc ->
   m (CentralState m peer anc)

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic/Announcements.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic/Announcements.hs
@@ -1,0 +1,338 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+{- |
+
+TO BE IMPORTED QUALIFIED
+
+The Leios node must relay EbAnnouncements promptly.
+CIP-0164 is designed around the idea that an EbAnnouncement at an honest stake pool will have propagated to all other honest stake pools within L_hdr, and suggests a value of 1 second.
+On a network that spans the globe, that's a very tight window.
+But each EbAnnouncement is slightly less than 1 kB, so it does seem plausible.
+
+In the current design of CIP-0164, the existing Praos header (aka RbHeader) was extended with new fields.
+One of those fields is an optional tuple: EbBody hash and EbBody size.
+That's the announcement.
+As part of the RbHeader, it is adjacent to the election proof that justifies the EbAnnouncement and it is signed by the electee.
+Because that election proof necessarily includes the slot of the election, every EbAnnouncement has an age.
+In particular, the existing stochastic bound on the number of elections also bounds the number of in-memory EbAnnouncements: zero (no announcement), one (unequivocal announcement), or two (equivocal announcements) per election.
+
+The LeiosNotify mini protocol in CIP-0164 already includes a notification MsgLeiosAnnouncement, whose payload is the RbHeader.
+It is sent as one of the possible responses to the generic MsgLeiosNotificationRequestNext message.
+The healthy honest node tries to maintain ~hundreds of those requests outstanding at all times, so that the upstream peer can always enqueue a notification immediately.
+The intended timeline one a single connection from an honest node X to an honest node Y is as follows.
+
+- X either receives or itself issues a new valid announcement.
+- If that's the first or second announcement X has seen for that election, then X tries to relay that announcement toits downstream peers, including Y.
+- X will be able to send to Y, because X should have received at least one more MsgLeiosNotificationRequestNext message from Y than X has replied to.
+- When Y receives the announcement from X, it confirms that X hasn't already sent this announcement or any two announcements for that election, disconnecting if it has.
+- Y also needs to validate that the announcement is well-signed and that its election proof is valid, disconnecting if either is invalid.
+
+TO BE IMPORTED QUALIFIED
+
+-}
+module LeiosDemoLogic.Announcements (module LeiosDemoLogic.Announcements) where
+
+import           Cardano.Slotting.Slot (SlotNo)
+import           Control.Concurrent.Class.MonadSTM (MonadSTM, atomically)
+import           Control.Concurrent.Class.MonadSTM.Strict.TVar (StrictTVar, readTVar, writeTVar)
+import           Control.Monad (foldM, void)
+import           Control.Monad.Except (ExceptT, throwError)
+import           Control.Monad.Trans (lift)
+import           Control.Tracer (Tracer, traceWith)
+import           Data.Functor.Compose (Compose (..))
+import qualified Data.Map.Strict as Strict (Map)
+import qualified Data.Map.Strict as Map
+import           Data.Set (Set)
+import qualified Data.Set as Set
+import           LeiosDemoLogic.Announcements.ElBimap
+
+-----
+-- The state of each LeiosNotify client
+-----
+
+-- | State maintained for a single LeiosNotify upstream peer
+data PeerState anc =
+    MkPeerState {
+        live :: !(Strict.Map ElId (ElState anc))
+      }
+
+emptyPeerState :: PeerState anc
+emptyPeerState = MkPeerState Map.empty
+
+-- | State maintained within 'PeerState' for each election
+data ElState anc =
+    -- | The peer has sent one announcement
+    --
+    -- INVARIANT: has valid signature and election proof
+    OneAnnouncement !anc
+  |
+    -- | The peer has sent two announcements
+    --
+    -- INVARIANT: the left announcement was received first
+    --
+    -- INVARIANT: both have valid signature and election proof
+    --
+    -- INVARIANT: they are different announcements
+    TwoAnnouncements !anc !anc
+
+firstAnnouncement :: ElState anc -> anc
+firstAnnouncement = \case
+    OneAnnouncement x -> x
+    TwoAnnouncements x1 _x2 -> x1
+
+secondAnnouncement :: ElState anc -> Maybe anc
+secondAnnouncement = \case
+    OneAnnouncement _x -> Nothing
+    TwoAnnouncements _x1 x2 -> Just x2
+
+-- | Called whenever the ChainDB's immutable tip advances to a new slot
+--
+-- NOTE this pruning should happen ~60 s after the immutable tip
+-- advances.  That accommodates clock skew, transmission time, etc
+-- with only an insignificant increase in the stochastic bound on
+-- election count
+prunePeerState :: SlotNo -> PeerState anc -> PeerState anc
+prunePeerState immTipSlot st =
+    MkPeerState { live = live' }
+  where
+    (_pruned, live') = Map.spanAntitone tooOld (live st)
+
+    -- NB strict comparison, so that the immtip's announcement remains
+    tooOld (MkElId elSlot _poolId) = elSlot < immTipSlot
+
+data ErrAnnouncement invalidity =
+    -- | The peer had already sent this same announcement before
+    ErrRepeat
+  |
+    -- | The peer had already sent two announcements for this election
+    ErrThird
+  |
+    -- | This announcement is invalid
+    ErrInvalid !invalidity
+
+-- | Returns 'Nothing' if this election was already 'TwoAnnouncements' or if this
+-- announcement was already received
+extendLive ::
+  forall anc invalidity.
+  Eq anc =>
+  ElId ->
+  anc ->
+  PeerState anc ->
+  Either (ErrAnnouncement invalidity) (ElState anc, PeerState anc)
+extendLive elId anc st =
+    getCompose
+  $ fmap
+        (\live' -> MkPeerState { live = live' })
+        (Map.alterF (inj . upd) elId (live st))
+  where
+    -- 0 -> 1 ok
+    -- 1 -> 2 ok when unequal
+    -- 2 -> 3 not ok
+    upd :: Maybe (ElState anc) -> Either (ErrAnnouncement x) (ElState anc)
+    upd = \case
+        Nothing -> Right $ OneAnnouncement anc
+        Just (OneAnnouncement x) ->
+            if x == anc then Left ErrRepeat else
+            Right $ TwoAnnouncements x anc
+        Just TwoAnnouncements{} -> Left ErrThird
+
+    inj :: Functor f => f a -> Compose f ((,) a) (Maybe a)
+    inj = Compose . fmap (\x -> (x, Just x))   -- success is never a delete
+
+-----
+-- The per-peer logic for receiving a MsgLeiosAnnouncement
+-----
+
+data TraceLeiosNotifyPeerEvent anc =
+    TracePeerAnnouncement !(ElState anc)
+
+onAnnouncement ::
+  (Eq anc, Monad m) =>
+  Tracer m (TraceLeiosNotifyPeerEvent anc) ->
+  (anc -> ElId) ->
+  (anc -> m (Maybe invalidity)) ->
+  -- ^ How to validate the announcement
+  --
+  -- ASSUMPTION: this function will reject an announcement that is
+  -- more than 60 seconds older than the local immutable tip.
+  (anc -> m ()) ->
+  -- ^ How this central logic should react to a new announcement from
+  -- this peer
+  --
+  -- ASSUMPTION: this is often a no-op (except maybe tracing), because
+  -- the same announcement has already been received from other peers.
+  PeerState anc ->
+  anc ->
+  ExceptT (ErrAnnouncement invalidity) m (PeerState anc)
+onAnnouncement tracer getEl validate process st anc = do
+    (elSt, st') <- case extendLive (getEl anc) anc st of
+        Left err -> throwError err
+        Right x -> pure x
+    lift $ traceWith tracer $ TracePeerAnnouncement elSt
+    -- do the more expensive validation only after the trivial
+    -- counting checks
+    lift (validate anc) >>= mapM_ (throwError . ErrInvalid)
+    lift $ process anc
+    pure st'
+
+-----
+-- The central logic for receiving a MsgLeiosAnnouncement
+-----
+
+-- | State maintained for a node's own LeiosNotify behaviors
+data CentralState m peer anc =
+    MkCentralState {
+        -- | An isomorph of `PeerState` that models the node itself as
+        -- an upstream peer of its downstream peers. This allows it to
+        -- ignore an announcement exactly when sending it would cause
+        -- the recipient's 'extendLive' to raise an error.
+        selfPeer :: !(PeerState anc)
+      ,
+        queues :: !(Strict.Map peer (QueueAnnouncementView m anc))
+      ,
+        -- | Which peers we have already sent announcements for this
+        -- election
+        --
+        -- We only send equivocation proofs to them.
+        --
+        -- We don't need to track whether or not we've sent them an
+        -- equivocation.
+        gate :: !(ElBimap peer)
+      }
+
+emptyCentralState :: CentralState m peer anc
+emptyCentralState = MkCentralState emptyPeerState Map.empty emptyElBimap
+
+-- | A downstream peer's send queue and its count of available credits
+data QueueAnnouncementView m anc =
+    forall q.
+    MkQueueAnnouncementView
+        !(StrictTVar m Int)
+        !(q -> anc -> q)
+        !(StrictTVar m q)
+
+data TraceLeiosNotifyEvent peer anc =
+    TraceNewAnnouncement !peer !ElId !(ElState anc)
+
+-- | Called whenever the ChainDB's immutable tip advances to a new slot
+--
+-- Unlike 'prunePeerState', a delay is undesirable here.
+pruneCentralState ::
+  Ord peer => SlotNo -> CentralState m peer anc -> CentralState m peer anc
+pruneCentralState immTipSlot st =
+    MkCentralState {
+       selfPeer = prunePeerState immTipSlot (selfPeer st)   -- NB no delay
+     ,
+       queues = queues st
+     ,
+       gate = pruneElBimap immTipSlot (gate st)
+     }
+
+insertPeerCentral ::
+  Ord peer =>
+  peer ->
+  QueueAnnouncementView m anc ->
+  CentralState m peer anc ->
+  CentralState m peer anc
+insertPeerCentral peer qav st =
+    MkCentralState {
+       selfPeer = selfPeer st
+     ,
+       queues = Map.insert peer qav (queues st)
+     ,
+       gate = gate st
+     }
+
+deletePeerCentral ::
+  Ord peer =>
+  peer ->
+  CentralState m peer anc ->
+  CentralState m peer anc
+deletePeerCentral peer st =
+    MkCentralState {
+       selfPeer = selfPeer st
+     ,
+       queues = Map.delete peer (queues st)
+     ,
+       gate = deleteElBimapR peer (gate st)
+     }
+
+-- | The nub of the callback argument to 'onAnnouncement'
+--
+-- NOTE: Should also be called by the block forging thread when
+-- issuing an announcement.
+onAnnouncementCentral ::
+  forall m peer anc.
+  (MonadSTM m, Ord peer, Eq anc) =>
+  Tracer m (TraceLeiosNotifyEvent peer anc) ->
+  (anc -> ElId) ->
+  (ElState anc -> m ()) ->
+  -- ^ Notify other components about a /new/ announcement
+  --
+  -- For example, notify the voting thread; it cares about both new
+  -- announcements and also equivocations.
+  --
+  -- Maybe also update a cache used to dedup header validation
+  -- computations. Etc.
+  CentralState m peer anc ->
+  peer ->
+  anc ->
+  m (CentralState m peer anc)
+onAnnouncementCentral tracer getEl publishLocally st peer anc =
+    case extendLive el anc (selfPeer st) of
+        Left{} -> pure st   -- complete noop for duplicates
+        Right (elSt, selfPeer') -> do
+            traceWith tracer $ TraceNewAnnouncement peer el elSt
+            -- urgently relay
+            let isOne = case elSt of
+                    OneAnnouncement{} -> True
+                    TwoAnnouncements{} -> False
+            peers' <- send isOne $ queues st
+            -- signal other components
+            publishLocally elSt
+            pure MkCentralState {
+                selfPeer = selfPeer'
+              ,
+                queues = queues st
+              ,
+                gate =
+                    if not isOne then gate st else
+                    insertElBimapLs el peers' (gate st)
+              }
+  where
+    el = getEl anc
+
+    send :: Bool -> Strict.Map peer (QueueAnnouncementView m anc) -> m (Set peer)
+    send isOne qs = do
+        let peers = lookupElBimapL el $ gate st
+        if isOne then foldM enqueue peers (Map.assocs qs) else do
+            -- Only send equivocation proofs to peers we've already
+            -- sent the first announcement to. Otherwise they'd be
+            -- interpreting it as /our/ /first/ announcement for that
+            -- election. TODO introduce a single message for the pair
+            -- OR send both announcements if they currently have at
+            -- least two credits.
+            --
+            -- And 'gate' doesn't change.
+            mapM_ (void . tryEnqueue) (Map.restrictKeys qs peers)
+            pure peers
+
+    enqueue :: Set peer -> (peer, QueueAnnouncementView m anc) -> m (Set peer)
+    enqueue !acc (peer', ancQueue) =
+        fmap
+            (\enqueued -> if not enqueued then acc else Set.insert peer' acc)
+            (tryEnqueue ancQueue)
+
+    tryEnqueue :: QueueAnnouncementView m anc -> m Bool
+    tryEnqueue (MkQueueAnnouncementView free snoc tvar) = atomically $ do
+        n <- readTVar free
+        -- just drop it if there are currently no credits
+        if n <= 0 then pure False else do
+            writeTVar free $! n - 1
+            q <- readTVar tvar
+            writeTVar tvar $! snoc q anc
+            pure True

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic/Announcements.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic/Announcements.hs
@@ -175,6 +175,14 @@ onAnnouncement tracer getEl validate process st anc = do
     lift $ traceWith tracer $ TracePeerAnnouncement elSt
     -- do the more expensive validation only after the trivial
     -- counting checks
+    --
+    -- TODO: BUG: FIXME: on a 'Just', this 'throwError' discards the
+    -- just-updated PeerState 'st''. That is correct for an invalidity
+    -- we disconnect on, but wrong for one the caller merely /skips/
+    -- (eg an opcert issue number greater than the immutable tip's
+    -- counter): the peer is still accountable, so the skipped
+    -- announcement must still be recorded in 'live' (keeping its
+    -- equivocation count). The skip path fails to do this.
     lift (validate anc) >>= mapM_ (throwError . ErrInvalid)
     lift $ process anc
     pure st'

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic/Announcements.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic/Announcements.hs
@@ -261,6 +261,16 @@ deletePeerCentral peer st =
        gate = deleteElBimapR peer (gate st)
      }
 
+-- | Whether 'onAnnouncementCentral' should relay an announcement downstream.
+--
+-- An honest node uses 'DoNotRelay' once an announcement's slot is old enough
+-- that a peer whose immutable tip has advanced slightly further would
+-- disconnect the relayer for relaying a below-its-immutable-tip announcement;
+-- the caller decides this from the announcement's wall-clock age. Local
+-- processing is unaffected either way.
+data ShouldRelay = DoRelay | DoNotRelay
+  deriving (Eq, Show)
+
 -- | The nub of the callback argument to 'onAnnouncement'
 --
 -- NOTE: Should also be called by the block forging thread when
@@ -280,18 +290,18 @@ onAnnouncementCentral ::
   -- computations. Etc.
   CentralState m peer anc ->
   peer ->
+  ShouldRelay ->
   anc ->
   m (CentralState m peer anc)
-onAnnouncementCentral tracer getEl publishLocally st peer anc =
+onAnnouncementCentral tracer getEl publishLocally st peer shouldRelay anc =
     case extendLive el anc (selfPeer st) of
         Left{} -> pure st   -- complete noop for duplicates
         Right (elSt, selfPeer') -> do
             traceWith tracer $ TraceNewAnnouncement peer el elSt
             -- urgently relay
-            let isOne = case elSt of
-                    OneAnnouncement{} -> True
-                    TwoAnnouncements{} -> False
-            peers' <- send isOne $ queues st
+            newPeers <- case shouldRelay of
+                DoNotRelay -> pure Set.empty
+                DoRelay -> send elSt (queues st)
             -- signal other components
             publishLocally elSt
             pure MkCentralState {
@@ -299,17 +309,16 @@ onAnnouncementCentral tracer getEl publishLocally st peer anc =
               ,
                 queues = queues st
               ,
-                gate =
-                    if not isOne then gate st else
-                    insertElBimapLs el peers' (gate st)
+                gate = insertElBimapLs el newPeers (gate st)
               }
   where
     el = getEl anc
 
-    send :: Bool -> Strict.Map peer (QueueAnnouncementView m anc) -> m (Set peer)
-    send isOne qs = do
-        let peers = lookupElBimapL el $ gate st
-        if isOne then foldM enqueue peers (Map.assocs qs) else do
+    -- returns new peers to add to 'gate' for this election
+    send :: ElState anc -> Strict.Map peer (QueueAnnouncementView m anc) -> m (Set peer)
+    send elSt qs = case elSt of
+        OneAnnouncement{} -> foldM enqueue Set.empty (Map.assocs qs)
+        TwoAnnouncements{} -> do
             -- Only send equivocation proofs to peers we've already
             -- sent the first announcement to. Otherwise they'd be
             -- interpreting it as /our/ /first/ announcement for that
@@ -318,8 +327,10 @@ onAnnouncementCentral tracer getEl publishLocally st peer anc =
             -- least two credits.
             --
             -- And 'gate' doesn't change.
-            mapM_ (void . tryEnqueue) (Map.restrictKeys qs peers)
-            pure peers
+            mapM_
+                (void . tryEnqueue)
+                (Map.restrictKeys qs $ lookupElBimapL el $ gate st)
+            pure Set.empty
 
     enqueue :: Set peer -> (peer, QueueAnnouncementView m anc) -> m (Set peer)
     enqueue !acc (peer', ancQueue) =

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic/Announcements.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic/Announcements.hs
@@ -18,17 +18,17 @@ One of those fields is an optional tuple: EbBody hash and EbBody size.
 That's the announcement.
 As part of the RbHeader, it is adjacent to the election proof that justifies the EbAnnouncement and it is signed by the electee.
 Because that election proof necessarily includes the slot of the election, every EbAnnouncement has an age.
-In particular, the existing stochastic bound on the number of elections also bounds the number of in-memory EbAnnouncements: zero (no announcement), one (unequivocal announcement), or two (equivocal announcements) per election.
+In particular, that age is used to evict too-old announcements so that the existing stochastic bound on the number of elections younger than some age also bounds the number of in-memory EbAnnouncements: zero (no announcement), one (unequivocal announcement), or two (equivocal announcements) per sufficiently-young election.
 
 The LeiosNotify mini protocol in CIP-0164 already includes a notification MsgLeiosAnnouncement, whose payload is the RbHeader.
 It is sent as one of the possible responses to the generic MsgLeiosNotificationRequestNext message.
 The healthy honest node tries to maintain ~hundreds of those requests outstanding at all times, so that the upstream peer can always enqueue a notification immediately.
 The intended timeline one a single connection from an honest node X to an honest node Y is as follows.
 
-- X either receives or itself issues a new valid announcement.
-- If that's the first or second announcement X has seen for that election, then X tries to relay that announcement toits downstream peers, including Y.
-- X will be able to send to Y, because X should have received at least one more MsgLeiosNotificationRequestNext message from Y than X has replied to.
-- When Y receives the announcement from X, it confirms that X hasn't already sent this announcement or any two announcements for that election, disconnecting if it has.
+- X either receives or itself issues a new valid EbAnnouncement.
+- If that's the first or second announcement X has seen for that election, then X tries to relay that announcement to its downstream peers, including Y.
+- X will be able to send to Y, because X should have received at least one more MsgLeiosNotificationRequestNext message from Y than X has already replied to.
+- When Y receives the announcement from X, it confirms that X hasn't already sent this announcement or any two distinct (equivocating) announcements for that same election, disconnecting if it has.
 - Y also needs to validate that the announcement is well-signed and that its election proof is valid, disconnecting if either is invalid.
 
 TO BE IMPORTED QUALIFIED
@@ -101,39 +101,12 @@ prunePeerState immTipSlot st =
   where
     (_pruned, live') = Map.spanAntitone tooOld (live st)
 
-    -- NB strict comparison, so that the immtip's announcement remains
+    -- NB strict comparison, so that the immtip's own announcement is
+    -- not pruned
     tooOld (MkElId elSlot _poolId) = elSlot < immTipSlot
 
 -- | Behaviors of a LeiosNotify upstream peer's announcement stream
 -- that an honest node rejects
---
--- There is one surprising and notable absence: the
--- MsgLeiosBlockAnnouncement handler /completely/ /ignores/
--- operational certificate (aka opcert) issue numbers. In effect, this
--- logic is assuming that all OCINs are controlled by the pool
--- owner. That's patentedly contrary the intended purpose of OCINs, so
--- it needs justification; hence this comment.
---
--- The crux is a Catch 22 if we consider different OCINs as different
--- identities. We must either treat all of those identities
--- _independently_ (ie as distinct elections) or _prioritize_ the
--- greater OCINs (which seems intuitive). The problem is that the
--- adversary can create arbitrarily many OCINs for its own pools. And
--- then it can abuse either choice we make: either it gets to multiply
--- the Leios load on the network per election, or it can cause
--- arbitrary "partitions" of the network, with one clique certifying a
--- lower OCIN's announcement but the other clique completely ignoring
--- that announcement.
---
--- The current behavior is to accept (and relay!) any OCIN at least as
--- great as the counter in our immutable tip's ledger state. The only
--- downside to this is that an increment OCIN doesn't revoke the old
--- opcert _for Leios_ until the increment is on the immutable tip
--- (Praos is still immediate). So a leaked hot key means the attacker
--- can equivocate all of the victim's announcements until the victim
--- notices, lands a new opcert on chain, and then waits for that
--- opcert to become immutable (~12 hr, <= ~36 hr). Not ideal, but
--- tolerable.
 data ErrAnnouncement invalidity =
     -- | The peer had already sent this same announcement before
     ErrRepeat

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic/Announcements.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic/Announcements.hs
@@ -117,6 +117,13 @@ data ErrAnnouncement invalidity =
   |
     -- | This announcement is invalid
     ErrInvalid !invalidity
+  |
+    -- | This announcement's election is too old (its wall-clock age exceeds
+    -- what a client tolerates from an upstream peer). Unlike 'ErrInvalid', this
+    -- verdict depends on the wall clock rather than on the announcement itself,
+    -- so 'onAnnouncement' cannot decide it directly; it is signalled by the
+    -- validation callback returning @Left Nothing@ (see 'onAnnouncement').
+    ErrTooOld
   deriving Show
 
 -- | Returns 'Nothing' if this election was already 'TwoAnnouncements' or if this
@@ -159,11 +166,14 @@ onAnnouncement ::
   (Eq anc, Monad m) =>
   Tracer m (TraceLeiosNotifyPeerEvent anc) ->
   (anc -> ElId) ->
-  (anc -> m (Either invalidity validated)) ->
+  (anc -> m (Either (Maybe invalidity) validated)) ->
   -- ^ How to validate the announcement
   --
-  -- ASSUMPTION: this function will reject an announcement that is
-  -- more than 60 seconds older than the local immutable tip.
+  -- Return @Left Nothing@ when the announcement violates the too-old
+  -- restriction (its election's wall-clock age exceeds what a client
+  -- tolerates); 'onAnnouncement' then raises 'ErrTooOld'. This callback owns
+  -- that check because only it holds the wall clock. Return @Left (Just inv)@
+  -- for any other rejection (raised as 'ErrInvalid'), and @Right@ when valid.
   (anc -> validated -> m ()) ->
   -- ^ How this central logic should react to a new announcement from
   -- this peer
@@ -181,7 +191,8 @@ onAnnouncement tracer getEl validate process st anc = do
     -- do the more expensive validation only after the trivial
     -- counting checks
     lift (validate anc) >>= \case
-        Left err -> throwError $ ErrInvalid err
+        Left Nothing -> throwError ErrTooOld
+        Left (Just err) -> throwError $ ErrInvalid err
         Right x -> do
             lift $ process anc x
             pure st'

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic/Announcements.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic/Announcements.hs
@@ -37,6 +37,7 @@ TO BE IMPORTED QUALIFIED
 module LeiosDemoLogic.Announcements (module LeiosDemoLogic.Announcements) where
 
 import           Cardano.Slotting.Slot (SlotNo)
+import           Data.Time.Clock (NominalDiffTime)
 import           Control.Concurrent.Class.MonadSTM (MonadSTM, atomically)
 import           Control.Concurrent.Class.MonadSTM.Strict.TVar (StrictTVar, readTVar, writeTVar)
 import           Control.Monad (foldM, void)
@@ -222,7 +223,10 @@ data QueueAnnouncementView m anc =
         !(StrictTVar m q)
 
 data TraceLeiosNotifyEvent peer anc =
-    TraceNewAnnouncement !(Maybe peer) !ElId !(ElState anc)
+    -- | The final field is how late the announcement was — seconds from the
+    -- election slot's wall-clock onset to when this node counted it — when
+    -- known (a relayed announcement has it; a locally-forged one does not).
+    TraceNewAnnouncement !(Maybe peer) !ElId !(ElState anc) !(Maybe NominalDiffTime)
 
 -- | Called whenever the ChainDB's immutable tip advances to a new slot
 --
@@ -303,13 +307,15 @@ onAnnouncementCentral ::
   -- ^ The upstream peer the announcement came from, or 'Nothing' if this node
   -- is itself the source (e.g. its own block forging).
   ShouldRelay ->
+  Maybe NominalDiffTime ->
+  -- ^ How late the announcement was (see 'TraceNewAnnouncement').
   anc ->
   m (CentralState m peer anc)
-onAnnouncementCentral tracer getEl publishLocally st peer shouldRelay anc =
+onAnnouncementCentral tracer getEl publishLocally st peer shouldRelay age anc =
     case extendLive el anc (selfPeer st) of
         Left{} -> pure st   -- complete noop for duplicates
         Right (elSt, selfPeer') -> do
-            traceWith tracer $ TraceNewAnnouncement peer el elSt
+            traceWith tracer $ TraceNewAnnouncement peer el elSt age
             -- urgently relay
             newPeers <- case shouldRelay of
                 DoNotRelay -> pure Set.empty

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic/Announcements/ElBimap.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic/Announcements/ElBimap.hs
@@ -16,6 +16,8 @@ import qualified Data.Set.NonEmpty as NESet
 -- | The slot number and pool id of an election
 data ElId =
     -- | The bytes are the hash of the pool's cold verification key
+    --
+    -- TODO should it be the hash, or just the key itself?
     MkElId !SlotNo !ShortByteString
   deriving (Eq)
 

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic/Announcements/ElBimap.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic/Announcements/ElBimap.hs
@@ -50,6 +50,7 @@ data ElBimap a =
       ,
         inverseHalf :: !(Strict.Map a (NESet ElId))
       }
+  deriving (Show)
 
 emptyElBimap :: ElBimap a
 emptyElBimap = MkElBimap Map.empty Map.empty

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic/Announcements/ElBimap.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic/Announcements/ElBimap.hs
@@ -1,0 +1,122 @@
+-- | A bidirectional map, both halves kept strict, relating each
+-- `ElId` to a set of `a` and back.
+--
+module LeiosDemoLogic.Announcements.ElBimap (module LeiosDemoLogic.Announcements.ElBimap) where
+
+import           Cardano.Slotting.Slot (SlotNo)
+import           Data.ByteString.Short (ShortByteString)
+import           Data.Foldable (foldl')
+import qualified Data.Map.Strict as Strict (Map)
+import qualified Data.Map.Strict as Map
+import           Data.Set (Set)
+import qualified Data.Set as Set
+import           Data.Set.NonEmpty (NESet)
+import qualified Data.Set.NonEmpty as NESet
+
+-- | The slot number and pool id of an election
+data ElId =
+    -- | The bytes are the hash of the pool's cold verification key
+    MkElId !SlotNo !ShortByteString
+  deriving (Eq)
+
+-- | INVARIANT: lexicographically starts with 'SlotNo'
+instance Ord ElId
+  where
+    compare (MkElId slL idL) (MkElId slR idR) =
+        compare slL (slR :: SlotNo)
+     <> compare idL idR
+
+-- | A many-to-many relation between 'ElId' (left) and @a@ (right),
+-- indexed in both directions
+--
+-- INVARIANT: the halves agree --- @r@ occurs in @forwardHalf ! l@ iff
+-- @l@ occurs in @inverseHalf ! r@.
+data ElBimap a =
+    MkElBimap {
+        forwardHalf :: !(Strict.Map ElId (NESet a))
+      ,
+        inverseHalf :: !(Strict.Map a (NESet ElId))
+      }
+
+emptyElBimap :: ElBimap a
+emptyElBimap = MkElBimap Map.empty Map.empty
+
+insertElBimap :: Ord a => ElId -> a -> ElBimap a -> ElBimap a
+insertElBimap l r bm =
+    MkElBimap {
+        forwardHalf = Map.insertWith (<>) l (NESet.singleton r) (forwardHalf bm)
+      ,
+        inverseHalf = Map.insertWith (<>) r (NESet.singleton l) (inverseHalf bm)
+      }
+
+-- | Insert an election paired with each element of a set
+insertElBimapLs :: Ord a => ElId -> Set a -> ElBimap a -> ElBimap a
+insertElBimapLs l rs bm =
+    case NESet.nonEmptySet rs of
+        Nothing -> bm
+        Just rs' -> MkElBimap {
+            forwardHalf = Map.insertWith (<>) l rs' (forwardHalf bm)
+          ,
+            inverseHalf = foldl' addToInverse (inverseHalf bm) rs
+          }
+  where
+    addToInverse inv r = Map.insertWith (<>) r (NESet.singleton l) inv
+
+lookupElBimapL :: ElId -> ElBimap a -> Set a
+lookupElBimapL l bm =
+    maybe Set.empty NESet.toSet
+  $ Map.lookup l
+  $ forwardHalf bm
+
+lookupElBimapR :: Ord a => a -> ElBimap a -> Set ElId
+lookupElBimapR r bm =
+    maybe Set.empty NESet.toSet
+  $ Map.lookup r
+  $ inverseHalf bm
+
+-- | Remove an election and every pair it was part of
+deleteElBimapL :: Ord a => ElId -> ElBimap a -> ElBimap a
+deleteElBimapL l bm =
+    case Map.lookup l (forwardHalf bm) of
+        Nothing -> bm
+        Just rs -> MkElBimap {
+            forwardHalf = Map.delete l (forwardHalf bm)
+          ,
+            inverseHalf = foldl' dropFromInverse (inverseHalf bm) rs
+          }
+  where
+    dropFromInverse inv r = Map.update (NESet.nonEmptySet . NESet.delete l) r inv
+
+-- | Remove a right key and every pair it was part of
+deleteElBimapR :: Ord a => a -> ElBimap a -> ElBimap a
+deleteElBimapR r bm =
+    case Map.lookup r (inverseHalf bm) of
+        Nothing -> bm
+        Just ls -> MkElBimap {
+            forwardHalf = foldl' dropFromForward (forwardHalf bm) ls
+          ,
+            inverseHalf = Map.delete r (inverseHalf bm)
+          }
+  where
+    dropFromForward fwd l = Map.update (NESet.nonEmptySet . NESet.delete r) l fwd
+
+-- | Remove every election older than the given slot and every pair
+-- those elections were part of
+--
+-- Called whenever the ChainDB's immutable tip advances to a new slot.
+pruneElBimap :: Ord a => SlotNo -> ElBimap a -> ElBimap a
+pruneElBimap immTipSlot bm =
+    MkElBimap {
+        forwardHalf = forwardHalf'
+      ,
+        inverseHalf = Map.foldlWithKey' dropElection (inverseHalf bm) pruned
+      }
+  where
+    (pruned, forwardHalf') = Map.spanAntitone tooOld (forwardHalf bm)
+
+    dropElection inv el rs = foldl' (dropPair el) inv rs
+
+    dropPair el inv r = Map.update (NESet.nonEmptySet . NESet.delete el) r inv
+
+    -- NB strict comparison, so that the immtip's announcement remains
+    tooOld (MkElId elSlot _poolId) = elSlot < immTipSlot

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic/Announcements/ElBimap.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic/Announcements/ElBimap.hs
@@ -5,7 +5,7 @@ module LeiosDemoLogic.Announcements.ElBimap (module LeiosDemoLogic.Announcements
 
 import           Cardano.Slotting.Slot (SlotNo)
 import           Data.ByteString.Short (ShortByteString)
-import           Data.Foldable (foldl')
+import qualified Data.Foldable
 import qualified Data.Map.Strict as Strict (Map)
 import qualified Data.Map.Strict as Map
 import           Data.Set (Set)
@@ -59,7 +59,7 @@ insertElBimapLs l rs bm =
         Just rs' -> MkElBimap {
             forwardHalf = Map.insertWith (<>) l rs' (forwardHalf bm)
           ,
-            inverseHalf = foldl' addToInverse (inverseHalf bm) rs
+            inverseHalf = Data.Foldable.foldl' addToInverse (inverseHalf bm) rs
           }
   where
     addToInverse inv r = Map.insertWith (<>) r (NESet.singleton l) inv
@@ -84,7 +84,7 @@ deleteElBimapL l bm =
         Just rs -> MkElBimap {
             forwardHalf = Map.delete l (forwardHalf bm)
           ,
-            inverseHalf = foldl' dropFromInverse (inverseHalf bm) rs
+            inverseHalf = Data.Foldable.foldl' dropFromInverse (inverseHalf bm) rs
           }
   where
     dropFromInverse inv r = Map.update (NESet.nonEmptySet . NESet.delete l) r inv
@@ -95,7 +95,7 @@ deleteElBimapR r bm =
     case Map.lookup r (inverseHalf bm) of
         Nothing -> bm
         Just ls -> MkElBimap {
-            forwardHalf = foldl' dropFromForward (forwardHalf bm) ls
+            forwardHalf = Data.Foldable.foldl' dropFromForward (forwardHalf bm) ls
           ,
             inverseHalf = Map.delete r (inverseHalf bm)
           }
@@ -116,7 +116,7 @@ pruneElBimap immTipSlot bm =
   where
     (pruned, forwardHalf') = Map.spanAntitone tooOld (forwardHalf bm)
 
-    dropElection inv el rs = foldl' (dropPair el) inv rs
+    dropElection inv el rs = Data.Foldable.foldl' (dropPair el) inv rs
 
     dropPair el inv r = Map.update (NESet.nonEmptySet . NESet.delete el) r inv
 

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic/Announcements/ElBimap.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic/Announcements/ElBimap.hs
@@ -4,7 +4,9 @@
 module LeiosDemoLogic.Announcements.ElBimap (module LeiosDemoLogic.Announcements.ElBimap) where
 
 import           Cardano.Slotting.Slot (SlotNo)
-import           Data.ByteString.Short (ShortByteString)
+import qualified Data.ByteString.Base16 as BS16
+import qualified Data.ByteString.Char8 as BS8
+import           Data.ByteString.Short (ShortByteString, fromShort)
 import qualified Data.Foldable
 import qualified Data.Map.Strict as Strict (Map)
 import qualified Data.Map.Strict as Map
@@ -20,6 +22,15 @@ data ElId =
     -- TODO should it be the hash, or just the key itself?
     MkElId !SlotNo !ShortByteString
   deriving (Eq)
+
+-- | Renders the pool id as hex rather than as a raw byte string.
+instance Show ElId where
+  showsPrec p (MkElId slot poolId) =
+    showParen (p > 10) $
+        showString "MkElId "
+      . showsPrec 11 slot
+      . showChar ' '
+      . showString (BS8.unpack (BS16.encode (fromShort poolId)))
 
 -- | INVARIANT: lexicographically starts with 'SlotNo'
 instance Ord ElId

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic/Announcements/Validate.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic/Announcements/Validate.hs
@@ -18,16 +18,17 @@ module LeiosDemoLogic.Announcements.Validate
   , validateAnnouncementHeader
   ) where
 
-import Control.Monad (void)
+import Control.Monad (void, when)
 import Control.Monad.Except (runExcept, throwError, withExcept)
 import LeiosDemoTypes (LeiosPoint, BytesSize)
-import Ouroboros.Consensus.Block (BlockProtocol, Header, blockSlot)
+import Ouroboros.Consensus.Block (BlockProtocol, Header, WithOrigin (NotOrigin), blockSlot)
 import Ouroboros.Consensus.Config (TopLevelConfig, configConsensus, configLedger)
 import Ouroboros.Consensus.Forecast (OutsideForecastRange, forecastFor)
 import Ouroboros.Consensus.HeaderValidation
   ( tickHeaderState
   , validateHeaderProtocol
   )
+import Ouroboros.Consensus.Ledger.Abstract (getTipSlot)
 import Ouroboros.Consensus.Ledger.Basics (EmptyMK)
 import Ouroboros.Consensus.Ledger.Extended (ExtLedgerState (..))
 import Ouroboros.Consensus.Ledger.SupportsProtocol
@@ -45,6 +46,13 @@ data AnnouncementInvalidity blk
     -- tip (should not occur for a caught-up node, by appeal to Praos Chain
     -- Growth).
     OutsideHorizon !OutsideForecastRange
+  | -- | The announced slot is before the immutable tip (the forecast anchor),
+    -- so it cannot be forecast/validated at all. This is a /separate/ case
+    -- because 'forecastFor' does not report a below-anchor slot as
+    -- 'OutsideForecastRange' (that only bounds the future end); a below-anchor
+    -- slot violates 'forecastFor''s precondition. For a caught-up node such a
+    -- stale slot is as bogus as a far-future one.
+    SlotBeforeImmutableTip
   | -- | The header failed protocol-level validation.
     HeaderInvalid !(ValidationErr (BlockProtocol blk))
   | -- | The header carries no EB announcement, so it should not have been
@@ -75,6 +83,11 @@ validateAnnouncementHeader cfg extLedger hdr =
     x <- case headerLeiosAnnouncement hdr of
       Nothing -> throwError NoAnnouncement
       Just x -> pure x
+    -- 'forecastFor' does not reject a slot below its anchor (the immutable
+    -- tip's slot) — that is a precondition violation, not 'OutsideForecastRange'
+    -- — so guard it explicitly before forecasting.
+    when (NotOrigin slot < getTipSlot (ledgerState extLedger)) $
+      throwError SlotBeforeImmutableTip
     ledgerView <-
       withExcept OutsideHorizon $
         forecastFor

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic/Announcements/Validate.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic/Announcements/Validate.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 
 -- | Validation of a relayed Leios EB announcement, which is carried as an RB
 -- 'Header'.
@@ -18,9 +20,9 @@ module LeiosDemoLogic.Announcements.Validate
   , validateAnnouncementHeader
   ) where
 
-import Control.Monad (void, when)
+import Control.Monad (when)
 import Control.Monad.Except (runExcept, throwError, withExcept)
-import LeiosDemoTypes (LeiosPoint, BytesSize)
+import LeiosDemoTypes (AnnouncementDisposition (..), LeiosPoint, BytesSize)
 import Ouroboros.Consensus.Block (BlockProtocol, Header, WithOrigin (NotOrigin), blockSlot)
 import Ouroboros.Consensus.Config (TopLevelConfig, configConsensus, configLedger)
 import Ouroboros.Consensus.Forecast (OutsideForecastRange, forecastFor)
@@ -38,13 +40,17 @@ import Ouroboros.Consensus.Ledger.SupportsProtocol
 import Ouroboros.Consensus.Protocol.Abstract (ValidationErr)
 import Ouroboros.Consensus.Storage.LedgerDB.Forker
   ( ResolveLeiosBlock
+  , classifyAnnouncementValidationErr
   , headerLeiosAnnouncement
   )
 
 data AnnouncementInvalidity blk
   = -- | The announced slot is beyond the forecast horizon from the immutable
-    -- tip (should not occur for a caught-up node, by appeal to Praos Chain
-    -- Growth).
+    -- tip. This should not occur for a caught-up node (by appeal to Praos Chain
+    -- Growth), so it is either a bogus far-future slot or we are falling behind;
+    -- either way disconnecting is acceptable (if we are behind, then either we
+    -- are unhealthy or the peer is not serving us well). We cannot simply ignore
+    -- it, because there is an unbounded supply of far-future slots.
     OutsideHorizon !OutsideForecastRange
   | -- | The announced slot is before the immutable tip (the forecast anchor),
     -- so it cannot be forecast/validated at all. This is a /separate/ case
@@ -52,6 +58,10 @@ data AnnouncementInvalidity blk
     -- 'OutsideForecastRange' (that only bounds the future end); a below-anchor
     -- slot violates 'forecastFor''s precondition. For a caught-up node such a
     -- stale slot is as bogus as a far-future one.
+    --
+    -- See 'LeiosDemoLogic.Announcements.ShouldRelay' for how honest
+    -- servers avoid triggering this case despite clock
+    -- skew\/transmission delays\/buffering, etc.
     SlotBeforeImmutableTip
   | -- | The header failed protocol-level validation.
     HeaderInvalid !(ValidationErr (BlockProtocol blk))
@@ -59,18 +69,31 @@ data AnnouncementInvalidity blk
     -- relayed as a 'MsgLeiosBlockAnnouncement' at all.
     NoAnnouncement
 
+-- | NB 'HeaderInvalid' does not render its 'ValidationErr', so that this
+-- instance is unconstrained in @blk@ (avoiding a
+-- @Show (ValidationErr (BlockProtocol blk))@ constraint that would have to be
+-- threaded through the node). The wrapped value still carries it.
+instance Show (AnnouncementInvalidity blk) where
+  show ai = case ai of
+    OutsideHorizon r -> "OutsideHorizon (" <> show r <> ")"
+    SlotBeforeImmutableTip -> "SlotBeforeImmutableTip"
+    HeaderInvalid{} -> "HeaderInvalid <header-validation-error>"
+    NoAnnouncement -> "NoAnnouncement"
+
 -- | Protocol-level validation of an announced RB 'Header' against the immutable
 -- tip's ledger state (forecast to the header's slot). Envelope check skipped;
 -- see the module header.
 --
--- Note that this will accept an opcert issue number that is equal to
--- or one greater than the opcert issue number from the immutable
--- tip's ledger state. TODO restrict opcert issue number increments to
--- be at least one stabiliy window apart, so that this limitation will
--- never falsely reject an honest opcert issue number increment.
+-- The opcert issue number is checked only as a lower bound: any number at
+-- least the immutable tip's counter is accepted (an over-increment, which the
+-- strict protocol check would reject, is 'Tolerate'd — see
+-- 'AnnouncementDisposition'), and a lower one is rejected as a revoked key. See
+-- the note on 'LeiosDemoLogic.Announcements.ErrAnnouncement' for why OCINs are
+-- otherwise ignored.
 --
 -- Returns the output of 'headerLeiosAnnouncement'.
 validateAnnouncementHeader ::
+  forall blk.
   ( LedgerSupportsProtocol blk
   , ResolveLeiosBlock blk
   ) =>
@@ -93,12 +116,19 @@ validateAnnouncementHeader cfg extLedger hdr =
         forecastFor
           (ledgerViewForecastAt (configLedger cfg) (ledgerState extLedger))
           slot
-    void $
-      withExcept HeaderInvalid $
-        validateHeaderProtocol
+    -- Reject a failed protocol-level check, /except/ for the out-of-context
+    -- artifacts we 'Tolerate' (an opcert issue number ahead of, or a pool
+    -- absent from, the immutable tip's counter state).
+    case runExcept
+      ( validateHeaderProtocol
           cfg
           hdr
           (tickHeaderState (configConsensus cfg) ledgerView slot (headerState extLedger))
+      ) of
+      Right _ -> pure ()
+      Left err -> case classifyAnnouncementValidationErr @blk err of
+        Tolerate -> pure ()
+        Reject -> throwError (HeaderInvalid err)
     pure x
  where
   slot = blockSlot hdr

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic/Announcements/Validate.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic/Announcements/Validate.hs
@@ -1,0 +1,91 @@
+{-# LANGUAGE FlexibleContexts #-}
+
+-- | Validation of a relayed Leios EB announcement, which is carried as an RB
+-- 'Header'.
+--
+-- The announcement arrives out-of-order with respect to the local chain, so we
+-- run only the /protocol-level/ header validation (see 'validateHeaderProtocol')
+-- against the immutable tip's ledger state, forecast to the announced slot; the
+-- envelope (chain-extension) check is deliberately skipped. As of Dijkstra the
+-- protocol-level header rules already fold in the announcement's checks (the
+-- EbBody size bound etc.), so this is the whole announcement validation.
+--
+-- For a caught-up node the immutable tip is always within the forecast horizon
+-- of a fresh announcement (by appeal to Praos Chain Growth); still-syncing
+-- nodes do not request LeiosNotify notifications, so they never reach here.
+module LeiosDemoLogic.Announcements.Validate
+  ( AnnouncementInvalidity (..)
+  , validateAnnouncementHeader
+  ) where
+
+import Control.Monad (void)
+import Control.Monad.Except (runExcept, throwError, withExcept)
+import LeiosDemoTypes (LeiosPoint, BytesSize)
+import Ouroboros.Consensus.Block (BlockProtocol, Header, blockSlot)
+import Ouroboros.Consensus.Config (TopLevelConfig, configConsensus, configLedger)
+import Ouroboros.Consensus.Forecast (OutsideForecastRange, forecastFor)
+import Ouroboros.Consensus.HeaderValidation
+  ( tickHeaderState
+  , validateHeaderProtocol
+  )
+import Ouroboros.Consensus.Ledger.Basics (EmptyMK)
+import Ouroboros.Consensus.Ledger.Extended (ExtLedgerState (..))
+import Ouroboros.Consensus.Ledger.SupportsProtocol
+  ( LedgerSupportsProtocol
+  , ledgerViewForecastAt
+  )
+import Ouroboros.Consensus.Protocol.Abstract (ValidationErr)
+import Ouroboros.Consensus.Storage.LedgerDB.Forker
+  ( ResolveLeiosBlock
+  , headerLeiosAnnouncement
+  )
+
+data AnnouncementInvalidity blk
+  = -- | The announced slot is beyond the forecast horizon from the immutable
+    -- tip (should not occur for a caught-up node, by appeal to Praos Chain
+    -- Growth).
+    OutsideHorizon !OutsideForecastRange
+  | -- | The header failed protocol-level validation.
+    HeaderInvalid !(ValidationErr (BlockProtocol blk))
+  | -- | The header carries no EB announcement, so it should not have been
+    -- relayed as a 'MsgLeiosBlockAnnouncement' at all.
+    NoAnnouncement
+
+-- | Protocol-level validation of an announced RB 'Header' against the immutable
+-- tip's ledger state (forecast to the header's slot). Envelope check skipped;
+-- see the module header.
+--
+-- Note that this will accept an opcert issue number that is equal to
+-- or one greater than the opcert issue number from the immutable
+-- tip's ledger state. TODO restrict opcert issue number increments to
+-- be at least one stabiliy window apart, so that this limitation will
+-- never falsely reject an honest opcert issue number increment.
+--
+-- Returns the output of 'headerLeiosAnnouncement'.
+validateAnnouncementHeader ::
+  ( LedgerSupportsProtocol blk
+  , ResolveLeiosBlock blk
+  ) =>
+  TopLevelConfig blk ->
+  ExtLedgerState blk EmptyMK ->
+  Header blk ->
+  Either (AnnouncementInvalidity blk) (LeiosPoint, BytesSize)
+validateAnnouncementHeader cfg extLedger hdr =
+  runExcept $ do
+    x <- case headerLeiosAnnouncement hdr of
+      Nothing -> throwError NoAnnouncement
+      Just x -> pure x
+    ledgerView <-
+      withExcept OutsideHorizon $
+        forecastFor
+          (ledgerViewForecastAt (configLedger cfg) (ledgerState extLedger))
+          slot
+    void $
+      withExcept HeaderInvalid $
+        validateHeaderProtocol
+          cfg
+          hdr
+          (tickHeaderState (configConsensus cfg) ledgerView slot (headerState extLedger))
+    pure x
+ where
+  slot = blockSlot hdr

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic/Announcements/Validate.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic/Announcements/Validate.hs
@@ -22,13 +22,24 @@ module LeiosDemoLogic.Announcements.Validate
 
 import Control.Monad (when)
 import Control.Monad.Except (runExcept, throwError, withExcept)
-import LeiosDemoTypes (AnnouncementDisposition (..), LeiosPoint, BytesSize)
-import Ouroboros.Consensus.Block (BlockProtocol, Header, WithOrigin (NotOrigin), blockSlot)
-import Ouroboros.Consensus.Config (TopLevelConfig, configConsensus, configLedger)
+import LeiosDemoTypes (LeiosPoint, BytesSize)
+import Ouroboros.Consensus.Block
+  ( BlockProtocol
+  , Header
+  , WithOrigin (NotOrigin)
+  , blockSlot
+  , validateView
+  )
+import Ouroboros.Consensus.Config
+  ( TopLevelConfig
+  , configBlock
+  , configConsensus
+  , configLedger
+  )
 import Ouroboros.Consensus.Forecast (OutsideForecastRange, forecastFor)
 import Ouroboros.Consensus.HeaderValidation
   ( tickHeaderState
-  , validateHeaderProtocol
+  , tickedHeaderStateChainDep
   )
 import Ouroboros.Consensus.Ledger.Abstract (getTipSlot)
 import Ouroboros.Consensus.Ledger.Basics (EmptyMK)
@@ -40,8 +51,8 @@ import Ouroboros.Consensus.Ledger.SupportsProtocol
 import Ouroboros.Consensus.Protocol.Abstract (ValidationErr)
 import Ouroboros.Consensus.Storage.LedgerDB.Forker
   ( ResolveLeiosBlock
-  , classifyAnnouncementValidationErr
   , headerLeiosAnnouncement
+  , validateAnnouncementChainDepState
   )
 
 -- | Reasons a LeiosNotify client would reject its upstream peer's announcement,
@@ -93,10 +104,10 @@ instance Show (AnnouncementInvalidity blk) where
 -- see the module header.
 --
 -- The operational certficiate (opcert) issue number (OCIN) is checked only as a
--- lower bound: any number at least the immutable tip's counter is accepted (an
--- over-increment, which the strict protocol check would reject, is 'Tolerate'd
--- — see 'AnnouncementDisposition'), and a lower one is rejected as a revoked
--- key.
+-- lower bound: any number at least the immutable tip's counter is accepted (the
+-- over-increment upper bound, which the strict protocol check would enforce, is
+-- skipped — see 'validateAnnouncementChainDepState' and
+-- 'WhetherToUpperBoundOCERT'), and a lower one is rejected as a revoked key.
 --
 -- OCINs are otherwise ignored. In effect, this logic is assuming that all OCINs
 -- are controlled by the pool owner. That's patentedly contrary the intended
@@ -148,19 +159,19 @@ validateAnnouncementHeader cfg extLedger hdr =
         forecastFor
           (ledgerViewForecastAt (configLedger cfg) (ledgerState extLedger))
           slot
-    -- Reject a failed protocol-level check, /except/ for the out-of-context
-    -- artifacts we 'Tolerate' (an opcert issue number ahead of, or a pool
-    -- absent from, the immutable tip's counter state).
-    case runExcept
-      ( validateHeaderProtocol
-          cfg
-          hdr
-          (tickHeaderState (configConsensus cfg) ledgerView slot (headerState extLedger))
-      ) of
-      Right _ -> pure ()
-      Left err -> case classifyAnnouncementValidationErr @blk err of
-        Tolerate -> pure ()
-        Reject -> throwError (HeaderInvalid err)
+    -- The out-of-context, relaxed protocol-level validation: the election proof
+    -- and the signature, but not the RB-header-specific checks nor the checks
+    -- that our lagging tip would spuriously trip (see
+    -- 'validateAnnouncementChainDepState'). Any error it returns is a genuine
+    -- rejection.
+    let tickedHeaderState =
+          tickHeaderState (configConsensus cfg) ledgerView slot (headerState extLedger)
+    withExcept HeaderInvalid $
+      validateAnnouncementChainDepState @blk
+        (configConsensus cfg)
+        (validateView (configBlock cfg) hdr)
+        slot
+        (tickedHeaderStateChainDep tickedHeaderState)
     pure x
  where
   slot = blockSlot hdr

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic/Announcements/Validate.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic/Announcements/Validate.hs
@@ -38,7 +38,8 @@ import Ouroboros.Consensus.Config
   )
 import Ouroboros.Consensus.Forecast (OutsideForecastRange, forecastFor)
 import Ouroboros.Consensus.HeaderValidation
-  ( tickHeaderState
+  ( ValidateEnvelope (..)
+  , tickHeaderState
   , tickedHeaderStateChainDep
   )
 import Ouroboros.Consensus.Ledger.Abstract (getTipSlot)
@@ -77,26 +78,29 @@ data AnnouncementInvalidity blk
     -- servers avoid triggering this case despite clock
     -- skew\/transmission delays\/buffering, etc.
     SlotBeforeImmutableTip
-  | -- | The header failed protocol-level validation.
-    --
-    -- See 'validateAnnouncementHeader' for a discussion of which RbHeader
-    -- checks are enabled/disabled within this function. In particular, note
-    -- that the upper bound on OCINs is not enforced, nor are the "envelope
-    -- checks".
+  | -- | The header failed the relaxed, out-of-context protocol-level validation
+    -- (election proof and signature). See 'validateAnnouncementChainDepState'
+    -- for which check is relaxed (the OCIN upper bound) and
+    -- 'validateAnnouncementHeader' for which are skipped (the chain-extension
+    -- envelope checks).
     HeaderInvalid !(ValidationErr (BlockProtocol blk))
+  | -- | The RbHeader failed an envelope check — chiefly, it exceeds the
+    -- protocol's max header size (see 'validateAnnouncementHeader').
+    RbHeaderEnvelopeInvalid !(OtherHeaderEnvelopeError blk)
   | -- | The header carries no EB announcement, so it should not have been
     -- relayed as a 'MsgLeiosBlockAnnouncement' at all.
     NoAnnouncement
 
--- | NB 'HeaderInvalid' does not render its 'ValidationErr', so that this
--- instance is unconstrained in @blk@ (avoiding a
--- @Show (ValidationErr (BlockProtocol blk))@ constraint that would have to be
--- threaded through the node). The wrapped value still carries it.
+-- | NB 'HeaderInvalid' and 'RbHeaderEnvelopeInvalid' do not render their
+-- wrapped errors, so that this instance is unconstrained in @blk@ (avoiding
+-- @Show@ constraints on those errors that would have to be threaded through the
+-- node). The wrapped values still carry them.
 instance Show (AnnouncementInvalidity blk) where
   show ai = case ai of
     OutsideHorizon r -> "OutsideHorizon (" <> show r <> ")"
     SlotBeforeImmutableTip -> "SlotBeforeImmutableTip"
     HeaderInvalid{} -> "HeaderInvalid <header-validation-error>"
+    RbHeaderEnvelopeInvalid{} -> "RbHeaderEnvelopeInvalid <envelope-error>"
     NoAnnouncement -> "NoAnnouncement"
 
 -- | Protocol-level validation of an announced RB 'Header' against the immutable
@@ -159,6 +163,14 @@ validateAnnouncementHeader cfg extLedger hdr =
         forecastFor
           (ledgerViewForecastAt (configLedger cfg) (ledgerState extLedger))
           slot
+    -- Reject an RbHeader bigger than the protocol allows: it is the
+    -- announcement's transmission unit. This is the full Shelley envelope check,
+    -- so it also bounds the declared RB body size and rejects an obsolete node.
+    -- Those two are harmless extras — a legitimate announcement's RbHeader always
+    -- passes them — and, being LedgerView-derived, they are meaningful
+    -- out-of-context (unlike the chain-extension checks, which we skip).
+    withExcept RbHeaderEnvelopeInvalid $
+      additionalEnvelopeChecks cfg ledgerView hdr
     -- The out-of-context, relaxed protocol-level validation: the election proof
     -- and the signature, but not the RB-header-specific checks nor the checks
     -- that our lagging tip would spuriously trip (see

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic/Announcements/Validate.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic/Announcements/Validate.hs
@@ -5,7 +5,7 @@
 -- | Validation of a relayed Leios EB announcement, which is carried as an RB
 -- 'Header'.
 --
--- The announcement arrives out-of-order with respect to the local chain, so we
+-- The announcement can arrive out-of-order with respect to the local chain, so we
 -- run only the /protocol-level/ header validation (see 'validateHeaderProtocol')
 -- against the immutable tip's ledger state, forecast to the announced slot; the
 -- envelope (chain-extension) check is deliberately skipped. As of Dijkstra the
@@ -44,6 +44,8 @@ import Ouroboros.Consensus.Storage.LedgerDB.Forker
   , headerLeiosAnnouncement
   )
 
+-- | Reasons a LeiosNotify client would reject its upstream peer's announcement,
+-- regardless of other messages they had sent
 data AnnouncementInvalidity blk
   = -- | The announced slot is beyond the forecast horizon from the immutable
     -- tip. This should not occur for a caught-up node (by appeal to Praos Chain
@@ -53,17 +55,23 @@ data AnnouncementInvalidity blk
     -- it, because there is an unbounded supply of far-future slots.
     OutsideHorizon !OutsideForecastRange
   | -- | The announced slot is before the immutable tip (the forecast anchor),
-    -- so it cannot be forecast/validated at all. This is a /separate/ case
-    -- because 'forecastFor' does not report a below-anchor slot as
-    -- 'OutsideForecastRange' (that only bounds the future end); a below-anchor
-    -- slot violates 'forecastFor''s precondition. For a caught-up node such a
-    -- stale slot is as bogus as a far-future one.
+    -- so it cannot be forecast\/validated at all. This is a separate case from
+    -- 'OutsideHorizon' because 'forecastFor' does not report a below-anchor
+    -- slot as 'OutsideForecastRange' (that only bounds the future
+    -- end)---instead, a below-anchor slot violates 'forecastFor''s
+    -- precondition. For a caught-up node a slot so stale is as bogus as one in
+    -- the far-future.
     --
     -- See 'LeiosDemoLogic.Announcements.ShouldRelay' for how honest
     -- servers avoid triggering this case despite clock
     -- skew\/transmission delays\/buffering, etc.
     SlotBeforeImmutableTip
   | -- | The header failed protocol-level validation.
+    --
+    -- See 'validateAnnouncementHeader' for a discussion of which RbHeader
+    -- checks are enabled/disabled within this function. In particular, note
+    -- that the upper bound on OCINs is not enforced, nor are the "envelope
+    -- checks".
     HeaderInvalid !(ValidationErr (BlockProtocol blk))
   | -- | The header carries no EB announcement, so it should not have been
     -- relayed as a 'MsgLeiosBlockAnnouncement' at all.
@@ -84,12 +92,36 @@ instance Show (AnnouncementInvalidity blk) where
 -- tip's ledger state (forecast to the header's slot). Envelope check skipped;
 -- see the module header.
 --
--- The opcert issue number is checked only as a lower bound: any number at
--- least the immutable tip's counter is accepted (an over-increment, which the
--- strict protocol check would reject, is 'Tolerate'd — see
--- 'AnnouncementDisposition'), and a lower one is rejected as a revoked key. See
--- the note on 'LeiosDemoLogic.Announcements.ErrAnnouncement' for why OCINs are
--- otherwise ignored.
+-- The operational certficiate (opcert) issue number (OCIN) is checked only as a
+-- lower bound: any number at least the immutable tip's counter is accepted (an
+-- over-increment, which the strict protocol check would reject, is 'Tolerate'd
+-- — see 'AnnouncementDisposition'), and a lower one is rejected as a revoked
+-- key.
+--
+-- OCINs are otherwise ignored. In effect, this logic is assuming that all OCINs
+-- are controlled by the pool owner. That's patentedly contrary the intended
+-- purpose of OCINs, so it needs justification; hence this comment.
+--
+-- The crux is a Catch 22 if we consider different OCINs as different
+-- identities. We must either treat all of those identities
+-- _independently_ (ie as distinct elections) or _prioritize_ the
+-- greater OCINs (which seems intuitive). The problem is that the
+-- adversary can create arbitrarily many OCINs for its own pools. And
+-- then it can abuse either choice we make: either it gets to multiply
+-- the Leios load on the network per election, or it can cause
+-- arbitrary "partitions" of the network, with one clique certifying a
+-- lower OCIN's announcement but the other clique completely ignoring
+-- that announcement.
+--
+-- The current behavior is to accept (and relay!) any OCIN at least as
+-- great as the counter in our immutable tip's ledger state. The only
+-- downside to this is that an increment OCIN doesn't revoke the old
+-- opcert _for Leios_ until the increment is on the immutable tip
+-- (Praos is still immediate). So a leaked hot key means the attacker
+-- can equivocate all of the victim's announcements until the victim
+-- notices, lands a new opcert on chain, and then waits for that
+-- opcert to become immutable (~12 hr, <= ~36 hr). Not ideal, but
+-- tolerable.
 --
 -- Returns the output of 'headerLeiosAnnouncement'.
 validateAnnouncementHeader ::

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic/Announcements/Validate.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic/Announcements/Validate.hs
@@ -77,6 +77,12 @@ data AnnouncementInvalidity blk
     -- See 'LeiosDemoLogic.Announcements.ShouldRelay' for how honest
     -- servers avoid triggering this case despite clock
     -- skew\/transmission delays\/buffering, etc.
+    --
+    -- The 'LeiosDemoLogic.Announcements.ErrTooOld' bound rejects any
+    -- announcement older than 'maxAnnouncementAgeRecv' (minutes), which is
+    -- always far younger than the immutable tip (hours), so this case should
+    -- never actually fire. It is kept as a distinct error to throw in case that
+    -- branch is somehow reached, eg on an oddly-configured testnet.
     SlotBeforeImmutableTip
   | -- | The header failed the relaxed, out-of-context protocol-level validation
     -- (election proof and signature). See 'validateAnnouncementChainDepState'

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoOnlyTestNotify.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoOnlyTestNotify.hs
@@ -6,11 +6,13 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE QuantifiedConstraints #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE StandaloneKindSignatures #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 
 module LeiosDemoOnlyTestNotify
   ( LeiosNotify (..)
@@ -23,10 +25,14 @@ module LeiosDemoOnlyTestNotify
   , timeLimitsLeiosNotify
   , LeiosNotifyClientPeerPipelined
   , LeiosNotifyServerPeer
+  , LeiosNotifyServerPeerAntiPipelined
   , leiosNotifyClientPeer
   , leiosNotifyClientPeerPipelined
   , leiosNotifyServerPeer
+  , leiosNotifyServerPeerAntiPipelined
   , toLeiosNotifyClientPeerPipelined
+
+  , runAntiPipelinedPeerWithLimits
   ) where
 
 import qualified Codec.CBOR.Decoding as CBOR
@@ -70,17 +76,32 @@ import Network.TypedProtocol.Core
   )
 import Network.TypedProtocol.Peer
   ( Peer (..)
+  , PeerAntiPipelined (..)
   , PeerPipelined (..)
   , Receiver (..)
+  , Sender (..)
   )
 import Ouroboros.Network.Protocol.Limits
-  ( ProtocolSizeLimits (..)
+  ( BearerBytes
+  , ProtocolSizeLimits (..)
   , ProtocolTimeLimits (..)
   , smallByteLimit
   , waitForever
   )
 import Ouroboros.Network.Util.ShowProxy (ShowProxy (..))
 import Text.Printf (printf)
+
+-- for runAntiPipelinedPeerWithLimits
+import Control.Monad.Class.MonadAsync
+import Control.Monad.Class.MonadFork
+import Control.Monad.Class.MonadSTM
+import Control.Monad.Class.MonadThrow
+import Control.Monad.Class.MonadTimer.SI
+import Control.Tracer (Tracer (..))
+import Network.Mux.Timeout (withTimeoutSerial)
+import Network.TypedProtocol.Driver (runAntiPipelinedPeerWithDriver)
+import Ouroboros.Network.Channel
+import Ouroboros.Network.Driver.Limits (TraceSendRecv, driverWithLimits)
 
 -----
 
@@ -403,6 +424,9 @@ leiosNotifyClientPeer checkDone =
 type LeiosNotifyServerPeer point announcement vote m a =
   Peer (LeiosNotify point announcement vote) AsServer NonPipelined StIdle m ()
 
+type LeiosNotifyServerPeerAntiPipelined point announcement vote m a =
+  PeerAntiPipelined (LeiosNotify point announcement vote) AsServer StIdle m ()
+
 leiosNotifyServerPeer ::
   forall m point announcement vote.
   Monad m =>
@@ -503,3 +527,72 @@ leiosNotifyClientPeerPipelined checkDone k0 =
       Collect
         Nothing
         (\MkC -> drainThePipe x m)
+
+leiosNotifyServerPeerAntiPipelined ::
+  forall m point announcement vote.
+  Monad m =>
+  m () ->
+  -- ^ increments the number of outstanding requests
+  m (Message (LeiosNotify point announcement vote) StBusy StIdle) ->
+  -- ^ blocks until the next reply (announcement\/offer\/vote) is ready
+  PeerAntiPipelined (LeiosNotify point announcement vote) AsServer StIdle m ()
+leiosNotifyServerPeerAntiPipelined incr next =
+    PeerAntiPipelined (go Zero)
+  where
+    responder :: Sender (LeiosNotify point announcement vote) AsServer StBusy StIdle m
+    responder = SenderEffect $ next <&> \msg -> SenderYield ReflServerAgency msg SenderDone
+
+    go :: forall n.
+      Nat n ->
+      Peer (LeiosNotify point announcement vote) AsServer (AntiPipelined n) StIdle m ()
+    go n =
+      Await ReflClientAgency $ \case
+        MsgDone                         -> drain n
+        MsgLeiosNotificationRequestNext ->
+          Effect $ do
+            incr
+            pure $ YieldAntiPipelined ReflServerAgency responder (go (Succ n))
+
+    -- on termination, flush the sends we've handed off, then Done.
+    drain :: forall k.
+      Nat k ->
+      Peer (LeiosNotify point announcement vote) AsServer (AntiPipelined k) StDone m ()
+    drain = \case
+      Zero   -> Done ReflNobodyAgency ()
+      Succ j -> AntiCollect (drain j) Nothing
+
+-----
+
+-- | Run an anti-pipelined peer with the given channel via the given codec.
+--
+-- The anti-pipelined dual of 'runPipelinedPeerWithLimits': the peer receives
+-- ahead and its sends are performed by a parallel thread, hence the
+-- 'MonadAsync' constraint.
+--
+-- TODO: upstream this to ouroboros-network
+runAntiPipelinedPeerWithLimits
+  :: forall ps (st :: ps) pr failure bytes m a.
+     ( MonadAsync m
+     , MonadEvaluate m
+     , MonadFork m
+     , MonadMask m
+     , MonadTimer m
+     , MonadThrow (STM m)
+     , ShowProxy ps
+     , forall (st' :: ps) stok. stok ~ StateToken st' => Show stok
+     , BearerBytes bytes
+     , NFData a
+     , NFData failure
+     , Show failure
+     )
+  => Tracer m (TraceSendRecv ps)
+  -> Codec ps failure m bytes
+  -> ProtocolSizeLimits ps bytes
+  -> ProtocolTimeLimits ps
+  -> Channel m bytes
+  -> PeerAntiPipelined ps pr st m a
+  -> m (a, Maybe bytes)
+runAntiPipelinedPeerWithLimits tracer codec slimits tlimits channel peer =
+    withTimeoutSerial $ \timeoutFn ->
+      let driver = driverWithLimits tracer timeoutFn codec slimits tlimits channel
+      in runAntiPipelinedPeerWithDriver driver peer

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoOnlyTestNotify.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoOnlyTestNotify.hs
@@ -537,26 +537,26 @@ leiosNotifyServerPeerAntiPipelined ::
   -- ^ blocks until the next reply (announcement\/offer\/vote) is ready
   PeerAntiPipelined (LeiosNotify point announcement vote) AsServer StIdle m ()
 leiosNotifyServerPeerAntiPipelined incr next =
-    PeerAntiPipelined (go Zero)
+    PeerAntiPipelined responder (go Zero)
   where
     responder :: Sender (LeiosNotify point announcement vote) AsServer StBusy StIdle m
     responder = SenderEffect $ next <&> \msg -> SenderYield ReflServerAgency msg SenderDone
 
     go :: forall n.
       Nat n ->
-      Peer (LeiosNotify point announcement vote) AsServer (AntiPipelined n) StIdle m ()
+      Peer (LeiosNotify point announcement vote) AsServer (AntiPipelined StBusy StIdle n) StIdle m ()
     go n =
       Await ReflClientAgency $ \case
         MsgDone                         -> drain n
         MsgLeiosNotificationRequestNext ->
           Effect $ do
             incr
-            pure $ YieldAntiPipelined ReflServerAgency responder (go (Succ n))
+            pure $ YieldAntiPipelined ReflServerAgency (go (Succ n))
 
     -- on termination, flush the sends we've handed off, then Done.
-    drain :: forall k.
-      Nat k ->
-      Peer (LeiosNotify point announcement vote) AsServer (AntiPipelined k) StDone m ()
+    drain :: forall n.
+      Nat n ->
+      Peer (LeiosNotify point announcement vote) AsServer (AntiPipelined StBusy StIdle n) StDone m ()
     drain = \case
       Zero   -> Done ReflNobodyAgency ()
       Succ j -> AntiCollect (drain j) Nothing

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoOnlyTestNotify.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoOnlyTestNotify.hs
@@ -39,7 +39,7 @@ import qualified Codec.CBOR.Decoding as CBOR
 import qualified Codec.CBOR.Encoding as CBOR
 import qualified Codec.CBOR.Read as CBOR
 import Control.DeepSeq (NFData (..))
-import Control.Monad (replicateM)
+import Control.Monad (replicateM, when)
 import Control.Monad.Class.MonadST (MonadST)
 import Control.Monad.Primitive (PrimMonad, PrimState)
 import Data.ByteString.Lazy (ByteString)
@@ -530,8 +530,8 @@ leiosNotifyClientPeerPipelined checkDone k0 =
 
 leiosNotifyServerPeerAntiPipelined ::
   forall m point announcement vote.
-  Monad m =>
-  m () ->
+  MonadThrow m =>
+  m Bool ->
   -- ^ increments the number of outstanding requests
   m (Message (LeiosNotify point announcement vote) StBusy StIdle) ->
   -- ^ blocks until the next reply (announcement\/offer\/vote) is ready
@@ -550,7 +550,7 @@ leiosNotifyServerPeerAntiPipelined incr next =
         MsgDone                         -> drain n
         MsgLeiosNotificationRequestNext ->
           Effect $ do
-            incr
+            incr >>= \b -> when b $ throwIO MkExnLeiosNotifyExcessiveRequests
             pure $ YieldAntiPipelined ReflServerAgency (go (Succ n))
 
     -- on termination, flush the sends we've handed off, then Done.
@@ -560,6 +560,11 @@ leiosNotifyServerPeerAntiPipelined incr next =
     drain = \case
       Zero   -> Done ReflNobodyAgency ()
       Succ j -> AntiCollect (drain j) Nothing
+
+data ExnLeiosNotifyExcessiveRequests = MkExnLeiosNotifyExcessiveRequests
+  deriving Show
+
+instance Exception ExnLeiosNotifyExcessiveRequests
 
 -----
 

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoOnlyTestNotify.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoOnlyTestNotify.hs
@@ -30,6 +30,7 @@ module LeiosDemoOnlyTestNotify
   , leiosNotifyClientPeerPipelined
   , leiosNotifyServerPeer
   , leiosNotifyServerPeerAntiPipelined
+  , WhetherExcessiveRequests (..)
   , toLeiosNotifyClientPeerPipelined
 
   , runAntiPipelinedPeerWithLimits
@@ -39,7 +40,7 @@ import qualified Codec.CBOR.Decoding as CBOR
 import qualified Codec.CBOR.Encoding as CBOR
 import qualified Codec.CBOR.Read as CBOR
 import Control.DeepSeq (NFData (..))
-import Control.Monad (replicateM, when)
+import Control.Monad (replicateM)
 import Control.Monad.Class.MonadST (MonadST)
 import Control.Monad.Primitive (PrimMonad, PrimState)
 import Data.ByteString.Lazy (ByteString)
@@ -462,6 +463,10 @@ data C = MkC
 
 data WhetherDraining = AlreadyDraining | NotYetDraining
 
+-- | Whether incrementing the count of outstanding LeiosNotify requests found the
+-- peer already at its pipelining bound, i.e. requesting more than it is allowed.
+data WhetherExcessiveRequests = ExcessiveRequests | NotExcessiveRequests
+
 leiosNotifyClientPeerPipelined ::
   forall m point announcement vote a.
   PrimMonad m =>
@@ -531,8 +536,7 @@ leiosNotifyClientPeerPipelined checkDone k0 =
 leiosNotifyServerPeerAntiPipelined ::
   forall m point announcement vote.
   MonadThrow m =>
-  m Bool ->
-  -- ^ increments the number of outstanding requests
+  m WhetherExcessiveRequests ->
   m (Message (LeiosNotify point announcement vote) StBusy StIdle) ->
   -- ^ blocks until the next reply (announcement\/offer\/vote) is ready
   PeerAntiPipelined (LeiosNotify point announcement vote) AsServer StIdle m ()
@@ -550,7 +554,9 @@ leiosNotifyServerPeerAntiPipelined incr next =
         MsgDone                         -> drain n
         MsgLeiosNotificationRequestNext ->
           Effect $ do
-            incr >>= \b -> when b $ throwIO MkExnLeiosNotifyExcessiveRequests
+            incr >>= \case
+              ExcessiveRequests -> throwIO MkExnLeiosNotifyExcessiveRequests
+              NotExcessiveRequests -> pure ()
             pure $ YieldAntiPipelined ReflServerAgency (go (Succ n))
 
     -- on termination, flush the sends we've handed off, then Done.

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoOnlyTestNotify.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoOnlyTestNotify.hs
@@ -25,15 +25,15 @@ module LeiosDemoOnlyTestNotify
   , timeLimitsLeiosNotify
   , LeiosNotifyClientPeerPipelined
   , LeiosNotifyServerPeer
-  , LeiosNotifyServerPeerAntiPipelined
+  , LeiosNotifyServerPeerLookahead
   , leiosNotifyClientPeer
   , leiosNotifyClientPeerPipelined
   , leiosNotifyServerPeer
-  , leiosNotifyServerPeerAntiPipelined
+  , leiosNotifyServerPeerLookahead
   , WhetherExcessiveRequests (..)
   , toLeiosNotifyClientPeerPipelined
 
-  , runAntiPipelinedPeerWithLimits
+  , runLookaheadFixedSenderPeerWithLimits
   ) where
 
 import qualified Codec.CBOR.Decoding as CBOR
@@ -72,12 +72,13 @@ import Network.TypedProtocol.Core
   , Nat (..)
   , Protocol (..)
   , ReflRelativeAgency (..)
+  , SenderVariability (..)
   , StateAgency
   , natToInt
   )
 import Network.TypedProtocol.Peer
   ( Peer (..)
-  , PeerAntiPipelined (..)
+  , PeerLookaheadFixedSender (..)
   , PeerPipelined (..)
   , Receiver (..)
   , Sender (..)
@@ -92,7 +93,7 @@ import Ouroboros.Network.Protocol.Limits
 import Ouroboros.Network.Util.ShowProxy (ShowProxy (..))
 import Text.Printf (printf)
 
--- for runAntiPipelinedPeerWithLimits
+-- for runLookaheadFixedSenderPeerWithLimits
 import Control.Monad.Class.MonadAsync
 import Control.Monad.Class.MonadFork
 import Control.Monad.Class.MonadSTM
@@ -100,7 +101,7 @@ import Control.Monad.Class.MonadThrow
 import Control.Monad.Class.MonadTimer.SI
 import Control.Tracer (Tracer (..))
 import Network.Mux.Timeout (withTimeoutSerial)
-import Network.TypedProtocol.Driver (runAntiPipelinedPeerWithDriver)
+import Network.TypedProtocol.Driver (runLookaheadFixedSenderPeerWithDriver)
 import Ouroboros.Network.Channel
 import Ouroboros.Network.Driver.Limits (TraceSendRecv, driverWithLimits)
 
@@ -425,8 +426,8 @@ leiosNotifyClientPeer checkDone =
 type LeiosNotifyServerPeer point announcement vote m a =
   Peer (LeiosNotify point announcement vote) AsServer NonPipelined StIdle m ()
 
-type LeiosNotifyServerPeerAntiPipelined point announcement vote m a =
-  PeerAntiPipelined (LeiosNotify point announcement vote) AsServer StIdle m ()
+type LeiosNotifyServerPeerLookahead point announcement vote m a =
+  PeerLookaheadFixedSender (LeiosNotify point announcement vote) AsServer StIdle m ()
 
 leiosNotifyServerPeer ::
   forall m point announcement vote.
@@ -533,39 +534,56 @@ leiosNotifyClientPeerPipelined checkDone k0 =
         Nothing
         (\MkC -> drainThePipe x m)
 
-leiosNotifyServerPeerAntiPipelined ::
+leiosNotifyServerPeerLookahead ::
   forall m point announcement vote.
   MonadThrow m =>
   m WhetherExcessiveRequests ->
   m (Message (LeiosNotify point announcement vote) StBusy StIdle) ->
   -- ^ blocks until the next reply (announcement\/offer\/vote) is ready
-  PeerAntiPipelined (LeiosNotify point announcement vote) AsServer StIdle m ()
-leiosNotifyServerPeerAntiPipelined incr next =
-    PeerAntiPipelined responder (go Zero)
+  PeerLookaheadFixedSender (LeiosNotify point announcement vote) AsServer StIdle m ()
+leiosNotifyServerPeerLookahead incr next =
+    PeerLookaheadFixedSender responder start
   where
-    responder :: Sender (LeiosNotify point announcement vote) AsServer StBusy StIdle m
+    responder :: Sender (LeiosNotify point announcement vote) AsServer VariableSender StBusy StIdle m
     responder = SenderEffect $ next <&> \msg -> SenderYield ReflServerAgency msg SenderDone
 
-    go :: forall n.
-      Nat n ->
-      Peer (LeiosNotify point announcement vote) AsServer (AntiPipelined StBusy StIdle n) StIdle m ()
-    go n =
+    -- StIdle with nothing outstanding: receive the first request (or done). A
+    -- plain 'Await' is required here; 'AwaitLookahead' defers the StBusy->StIdle
+    -- send, so it is only usable once we hold a request (i.e. are at StBusy).
+    start ::
+      Peer (LeiosNotify point announcement vote) AsServer (Lookahead Z (FixedSender StBusy StIdle)) StIdle m ()
+    start =
       Await ReflClientAgency $ \case
-        MsgDone                         -> drain n
+        MsgDone                         -> Done ReflNobodyAgency ()
         MsgLeiosNotificationRequestNext ->
           Effect $ do
             incr >>= \case
               ExcessiveRequests -> throwIO MkExnLeiosNotifyExcessiveRequests
               NotExcessiveRequests -> pure ()
-            pure $ YieldAntiPipelined ReflServerAgency (go (Succ n))
+            pure $ busy Zero
+
+    -- StBusy with @n@ deferred sends outstanding: hand this reply off to the
+    -- responder and look ahead to the next request (or done) in one step.
+    busy :: forall n.
+      Nat n ->
+      Peer (LeiosNotify point announcement vote) AsServer (Lookahead n (FixedSender StBusy StIdle)) StBusy m ()
+    busy n =
+      AwaitLookahead ReflClientAgency TheSender $ \case
+        MsgDone                         -> drain (Succ n)
+        MsgLeiosNotificationRequestNext ->
+          Effect $ do
+            incr >>= \case
+              ExcessiveRequests -> throwIO MkExnLeiosNotifyExcessiveRequests
+              NotExcessiveRequests -> pure ()
+            pure $ busy (Succ n)
 
     -- on termination, flush the sends we've handed off, then Done.
     drain :: forall n.
       Nat n ->
-      Peer (LeiosNotify point announcement vote) AsServer (AntiPipelined StBusy StIdle n) StDone m ()
+      Peer (LeiosNotify point announcement vote) AsServer (Lookahead n (FixedSender StBusy StIdle)) StDone m ()
     drain = \case
       Zero   -> Done ReflNobodyAgency ()
-      Succ j -> AntiCollect (drain j) Nothing
+      Succ j -> FlushSender Nothing (drain j)
 
 data ExnLeiosNotifyExcessiveRequests = MkExnLeiosNotifyExcessiveRequests
   deriving Show
@@ -574,14 +592,14 @@ instance Exception ExnLeiosNotifyExcessiveRequests
 
 -----
 
--- | Run an anti-pipelined peer with the given channel via the given codec.
+-- | Run a lookahead (fixed-sender) peer with the given channel via the given codec.
 --
--- The anti-pipelined dual of 'runPipelinedPeerWithLimits': the peer receives
--- ahead and its sends are performed by a parallel thread, hence the
--- 'MonadAsync' constraint.
+-- The lookahead dual of 'runPipelinedPeerWithLimits': the peer receives ahead
+-- and its sends are performed by a parallel thread, hence the 'MonadAsync'
+-- constraint.
 --
 -- TODO: upstream this to ouroboros-network
-runAntiPipelinedPeerWithLimits
+runLookaheadFixedSenderPeerWithLimits
   :: forall ps (st :: ps) pr failure bytes m a.
      ( MonadAsync m
      , MonadEvaluate m
@@ -601,9 +619,9 @@ runAntiPipelinedPeerWithLimits
   -> ProtocolSizeLimits ps bytes
   -> ProtocolTimeLimits ps
   -> Channel m bytes
-  -> PeerAntiPipelined ps pr st m a
+  -> PeerLookaheadFixedSender ps pr st m a
   -> m (a, Maybe bytes)
-runAntiPipelinedPeerWithLimits tracer codec slimits tlimits channel peer =
+runLookaheadFixedSenderPeerWithLimits tracer codec slimits tlimits channel peer =
     withTimeoutSerial $ \timeoutFn ->
       let driver = driverWithLimits tracer timeoutFn codec slimits tlimits channel
-      in runAntiPipelinedPeerWithDriver driver peer
+      in runLookaheadFixedSenderPeerWithDriver driver peer

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoTypes.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoTypes.hs
@@ -374,6 +374,20 @@ newLeiosPeerVars = do
   requestsToSend <- StrictSTM.newTVarIO Seq.empty
   pure MkLeiosPeerVars{offerings, requestsToSend}
 
+-- | Whether a failed announcement-header validation should skip the
+-- announcement or disconnect the peer. An opcert-counter failure can be a false
+-- positive, because we validate against our immutable tip, which lags the
+-- announcement's own chain; such failures skip. A bad signature or other
+-- context-independent failure is unambiguous misbehaviour, so it disconnects.
+--
+-- TODO once we restrict opcert issue number increments to be at least one
+-- stability window apart, the 'SkipAnnouncement' constructor will be dead code,
+-- which will cascade to this type and a few other places.
+data AnnouncementDisposition
+  = SkipAnnouncement
+  | DisconnectPeer
+  deriving (Eq, Show)
+
 -- | Main data structure used in the Leios fetching logic.
 --
 -- Tracks both EB-level state (what EBs we have/need) and TX-level state

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoTypes.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoTypes.hs
@@ -374,18 +374,19 @@ newLeiosPeerVars = do
   requestsToSend <- StrictSTM.newTVarIO Seq.empty
   pure MkLeiosPeerVars{offerings, requestsToSend}
 
--- | Whether a failed announcement-header validation should skip the
--- announcement or disconnect the peer. An opcert-counter failure can be a false
--- positive, because we validate against our immutable tip, which lags the
--- announcement's own chain; such failures skip. A bad signature or other
--- context-independent failure is unambiguous misbehaviour, so it disconnects.
+-- | How to treat a protocol-level header 'ValidationErr' encountered while
+-- validating a relayed announcement out-of-context against the immutable tip.
 --
--- TODO once we restrict opcert issue number increments to be at least one
--- stability window apart, the 'SkipAnnouncement' constructor will be dead code,
--- which will cascade to this type and a few other places.
+-- Some failures are 'Tolerate'd (the announcement is accepted anyway) because
+-- they are artifacts of validating against our immutable tip, which lags the
+-- announcement's own chain: an opcert issue number greater than the tip's
+-- counter (or a pool absent from the tip's counter map) may simply be a rotation
+-- we have not caught up to. A signature, KES-window, or other
+-- context-independent failure — and an opcert issue number /below/ the tip's
+-- counter (a revoked key) — is unambiguous misbehaviour, so 'Reject'.
 data AnnouncementDisposition
-  = SkipAnnouncement
-  | DisconnectPeer
+  = Tolerate
+  | Reject
   deriving (Eq, Show)
 
 -- | Main data structure used in the Leios fetching logic.

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoTypes.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoTypes.hs
@@ -72,6 +72,8 @@ import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Base16 as BS16
 import qualified Data.ByteString.Char8 as BS8
+import qualified Data.ByteString.Short as SBS
+import LeiosDemoLogic.Announcements.ElBimap (ElId (..))
 import Data.Fixed (Pico)
 import qualified Data.Foldable as F
 import Data.Function (on)
@@ -900,6 +902,37 @@ data TraceLeiosKernel
   | TraceLeiosDb TraceLeiosDb
   | -- | A forged RB both certifies an EB and announce a new one
     TraceLeiosCertifiedAndAnnounced {atSlot :: SlotNo, rbHash :: RbHash}
+  | -- | The node accepted a new EB announcement, deduplicated across all peers
+    -- and its own block forging (see 'AnnouncementSource').
+    TraceLeiosAnnouncementAccepted
+      !AnnouncementSource
+      !AnnouncementEquivocation
+      !AnnouncementFields
+
+-- | The data of a relayed EB announcement, shared by 'TraceLeiosPeerAnnouncement'
+-- and 'TraceLeiosAnnouncementAccepted'. A separate record so its selectors are
+-- total rather than partial over the trace sum types.
+data AnnouncementFields = MkAnnouncementFields
+  { announcementElection :: !ElId
+  , announcementEbHash :: !EbHash
+  , announcementEbBodySize :: !BytesSize
+  }
+  deriving (Eq, Show)
+
+-- | Whether the accepted announcement equivocates: a second, distinct header
+-- announcing an election that a prior header already announced. (The two
+-- headers can even announce the same EB hash and size and still equivocate,
+-- since it is the header, not the EB, that carries the election.) The flag
+-- spares a log consumer from statefully correlating the two announcements.
+data AnnouncementEquivocation
+  = NoEquivocation
+  | Equivocation
+  deriving (Eq, Show)
+
+-- | Whether the node accepted an EB announcement it forged itself or one
+-- relayed by an upstream peer.
+data AnnouncementSource = ForgedLocally | ReceivedFromPeer
+  deriving (Eq, Show)
 
 -- | Reasons 'runLeiosVoting' may decline to cast a vote after acquiring an
 -- EB closure. See 'TraceLeiosNotVoted'.
@@ -1011,6 +1044,33 @@ traceLeiosKernelToObject = \case
       , "slotNo" .= slotNo
       , "rbHash" .= prettyRbHash rbHash
       ]
+  TraceLeiosAnnouncementAccepted announcementSource equivocation acc ->
+    mconcat
+      [ "kind" .= Aeson.String "LeiosAnnouncementAccepted"
+      , "source" .= announcementSourceText announcementSource
+      , announcementFieldsToObject acc
+      , announcementEquivocationToObject equivocation
+      ]
+
+announcementFieldsToObject :: AnnouncementFields -> Aeson.Object
+announcementFieldsToObject
+  (MkAnnouncementFields (MkElId (SlotNo electionSlot) poolId) ebHash ebBodySize) =
+    mconcat
+      [ "electionSlot" .= electionSlot
+      , "electionPool" .= BS8.unpack (BS16.encode (SBS.fromShort poolId))
+      , "ebHash" .= prettyEbHash ebHash
+      , "ebBodySize" .= ebBodySize
+      ]
+
+announcementEquivocationToObject :: AnnouncementEquivocation -> Aeson.Object
+announcementEquivocationToObject = \case
+  NoEquivocation -> "equivocation" .= False
+  Equivocation -> "equivocation" .= True
+
+announcementSourceText :: AnnouncementSource -> Aeson.Value
+announcementSourceText = \case
+  ForgedLocally -> Aeson.String "forgedLocally"
+  ReceivedFromPeer -> Aeson.String "receivedFromPeer"
 
 notVotedReasonText :: LeiosNotVotedReason -> Aeson.Value
 notVotedReasonText = \case
@@ -1021,12 +1081,20 @@ notVotedReasonText = \case
 data TraceLeiosPeer
   = MkTraceLeiosPeer String
   | TraceLeiosPeerDbException LeiosDbException
+  | -- | This upstream peer relayed a valid, newly-counted EB announcement.
+    TraceLeiosPeerAnnouncement !AnnouncementEquivocation !AnnouncementFields
   deriving Show
 
 traceLeiosPeerToObject :: TraceLeiosPeer -> Aeson.Object
 traceLeiosPeerToObject = \case
   MkTraceLeiosPeer s -> fromString "msg" .= Aeson.String (fromString s)
   TraceLeiosPeerDbException e -> jsonLeiosDbException e
+  TraceLeiosPeerAnnouncement equivocation acc ->
+    mconcat
+      [ fromString "kind" .= Aeson.String "LeiosPeerAnnouncement"
+      , announcementFieldsToObject acc
+      , announcementEquivocationToObject equivocation
+      ]
 
 -- * Protocol parameters
 

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoTypes.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoTypes.hs
@@ -376,21 +376,6 @@ newLeiosPeerVars = do
   requestsToSend <- StrictSTM.newTVarIO Seq.empty
   pure MkLeiosPeerVars{offerings, requestsToSend}
 
--- | How to treat a protocol-level header 'ValidationErr' encountered while
--- validating a relayed announcement out-of-context against the immutable tip.
---
--- Some failures are 'Tolerate'd (the announcement is accepted anyway) because
--- they are artifacts of validating against our immutable tip, which lags the
--- announcement's own chain: an opcert issue number greater than the tip's
--- counter (or a pool absent from the tip's counter map) may simply be a rotation
--- we have not caught up to. A signature, KES-window, or other
--- context-independent failure — and an opcert issue number /below/ the tip's
--- counter (a revoked key) — is unambiguous misbehaviour, so 'Reject'.
-data AnnouncementDisposition
-  = Tolerate
-  | Reject
-  deriving (Eq, Show)
-
 -- | Main data structure used in the Leios fetching logic.
 --
 -- Tracks both EB-level state (what EBs we have/need) and TX-level state

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoTypes.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoTypes.hs
@@ -782,17 +782,26 @@ class HasLeiosVoting blk where
 -- * Tracing
 
 messageLeiosNotifyToObject ::
+  -- | Extracts the announced EB point and body size from the relayed RB
+  -- header, so an announcement's diffusion can be correlated with its EB.
+  (announcement -> Maybe (LeiosPoint, BytesSize)) ->
   Message (LeiosNotify LeiosPoint announcement LeiosVote) st st' ->
   Aeson.Object
-messageLeiosNotifyToObject = \case
+messageLeiosNotifyToObject announcedEb = \case
   MsgLeiosNotificationRequestNext ->
     mconcat
       [ "kind" .= Aeson.String "MsgLeiosNotificationRequestNext"
       ]
-  MsgLeiosBlockAnnouncement{} ->
-    mconcat
-      [ "kind" .= Aeson.String "MsgLeiosBlockAnnouncement"
-      ]
+  MsgLeiosBlockAnnouncement announcement ->
+    mconcat $
+      "kind" .= Aeson.String "MsgLeiosBlockAnnouncement"
+        : case announcedEb announcement of
+          Nothing -> []
+          Just (MkLeiosPoint ebSlot ebHash, ebBodySize) ->
+            [ "ebSlot" .= ebSlot
+            , "ebHash" .= prettyEbHash ebHash
+            , "ebBodySize" .= ebBodySize
+            ]
   MsgLeiosBlockOffer (MkLeiosPoint ebSlot ebHash) ebBytesSize ->
     mconcat
       [ "kind" .= Aeson.String "MsgLeiosBlockOffer"

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoTypes.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoTypes.hs
@@ -92,6 +92,7 @@ import qualified Data.Set.NonEmpty as NESet
 import Data.String (fromString)
 import Data.Vector.Strict (Vector)
 import qualified Data.Vector.Strict as V
+import Data.Time.Clock (NominalDiffTime)
 import Data.Word (Word16, Word32, Word64)
 import Debug.Trace (trace)
 import GHC.Generics (Generic)
@@ -902,6 +903,10 @@ data TraceLeiosKernel
       !AnnouncementSource
       !AnnouncementEquivocation
       !AnnouncementFields
+      !(Maybe NominalDiffTime)
+      -- ^ How late the announcement was — seconds from the election slot's
+      -- wall-clock onset to when this node counted it — when known (relayed
+      -- announcements carry it; a locally-forged one does not).
 
 -- | The data of a relayed EB announcement, shared by 'TraceLeiosPeerAnnouncement'
 -- and 'TraceLeiosAnnouncementAccepted'. A separate record so its selectors are
@@ -1038,13 +1043,14 @@ traceLeiosKernelToObject = \case
       , "slotNo" .= slotNo
       , "rbHash" .= prettyRbHash rbHash
       ]
-  TraceLeiosAnnouncementAccepted announcementSource equivocation acc ->
-    mconcat
+  TraceLeiosAnnouncementAccepted announcementSource equivocation acc mbAge ->
+    mconcat $
       [ "kind" .= Aeson.String "LeiosAnnouncementAccepted"
       , "source" .= announcementSourceText announcementSource
       , announcementFieldsToObject acc
       , announcementEquivocationToObject equivocation
       ]
+        ++ foldMap (\age -> ["announcementAgeSeconds" .= (realToFrac age :: Double)]) mbAge
 
 announcementFieldsToObject :: AnnouncementFields -> Aeson.Object
 announcementFieldsToObject

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Protocol.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Protocol.hs
@@ -28,6 +28,10 @@ module Ouroboros.Consensus.HardFork.Combinator.Protocol
 
     -- * Type family instances
   , Ticked (..)
+
+    -- * For Leios code, maybe only temporary
+  , chainDepStateInfo
+  , injectValidationErr
   ) where
 
 import Control.Monad.Except

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HeaderValidation.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HeaderValidation.hs
@@ -21,6 +21,7 @@
 module Ouroboros.Consensus.HeaderValidation
   ( revalidateHeader
   , validateHeader
+  , validateHeaderProtocol
 
     -- * Annotated tips
   , AnnTip (..)
@@ -514,8 +515,25 @@ validateHeader cfg ledgerView hdr st = do
       ledgerView
       (untickedHeaderStateTip st)
       hdr
+  withExcept HeaderProtocolError $
+    validateHeaderProtocol cfg hdr st
+
+-- | The protocol-level portion of 'validateHeader' (KES\/VRF\/operational
+-- certificate, and any header rules the ledger layers on top), i.e.
+-- 'validateHeader' /without/ the envelope check.
+--
+-- Leios EB-announcement relay uses this directly: an announced RB header is
+-- out-of-order with respect to the local chain, so the envelope check
+-- (previous hash and block number) does not apply — but the rest of header
+-- validation still must.
+validateHeaderProtocol ::
+  (BlockSupportsProtocol blk, HasAnnTip blk) =>
+  TopLevelConfig blk ->
+  Header blk ->
+  Ticked (HeaderState blk) ->
+  Except (ValidationErr (BlockProtocol blk)) (HeaderState blk)
+validateHeaderProtocol cfg hdr st = do
   chainDepState' <-
-    withExcept HeaderProtocolError $
       updateChainDepState
         (configConsensus cfg)
         (validateView (configBlock cfg) hdr)

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/Forker.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/Forker.hs
@@ -78,7 +78,8 @@ import GHC.Generics
 import LeiosDemoDb (LeiosDbConnection)
 import LeiosDemoLogic.Announcements.ElBimap (ElId)
 import LeiosDemoTypes
-  ( BytesSize
+  ( AnnouncementDisposition (..)
+  , BytesSize
   , EbHash
   , HasLeiosVoting (..)
   , LeiosCert
@@ -99,7 +100,7 @@ import Ouroboros.Consensus.Ledger.Tables.Utils
   , prependDiffs
   , trackingToDiffs
   )
-import Ouroboros.Consensus.Protocol.Abstract (ChainDepState)
+import Ouroboros.Consensus.Protocol.Abstract (ChainDepState, ValidationErr)
 import Ouroboros.Consensus.Storage.ChainDB.Impl.BlockCache
 import qualified Ouroboros.Consensus.Storage.ChainDB.Impl.BlockCache as BlockCache
 import Ouroboros.Consensus.Util.CallStack
@@ -793,6 +794,12 @@ class ResolveLeiosBlock blk where
   -- this, even though only Dijkstra+ would ever currently call it
   headerElId :: Header blk -> ElId
   headerElId _ = error "TODO headerElId stub"
+
+  -- | Classify a header 'ValidationErr' from a relayed announcement (see
+  -- 'AnnouncementDisposition').
+  classifyAnnouncementValidationErr ::
+    ValidationErr (BlockProtocol blk) -> AnnouncementDisposition
+  classifyAnnouncementValidationErr _ = DisconnectPeer
 
   -- | The EB most recent announcement in the 'HeaderState', if any. 'Nothing'
   -- for headers in eras that don't carry Leios announcements.

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/Forker.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/Forker.hs
@@ -799,7 +799,7 @@ class ResolveLeiosBlock blk where
   -- 'AnnouncementDisposition').
   classifyAnnouncementValidationErr ::
     ValidationErr (BlockProtocol blk) -> AnnouncementDisposition
-  classifyAnnouncementValidationErr _ = DisconnectPeer
+  classifyAnnouncementValidationErr _ = Reject
 
   -- | The EB most recent announcement in the 'HeaderState', if any. 'Nothing'
   -- for headers in eras that don't carry Leios announcements.

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/Forker.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/Forker.hs
@@ -76,6 +76,7 @@ import qualified Data.Set as Set
 import Data.Word
 import GHC.Generics
 import LeiosDemoDb (LeiosDbConnection)
+import LeiosDemoLogic.Announcements.ElBimap (ElId)
 import LeiosDemoTypes
   ( BytesSize
   , EbHash
@@ -785,6 +786,13 @@ class ResolveLeiosBlock blk where
   -- Leios announcements.
   headerLeiosAnnouncement :: Header blk -> Maybe (LeiosPoint, BytesSize)
   headerLeiosAnnouncement _ = Nothing
+
+  -- | The election id (slot + block issuer) of this header.
+  --
+  -- TODO no default; every block type should be able to implement
+  -- this, even though only Dijkstra+ would ever currently call it
+  headerElId :: Header blk -> ElId
+  headerElId _ = error "TODO headerElId stub"
 
   -- | The EB most recent announcement in the 'HeaderState', if any. 'Nothing'
   -- for headers in eras that don't carry Leios announcements.

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/Forker.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/Forker.hs
@@ -64,7 +64,8 @@ module Ouroboros.Consensus.Storage.LedgerDB.Forker
   ) where
 
 import Control.Monad.Except
-  ( runExcept
+  ( Except
+  , runExcept
   )
 import Data.Bifunctor (first)
 import Data.Functor ((<&>))
@@ -78,8 +79,7 @@ import GHC.Generics
 import LeiosDemoDb (LeiosDbConnection)
 import LeiosDemoLogic.Announcements.ElBimap (ElId)
 import LeiosDemoTypes
-  ( AnnouncementDisposition (..)
-  , BytesSize
+  ( BytesSize
   , EbHash
   , HasLeiosVoting (..)
   , LeiosCert
@@ -100,7 +100,14 @@ import Ouroboros.Consensus.Ledger.Tables.Utils
   , prependDiffs
   , trackingToDiffs
   )
-import Ouroboros.Consensus.Protocol.Abstract (ChainDepState, ValidationErr)
+import Ouroboros.Consensus.Protocol.Abstract
+  ( ChainDepState
+  , ConsensusConfig
+  , ConsensusProtocol
+  , ValidateView
+  , ValidationErr
+  , updateChainDepState
+  )
 import Ouroboros.Consensus.Storage.ChainDB.Impl.BlockCache
 import qualified Ouroboros.Consensus.Storage.ChainDB.Impl.BlockCache as BlockCache
 import Ouroboros.Consensus.Util.CallStack
@@ -795,11 +802,25 @@ class ResolveLeiosBlock blk where
   headerElId :: Header blk -> ElId
   headerElId _ = error "TODO headerElId stub"
 
-  -- | Classify a header 'ValidationErr' from a relayed announcement (see
-  -- 'AnnouncementDisposition').
-  classifyAnnouncementValidationErr ::
-    ValidationErr (BlockProtocol blk) -> AnnouncementDisposition
-  classifyAnnouncementValidationErr _ = Reject
+  -- | Protocol-level validation of a relayed announcement's header, against the
+  -- ticked chain-dep state at the announced slot.
+  --
+  -- Mirrors 'updateChainDepState' (its strict behaviour is the default), but is
+  -- run out-of-context against a possibly-lagging immutable tip, so eras that
+  -- relay announcements override it to skip the checks that such lag spuriously
+  -- trips — currently just the OCERT counter's upper bound (see
+  -- 'WhetherToUpperBoundOCERT'). Unlike a full header validation it also omits
+  -- the RB-header-specific checks (body size etc.) that a bare EB announcement
+  -- would not carry. Any error it returns is therefore a genuine rejection.
+  validateAnnouncementChainDepState ::
+    ConsensusProtocol (BlockProtocol blk) =>
+    ConsensusConfig (BlockProtocol blk) ->
+    ValidateView (BlockProtocol blk) ->
+    SlotNo ->
+    Ticked (ChainDepState (BlockProtocol blk)) ->
+    Except (ValidationErr (BlockProtocol blk)) ()
+  validateAnnouncementChainDepState cfg vv slot tcs =
+    () <$ updateChainDepState cfg vv slot tcs
 
   -- | The EB most recent announcement in the 'HeaderState', if any. 'Nothing'
   -- for headers in eras that don't carry Leios announcements.

--- a/ouroboros-consensus/test/consensus-test/Main.hs
+++ b/ouroboros-consensus/test/consensus-test/Main.hs
@@ -25,6 +25,7 @@ import qualified Test.Consensus.Util.Pred (tests)
 import qualified Test.Consensus.Util.Versioned (tests)
 import qualified Test.LeiosDemoDb (tests)
 import qualified Test.LeiosDemoLogic (tests)
+import qualified Test.LeiosDemoLogic.Announcements (tests)
 import qualified Test.LeiosDemoTypes (tests)
 import qualified Test.LeiosUtils.CallTrace (tests)
 import qualified Test.LeiosVoteState (tests)
@@ -82,6 +83,7 @@ tests =
         [ Test.LeiosDemoTypes.tests
         , Test.LeiosDemoDb.tests
         , Test.LeiosDemoLogic.tests
+        , Test.LeiosDemoLogic.Announcements.tests
         , Test.LeiosVoteState.tests
         , Test.LeiosUtils.CallTrace.tests
         ]

--- a/ouroboros-consensus/test/consensus-test/Test/LeiosDemoLogic/Announcements.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/LeiosDemoLogic/Announcements.hs
@@ -1,0 +1,389 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+-- | Tests for the block-agnostic announcement logic in
+-- 'LeiosDemoLogic.Announcements' and 'LeiosDemoLogic.Announcements.ElBimap':
+-- per-peer equivocation counting ('extendLive'\/'onAnnouncement'), the
+-- node-wide dedup + relay ('onAnnouncementCentral'), pruning, and the
+-- bidirectional election map.
+--
+-- Everything here is exercised through a trivial mock announcement type
+-- ('Anc'), so the tests depend on none of the block\/ledger machinery — which
+-- is the point of keeping that logic polymorphic.
+module Test.LeiosDemoLogic.Announcements (tests) where
+
+import Cardano.Slotting.Slot (SlotNo (..))
+import Control.Concurrent.Class.MonadSTM.Strict.TVar
+  ( StrictTVar
+  , newTVarIO
+  , readTVarIO
+  )
+import Control.Monad.Except (runExceptT)
+import Control.Tracer (nullTracer)
+import qualified Data.ByteString.Short as SBS
+import Data.IORef
+import Data.List (nub)
+import qualified Data.Map.Strict as Map
+import qualified Data.Set as Set
+import Data.Void (Void)
+import Data.Word (Word64, Word8)
+import LeiosDemoLogic.Announcements
+import LeiosDemoLogic.Announcements.ElBimap
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (Assertion, assertFailure, testCase, (@?=))
+import Test.Tasty.QuickCheck
+  ( Gen
+  , Property
+  , chooseInt
+  , counterexample
+  , forAll
+  , listOf
+  , oneof
+  , testProperty
+  , (===)
+  )
+
+tests :: TestTree
+tests =
+  testGroup
+    "Announcements"
+    [ extendLiveTests
+    , onAnnouncementTests
+    , centralTests
+    , pruneTests
+    , elBimapTests
+    ]
+
+{-------------------------------------------------------------------------------
+  Mock announcement type
+-------------------------------------------------------------------------------}
+
+-- | A mock announcement: its election plus a tag distinguishing announcements
+-- for the same election. Two 'Anc's with the same election but different tags
+-- are an equivocation; identical 'Anc's are a repeat.
+data Anc = Anc !ElId !Int
+  deriving (Eq, Show)
+
+ancEl :: Anc -> ElId
+ancEl (Anc e _) = e
+
+ancTag :: Anc -> Int
+ancTag (Anc _ i) = i
+
+-- | An election at the given slot for the given (one-byte) pool id.
+mkEl :: Word64 -> Word8 -> ElId
+mkEl slot poolId = MkElId (SlotNo slot) (SBS.pack [poolId])
+
+elSlot :: ElId -> Word64
+elSlot (MkElId (SlotNo s) _) = s
+
+{-------------------------------------------------------------------------------
+  extendLive
+-------------------------------------------------------------------------------}
+
+-- | A comparable summary of an 'extendLive' outcome. 'St' lists the tags of the
+-- election's stored announcements (in order).
+data Ext = ErrR | ErrT | St [Int]
+  deriving (Eq, Show)
+
+step :: PeerState Anc -> Anc -> Either (ErrAnnouncement Void) (ElState Anc, PeerState Anc)
+step st a = extendLive (ancEl a) a st
+
+classifyExt :: Either (ErrAnnouncement Void) (ElState Anc, PeerState Anc) -> Ext
+classifyExt = \case
+  Left ErrRepeat -> ErrR
+  Left ErrThird -> ErrT
+  Right (elSt, _) -> St (elStateTags elSt)
+
+elStateTags :: ElState Anc -> [Int]
+elStateTags elSt =
+  ancTag (firstAnnouncement elSt) : maybe [] (pure . ancTag) (secondAnnouncement elSt)
+
+-- | Fold announcements into a 'PeerState', keeping successful extensions and
+-- silently dropping rejected ones.
+buildState :: [Anc] -> PeerState Anc
+buildState = foldl (\st a -> either (const st) snd (step st a)) emptyPeerState
+
+el0 :: ElId
+el0 = mkEl 10 0
+
+extendLiveTests :: TestTree
+extendLiveTests =
+  testGroup
+    "extendLive"
+    [ testCase "first announcement is accepted" $
+        classifyExt (step emptyPeerState (Anc el0 0)) @?= St [0]
+    , testCase "identical repeat is ErrRepeat" $
+        classifyExt (step (buildState [Anc el0 0]) (Anc el0 0)) @?= ErrR
+    , testCase "second distinct announcement equivocates (kept as two)" $
+        classifyExt (step (buildState [Anc el0 0]) (Anc el0 1)) @?= St [0, 1]
+    , testCase "third announcement is ErrThird" $
+        classifyExt (step (buildState [Anc el0 0, Anc el0 1]) (Anc el0 2)) @?= ErrT
+    , testCase "repeat of one of two is still ErrThird" $
+        classifyExt (step (buildState [Anc el0 0, Anc el0 1]) (Anc el0 0)) @?= ErrT
+    , testCase "distinct elections are independent" $
+        Set.fromList (map elSlot (Map.keys (live (buildState [Anc (mkEl 10 0) 0, Anc (mkEl 20 0) 0]))))
+          @?= Set.fromList [10, 20]
+    , testProperty "stored announcements are the first <=2 distinct tags, in order" $
+        prop_extendLiveModel
+    ]
+
+-- | Folding a random announcement stream leaves, for each election, exactly the
+-- first at-most-two distinct tags in order of first appearance.
+prop_extendLiveModel :: Property
+prop_extendLiveModel = forAll genStream $ \ops ->
+  let actual = Map.map elStateTags (live (buildState [Anc e t | (e, t) <- ops]))
+      model = Map.map (take 2 . nub) (Map.fromListWith (\new old -> old ++ new) [(e, [t]) | (e, t) <- ops])
+   in actual === model
+
+genElId :: Gen ElId
+genElId = mkEl <$> (fromIntegral <$> chooseInt (1, 3)) <*> (fromIntegral <$> chooseInt (0, 1))
+
+genStream :: Gen [(ElId, Int)]
+genStream = listOf ((,) <$> genElId <*> chooseInt (0, 3))
+
+{-------------------------------------------------------------------------------
+  onAnnouncement (per-peer wrapper: count, then validate, then process)
+-------------------------------------------------------------------------------}
+
+onAnnouncementTests :: TestTree
+onAnnouncementTests =
+  testGroup
+    "onAnnouncement"
+    [ testCase "invalid announcement surfaces as ErrInvalid" test_oaInvalid
+    , testCase "valid announcement runs process and returns new state" test_oaProcess
+    , testCase "process does not run for an invalid announcement" test_oaNoProcessOnInvalid
+    , testCase "repeat is rejected without running process" test_oaRepeat
+    ]
+
+test_oaInvalid :: Assertion
+test_oaInvalid = do
+  res <-
+    runExceptT $
+      onAnnouncement nullTracer ancEl (\_ -> pure (Left "bad") :: IO (Either String ())) (\_ _ -> pure ()) emptyPeerState (Anc el0 0)
+  case res of
+    Left (ErrInvalid inv) -> inv @?= "bad"
+    _ -> assertFailure "expected ErrInvalid"
+
+test_oaProcess :: Assertion
+test_oaProcess = do
+  ref <- newIORef []
+  res <-
+    runExceptT $
+      onAnnouncement nullTracer ancEl (\_ -> pure (Right ())) (\a () -> modifyIORef' ref (a :)) emptyPeerState (Anc el0 0)
+  readIORef ref >>= (@?= [Anc el0 0])
+  case res of
+    Right _ -> pure ()
+    Left _ -> assertFailure "expected success"
+
+test_oaNoProcessOnInvalid :: Assertion
+test_oaNoProcessOnInvalid = do
+  ref <- newIORef (0 :: Int)
+  _ <-
+    runExceptT $
+      onAnnouncement nullTracer ancEl (\_ -> pure (Left ()) :: IO (Either () ())) (\_ _ -> modifyIORef' ref (+ 1)) emptyPeerState (Anc el0 0)
+  readIORef ref >>= (@?= 0)
+
+test_oaRepeat :: Assertion
+test_oaRepeat = do
+  ref <- newIORef (0 :: Int)
+  let validate = \_ -> pure (Right ())
+      process = \_ _ -> modifyIORef' ref (+ 1) :: IO ()
+      go st = runExceptT $ onAnnouncement nullTracer ancEl validate process st (Anc el0 0)
+  Right st1 <- go emptyPeerState
+  res2 <- go st1
+  case res2 of
+    Left ErrRepeat -> pure ()
+    _ -> assertFailure "expected ErrRepeat"
+  readIORef ref >>= (@?= 1) -- process ran once (the first, not the repeat)
+
+{-------------------------------------------------------------------------------
+  onAnnouncementCentral (node-wide dedup + relay)
+-------------------------------------------------------------------------------}
+
+-- | A downstream peer's queue: a credit counter and a FIFO of relayed
+-- announcements, plus readers for both.
+data TestQueue = TestQueue
+  { tqView :: QueueAnnouncementView IO Anc
+  , tqRead :: IO [Anc]
+  , tqCredits :: IO Int
+  }
+
+newQueue :: Int -> IO TestQueue
+newQueue credits = do
+  free <- newTVarIO credits :: IO (StrictTVar IO Int)
+  q <- newTVarIO [] :: IO (StrictTVar IO [Anc])
+  pure
+    TestQueue
+      { tqView = MkQueueAnnouncementView free (\xs a -> xs ++ [a]) q
+      , tqRead = readTVarIO q
+      , tqCredits = readTVarIO free
+      }
+
+-- | Central-state helper: relay from a given source with a given 'ShouldRelay'.
+central ::
+  Maybe Int ->
+  ShouldRelay ->
+  Anc ->
+  CentralState IO Int Anc ->
+  IO (CentralState IO Int Anc)
+central src rel anc st =
+  onAnnouncementCentral nullTracer ancEl (\_ -> pure ()) st src rel anc
+
+centralTests :: TestTree
+centralTests =
+  testGroup
+    "onAnnouncementCentral"
+    [ testCase "new announcement is relayed, credit spent, peer gated" test_relay
+    , testCase "duplicate announcement is a no-op" test_dedup
+    , testCase "DoNotRelay skips the queue but still dedups" test_noRelay
+    , testCase "no relay when the peer has no credits" test_noCredit
+    , testCase "equivocation goes only to peers already sent the first" test_equivocation
+    , testCase "publishLocally fires once per new announcement" test_publish
+    ]
+
+test_relay :: Assertion
+test_relay = do
+  tq <- newQueue 5
+  let st0 = insertPeerCentral 1 (tqView tq) emptyCentralState
+  st1 <- central (Just 2) DoRelay (Anc el0 0) st0
+  tqRead tq >>= (@?= [Anc el0 0])
+  tqCredits tq >>= (@?= 4)
+  Set.toList (lookupElBimapL el0 (gate st1)) @?= [1]
+
+test_dedup :: Assertion
+test_dedup = do
+  tq <- newQueue 5
+  let st0 = insertPeerCentral 1 (tqView tq) emptyCentralState
+  st1 <- central (Just 2) DoRelay (Anc el0 0) st0
+  _ <- central (Just 2) DoRelay (Anc el0 0) st1 -- same announcement again
+  tqRead tq >>= (@?= [Anc el0 0]) -- not relayed twice
+  tqCredits tq >>= (@?= 4) -- credit spent only once
+
+test_noRelay :: Assertion
+test_noRelay = do
+  tq <- newQueue 5
+  let st0 = insertPeerCentral 1 (tqView tq) emptyCentralState
+  st1 <- central Nothing DoNotRelay (Anc el0 0) st0 -- e.g. self-forged, too old to relay
+  tqRead tq >>= (@?= []) -- nothing sent
+  _st2 <- central (Just 2) DoRelay (Anc el0 0) st1 -- same announcement, now DoRelay
+  tqRead tq >>= (@?= []) -- still nothing: DoNotRelay had recorded it in selfPeer
+
+test_noCredit :: Assertion
+test_noCredit = do
+  tq <- newQueue 0
+  let st0 = insertPeerCentral 1 (tqView tq) emptyCentralState
+  st1 <- central (Just 2) DoRelay (Anc el0 0) st0
+  tqRead tq >>= (@?= []) -- dropped for lack of credits
+  Set.toList (lookupElBimapL el0 (gate st1)) @?= [] -- and not gated
+
+test_equivocation :: Assertion
+test_equivocation = do
+  tqA <- newQueue 5
+  tqB <- newQueue 5
+  let stA = insertPeerCentral 1 (tqView tqA) emptyCentralState
+  st1 <- central (Just 9) DoRelay (Anc el0 0) stA -- peer 1 gets the first
+  let stAB = insertPeerCentral 2 (tqView tqB) st1 -- peer 2 joins afterwards
+  _ <- central (Just 9) DoRelay (Anc el0 1) stAB -- the equivocating second
+  tqRead tqA >>= (@?= [Anc el0 0, Anc el0 1]) -- peer 1: first + equivocation proof
+  tqRead tqB >>= (@?= []) -- peer 2: never saw the first, so not the proof
+
+test_publish :: Assertion
+test_publish = do
+  ref <- newIORef (0 :: Int)
+  tq <- newQueue 5
+  let st0 = insertPeerCentral 'A' (tqView tq) emptyCentralState
+      pub = \_ -> modifyIORef' ref (+ 1)
+  st1 <- onAnnouncementCentral nullTracer ancEl pub st0 (Just 'B') DoRelay (Anc el0 0)
+  _ <- onAnnouncementCentral nullTracer ancEl pub st1 (Just 'B') DoRelay (Anc el0 0) -- duplicate
+  readIORef ref >>= (@?= 1)
+
+{-------------------------------------------------------------------------------
+  pruning
+-------------------------------------------------------------------------------}
+
+pruneTests :: TestTree
+pruneTests =
+  testGroup
+    "prunePeerState"
+    [ testCase "drops elections strictly below the immutable tip" $
+        let st = buildState [Anc (mkEl s 0) 0 | s <- [10, 20, 30]]
+         in Set.fromList (map elSlot (Map.keys (live (prunePeerState (SlotNo 20) st))))
+              @?= Set.fromList [20, 30]
+    ]
+
+{-------------------------------------------------------------------------------
+  ElBimap
+-------------------------------------------------------------------------------}
+
+elBimapTests :: TestTree
+elBimapTests =
+  testGroup
+    "ElBimap"
+    [ testCase "insert then look up both directions" test_bimapRoundtrip
+    , testCase "deleteElBimapR removes the right key from both halves" test_bimapDeleteR
+    , testCase "pruneElBimap drops old elections from both halves" test_bimapPrune
+    , testProperty "the two halves always agree" prop_bimapConsistent
+    ]
+
+test_bimapRoundtrip :: Assertion
+test_bimapRoundtrip = do
+  let bm =
+        insertElBimap (mkEl 1 0) (10 :: Int) $
+          insertElBimap (mkEl 1 0) 11 $
+            insertElBimap (mkEl 2 0) 10 emptyElBimap
+  lookupElBimapL (mkEl 1 0) bm @?= Set.fromList [10, 11]
+  lookupElBimapR 10 bm @?= Set.fromList [mkEl 1 0, mkEl 2 0]
+  lookupElBimapR 11 bm @?= Set.fromList [mkEl 1 0]
+
+test_bimapDeleteR :: Assertion
+test_bimapDeleteR = do
+  let bm =
+        deleteElBimapR 10 $
+          insertElBimap (mkEl 1 0) (10 :: Int) $
+            insertElBimap (mkEl 1 0) 11 emptyElBimap
+  lookupElBimapL (mkEl 1 0) bm @?= Set.fromList [11]
+  lookupElBimapR 10 bm @?= Set.empty
+
+test_bimapPrune :: Assertion
+test_bimapPrune = do
+  let bm =
+        pruneElBimap (SlotNo 10) $
+          insertElBimap (mkEl 5 0) (1 :: Int) $
+            insertElBimap (mkEl 15 0) 1 emptyElBimap
+  lookupElBimapL (mkEl 5 0) bm @?= Set.empty
+  lookupElBimapL (mkEl 15 0) bm @?= Set.fromList [1]
+  lookupElBimapR 1 bm @?= Set.fromList [mkEl 15 0]
+
+data BOp = Ins ElId Int | DelL ElId | DelR Int | Prune Word64
+  deriving Show
+
+applyBOp :: ElBimap Int -> BOp -> ElBimap Int
+applyBOp bm = \case
+  Ins l r -> insertElBimap l r bm
+  DelL l -> deleteElBimapL l bm
+  DelR r -> deleteElBimapR r bm
+  Prune s -> pruneElBimap (SlotNo s) bm
+
+-- | @r@ is in the forward image of @l@ iff @l@ is in the inverse image of @r@.
+prop_bimapConsistent :: Property
+prop_bimapConsistent = forAll (listOf genBOp) $ \ops ->
+  let bm = foldl applyBOp emptyElBimap ops
+      fwdOK =
+        all
+          (\l -> all (\r -> l `Set.member` lookupElBimapR r bm) (lookupElBimapL l bm))
+          (Map.keys (forwardHalf bm))
+      invOK =
+        all
+          (\r -> all (\l -> r `Set.member` lookupElBimapL l bm) (lookupElBimapR r bm))
+          (Map.keys (inverseHalf bm))
+   in counterexample "halves disagree" (fwdOK && invOK)
+
+genBOp :: Gen BOp
+genBOp =
+  oneof
+    [ Ins <$> genElId <*> chooseInt (0, 3)
+    , DelL <$> genElId
+    , DelR <$> chooseInt (0, 3)
+    , Prune . fromIntegral <$> chooseInt (0, 4)
+    ]

--- a/ouroboros-consensus/test/consensus-test/Test/LeiosDemoLogic/Announcements.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/LeiosDemoLogic/Announcements.hs
@@ -10,6 +10,12 @@
 -- Everything here is exercised through a trivial mock announcement type
 -- ('Anc'), so the tests depend on none of the block\/ledger machinery — which
 -- is the point of keeping that logic polymorphic.
+--
+-- The third announcement module, 'LeiosDemoLogic.Announcements.Validate', is
+-- deliberately out of scope for this specific test suite:
+-- 'validateAnnouncementHeader' needs a concrete block (@LedgerSupportsProtocol@
+-- + @ResolveLeiosBlock@, plus forecasting and header-protocol validation), so
+-- it is exercised by the proto-devnet rather than here.
 module Test.LeiosDemoLogic.Announcements (tests) where
 
 import Cardano.Slotting.Slot (SlotNo (..))
@@ -25,17 +31,19 @@ import Data.IORef
 import Data.List (nub)
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
+import Data.Set.NonEmpty (NESet)
+import qualified Data.Set.NonEmpty as NESet
 import Data.Void (Void)
 import Data.Word (Word64, Word8)
 import LeiosDemoLogic.Announcements
 import LeiosDemoLogic.Announcements.ElBimap
-import Test.Tasty (TestTree, testGroup)
+import Test.Tasty (TestTree, adjustOption, testGroup)
 import Test.Tasty.HUnit (Assertion, assertFailure, testCase, (@?=))
 import Test.Tasty.QuickCheck
   ( Gen
   , Property
+  , QuickCheckTests (..)
   , chooseInt
-  , counterexample
   , forAll
   , listOf
   , oneof
@@ -45,14 +53,16 @@ import Test.Tasty.QuickCheck
 
 tests :: TestTree
 tests =
-  testGroup
-    "Announcements"
-    [ extendLiveTests
-    , onAnnouncementTests
-    , centralTests
-    , pruneTests
-    , elBimapTests
-    ]
+  -- These properties are cheap; run 1000x the usual repetitions.
+  adjustOption (\(QuickCheckTests n) -> QuickCheckTests (n * 1000)) $
+    testGroup
+      "Announcements"
+      [ extendLiveTests
+      , onAnnouncementTests
+      , centralTests
+      , pruneTests
+      , elBimapTests
+      ]
 
 {-------------------------------------------------------------------------------
   Mock announcement type
@@ -152,7 +162,6 @@ onAnnouncementTests =
     "onAnnouncement"
     [ testCase "invalid announcement surfaces as ErrInvalid" test_oaInvalid
     , testCase "valid announcement runs process and returns new state" test_oaProcess
-    , testCase "process does not run for an invalid announcement" test_oaNoProcessOnInvalid
     , testCase "repeat is rejected without running process" test_oaRepeat
     ]
 
@@ -175,14 +184,6 @@ test_oaProcess = do
   case res of
     Right _ -> pure ()
     Left _ -> assertFailure "expected success"
-
-test_oaNoProcessOnInvalid :: Assertion
-test_oaNoProcessOnInvalid = do
-  ref <- newIORef (0 :: Int)
-  _ <-
-    runExceptT $
-      onAnnouncement nullTracer ancEl (\_ -> pure (Left ()) :: IO (Either () ())) (\_ _ -> modifyIORef' ref (+ 1)) emptyPeerState (Anc el0 0)
-  readIORef ref >>= (@?= 0)
 
 test_oaRepeat :: Assertion
 test_oaRepeat = do
@@ -236,7 +237,7 @@ centralTests =
     "onAnnouncementCentral"
     [ testCase "new announcement is relayed, credit spent, peer gated" test_relay
     , testCase "duplicate announcement is a no-op" test_dedup
-    , testCase "DoNotRelay skips the queue but still dedups" test_noRelay
+    , testCase "DoNotRelay skips the queue and subsequent DoRelay can't retcon that" test_noRelay
     , testCase "no relay when the peer has no credits" test_noCredit
     , testCase "equivocation goes only to peers already sent the first" test_equivocation
     , testCase "publishLocally fires once per new announcement" test_publish
@@ -306,11 +307,17 @@ pruneTests :: TestTree
 pruneTests =
   testGroup
     "prunePeerState"
-    [ testCase "drops elections strictly below the immutable tip" $
-        let st = buildState [Anc (mkEl s 0) 0 | s <- [10, 20, 30]]
-         in Set.fromList (map elSlot (Map.keys (live (prunePeerState (SlotNo 20) st))))
-              @?= Set.fromList [20, 30]
+    [ testProperty "keeps exactly the elections at or above the immutable tip" prop_prune
     ]
+
+-- | 'prunePeerState' keeps precisely the elections whose slot is at or above the
+-- immutable tip, leaving each such election's announcements untouched.
+prop_prune :: Property
+prop_prune = forAll genStream $ \ops -> forAll genSlot $ \s ->
+  let st = buildState [Anc e t | (e, t) <- ops]
+      tagsOf ps = Map.map elStateTags (live ps)
+   in tagsOf (prunePeerState (SlotNo s) st)
+        === Map.filterWithKey (\e _ -> elSlot e >= s) (tagsOf st)
 
 {-------------------------------------------------------------------------------
   ElBimap
@@ -320,40 +327,42 @@ elBimapTests :: TestTree
 elBimapTests =
   testGroup
     "ElBimap"
-    [ testCase "insert then look up both directions" test_bimapRoundtrip
-    , testCase "deleteElBimapR removes the right key from both halves" test_bimapDeleteR
-    , testCase "pruneElBimap drops old elections from both halves" test_bimapPrune
-    , testProperty "the two halves always agree" prop_bimapConsistent
+    [ testProperty "forward half is a plain Map ElId (NESet a)" prop_bimapForwardModel
+    , testProperty "inverse half is a plain Map a (NESet ElId)" prop_bimapInverseModel
     ]
 
-test_bimapRoundtrip :: Assertion
-test_bimapRoundtrip = do
-  let bm =
-        insertElBimap (mkEl 1 0) (10 :: Int) $
-          insertElBimap (mkEl 1 0) 11 $
-            insertElBimap (mkEl 2 0) 10 emptyElBimap
-  lookupElBimapL (mkEl 1 0) bm @?= Set.fromList [10, 11]
-  lookupElBimapR 10 bm @?= Set.fromList [mkEl 1 0, mkEl 2 0]
-  lookupElBimapR 11 bm @?= Set.fromList [mkEl 1 0]
+-- | An immutable-tip slot spanning the range of generated election slots (so
+-- prune boundaries are exercised). Used by 'prop_prune'.
+genSlot :: Gen Word64
+genSlot = fromIntegral <$> chooseInt (0, 4)
 
-test_bimapDeleteR :: Assertion
-test_bimapDeleteR = do
-  let bm =
-        deleteElBimapR 10 $
-          insertElBimap (mkEl 1 0) (10 :: Int) $
-            insertElBimap (mkEl 1 0) 11 emptyElBimap
-  lookupElBimapL (mkEl 1 0) bm @?= Set.fromList [11]
-  lookupElBimapR 10 bm @?= Set.empty
+-- | The forward half's semantics, implemented directly on a plain 'Map'.
+applyFwd :: Map.Map ElId (NESet Int) -> BOp -> Map.Map ElId (NESet Int)
+applyFwd m = \case
+  Ins l r -> Map.insertWith NESet.union l (NESet.singleton r) m
+  DelL l -> Map.delete l m
+  DelR r -> Map.mapMaybe (NESet.nonEmptySet . NESet.delete r) m
+  Prune s -> Map.filterWithKey (\l _ -> elSlot l >= s) m
 
-test_bimapPrune :: Assertion
-test_bimapPrune = do
-  let bm =
-        pruneElBimap (SlotNo 10) $
-          insertElBimap (mkEl 5 0) (1 :: Int) $
-            insertElBimap (mkEl 15 0) 1 emptyElBimap
-  lookupElBimapL (mkEl 5 0) bm @?= Set.empty
-  lookupElBimapL (mkEl 15 0) bm @?= Set.fromList [1]
-  lookupElBimapR 1 bm @?= Set.fromList [mkEl 15 0]
+-- | The inverse half's semantics, implemented directly on a plain 'Map'.
+applyInv :: Map.Map Int (NESet ElId) -> BOp -> Map.Map Int (NESet ElId)
+applyInv m = \case
+  Ins l r -> Map.insertWith NESet.union r (NESet.singleton l) m
+  DelL l -> Map.mapMaybe (NESet.nonEmptySet . NESet.delete l) m
+  DelR r -> Map.delete r m
+  Prune s -> Map.mapMaybe (NESet.nonEmptySet . NESet.filter (\l -> elSlot l >= s)) m
+
+-- | The forward half is indistinguishable from a plain @Map ElId (NESet a)@
+-- maintained directly, under any mix of inserts, deletes, and prunes.
+prop_bimapForwardModel :: Property
+prop_bimapForwardModel = forAll (listOf genBOp) $ \ops ->
+  forwardHalf (foldl applyBOp emptyElBimap ops) === foldl applyFwd Map.empty ops
+
+-- | The inverse half is indistinguishable from a plain @Map a (NESet ElId)@
+-- maintained directly, under any mix of inserts, deletes, and prunes.
+prop_bimapInverseModel :: Property
+prop_bimapInverseModel = forAll (listOf genBOp) $ \ops ->
+  inverseHalf (foldl applyBOp emptyElBimap ops) === foldl applyInv Map.empty ops
 
 data BOp = Ins ElId Int | DelL ElId | DelR Int | Prune Word64
   deriving Show
@@ -364,20 +373,6 @@ applyBOp bm = \case
   DelL l -> deleteElBimapL l bm
   DelR r -> deleteElBimapR r bm
   Prune s -> pruneElBimap (SlotNo s) bm
-
--- | @r@ is in the forward image of @l@ iff @l@ is in the inverse image of @r@.
-prop_bimapConsistent :: Property
-prop_bimapConsistent = forAll (listOf genBOp) $ \ops ->
-  let bm = foldl applyBOp emptyElBimap ops
-      fwdOK =
-        all
-          (\l -> all (\r -> l `Set.member` lookupElBimapR r bm) (lookupElBimapL l bm))
-          (Map.keys (forwardHalf bm))
-      invOK =
-        all
-          (\r -> all (\l -> r `Set.member` lookupElBimapL l bm) (lookupElBimapR r bm))
-          (Map.keys (inverseHalf bm))
-   in counterexample "halves disagree" (fwdOK && invOK)
 
 genBOp :: Gen BOp
 genBOp =

--- a/ouroboros-consensus/test/consensus-test/Test/LeiosDemoLogic/Announcements.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/LeiosDemoLogic/Announcements.hs
@@ -103,6 +103,7 @@ classifyExt :: Either (ErrAnnouncement Void) (ElState Anc, PeerState Anc) -> Ext
 classifyExt = \case
   Left ErrRepeat -> ErrR
   Left ErrThird -> ErrT
+  Left ErrTooOld -> error "unreachable: extendLive never yields ErrTooOld"
   Right (elSt, _) -> St (elStateTags elSt)
 
 elStateTags :: ElState Anc -> [Int]
@@ -161,6 +162,7 @@ onAnnouncementTests =
   testGroup
     "onAnnouncement"
     [ testCase "invalid announcement surfaces as ErrInvalid" test_oaInvalid
+    , testCase "too-old announcement (Left Nothing) surfaces as ErrTooOld" test_oaTooOld
     , testCase "valid announcement runs process and returns new state" test_oaProcess
     , testCase "repeat is rejected without running process" test_oaRepeat
     ]
@@ -169,10 +171,19 @@ test_oaInvalid :: Assertion
 test_oaInvalid = do
   res <-
     runExceptT $
-      onAnnouncement nullTracer ancEl (\_ -> pure (Left "bad") :: IO (Either String ())) (\_ _ -> pure ()) emptyPeerState (Anc el0 0)
+      onAnnouncement nullTracer ancEl (\_ -> pure (Left (Just "bad")) :: IO (Either (Maybe String) ())) (\_ _ -> pure ()) emptyPeerState (Anc el0 0)
   case res of
     Left (ErrInvalid inv) -> inv @?= "bad"
     _ -> assertFailure "expected ErrInvalid"
+
+test_oaTooOld :: Assertion
+test_oaTooOld = do
+  res <-
+    runExceptT $
+      onAnnouncement nullTracer ancEl (\_ -> pure (Left Nothing) :: IO (Either (Maybe String) ())) (\_ _ -> pure ()) emptyPeerState (Anc el0 0)
+  case res of
+    Left ErrTooOld -> pure ()
+    _ -> assertFailure "expected ErrTooOld"
 
 test_oaProcess :: Assertion
 test_oaProcess = do

--- a/ouroboros-consensus/test/consensus-test/Test/LeiosDemoLogic/Announcements.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/LeiosDemoLogic/Announcements.hs
@@ -229,7 +229,7 @@ central ::
   CentralState IO Int Anc ->
   IO (CentralState IO Int Anc)
 central src rel anc st =
-  onAnnouncementCentral nullTracer ancEl (\_ -> pure ()) st src rel anc
+  onAnnouncementCentral nullTracer ancEl (\_ -> pure ()) st src rel Nothing anc
 
 centralTests :: TestTree
 centralTests =
@@ -295,8 +295,8 @@ test_publish = do
   tq <- newQueue 5
   let st0 = insertPeerCentral 'A' (tqView tq) emptyCentralState
       pub = \_ -> modifyIORef' ref (+ 1)
-  st1 <- onAnnouncementCentral nullTracer ancEl pub st0 (Just 'B') DoRelay (Anc el0 0)
-  _ <- onAnnouncementCentral nullTracer ancEl pub st1 (Just 'B') DoRelay (Anc el0 0) -- duplicate
+  st1 <- onAnnouncementCentral nullTracer ancEl pub st0 (Just 'B') DoRelay Nothing (Anc el0 0)
+  _ <- onAnnouncementCentral nullTracer ancEl pub st1 (Just 'B') DoRelay Nothing (Anc el0 0) -- duplicate
   readIORef ref >>= (@?= 1)
 
 {-------------------------------------------------------------------------------


### PR DESCRIPTION
This PR relates to https://github.com/input-output-hk/ouroboros-leios/issues/772 but doesn't close it.

- That Issue also deserves documentation update.
- This PR only adds _generation_ and _diffusion_ of announcements. It does not yet integrate them into the other Leios components that should be sensitive to them (LeiosFetch + LeiosVoting, off the top of my head). Generating and diffusing them is necessary first step.

I recommend reviewers start with these three modules---they're new, polymorphic, and entirely pure.

- `LeiosDemoLogic.Announcements`
- `LeiosDemoLogic.Announcements.ElBimap`
- `LeiosDemoLogic.Announcements.Validate` (not as polymorphic as those two, but still `blk`-agnostic)

The rest of this PR is for the most part arranging to call this core logic from the correct places---the major exception to that characterization is that some important logic is added in `LeiosDemoLogic`---it's at least starting there instead of these three modules because is _impure_.