### PR TITLE
Re-enable the mempool atomic QSM test

### DIFF
--- a/ouroboros-consensus.cabal
+++ b/ouroboros-consensus.cabal
@@ -773,7 +773,6 @@ test-suite consensus-test
     sop-extras,
     strict-sop-core,
     tasty,
-    tasty-expected-failure,
     tasty-hunit,
     tasty-quickcheck,
     temporary,

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/Mempool/StateMachine.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/Mempool/StateMachine.hs
@@ -80,7 +80,6 @@ import Test.StateMachine.Types (History (..), HistoryEvent (..))
 import qualified Test.StateMachine.Types as QC
 import qualified Test.StateMachine.Types.Rank2 as Rank2
 import Test.Tasty
-import Test.Tasty.ExpectedFailure (ignoreTestBecause)
 import Test.Tasty.QuickCheck
 import Test.Util.Orphans.ToExpr ()
 import Test.Util.ToExpr ()
@@ -802,7 +801,9 @@ tests =
             \i -> fmap (fmap fst . fst) . genTxs i
     , testGroup
         "parallel"
-        [ ignoreTestBecause "FIXME: currently OOMs, which likely indicates a bug in the mempool." $
+        [ -- Restring the length of the command list for QSM parallel testing.
+          -- More commands require exponentially more memory to explore.
+          localOption (QuickCheckMaxSize 40) $
             testProperty "atomic" $
               withMaxSuccess 10000 $
                 prop_mempoolParallel testLedgerConfigNoSizeLimits txMaxBytes' testInitLedger Atomic $


### PR DESCRIPTION
Fixes https://github.com/IntersectMBO/ouroboros-consensus/issues/2116.

This PR re-enables the test that used to run out of memory in CI. 

The suspected reason for this test to OOM is the way `quickcheck-state-machine` parallel testing explores the generated sequence of test steps. The memory required to explore the sequence of steps grows exponentially with the length of the sequence. On `main`, we use the default length of 100 steps, but apparently something Leios-related makes things more expensive.

I've restricted the length of the sequence of actions run by QSM to 40 steps, which locally seems to hover around 200MB max residency.