### PR TITLE
[Peras 37] Add Peras error type class and types

### DIFF
--- a/changelog.d/20260723_155158_agustin.mista_introduce_error_types.md
+++ b/changelog.d/20260723_155158_agustin.mista_introduce_error_types.md
@@ -1,0 +1,23 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+<!--
+### Breaking
+
+- A bullet item for the Breaking category.
+
+-->
+### Non-Breaking
+
+- Introduce `IsPerasError` type class and `V1.PerasError` type.
+
+<!--
+### Patch
+
+- A bullet item for the Patch category.
+
+-->

--- a/ouroboros-consensus.cabal
+++ b/ouroboros-consensus.cabal
@@ -447,6 +447,7 @@ library unstable-consensus-testlib
   exposed-modules:
     Ouroboros.Consensus.Peras.Cert.Mock
     Ouroboros.Consensus.Peras.Crypto.Mock
+    Ouroboros.Consensus.Peras.Error.Mock
     Ouroboros.Consensus.Peras.Vote.Mock
     Test.LedgerTables
     Test.Ouroboros.Consensus.ChainGenerator.Adversarial

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Block/SupportsPeras.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Block/SupportsPeras.hs
@@ -13,7 +13,6 @@
 
 module Ouroboros.Consensus.Block.SupportsPeras
   ( PerasRoundNo (..)
-  , onPerasRoundNo
   , PerasBoostedBlock (..)
   , PerasSeatIndex (..)
   , PerasVoteId (..)
@@ -44,8 +43,13 @@ module Ouroboros.Consensus.Block.SupportsPeras
   , HasPerasVoteTarget (..)
   , HasPerasVoteId (..)
 
+    -- * Peras error types
+  , IsPerasError (..)
+  , PerasVotingCommitteeError
+
     -- * Convenience re-exports
   , module Ouroboros.Consensus.Peras.Params
+  , module Ouroboros.Consensus.Peras.Types
   ) where
 
 import qualified Cardano.Binary as KeyHash
@@ -63,13 +67,8 @@ import NoThunks.Class
 import Ouroboros.Consensus.Block.Abstract
 import Ouroboros.Consensus.BlockchainTime.WallClock.Types (WithArrivalTime (..))
 import Ouroboros.Consensus.Peras.Params
-import Ouroboros.Consensus.Peras.Types
-  ( PerasBoostedBlock (..)
-  , PerasRoundNo (..)
-  , PerasSeatIndex (..)
-  , PerasVoteTarget (..)
-  , onPerasRoundNo
-  )
+import Ouroboros.Consensus.Peras.Types hiding (PerasVoteId (..))
+import Ouroboros.Consensus.Peras.Voting.Adapter (PerasConversionError)
 import Ouroboros.Consensus.Util
 import Quiet (Quiet (..))
 
@@ -525,3 +524,14 @@ instance
   HasPerasVoteId (WithArrivalTime vote) blk
   where
   getPerasVoteId = getPerasVoteId . forgetArrivalTime
+
+--- * Peras error types
+
+-- NOTE: this will be replaced by an associated type in 'BlockSupportsPeras'.
+data PerasVotingCommitteeError blk
+
+-- | Error types that support injecting certain types of Peras errors
+class IsPerasError err blk | err -> blk where
+  injectVotingCommitteeError :: PerasVotingCommitteeError blk -> err
+  injectConversionError :: PerasConversionError -> err
+  injectQuorumNotReachedError :: VoteWeight -> err

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Peras/Error/V1.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Peras/Error/V1.hs
@@ -1,0 +1,61 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+-- | Concrete Peras error types for the V1 voting protocol.
+--
+-- NOTE: this module is meant to be imported qualified.
+module Ouroboros.Consensus.Peras.Error.V1
+  ( PerasError (..)
+  ) where
+
+import Control.Exception (Exception)
+import Data.Typeable (Typeable)
+import GHC.Generics (Generic)
+import NoThunks.Class (NoThunks)
+import Ouroboros.Consensus.Block.SupportsPeras
+  ( IsPerasError (..)
+  , PerasVotingCommitteeError
+  , VoteWeight
+  )
+import Ouroboros.Consensus.Committee.WFA (WFAError)
+import Ouroboros.Consensus.Peras.Voting.Adapter (PerasConversionError)
+
+-- | Collection of voting-related errors for Peras
+data PerasError blk
+  = PerasVotingWFAError
+      WFAError
+  | PerasVotingCommitteeError
+      (PerasVotingCommitteeError blk)
+  | PerasVotingConversionError
+      PerasConversionError
+  | PerasQuorumNotReachedError
+      VoteWeight
+  | PerasTemporaryPublicKeyHackError
+      String
+
+deriving instance
+  Show (PerasVotingCommitteeError blk) =>
+  Show (PerasError blk)
+deriving instance
+  Eq (PerasVotingCommitteeError blk) =>
+  Eq (PerasError blk)
+deriving instance
+  NoThunks (PerasVotingCommitteeError blk) =>
+  NoThunks (PerasError blk)
+deriving instance
+  Generic (PerasError blk)
+deriving instance
+  ( Typeable blk
+  , Show (PerasVotingCommitteeError blk)
+  ) =>
+  Exception (PerasError blk)
+
+instance IsPerasError (PerasError blk) blk where
+  injectVotingCommitteeError = PerasVotingCommitteeError
+  injectConversionError = PerasVotingConversionError
+  injectQuorumNotReachedError = PerasQuorumNotReachedError

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Ouroboros/Consensus/Peras/Error/Mock.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Ouroboros/Consensus/Peras/Error/Mock.hs
@@ -1,0 +1,57 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+-- | Concrete Peras error types for the V1 voting protocol.
+--
+-- NOTE: this module is meant to be imported qualified.
+module Ouroboros.Consensus.Peras.Error.Mock
+  ( MockPerasError (..)
+  ) where
+
+import Control.Exception (Exception)
+import Data.Typeable (Typeable)
+import GHC.Generics (Generic)
+import NoThunks.Class (NoThunks)
+import Ouroboros.Consensus.Block.SupportsPeras
+  ( IsPerasError (..)
+  , PerasVotingCommitteeError
+  , VoteWeight
+  )
+import Ouroboros.Consensus.Peras.Voting.Adapter (PerasConversionError)
+
+-- | Collection of voting-related errors for Peras
+data MockPerasError blk
+  = PerasVotingCommitteeError
+      (PerasVotingCommitteeError blk)
+  | PerasVotingConversionError
+      PerasConversionError
+  | PerasQuorumNotReachedError
+      VoteWeight
+  | InputStakeDistrIsEmpty
+
+deriving instance
+  Show (PerasVotingCommitteeError blk) =>
+  Show (MockPerasError blk)
+deriving instance
+  Eq (PerasVotingCommitteeError blk) =>
+  Eq (MockPerasError blk)
+deriving instance
+  NoThunks (PerasVotingCommitteeError blk) =>
+  NoThunks (MockPerasError blk)
+deriving instance
+  Generic (MockPerasError blk)
+deriving instance
+  ( Typeable blk
+  , Show (PerasVotingCommitteeError blk)
+  ) =>
+  Exception (MockPerasError blk)
+
+instance IsPerasError (MockPerasError blk) blk where
+  injectVotingCommitteeError = PerasVotingCommitteeError
+  injectConversionError = PerasVotingConversionError
+  injectQuorumNotReachedError = PerasQuorumNotReachedError


### PR DESCRIPTION
This commit introduces the `IsPerasError` type class that allows us to inject certain errors from the abstract `BlockSupportsPeras` implementation into the concrete error types used in different places (e.g. production vs. tests).

In addition, it introduces two separate Peras error types for production and mocked implementations, with their corresponding `IsPerasError` instances.

NOTE: the `PerasVotingCommitteeError` type is temporary until we refactor
`BlockSupportsPeras` and derive it from there.