### PR TITLE
[Peras 34] Introduce mocked Peras votes, certs, and crypto scheme

### DIFF
--- a/ouroboros-consensus.cabal
+++ b/ouroboros-consensus.cabal
@@ -446,6 +446,9 @@ library unstable-consensus-testlib
   visibility: public
   hs-source-dirs: ouroboros-consensus/src/unstable-consensus-testlib
   exposed-modules:
+    Ouroboros.Consensus.Peras.Cert.Mock
+    Ouroboros.Consensus.Peras.Crypto.Mock
+    Ouroboros.Consensus.Peras.Vote.Mock
     Test.LedgerTables
     Test.Ouroboros.Consensus.ChainGenerator.Adversarial
     Test.Ouroboros.Consensus.ChainGenerator.BitVector
@@ -523,6 +526,7 @@ library unstable-consensus-testlib
     contra-tracer,
     deepseq,
     directory,
+    extra,
     file-embed,
     filepath,
     fs-api,
@@ -533,6 +537,7 @@ library unstable-consensus-testlib
     io-sim,
     mempack,
     mtl,
+    nonempty-containers,
     nothunks,
     optparse-applicative,
     ouroboros-consensus,

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Node/Serialisation.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Node/Serialisation.hs
@@ -36,6 +36,7 @@ module Ouroboros.Consensus.Node.Serialisation
   , Some (..)
   ) where
 
+import Cardano.Binary (FromCBOR (..), ToCBOR (..))
 import qualified Cardano.Binary as KeyHash
 import Codec.CBOR.Decoding (Decoder, decodeListLenOf)
 import Codec.CBOR.Encoding (Encoding, encodeListLen)
@@ -196,6 +197,10 @@ instance ConvertRawHash blk => SerialiseNodeToNode blk (Tip blk) where
 instance SerialiseNodeToNode blk PerasRoundNo where
   encodeNodeToNode _ccfg _version = encode
   decodeNodeToNode _ccfg _version = decode
+
+instance SerialiseNodeToNode blk PerasSeatIndex where
+  encodeNodeToNode _ccfg _version = toCBOR . unPerasSeatIndex
+  decodeNodeToNode _ccfg _version = PerasSeatIndex <$> fromCBOR
 
 instance ConvertRawHash blk => SerialiseNodeToNode blk (PerasCert blk) where
   -- Consistent with the 'Serialise' instance for 'PerasCert' defined in Ouroboros.Consensus.Block.SupportsPeras

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Util/Orphans.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Util/Orphans.hs
@@ -32,6 +32,8 @@ import qualified Data.IntPSQ as PSQ
 import Data.MultiSet (MultiSet)
 import qualified Data.MultiSet as MultiSet
 import Data.SOP.BasicFunctors
+import Data.Set.NonEmpty (NESet)
+import qualified Data.Set.NonEmpty as NESet
 import Data.Typeable (Typeable)
 import NoThunks.Class
   ( InspectHeapNamed (..)
@@ -107,6 +109,10 @@ instance NoThunks a => NoThunks (K a b) where
 instance NoThunks a => NoThunks (MultiSet a) where
   showTypeOf _ = "MultiSet"
   wNoThunks ctxt = wNoThunks ctxt . MultiSet.toMap
+
+instance NoThunks v => NoThunks (NESet v) where
+  showTypeOf _ = "NESet"
+  wNoThunks ctxt = wNoThunks ctxt . NESet.toSet
 
 instance NoThunks a => NoThunks (Array i a) where
   showTypeOf _ = "Array"

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Ouroboros/Consensus/Peras/Cert/Mock.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Ouroboros/Consensus/Peras/Cert/Mock.hs
@@ -1,0 +1,156 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+-- | Mocked Peras certificates without crypto.
+module Ouroboros.Consensus.Peras.Cert.Mock
+  ( MockPerasCert (..)
+  ) where
+
+import Cardano.Binary
+  ( FromCBOR (..)
+  , ToCBOR (..)
+  , decodeListLenOf
+  , encodeListLen
+  )
+import Control.DeepSeq (NFData)
+import Data.Containers.NonEmpty (NE)
+import Data.Data (Proxy (..))
+import qualified Data.List.NonEmpty as NonEmpty
+import Data.Set (Set)
+import qualified Data.Set.NonEmpty as NESet
+import Data.Set.NonEmpty.Internal (NESet (..))
+import Data.Typeable (Typeable)
+import GHC.Generics (Generic)
+import NoThunks.Class (NoThunks)
+import Ouroboros.Consensus.Block.Abstract
+  ( ConvertRawHash
+  , Point
+  , StandardHash
+  )
+import Ouroboros.Consensus.Node.Serialisation (SerialiseNodeToNode (..))
+import Ouroboros.Consensus.Peras.Cert.Class (IsPerasCert (..))
+import Ouroboros.Consensus.Peras.Types
+  ( BoostedBlock
+  , PerasRoundNo
+  , PerasSeatIndex
+  )
+import Ouroboros.Consensus.Util (ShowProxy)
+import Ouroboros.Network.Util (ShowProxy (..))
+
+-- | Mocked Peras certificates without crypto.
+--
+-- NOTE: this is parameterized around the concrete block type being certified.
+data MockPerasCert blk
+  = MockPerasCert
+  { mockCertRound :: PerasRoundNo
+  , mockCertBlock :: Point blk
+  , mockCertVoters :: NE (Set PerasSeatIndex)
+  }
+
+deriving instance StandardHash blk => Show (MockPerasCert blk)
+deriving instance StandardHash blk => Eq (MockPerasCert blk)
+deriving instance StandardHash blk => Ord (MockPerasCert blk)
+deriving instance StandardHash blk => NoThunks (MockPerasCert blk)
+deriving instance StandardHash blk => NFData (MockPerasCert blk)
+deriving instance Generic (MockPerasCert blk)
+
+type instance BoostedBlock (MockPerasCert blk) = Point blk
+
+instance IsPerasCert (MockPerasCert blk) blk where
+  getPerasCertRound = mockCertRound
+  getPerasCertBlock = mockCertBlock
+
+instance ShowProxy blk => ShowProxy (MockPerasCert blk) where
+  showProxy _ = "MockPerasCert(" <> showProxy (Proxy @blk) <> ")"
+
+instance
+  ( Typeable blk
+  , FromCBOR (Point blk)
+  ) =>
+  FromCBOR (MockPerasCert blk)
+  where
+  fromCBOR = do
+    decodeListLenOf 3
+    mockCertRound <- fromCBOR
+    mockCertBlock <- fromCBOR
+    mockCertVoters <- decodeNonEmptySet
+    pure
+      MockPerasCert
+        { mockCertRound
+        , mockCertBlock
+        , mockCertVoters
+        }
+   where
+    decodeNonEmptySet = do
+      xs <- fromCBOR
+      case NonEmpty.nonEmpty xs of
+        Nothing -> fail "Expected a non-empty set of PerasSeatIndex"
+        Just neSet -> pure (NESet.fromList neSet)
+
+instance
+  ( Typeable blk
+  , ToCBOR (Point blk)
+  ) =>
+  ToCBOR (MockPerasCert blk)
+  where
+  toCBOR
+    MockPerasCert
+      { mockCertRound
+      , mockCertBlock
+      , mockCertVoters
+      } =
+      encodeListLen 3
+        <> toCBOR mockCertRound
+        <> toCBOR mockCertBlock
+        <> toCBOR (NonEmpty.toList (NESet.toList mockCertVoters))
+
+instance
+  ConvertRawHash blk =>
+  SerialiseNodeToNode blk (MockPerasCert blk)
+  where
+  encodeNodeToNode
+    ccfg
+    version
+    MockPerasCert
+      { mockCertRound
+      , mockCertBlock
+      , mockCertVoters
+      } =
+      encodeListLen 3
+        <> encodeNodeToNode ccfg version mockCertRound
+        <> encodeNodeToNode ccfg version mockCertBlock
+        <> toCBOR (NonEmpty.toList (NESet.toList mockCertVoters))
+  decodeNodeToNode ccfg version = do
+    decodeListLenOf 3
+    mockCertRound <- decodeNodeToNode ccfg version
+    mockCertBlock <- decodeNodeToNode ccfg version
+    mockCertVoters <- decodeNodeToNodeNonEmptySet ccfg version
+    pure
+      MockPerasCert
+        { mockCertRound
+        , mockCertBlock
+        , mockCertVoters
+        }
+   where
+    decodeNodeToNodeNonEmptySet _ccfg _version = do
+      xs <- fromCBOR
+      case NonEmpty.nonEmpty xs of
+        Nothing -> fail "Expected a non-empty set of PerasSeatIndex"
+        Just neSet -> pure (NESet.fromList neSet)
+
+-- * Orphan instances
+
+-- NOTE: we need this to be able to derive a couple of other classes for
+-- 'NESet PerasSeatIndex'.
+deriving instance Generic (NESet a)

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Ouroboros/Consensus/Peras/Crypto/Mock.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Ouroboros/Consensus/Peras/Crypto/Mock.hs
@@ -1,0 +1,441 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE EmptyDataDeriving #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE InstanceSigs #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+-- | Mocked crypto for Peras.
+--
+-- This crypto scheme doesn't use any real cryptography, and should only be used
+-- for testing purposes. The only possible error thrown by this implementation
+-- is when a seat index is out of bounds for a given voting committee.
+module Ouroboros.Consensus.Peras.Crypto.Mock
+  ( -- * Mocked crypto for Peras
+    MockPerasVotingCommitteeScheme
+  , MockPerasCrypto
+  , VotingCommittee (..)
+  , VotingCommitteeInput (..)
+  , VotingCommitteeError (..)
+  , EligibilityWitness (..)
+  , Vote (..)
+  , Cert (..)
+
+    -- * Helpers
+  , seatIndexToInt
+  , unsafeIntToSeatIndex
+  , getEligibilityWitness
+  ) where
+
+import Cardano.Binary
+  ( FromCBOR (..)
+  , ToCBOR (..)
+  , decodeListLenOf
+  , encodeListLen
+  )
+import Cardano.Prelude (Bifunctor (second))
+import Control.Exception.Base (Exception)
+import Data.Either.Extra (maybeToEither)
+import qualified Data.List as List
+import Data.List.Extra ((!?))
+import Data.List.NonEmpty (NonEmpty)
+import qualified Data.List.NonEmpty as NonEmpty
+import qualified Data.Set.NonEmpty as NESet
+import Data.Typeable (Typeable)
+import Data.Word (Word16)
+import GHC.Generics (Generic)
+import NoThunks.Class (NoThunks)
+import Ouroboros.Consensus.Block.Abstract (Point, StandardHash)
+import Ouroboros.Consensus.Committee.Class
+  ( CryptoSupportsVotingCommittee (..)
+  , VotingCommittee
+  , getElectionIdFromVotes
+  , getRawVotes
+  , getVoteCandidateFromVotes
+  )
+import Ouroboros.Consensus.Committee.Crypto
+  ( CryptoSupportsAggregateVoteSigning (..)
+  , CryptoSupportsVoteSigning (..)
+  , ElectionId
+  , PrivateKey
+  , PublicKey
+  , VoteCandidate
+  )
+import Ouroboros.Consensus.Committee.Types (LedgerStake (..), PoolId)
+import Ouroboros.Consensus.Peras.Cert.Mock (MockPerasCert (..))
+import Ouroboros.Consensus.Peras.Types
+  ( PerasRoundNo
+  , PerasSeatIndex (..)
+  , VoteWeight (..)
+  )
+import Ouroboros.Consensus.Peras.Vote.Mock (MockPerasVote (..))
+import Ouroboros.Consensus.Peras.Voting.Adapter
+  ( PerasCertCompatibleWithVotingCommittee (..)
+  , PerasVoteCompatibleWithVotingCommittee (..)
+  )
+
+-- * | A mock crypto scheme for Peras.
+
+-- | A mock crypto scheme for Peras
+data MockPerasCrypto blk
+  deriving (Show, Eq, Generic, NoThunks)
+
+type instance ElectionId (MockPerasCrypto blk) = PerasRoundNo
+type instance VoteCandidate (MockPerasCrypto blk) = Point blk
+
+type instance PrivateKey (MockPerasCrypto blk) = ()
+type instance PublicKey (MockPerasCrypto blk) = ()
+
+instance CryptoSupportsVoteSigning (MockPerasCrypto blk) where
+  type VoteSigningKey (MockPerasCrypto blk) = ()
+  type VoteVerificationKey (MockPerasCrypto blk) = ()
+  data VoteSignature (MockPerasCrypto blk) = MockVoteSignature
+  getVoteSigningKey _proxy privateKey = privateKey
+  getVoteVerificationKey _proxy publicKey = publicKey
+  signVote _ _ _ = MockVoteSignature
+  verifyVoteSignature _ _ _ _ = Right ()
+
+instance CryptoSupportsAggregateVoteSigning (MockPerasCrypto blk) where
+  type AggregateVoteSignature (MockPerasCrypto blk) = ()
+  type AggregateVoteVerificationKey (MockPerasCrypto blk) = ()
+  aggregateVoteSignatures _ _ = Right ()
+  verifyAggregateVoteSignature _ _ _ _ _ = Right ()
+  aggregateVoteVerificationKeys _ _ = Right ()
+
+-- | A mock voting committee scheme for Peras
+data MockPerasVotingCommitteeScheme blk
+  deriving (Show, Eq, Generic, NoThunks)
+
+newtype instance VotingCommittee crypto (MockPerasVotingCommitteeScheme blk)
+  = MockPerasVotingCommittee
+  { -- Stake distribution
+    weightDistr :: NonEmpty (PoolId, VoteWeight)
+  }
+
+instance
+  ( Ord (ElectionId crypto)
+  , ElectionId crypto ~ PerasRoundNo
+  , VoteCandidate crypto ~ Point blk
+  , CryptoSupportsAggregateVoteSigning crypto
+  ) =>
+  CryptoSupportsVotingCommittee crypto (MockPerasVotingCommitteeScheme blk)
+  where
+  newtype VotingCommitteeInput crypto (MockPerasVotingCommitteeScheme blk)
+    = MockPerasVotingCommitteeInput (NonEmpty (PoolId, LedgerStake))
+
+  newtype VotingCommitteeError crypto (MockPerasVotingCommitteeScheme blk)
+    = -- Seat index is out of bounds for the voting committee
+      MissingSeatIndex PerasSeatIndex
+
+  data EligibilityWitness crypto (MockPerasVotingCommitteeScheme blk)
+    = MockPerasVotingCommitteeSchemeMember
+        !PerasSeatIndex
+        !VoteWeight
+
+  newtype Vote crypto (MockPerasVotingCommitteeScheme blk)
+    = MockPerasVotingCommitteeSchemeVote (MockPerasVote blk)
+
+  newtype Cert crypto (MockPerasVotingCommitteeScheme blk)
+    = MockPerasVotingCommitteeSchemeCert (MockPerasCert blk)
+
+  mkVotingCommittee (MockPerasVotingCommitteeInput stakeDistr) =
+    Right
+      MockPerasVotingCommittee
+        { weightDistr = second normalize <$> stakeDistr
+        }
+   where
+    LedgerStake totalStake = sum (snd <$> stakeDistr)
+    normalize (LedgerStake stake)
+      | totalStake == 0 = 0
+      | otherwise = VoteWeight (stake / totalStake)
+
+  checkShouldVote MockPerasVotingCommittee{weightDistr} poolId _ _ =
+    case findWithIndex (\(pid, _) -> pid == poolId) weightDistr of
+      Just (rawIndex, (_pid, voteWeight)) ->
+        Right . Just $
+          MockPerasVotingCommitteeSchemeMember
+            (unsafeIntToSeatIndex rawIndex)
+            voteWeight
+      _ ->
+        Right Nothing
+   where
+    findWithIndex :: (a -> Bool) -> NonEmpty a -> Maybe (Int, a)
+    findWithIndex p xs = List.find (p . snd) (zip [0 ..] (NonEmpty.toList xs))
+
+  forgeVote (MockPerasVotingCommitteeSchemeMember seatIndex _) _ roundNo block =
+    MockPerasVotingCommitteeSchemeVote $
+      MockPerasVote
+        { mockVoteRound = roundNo
+        , mockVoteBlock = block
+        , mockVoteSeatIndex = seatIndex
+        }
+
+  verifyVote
+    MockPerasVotingCommittee{weightDistr}
+    (MockPerasVotingCommitteeSchemeVote mockVote) =
+      case NonEmpty.toList weightDistr !? seatIndexToInt seatIndex of
+        Just (_pid, voteWeight) ->
+          Right (MockPerasVotingCommitteeSchemeMember seatIndex voteWeight)
+        _ ->
+          Left (MissingSeatIndex seatIndex)
+     where
+      seatIndex = mockVoteSeatIndex mockVote
+
+  eligiblePartyVoteWeight
+    _
+    (MockPerasVotingCommitteeSchemeMember _seatIndex voteWeight) =
+      voteWeight
+
+  forgeCert uniqueVoteWithSameTarget = do
+    pure $
+      MockPerasVotingCommitteeSchemeCert $
+        MockPerasCert
+          { mockCertRound = roundNo
+          , mockCertBlock = block
+          , mockCertVoters = voters
+          }
+   where
+    roundNo = getElectionIdFromVotes uniqueVoteWithSameTarget
+    block = getVoteCandidateFromVotes uniqueVoteWithSameTarget
+    rawVotes = getRawVotes uniqueVoteWithSameTarget
+    voters = NESet.fromList (getSeatIndex <$> rawVotes)
+    getSeatIndex (MockPerasVotingCommitteeSchemeVote mockVote) =
+      mockVoteSeatIndex mockVote
+
+  verifyCert committee (MockPerasVotingCommitteeSchemeCert mockCert) =
+    traverse getProof voterList
+   where
+    voterList = NESet.toList (mockCertVoters mockCert)
+    getProof seatIndex =
+      maybeToEither (MissingSeatIndex seatIndex) $
+        getEligibilityWitness committee seatIndex
+
+  voteTarget
+    ( MockPerasVotingCommitteeSchemeVote
+        MockPerasVote{mockVoteRound, mockVoteBlock}
+      ) =
+      (mockVoteRound, mockVoteBlock)
+
+  compareVotesById
+    ( MockPerasVotingCommitteeSchemeVote
+        MockPerasVote
+          { mockVoteRound = mockVoteRound1
+          , mockVoteSeatIndex = mockVoteSeatIndex1
+          }
+      )
+    ( MockPerasVotingCommitteeSchemeVote
+        MockPerasVote
+          { mockVoteRound = mockVoteRound2
+          , mockVoteSeatIndex = mockVoteSeatIndex2
+          }
+      ) =
+      compare
+        (mockVoteRound1, mockVoteSeatIndex1)
+        (mockVoteRound2, mockVoteSeatIndex2)
+
+deriving newtype instance
+  Show (VotingCommittee crypto (MockPerasVotingCommitteeScheme blk))
+deriving newtype instance
+  Eq (VotingCommittee crypto (MockPerasVotingCommitteeScheme blk))
+deriving newtype instance
+  NoThunks (VotingCommittee crypto (MockPerasVotingCommitteeScheme blk))
+deriving newtype instance
+  Generic (VotingCommittee crypto (MockPerasVotingCommitteeScheme blk))
+
+deriving instance
+  Show (VotingCommitteeInput crypto (MockPerasVotingCommitteeScheme blk))
+deriving instance
+  Eq (VotingCommitteeInput crypto (MockPerasVotingCommitteeScheme blk))
+deriving newtype instance
+  NoThunks (VotingCommitteeInput crypto (MockPerasVotingCommitteeScheme blk))
+deriving newtype instance
+  Generic (VotingCommitteeInput crypto (MockPerasVotingCommitteeScheme blk))
+
+deriving newtype instance
+  Show (VotingCommitteeError crypto (MockPerasVotingCommitteeScheme blk))
+deriving newtype instance
+  Eq (VotingCommitteeError crypto (MockPerasVotingCommitteeScheme blk))
+deriving newtype instance
+  NoThunks (VotingCommitteeError crypto (MockPerasVotingCommitteeScheme blk))
+deriving newtype instance
+  Generic (VotingCommitteeError crypto (MockPerasVotingCommitteeScheme blk))
+deriving anyclass instance
+  ( Typeable crypto
+  , Typeable blk
+  ) =>
+  Exception (VotingCommitteeError crypto (MockPerasVotingCommitteeScheme blk))
+
+deriving newtype instance
+  StandardHash blk =>
+  Show (Vote crypto (MockPerasVotingCommitteeScheme blk))
+deriving newtype instance
+  StandardHash blk =>
+  Eq (Vote crypto (MockPerasVotingCommitteeScheme blk))
+deriving newtype instance
+  StandardHash blk =>
+  NoThunks (Vote crypto (MockPerasVotingCommitteeScheme blk))
+deriving newtype instance
+  Generic (Vote crypto (MockPerasVotingCommitteeScheme blk))
+
+deriving newtype instance
+  StandardHash blk =>
+  Show (Cert crypto (MockPerasVotingCommitteeScheme blk))
+deriving newtype instance
+  StandardHash blk =>
+  Eq (Cert crypto (MockPerasVotingCommitteeScheme blk))
+deriving newtype instance
+  StandardHash blk =>
+  NoThunks (Cert crypto (MockPerasVotingCommitteeScheme blk))
+deriving newtype instance
+  Generic (Cert crypto (MockPerasVotingCommitteeScheme blk))
+
+deriving instance
+  Show (EligibilityWitness crypto (MockPerasVotingCommitteeScheme blk))
+deriving instance
+  Eq (EligibilityWitness crypto (MockPerasVotingCommitteeScheme blk))
+deriving instance
+  NoThunks (EligibilityWitness crypto (MockPerasVotingCommitteeScheme blk))
+deriving instance
+  Generic (EligibilityWitness crypto (MockPerasVotingCommitteeScheme blk))
+
+instance
+  PerasVoteCompatibleWithVotingCommittee
+    (MockPerasVote blk)
+    (MockPerasCrypto blk)
+    (MockPerasVotingCommitteeScheme blk)
+  where
+  toPerasVote (MockPerasVotingCommitteeSchemeVote mockVote) =
+    Right mockVote
+  fromPerasVote mockVote =
+    Right (MockPerasVotingCommitteeSchemeVote mockVote)
+
+instance
+  PerasCertCompatibleWithVotingCommittee
+    (MockPerasCert blk)
+    (MockPerasCrypto blk)
+    (MockPerasVotingCommitteeScheme blk)
+  where
+  toPerasCert (MockPerasVotingCommitteeSchemeCert mockCert) =
+    Right mockCert
+  fromPerasCert mockCert =
+    Right (MockPerasVotingCommitteeSchemeCert mockCert)
+
+-- * FromCBOR / ToCBOR instances
+
+deriving newtype instance
+  ( Typeable crypto
+  , Typeable blk
+  ) =>
+  FromCBOR (VotingCommittee crypto (MockPerasVotingCommitteeScheme blk))
+
+deriving newtype instance
+  ( Typeable crypto
+  , Typeable blk
+  ) =>
+  ToCBOR (VotingCommittee crypto (MockPerasVotingCommitteeScheme blk))
+
+deriving newtype instance
+  ( Typeable crypto
+  , Typeable blk
+  ) =>
+  FromCBOR (VotingCommitteeInput crypto (MockPerasVotingCommitteeScheme blk))
+
+deriving newtype instance
+  ( Typeable crypto
+  , Typeable blk
+  ) =>
+  ToCBOR (VotingCommitteeInput crypto (MockPerasVotingCommitteeScheme blk))
+
+deriving newtype instance
+  ( Typeable crypto
+  , Typeable blk
+  ) =>
+  FromCBOR (VotingCommitteeError crypto (MockPerasVotingCommitteeScheme blk))
+
+deriving newtype instance
+  ( Typeable crypto
+  , Typeable blk
+  ) =>
+  ToCBOR (VotingCommitteeError crypto (MockPerasVotingCommitteeScheme blk))
+
+instance
+  ( Typeable crypto
+  , Typeable blk
+  ) =>
+  FromCBOR (EligibilityWitness crypto (MockPerasVotingCommitteeScheme blk))
+  where
+  fromCBOR = do
+    decodeListLenOf 2
+    seatIndex <- fromCBOR
+    voteWeight <- fromCBOR
+    pure (MockPerasVotingCommitteeSchemeMember seatIndex voteWeight)
+
+instance
+  ( Typeable crypto
+  , Typeable blk
+  ) =>
+  ToCBOR (EligibilityWitness crypto (MockPerasVotingCommitteeScheme blk))
+  where
+  toCBOR (MockPerasVotingCommitteeSchemeMember seatIndex voteWeight) =
+    encodeListLen 2
+      <> toCBOR seatIndex
+      <> toCBOR voteWeight
+
+deriving newtype instance
+  ( Typeable crypto
+  , Typeable blk
+  , FromCBOR (Point blk)
+  ) =>
+  FromCBOR (Vote crypto (MockPerasVotingCommitteeScheme blk))
+
+deriving newtype instance
+  ( Typeable crypto
+  , Typeable blk
+  , ToCBOR (Point blk)
+  ) =>
+  ToCBOR (Vote crypto (MockPerasVotingCommitteeScheme blk))
+
+deriving newtype instance
+  ( Typeable crypto
+  , Typeable blk
+  , FromCBOR (Point blk)
+  ) =>
+  FromCBOR (Cert crypto (MockPerasVotingCommitteeScheme blk))
+
+deriving newtype instance
+  ( Typeable crypto
+  , Typeable blk
+  , ToCBOR (Point blk)
+  ) =>
+  ToCBOR (Cert crypto (MockPerasVotingCommitteeScheme blk))
+
+-- * Helpers
+
+seatIndexToInt :: PerasSeatIndex -> Int
+seatIndexToInt (PerasSeatIndex seatIndex) =
+  fromIntegral @Word16 @Int seatIndex
+
+unsafeIntToSeatIndex :: Int -> PerasSeatIndex
+unsafeIntToSeatIndex int
+  | int >= 0 && int <= fromIntegral @Word16 @Int maxBound =
+      PerasSeatIndex (fromIntegral @Int @Word16 int)
+  | otherwise =
+      error $ "unsafeIntToSeatIndex: Int out of bounds for PerasSeatIndex: " <> show int
+
+getEligibilityWitness ::
+  VotingCommittee crypto (MockPerasVotingCommitteeScheme blk) ->
+  PerasSeatIndex ->
+  Maybe (EligibilityWitness crypto (MockPerasVotingCommitteeScheme blk))
+getEligibilityWitness MockPerasVotingCommittee{weightDistr} seatIndex = do
+  (_poolId, voteWeight) <- NonEmpty.toList weightDistr !? seatIndexToInt seatIndex
+  pure $ MockPerasVotingCommitteeSchemeMember seatIndex voteWeight

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Ouroboros/Consensus/Peras/Vote/Mock.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Ouroboros/Consensus/Peras/Vote/Mock.hs
@@ -1,0 +1,128 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+-- | Mocked Peras votes without crypto.
+module Ouroboros.Consensus.Peras.Vote.Mock
+  ( MockPerasVote (..)
+  ) where
+
+import Cardano.Binary (FromCBOR (..), ToCBOR (..), decodeListLenOf, encodeListLen)
+import Control.DeepSeq (NFData)
+import Data.Data (Proxy (..))
+import Data.Typeable (Typeable)
+import GHC.Generics (Generic)
+import NoThunks.Class (NoThunks)
+import Ouroboros.Consensus.Block.Abstract
+  ( ConvertRawHash
+  , Point
+  , StandardHash
+  )
+import Ouroboros.Consensus.Node.Serialisation (SerialiseNodeToNode (..))
+import Ouroboros.Consensus.Peras.Types
+  ( BoostedBlock
+  , PerasRoundNo
+  , PerasSeatIndex (..)
+  )
+import Ouroboros.Consensus.Peras.Vote.Class (IsPerasVote (..))
+import Ouroboros.Consensus.Util (ShowProxy)
+import Ouroboros.Network.Util (ShowProxy (..))
+
+-- | Mocked Peras votes without crypto.
+--
+-- NOTE: this is parameterized around the concrete block type being voted for.
+data MockPerasVote blk
+  = MockPerasVote
+  { mockVoteRound :: PerasRoundNo
+  , mockVoteBlock :: Point blk
+  , mockVoteSeatIndex :: PerasSeatIndex
+  }
+
+deriving instance StandardHash blk => Show (MockPerasVote blk)
+deriving instance StandardHash blk => Eq (MockPerasVote blk)
+deriving instance StandardHash blk => Ord (MockPerasVote blk)
+deriving instance StandardHash blk => NoThunks (MockPerasVote blk)
+deriving instance StandardHash blk => NFData (MockPerasVote blk)
+deriving instance Generic (MockPerasVote blk)
+
+type instance BoostedBlock (MockPerasVote blk) = Point blk
+
+instance IsPerasVote (MockPerasVote blk) blk where
+  getPerasVoteRound = mockVoteRound
+  getPerasVoteBlock = mockVoteBlock
+  getPerasVoteSeatIndex = mockVoteSeatIndex
+
+instance ShowProxy blk => ShowProxy (MockPerasVote blk) where
+  showProxy _ = "MockPerasVote(" <> showProxy (Proxy @blk) <> ")"
+
+instance
+  ( Typeable blk
+  , FromCBOR (Point blk)
+  ) =>
+  FromCBOR (MockPerasVote blk)
+  where
+  fromCBOR = do
+    decodeListLenOf 3
+    mockVoteRound <- fromCBOR
+    mockVoteBlock <- fromCBOR
+    mockVoteSeatIndex <- fromCBOR
+    pure
+      MockPerasVote
+        { mockVoteRound
+        , mockVoteBlock
+        , mockVoteSeatIndex
+        }
+
+instance
+  ( Typeable blk
+  , ToCBOR (Point blk)
+  ) =>
+  ToCBOR (MockPerasVote blk)
+  where
+  toCBOR
+    MockPerasVote
+      { mockVoteRound
+      , mockVoteBlock
+      , mockVoteSeatIndex
+      } =
+      encodeListLen 3
+        <> toCBOR mockVoteRound
+        <> toCBOR mockVoteBlock
+        <> toCBOR mockVoteSeatIndex
+
+instance
+  ConvertRawHash blk =>
+  SerialiseNodeToNode blk (MockPerasVote blk)
+  where
+  encodeNodeToNode
+    ccfg
+    version
+    MockPerasVote
+      { mockVoteRound
+      , mockVoteBlock
+      , mockVoteSeatIndex
+      } =
+      encodeListLen 3
+        <> encodeNodeToNode ccfg version mockVoteRound
+        <> encodeNodeToNode ccfg version mockVoteBlock
+        <> encodeNodeToNode ccfg version mockVoteSeatIndex
+  decodeNodeToNode ccfg version = do
+    decodeListLenOf 3
+    mockVoteRound <- decodeNodeToNode ccfg version
+    mockVoteBlock <- decodeNodeToNode ccfg version
+    mockVoteSeatIndex <- decodeNodeToNode ccfg version
+    pure
+      MockPerasVote
+        { mockVoteRound
+        , mockVoteBlock
+        , mockVoteSeatIndex
+        }


### PR DESCRIPTION
This commit introduces mocked (crypto-less) types for Peras votes, certificates, and a crypto scheme compatible with those. These are all meant to be used in the future for non-production block types that should have some limited Peras support.