### PR TITLE
LeiosNotify: accept but ignore proper MsgLeiosBlockAnnouncement messages

### DIFF
--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToNode.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToNode.hs
@@ -148,7 +148,11 @@ import Ouroboros.Consensus.Node.Serialisation
 import qualified Ouroboros.Consensus.Node.Tracers as Node
 import Ouroboros.Consensus.NodeKernel
 import qualified Ouroboros.Consensus.Storage.ChainDB.API as ChainDB
-import Ouroboros.Consensus.Storage.LedgerDB.Forker (ResolveLeiosBlock)
+import Ouroboros.Consensus.Storage.LedgerDB.Forker
+  ( ResolveLeiosBlock
+  , headerContainsLeiosCert
+  , headerLeiosAnnouncement
+  )
 import Ouroboros.Consensus.Storage.Serialisation (SerialisedHeader)
 import Ouroboros.Consensus.Util (ShowProxy)
 import Ouroboros.Consensus.Util.IOLike
@@ -317,11 +321,11 @@ data Handlers m addr blk = Handlers
       ControlMessageSTM m ->
       ConnectionId addr ->
       Leios.LeiosPeerVars m ->
-      LeiosNotifyClientPeerPipelined LeiosPoint () LeiosVote m ()
+      LeiosNotifyClientPeerPipelined LeiosPoint (Header blk) LeiosVote m ()
   , hLeiosNotifyServer ::
       NodeToNodeVersion ->
       ConnectionId addr ->
-      LeiosNotifyServerPeer LeiosPoint () LeiosVote m ()
+      LeiosNotifyServerPeer LeiosPoint (Header blk) LeiosVote m ()
   , hLeiosFetchClient ::
       LeiosDbConnection m ->
       NodeToNodeVersion ->
@@ -456,7 +460,19 @@ mkHandlers
                   _ -> Right 100 {- TODO magic number -}
               )
               ( pure $ \case
-                  MsgLeiosBlockAnnouncement{} -> error "Demo does not send EB announcements!"
+                  MsgLeiosBlockAnnouncement hdr -> do
+                    traceWith tracer $
+                      MkTraceLeiosPeer $
+                        unwords
+                          [ "MsgLeiosBlockAnnouncement"
+                          , "(ignored)"
+                          , show (headerPoint hdr)
+                          , "containsCert=" <> show (headerContainsLeiosCert hdr)
+                          , "announcedEb=" <> case headerLeiosAnnouncement hdr of
+                              Nothing -> "none"
+                              Just (ebPoint, ebSize) ->
+                                Leios.prettyEbHash (Leios.pointEbHash ebPoint) <> " size=" <> show ebSize
+                          ]
                   MsgLeiosBlockOffer point ebBytesSize -> do
                     traceWith tracer $ MkTraceLeiosPeer $ "MsgLeiosBlockOffer " <> Leios.prettyLeiosPoint point
                     let MkLeiosPoint{pointEbHash = ebHash} = point
@@ -519,7 +535,7 @@ mkHandlers
                 STM
                   m
                   ( LeiosDemoOnlyTestNotify.Message
-                      (LeiosNotify LeiosPoint () LeiosVote)
+                      (LeiosNotify LeiosPoint (Header blk) LeiosVote)
                       LeiosDemoOnlyTestNotify.StBusy
                       LeiosDemoOnlyTestNotify.StIdle
                   )
@@ -535,7 +551,7 @@ mkHandlers
                 STM
                   m
                   ( LeiosDemoOnlyTestNotify.Message
-                      (LeiosNotify LeiosPoint () LeiosVote)
+                      (LeiosNotify LeiosPoint (Header blk) LeiosVote)
                       LeiosDemoOnlyTestNotify.StBusy
                       LeiosDemoOnlyTestNotify.StIdle
                   )
@@ -597,7 +613,7 @@ data Codecs blk addr e m bCS bSCS bBF bSBF bTX bKA bPS bLN bLF = Codecs
   , cTxSubmission2Codec :: Codec (TxSubmission2 (GenTxId blk) (GenTx blk)) e m bTX
   , cKeepAliveCodec :: Codec KeepAlive e m bKA
   , cPeerSharingCodec :: Codec (PeerSharing addr) e m bPS
-  , cLeiosNotifyCodec :: Codec (LeiosNotify LeiosPoint () LeiosVote) e m bLN
+  , cLeiosNotifyCodec :: Codec (LeiosNotify LeiosPoint (Header blk) LeiosVote) e m bLN
   , cLeiosFetchCodec :: Codec (LeiosFetch LeiosPoint LeiosEb LeiosTx) e m bLF
   }
 
@@ -668,8 +684,8 @@ defaultCodecs ccfg version encAddr decAddr nodeToNodeVersion =
         codecLeiosNotify
           Leios.encodeLeiosPoint
           Leios.decodeLeiosPoint
-          (\() -> CBOR.encodeNull)
-          CBOR.decodeNull
+          enc
+          dec
           Leios.encodeLeiosVote
           Leios.decodeLeiosVote
     , cLeiosFetchCodec =
@@ -706,7 +722,7 @@ identityCodecs ::
     (AnyMessage (TxSubmission2 (GenTxId blk) (GenTx blk)))
     (AnyMessage KeepAlive)
     (AnyMessage (PeerSharing addr))
-    (AnyMessage (LeiosNotify LeiosPoint () LeiosVote))
+    (AnyMessage (LeiosNotify LeiosPoint (Header blk) LeiosVote))
     (AnyMessage (LeiosFetch LeiosPoint LeiosEb LeiosTx))
 identityCodecs =
   Codecs
@@ -743,7 +759,7 @@ data Tracers' peer ntnAddr blk e f = Tracers
   , tPeerSharingTracer :: f (TraceLabelPeer peer (TraceSendRecv (PeerSharing ntnAddr)))
   , tTxLogicTracer :: f (TraceLabelPeer peer (TraceTxLogic peer (GenTxId blk) (GenTx blk)))
   , tLeiosNotifyTracer ::
-      f (TraceLabelPeer peer (TraceSendRecv (LeiosNotify LeiosPoint () LeiosVote)))
+      f (TraceLabelPeer peer (TraceSendRecv (LeiosNotify LeiosPoint (Header blk) LeiosVote)))
   , tLeiosFetchTracer ::
       f (TraceLabelPeer peer (TraceSendRecv (LeiosFetch LeiosPoint LeiosEb LeiosTx)))
   }

--- a/ouroboros-consensus-diffusion/src/unstable-diffusion-testlib/Test/ThreadNet/Network.hs
+++ b/ouroboros-consensus-diffusion/src/unstable-diffusion-testlib/Test/ThreadNet/Network.hs
@@ -1242,7 +1242,7 @@ runThreadNetwork
         (AnyMessage (TxSubmission2 (GenTxId blk) (GenTx blk)))
         (AnyMessage KeepAlive)
         (AnyMessage (PeerSharing NodeId))
-        (AnyMessage (LeiosNotify LeiosDemoTypes.LeiosPoint () LeiosDemoTypes.LeiosVote))
+        (AnyMessage (LeiosNotify LeiosDemoTypes.LeiosPoint (Header blk) LeiosDemoTypes.LeiosVote))
         (AnyMessage (LeiosFetch LeiosDemoTypes.LeiosPoint LeiosDemoTypes.LeiosEb LeiosDemoTypes.LeiosTx))
     customNodeToNodeCodecs cfg ntnVersion =
       NTN.Codecs
@@ -1903,7 +1903,7 @@ type LimitedApp' m addr blk =
     (AnyMessage (TxSubmission2 (GenTxId blk) (GenTx blk)))
     (AnyMessage KeepAlive)
     (AnyMessage (PeerSharing addr))
-    (AnyMessage (LeiosNotify LeiosDemoTypes.LeiosPoint () LeiosDemoTypes.LeiosVote))
+    (AnyMessage (LeiosNotify LeiosDemoTypes.LeiosPoint (Header blk) LeiosDemoTypes.LeiosVote))
     (AnyMessage (LeiosFetch LeiosDemoTypes.LeiosPoint LeiosDemoTypes.LeiosEb LeiosDemoTypes.LeiosTx))
     NodeToNodeInitiatorResult
     ()

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoTypes.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoTypes.hs
@@ -780,7 +780,7 @@ class HasLeiosVoting blk where
 -- * Tracing
 
 messageLeiosNotifyToObject ::
-  Message (LeiosNotify LeiosPoint () LeiosVote) st st' ->
+  Message (LeiosNotify LeiosPoint announcement LeiosVote) st st' ->
   Aeson.Object
 messageLeiosNotifyToObject = \case
   MsgLeiosNotificationRequestNext ->


### PR DESCRIPTION
- Payload is now Header blk instead of ().
- Handler merely traces a message with the header's Point instead of throwing an error.

This PR makes a tiny change that will allow use to run the much more significant patch in PR https://github.com/IntersectMBO/ouroboros-consensus/pull/2132 in the testnet without constant disconnections, which is desirable for validating that PR before merging it.