### PR TITLE
[Peras 32] Define Peras IsPerasVote and IsPerasCert type classes

### DIFF
--- a/changelog.d/20260720_115308_agustin.mista_introduce_vote_cert_classes.md
+++ b/changelog.d/20260720_115308_agustin.mista_introduce_vote_cert_classes.md
@@ -1,0 +1,23 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+<!--
+### Breaking
+
+- A bullet item for the Breaking category.
+
+-->
+### Non-Breaking
+
+- Introduce `IsPerasVote` and `IsPerasCert` type projection clases.
+
+<!--
+### Patch
+
+- A bullet item for the Patch category.
+
+-->

--- a/ouroboros-consensus.cabal
+++ b/ouroboros-consensus.cabal
@@ -235,6 +235,7 @@ library
     Ouroboros.Consensus.Node.Run
     Ouroboros.Consensus.Node.Serialisation
     Ouroboros.Consensus.NodeId
+    Ouroboros.Consensus.Peras.Cert.Class
     Ouroboros.Consensus.Peras.Cert.Inclusion
     Ouroboros.Consensus.Peras.Cert.V1
     Ouroboros.Consensus.Peras.Crypto.BLS
@@ -242,6 +243,7 @@ library
     Ouroboros.Consensus.Peras.SelectView
     Ouroboros.Consensus.Peras.Types
     Ouroboros.Consensus.Peras.Vote.Aggregation
+    Ouroboros.Consensus.Peras.Vote.Class
     Ouroboros.Consensus.Peras.Vote.V1
     Ouroboros.Consensus.Peras.Voting.Committee
     Ouroboros.Consensus.Peras.Voting.Rules

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Peras/Cert/Class.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Peras/Cert/Class.hs
@@ -1,0 +1,37 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+-- | The 'IsPerasCert' projection/injection class.
+module Ouroboros.Consensus.Peras.Cert.Class
+  ( IsPerasCert (..)
+  ) where
+
+import Ouroboros.Consensus.Block.Abstract (Point)
+import Ouroboros.Consensus.BlockchainTime.WallClock.Types (WithArrivalTime (..))
+import Ouroboros.Consensus.Peras.Types
+  ( BoostedBlock
+  , BoostedBlockCompatibleWithPoint (..)
+  , PerasRoundNo
+  )
+
+-- | Types that support being treated as Peras certificates
+class
+  BoostedBlockCompatibleWithPoint (BoostedBlock cert) blk =>
+  IsPerasCert cert blk
+    | cert -> blk
+  where
+  getPerasCertRound :: cert -> PerasRoundNo
+  getPerasCertBlock :: cert -> BoostedBlock cert
+
+  getPerasCertPoint :: cert -> Point blk
+  getPerasCertPoint = boostedBlockToPoint . getPerasCertBlock
+
+instance
+  IsPerasCert cert blk =>
+  IsPerasCert (WithArrivalTime cert) blk
+  where
+  getPerasCertRound = getPerasCertRound . forgetArrivalTime
+  getPerasCertBlock = getPerasCertBlock . forgetArrivalTime

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Peras/Vote/Class.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Peras/Vote/Class.hs
@@ -1,0 +1,60 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+-- | The 'IsPerasVote' projection/injection class.
+module Ouroboros.Consensus.Peras.Vote.Class
+  ( IsPerasVote (..)
+  , getPerasVoteId
+  , getPerasVoteTarget
+  ) where
+
+import Ouroboros.Consensus.Block.Abstract (Point)
+import Ouroboros.Consensus.BlockchainTime.WallClock.Types (WithArrivalTime (..))
+import Ouroboros.Consensus.Peras.Types
+  ( BoostedBlock
+  , BoostedBlockCompatibleWithPoint (..)
+  , PerasRoundNo
+  , PerasSeatIndex
+  , PerasVoteId (..)
+  , PerasVoteTarget (..)
+  )
+
+-- | Types that support being treated as Peras votes
+class
+  BoostedBlockCompatibleWithPoint (BoostedBlock vote) blk =>
+  IsPerasVote vote blk
+    | vote -> blk
+  where
+  getPerasVoteRound :: vote -> PerasRoundNo
+  getPerasVoteBlock :: vote -> BoostedBlock vote
+  getPerasVoteSeatIndex :: vote -> PerasSeatIndex
+
+  getPerasVotePoint :: vote -> Point blk
+  getPerasVotePoint = boostedBlockToPoint . getPerasVoteBlock
+
+-- | Extract the vote ID from a Peras vote container
+getPerasVoteId :: IsPerasVote vote blk => vote -> PerasVoteId
+getPerasVoteId vote =
+  PerasVoteId
+    { pviRoundNo = getPerasVoteRound vote
+    , pviSeatIndex = getPerasVoteSeatIndex vote
+    }
+
+-- | Extract the vote target from a Peras vote container
+getPerasVoteTarget :: IsPerasVote vote blk => vote -> PerasVoteTarget blk
+getPerasVoteTarget vote =
+  PerasVoteTarget
+    { pvtRoundNo = getPerasVoteRound vote
+    , pvtBlock = getPerasVotePoint vote
+    }
+
+instance
+  IsPerasVote vote blk =>
+  IsPerasVote (WithArrivalTime vote) blk
+  where
+  getPerasVoteRound = getPerasVoteRound . forgetArrivalTime
+  getPerasVoteBlock = getPerasVoteBlock . forgetArrivalTime
+  getPerasVoteSeatIndex = getPerasVoteSeatIndex . forgetArrivalTime


### PR DESCRIPTION
This commit introduces the `IsPerasVote` and `IsPerasCert` type classes, which will allow us to project fields from different vote/cert container types (notably mocked and production ones).

NOTE: these type classes will replace the existing `HasPeras(Vote|Cert)X` ones in the future.