### PR TITLE
Fix EB diffusion of already complete closures

### DIFF
--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/HFEras.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/HFEras.hs
@@ -85,9 +85,8 @@ instance Praos.PraosCrypto c => ShelleyCompatible (Praos c) BabbageEra
 
 instance Praos.PraosCrypto c => ShelleyCompatible (Praos c) ConwayEra
 
-instance Praos.PraosCrypto c => ShelleyCompatible (Praos c) DijkstraEra
-  where
-    workaroundLedgerIssue5937 = encodeShelleyBlockWorkaroundLedgerIssue5937
+instance Praos.PraosCrypto c => ShelleyCompatible (Praos c) DijkstraEra where
+  workaroundLedgerIssue5937 = encodeShelleyBlockWorkaroundLedgerIssue5937
 
 instance Crypto c => DijkstraEraBlockHeader (Header c) DijkstraEra where
   prevNonceBlockHeaderL = error "Not implemented. Peras placeholder"

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Forge.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Forge.hs
@@ -187,7 +187,7 @@ forgeShelleyBlock hotKey cbl ForgeBlockArgs{..} = do
           , mempoolRestMeasure = ByteSize32 0
           }
       leiosDbInsertEbPoint fbLeiosDb ebPoint ebSize
-      leiosDbInsertEbBody fbLeiosDb ebPoint forgedEb.body
+      void $ leiosDbInsertEbBody fbLeiosDb ebPoint forgedEb.body
       void $ leiosDbInsertTxs fbLeiosDb forgedEb.txClosure
       traceWith fbLeiosTracer $
         TraceLeiosBlockStored

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/ImmDBServer/Diffusion.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/ImmDBServer/Diffusion.hs
@@ -100,6 +100,7 @@ run ::
   forall blk.
   ( GetPrevHash blk
   , ShowProxy blk
+  , ShowProxy (Header blk)
   , SupportedNetworkProtocolVersion blk
   , SerialiseNodeToNodeConstraints blk
   , ImmutableDB.ImmutableDbSerialiseConstraints blk

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/ImmDBServer/MiniProtocols.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/ImmDBServer/MiniProtocols.hs
@@ -105,6 +105,7 @@ immDBServer ::
   ( IOLike m
   , HasHeader blk
   , ShowProxy blk
+  , ShowProxy (Header blk)
   , SerialiseNodeToNodeConstraints blk
   , Show addr
   , SupportedNetworkProtocolVersion blk

--- a/ouroboros-consensus-cardano/test/cardano-test/Test/ThreadNet/Leios.hs
+++ b/ouroboros-consensus-cardano/test/cardano-test/Test/ThreadNet/Leios.hs
@@ -56,8 +56,8 @@ import Control.Monad.IOSim (Time, runSimOrThrow)
 import qualified Control.Tracer as Tracer
 import Data.Foldable (toList)
 import Data.Function ((&))
-import Data.List (isInfixOf, sortOn)
 import Data.Functor.Identity (runIdentity)
+import Data.List (isInfixOf, sortOn)
 import Data.Map (Map)
 import qualified Data.Map.Strict as Map
 import Data.Maybe (isNothing, mapMaybe)
@@ -403,7 +403,8 @@ prop_leios seed =
         -- the protocol's own diffusion assumption.
         length forgedPointsToDiffuse === length acquiredPointsToDiffuse
           & counterexample "endorser blocks not fully diffused"
-          & counterexample (missingEbTimelines testOutput.allTracesWithTime forgedPointsToDiffuse acquiredPointsToDiffuse)
+          & counterexample
+            (missingEbTimelines testOutput.allTracesWithTime forgedPointsToDiffuse acquiredPointsToDiffuse)
           & prettyCounterexampleList "acquired leios EBs (diffusion required)" 120 acquiredPointsToDiffuse
           & prettyCounterexampleList "forged leios EBs (diffusion required)" 120 forgedPointsToDiffuse
           & prettyCounterexampleList "acquired leios EBs (all)" 120 acquiredPoints

--- a/ouroboros-consensus-cardano/test/cardano-test/Test/ThreadNet/Leios.hs
+++ b/ouroboros-consensus-cardano/test/cardano-test/Test/ThreadNet/Leios.hs
@@ -52,10 +52,11 @@ import qualified Control.Concurrent.Class.MonadSTM.Strict.TVar as StrictTVar
 import Control.DeepSeq (force)
 import Control.Exception (SomeException, evaluate, try)
 import Control.Monad (foldM, replicateM)
-import Control.Monad.IOSim (runSimOrThrow)
+import Control.Monad.IOSim (Time, runSimOrThrow)
 import qualified Control.Tracer as Tracer
 import Data.Foldable (toList)
 import Data.Function ((&))
+import Data.List (isInfixOf, sortOn)
 import Data.Functor.Identity (runIdentity)
 import Data.Map (Map)
 import qualified Data.Map.Strict as Map
@@ -75,6 +76,8 @@ import LeiosDemoTypes
   , TraceLeiosKernel (..)
   , hashLeiosEb
   , minCertificationGap
+  , prettyEbHash
+  , prettyLeiosPoint
   )
 import Lens.Micro ((%~), (^.))
 import Ouroboros.Consensus.Block (SlotNo (..), blockSlot, getHeader)
@@ -250,6 +253,17 @@ prop_leios seed =
     TraceLeiosBlockTxsAcquired point -> Just point
     _ -> Nothing
 
+  -- An EB forged at slot @s@ is required to diffuse iff it has at least
+  -- 'minCertificationGap' slots to propagate before the sim ends, i.e.
+  -- @s + minCertificationGap <= numSlots@. 'minCertificationGap' will
+  -- eventually be a protocol parameter capturing the worst case diffusion
+  -- time; the property therefore assumes it is sufficient by definition.
+  diffusionRequired point =
+    unSlotNo point.pointSlotNo + minCertificationGap <= numSlots
+
+  forgedPointsToDiffuse = Set.filter diffusionRequired forgedPoints
+  acquiredPointsToDiffuse = Set.filter diffusionRequired acquiredPoints
+
   propVoting =
     conjoin
       [ length castVotes > 0
@@ -382,10 +396,18 @@ prop_leios seed =
           & counterexample "no endorser blocks were forged"
           & prettyCounterexampleMap "forged leios EBs" 120 forgedEBs
           & prettyCounterexampleList "leios kernel traces" 120 leiosTraces
-      , length forgedPoints === length acquiredPoints
+      , -- Only require diffusion for EBs forged early enough that they have
+        -- 'minCertificationGap' slots to propagate before the sim ends. In
+        -- Leios this gap will become a protocol parameter capturing the worst
+        -- case diffusion time; using it here keeps the property aligned with
+        -- the protocol's own diffusion assumption.
+        length forgedPointsToDiffuse === length acquiredPointsToDiffuse
           & counterexample "endorser blocks not fully diffused"
-          & prettyCounterexampleList "acquired leios EBs" 120 acquiredPoints
-          & prettyCounterexampleList "forged leios EBs" 120 forgedPoints
+          & counterexample (missingEbTimelines testOutput.allTracesWithTime forgedPointsToDiffuse acquiredPointsToDiffuse)
+          & prettyCounterexampleList "acquired leios EBs (diffusion required)" 120 acquiredPointsToDiffuse
+          & prettyCounterexampleList "forged leios EBs (diffusion required)" 120 forgedPointsToDiffuse
+          & prettyCounterexampleList "acquired leios EBs (all)" 120 acquiredPoints
+          & prettyCounterexampleList "forged leios EBs (all)" 120 forgedPoints
       ]
       & counterexample ("mempool total added: " <> show (length mempoolAddedTxs))
       & counterexample ("mempool total rejected: " <> show (length mempoolRejectedTxs))
@@ -903,6 +925,34 @@ indented n =
   unlines' [] = []
   unlines' [x] = x
   unlines' (x : xs) = x <> "\n" <> unlines' xs
+
+-- | For every EB that was required to diffuse but wasn't acquired, dump a
+-- time-ordered timeline of every trace event that mentions its hash, tagged by
+-- the emitting node. Intended purely as a diagnostic aid on failure — makes it
+-- possible to eyeball the diffusion pipeline (forge → announce → offer →
+-- fetch → txs-acquired) and see where the latency lives.
+missingEbTimelines ::
+  [(Time, TraceThreadNet (CardanoBlock StandardCrypto))] ->
+  Set.Set LeiosPoint ->
+  Set.Set LeiosPoint ->
+  String
+missingEbTimelines timedTraces required acquired
+  | Set.null missing = ""
+  | otherwise =
+      "missing EB diffusion timelines:\n" <> concatMap oneEb (Set.toAscList missing)
+ where
+  missing = required `Set.difference` acquired
+
+  oneEb point =
+    let hashHex = prettyEbHash point.pointEbHash
+        events = filter (\(_, ev) -> hashHex `isInfixOf` show ev) timedTraces
+     in "  "
+          <> prettyLeiosPoint point
+          <> "\n"
+          <> unlines
+            [ indented 4 (show t <> " " <> show ev)
+            | (t, ev) <- sortOn fst events
+            ]
 
 -- | Elide a string to a target length by keeping the prefix and suffix and
 -- replacing the middle with an ellipsis. If target length is 0 or negative, no

--- a/ouroboros-consensus-diffusion/src/unstable-diffusion-testlib/Test/ThreadNet/General.hs
+++ b/ouroboros-consensus-diffusion/src/unstable-diffusion-testlib/Test/ThreadNet/General.hs
@@ -40,6 +40,7 @@ import Control.Monad (guard)
 import Control.Monad.IOSim
   ( runSimTrace
   , selectTraceEventsDynamic
+  , selectTraceEventsDynamicWithTime
   , setCurrentTime
   , traceM
   , traceResult
@@ -254,6 +255,7 @@ runTestNetwork
       Right x ->
         x
           { allTraces = selectTraceEventsDynamic trace
+          , allTracesWithTime = selectTraceEventsDynamicWithTime trace
           , exceptionThrown = Nothing
           }
    where

--- a/ouroboros-consensus-diffusion/src/unstable-diffusion-testlib/Test/ThreadNet/Network.hs
+++ b/ouroboros-consensus-diffusion/src/unstable-diffusion-testlib/Test/ThreadNet/Network.hs
@@ -1739,6 +1739,10 @@ data TestOutput blk = TestOutput
   , testOutputTipBlockNos :: Map SlotNo (Map NodeId (WithOrigin BlockNo))
   , allTraces :: [TraceThreadNet blk]
   -- ^ All ThreadNet-level traces emitted during the run.
+  , allTracesWithTime :: [(Time, TraceThreadNet blk)]
+  -- ^ Same as 'allTraces' but paired with the simulated wall-clock time at
+  -- which each event fired. Useful for diagnosing timing-sensitive test
+  -- failures (e.g. diffusion latencies).
   , exceptionThrown :: Maybe SomeException
   -- ^ Captured exception if any thread threw and the test aborted.
   }
@@ -1834,6 +1838,7 @@ mkTestOutput vertexInfos = do
       { testOutputNodes = Map.unions nodeOutputs'
       , testOutputTipBlockNos = Map.unionsWith Map.union tipBlockNos'
       , allTraces = []
+      , allTracesWithTime = []
       , exceptionThrown = Nothing
       }
 

--- a/ouroboros-consensus/bench/leios-db-bench/Main.hs
+++ b/ouroboros-consensus/bench/leios-db-bench/Main.hs
@@ -273,7 +273,7 @@ insertOneEb conn ebIdx = do
         , let h = genTxHash ebIdx txIdx
         ]
   leiosDbInsertEbPoint conn point (leiosEbBytesSize eb)
-  leiosDbInsertEbBody conn point eb
+  _ <- leiosDbInsertEbBody conn point eb
   _ <- leiosDbInsertTxs conn txs
   pure ()
 

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoDb/Common.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoDb/Common.hs
@@ -102,10 +102,18 @@ data LeiosDbConnection m = LeiosDbConnection
   -- ^ Read the EB "body": the ordered list of tx-hash + tx-byte-size
   -- pairs that constitute this EB. No tx bytes are fetched; contrast
   -- with 'leiosDbLookupEbClosure' which joins with the 'txs' table.
-  , leiosDbInsertEbBody :: HasCallStack => LeiosPoint -> LeiosEb -> m ()
+  , leiosDbInsertEbBody :: HasCallStack => LeiosPoint -> LeiosEb -> m CompletedEbs
   -- ^ Persist an EB body. The point MUST already have been inserted
   -- via 'leiosDbInsertEbPoint' (announcement path). Yields an
   -- 'AcquiredEb' notification.
+  --
+  -- Returns any EBs whose closure just became complete because their body
+  -- landed after all their txs were already present in the DB (typical
+  -- when mempool-relayed txs beat the EB body). Those EBs also get an
+  -- 'AcquiredEbTxs' notification. Callers that need the trace-level
+  -- signal ('TraceLeiosBlockTxsAcquired') should emit it from this
+  -- result — for the common case where the body arrives first, the
+  -- returned list is empty.
   , leiosDbInsertTxs :: HasCallStack => [(TxHash, ByteString)] -> m CompletedEbs
   -- ^ Insert transactions into the global 'txs' table (INSERT OR IGNORE).
   -- After inserting, checks which EBs referencing these txs are now complete

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoDb/Common.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoDb/Common.hs
@@ -114,6 +114,8 @@ data LeiosDbConnection m = LeiosDbConnection
   -- signal ('TraceLeiosBlockTxsAcquired') should emit it from this
   -- result — for the common case where the body arrives first, the
   -- returned list is empty.
+  --
+  -- XXX: return type only used for tracing
   , leiosDbInsertTxs :: HasCallStack => [(TxHash, ByteString)] -> m CompletedEbs
   -- ^ Insert transactions into the global 'txs' table (INSERT OR IGNORE).
   -- After inserting, checks which EBs referencing these txs are now complete
@@ -123,7 +125,7 @@ data LeiosDbConnection m = LeiosDbConnection
   -- complete via multiple insert batches (e.g., if txs are inserted twice).
   -- Consumers should handle notifications idempotently.
   --
-  -- REVIEW: return type only used for tracing, necessary?
+  -- XXX: return type only used for tracing
   , leiosDbBatchRetrieveTxs :: HasCallStack => EbHash -> [Int] -> m [(Int, TxHash, Maybe ByteString)]
   , leiosDbFilterMissingEbBodies :: HasCallStack => [LeiosPoint] -> m [LeiosPoint]
   -- ^ Batch filter: returns the subset of input LeiosPoints whose EB bodies are missing.

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoDb/Common.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoDb/Common.hs
@@ -103,17 +103,13 @@ data LeiosDbConnection m = LeiosDbConnection
   -- pairs that constitute this EB. No tx bytes are fetched; contrast
   -- with 'leiosDbLookupEbClosure' which joins with the 'txs' table.
   , leiosDbInsertEbBody :: HasCallStack => LeiosPoint -> LeiosEb -> m CompletedEbs
-  -- ^ Persist an EB body. The point MUST already have been inserted
-  -- via 'leiosDbInsertEbPoint' (announcement path). Yields an
-  -- 'AcquiredEb' notification.
+  -- ^ Persist an EB body. The point MUST already have been inserted via
+  -- 'leiosDbInsertEbPoint' (announcement path). Yields an 'AcquiredEb'
+  -- notification.
   --
   -- Returns any EBs whose closure just became complete because their body
-  -- landed after all their txs were already present in the DB (typical
-  -- when mempool-relayed txs beat the EB body). Those EBs also get an
-  -- 'AcquiredEbTxs' notification. Callers that need the trace-level
-  -- signal ('TraceLeiosBlockTxsAcquired') should emit it from this
-  -- result — for the common case where the body arrives first, the
-  -- returned list is empty.
+  -- landed after all their txs were already present in the DB. Those EBs also
+  -- get an 'AcquiredEbTxs' notification.
   --
   -- XXX: return type only used for tracing
   , leiosDbInsertTxs :: HasCallStack => [(TxHash, ByteString)] -> m CompletedEbs

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoDb/InMemory.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoDb/InMemory.hs
@@ -161,7 +161,7 @@ imInsertEbBody ::
   StrictTChan m LeiosEbNotification ->
   LeiosPoint ->
   LeiosEb ->
-  m ()
+  m CompletedEbs
 imInsertEbBody stateVar notificationChan point eb = do
   let items = leiosEbBodyItems eb
       ebBytesSize = leiosEbBytesSize eb
@@ -191,6 +191,23 @@ imInsertEbBody stateVar notificationChan point eb = do
             Set.insert point (imEbBodiesDownloaded s)
         }
     writeTChan notificationChan $ AcquiredEb point ebBytesSize
+    -- If every tx referenced by this body is already present, the closure
+    -- is complete the moment the body lands — no subsequent
+    -- 'leiosDbInsertTxs' will fire for this point, so we must notify here.
+    -- Only trigger for a novel point ('imCompletedEbs' is our idempotency
+    -- guard). This mirrors what 'imInsertTxs' does when the last missing
+    -- tx of an already-downloaded body arrives.
+    state <- readTVar stateVar
+    let allTxsPresent =
+          all (\e -> Map.member (eteTxHash e) (imTxs state)) (IntMap.elems entries)
+        alreadyNotified = Set.member point (imCompletedEbs state)
+    if allTxsPresent && not alreadyNotified
+      then do
+        modifyTVar stateVar $ \s ->
+          s{imCompletedEbs = Set.insert point (imCompletedEbs s)}
+        writeTChan notificationChan (AcquiredEbTxs point)
+        pure [point]
+      else pure []
 
 imInsertTxs ::
   IOLike m =>

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoDb/SQLite.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoDb/SQLite.hs
@@ -275,13 +275,13 @@ sqlInsertEbBody ::
   (LeiosEbNotification -> IO ()) ->
   LeiosPoint ->
   LeiosEb ->
-  IO ()
-sqlInsertEbBody tracer Conn{connDb = db, connStmts = Stmts{stInsertEbTxsRow, stInitMissingCount}} notify point eb = do
+  IO CompletedEbs
+sqlInsertEbBody tracer Conn{connDb = db, connStmts = Stmts{stInsertEbTxsRow, stInitMissingCount, stFindCompleteEbs, stMarkNotifiedEbs}} notify point eb = do
   let items = leiosEbBodyItems eb
       ebBytesSize = leiosEbBytesSize eb
   when (null items) $
     error "leiosDbInsertEbBody: empty EB body (programmer error)"
-  dbWithBEGIN db $ do
+  completed <- dbWithBEGIN db $ do
     forM_ items $ \(txOffset, txHash, txBytesSize) -> useStmt stInsertEbTxsRow $ do
       dbBindBlob stInsertEbTxsRow 1 point.pointEbHash.ebHashBytes
       dbBindInt64 stInsertEbTxsRow 2 (fromIntegral txOffset)
@@ -298,7 +298,24 @@ sqlInsertEbBody tracer Conn{connDb = db, connStmts = Stmts{stInsertEbTxsRow, stI
       dbBindBlob stInitMissingCount 2 point.pointEbHash.ebHashBytes
       dbBindInt64 stInitMissingCount 3 (fromIntegral $ unSlotNo point.pointSlotNo)
       dbStep1 stInitMissingCount
+    -- If every referenced tx is already present, 'stInitMissingCount' just
+    -- set missingTxCount to 0 for this EB. No subsequent 'sqlInsertTxs'
+    -- will fire for this point, so drain the pending-completion set here
+    -- (mirrors what 'sqlInsertTxs' does after 'stDecrMissingCount').
+    completedNow <- useStmt stFindCompleteEbs $ do
+      let loop acc =
+            dbStep stFindCompleteEbs >>= \case
+              DB.Done -> pure (reverse acc)
+              DB.Row -> do
+                ebHash <- MkEbHash <$> DB.columnBlob stFindCompleteEbs 0
+                slot <- SlotNo . fromIntegral <$> DB.columnInt64 stFindCompleteEbs 1
+                loop (MkLeiosPoint slot ebHash : acc)
+      loop []
+    useStmt stMarkNotifiedEbs $ dbStep1 stMarkNotifiedEbs
+    pure completedNow
   notify $ AcquiredEb point ebBytesSize
+  forM_ completed $ \p -> notify (AcquiredEbTxs p)
+  pure completed
 
 sqlInsertTxs ::
   Tracer IO TraceLeiosDb ->

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoDb/SQLite.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoDb/SQLite.hs
@@ -222,16 +222,17 @@ openSQLiteConnection tracer dbPath notificationChan = do
 -- * Top-level implementations
 
 sqlScanEbPoints :: Conn -> IO [(SlotNo, EbHash)]
-sqlScanEbPoints Conn{connDb = db, connStmts = Stmts{stScanEbPoints = stmt}} =
-  dbWithBEGIN db $ useStmt stmt $ do
-    let loop acc =
-          dbStep stmt >>= \case
-            DB.Done -> pure (reverse acc)
-            DB.Row -> do
-              slot <- SlotNo . fromIntegral <$> DB.columnInt64 stmt 0
-              hash <- MkEbHash <$> DB.columnBlob stmt 1
-              loop ((slot, hash) : acc)
-    loop []
+sqlScanEbPoints conn =
+  dbWithBEGIN db $ useStmt stmt $ loop []
+ where
+  Conn{connDb = db, connStmts = Stmts{stScanEbPoints = stmt}} = conn
+  loop acc =
+    dbStep stmt >>= \case
+      DB.Done -> pure (reverse acc)
+      DB.Row -> do
+        slot <- SlotNo . fromIntegral <$> DB.columnInt64 stmt 0
+        hash <- MkEbHash <$> DB.columnBlob stmt 1
+        loop ((slot, hash) : acc)
 
 sqlScanCompleteEbPointsSince :: DB.Database -> SlotNo -> IO [LeiosPoint]
 sqlScanCompleteEbPointsSince db sinceSlot =
@@ -247,25 +248,29 @@ sqlScanCompleteEbPointsSince db sinceSlot =
     loop []
 
 sqlLookupEbBody :: Conn -> EbHash -> IO [(TxHash, BytesSize)]
-sqlLookupEbBody Conn{connDb = db, connStmts = Stmts{stLookupEbBody = stmt}} ebHash =
+sqlLookupEbBody conn ebHash =
   dbWithBEGIN db $ useStmt stmt $ do
     dbBindBlob stmt 1 (let MkEbHash bytes = ebHash in bytes)
-    let loop acc =
-          dbStep stmt >>= \case
-            DB.Done -> pure (reverse acc)
-            DB.Row -> do
-              txHash <- MkTxHash <$> DB.columnBlob stmt 0
-              size <- fromIntegral <$> DB.columnInt64 stmt 1
-              loop ((txHash, size) : acc)
     loop []
+ where
+  Conn{connDb = db, connStmts = Stmts{stLookupEbBody = stmt}} = conn
+  loop acc =
+    dbStep stmt >>= \case
+      DB.Done -> pure (reverse acc)
+      DB.Row -> do
+        txHash <- MkTxHash <$> DB.columnBlob stmt 0
+        size <- fromIntegral <$> DB.columnInt64 stmt 1
+        loop ((txHash, size) : acc)
 
 sqlInsertEbPoint :: Conn -> LeiosPoint -> BytesSize -> IO ()
-sqlInsertEbPoint Conn{connDb = db, connStmts = Stmts{stInsertEbPoint = stmt}} point ebBytesSize =
+sqlInsertEbPoint conn point ebBytesSize =
   dbWithBEGIN db $ useStmt stmt $ do
     dbBindInt64 stmt 1 (fromIntegral $ unSlotNo point.pointSlotNo)
     dbBindBlob stmt 2 point.pointEbHash.ebHashBytes
     dbBindInt64 stmt 3 (fromIntegral ebBytesSize)
     dbStep1 stmt
+ where
+  Conn{connDb = db, connStmts = Stmts{stInsertEbPoint = stmt}} = conn
 
 -- | Persist an EB body. The point MUST already be present (inserted
 -- via 'sqlInsertEbPoint' on the announcement path).
@@ -276,9 +281,7 @@ sqlInsertEbBody ::
   LeiosPoint ->
   LeiosEb ->
   IO CompletedEbs
-sqlInsertEbBody tracer Conn{connDb = db, connStmts = Stmts{stInsertEbTxsRow, stInitMissingCount, stFindCompleteEbs, stMarkNotifiedEbs}} notify point eb = do
-  let items = leiosEbBodyItems eb
-      ebBytesSize = leiosEbBytesSize eb
+sqlInsertEbBody tracer conn notify point eb = do
   when (null items) $
     error "leiosDbInsertEbBody: empty EB body (programmer error)"
   completed <- dbWithBEGIN db $ do
@@ -302,20 +305,22 @@ sqlInsertEbBody tracer Conn{connDb = db, connStmts = Stmts{stInsertEbTxsRow, stI
     -- set missingTxCount to 0 for this EB. No subsequent 'sqlInsertTxs'
     -- will fire for this point, so drain the pending-completion set here
     -- (mirrors what 'sqlInsertTxs' does after 'stDecrMissingCount').
-    completedNow <- useStmt stFindCompleteEbs $ do
-      let loop acc =
-            dbStep stFindCompleteEbs >>= \case
-              DB.Done -> pure (reverse acc)
-              DB.Row -> do
-                ebHash <- MkEbHash <$> DB.columnBlob stFindCompleteEbs 0
-                slot <- SlotNo . fromIntegral <$> DB.columnInt64 stFindCompleteEbs 1
-                loop (MkLeiosPoint slot ebHash : acc)
-      loop []
+    completedNow <- useStmt stFindCompleteEbs $ findCompleteEbs stFindCompleteEbs
     useStmt stMarkNotifiedEbs $ dbStep1 stMarkNotifiedEbs
     pure completedNow
   notify $ AcquiredEb point ebBytesSize
   forM_ completed $ \p -> notify (AcquiredEbTxs p)
   pure completed
+ where
+  items = leiosEbBodyItems eb
+  ebBytesSize = leiosEbBytesSize eb
+  Conn{connDb = db, connStmts} = conn
+  Stmts
+    { stInsertEbTxsRow
+    , stInitMissingCount
+    , stFindCompleteEbs
+    , stMarkNotifiedEbs
+    } = connStmts
 
 sqlInsertTxs ::
   Tracer IO TraceLeiosDb ->
@@ -329,16 +334,11 @@ sqlInsertTxs _tracer conn notify txs = do
   -- hashes; attempting the INSERT and catching a constraint violation
   -- still pays the bind + PK-lookup + reset cost per row.
   missing <- Set.fromList <$> sqlFilterMissingTxs conn (map fst txs)
-  let novel = filter (\(h, _) -> h `Set.member` missing) txs
-      Conn
-        { connDb = db
-        , connStmts = Stmts{stInsertTx, stDecrMissingCount, stFindCompleteEbs, stMarkNotifiedEbs}
-        } = conn
   completed <- dbWithBEGIN db $ do
     -- 'dbStepInsert' still handles the rare race where a concurrent
     -- writer inserted the same hash between the filter above and the
     -- INSERT below.
-    forM_ novel $ \(txHash, txBytes) -> do
+    forM_ (novel missing) $ \(txHash, txBytes) -> do
       let txBytesSize = fromIntegral $ BS.length txBytes
           txHashBytes = let MkTxHash bytes = txHash in bytes
       inserted <- useStmt stInsertTx $ do
@@ -350,21 +350,32 @@ sqlInsertTxs _tracer conn notify txs = do
         dbBindBlob stDecrMissingCount 1 txHashBytes
         dbStep1 stDecrMissingCount
     -- Find newly-complete EBs (missingTxCount reached 0)
-    completed <- useStmt stFindCompleteEbs $ do
-      let loop acc =
-            dbStep stFindCompleteEbs >>= \case
-              DB.Done -> pure (reverse acc)
-              DB.Row -> do
-                ebHash <- MkEbHash <$> DB.columnBlob stFindCompleteEbs 0
-                slot <- SlotNo . fromIntegral <$> DB.columnInt64 stFindCompleteEbs 1
-                loop (MkLeiosPoint slot ebHash : acc)
-      loop []
+    completed <- useStmt stFindCompleteEbs $ findCompleteEbs stFindCompleteEbs
     -- Mark them as notified so they are not found again
     useStmt stMarkNotifiedEbs $ dbStep1 stMarkNotifiedEbs
     pure completed
   -- Emit a closure-completion notification for each completed EB
   forM_ completed $ \point -> notify (AcquiredEbTxs point)
   pure completed
+ where
+  Conn{connDb = db, connStmts} = conn
+  Stmts{stInsertTx, stDecrMissingCount, stFindCompleteEbs, stMarkNotifiedEbs} = connStmts
+  novel missing = filter (\(h, _) -> h `Set.member` missing) txs
+
+-- | Loop over 'stFindCompleteEbs' results, accumulating the points whose
+-- @missingTxCount@ just reached 0. Caller is responsible for holding the
+-- prepared statement inside 'useStmt' and for running
+-- 'stMarkNotifiedEbs' afterwards.
+findCompleteEbs :: DB.Statement -> IO [LeiosPoint]
+findCompleteEbs stmt = go []
+ where
+  go acc =
+    dbStep stmt >>= \case
+      DB.Done -> pure (reverse acc)
+      DB.Row -> do
+        ebHash <- MkEbHash <$> DB.columnBlob stmt 0
+        slot <- SlotNo . fromIntegral <$> DB.columnInt64 stmt 1
+        go (MkLeiosPoint slot ebHash : acc)
 
 -- | Retrieve tx bytes for a batch of @(ebHash, txOffset)@ points. Passes
 -- the offsets list as a JSON int array bound to a single parameter;
@@ -377,53 +388,59 @@ sqlBatchRetrieveTxs ::
   EbHash ->
   [Int] ->
   IO [(Int, TxHash, Maybe ByteString)]
-sqlBatchRetrieveTxs Conn{connDb = db, connStmts = Stmts{stBatchRetrieveTxs = stmt}} ebHash offsets =
+sqlBatchRetrieveTxs conn ebHash offsets =
   dbWithBEGIN db $ useStmt stmt $ do
     dbBindBlob stmt 1 (let MkEbHash bytes = ebHash in bytes)
     dbBindUtf8 stmt 2 (jsonIntArray offsets)
-    let loop acc =
-          dbStep stmt >>= \case
-            DB.Done -> pure (reverse acc)
-            DB.Row -> do
-              offset <- fromIntegral <$> DB.columnInt64 stmt 0
-              txHash <- MkTxHash <$> DB.columnBlob stmt 1
-              -- Column 2 is from LEFT JOIN, NULL if tx not in txs table
-              txBytes <- DB.columnBlob stmt 2
-              let mbTxBytes = if txBytes == mempty then Nothing else Just txBytes
-              loop ((offset, txHash, mbTxBytes) : acc)
     loop []
+ where
+  Conn{connDb = db, connStmts = Stmts{stBatchRetrieveTxs = stmt}} = conn
+  loop acc =
+    dbStep stmt >>= \case
+      DB.Done -> pure (reverse acc)
+      DB.Row -> do
+        offset <- fromIntegral <$> DB.columnInt64 stmt 0
+        txHash <- MkTxHash <$> DB.columnBlob stmt 1
+        -- Column 2 is from LEFT JOIN, NULL if tx not in txs table
+        txBytes <- DB.columnBlob stmt 2
+        let mbTxBytes = if txBytes == mempty then Nothing else Just txBytes
+        loop ((offset, txHash, mbTxBytes) : acc)
 
 -- | Batch-filter EB points against @ebTxs@. Passes ebHashes as a JSON
 -- array of hex strings; SQL decodes with @unhex()@ so index lookups on
 -- @ebTxs.ebHashBytes@ still fire.
 sqlFilterMissingEbBodies :: Conn -> [LeiosPoint] -> IO [LeiosPoint]
-sqlFilterMissingEbBodies Conn{connDb = db, connStmts = Stmts{stFilterMissingEbBodies = stmt}} points =
+sqlFilterMissingEbBodies conn points =
   dbWithBEGIN db $ useStmt stmt $ do
-    let pointsByHash = Map.fromList [(p.pointEbHash, p) | p <- points]
     dbBindUtf8 stmt 1 (jsonHexArray (map ebHashBytes (Map.keys pointsByHash)))
-    let loop acc =
-          dbStep stmt >>= \case
-            DB.Done -> pure (reverse acc)
-            DB.Row -> do
-              ebHash <- MkEbHash <$> DB.columnBlob stmt 0
-              case Map.lookup ebHash pointsByHash of
-                Just p -> loop (p : acc)
-                Nothing -> loop acc
     loop []
+ where
+  Conn{connDb = db, connStmts = Stmts{stFilterMissingEbBodies = stmt}} = conn
+  pointsByHash = Map.fromList [(p.pointEbHash, p) | p <- points]
+  loop acc =
+    dbStep stmt >>= \case
+      DB.Done -> pure (reverse acc)
+      DB.Row -> do
+        ebHash <- MkEbHash <$> DB.columnBlob stmt 0
+        case Map.lookup ebHash pointsByHash of
+          Just p -> loop (p : acc)
+          Nothing -> loop acc
 
 -- | Batch-filter tx hashes against @txs@. Same idiom as
 -- 'sqlFilterMissingEbBodies'.
 sqlFilterMissingTxs :: Conn -> [TxHash] -> IO [TxHash]
-sqlFilterMissingTxs Conn{connDb = db, connStmts = Stmts{stFilterMissingTxs = stmt}} txHashes =
+sqlFilterMissingTxs conn txHashes =
   dbWithBEGIN db $ useStmt stmt $ do
     dbBindUtf8 stmt 1 (jsonHexArray [b | MkTxHash b <- txHashes])
-    let loop acc =
-          dbStep stmt >>= \case
-            DB.Done -> pure (reverse acc)
-            DB.Row -> do
-              txHash <- MkTxHash <$> DB.columnBlob stmt 0
-              loop (txHash : acc)
     loop []
+ where
+  Conn{connDb = db, connStmts = Stmts{stFilterMissingTxs = stmt}} = conn
+  loop acc =
+    dbStep stmt >>= \case
+      DB.Done -> pure (reverse acc)
+      DB.Row -> do
+        txHash <- MkTxHash <$> DB.columnBlob stmt 0
+        loop (txHash : acc)
 
 -- | Build a JSON array of hex-encoded blobs: @["aabb...","1234...",...]@.
 -- Consumed on the SQL side via @json_each(?)@ + @unhex(je.value)@.
@@ -451,22 +468,24 @@ jsonIntArray xs =
   intersperseB s (x : rest) = x : s : intersperseB s rest
 
 sqlLookupEbClosure :: Conn -> EbHash -> IO (Maybe [(TxHash, ByteString)])
-sqlLookupEbClosure Conn{connDb = db, connStmts = Stmts{stLookupEbClosure = stmt}} ebHash =
+sqlLookupEbClosure conn ebHash =
   dbWithBEGIN db $ useStmt stmt $ do
     dbBindBlob stmt 1 (ebHashBytes ebHash)
     -- FIXME(bladyjoker): This should have a SlotNo as the second part of the key
-    let loop acc =
-          dbStep stmt >>= \case
-            DB.Done ->
-              -- No rows means the EB body hasn't been downloaded yet
-              if null acc then pure Nothing else pure $ Just (reverse acc)
-            DB.Row -> do
-              txHash <- MkTxHash <$> DB.columnBlob stmt 0
-              txBytes :: ByteString <- DB.columnBlob stmt 1
-              if txBytes == mempty
-                then return Nothing
-                else loop ((txHash, txBytes) : acc)
     loop []
+ where
+  Conn{connDb = db, connStmts = Stmts{stLookupEbClosure = stmt}} = conn
+  loop acc =
+    dbStep stmt >>= \case
+      DB.Done ->
+        -- No rows means the EB body hasn't been downloaded yet
+        if null acc then pure Nothing else pure $ Just (reverse acc)
+      DB.Row -> do
+        txHash <- MkTxHash <$> DB.columnBlob stmt 0
+        txBytes :: ByteString <- DB.columnBlob stmt 1
+        if txBytes == mempty
+          then return Nothing
+          else loop ((txHash, txBytes) : acc)
 
 -- * SQL strings
 

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoDb/SQLite.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoDb/SQLite.hs
@@ -27,10 +27,7 @@ import Control.Concurrent.Class.MonadSTM.Strict
   )
 import Control.Exception (throwIO)
 import Control.Monad (unless, void)
-import Control.Monad.Class.MonadThrow
-  ( bracket
-  , generalBracket
-  )
+import Control.Monad.Class.MonadThrow (generalBracket)
 import qualified Control.Monad.Class.MonadThrow as MonadThrow
 import Control.Tracer (Tracer, traceWith)
 import Data.Bifunctor (first)
@@ -134,6 +131,7 @@ data Stmts = Stmts
   , stFilterMissingEbBodies :: !DB.Statement
   , stFilterMissingTxs :: !DB.Statement
   , stLookupEbClosure :: !DB.Statement
+  , stScanCompleteEbsSince :: !DB.Statement
   }
 
 data Conn = Conn
@@ -158,6 +156,7 @@ prepareStmts db =
     <*> dbPrepare db (fromString sql_filter_missing_eb_bodies_json)
     <*> dbPrepare db (fromString sql_filter_missing_txs_json)
     <*> dbPrepare db (fromString sql_lookup_eb_closure)
+    <*> dbPrepare db (fromString sql_scan_complete_ebs_since)
 
 -- | Finalise every statement in 'Stmts'. Called from 'close' immediately
 -- before 'sqlite3_close_v2', on the connection's owner thread.
@@ -176,6 +175,7 @@ finalizeStmts Stmts{..} = do
   dbFinalize stFilterMissingEbBodies
   dbFinalize stFilterMissingTxs
   dbFinalize stLookupEbClosure
+  dbFinalize stScanCompleteEbsSince
 
 -- | Run an action on a pre-prepared statement and always @sqlite3_reset@
 -- it afterwards, regardless of outcome. Reset uses raw 'DB.reset' (no
@@ -208,7 +208,7 @@ openSQLiteConnection tracer dbPath notificationChan = do
     LeiosDbConnection
       { close = finalizeStmts stmts >> void (DB.close db)
       , leiosDbScanEbPoints = sqlScanEbPoints conn
-      , leiosDbScanCompleteEbClosuresNotOlderThanSlot = sqlScanCompleteEbPointsSince db
+      , leiosDbScanCompleteEbClosuresNotOlderThanSlot = sqlScanCompleteEbPointsSince conn
       , leiosDbInsertEbPoint = sqlInsertEbPoint conn
       , leiosDbLookupEbBody = sqlLookupEbBody conn
       , leiosDbInsertEbBody = sqlInsertEbBody tracer conn notify
@@ -234,18 +234,20 @@ sqlScanEbPoints conn =
         hash <- MkEbHash <$> DB.columnBlob stmt 1
         loop ((slot, hash) : acc)
 
-sqlScanCompleteEbPointsSince :: DB.Database -> SlotNo -> IO [LeiosPoint]
-sqlScanCompleteEbPointsSince db sinceSlot =
-  dbWithBEGIN db $ dbWithPrepare db (fromString sql_scan_complete_ebs_since) $ \stmt -> do
+sqlScanCompleteEbPointsSince :: Conn -> SlotNo -> IO [LeiosPoint]
+sqlScanCompleteEbPointsSince conn sinceSlot =
+  dbWithBEGIN db $ useStmt stmt $ do
     dbBindInt64 stmt 1 (fromIntegral $ unSlotNo sinceSlot)
-    let loop acc =
-          dbStep stmt >>= \case
-            DB.Done -> pure (reverse acc)
-            DB.Row -> do
-              slot <- SlotNo . fromIntegral <$> DB.columnInt64 stmt 0
-              hash <- MkEbHash <$> DB.columnBlob stmt 1
-              loop (MkLeiosPoint slot hash : acc)
     loop []
+ where
+  Conn{connDb = db, connStmts = Stmts{stScanCompleteEbsSince = stmt}} = conn
+  loop acc =
+    dbStep stmt >>= \case
+      DB.Done -> pure (reverse acc)
+      DB.Row -> do
+        slot <- SlotNo . fromIntegral <$> DB.columnInt64 stmt 0
+        hash <- MkEbHash <$> DB.columnBlob stmt 1
+        loop (MkLeiosPoint slot hash : acc)
 
 sqlLookupEbBody :: Conn -> EbHash -> IO [(TxHash, BytesSize)]
 sqlLookupEbBody conn ebHash =
@@ -656,9 +658,6 @@ dbFinalize q = withDieStmt q $ DB.finalize q
 
 dbPrepare :: HasCallStack => DB.Database -> DB.Utf8 -> IO DB.Statement
 dbPrepare db q = withDieJust db $ DB.prepare db q
-
-dbWithPrepare :: HasCallStack => DB.Database -> DB.Utf8 -> (DB.Statement -> IO a) -> IO a
-dbWithPrepare db q k = bracket (dbPrepare db q) dbFinalize k
 
 -- TODO: alternative: bind and use https://www.sqlite.org/c3ref/busy_handler.html
 dbWithBEGIN :: HasCallStack => DB.Database -> IO a -> IO a

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoDb/SQLite.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoDb/SQLite.hs
@@ -141,22 +141,22 @@ data Conn = Conn
 
 -- | Prepare every statement 'Stmts' names. Order is not observable.
 prepareStmts :: DB.Database -> IO Stmts
-prepareStmts db =
-  Stmts
-    <$> dbPrepare db (fromString sql_scan_ebs)
-    <*> dbPrepare db (fromString sql_insert_eb)
-    <*> dbPrepare db (fromString sql_lookup_ebBodies)
-    <*> dbPrepare db (fromString sql_insert_ebBody)
-    <*> dbPrepare db (fromString sql_init_missing_tx_count)
-    <*> dbPrepare db (fromString sql_insert_tx)
-    <*> dbPrepare db (fromString sql_decrement_missing_tx_count)
-    <*> dbPrepare db (fromString sql_find_complete_ebs)
-    <*> dbPrepare db (fromString sql_mark_notified_ebs)
-    <*> dbPrepare db (fromString sql_retrieve_from_ebTxs_json)
-    <*> dbPrepare db (fromString sql_filter_missing_eb_bodies_json)
-    <*> dbPrepare db (fromString sql_filter_missing_txs_json)
-    <*> dbPrepare db (fromString sql_lookup_eb_closure)
-    <*> dbPrepare db (fromString sql_scan_complete_ebs_since)
+prepareStmts db = do
+  stScanEbPoints <- dbPrepare db (fromString sql_scan_ebs)
+  stInsertEbPoint <- dbPrepare db (fromString sql_insert_eb)
+  stLookupEbBody <- dbPrepare db (fromString sql_lookup_ebBodies)
+  stInsertEbTxsRow <- dbPrepare db (fromString sql_insert_ebBody)
+  stInitMissingCount <- dbPrepare db (fromString sql_init_missing_tx_count)
+  stInsertTx <- dbPrepare db (fromString sql_insert_tx)
+  stDecrMissingCount <- dbPrepare db (fromString sql_decrement_missing_tx_count)
+  stFindCompleteEbs <- dbPrepare db (fromString sql_find_complete_ebs)
+  stMarkNotifiedEbs <- dbPrepare db (fromString sql_mark_notified_ebs)
+  stBatchRetrieveTxs <- dbPrepare db (fromString sql_retrieve_from_ebTxs_json)
+  stFilterMissingEbBodies <- dbPrepare db (fromString sql_filter_missing_eb_bodies_json)
+  stFilterMissingTxs <- dbPrepare db (fromString sql_filter_missing_txs_json)
+  stLookupEbClosure <- dbPrepare db (fromString sql_lookup_eb_closure)
+  stScanCompleteEbsSince <- dbPrepare db (fromString sql_scan_complete_ebs_since)
+  pure Stmts{..}
 
 -- | Finalise every statement in 'Stmts'. Called from 'close' immediately
 -- before 'sqlite3_close_v2', on the connection's owner thread.
@@ -223,7 +223,7 @@ openSQLiteConnection tracer dbPath notificationChan = do
 
 sqlScanEbPoints :: Conn -> IO [(SlotNo, EbHash)]
 sqlScanEbPoints conn =
-  dbWithBEGIN db $ useStmt stmt $ loop []
+  dbWithTransaction db $ useStmt stmt $ loop []
  where
   Conn{connDb = db, connStmts = Stmts{stScanEbPoints = stmt}} = conn
   loop acc =
@@ -236,7 +236,7 @@ sqlScanEbPoints conn =
 
 sqlScanCompleteEbPointsSince :: Conn -> SlotNo -> IO [LeiosPoint]
 sqlScanCompleteEbPointsSince conn sinceSlot =
-  dbWithBEGIN db $ useStmt stmt $ do
+  dbWithTransaction db $ useStmt stmt $ do
     dbBindInt64 stmt 1 (fromIntegral $ unSlotNo sinceSlot)
     loop []
  where
@@ -251,7 +251,7 @@ sqlScanCompleteEbPointsSince conn sinceSlot =
 
 sqlLookupEbBody :: Conn -> EbHash -> IO [(TxHash, BytesSize)]
 sqlLookupEbBody conn ebHash =
-  dbWithBEGIN db $ useStmt stmt $ do
+  dbWithTransaction db $ useStmt stmt $ do
     dbBindBlob stmt 1 (let MkEbHash bytes = ebHash in bytes)
     loop []
  where
@@ -266,7 +266,7 @@ sqlLookupEbBody conn ebHash =
 
 sqlInsertEbPoint :: Conn -> LeiosPoint -> BytesSize -> IO ()
 sqlInsertEbPoint conn point ebBytesSize =
-  dbWithBEGIN db $ useStmt stmt $ do
+  dbWithTransaction db $ useStmt stmt $ do
     dbBindInt64 stmt 1 (fromIntegral $ unSlotNo point.pointSlotNo)
     dbBindBlob stmt 2 point.pointEbHash.ebHashBytes
     dbBindInt64 stmt 3 (fromIntegral ebBytesSize)
@@ -286,7 +286,7 @@ sqlInsertEbBody ::
 sqlInsertEbBody tracer conn notify point eb = do
   when (null items) $
     error "leiosDbInsertEbBody: empty EB body (programmer error)"
-  completed <- dbWithBEGIN db $ do
+  completedAndNovel <- dbWithTransaction db $ do
     forM_ items $ \(txOffset, txHash, txBytesSize) -> useStmt stInsertEbTxsRow $ do
       dbBindBlob stInsertEbTxsRow 1 point.pointEbHash.ebHashBytes
       dbBindInt64 stInsertEbTxsRow 2 (fromIntegral txOffset)
@@ -303,16 +303,16 @@ sqlInsertEbBody tracer conn notify point eb = do
       dbBindBlob stInitMissingCount 2 point.pointEbHash.ebHashBytes
       dbBindInt64 stInitMissingCount 3 (fromIntegral $ unSlotNo point.pointSlotNo)
       dbStep1 stInitMissingCount
-    -- If every referenced tx is already present, 'stInitMissingCount' just
-    -- set missingTxCount to 0 for this EB. No subsequent 'sqlInsertTxs'
-    -- will fire for this point, so drain the pending-completion set here
-    -- (mirrors what 'sqlInsertTxs' does after 'stDecrMissingCount').
+    -- If every referenced tx is already present, 'stInitMissingCount' just set
+    -- missingTxCount to 0 for this EB. For all such EBs we need to notify that
+    -- we acquired the whole closure.
+    -- XXX: This scans the ebs table while we would know which row to check
     completedNow <- useStmt stFindCompleteEbs $ findCompleteEbs stFindCompleteEbs
     useStmt stMarkNotifiedEbs $ dbStep1 stMarkNotifiedEbs
     pure completedNow
   notify $ AcquiredEb point ebBytesSize
-  forM_ completed $ \p -> notify (AcquiredEbTxs p)
-  pure completed
+  forM_ completedAndNovel $ \p -> notify (AcquiredEbTxs p)
+  pure completedAndNovel
  where
   items = leiosEbBodyItems eb
   ebBytesSize = leiosEbBytesSize eb
@@ -336,7 +336,7 @@ sqlInsertTxs _tracer conn notify txs = do
   -- hashes; attempting the INSERT and catching a constraint violation
   -- still pays the bind + PK-lookup + reset cost per row.
   missing <- Set.fromList <$> sqlFilterMissingTxs conn (map fst txs)
-  completed <- dbWithBEGIN db $ do
+  completed <- dbWithTransaction db $ do
     -- 'dbStepInsert' still handles the rare race where a concurrent
     -- writer inserted the same hash between the filter above and the
     -- INSERT below.
@@ -391,7 +391,7 @@ sqlBatchRetrieveTxs ::
   [Int] ->
   IO [(Int, TxHash, Maybe ByteString)]
 sqlBatchRetrieveTxs conn ebHash offsets =
-  dbWithBEGIN db $ useStmt stmt $ do
+  dbWithTransaction db $ useStmt stmt $ do
     dbBindBlob stmt 1 (let MkEbHash bytes = ebHash in bytes)
     dbBindUtf8 stmt 2 (jsonIntArray offsets)
     loop []
@@ -413,7 +413,7 @@ sqlBatchRetrieveTxs conn ebHash offsets =
 -- @ebTxs.ebHashBytes@ still fire.
 sqlFilterMissingEbBodies :: Conn -> [LeiosPoint] -> IO [LeiosPoint]
 sqlFilterMissingEbBodies conn points =
-  dbWithBEGIN db $ useStmt stmt $ do
+  dbWithTransaction db $ useStmt stmt $ do
     dbBindUtf8 stmt 1 (jsonHexArray (map ebHashBytes (Map.keys pointsByHash)))
     loop []
  where
@@ -432,7 +432,7 @@ sqlFilterMissingEbBodies conn points =
 -- 'sqlFilterMissingEbBodies'.
 sqlFilterMissingTxs :: Conn -> [TxHash] -> IO [TxHash]
 sqlFilterMissingTxs conn txHashes =
-  dbWithBEGIN db $ useStmt stmt $ do
+  dbWithTransaction db $ useStmt stmt $ do
     dbBindUtf8 stmt 1 (jsonHexArray [b | MkTxHash b <- txHashes])
     loop []
  where
@@ -471,7 +471,7 @@ jsonIntArray xs =
 
 sqlLookupEbClosure :: Conn -> EbHash -> IO (Maybe [(TxHash, ByteString)])
 sqlLookupEbClosure conn ebHash =
-  dbWithBEGIN db $ useStmt stmt $ do
+  dbWithTransaction db $ useStmt stmt $ do
     dbBindBlob stmt 1 (ebHashBytes ebHash)
     -- FIXME(bladyjoker): This should have a SlotNo as the second part of the key
     loop []
@@ -660,8 +660,8 @@ dbPrepare :: HasCallStack => DB.Database -> DB.Utf8 -> IO DB.Statement
 dbPrepare db q = withDieJust db $ DB.prepare db q
 
 -- TODO: alternative: bind and use https://www.sqlite.org/c3ref/busy_handler.html
-dbWithBEGIN :: HasCallStack => DB.Database -> IO a -> IO a
-dbWithBEGIN db k =
+dbWithTransaction :: HasCallStack => DB.Database -> IO a -> IO a
+dbWithTransaction db k =
   do
     fmap fst
     $ generalBracket

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoDb/SQLite.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoDb/SQLite.hs
@@ -127,6 +127,7 @@ data Stmts = Stmts
   , stDecrMissingCount :: !DB.Statement
   , stFindCompleteEbs :: !DB.Statement
   , stMarkNotifiedEbs :: !DB.Statement
+  , stMarkPointNotified :: !DB.Statement
   , stBatchRetrieveTxs :: !DB.Statement
   , stFilterMissingEbBodies :: !DB.Statement
   , stFilterMissingTxs :: !DB.Statement
@@ -151,6 +152,7 @@ prepareStmts db = do
   stDecrMissingCount <- dbPrepare db (fromString sql_decrement_missing_tx_count)
   stFindCompleteEbs <- dbPrepare db (fromString sql_find_complete_ebs)
   stMarkNotifiedEbs <- dbPrepare db (fromString sql_mark_notified_ebs)
+  stMarkPointNotified <- dbPrepare db (fromString sql_mark_point_notified)
   stBatchRetrieveTxs <- dbPrepare db (fromString sql_retrieve_from_ebTxs_json)
   stFilterMissingEbBodies <- dbPrepare db (fromString sql_filter_missing_eb_bodies_json)
   stFilterMissingTxs <- dbPrepare db (fromString sql_filter_missing_txs_json)
@@ -171,6 +173,7 @@ finalizeStmts Stmts{..} = do
   dbFinalize stDecrMissingCount
   dbFinalize stFindCompleteEbs
   dbFinalize stMarkNotifiedEbs
+  dbFinalize stMarkPointNotified
   dbFinalize stBatchRetrieveTxs
   dbFinalize stFilterMissingEbBodies
   dbFinalize stFilterMissingTxs
@@ -286,7 +289,7 @@ sqlInsertEbBody ::
 sqlInsertEbBody tracer conn notify point eb = do
   when (null items) $
     error "leiosDbInsertEbBody: empty EB body (programmer error)"
-  completedAndNovel <- dbWithTransaction db $ do
+  completedNow <- dbWithTransaction db $ do
     forM_ items $ \(txOffset, txHash, txBytesSize) -> useStmt stInsertEbTxsRow $ do
       dbBindBlob stInsertEbTxsRow 1 point.pointEbHash.ebHashBytes
       dbBindInt64 stInsertEbTxsRow 2 (fromIntegral txOffset)
@@ -297,22 +300,25 @@ sqlInsertEbBody tracer conn notify point eb = do
         "ebTxs"
         (show point.pointEbHash <> "@" <> show txOffset)
         stInsertEbTxsRow
-    -- Initialize missingTxCount (accounts for txs already in the DB)
-    useStmt stInitMissingCount $ do
+    -- Initialize missingTxCount and read the resulting value via
+    -- @RETURNING missingTxCount@. Only /this/ point's row can have
+    -- transitioned to 0 as a consequence of the insert above.
+    missingCount <- useStmt stInitMissingCount $ do
       dbBindBlob stInitMissingCount 1 point.pointEbHash.ebHashBytes
       dbBindBlob stInitMissingCount 2 point.pointEbHash.ebHashBytes
       dbBindInt64 stInitMissingCount 3 (fromIntegral $ unSlotNo point.pointSlotNo)
-      dbStep1 stInitMissingCount
-    -- If every referenced tx is already present, 'stInitMissingCount' just set
-    -- missingTxCount to 0 for this EB. For all such EBs we need to notify that
-    -- we acquired the whole closure.
-    -- XXX: This scans the ebs table while we would know which row to check
-    completedNow <- useStmt stFindCompleteEbs $ findCompleteEbs stFindCompleteEbs
-    useStmt stMarkNotifiedEbs $ dbStep1 stMarkNotifiedEbs
-    pure completedNow
+      readReturningInt64 stInitMissingCount
+    if missingCount == 0
+      then do
+        useStmt stMarkPointNotified $ do
+          dbBindInt64 stMarkPointNotified 1 (fromIntegral $ unSlotNo point.pointSlotNo)
+          dbBindBlob stMarkPointNotified 2 point.pointEbHash.ebHashBytes
+          dbStep1 stMarkPointNotified
+        pure [point]
+      else pure []
   notify $ AcquiredEb point ebBytesSize
-  forM_ completedAndNovel $ \p -> notify (AcquiredEbTxs p)
-  pure completedAndNovel
+  forM_ completedNow $ \p -> notify (AcquiredEbTxs p)
+  pure completedNow
  where
   items = leiosEbBodyItems eb
   ebBytesSize = leiosEbBytesSize eb
@@ -320,9 +326,22 @@ sqlInsertEbBody tracer conn notify point eb = do
   Stmts
     { stInsertEbTxsRow
     , stInitMissingCount
-    , stFindCompleteEbs
-    , stMarkNotifiedEbs
+    , stMarkPointNotified
     } = connStmts
+
+-- | Read a single-column @Int64@ from a statement that uses a
+-- @RETURNING@ clause on a PK-scoped @UPDATE@ (i.e. produces exactly one
+-- row followed by 'DB.Done'). Any other shape is a programmer error.
+readReturningInt64 :: DB.Statement -> IO Int64
+readReturningInt64 stmt =
+  dbStep stmt >>= \case
+    DB.Done ->
+      error "readReturningInt64: expected one row from RETURNING, got Done"
+    DB.Row -> do
+      n <- DB.columnInt64 stmt 0
+      dbStep stmt >>= \case
+        DB.Done -> pure n
+        DB.Row -> error "readReturningInt64: expected exactly one row from RETURNING"
 
 sqlInsertTxs ::
   Tracer IO TraceLeiosDb ->
@@ -352,7 +371,15 @@ sqlInsertTxs _tracer conn notify txs = do
         dbBindBlob stDecrMissingCount 1 txHashBytes
         dbStep1 stDecrMissingCount
     -- Find newly-complete EBs (missingTxCount reached 0)
-    completed <- useStmt stFindCompleteEbs $ findCompleteEbs stFindCompleteEbs
+    completed <- useStmt stFindCompleteEbs $ do
+      let loop acc =
+            dbStep stFindCompleteEbs >>= \case
+              DB.Done -> pure (reverse acc)
+              DB.Row -> do
+                ebHash <- MkEbHash <$> DB.columnBlob stFindCompleteEbs 0
+                slot <- SlotNo . fromIntegral <$> DB.columnInt64 stFindCompleteEbs 1
+                loop (MkLeiosPoint slot ebHash : acc)
+      loop []
     -- Mark them as notified so they are not found again
     useStmt stMarkNotifiedEbs $ dbStep1 stMarkNotifiedEbs
     pure completed
@@ -363,21 +390,6 @@ sqlInsertTxs _tracer conn notify txs = do
   Conn{connDb = db, connStmts} = conn
   Stmts{stInsertTx, stDecrMissingCount, stFindCompleteEbs, stMarkNotifiedEbs} = connStmts
   novel missing = filter (\(h, _) -> h `Set.member` missing) txs
-
--- | Loop over 'stFindCompleteEbs' results, accumulating the points whose
--- @missingTxCount@ just reached 0. Caller is responsible for holding the
--- prepared statement inside 'useStmt' and for running
--- 'stMarkNotifiedEbs' afterwards.
-findCompleteEbs :: DB.Statement -> IO [LeiosPoint]
-findCompleteEbs stmt = go []
- where
-  go acc =
-    dbStep stmt >>= \case
-      DB.Done -> pure (reverse acc)
-      DB.Row -> do
-        ebHash <- MkEbHash <$> DB.columnBlob stmt 0
-        slot <- SlotNo . fromIntegral <$> DB.columnInt64 stmt 1
-        go (MkLeiosPoint slot ebHash : acc)
 
 -- | Retrieve tx bytes for a batch of @(ebHash, txOffset)@ points. Passes
 -- the offsets list as a JSON int array bound to a single parameter;
@@ -602,8 +614,13 @@ sql_decrement_missing_tx_count =
   \WHERE ebHashBytes IN (SELECT ebHashBytes FROM ebTxs WHERE txHashBytes = ?)\n\
   \"
 
--- | Initialize missingTxCount after EB body is inserted.
--- Counts ebTxs entries that don't yet have a corresponding tx in the txs table.
+-- | Initialize missingTxCount after EB body is inserted, returning the
+-- resulting count. Counts ebTxs entries that don't yet have a corresponding
+-- tx in the txs table. The RETURNING clause lets the caller detect the
+-- special case @missingTxCount = 0@ (all referenced txs already present) with
+-- a PK lookup on the row that was just touched, instead of a full-table
+-- scan via 'sql_find_complete_ebs'.
+--
 -- Parameters: 1 = ebHashBytes, 2 = ebHashBytes, 3 = ebSlot
 sql_init_missing_tx_count :: String
 sql_init_missing_tx_count =
@@ -612,7 +629,17 @@ sql_init_missing_tx_count =
   \    LEFT JOIN txs t ON e.txHashBytes = t.txHashBytes\n\
   \    WHERE e.ebHashBytes = ? AND t.txHashBytes IS NULL\n\
   \) WHERE ebHashBytes = ? AND ebSlot = ?\n\
+  \RETURNING missingTxCount\n\
   \"
+
+-- | Mark a specific EB as notified (@missingTxCount = -1@). PK-scoped
+-- variant of 'sql_mark_notified_ebs'; used by 'sqlInsertEbBody' when the
+-- body's arrival is what completed the closure.
+--
+-- Parameters: 1 = ebSlot, 2 = ebHashBytes
+sql_mark_point_notified :: String
+sql_mark_point_notified =
+  "UPDATE ebs SET missingTxCount = -1 WHERE ebSlot = ? AND ebHashBytes = ?"
 
 -- | Batch retrieve of tx bytes for a batch of @(ebHash, offset)@ points.
 -- @?1@ is the ebHash blob (all offsets belong to the same EB); @?2@ is a

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic.hs
@@ -660,8 +660,16 @@ msgLeiosBlock ktracer tracer (outstandingVar, readyVar) db peerId req eb = do
         -- the point idempotently as a stop-gap and trace a warning.
         traceWith ktracer $ TraceLeiosBlockPointMissing point
         leiosDbInsertEbPoint db point ebBytesSize
-        leiosDbInsertEbBody db point eb
+        completedByBody <- leiosDbInsertEbBody db point eb
         traceWith ktracer $ TraceLeiosBlockAcquired point
+        -- 'leiosDbInsertEbBody' returns a non-empty list only when this
+        -- body's arrival is what completed the closure — every referenced
+        -- tx was already in the DB (typical for the forger's own txs
+        -- reaching peers via mempool before the EB body catches up). In
+        -- that path 'msgLeiosBlockTxs' will never run for these EBs, so
+        -- surface the trace here to keep 'TraceLeiosBlockTxsAcquired' the
+        -- authoritative "closure available" signal for observers.
+        forM_ completedByBody $ traceWith ktracer . TraceLeiosBlockTxsAcquired
     -- update NodeKernel state
     --
     -- 'refundEbRequest' reverses this peer's per-request accounting (but skips

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic.hs
@@ -662,13 +662,6 @@ msgLeiosBlock ktracer tracer (outstandingVar, readyVar) db peerId req eb = do
         leiosDbInsertEbPoint db point ebBytesSize
         completedByBody <- leiosDbInsertEbBody db point eb
         traceWith ktracer $ TraceLeiosBlockAcquired point
-        -- 'leiosDbInsertEbBody' returns a non-empty list only when this
-        -- body's arrival is what completed the closure — every referenced
-        -- tx was already in the DB (typical for the forger's own txs
-        -- reaching peers via mempool before the EB body catches up). In
-        -- that path 'msgLeiosBlockTxs' will never run for these EBs, so
-        -- surface the trace here to keep 'TraceLeiosBlockTxsAcquired' the
-        -- authoritative "closure available" signal for observers.
         forM_ completedByBody $ traceWith ktracer . TraceLeiosBlockTxsAcquired
     -- update NodeKernel state
     --

--- a/ouroboros-consensus/test/consensus-test/Test/LeiosDemoDb.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/LeiosDemoDb.hs
@@ -11,10 +11,15 @@
 module Test.LeiosDemoDb (module Test.LeiosDemoDb) where
 
 import Cardano.Slotting.Slot (SlotNo (..))
-import Control.Concurrent.Class.MonadSTM.Strict (atomically, readTChan, tryReadTChan)
+import Control.Concurrent.Class.MonadSTM.Strict
+  ( StrictTChan
+  , atomically
+  , readTChan
+  , tryReadTChan
+  )
 import Control.DeepSeq (force)
 import Control.Exception (bracket)
-import Control.Monad (forM, forM_, replicateM)
+import Control.Monad (forM, forM_, replicateM, void)
 import Control.Monad.Class.MonadTime.SI (diffTime, getMonotonicTime)
 import Control.Tracer (nullTracer)
 import qualified Data.ByteString as BS
@@ -49,6 +54,7 @@ import LeiosDemoTypes
   )
 import System.Directory (removeDirectoryRecursive)
 import System.IO.Temp (createTempDirectory, getCanonicalTemporaryDirectory)
+import qualified System.Timeout as Timeout
 import Test.QuickCheck
   ( Gen
   , Property
@@ -129,6 +135,8 @@ mkTestGroups impl =
       , testCase "multiple notifications" $ withFreshDb impl test_multipleNotifications
       , testCase "no offerBlockTxs before last update" $ withFreshDb impl test_noOfferBlockTxsBeforeComplete
       , testCase "offerBlockTxs on last update" $ withFreshDb impl test_offerBlockTxs
+      , testCase "offerBlockTxs when body arrives after all txs" $
+          withFreshDb impl test_offerBlockTxsWhenBodyArrivesAfterTxs
       , testCase "no re-notification of completed EBs" $ withFreshDb impl test_noReNotifyCompletedEbs
       , testCase "no re-notification when re-inserting an EB's own tx" $
           withFreshDb impl test_noReNotifyOnRelatedTxReinsert
@@ -347,7 +355,7 @@ prop_txsInsertThenRetrieve impl =
         ioProperty $ withFreshDb impl $ \db -> withLeiosDb db $ \con -> do
           -- Insert the EB first (point then body)
           leiosDbInsertEbPoint con point (leiosEbBytesSize eb)
-          leiosDbInsertEbBody con point eb
+          void $ leiosDbInsertEbBody con point eb
           -- Get the txHashes from the EB for the offsets we want to insert
           let ebTxList = V.toList (leiosEbTxs eb)
               !txsToInsert =
@@ -403,7 +411,7 @@ test_singleSubscriber db = do
       eb = mkTestEb 3
   withLeiosDb db $ \con -> do
     leiosDbInsertEbPoint con point (leiosEbBytesSize eb)
-    leiosDbInsertEbBody con point eb
+    void $ leiosDbInsertEbBody con point eb
   notification <- atomically $ readTChan chan
   case notification of
     AcquiredEb notifPoint _ ->
@@ -421,7 +429,7 @@ test_multipleSubscribers db = do
       eb = mkTestEb 5
   withLeiosDb db $ \con -> do
     leiosDbInsertEbPoint con point (leiosEbBytesSize eb)
-    leiosDbInsertEbBody con point eb
+    void $ leiosDbInsertEbBody con point eb
   -- All subscribers should receive the notification
   notif1 <- atomically $ readTChan chan1
   notif2 <- atomically $ readTChan chan2
@@ -439,7 +447,7 @@ test_correctData db = do
       expectedSize = leiosEbBytesSize eb
   withLeiosDb db $ \con -> do
     leiosDbInsertEbPoint con point (leiosEbBytesSize eb)
-    leiosDbInsertEbBody con point eb
+    void $ leiosDbInsertEbBody con point eb
   notification <- atomically $ readTChan chan
   case notification of
     AcquiredEb notifPoint notifSize -> do
@@ -458,7 +466,7 @@ test_lateSubscriber db = do
       eb1 = mkTestEb 2
   withLeiosDb db $ \con -> do
     leiosDbInsertEbPoint con point1 (leiosEbBytesSize eb1)
-    leiosDbInsertEbBody con point1 eb1
+    void $ leiosDbInsertEbBody con point1 eb1
   -- Now subscribe
   chan <- subscribeEbNotifications db
   -- The channel should be empty (no past notifications)
@@ -471,7 +479,7 @@ test_lateSubscriber db = do
       eb2 = mkTestEb 3
   withLeiosDb db $ \con -> do
     leiosDbInsertEbPoint con point2 (leiosEbBytesSize eb2)
-    leiosDbInsertEbBody con point2 eb2
+    void $ leiosDbInsertEbBody con point2 eb2
   notification <- atomically $ readTChan chan
   assertOfferBlock point2 notification
 
@@ -488,7 +496,7 @@ test_multipleNotifications db = do
   withLeiosDb db $ \con ->
     forM_ (zip points ebs) $ \(point, eb) -> do
       leiosDbInsertEbPoint con point (leiosEbBytesSize eb)
-      leiosDbInsertEbBody con point eb
+      void $ leiosDbInsertEbBody con point eb
   -- Read all notifications and verify order
   notifications <- replicateM 5 (atomically $ readTChan chan)
   mapM_
@@ -505,7 +513,7 @@ test_noOfferBlockTxsBeforeComplete db = do
       ebTxList = V.toList (leiosEbTxs eb)
   withLeiosDb db $ \con -> do
     leiosDbInsertEbPoint con point (leiosEbBytesSize eb)
-    leiosDbInsertEbBody con point eb
+    void $ leiosDbInsertEbBody con point eb
     -- Consume the LeiosOfferBlock notification
     _ <- atomically $ readTChan chan
     -- Insert only 2 of 3 txs (by txHash)
@@ -531,7 +539,7 @@ test_offerBlockTxs db = do
   withLeiosDb db $ \con -> do
     -- Insert the EB (point then body)
     leiosDbInsertEbPoint con point (leiosEbBytesSize eb)
-    leiosDbInsertEbBody con point eb
+    void $ leiosDbInsertEbBody con point eb
     -- Consume the LeiosOfferBlock notification
     _ <- atomically $ readTChan chan
     -- Insert all txs (by txHash)
@@ -544,6 +552,44 @@ test_offerBlockTxs db = do
     notification <- atomically $ readTChan chan
     assertOfferBlockTxs point notification
 
+-- | An EB whose txs were already inserted (e.g. previously seen via mempool
+-- diffusion or another EB carrying overlapping content) becomes complete the
+-- moment its body arrives — no tx-insert batch will ever touch it again.
+-- 'leiosDbInsertEbBody' must therefore detect this and emit
+-- 'AcquiredEbTxs' itself, otherwise downstream consumers (voting, ChainDB
+-- closure tracking, LeiosBlockTxsOffer relay) never learn the EB is
+-- complete. Regression test for a bug seen in the Leios ThreadNet where an
+-- EB forged near the end of the run stayed silent on receiving nodes.
+test_offerBlockTxsWhenBodyArrivesAfterTxs :: LeiosDbHandle IO -> IO ()
+test_offerBlockTxsWhenBodyArrivesAfterTxs db = do
+  chan <- subscribeEbNotifications db
+  let point = mkTestPoint (SlotNo 1) 1
+      eb = mkTestEb 3
+      ebTxList = V.toList (leiosEbTxs eb)
+  withLeiosDb db $ \con -> do
+    -- Insert all of the EB's txs BEFORE any point/body — as if they had
+    -- reached this node via mempool diffusion. No completion notification
+    -- can fire yet: the DB has no body to associate them with.
+    let txsToInsert =
+          [ (txHash, BS.pack [fromIntegral i, 1, 2, 3])
+          | (i, (txHash, _size)) <- zip [0 :: Int ..] ebTxList
+          ]
+    _ <- leiosDbInsertTxs con txsToInsert
+    noEarlyNotif <- atomically $ tryReadTChan chan
+    case noEarlyNotif of
+      Nothing -> pure ()
+      Just _ -> assertFailure "must not notify before any EB body is inserted"
+    -- Now insert the EB (point then body). The closure is immediately
+    -- complete, so we expect BOTH notifications in sequence. Use a
+    -- timeout on the reads: without the fix the second read would block
+    -- forever, so we surface the failure explicitly instead of hanging.
+    leiosDbInsertEbPoint con point (leiosEbBytesSize eb)
+    void $ leiosDbInsertEbBody con point eb
+    acquiredEb <- readTChanWithin 1_000_000 chan "AcquiredEb"
+    assertOfferBlock point acquiredEb
+    acquiredTxs <- readTChanWithin 1_000_000 chan "AcquiredEbTxs"
+    assertOfferBlockTxs point acquiredTxs
+
 -- | Test that completed EBs are not re-notified when subsequent unrelated
 -- transactions are inserted.
 test_noReNotifyCompletedEbs :: LeiosDbHandle IO -> IO ()
@@ -555,7 +601,7 @@ test_noReNotifyCompletedEbs db = do
   withLeiosDb db $ \con -> do
     -- Insert and complete the EB
     leiosDbInsertEbPoint con point (leiosEbBytesSize eb)
-    leiosDbInsertEbBody con point eb
+    void $ leiosDbInsertEbBody con point eb
     -- Consume the AcquiredEb notification
     acquiredEb <- atomically $ tryReadTChan chan
     case acquiredEb of
@@ -593,7 +639,7 @@ test_noReNotifyOnRelatedTxReinsert db = do
       ebTxList = V.toList (leiosEbTxs eb)
   withLeiosDb db $ \con -> do
     leiosDbInsertEbPoint con point (leiosEbBytesSize eb)
-    leiosDbInsertEbBody con point eb
+    void $ leiosDbInsertEbBody con point eb
     acquiredEb <- atomically $ tryReadTChan chan
     case acquiredEb of
       Just (AcquiredEb{}) -> pure ()
@@ -642,8 +688,8 @@ test_multipleSlotsSameHash db = do
     -- Announce the same EB at two slots and insert the body twice.
     leiosDbInsertEbPoint con point1 (leiosEbBytesSize eb)
     leiosDbInsertEbPoint con point2 (leiosEbBytesSize eb)
-    leiosDbInsertEbBody con point1 eb
-    leiosDbInsertEbBody con point2 eb
+    void $ leiosDbInsertEbBody con point1 eb
+    void $ leiosDbInsertEbBody con point2 eb
     -- Drain the two AcquiredEb notifications (order matches insertion).
     acquiredEbs <- drainNotifications
     let acquiredEbPoints =
@@ -664,6 +710,19 @@ test_multipleSlotsSameHash db = do
   setEquals xs ys = Map.fromList [(p, ()) | p <- xs] @?= Map.fromList [(p, ()) | p <- ys]
 
 -- * Test utilities
+
+-- | Read a notification with a microsecond timeout. Fails the enclosing
+-- test if no notification arrives within the deadline (so a missing
+-- notification surfaces as a normal test failure rather than a hang).
+readTChanWithin ::
+  Int ->
+  StrictTChan IO LeiosEbNotification ->
+  String ->
+  IO LeiosEbNotification
+readTChanWithin micros chan label =
+  Timeout.timeout micros (atomically (readTChan chan)) >>= \case
+    Just x -> pure x
+    Nothing -> assertFailure $ "expected " <> label <> " notification within " <> show micros <> "μs, got none"
 
 -- | Assert that a notification is AcquiredEb with the expected point.
 assertOfferBlock :: LeiosPoint -> LeiosEbNotification -> IO ()
@@ -702,7 +761,7 @@ prop_filterEbBodiesCorrect impl =
               -- Insert some EBs (those in toInsert will have bodies)
               forM_ toInsert $ \(point, eb) -> do
                 leiosDbInsertEbPoint con point (leiosEbBytesSize eb)
-                leiosDbInsertEbBody con point eb
+                void $ leiosDbInsertEbBody con point eb
               -- Also insert points without bodies for the rest
               let withoutBodies = filter (`notElem` toInsert) pointsAndEbs
               forM_ withoutBodies $ \(point, eb) ->
@@ -761,7 +820,7 @@ prop_completedEbComplete impl =
       forAllBlind genTxBytes $ \txBytes ->
         ioProperty $ withFreshDb impl $ \db -> withLeiosDb db $ \con -> do
           leiosDbInsertEbPoint con point (leiosEbBytesSize eb)
-          leiosDbInsertEbBody con point eb
+          void $ leiosDbInsertEbBody con point eb
           let ebTxList = V.toList (leiosEbTxs eb)
               txsToInsert = [(txHash, txBytes) | (txHash, _size) <- ebTxList]
           _ <- leiosDbInsertTxs con txsToInsert
@@ -791,7 +850,7 @@ prop_completedEbMissingTxs impl =
     forAllBlind (genPointAndEb numTxs) $ \(point, eb) ->
       ioProperty $ withFreshDb impl $ \db -> withLeiosDb db $ \con -> do
         leiosDbInsertEbPoint con point (leiosEbBytesSize eb)
-        leiosDbInsertEbBody con point eb
+        void $ leiosDbInsertEbBody con point eb
         (result, queryTime) <- timed $ leiosDbLookupEbClosure con (pointEbHash point)
         pure $
           result === Nothing
@@ -807,7 +866,7 @@ prop_completedEbPartialTxs impl =
       forAllBlind genTxBytes $ \txBytes ->
         ioProperty $ withFreshDb impl $ \db -> withLeiosDb db $ \con -> do
           leiosDbInsertEbPoint con point (leiosEbBytesSize eb)
-          leiosDbInsertEbBody con point eb
+          void $ leiosDbInsertEbBody con point eb
           -- Insert only the first half of txs, leaving at least one missing
           let ebTxList = V.toList (leiosEbTxs eb)
               partialTxs = take (numTxs `div` 2) ebTxList

--- a/ouroboros-consensus/test/consensus-test/Test/LeiosDemoDb.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/LeiosDemoDb.hs
@@ -552,14 +552,13 @@ test_offerBlockTxs db = do
     notification <- atomically $ readTChan chan
     assertOfferBlockTxs point notification
 
--- | An EB whose txs were already inserted (e.g. previously seen via mempool
--- diffusion or another EB carrying overlapping content) becomes complete the
--- moment its body arrives — no tx-insert batch will ever touch it again.
--- 'leiosDbInsertEbBody' must therefore detect this and emit
--- 'AcquiredEbTxs' itself, otherwise downstream consumers (voting, ChainDB
--- closure tracking, LeiosBlockTxsOffer relay) never learn the EB is
--- complete. Regression test for a bug seen in the Leios ThreadNet where an
--- EB forged near the end of the run stayed silent on receiving nodes.
+-- | An EB whose txs were already inserted becomes complete the moment its body
+-- arrives — no tx-insert batch will ever touch it again. 'leiosDbInsertEbBody'
+-- must therefore detect this and emit 'AcquiredEbTxs' itself, otherwise
+-- downstream consumers (voting, ChainDB closure tracking, LeiosBlockTxsOffer
+-- relay) never learn the EB is complete. Regression test for a bug seen in the
+-- Leios ThreadNet where an EB forged near the end of the run stayed silent on
+-- receiving nodes.
 test_offerBlockTxsWhenBodyArrivesAfterTxs :: LeiosDbHandle IO -> IO ()
 test_offerBlockTxsWhenBodyArrivesAfterTxs db = do
   chan <- subscribeEbNotifications db


### PR DESCRIPTION
Notify `AcquiredEBTxs` if an already complete closure for EB body is inserted

This was preventing offers of EBs that we already have the full closure
of and resulted in EBs not being diffused.

Reproducible in Leios threadnet test with seed `(SMGen 10792080524324648525 17850122056530710967,60)` and it was noticed on https://github.com/IntersectMBO/ouroboros-consensus/pull/2140/checks?check_run_id=88666825762 of #2140 PR