### PR TITLE
Do not translate transactions, instead encode and re-decode

### DIFF
--- a/changelog.d/20260721_105834_javier.sagredo_no_tx_translate.md
+++ b/changelog.d/20260721_105834_javier.sagredo_no_tx_translate.md
@@ -1,0 +1,28 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+### Breaking
+
+- Delete `hardForkInjectTxs` from `CanHardFork`.
+- Delete `TranslateEra` instances for `(GenTx :.: ShelleyBlock proto)` and `(WrapValidatedGenTx :.: ShelleyBlock proto)`.
+- Require `From|ToCBOR (GenTx blk)` in `SingleEraBlock`.
+- Delete contents of `InjectTxs.hs` to keep only `matchTx` and `rematchValidatedTxs`.
+- `TraceMempoolRemoveTxs` and `TraceMempoolManuallyRemovedTxs` now carry a `GenTx blk` instead of a `Validated (GenTx blk)`.
+
+
+### Non-Breaking
+
+- When injecting transactions from other eras into the current era in the HFC
+  mempool, encode the transaction in the origin era and decode it in the target
+  era instead of wastefully translate the transaction through all intermediate eras.
+
+<!--
+### Patch
+
+- A bullet item for the Patch category.
+
+-->

--- a/ouroboros-consensus-cardano/src/byron/Ouroboros/Consensus/Byron/ByronHFC.hs
+++ b/ouroboros-consensus-cardano/src/byron/Ouroboros/Consensus/Byron/ByronHFC.hs
@@ -236,6 +236,11 @@ byronTransition partialConfig shelleyMajorVersion state =
   SingleEraBlock Byron
 -------------------------------------------------------------------------------}
 
+instance FromCBOR (GenTx ByronBlock) where
+  fromCBOR = decodeByronGenTx
+instance ToCBOR (GenTx ByronBlock) where
+  toCBOR = encodeByronGenTx
+
 instance SingleEraBlock ByronBlock where
   singleEraTransition pcfg _eraParams _eraStart ledgerState =
     case byronTriggerHardFork pcfg of

--- a/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/CanHardFork.hs
+++ b/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/CanHardFork.hs
@@ -45,7 +45,7 @@ import Cardano.Ledger.Shelley.Translation
 import qualified Cardano.Protocol.TPraos.API as SL
 import qualified Cardano.Protocol.TPraos.Rules.Prtcl as SL
 import qualified Cardano.Protocol.TPraos.Rules.Tickn as SL
-import Control.Monad.Except (runExcept, throwError)
+import Control.Monad.Except (throwError)
 import Data.Coerce (coerce)
 import qualified Data.Map.Strict as Map
 import Data.Maybe.Strict (StrictMaybe (..))
@@ -99,7 +99,7 @@ import Ouroboros.Consensus.Shelley.Node ()
 import Ouroboros.Consensus.Shelley.Protocol.Praos ()
 import Ouroboros.Consensus.Shelley.ShelleyHFC
 import Ouroboros.Consensus.TypeFamilyWrappers
-import Ouroboros.Consensus.Util (coerceMapKeys, eitherToMaybe)
+import Ouroboros.Consensus.Util (coerceMapKeys)
 
 {-------------------------------------------------------------------------------
   CanHardFork
@@ -176,49 +176,6 @@ instance CardanoHardForkConstraints c => CanHardFork (CardanoEras c) where
     -- Inter-Shelley-based
     $
       Tails.hcpure (Proxy @(HasPraosTiebreakerView c)) SameTiebreakerAcrossEras
-  hardForkInjectTxs =
-    PCons (ignoringBoth $ Pair2 cannotInjectTx cannotInjectValidatedTx)
-      $ PCons
-        ( ignoringBoth $
-            Pair2
-              translateTxShelleyToAllegraWrapper
-              translateValidatedTxShelleyToAllegraWrapper
-        )
-      $ PCons
-        ( ignoringBoth $
-            Pair2
-              translateTxAllegraToMaryWrapper
-              translateValidatedTxAllegraToMaryWrapper
-        )
-      $ PCons
-        ( RequireBoth $ \_cfgMary cfgAlonzo ->
-            let ctxt = getAlonzoTranslationContext cfgAlonzo
-             in Pair2
-                  (translateTxMaryToAlonzoWrapper ctxt)
-                  (translateValidatedTxMaryToAlonzoWrapper ctxt)
-        )
-      $ PCons
-        ( RequireBoth $ \_cfgAlonzo _cfgBabbage ->
-            let ctxt = SL.NoGenesis
-             in Pair2
-                  (translateTxAlonzoToBabbageWrapper ctxt)
-                  (translateValidatedTxAlonzoToBabbageWrapper ctxt)
-        )
-      $ PCons
-        ( RequireBoth $ \_cfgBabbage cfgConway ->
-            let ctxt = getConwayTranslationContext cfgConway
-             in Pair2
-                  (translateTxBabbageToConwayWrapper ctxt)
-                  (translateValidatedTxBabbageToConwayWrapper ctxt)
-        )
-      $ PCons
-        ( RequireBoth $ \_cfgConway cfgDijkstra ->
-            let ctxt = getDijkstraTranslationContext cfgDijkstra
-             in Pair2
-                  (translateTxConwayToDijkstraWrapper ctxt)
-                  (translateValidatedTxConwayToDijkstraWrapper ctxt)
-        )
-      $ PNil
 
   hardForkInjTxMeasurePhase1 =
     fromByteSize
@@ -537,22 +494,6 @@ translateLedgerTablesShelleyToAllegraWrapper =
     , translateTxOutWith = SL.upgradeTxOut
     }
 
-translateTxShelleyToAllegraWrapper ::
-  InjectTx
-    (ShelleyBlock (TPraos c) ShelleyEra)
-    (ShelleyBlock (TPraos c) AllegraEra)
-translateTxShelleyToAllegraWrapper =
-  InjectTx $
-    fmap unComp . eitherToMaybe . runExcept . SL.translateEra SL.NoGenesis . Comp
-
-translateValidatedTxShelleyToAllegraWrapper ::
-  InjectValidatedTx
-    (ShelleyBlock (TPraos c) ShelleyEra)
-    (ShelleyBlock (TPraos c) AllegraEra)
-translateValidatedTxShelleyToAllegraWrapper =
-  InjectValidatedTx $
-    fmap unComp . eitherToMaybe . runExcept . SL.translateEra SL.NoGenesis . Comp
-
 {-------------------------------------------------------------------------------
   Translation from Allegra to Mary
 -------------------------------------------------------------------------------}
@@ -584,22 +525,6 @@ translateLedgerTablesAllegraToMaryWrapper =
     { translateTxInWith = coerce
     , translateTxOutWith = SL.upgradeTxOut
     }
-
-translateTxAllegraToMaryWrapper ::
-  InjectTx
-    (ShelleyBlock (TPraos c) AllegraEra)
-    (ShelleyBlock (TPraos c) MaryEra)
-translateTxAllegraToMaryWrapper =
-  InjectTx $
-    fmap unComp . eitherToMaybe . runExcept . SL.translateEra SL.NoGenesis . Comp
-
-translateValidatedTxAllegraToMaryWrapper ::
-  InjectValidatedTx
-    (ShelleyBlock (TPraos c) AllegraEra)
-    (ShelleyBlock (TPraos c) MaryEra)
-translateValidatedTxAllegraToMaryWrapper =
-  InjectValidatedTx $
-    fmap unComp . eitherToMaybe . runExcept . SL.translateEra SL.NoGenesis . Comp
 
 {-------------------------------------------------------------------------------
   Translation from Mary to Alonzo
@@ -638,25 +563,6 @@ getAlonzoTranslationContext ::
   SL.TranslationContext AlonzoEra
 getAlonzoTranslationContext =
   shelleyLedgerTranslationContext . unwrapLedgerConfig
-
-translateTxMaryToAlonzoWrapper ::
-  SL.TranslationContext AlonzoEra ->
-  InjectTx
-    (ShelleyBlock (TPraos c) MaryEra)
-    (ShelleyBlock (TPraos c) AlonzoEra)
-translateTxMaryToAlonzoWrapper ctxt =
-  InjectTx $
-    fmap unComp . eitherToMaybe . runExcept . SL.translateEra ctxt . Comp
-
-translateValidatedTxMaryToAlonzoWrapper ::
-  forall c.
-  SL.TranslationContext AlonzoEra ->
-  InjectValidatedTx
-    (ShelleyBlock (TPraos c) MaryEra)
-    (ShelleyBlock (TPraos c) AlonzoEra)
-translateValidatedTxMaryToAlonzoWrapper ctxt =
-  InjectValidatedTx $
-    fmap unComp . eitherToMaybe . runExcept . SL.translateEra ctxt . Comp
 
 {-------------------------------------------------------------------------------
   Translation from Alonzo to Babbage
@@ -703,43 +609,6 @@ translateLedgerTablesAlonzoToBabbageWrapper =
     , translateTxOutWith = SL.upgradeTxOut
     }
 
-translateTxAlonzoToBabbageWrapper ::
-  SL.TranslationContext BabbageEra ->
-  InjectTx
-    (ShelleyBlock (TPraos c) AlonzoEra)
-    (ShelleyBlock (Praos c) BabbageEra)
-translateTxAlonzoToBabbageWrapper ctxt =
-  InjectTx $
-    fmap unComp . eitherToMaybe . runExcept . SL.translateEra ctxt . Comp . transPraosTx
- where
-  transPraosTx ::
-    GenTx (ShelleyBlock (TPraos c) AlonzoEra) ->
-    GenTx (ShelleyBlock (Praos c) AlonzoEra)
-  transPraosTx (ShelleyTx ti tx) = ShelleyTx ti (coerce tx)
-
-translateValidatedTxAlonzoToBabbageWrapper ::
-  forall c.
-  SL.TranslationContext BabbageEra ->
-  InjectValidatedTx
-    (ShelleyBlock (TPraos c) AlonzoEra)
-    (ShelleyBlock (Praos c) BabbageEra)
-translateValidatedTxAlonzoToBabbageWrapper ctxt =
-  InjectValidatedTx $
-    fmap unComp
-      . eitherToMaybe
-      . runExcept
-      . SL.translateEra ctxt
-      . Comp
-      . transPraosValidatedTx
- where
-  transPraosValidatedTx ::
-    WrapValidatedGenTx (ShelleyBlock (TPraos c) AlonzoEra) ->
-    WrapValidatedGenTx (ShelleyBlock (Praos c) AlonzoEra)
-  transPraosValidatedTx (WrapValidatedGenTx x) = case x of
-    ShelleyValidatedTx txid vtx ->
-      WrapValidatedGenTx $
-        ShelleyValidatedTx txid (SL.coerceValidated vtx)
-
 {-------------------------------------------------------------------------------
   Translation from Babbage to Conway
 -------------------------------------------------------------------------------}
@@ -778,25 +647,6 @@ getConwayTranslationContext ::
 getConwayTranslationContext =
   shelleyLedgerTranslationContext . unwrapLedgerConfig
 
-translateTxBabbageToConwayWrapper ::
-  SL.TranslationContext ConwayEra ->
-  InjectTx
-    (ShelleyBlock (Praos c) BabbageEra)
-    (ShelleyBlock (Praos c) ConwayEra)
-translateTxBabbageToConwayWrapper ctxt =
-  InjectTx $
-    fmap unComp . eitherToMaybe . runExcept . SL.translateEra ctxt . Comp
-
-translateValidatedTxBabbageToConwayWrapper ::
-  forall c.
-  SL.TranslationContext ConwayEra ->
-  InjectValidatedTx
-    (ShelleyBlock (Praos c) BabbageEra)
-    (ShelleyBlock (Praos c) ConwayEra)
-translateValidatedTxBabbageToConwayWrapper ctxt =
-  InjectValidatedTx $
-    fmap unComp . eitherToMaybe . runExcept . SL.translateEra ctxt . Comp
-
 {-------------------------------------------------------------------------------
   Translation from Conway to Dijkstra
 -------------------------------------------------------------------------------}
@@ -834,22 +684,3 @@ getDijkstraTranslationContext ::
   SL.TranslationContext DijkstraEra
 getDijkstraTranslationContext =
   shelleyLedgerTranslationContext . unwrapLedgerConfig
-
-translateTxConwayToDijkstraWrapper ::
-  SL.TranslationContext DijkstraEra ->
-  InjectTx
-    (ShelleyBlock (Praos c) ConwayEra)
-    (ShelleyBlock (Praos c) DijkstraEra)
-translateTxConwayToDijkstraWrapper ctxt =
-  InjectTx $
-    fmap unComp . eitherToMaybe . runExcept . SL.translateEra ctxt . Comp
-
-translateValidatedTxConwayToDijkstraWrapper ::
-  forall c.
-  SL.TranslationContext DijkstraEra ->
-  InjectValidatedTx
-    (ShelleyBlock (Praos c) ConwayEra)
-    (ShelleyBlock (Praos c) DijkstraEra)
-translateValidatedTxConwayToDijkstraWrapper ctxt =
-  InjectValidatedTx $
-    fmap unComp . eitherToMaybe . runExcept . SL.translateEra ctxt . Comp

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/ShelleyHFC.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/ShelleyHFC.hs
@@ -394,33 +394,6 @@ translateShelleyTables ::
 translateShelleyTables (LedgerTables utxoTable) =
   LedgerTables $ mapKeysMK coerce $ mapMK SL.upgradeTxOut utxoTable
 
-instance
-  ( ShelleyBasedEra era
-  , SL.TranslateEra era (SL.Tx SL.TopTx)
-  ) =>
-  SL.TranslateEra era (GenTx :.: ShelleyBlock proto)
-  where
-  type TranslationError era (GenTx :.: ShelleyBlock proto) = SL.TranslationError era (SL.Tx SL.TopTx)
-  translateEra ctxt (Comp (ShelleyTx _txId tx)) =
-    Comp . mkShelleyTx
-      <$> SL.translateEra ctxt tx
-
-instance
-  ( ShelleyBasedEra era
-  , SL.TranslateEra era (SL.Tx SL.TopTx)
-  ) =>
-  SL.TranslateEra era (WrapValidatedGenTx :.: ShelleyBlock proto)
-  where
-  type
-    TranslationError era (WrapValidatedGenTx :.: ShelleyBlock proto) =
-      SL.TranslationError era (SL.Tx SL.TopTx)
-  translateEra ctxt (Comp (WrapValidatedGenTx (ShelleyValidatedTx _txId vtx))) =
-    Comp
-      . WrapValidatedGenTx
-      . mkShelleyValidatedTx
-      . SL.coerceValidated
-      <$> SL.translateValidated @era @(SL.Tx SL.TopTx) ctxt (SL.coerceValidated vtx)
-
 {-------------------------------------------------------------------------------
   Canonical TxIn
 -------------------------------------------------------------------------------}

--- a/ouroboros-consensus-cardano/src/unstable-cardano-testlib/Test/ThreadNet/Infra/ShelleyBasedHardFork.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-testlib/Test/ThreadNet/Infra/ShelleyBasedHardFork.hs
@@ -53,7 +53,6 @@ import qualified Cardano.Ledger.Shelley.API as SL
 import qualified Cardano.Ledger.Shelley.LedgerState as SL
 import Codec.CBOR.Decoding
 import Codec.CBOR.Encoding
-import Control.Monad.Except (runExcept)
 import qualified Control.Tracer as Tracer
 import Data.Coerce
 import qualified Data.Map.Strict as Map
@@ -100,7 +99,6 @@ import Ouroboros.Consensus.Shelley.Node
 import Ouroboros.Consensus.Shelley.Protocol.Abstract (ProtoCrypto)
 import Ouroboros.Consensus.Storage.LedgerDB
 import Ouroboros.Consensus.TypeFamilyWrappers
-import Ouroboros.Consensus.Util (eitherToMaybe)
 import Ouroboros.Consensus.Util.IndexedMemPack
 import System.FS.API (SomeHasFS)
 import Test.ThreadNet.TxGen

--- a/ouroboros-consensus-cardano/src/unstable-cardano-testlib/Test/ThreadNet/Infra/ShelleyBasedHardFork.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-testlib/Test/ThreadNet/Infra/ShelleyBasedHardFork.hs
@@ -288,36 +288,6 @@ instance
 
   hardForkChainSel = Tails.mk2 SameTiebreakerAcrossEras
 
-  hardForkInjectTxs =
-    InPairs.mk2 $
-      InPairs.RequireBoth $ \_cfg1 cfg2 ->
-        let ctxt = shelleyLedgerTranslationContext (unwrapLedgerConfig cfg2)
-         in Pair2
-              (InjectTx (translateTx ctxt))
-              (InjectValidatedTx (translateValidatedTx ctxt))
-   where
-    translateTx ::
-      SL.TranslationContext era2 ->
-      GenTx (ShelleyBlock proto era1) ->
-      Maybe (GenTx (ShelleyBlock proto era2))
-    translateTx transCtxt =
-      fmap unComp
-        . eitherToMaybe
-        . runExcept
-        . SL.translateEra transCtxt
-        . Comp
-
-    translateValidatedTx ::
-      SL.TranslationContext era2 ->
-      WrapValidatedGenTx (ShelleyBlock proto era1) ->
-      Maybe (WrapValidatedGenTx (ShelleyBlock proto era2))
-    translateValidatedTx transCtxt =
-      fmap unComp
-        . eitherToMaybe
-        . runExcept
-        . SL.translateEra transCtxt
-        . Comp
-
   hardForkInjTxMeasurePhase1 = \case
     (Z (WrapTxMeasurePhase1 x)) -> translateTxMeasure x
     S (Z (WrapTxMeasurePhase1 x)) -> x

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator.hs
@@ -443,7 +443,6 @@ instance CanHardFork '[BlockA, BlockB] where
       , crossEraForecast = PCons forecast_AtoB PNil
       }
   hardForkChainSel = Tails.mk2 NoTiebreakerAcrossEras
-  hardForkInjectTxs = InPairs.mk2 injectTx_AtoB
 
   hardForkInjTxMeasurePhase1 = \case
     (Z (WrapTxMeasurePhase1 x)) -> x
@@ -583,15 +582,6 @@ forecast_AtoB ::
 forecast_AtoB = InPairs.ignoringBoth $ CrossEraForecaster $ \_ _ _ ->
   return $
     WrapLedgerView ()
-
-injectTx_AtoB ::
-  RequiringBoth
-    WrapLedgerConfig
-    (Product2 InjectTx InjectValidatedTx)
-    BlockA
-    BlockB
-injectTx_AtoB =
-  InPairs.ignoringBoth $ Pair2 cannotInjectTx cannotInjectValidatedTx
 
 {-------------------------------------------------------------------------------
   Query HF

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator/A.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator/A.hs
@@ -40,7 +40,7 @@ module Test.Consensus.HardFork.Combinator.A
   , TxId (..)
   ) where
 
-import Cardano.Binary (DecoderError)
+import Cardano.Binary (DecoderError, FromCBOR (..), ToCBOR (..))
 import Cardano.Ledger.BaseTypes.NonZero
 import Cardano.Slotting.EpochInfo
 import qualified Codec.CBOR.Decoding as CBOR
@@ -378,6 +378,11 @@ data instance GenTx BlockA = TxA
   }
   deriving (Show, Eq, Generic, Serialise)
   deriving NoThunks via OnlyCheckWhnfNamed "TxA" (GenTx BlockA)
+
+instance FromCBOR (GenTx BlockA) where
+  fromCBOR = decode
+instance ToCBOR (GenTx BlockA) where
+  toCBOR = encode
 
 newtype instance Validated (GenTx BlockA) = ValidatedGenTxA {forgetValidatedGenTxA :: GenTx BlockA}
   deriving stock Show

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator/B.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator/B.hs
@@ -34,7 +34,7 @@ module Test.Consensus.HardFork.Combinator.B
   , TxId (..)
   ) where
 
-import Cardano.Binary (DecoderError)
+import Cardano.Binary (DecoderError, FromCBOR (..), ToCBOR (..))
 import Cardano.Ledger.BaseTypes (unNonZero)
 import qualified Codec.CBOR.Decoding as CBOR
 import qualified Codec.CBOR.Encoding as CBOR
@@ -318,6 +318,11 @@ safeZoneB (SecurityParam k) = History.StandardSafeZone $ unNonZero k
 
 data instance GenTx BlockB
   deriving (Show, Eq, Generic, NoThunks, Serialise)
+
+instance FromCBOR (GenTx BlockB) where
+  fromCBOR = fail "no GenTx BlockB to be decoded"
+instance ToCBOR (GenTx BlockB) where
+  toCBOR = \case {}
 
 data instance Validated (GenTx BlockB)
   deriving (Show, Eq, Generic, NoThunks)

--- a/ouroboros-consensus.cabal
+++ b/ouroboros-consensus.cabal
@@ -1641,7 +1641,6 @@ library unstable-cardano-testlib
     fs-sim,
     mempack,
     microlens,
-    mtl,
     nothunks,
     ouroboros-consensus:{cardano, diffusion, ouroboros-consensus, protocol, unstable-consensus-testlib, unstable-diffusion-testlib, unstable-protocol-testlib},
     ouroboros-network:api,

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE PatternSynonyms #-}
-
 -- | The hard fork combinator
 --
 -- Intended for unqualified import
@@ -33,12 +31,9 @@ import Ouroboros.Consensus.HardFork.Combinator.Forging as X
   )
 import Ouroboros.Consensus.HardFork.Combinator.Info as X
 import Ouroboros.Consensus.HardFork.Combinator.InjectTxs as X
-  ( InjectTx
-  , InjectValidatedTx
-  , cannotInjectTx
-  , cannotInjectValidatedTx
-  , pattern InjectTx
-  , pattern InjectValidatedTx
+  ( TxsToApply (..)
+  , matchTx
+  , rematchValidatedTxs
   )
 import Ouroboros.Consensus.HardFork.Combinator.Ledger as X
 import Ouroboros.Consensus.HardFork.Combinator.Ledger.CommonProtocolParams as X ()

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Abstract/CanHardFork.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Abstract/CanHardFork.hs
@@ -14,9 +14,6 @@ module Ouroboros.Consensus.HardFork.Combinator.Abstract.CanHardFork
 
 import Data.Measure (Measure)
 import Data.SOP.Constraint
-import Data.SOP.Functors (Product2)
-import Data.SOP.InPairs (InPairs, RequiringBoth)
-import qualified Data.SOP.InPairs as InPairs
 import Data.SOP.NonEmpty
 import qualified Data.SOP.Strict as SOP
 import Data.SOP.Tails (Tails)
@@ -26,7 +23,6 @@ import GHC.TypeNats (KnownNat)
 import NoThunks.Class (NoThunks)
 import Ouroboros.Consensus.Block (HashSize)
 import Ouroboros.Consensus.HardFork.Combinator.Abstract.SingleEraBlock
-import Ouroboros.Consensus.HardFork.Combinator.InjectTxs
 import Ouroboros.Consensus.HardFork.Combinator.Protocol.ChainSel
 import Ouroboros.Consensus.HardFork.Combinator.Translation
 import Ouroboros.Consensus.Ledger.SupportsMempool
@@ -86,13 +82,6 @@ class
 
   hardForkEraTranslation :: EraTranslation xs
   hardForkChainSel :: Tails AcrossEraTiebreaker xs
-  hardForkInjectTxs ::
-    InPairs
-      ( RequiringBoth
-          WrapLedgerConfig
-          (Product2 InjectTx InjectValidatedTx)
-      )
-      xs
 
   -- | This is ideally exact.
   --
@@ -109,7 +98,6 @@ instance SingleEraBlock blk => CanHardFork '[blk] where
 
   hardForkEraTranslation = trivialEraTranslation
   hardForkChainSel = Tails.mk1
-  hardForkInjectTxs = InPairs.mk1
 
   hardForkInjTxMeasurePhase1 (SOP.Z (WrapTxMeasurePhase1 x)) = x
   hardForkInjTxMeasurePhase2 (SOP.Z (WrapTxMeasurePhase2 x)) = x

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Abstract/SingleEraBlock.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Abstract/SingleEraBlock.hs
@@ -22,6 +22,7 @@ module Ouroboros.Consensus.HardFork.Combinator.Abstract.SingleEraBlock
   , eraIndexZero
   ) where
 
+import Cardano.Binary (FromCBOR, ToCBOR)
 import Codec.Serialise
 import Data.Either (isRight)
 import Data.Proxy
@@ -83,6 +84,8 @@ class
     CanStowLedgerTables (LedgerState blk)
   , HasLedgerTables LedgerState blk
   , HasLedgerTables (Ticked LedgerState) blk
+  , ToCBOR (GenTx blk)
+  , FromCBOR (GenTx blk)
   , -- Instances required to support testing
     Eq (GenTx blk)
   , Eq (Validated (GenTx blk))

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Forging.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Forging.hs
@@ -365,11 +365,15 @@ hardForkForgeBlock
         ([], hfs) ->
           hmap
             ( \case
-                Pair _ ApplyTxs{} -> error "Impossible!!"
+                Pair _ ApplyTxs{} ->
+                  error
+                    "Impossible! we have translated the txs to the current era, but they should already be in this era!"
                 Pair a (ReapplyTxs b) -> Pair a $ Comp $ map (\(x, (), ()) -> x) b
             )
             $ State.tip hfs
-        (_ : _, _) -> error "Impossible!!"
+        (_ : _, _) ->
+          error
+            "Impossible! some transactions were rejected as untranslatable by rematchValidatedTxs but all of them have been translated and applied just now."
 
     -- \| Unwraps all the layers needed for SOP and call 'forgeBlock'.
     forgeBlockOne ::

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Forging.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Forging.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -20,9 +21,6 @@ import Data.Maybe (fromMaybe)
 import Data.SOP (Top)
 import Data.SOP.BasicFunctors
 import Data.SOP.Constraint (All)
-import Data.SOP.Functors (Product2 (..))
-import Data.SOP.InPairs (InPairs)
-import qualified Data.SOP.InPairs as InPairs
 import Data.SOP.Index
 import qualified Data.SOP.Match as Match
 import Data.SOP.OptNP (NonEmptyOptNP, OptNP, ViewOptNP (..))
@@ -330,14 +328,13 @@ hardForkForgeBlock
         forgeBlockOne
         cfgs
         (OptNP.toNP blockForging)
-      $ injectValidatedTxs (map (getOneEraValidatedGenTx . getHardForkValidatedGenTx) txs)
       -- We know both NSs must be from the same era, because they were all
       -- produced from the same 'BlockForging'. Unfortunately, we can't enforce
       -- it statically.
       $ Match.mustMatchNS
         "IsLeader"
         (getOneEraIsLeader isLeader)
-        (State.tip ledgerState)
+      $ injectValidatedTxs ledgerState
    where
     cfgs = distribTopLevelConfig ei cfg
     ei =
@@ -351,27 +348,28 @@ hardForkForgeBlock
       "impossible: current era lacks block forging but we have an IsLeader proof "
         <> show eraIndex
 
+    -- If we crossed an era boundary in this forge, the transactions were
+    -- revalidated against the tip in the new era so:
+    --
+    --  * Re-matching them MUST leave them in the right era via returning
+    --    'ReapplyTxs'.
+    --
+    --  * There should be no rejected-by-untranslatable transactions.
+    --
+    -- Otherwise there is a bug.
     injectValidatedTxs ::
-      [NS WrapValidatedGenTx xs] ->
-      NS f xs ->
+      State.HardForkState f xs ->
       NS (Product f ([] :.: WrapValidatedGenTx)) xs
-    injectValidatedTxs = noMismatches .: flip (matchValidatedTxsNS injTxs)
-     where
-      injTxs :: InPairs InjectValidatedTx xs
-      injTxs =
-        InPairs.hmap (\(Pair2 _ x) -> x) $
-          InPairs.requiringBoth
-            (hmap (WrapLedgerConfig . configLedger) cfgs)
-            hardForkInjectTxs
-
-      -- \| We know the transactions must be valid w.r.t. the given ledger
-      -- state, the Mempool maintains that invariant. That means they are
-      -- either from the same era, or can be injected into that era.
-      noMismatches ::
-        ([Match.Mismatch WrapValidatedGenTx f xs], NS (Product f ([] :.: WrapValidatedGenTx)) xs) ->
-        NS (Product f ([] :.: WrapValidatedGenTx)) xs
-      noMismatches ([], xs) = xs
-      noMismatches (_errs, _) = error "unexpected unmatchable transactions"
+    injectValidatedTxs st =
+      case rematchValidatedTxs getHardForkValidatedGenTx st $ map (\x -> (x, (), ())) txs of
+        ([], hfs) ->
+          hmap
+            ( \case
+                Pair _ ApplyTxs{} -> error "Impossible!!"
+                Pair a (ReapplyTxs b) -> Pair a $ Comp $ map (\(x, (), ()) -> x) b
+            )
+            $ State.tip hfs
+        (_ : _, _) -> error "Impossible!!"
 
     -- \| Unwraps all the layers needed for SOP and call 'forgeBlock'.
     forgeBlockOne ::
@@ -379,11 +377,11 @@ hardForkForgeBlock
       TopLevelConfig blk ->
       (Maybe :.: BlockForging m) blk ->
       Product
+        WrapIsLeader
         ( Product
-            WrapIsLeader
             (FlipTickedLedgerState EmptyMK)
+            ([] :.: WrapValidatedGenTx)
         )
-        ([] :.: WrapValidatedGenTx)
         blk ->
       m blk
     forgeBlockOne
@@ -391,8 +389,8 @@ hardForkForgeBlock
       cfg'
       (Comp mBlockForging')
       ( Pair
-          (Pair (WrapIsLeader isLeader') (FlipTickedLedgerState ledgerState'))
-          (Comp txs')
+          (WrapIsLeader isLeader')
+          (Pair (FlipTickedLedgerState ledgerState') (Comp txs'))
         ) =
         forgeBlock
           ( fromMaybe

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/InjectTxs.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/InjectTxs.hs
@@ -16,7 +16,7 @@ import Cardano.Binary (fromCBOR, toCBOR)
 import Codec.CBOR.Read
 import Codec.CBOR.Write
 import Data.Bifunctor (second)
-import Data.ByteString.Lazy
+import Data.ByteString.Lazy as BS
 import Data.Functor.Product
 import qualified Data.List as L
 import qualified Data.SOP as LazySOP
@@ -163,7 +163,9 @@ rematchValidatedTxs projectValidatedTx (State.HardForkState tele) vtxs =
     go' (rej, surv) ((Left bs, txEraNS, orig, a, b) : txs) =
       case deserialiseFromBytes fromCBOR bs of
         Left _ -> go' ((orig, reject txEraNS) : rej, surv) txs
-        Right (_, t) -> go' (rej, (Right t, a, b) : surv) txs
+        Right (rest, t)
+          | BS.null rest -> go' (rej, (Right t, a, b) : surv) txs
+          | otherwise -> go' ((orig, reject txEraNS) : rej, surv) txs
     -- A transaction already in the tip era: kept as-is.
     go' (rej, surv) ((Right (Z v), _, _, a, b) : txs) =
       go' (rej, (Left v, a, b) : surv) txs
@@ -174,7 +176,9 @@ rematchValidatedTxs projectValidatedTx (State.HardForkState tele) vtxs =
               hcmap proxySingle (K . toLazyByteString . toCBOR . txForgetValidated . unwrapValidatedGenTx) tx
        in case deserialiseFromBytes fromCBOR bs of
             Left _ -> go' ((orig, reject txEraNS) : rej, surv) txs
-            Right (_, t) -> go' (rej, (Right t, a, b) : surv) txs
+            Right (rest, t)
+              | BS.null rest -> go' (rej, (Right t, a, b) : surv) txs
+              | otherwise -> go' ((orig, reject txEraNS) : rej, surv) txs
 
     -- Collapse the ordered, tagged survivors into a single 'TxsToApply'. The
     -- fold preserves order; a mix of tags would violate the single-era invariant.
@@ -221,13 +225,13 @@ matchTx tx (State.HardForkState tele) =
     Left mm ->
       case State.sequenceHardForkState $ State.HardForkState $ hcmap proxySingle de tele of
         -- Tx failed to deserialise in the target era
-        Left _ ->
+        Nothing ->
           Left
             . MismatchEraInfo
             . Match.bihcmap proxySingle singleEraInfo (LedgerEraInfo . singleEraInfo)
             $ mm
         -- Tx deserialised in the target era
-        Right n -> Right n
+        Just n -> Right n
  where
   flipCurrAndProd :: Product GenTx (State.Current f) a -> State.Current (Product f GenTx) a
   flipCurrAndProd (Pair a (State.Current b c)) = State.Current b (Pair c a)
@@ -235,7 +239,9 @@ matchTx tx (State.HardForkState tele) =
   ser = hcollapse $ hcmap proxySingle (K . toLazyByteString . toCBOR) tx
   de ::
     SingleEraBlock blk =>
-    State.Current f blk -> State.Current (Either DeserialiseFailure :.: Product f GenTx) blk
+    State.Current f blk -> State.Current (Maybe :.: Product f GenTx) blk
   de (State.Current s st) = case deserialiseFromBytes fromCBOR ser of
-    Left err -> State.Current s (Comp $ Left $ err)
-    Right (_, v) -> State.Current s (Comp $ Right $ Pair st v)
+    Left _ -> State.Current s (Comp Nothing)
+    Right (rest, v)
+      | BS.null rest -> State.Current s (Comp . Just . Pair st $ v)
+      | otherwise -> State.Current s (Comp Nothing)

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/InjectTxs.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/InjectTxs.hs
@@ -1,190 +1,217 @@
+{-# LANGUAGE EmptyCase #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
-{-# LANGUAGE PatternSynonyms #-}
-{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeOperators #-}
 
 -- | Injecting a transaction from one block type to another
 module Ouroboros.Consensus.HardFork.Combinator.InjectTxs
-  ( -- * Polymorphic
-    InjectPolyTx (..)
-  , cannotInjectPolyTx
-  , matchPolyTx
-  , matchPolyTxsTele
-
-    -- * Unvalidated transactions
-  , InjectTx
-  , cannotInjectTx
+  ( TxsToApply (..)
+  , rematchValidatedTxs
   , matchTx
-  , pattern InjectTx
-
-    -- * Validated transactions
-  , InjectValidatedTx
-  , cannotInjectValidatedTx
-  , matchValidatedTx
-  , matchValidatedTxsNS
-  , pattern InjectValidatedTx
   ) where
 
-import Data.Bifunctor
+import Cardano.Binary (fromCBOR, toCBOR)
+import Codec.CBOR.Read
+import Codec.CBOR.Write
+import Data.Bifunctor (bimap, second)
+import Data.ByteString.Lazy
 import Data.Functor.Product
+import qualified Data.List as L
+import qualified Data.SOP as LazySOP
 import Data.SOP.BasicFunctors
-import Data.SOP.InPairs (InPairs (..))
-import Data.SOP.Match
-import Data.SOP.Sing
+import Data.SOP.Constraint
+import qualified Data.SOP.Dict as Dict
+import qualified Data.SOP.Match as Match
 import Data.SOP.Strict
-import Data.SOP.Telescope (Telescope (..))
-import qualified Data.SOP.Telescope as Telescope
-import Ouroboros.Consensus.HardFork.Combinator.State.Types
+import qualified Data.SOP.Telescope as Tele
+import Ouroboros.Consensus.HardFork.Combinator.Abstract.SingleEraBlock
+import Ouroboros.Consensus.HardFork.Combinator.AcrossEras
+import Ouroboros.Consensus.HardFork.Combinator.Basics
+import Ouroboros.Consensus.HardFork.Combinator.Info
+import qualified Ouroboros.Consensus.HardFork.Combinator.State as State
+import Ouroboros.Consensus.Ledger.Abstract
 import Ouroboros.Consensus.Ledger.SupportsMempool
 import Ouroboros.Consensus.TypeFamilyWrappers
-import Ouroboros.Consensus.Util (pairFst)
 
-{-------------------------------------------------------------------------------
-  Polymorphic definitions
--------------------------------------------------------------------------------}
+-- | How a re-matched transaction must be applied at the ledger tip era.
+data TxsToApply a b blk
+  = -- | The transaction is already in the tip era; its validation evidence
+    -- still holds, so it can be reapplied cheaply.
+    ReapplyTxs [(WrapValidatedGenTx blk, a, b)]
+  | -- | The transaction was upgraded from an earlier era (serialised there and
+    -- decoded here as a plain 'GenTx'), losing its validation evidence, so it
+    -- must be fully applied again.
+    ApplyTxs [(GenTx blk, a, b)]
 
--- | @tx@ is either 'GenTx' or 'WrapValidatedGenTx'
+-- | Re-match a batch of already-validated transactions against a
+-- 'State.HardForkState' whose era might have changed, /without/ translating the
+-- transactions across eras.
 --
--- See 'InjectTx' and 'InjectValidatedTx', respectively.
-data InjectPolyTx tx blk blk' = InjectPolyTx
-  { injectTxWith :: tx blk -> Maybe (tx blk')
-  }
-
--- | The injection that always fails
-cannotInjectPolyTx :: InjectPolyTx tx blk blk'
-cannotInjectPolyTx = InjectPolyTx $ const Nothing
-
--- | Match transaction with a telescope, attempting to inject where possible
-matchPolyTx' ::
-  InPairs (InjectPolyTx tx) xs ->
-  NS tx xs ->
-  Telescope g f xs ->
-  Either
-    (Mismatch tx f xs)
-    (Telescope g (Product tx f) xs)
-matchPolyTx' = go
- where
-  go ::
-    InPairs (InjectPolyTx tx) xs ->
-    NS tx xs ->
-    Telescope g f xs ->
-    Either
-      (Mismatch tx f xs)
-      (Telescope g (Product tx f) xs)
-  go _ (Z x) (TZ f) = Right $ TZ (Pair x f)
-  go (PCons _ is) (S x) (TS g f) = bimap MS (TS g) $ go is x f
-  go _ (S x) (TZ f) = Left $ MR x f
-  go (PCons i is) (Z x) (TS g f) =
-    case injectTxWith i x of
-      Nothing -> Left $ ML x (Telescope.tip f)
-      Just x' -> bimap MS (TS g) $ go is (Z x') f
-
-matchPolyTx ::
-  SListI xs =>
-  InPairs (InjectPolyTx tx) xs ->
-  NS tx xs ->
-  HardForkState f xs ->
-  Either
-    (Mismatch tx (Current f) xs)
-    (HardForkState (Product tx f) xs)
-matchPolyTx is tx =
-  fmap (HardForkState . hmap distrib)
-    . matchPolyTx' is tx
-    . getHardForkState
- where
-  distrib :: Product tx (Current f) blk -> Current (Product tx f) blk
-  distrib (Pair tx' Current{..}) =
-    Current
-      { currentStart = currentStart
-      , currentState = Pair tx' currentState
-      }
-
--- | Match a list of transactions with an 'Telescope', attempting to inject
--- where possible
-matchPolyTxsTele ::
-  forall tx g f xs.
-  SListI xs =>
-  InPairs (InjectPolyTx tx) xs ->
-  Telescope g f xs ->
-  [NS tx xs] ->
-  ( [(NS tx xs, Mismatch tx f xs)]
-  , Telescope g (Product f ([] :.: tx)) xs
+-- The ledger state lives in a single era: the tip of the telescope. Walking the
+-- telescope era by era, each transaction that belongs to an era we pass (a @Z@
+-- at that point) is serialised to CBOR with that era's 'toCBOR' (after forgetting
+-- its validation evidence — we can only encode a 'GenTx'). Once we reach the tip,
+-- those bytes are decoded with the tip era's 'fromCBOR', as a 'GenTx':
+--
+--   * a transaction already in the tip era is kept as-is ('ReapplyTxs');
+--
+--   * a past-era transaction whose bytes decode in the tip era is upgraded
+--     ('ApplyTxs'); it must be fully applied since it lost its evidence;
+--
+--   * a past-era transaction whose bytes do /not/ decode is untranslatable and
+--     is reported back as a 'MismatchEraInfo';
+--
+--   * a transaction from a /later/ era than the tip (the ledger tip retracted)
+--     is reported back as a 'MismatchEraInfo'.
+--
+-- Reports are built with 'Match.matchNS' from the transaction's original era and
+-- the ledger tip era, which is why each transaction carries its original era
+-- ('NS' 'SingleEraInfo') alongside its serialised bytes.
+rematchValidatedTxs ::
+  forall xs a b f.
+  All SingleEraBlock xs =>
+  -- | How to project a validated transaction
+  (forall xs0. Validated (GenTx (HardForkBlock xs0)) -> OneEraValidatedGenTx xs0) ->
+  -- | HardForkState
+  State.HardForkState f xs ->
+  -- | List of transactions to re-match
+  [(Validated (GenTx (HardForkBlock xs)), a, b)] ->
+  ( [(Validated (GenTx (HardForkBlock xs)), MismatchEraInfo xs)]
+  , State.HardForkState (Product f (TxsToApply a b)) xs
   )
-matchPolyTxsTele is ns = go
+rematchValidatedTxs projectValidatedTx (State.HardForkState tele) vtxs =
+  second State.HardForkState $ go Dict.hdicts tele vtxs'
  where
+  vtxs' =
+    [ (Right ns, hcmap proxySingle singleEraInfo ns, tx, a, b)
+    | (tx, a, b) <- vtxs
+    , let ns = getOneEraValidatedGenTx $ projectValidatedTx tx
+    ]
+
+  -- The ledger era (the tip of the telescope) as an 'NS' inhabited exactly at
+  -- the ledger's position.
+  ledgerEraNS :: NS LedgerEraInfo xs
+  ledgerEraNS = hcmap proxySingle (LedgerEraInfo . singleEraInfo) (Tele.tip tele)
+
+  -- Build the mismatch for a transaction whose era differs from the ledger era.
+  -- 'Match.matchNS' positions it correctly (earlier or later than the ledger).
+  reject :: NS SingleEraInfo xs -> MismatchEraInfo xs
+  reject txEraNS = MismatchEraInfo $ case Match.matchNS txEraNS ledgerEraNS of
+    Left mismatch -> mismatch
+    Right _ ->
+      error
+        "rematchValidatedTxs: expected an era mismatch, but the transaction and \
+        \ledger eras agreed; this is a bug"
+
   go ::
-    [NS tx xs] ->
-    ([(NS tx xs, Mismatch tx f xs)], Telescope g (Product f ([] :.: tx)) xs)
-  go [] = ([], hmap (`Pair` Comp []) ns)
-  go (tx : txs) =
-    let (mismatched, matched) = go txs
-     in case matchPolyTx' is tx matched of
-          Left err -> ((tx, hmap pairFst err) : mismatched, matched)
-          Right matched' -> (mismatched, insert matched')
+    forall f1 xs'.
+    LazySOP.NP (Dict.Dict SingleEraBlock) xs' ->
+    Tele.Telescope f1 (State.Current f) xs' ->
+    [ATx xs a b xs'] ->
+    ( [(Validated (GenTx (HardForkBlock xs)), MismatchEraInfo xs)]
+    , Tele.Telescope f1 (State.Current (Product f (TxsToApply a b))) xs'
+    )
+  go LazySOP.Nil t _ = case t of {}
+  -- We are passing a past era: serialise the transactions that belong to it
+  -- (forgetting their evidence) and forward everything to the next era. The
+  -- transform is inlined (rather than a @where@ helper) so that the @Z@ match
+  -- stays coupled to the head era brought in scope by the 'Dict' match.
+  go (Dict.Dict LazySOP.:* nextDicts) (Tele.TS i st) txs =
+    second (Tele.TS i) $
+      go
+        nextDicts
+        st
+        [ ( case tx of
+              Left bs -> Left bs
+              Right (Z t) ->
+                Left . toLazyByteString . toCBOR . txForgetValidated . unwrapValidatedGenTx $ t
+              Right (S t) -> Right t
+          , txEraNS
+          , orig
+          , a
+          , b
+          )
+        | (tx, txEraNS, orig, a, b) <- txs
+        ]
+  go (Dict.Dict LazySOP.:* d) (Tele.TZ (State.Current start (st :: f blk))) txs0 =
+    second (Tele.TZ . State.Current start . Pair st) $
+      Dict.withDict (Dict.all_NP d) $
+        go' ([], []) txs0
+   where
+    -- Survivors are accumulated in a single list, preserving the original order
+    -- of the transactions, tagged with how each must be applied: 'Left' = kept
+    -- validated (reapply), 'Right' = upgraded (fully apply). By the single-era
+    -- invariant the tags are uniform, and 'toTxsToApply' turns them into the
+    -- matching 'TxsToApply' constructor.
+    go' ::
+      All SingleEraBlock xs' =>
+      Acc xs a b blk ->
+      [ATx xs a b xs'] ->
+      ( [(Validated (GenTx (HardForkBlock xs)), MismatchEraInfo xs)]
+      , TxsToApply a b blk
+      )
+    go' (rej, surv) [] = (L.reverse rej, toTxsToApply (L.reverse surv))
+    -- A serialised past-era transaction: upgrade it if it decodes in the tip
+    -- era, report it as untranslatable otherwise.
+    go' (rej, surv) ((Left bs, txEraNS, orig, a, b) : txs) =
+      case deserialiseFromBytes fromCBOR bs of
+        Left _ -> go' ((orig, reject txEraNS) : rej, surv) txs
+        Right (_, t) -> go' (rej, (Right t, a, b) : surv) txs
+    -- A transaction already in the tip era: kept as-is.
+    go' (rej, surv) ((Right (Z v), _, _, a, b) : txs) =
+      go' (rej, (Left v, a, b) : surv) txs
+    -- A transaction from a later era: we try to downgrade it.
+    go' (rej, surv) ((Right (S tx), txEraNS, orig, a, b) : txs) =
+      let bs =
+            hcollapse $
+              hcmap proxySingle (K . toLazyByteString . toCBOR . txForgetValidated . unwrapValidatedGenTx) tx
+       in case deserialiseFromBytes fromCBOR bs of
+            Left _ -> go' ((orig, reject txEraNS) : rej, surv) txs
+            Right (_, t) -> go' (rej, (Right t, a, b) : surv) txs
 
-  insert ::
-    Telescope g (Product tx (Product f ([] :.: tx))) xs ->
-    Telescope g (Product f ([] :.: tx)) xs
-  insert = hmap (\(Pair tx (Pair f (Comp txs))) -> Pair f (Comp (tx : txs)))
+    -- Collapse the ordered, tagged survivors into a single 'TxsToApply'. The
+    -- fold preserves order; a mix of tags would violate the single-era invariant.
+    toTxsToApply ::
+      [(Either (WrapValidatedGenTx blk) (GenTx blk), a, b)] -> TxsToApply a b blk
+    toTxsToApply = L.foldr step (ReapplyTxs [])
+     where
+      step (Left v, a, b) (ReapplyTxs vs) = ReapplyTxs ((v, a, b) : vs)
+      step (Right t, a, b) (ReapplyTxs []) = ApplyTxs [(t, a, b)]
+      step (Right t, a, b) (ApplyTxs ts) = ApplyTxs ((t, a, b) : ts)
+      step _ _ =
+        error "rematchValidatedTxs: the batch spans more than one era; this is a bug"
 
-{-------------------------------------------------------------------------------
-  Monomorphic aliases
--------------------------------------------------------------------------------}
+type Acc xs a b blk =
+  ( [(Validated (GenTx (HardForkBlock xs)), MismatchEraInfo xs)]
+  , [(Either (WrapValidatedGenTx blk) (GenTx blk), a, b)]
+  )
 
-type InjectTx = InjectPolyTx GenTx
+-- | A transaction being re-matched, as it travels down the telescope.
+--
+-- The first component is either the CBOR bytes of a transaction from an era we
+-- have already passed, or the (era-tagged) validated transaction for the eras we
+-- have not reached yet. The second component records the transaction's original
+-- era over the whole @xs@, used to report a 'MismatchEraInfo' if untranslatable
+-- or from a later era.
+type ATx xs a b xs' =
+  ( Either ByteString (NS WrapValidatedGenTx xs')
+  , NS SingleEraInfo xs
+  , Validated (GenTx (HardForkBlock xs))
+  , a
+  , b
+  )
 
--- | 'InjectPolyTx' at type 'InjectTx'
-pattern InjectTx :: (GenTx blk -> Maybe (GenTx blk')) -> InjectTx blk blk'
-pattern InjectTx f = InjectPolyTx f
-
--- | 'cannotInjectPolyTx' at type 'InjectTx'
-cannotInjectTx :: InjectTx blk blk'
-cannotInjectTx = cannotInjectPolyTx
-
--- | 'matchPolyTx' at type 'InjectTx'
 matchTx ::
-  SListI xs =>
-  InPairs InjectTx xs ->
+  All SingleEraBlock xs =>
   NS GenTx xs ->
-  HardForkState f xs ->
-  Either
-    (Mismatch GenTx (Current f) xs)
-    (HardForkState (Product GenTx f) xs)
-matchTx = matchPolyTx
-
------
-
-type InjectValidatedTx = InjectPolyTx WrapValidatedGenTx
-
--- | 'InjectPolyTx' at type 'InjectValidatedTx'
-pattern InjectValidatedTx ::
-  (WrapValidatedGenTx blk -> Maybe (WrapValidatedGenTx blk')) ->
-  InjectValidatedTx blk blk'
-pattern InjectValidatedTx f = InjectPolyTx f
-
--- | 'cannotInjectPolyTx' at type 'InjectValidatedTx'
-cannotInjectValidatedTx :: InjectValidatedTx blk blk'
-cannotInjectValidatedTx = cannotInjectPolyTx
-
--- | 'matchPolyTx' at type 'InjectValidatedTx'
-matchValidatedTx ::
-  SListI xs =>
-  InPairs InjectValidatedTx xs ->
-  NS WrapValidatedGenTx xs ->
-  HardForkState f xs ->
-  Either
-    (Mismatch WrapValidatedGenTx (Current f) xs)
-    (HardForkState (Product WrapValidatedGenTx f) xs)
-matchValidatedTx = matchPolyTx
-
--- | 'matchPolyTxsNS' at type 'InjectValidatedTx'
-matchValidatedTxsNS ::
-  forall f xs.
-  SListI xs =>
-  InPairs InjectValidatedTx xs ->
-  NS f xs ->
-  [NS WrapValidatedGenTx xs] ->
-  ([Mismatch WrapValidatedGenTx f xs], NS (Product f ([] :.: WrapValidatedGenTx)) xs)
-matchValidatedTxsNS ips ns txs = bimap (map snd) Telescope.tip $ matchPolyTxsTele ips (Telescope.fromTip ns) txs
+  State.HardForkState f xs ->
+  Either (MismatchEraInfo xs) (State.HardForkState (Product f GenTx) xs)
+matchTx tx (State.HardForkState tele) =
+  bimap
+    (MismatchEraInfo . Match.bihcmap proxySingle singleEraInfo (LedgerEraInfo . singleEraInfo))
+    (State.HardForkState . hmap flipCurrAndProd)
+    $ Match.matchTelescope tx tele
+ where
+  flipCurrAndProd :: Product GenTx (State.Current f) a -> State.Current (Product f GenTx) a
+  flipCurrAndProd (Pair a (State.Current b c)) = State.Current b (Pair c a)

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/InjectTxs.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/InjectTxs.hs
@@ -15,7 +15,7 @@ module Ouroboros.Consensus.HardFork.Combinator.InjectTxs
 import Cardano.Binary (fromCBOR, toCBOR)
 import Codec.CBOR.Read
 import Codec.CBOR.Write
-import Data.Bifunctor (bimap, second)
+import Data.Bifunctor (second)
 import Data.ByteString.Lazy
 import Data.Functor.Product
 import qualified Data.List as L
@@ -35,7 +35,10 @@ import Ouroboros.Consensus.Ledger.Abstract
 import Ouroboros.Consensus.Ledger.SupportsMempool
 import Ouroboros.Consensus.TypeFamilyWrappers
 
--- | How a re-matched transaction must be applied at the ledger tip era.
+-- | How the re-matched transactions must be applied at the ledger tip era.
+--
+-- Either we translate all and need to use 'ApplyTxs' or we don't translate and
+-- we can use 'ReapplyTxs'.
 data TxsToApply a b blk
   = -- | The transaction is already in the tip era; its validation evidence
     -- still holds, so it can be reapplied cheaply.
@@ -64,7 +67,7 @@ data TxsToApply a b blk
 --     is reported back as a 'MismatchEraInfo';
 --
 --   * a transaction from a /later/ era than the tip (the ledger tip retracted)
---     is reported back as a 'MismatchEraInfo'.
+--     is downgraded to the era of the tip.
 --
 -- Reports are built with 'Match.matchNS' from the transaction's original era and
 -- the ledger tip era, which is why each transaction carries its original era

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/InjectTxs.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/InjectTxs.hs
@@ -81,6 +81,8 @@ rematchValidatedTxs ::
   ( [(Validated (GenTx (HardForkBlock xs)), MismatchEraInfo xs)]
   , State.HardForkState (Product f (TxsToApply a b)) xs
   )
+rematchValidatedTxs _ hfs [] =
+  ([], hmap (\x -> Pair x (ReapplyTxs [])) hfs)
 rematchValidatedTxs projectValidatedTx (State.HardForkState tele) vtxs =
   second State.HardForkState $ go Dict.hdicts tele vtxs'
  where

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/InjectTxs.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/InjectTxs.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeOperators #-}
 
 -- | Injecting a transaction from one block type to another
 module Ouroboros.Consensus.HardFork.Combinator.InjectTxs
@@ -208,10 +209,28 @@ matchTx ::
   State.HardForkState f xs ->
   Either (MismatchEraInfo xs) (State.HardForkState (Product f GenTx) xs)
 matchTx tx (State.HardForkState tele) =
-  bimap
-    (MismatchEraInfo . Match.bihcmap proxySingle singleEraInfo (LedgerEraInfo . singleEraInfo))
-    (State.HardForkState . hmap flipCurrAndProd)
-    $ Match.matchTelescope tx tele
+  case Match.matchTelescope tx tele of
+    -- Transaction and state are in the same era
+    Right m -> Right . State.HardForkState . hmap flipCurrAndProd $ m
+    -- Transaction and state are in different eras
+    Left mm ->
+      case State.sequenceHardForkState $ State.HardForkState $ hcmap proxySingle de tele of
+        -- Tx failed to deserialise in the target era
+        Left _ ->
+          Left
+            . MismatchEraInfo
+            . Match.bihcmap proxySingle singleEraInfo (LedgerEraInfo . singleEraInfo)
+            $ mm
+        -- Tx deserialised in the target era
+        Right n -> Right n
  where
   flipCurrAndProd :: Product GenTx (State.Current f) a -> State.Current (Product f GenTx) a
   flipCurrAndProd (Pair a (State.Current b c)) = State.Current b (Pair c a)
+
+  ser = hcollapse $ hcmap proxySingle (K . toLazyByteString . toCBOR) tx
+  de ::
+    SingleEraBlock blk =>
+    State.Current f blk -> State.Current (Either DeserialiseFailure :.: Product f GenTx) blk
+  de (State.Current s st) = case deserialiseFromBytes fromCBOR ser of
+    Left err -> State.Current s (Comp $ Left $ err)
+    Right (_, v) -> State.Current s (Comp $ Right $ Pair st v)

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Mempool.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Mempool.hs
@@ -8,7 +8,6 @@
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
@@ -27,17 +26,14 @@ module Ouroboros.Consensus.HardFork.Combinator.Mempool
 import Control.Arrow ((+++))
 import Control.Monad.Except
 import Data.ByteString.Short (ShortByteString)
+import qualified Data.Foldable as Foldable
 import Data.Functor.Identity
 import Data.Functor.Product
-import Data.Kind (Type)
 import qualified Data.Measure as Measure
 import Data.SOP.BasicFunctors
 import Data.SOP.Constraint
-import Data.SOP.Functors
-import Data.SOP.InPairs (InPairs)
 import qualified Data.SOP.InPairs as InPairs
 import Data.SOP.Index
-import qualified Data.SOP.Match as Match
 import Data.SOP.Strict
 import qualified Data.SOP.Telescope as Tele
 import Data.Typeable (Typeable)
@@ -47,13 +43,13 @@ import Ouroboros.Consensus.Block
 import Ouroboros.Consensus.HardFork.Combinator.Abstract
 import Ouroboros.Consensus.HardFork.Combinator.AcrossEras
 import Ouroboros.Consensus.HardFork.Combinator.Basics
-import Ouroboros.Consensus.HardFork.Combinator.Info
 import Ouroboros.Consensus.HardFork.Combinator.InjectTxs
 import Ouroboros.Consensus.HardFork.Combinator.Ledger
 import Ouroboros.Consensus.HardFork.Combinator.PartialConfig
 import qualified Ouroboros.Consensus.HardFork.Combinator.State as State
 import Ouroboros.Consensus.Ledger.Abstract
 import Ouroboros.Consensus.Ledger.SupportsMempool
+import Ouroboros.Consensus.Ledger.Tables.Utils (applyDiffs, forgetLedgerTables)
 import Ouroboros.Consensus.TypeFamilyWrappers
 import Ouroboros.Consensus.Util
 import Ouroboros.Network.Tx (HasRawTxId (..))
@@ -61,7 +57,7 @@ import Ouroboros.Network.Tx (HasRawTxId (..))
 data HardForkApplyTxErr xs
   = -- | Validation error from one of the eras
     HardForkApplyTxErrFromEra !(OneEraApplyTxErr xs)
-  | -- | We tried to apply a block from the wrong era
+  | -- | We tried to apply a transaction from the wrong era
     HardForkApplyTxErrWrongEra !(MismatchEraInfo xs)
   deriving Generic
 
@@ -129,17 +125,10 @@ instance
   ) =>
   LedgerSupportsMempool (HardForkBlock xs)
   where
-  applyTx = applyHelper ModeApply
+  applyTx = applyHelper
 
-  reapplyTx cfg slot vtx tls =
-    fst
-      <$> applyHelper
-        ModeReapply
-        cfg
-        DoNotIntervene
-        slot
-        (WrapValidatedGenTx vtx)
-        tls
+  reapplyTx =
+    error "This method is unreachable"
 
   reapplyTxs ::
     forall wtd extra.
@@ -159,14 +148,17 @@ instance
     vtxs
     (TickedHardForkLedgerState transition hardForkState) =
       ( \(err, val, st) ->
-          ReapplyTxsResult (mismatched' ++ err) val (TickedHardForkLedgerState transition st)
+          ReapplyTxsResult
+            (map (\(x, y) -> Invalidated (txForgetValidated x) $ HardForkApplyTxErrWrongEra y) mismatched ++ err)
+            val
+            (TickedHardForkLedgerState transition st)
       )
         $ hsequence'
         $ hcizipWith
           proxySingle
           modeApplyCurrent
           cfgs
-          (State.HardForkState $ hmap flipCurrentAndProduct matched)
+          matched
      where
       pcfgs = getPerEraLedgerConfig hardForkLedgerConfigPerEra
       cfgs = hcmap proxySingle (completeLedgerConfig'' ei) pcfgs
@@ -176,37 +168,7 @@ instance
           transition
           hardForkState
 
-      flipCurrentAndProduct (Pair (State.Current c s) b) = State.Current c (Pair s b)
-
-      -- Transactions are unwrapped into the particular era transactions.
-      (mismatched, matched) =
-        matchPolyTxsTele
-          -- How to translate txs to later eras
-          ( InPairs.hmap
-              (\(Pair2 _ (InjectPolyTx w)) -> InjectPolyTx (\(Comp (ex, df, tx)) -> Comp . (ex,df,) <$> w tx))
-              (InPairs.requiringBoth cfgs hardForkInjectTxs)
-          )
-          (State.getHardForkState hardForkState)
-          [ hmap (Comp . (extra,df,)) . getOneEraValidatedGenTx . getHardForkValidatedGenTx $ tx
-          | (tx, df, extra) <- vtxs
-          ]
-
-      mismatched' :: [Invalidated (HardForkBlock xs)]
-      mismatched' =
-        [ flip
-            Invalidated
-            ( HardForkApplyTxErrWrongEra $
-                MismatchEraInfo $
-                  Match.bihcmap proxySingle singleEraInfo ledgerInfo y
-            )
-            . HardForkValidatedGenTx
-            . OneEraValidatedGenTx
-            . hmap (thd . unComp)
-            $ x
-        | (x, y) <- mismatched
-        ]
-
-      thd (_, _, x) = x
+      (mismatched, matched) = rematchValidatedTxs getHardForkValidatedGenTx hardForkState vtxs
 
       modeApplyCurrent ::
         forall blk.
@@ -215,28 +177,51 @@ instance
         WrapLedgerConfig blk ->
         Product
           (FlipTickedLedgerState ValuesMK)
-          ( []
-              :.: (,,) extra (InputTxDiffs (HardForkBlock xs) wtd)
-              :.: WrapValidatedGenTx
-          )
+          (TxsToApply (InputTxDiffs (HardForkBlock xs) wtd) extra)
           blk ->
         DecomposedReapplyTxsResult extra xs wtd blk
-      modeApplyCurrent index cfg (Pair (FlipTickedLedgerState st) txs) =
+      modeApplyCurrent index cfg (Pair (FlipTickedLedgerState st) (ReapplyTxs txs)) =
         let ReapplyTxsResult err val st' =
               reapplyTxs @blk @Discard
                 (unwrapLedgerConfig cfg)
                 slot
-                [(unwrapValidatedGenTx tx, (), (df, tk)) | (Comp (tk, df, tx)) <- unComp txs]
+                [(unwrapValidatedGenTx tx, (), (df, tk)) | (tx, tk, df) <- txs]
                 st
          in Comp
-              ( [ injectValidatedGenTx index (getInvalidated x) `Invalidated` injectApplyTxErr index (getReason x)
+              ( [ injectGenTx index (getInvalidated x) `Invalidated` injectApplyTxErr index (getReason x)
                 | x <- err
                 ]
               , [ (HardForkValidatedGenTx . OneEraValidatedGenTx . injectNS index . WrapValidatedGenTx $ x, z1, z2)
-                | (x, (), (z1, z2)) <- val
+                | (x, (), (z2, z1)) <- val
                 ]
               , FlipTickedLedgerState st'
               )
+      modeApplyCurrent index cfg (Pair (FlipTickedLedgerState st) (ApplyTxs txs)) =
+        let (err, val, st') = foldApplyTxs txs
+         in Comp
+              ( [ injectGenTx index (getInvalidated x) `Invalidated` injectApplyTxErr index (getReason x)
+                | x <- err
+                ]
+              , [ (HardForkValidatedGenTx . OneEraValidatedGenTx . injectNS index . WrapValidatedGenTx $ x, z1, z2)
+                | (x, z1, z2) <- val
+                ]
+              , FlipTickedLedgerState $ forgetLedgerTables st'
+              )
+       where
+        foldApplyTxs ::
+          [(GenTx blk, InputTxDiffs (HardForkBlock xs) wtd, extra)] ->
+          ( [Invalidated blk]
+          , [(Validated (GenTx blk), InputTxDiffs (HardForkBlock xs) wtd, extra)]
+          , TickedLedgerState blk ValuesMK
+          )
+        foldApplyTxs =
+          Foldable.foldl'
+            ( \(accE, accV, st') (a, d, e) ->
+                case runExcept (applyTx (unwrapLedgerConfig cfg) DoNotIntervene slot a st') of
+                  Left err -> (Invalidated a err : accE, accV, st')
+                  Right (st'', validated) -> (accE, (validated, d, e) : accV, applyDiffs st' st'')
+            )
+            ([], [], st)
 
   txForgetValidated =
     HardForkGenTx
@@ -372,7 +357,7 @@ instance CanHardFork xs => TxLimits (HardForkBlock xs) where
     HardForkLedgerConfig{..}
     (TickedHardForkLedgerState transition hardForkState)
     tx =
-      case matchTx injs (unwrapTx tx) hardForkState of
+      case matchTx (unwrapTx tx) hardForkState of
         Left{} -> pure Measure.zero -- safe b/c the tx will be found invalid
         Right pair -> hcollapse $ hcizipWith proxySingle aux cfgs pair
      where
@@ -386,19 +371,14 @@ instance CanHardFork xs => TxLimits (HardForkBlock xs) where
 
       unwrapTx = getOneEraGenTx . getHardForkGenTx
 
-      injs :: InPairs (InjectPolyTx GenTx) xs
-      injs =
-        InPairs.hmap (\(Pair2 injTx _injValidatedTx) -> injTx) $
-          InPairs.requiringBoth cfgs hardForkInjectTxs
-
       aux ::
         forall blk.
         SingleEraBlock blk =>
         Index xs blk ->
         WrapLedgerConfig blk ->
-        (Product GenTx (FlipTickedLedgerState EmptyMK)) blk ->
+        (Product (FlipTickedLedgerState EmptyMK) GenTx) blk ->
         K (Except (HardForkApplyTxErr xs) (HardForkTxMeasurePhase1 xs)) blk
-      aux idx cfg (Pair tx' st') =
+      aux idx cfg (Pair st' tx') =
         K
           $ mapExcept
             ( ( HardForkApplyTxErrFromEra
@@ -417,7 +397,7 @@ instance CanHardFork xs => TxLimits (HardForkBlock xs) where
     HardForkLedgerConfig{..}
     (TickedHardForkLedgerState transition hardForkState)
     tx =
-      case matchTx injs (unwrapTx tx) hardForkState of
+      case matchTx (unwrapTx tx) hardForkState of
         Left{} -> pure Measure.zero -- safe b/c the tx will be found invalid
         Right pair -> hcollapse $ hcizipWith proxySingle aux cfgs pair
      where
@@ -431,19 +411,14 @@ instance CanHardFork xs => TxLimits (HardForkBlock xs) where
 
       unwrapTx = getOneEraGenTx . getHardForkGenTx
 
-      injs :: InPairs (InjectPolyTx GenTx) xs
-      injs =
-        InPairs.hmap (\(Pair2 injTx _injValidatedTx) -> injTx) $
-          InPairs.requiringBoth cfgs hardForkInjectTxs
-
       aux ::
         forall blk.
         SingleEraBlock blk =>
         Index xs blk ->
         WrapLedgerConfig blk ->
-        (Product GenTx (FlipTickedLedgerState ValuesMK)) blk ->
+        (Product (FlipTickedLedgerState ValuesMK) GenTx) blk ->
         K (Except (HardForkApplyTxErr xs) (HardForkTxMeasurePhase2 xs)) blk
-      aux idx cfg (Pair tx' st') =
+      aux idx cfg (Pair st' tx') =
         K
           $ mapExcept
             ( ( HardForkApplyTxErrFromEra
@@ -458,19 +433,9 @@ instance CanHardFork xs => TxLimits (HardForkBlock xs) where
             (getFlipTickedLedgerState st')
             tx'
 
--- | A private type used only to clarify the parameterization of 'applyHelper'
-data ApplyHelperMode :: (Type -> Type) -> Type where
-  ModeApply :: ApplyHelperMode GenTx
-  ModeReapply :: ApplyHelperMode WrapValidatedGenTx
-
--- | 'applyHelper' has to return one of these, depending on the apply mode used.
-type family ApplyMK k where
-  ApplyMK (ApplyHelperMode GenTx) = DiffMK
-  ApplyMK (ApplyHelperMode WrapValidatedGenTx) = ValuesMK
-
 -- | A private type used only to clarify the definition of 'applyHelper'
-data ApplyResult xs txIn blk = ApplyResult
-  { arState :: Ticked LedgerState blk (ApplyMK (ApplyHelperMode txIn))
+data ApplyResult xs blk = ApplyResult
+  { arState :: Ticked LedgerState blk DiffMK
   , arValidatedTx :: Validated (GenTx (HardForkBlock xs))
   }
 
@@ -479,31 +444,26 @@ data ApplyResult xs txIn blk = ApplyResult
 -- The @txIn@ variable is 'GenTx' or 'WrapValidatedGenTx', respectively. See
 -- 'ApplyHelperMode'.
 applyHelper ::
-  forall xs txIn.
+  forall xs.
   CanHardFork xs =>
-  ApplyHelperMode txIn ->
   LedgerConfig (HardForkBlock xs) ->
   WhetherToIntervene ->
   SlotNo ->
-  txIn (HardForkBlock xs) ->
+  GenTx (HardForkBlock xs) ->
   TickedLedgerState (HardForkBlock xs) ValuesMK ->
   Except
     (HardForkApplyTxErr xs)
-    ( TickedLedgerState (HardForkBlock xs) (ApplyMK (ApplyHelperMode txIn))
+    ( TickedLedgerState (HardForkBlock xs) DiffMK
     , Validated (GenTx (HardForkBlock xs))
     )
 applyHelper
-  mode
   HardForkLedgerConfig{..}
   wti
   slot
   tx
   (TickedHardForkLedgerState transition hardForkState) =
-    case matchPolyTx injs (modeGetTx tx) hardForkState of
-      Left mismatch ->
-        throwError $
-          HardForkApplyTxErrWrongEra . MismatchEraInfo $
-            Match.bihcmap proxySingle singleEraInfo ledgerInfo mismatch
+    case matchTx (unwrapTx tx) hardForkState of
+      Left mismatch -> throwError $ HardForkApplyTxErrWrongEra mismatch
       Right matched ->
         -- We are updating the ticked ledger state by applying a transaction,
         -- but for the HFC that ledger state contains a bundled
@@ -525,9 +485,9 @@ applyHelper
           result <-
             hsequence' $
               hcizipWith proxySingle modeApplyCurrent cfgs matched
-          let _ = result :: State.HardForkState (ApplyResult xs txIn) xs
+          let _ = result :: State.HardForkState (ApplyResult xs) xs
 
-              st' :: State.HardForkState (FlipTickedLedgerState (ApplyMK (ApplyHelperMode txIn))) xs
+              st' :: State.HardForkState (FlipTickedLedgerState DiffMK) xs
               st' = (FlipTickedLedgerState . arState) `hmap` result
 
               vtx :: Validated (GenTx (HardForkBlock xs))
@@ -543,62 +503,27 @@ applyHelper
         transition
         hardForkState
 
-    injs :: InPairs (InjectPolyTx txIn) xs
-    injs =
-      InPairs.hmap
-        modeGetInjection
-        (InPairs.requiringBoth cfgs hardForkInjectTxs)
-
-    modeGetTx :: txIn (HardForkBlock xs) -> NS txIn xs
-    modeGetTx = case mode of
-      ModeApply ->
-        getOneEraGenTx
-          . getHardForkGenTx
-      ModeReapply ->
-        getOneEraValidatedGenTx
-          . getHardForkValidatedGenTx
-          . unwrapValidatedGenTx
-
-    modeGetInjection ::
-      forall blk1 blk2.
-      Product2 InjectTx InjectValidatedTx blk1 blk2 ->
-      InjectPolyTx txIn blk1 blk2
-    modeGetInjection (Pair2 injTx injValidatedTx) = case mode of
-      ModeApply -> injTx
-      ModeReapply -> injValidatedTx
+    unwrapTx = getOneEraGenTx . getHardForkGenTx
 
     modeApplyCurrent ::
       forall blk.
       SingleEraBlock blk =>
       Index xs blk ->
       WrapLedgerConfig blk ->
-      Product txIn (FlipTickedLedgerState ValuesMK) blk ->
+      Product (FlipTickedLedgerState ValuesMK) GenTx blk ->
       ( Except (HardForkApplyTxErr xs)
-          :.: ApplyResult xs txIn
+          :.: ApplyResult xs
       )
         blk
-    modeApplyCurrent index cfg (Pair tx' (FlipTickedLedgerState st)) =
-      Comp $
-        withExcept (injectApplyTxErr index) $
-          do
-            let lcfg = unwrapLedgerConfig cfg
-            case mode of
-              ModeApply -> do
-                (st', vtx) <- applyTx lcfg wti slot tx' st
-                pure
-                  ApplyResult
-                    { arValidatedTx = injectValidatedGenTx index vtx
-                    , arState = st'
-                    }
-              ModeReapply -> do
-                let vtx' = unwrapValidatedGenTx tx'
-                st' <- reapplyTx lcfg slot vtx' st
-                -- provide the given transaction, which was already validated
-                pure
-                  ApplyResult
-                    { arValidatedTx = injectValidatedGenTx index vtx'
-                    , arState = st'
-                    }
+    modeApplyCurrent index cfg (Pair (FlipTickedLedgerState st) tx') =
+      Comp $ withExcept (injectApplyTxErr index) $ do
+        let lcfg = unwrapLedgerConfig cfg
+        (st', vtx) <- applyTx lcfg wti slot tx' st
+        pure
+          ApplyResult
+            { arValidatedTx = injectValidatedGenTx index vtx
+            , arState = st'
+            }
 
 newtype instance TxId (GenTx (HardForkBlock xs)) = HardForkGenTxId
   { getHardForkGenTxId :: OneEraGenTxId xs
@@ -644,12 +569,6 @@ instance All HasTxs xs => HasTxs (HardForkBlock xs) where
   Auxiliary
 -------------------------------------------------------------------------------}
 
-ledgerInfo ::
-  forall blk mk.
-  SingleEraBlock blk =>
-  State.Current (FlipTickedLedgerState mk) blk -> LedgerEraInfo blk
-ledgerInfo _ = LedgerEraInfo $ singleEraInfo (Proxy @blk)
-
 injectApplyTxErr :: SListI xs => Index xs blk -> ApplyTxErr blk -> HardForkApplyTxErr xs
 injectApplyTxErr index =
   HardForkApplyTxErrFromEra
@@ -664,3 +583,10 @@ injectValidatedGenTx index =
     . OneEraValidatedGenTx
     . injectNS index
     . WrapValidatedGenTx
+
+injectGenTx ::
+  SListI xs => Index xs blk -> GenTx blk -> GenTx (HardForkBlock xs)
+injectGenTx index =
+  HardForkGenTx
+    . OneEraGenTx
+    . injectNS index

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Mempool.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Mempool.hs
@@ -214,14 +214,13 @@ instance
           , [(Validated (GenTx blk), InputTxDiffs (HardForkBlock xs) wtd, extra)]
           , TickedLedgerState blk ValuesMK
           )
-        foldApplyTxs =
-          Foldable.foldl'
-            ( \(accE, accV, st') (a, d, e) ->
-                case runExcept (applyTx (unwrapLedgerConfig cfg) DoNotIntervene slot a st') of
-                  Left err -> (Invalidated a err : accE, accV, st')
-                  Right (st'', validated) -> (accE, (validated, d, e) : accV, applyDiffs st' st'')
-            )
-            ([], [], st)
+        foldApplyTxs xs =
+          let step (accE, accV, accSt) (a, d, e) =
+                case runExcept (applyTx (unwrapLedgerConfig cfg) DoNotIntervene slot a accSt) of
+                  Left err -> (Invalidated a err : accE, accV, accSt)
+                  Right (accSt', validated) -> (accE, (validated, d, e) : accV, applyDiffs accSt accSt')
+              (invalids, valids, finalSt) = Foldable.foldl' step ([], [], st) xs
+           in (reverse invalids, reverse valids, finalSt)
 
   txForgetValidated =
     HardForkGenTx

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/SupportsMempool.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/SupportsMempool.hs
@@ -195,7 +195,7 @@ class
       Foldable.foldl'
         ( \(accE, accV, st') a ->
             case runExcept (reapplyTx cfg slot (projectTx a) st') of
-              Left err -> (Invalidated (projectTx a) err : accE, accV, st')
+              Left err -> (Invalidated (txForgetValidated $ projectTx a) err : accE, accV, st')
               Right st'' -> (accE, a : accV, st'')
         )
         ([], [], st)
@@ -529,6 +529,6 @@ instance TxMeasurePhase1Metrics ByteSize32 where
 -- | A transaction that was previously valid. Used to clarify the types on the
 -- 'reapplyTxs' function.
 data Invalidated blk = Invalidated
-  { getInvalidated :: !(Validated (GenTx blk))
+  { getInvalidated :: !(GenTx blk)
   , getReason :: !(ApplyTxErr blk)
   }

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Impl/Common.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Impl/Common.hs
@@ -576,7 +576,7 @@ data TraceEventMempool blk
       -- | Previously valid transactions that are no longer valid because of
       -- changes in the ledger state (details are in the provided 'ApplyTxErr').
       -- These transactions have been removed from the Mempool.
-      [(Validated (GenTx blk), ApplyTxErr blk)]
+      [(GenTx blk, ApplyTxErr blk)]
       -- | The current size of the Mempool.
       MempoolSize
   | TraceMempoolManuallyRemovedTxs
@@ -588,7 +588,7 @@ data TraceEventMempool blk
       --
       -- This list shares not transactions with the list of manually removed
       -- transactions.
-      [Validated (GenTx blk)]
+      [GenTx blk]
       -- | The current size of the Mempool.
       MempoolSize
   | -- | Emitted when the mempool is adjusted after the tip has changed.

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/Mempool.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/Mempool.hs
@@ -318,7 +318,7 @@ prop_Mempool_TraceRemovedTxs setup =
   cfg = testLedgerCfg setup
 
   isRemoveTxsEvent :: TraceEventMempool TestBlock -> Maybe [(TestTx, TestTxError)]
-  isRemoveTxsEvent (TraceMempoolRemoveTxs txs _) = Just (map (first txForgetValidated) txs)
+  isRemoveTxsEvent (TraceMempoolRemoveTxs txs _) = Just txs
   isRemoveTxsEvent _ = Nothing
 
   expectedToBeRemoved :: LedgerState TestBlock ValuesMK -> [TestTx] -> [(TestTx, TestTxError)]


### PR DESCRIPTION
Translating a transaction means throwing away the decoded transaction and then re-decoding it in the new era. When matching transactions for the HF mempool, we now do the same but from the origin era to the target era directly, without computing it for the intermediate eras.
