### PR TITLE
[Peras 35] Tweak PerasBLSCrypto and add several instances

### DIFF
--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Block/RealPoint.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Block/RealPoint.hs
@@ -28,7 +28,7 @@ module Ouroboros.Consensus.Block.RealPoint
   , withOriginRealPointToPoint
 
     -- * Bytes32RealPoint
-  , Bytes32RealPoint
+  , Bytes32RealPoint (..)
   , bytes32RealPointHash
   , bytes32RealPointSlot
   , decodeBytes32RealPoint

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Block/SupportsPeras.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Block/SupportsPeras.hs
@@ -48,7 +48,6 @@ module Ouroboros.Consensus.Block.SupportsPeras
   , module Ouroboros.Consensus.Peras.Params
   ) where
 
-import Cardano.Binary (FromCBOR, ToCBOR)
 import qualified Cardano.Binary as KeyHash
 import Cardano.Ledger.Hashes (KeyHash, KeyRole (..))
 import Codec.Serialise (Serialise (..))
@@ -62,15 +61,11 @@ import Data.Proxy (Proxy (..))
 import GHC.Generics (Generic)
 import NoThunks.Class
 import Ouroboros.Consensus.Block.Abstract
-import Ouroboros.Consensus.Block.RealPoint
-  ( Bytes32RealPoint
-  , decodeBytes32RealPoint
-  , encodeBytes32RealPoint
-  )
 import Ouroboros.Consensus.BlockchainTime.WallClock.Types (WithArrivalTime (..))
 import Ouroboros.Consensus.Peras.Params
 import Ouroboros.Consensus.Peras.Types
-  ( PerasRoundNo (..)
+  ( PerasBoostedBlock (..)
+  , PerasRoundNo (..)
   , PerasSeatIndex (..)
   , PerasVoteTarget (..)
   , onPerasRoundNo
@@ -81,23 +76,6 @@ import Quiet (Quiet (..))
 {-------------------------------------------------------------------------------
 -- * Peras types
 -------------------------------------------------------------------------------}
-
--- ** Boosted blocks
-
--- | The slot number and 32-byte hash of the block being voted for
---
--- NOTE: to be removed in favor of the one in 'Ouroboros.Consensus.Peras.Types'
-newtype PerasBoostedBlock
-  = PerasBoostedBlock
-  { unPerasBoostedBlock :: Bytes32RealPoint
-  }
-  deriving stock (Eq, Show)
-
-instance FromCBOR PerasBoostedBlock where
-  fromCBOR = PerasBoostedBlock <$> decodeBytes32RealPoint
-
-instance ToCBOR PerasBoostedBlock where
-  toCBOR = encodeBytes32RealPoint . unPerasBoostedBlock
 
 -- ** Stake pool distributions
 

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Peras/Crypto/BLS.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Peras/Crypto/BLS.hs
@@ -1,4 +1,7 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE EmptyDataDeriving #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE RankNTypes #-}
@@ -25,7 +28,12 @@ module Ouroboros.Consensus.Peras.Crypto.BLS
   , PerasBLSCryptoAggregateVoteSignature (..)
   ) where
 
-import Cardano.Binary (FromCBOR, ToCBOR (..))
+import Cardano.Binary
+  ( FromCBOR (..)
+  , ToCBOR (..)
+  , decodeListLenOf
+  , encodeListLen
+  )
 import Cardano.Crypto.DSIGN (BLS12381MinSigDSIGN, DSIGNAlgorithm (..))
 import Cardano.Crypto.Hash (Hash)
 import qualified Cardano.Crypto.Hash as Hash
@@ -35,6 +43,10 @@ import Cardano.Ledger.Hashes (HASH)
 import qualified Data.ByteString.Builder as BS
 import qualified Data.ByteString.Builder.Extra as BS
 import qualified Data.ByteString.Short as BS
+import GHC.Base (Any)
+import GHC.Generics (Generic)
+import NoThunks.Class (NoThunks)
+import Ouroboros.Consensus.Block.Abstract (WithOrigin (..))
 import Ouroboros.Consensus.Block.RealPoint
   ( bytes32RealPointHash
   , bytes32RealPointSlot
@@ -58,28 +70,53 @@ import Ouroboros.Consensus.Committee.Crypto.BLS (KeyRole (..))
 import qualified Ouroboros.Consensus.Committee.Crypto.BLS as BLS
 
 -- | BLS-based crypto scheme used in Peras voting committees
+--
+-- TODO: we should investigate why this type needs these instances at all.
+-- See https://github.com/tweag/cardano-peras/issues/272
 data PerasBLSCrypto
+  deriving (Show, Eq, Generic, NoThunks)
 
 type instance ElectionId PerasBLSCrypto = PerasRoundNo
 type instance VoteCandidate PerasBLSCrypto = PerasBoostedBlock
 
 -- | Private key of a Peras committee member
-data PerasPrivateKey
-  = PerasPrivateKey
-  { perasVoteSignKey :: BLS.PrivateKey SIGN
-  , perasVRFSignKey :: BLS.PrivateKey VRF
-  }
+newtype PerasPrivateKey
+  = PerasPrivateKey (BLS.PrivateKey Any)
+  deriving stock Generic
+  deriving anyclass NoThunks
 
 type instance PrivateKey PerasBLSCrypto = PerasPrivateKey
 
 -- | Public key of a Peras committee member
 data PerasPublicKey
-  = PerasPublicKey
-  { perasVoteVerKey :: BLS.PublicKey SIGN
-  , perasVRFVerKey :: BLS.PublicKey VRF
-  }
+  = PerasPublicKey (BLS.PublicKey Any)
+  deriving stock (Eq, Show, Generic)
+  deriving anyclass NoThunks
 
 type instance PublicKey PerasBLSCrypto = PerasPublicKey
+
+-- NOTE: we include the key scope in the serialised format of the public key
+instance FromCBOR PerasPublicKey where
+  fromCBOR = do
+    decodeListLenOf 2
+    keyScope <- fromCBOR
+    keyBytes <- fromCBOR
+    case BLS.rawDeserialisePublicKey keyScope keyBytes of
+      Just pk ->
+        pure (PerasPublicKey pk)
+      Nothing ->
+        fail
+          ( "Failed to decode PerasPublicKey, invalid public key bytes: "
+              <> show keyBytes
+              <> " with scope: "
+              <> show keyScope
+          )
+
+instance ToCBOR PerasPublicKey where
+  toCBOR (PerasPublicKey pk) = do
+    encodeListLen 2
+      <> toCBOR (BLS.publicKeyScope pk)
+      <> toCBOR (BLS.rawSerialisePublicKey pk)
 
 -- | Hash the message of a Peras vote
 --
@@ -93,26 +130,28 @@ hashVoteSignature roundNo boostedBlock =
   Hash.castHash
     . Hash.hashWith id
     . runByteBuilder (8 + 8 + 32)
-    $ roundNoBytes
-      <> boostedBlockSlotBytes
-      <> boostedBlockHashBytes
+    $ roundNoBytes <> boostedBlockBytes
  where
   roundNoBytes =
     BS.word64BE
       . unPerasRoundNo
       $ roundNo
-  boostedBlockSlotBytes =
+  boostedBlockBytes =
+    case unPerasBoostedBlock boostedBlock of
+      Origin ->
+        mempty
+      NotOrigin point ->
+        bytes32RealPointSlotBytes point
+          <> bytes32RealPointHashBytes point
+
+  bytes32RealPointSlotBytes =
     BS.word64BE
       . unSlotNo
       . bytes32RealPointSlot
-      . unPerasBoostedBlock
-      $ boostedBlock
-  boostedBlockHashBytes =
+  bytes32RealPointHashBytes =
     BS.byteStringCopy
       . BS.fromShort
       . bytes32RealPointHash
-      . unPerasBoostedBlock
-      $ boostedBlock
 
 -- | Hash the input for the VRF used in Peras elections
 --
@@ -146,13 +185,14 @@ instance CryptoSupportsVoteSigning PerasBLSCrypto where
     { unPerasBLSCryptoVoteSignature ::
         BLS.Signature BLS.SIGN
     }
-    deriving stock (Eq, Show)
+    deriving stock (Show, Eq, Generic)
     deriving newtype (FromCBOR, ToCBOR)
+    deriving anyclass NoThunks
 
-  getVoteSigningKey _ =
-    perasVoteSignKey
-  getVoteVerificationKey _ =
-    perasVoteVerKey
+  getVoteSigningKey _ (PerasPrivateKey sk) =
+    BLS.coercePrivateKey @SIGN sk
+  getVoteVerificationKey _ (PerasPublicKey pk) =
+    BLS.coercePublicKey @SIGN pk
 
   signVote sk roundNo boostedBlock =
     PerasBLSCryptoVoteSignature
@@ -185,14 +225,15 @@ instance CryptoSupportsVRF PerasBLSCrypto where
     { unPerasBLSCryptoVRFOutput ::
         BLS.Signature VRF
     }
-    deriving stock (Eq, Show)
+    deriving stock (Show, Eq, Generic)
     deriving newtype (FromCBOR, ToCBOR)
+    deriving anyclass NoThunks
 
-  getVRFSigningKey _ =
-    perasVRFSignKey
+  getVRFSigningKey _ (PerasPrivateKey sk) =
+    BLS.coercePrivateKey @VRF sk
 
-  getVRFVerificationKey _ =
-    perasVRFVerKey
+  getVRFVerificationKey _ (PerasPublicKey pk) =
+    BLS.coercePublicKey @VRF pk
 
   mkVRFElectionInput epochNonce roundNo =
     PerasBLSCryptoVRFElectionInput $
@@ -226,8 +267,9 @@ newtype PerasBLSCryptoAggregateVoteSignature
   { unPerasBLSCryptoAggregateVoteSignature ::
       BLS.Signature SIGN
   }
-  deriving stock (Eq, Show)
+  deriving stock (Show, Eq, Generic)
   deriving newtype (FromCBOR, ToCBOR)
+  deriving anyclass NoThunks
 
 instance CryptoSupportsAggregateVoteSigning PerasBLSCrypto where
   type

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/Peras/Util.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/Peras/Util.hs
@@ -38,8 +38,8 @@ import Data.Traversable (mapAccumM)
 import Data.Word (Word8)
 import GHC.Word (Word16)
 import Ouroboros.Consensus.Block (ConvertRawHash, HeaderHash)
-import Ouroboros.Consensus.Block.Abstract (ConvertRawHash (..))
-import Ouroboros.Consensus.Block.RealPoint (RealPoint (..), toBytes32RealPoint)
+import Ouroboros.Consensus.Block.Abstract (ConvertRawHash (..), WithOrigin (..))
+import Ouroboros.Consensus.Block.RealPoint (Bytes32RealPoint (..))
 import Ouroboros.Consensus.Block.SupportsPeras
   ( PerasBoostedBlock (..)
   , PerasRoundNo (..)
@@ -100,13 +100,17 @@ instance ConvertRawHash BlockWith32BytesHeaderHash where
   unsafeFromRawHash _ = ShortBytesString.toShort
 
 genBoostedBlock :: Gen PerasBoostedBlock
-genBoostedBlock = do
-  slotNo <- SlotNo <$> arbitrary
-  hash <- ShortByteString.pack <$> vectorOf 32 arbitrary
-  let bytes32realPoint =
-        toBytes32RealPoint @BlockWith32BytesHeaderHash $
-          RealPoint slotNo hash
-  pure (PerasBoostedBlock bytes32realPoint)
+genBoostedBlock = PerasBoostedBlock <$> genWithOrigin genBytes32RealPoint
+ where
+  genWithOrigin gen =
+    frequency
+      [ (1, pure Origin)
+      , (9, NotOrigin <$> gen)
+      ]
+  genBytes32RealPoint = do
+    slotNo <- SlotNo <$> arbitrary
+    hash <- ShortByteString.pack <$> vectorOf 32 arbitrary
+    pure $ Bytes32RealPoint slotNo hash
 
 genSeatIndex :: Gen PerasSeatIndex
 genSeatIndex = PerasSeatIndex <$> arbitrary


### PR DESCRIPTION
This PR simplifies the Peras public and private keys by reusing the same BLS key for both signing and VRF roles. In addition, it provides a couple of extra instances for the types defined in that module that will be needed later, notably `NoThunks` and `FromCBOR`/`ToCBOR`.

Moreover, we took the opportunity to replace the old `PerasBoostedBlock` from `O.C.Block.SupportsPeras` with the one from `O.C.Peras.Types`, which notably just adds a `WithOrigin` wrapper.