### PR TITLE
High-throughput, double buffered mempool

### DIFF
--- a/changelog.d/20260821_093607_sebastian.nagel_mempool_decouple_sync.md
+++ b/changelog.d/20260821_093607_sebastian.nagel_mempool_decouple_sync.md
@@ -1,0 +1,18 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+### Non-Breaking
+
+- Decoupled mempool snapshot readers and adders from ledger revalidation. On a
+  tip change, `implSyncWithLedger` now revalidates the mempool off the state
+  lock against a `readTMVar` snapshot and holds the lock only for a bounded
+  residual reapply before committing, instead of revalidating the whole mempool
+  under the lock. The committed state is byte-identical to a full revalidation;
+  the sync retries under the lock if the tip moved or a transaction was
+  force-removed while it worked off the lock. This bounds `getSnapshot` latency
+  independently of mempool occupancy (seconds down to tens of milliseconds at
+  high occupancy) at no ingestion cost.

--- a/ouroboros-consensus.cabal
+++ b/ouroboros-consensus.cabal
@@ -907,6 +907,41 @@ benchmark mempool-bench
     unstable-mempool-test-utils,
     with-utf8,
 
+benchmark mempool-state-bench
+  import: common-bench
+  type: exitcode-stdio-1.0
+  hs-source-dirs:
+    ouroboros-consensus/bench/mempool-state-bench
+    ouroboros-consensus/bench/mempool-bench
+
+  main-is: Main.hs
+  other-modules:
+    Bench.Consensus.Mempool.TestBlock
+
+  ghc-options:
+    -threaded
+    -rtsopts
+    -with-rtsopts=-N4
+
+  build-depends:
+    async,
+    base,
+    cardano-ledger-core,
+    cardano-slotting,
+    containers,
+    contra-tracer,
+    deepseq,
+    io-classes:si-timers,
+    mempack,
+    nothunks,
+    optparse-applicative,
+    ouroboros-consensus,
+    serialise,
+    time,
+    transformers,
+    tree-diff,
+    unstable-consensus-testlib,
+
 benchmark ChainSync-client-bench
   import: common-bench
   type: exitcode-stdio-1.0

--- a/ouroboros-consensus.cabal
+++ b/ouroboros-consensus.cabal
@@ -949,6 +949,36 @@ benchmark mempool-bench
     unstable-mempool-test-utils,
     with-utf8,
 
+benchmark mempool-state-bench
+  import: common-bench
+  type: exitcode-stdio-1.0
+  hs-source-dirs:
+    ouroboros-consensus/bench/mempool-state-bench
+    ouroboros-consensus/bench/mempool-bench
+
+  main-is: Main.hs
+  other-modules:
+    Bench.Consensus.Mempool.TestBlock
+
+  ghc-options: -threaded -rtsopts -with-rtsopts=-N4
+  build-depends:
+    async,
+    base,
+    cardano-ledger-core,
+    cardano-slotting,
+    containers,
+    contra-tracer,
+    deepseq,
+    io-classes:si-timers,
+    mempack,
+    nothunks,
+    ouroboros-consensus,
+    serialise,
+    time,
+    transformers,
+    tree-diff,
+    unstable-consensus-testlib,
+
 benchmark ChainSync-client-bench
   import: common-bench
   type: exitcode-stdio-1.0

--- a/ouroboros-consensus/bench/mempool-bench/Bench/Consensus/Mempool/TestBlock.hs
+++ b/ouroboros-consensus/bench/mempool-bench/Bench/Consensus/Mempool/TestBlock.hs
@@ -18,6 +18,8 @@ module Bench.Consensus.Mempool.TestBlock
 
     -- * Initial parameters
   , initialLedgerState
+  , mkInitialLedgerState
+  , advanceTip
   , sampleLedgerConfig
 
     -- * Transactions
@@ -37,6 +39,7 @@ import Data.MemPack
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.TreeDiff (ToExpr)
+import Data.Word (Word64)
 import GHC.Generics (Generic)
 import NoThunks.Class (NoThunks)
 import qualified Ouroboros.Consensus.Block as Block
@@ -86,14 +89,28 @@ mkTx cons prod =
 -------------------------------------------------------------------------------}
 
 initialLedgerState :: LedgerState (TestBlockWith Tx) ValuesMK
-initialLedgerState =
+initialLedgerState = mkInitialLedgerState []
+
+-- | Like 'initialLedgerState' but seeded with a set of available tokens (the
+-- UTxO). Chains of transactions can then be built by consuming a seed token and
+-- producing the next one.
+mkInitialLedgerState :: [Token] -> LedgerState (TestBlockWith Tx) ValuesMK
+mkInitialLedgerState toks =
   TestLedger
     { lastAppliedPoint = Block.GenesisPoint
     , payloadDependentState =
         TestPLDS
-          { getTestPLDS = ValuesMK Map.empty
+          { getTestPLDS = ValuesMK (Map.fromList [(t, ()) | t <- toks])
           }
     }
+
+-- | Move the tip to a fresh point (distinct per @n@) while keeping the ledger
+-- tables unchanged. Used to force the mempool to resync/revalidate against a
+-- "new" tip without invalidating any of its transactions.
+advanceTip ::
+  Word64 -> LedgerState (TestBlockWith Tx) ValuesMK -> LedgerState (TestBlockWith Tx) ValuesMK
+advanceTip n st =
+  st{lastAppliedPoint = Block.blockPoint (firstBlockWithPayload n (Tx Set.empty Set.empty))}
 
 sampleLedgerConfig :: Ledger.LedgerConfig TestBlock
 sampleLedgerConfig =

--- a/ouroboros-consensus/bench/mempool-bench/Bench/Consensus/Mempool/TestBlock.hs
+++ b/ouroboros-consensus/bench/mempool-bench/Bench/Consensus/Mempool/TestBlock.hs
@@ -40,6 +40,7 @@ import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.TreeDiff (ToExpr)
 import Data.Word (Word64)
+import GHC.Clock (getMonotonicTimeNSec)
 import GHC.Generics (Generic)
 import NoThunks.Class (NoThunks)
 import qualified Ouroboros.Consensus.Block as Block
@@ -51,7 +52,10 @@ import Ouroboros.Consensus.Ledger.Tables
 import qualified Ouroboros.Consensus.Ledger.Tables.Diff as Diff
 import qualified Ouroboros.Consensus.Ledger.Tables.Utils as Ledger
 import Ouroboros.Consensus.Util.IndexedMemPack (IndexedMemPack (..))
+import System.Environment (lookupEnv)
+import System.IO.Unsafe (unsafePerformIO)
 import Test.Util.TestBlock hiding (TestBlock)
+import Text.Read (readMaybe)
 
 {-------------------------------------------------------------------------------
   MempoolTestBlock
@@ -240,17 +244,62 @@ txSize (TestBlockGenTx tx) =
     fromIntegral $
       1 + length (consumed tx) + length (produced tx)
 
+-- | Simulated CPU cost, in microseconds, of /fully/ validating a transaction
+-- (the script and signature checks a real ledger performs in 'applyTx'). Read
+-- once from @MEMPOOL_APPLY_CPU_US@; defaults to @0@ so ordinary tests and the
+-- criterion @mempool-bench@ are unaffected.
+--
+-- Together with 'reapplyCpuMicros' this lets a benchmark reproduce the
+-- real-node relationship @reapply ≪ apply@: reapplication skips the expensive
+-- checks, so a mempool sync (which only reapplies) is strictly cheaper per tx
+-- than ingestion (which fully validates). The mempool-state-bench relies on
+-- this for its sync-vs-ingest convergence to be faithful.
+{-# NOINLINE applyCpuMicros #-}
+applyCpuMicros :: Int
+applyCpuMicros = envInt "MEMPOOL_APPLY_CPU_US" 0
+
+-- | Simulated CPU cost, in microseconds, of /reapplying/ an already-validated
+-- transaction. Read once from @MEMPOOL_REAPPLY_CPU_US@; defaults to @0@. Keep
+-- this well below 'applyCpuMicros' to model @reapply ≪ apply@.
+{-# NOINLINE reapplyCpuMicros #-}
+reapplyCpuMicros :: Int
+reapplyCpuMicros = envInt "MEMPOOL_REAPPLY_CPU_US" 0
+
+{-# NOINLINE envInt #-}
+envInt :: String -> Int -> Int
+envInt k d = unsafePerformIO $ maybe d id . (>>= readMaybe) <$> lookupEnv k
+
+-- | Busy-wait (burning CPU, /not/ sleeping — validation contends for cores)
+-- for @us@ microseconds, then return @tx@. The result is @tx@ itself and the
+-- caller feeds it into the ledger transition, so the spin depends on the tx
+-- and cannot be shared across calls or optimised away.
+{-# NOINLINE burnCpuMicros #-}
+burnCpuMicros :: Int -> Tx -> Tx
+burnCpuMicros us tx
+  | us <= 0 = tx
+  | otherwise = unsafePerformIO $ do
+      let targetNs = fromIntegral us * 1000 :: Word64
+      start <- getMonotonicTimeNSec
+      let go = do
+            now <- getMonotonicTimeNSec
+            if now - start >= targetNs then pure tx else go
+      go
+
 instance Ledger.LedgerSupportsMempool TestBlock where
   applyTx _cfg _shouldIntervene _slot (TestBlockGenTx tx) tickedSt =
     except $
       fmap ((,ValidatedGenTx (TestBlockGenTx tx)) . Ledger.trackingToDiffs) $
-        applyDirectlyToPayloadDependentState tickedSt tx
+        -- Pay the (simulated) full-validation cost. 'burnCpuMicros' returns the
+        -- tx we then apply, so it is forced as part of producing the result.
+        applyDirectlyToPayloadDependentState tickedSt (burnCpuMicros applyCpuMicros tx)
 
-  reapplyTx cfg slot (ValidatedGenTx genTx) tickedSt =
-    Ledger.applyDiffs tickedSt . fst
-      <$> Ledger.applyTx cfg Ledger.DoNotIntervene slot genTx tickedSt
-
-  -- FIXME: it is ok to use 'DoNotIntervene' here?
+  -- Reapplication does /not/ route through 'applyTx' (which would pay the full
+  -- validation cost); it runs the ledger transition directly, paying only the
+  -- much cheaper 'reapplyCpuMicros'.
+  reapplyTx _cfg _slot (ValidatedGenTx (TestBlockGenTx tx)) tickedSt =
+    except $
+      Ledger.applyDiffs tickedSt . Ledger.trackingToDiffs
+        <$> applyDirectlyToPayloadDependentState tickedSt (burnCpuMicros reapplyCpuMicros tx)
 
   txForgetValidated (ValidatedGenTx tx) = tx
 

--- a/ouroboros-consensus/bench/mempool-bench/Bench/Consensus/Mempool/TestBlock.hs
+++ b/ouroboros-consensus/bench/mempool-bench/Bench/Consensus/Mempool/TestBlock.hs
@@ -19,6 +19,8 @@ module Bench.Consensus.Mempool.TestBlock
 
     -- * Initial parameters
   , initialLedgerState
+  , mkInitialLedgerState
+  , advanceTip
   , sampleLedgerConfig
 
     -- * Transactions
@@ -38,6 +40,8 @@ import Data.MemPack
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.TreeDiff (ToExpr)
+import Data.Word (Word64)
+import GHC.Clock (getMonotonicTimeNSec)
 import GHC.Generics (Generic)
 import NoThunks.Class (NoThunks)
 import qualified Ouroboros.Consensus.Block as Block
@@ -50,7 +54,10 @@ import Ouroboros.Consensus.Ledger.Tables
 import qualified Ouroboros.Consensus.Ledger.Tables.Diff as Diff
 import qualified Ouroboros.Consensus.Ledger.Tables.Utils as Ledger
 import Ouroboros.Consensus.Util.IndexedMemPack (IndexedMemPack (..))
+import System.Environment (lookupEnv)
+import System.IO.Unsafe (unsafePerformIO)
 import Test.Util.TestBlock hiding (TestBlock)
+import Text.Read (readMaybe)
 
 {-------------------------------------------------------------------------------
   MempoolTestBlock
@@ -88,14 +95,28 @@ mkTx cons prod =
 -------------------------------------------------------------------------------}
 
 initialLedgerState :: LedgerState (TestBlockWith Tx) ValuesMK
-initialLedgerState =
+initialLedgerState = mkInitialLedgerState []
+
+-- | Like 'initialLedgerState' but seeded with a set of available tokens (the
+-- UTxO). Chains of transactions can then be built by consuming a seed token and
+-- producing the next one.
+mkInitialLedgerState :: [Token] -> LedgerState (TestBlockWith Tx) ValuesMK
+mkInitialLedgerState toks =
   TestLedger
     { lastAppliedPoint = Block.GenesisPoint
     , payloadDependentState =
         TestPLDS
-          { getTestPLDS = ValuesMK Map.empty
+          { getTestPLDS = ValuesMK (Map.fromList [(t, ()) | t <- toks])
           }
     }
+
+-- | Move the tip to a fresh point (distinct per @n@) while keeping the ledger
+-- tables unchanged. Used to force the mempool to resync/revalidate against a
+-- "new" tip without invalidating any of its transactions.
+advanceTip ::
+  Word64 -> LedgerState (TestBlockWith Tx) ValuesMK -> LedgerState (TestBlockWith Tx) ValuesMK
+advanceTip n st =
+  st{lastAppliedPoint = Block.blockPoint (firstBlockWithPayload n (Tx Set.empty Set.empty))}
 
 sampleLedgerConfig :: Ledger.LedgerConfig TestBlock
 sampleLedgerConfig =
@@ -225,17 +246,66 @@ txSize (TestBlockGenTx tx) =
     fromIntegral $
       1 + length (consumed tx) + length (produced tx)
 
+-- | Simulated CPU cost, in microseconds, of /fully/ validating a transaction
+-- (the script and signature checks a real ledger performs in 'applyTx').
+-- Overridable via @MEMPOOL_APPLY_CPU_US@; defaults to @128@, the measured median
+-- applyBlock cost (~128us/tx) on an nvme SSD (see
+-- input-output-hk/ouroboros-leios#553). Set it to @0@ to remove the injected
+-- cost (e.g. for the criterion @mempool-bench@).
+--
+-- Together with 'reapplyCpuMicros' this lets a benchmark reproduce the
+-- real-node relationship @reapply ≪ apply@: reapplication skips the expensive
+-- checks, so a mempool sync (which only reapplies) is strictly cheaper per tx
+-- than ingestion (which fully validates). The mempool-state-bench relies on
+-- this for its sync-vs-ingest convergence to be faithful.
+{-# NOINLINE applyCpuMicros #-}
+applyCpuMicros :: Int
+applyCpuMicros = envInt "MEMPOOL_APPLY_CPU_US" 128
+
+-- | Simulated CPU cost, in microseconds, of /reapplying/ an already-validated
+-- transaction. Overridable via @MEMPOOL_REAPPLY_CPU_US@; defaults to @20@. This
+-- is an estimate — reapplyBlock was not measured in #553 — kept well below
+-- 'applyCpuMicros' to model @reapply ≪ apply@ (reapply skips the expensive
+-- script/signature checks).
+{-# NOINLINE reapplyCpuMicros #-}
+reapplyCpuMicros :: Int
+reapplyCpuMicros = envInt "MEMPOOL_REAPPLY_CPU_US" 20
+
+{-# NOINLINE envInt #-}
+envInt :: String -> Int -> Int
+envInt k d = unsafePerformIO $ maybe d id . (>>= readMaybe) <$> lookupEnv k
+
+-- | Busy-wait (burning CPU, /not/ sleeping — validation contends for cores)
+-- for @us@ microseconds, then return @tx@. The result is @tx@ itself and the
+-- caller feeds it into the ledger transition, so the spin depends on the tx
+-- and cannot be shared across calls or optimised away.
+{-# NOINLINE burnCpuMicros #-}
+burnCpuMicros :: Int -> Tx -> Tx
+burnCpuMicros us tx
+  | us <= 0 = tx
+  | otherwise = unsafePerformIO $ do
+      let targetNs = fromIntegral us * 1000 :: Word64
+      start <- getMonotonicTimeNSec
+      let go = do
+            now <- getMonotonicTimeNSec
+            if now - start >= targetNs then pure tx else go
+      go
+
 instance Ledger.LedgerSupportsMempool TestBlock where
   applyTx _cfg _shouldIntervene _slot (TestBlockGenTx tx) tickedSt =
     except $
       fmap ((,ValidatedGenTx (TestBlockGenTx tx)) . Ledger.trackingToDiffs) $
-        applyDirectlyToPayloadDependentState tickedSt tx
+        -- Pay the (simulated) full-validation cost. 'burnCpuMicros' returns the
+        -- tx we then apply, so it is forced as part of producing the result.
+        applyDirectlyToPayloadDependentState tickedSt (burnCpuMicros applyCpuMicros tx)
 
-  reapplyTx cfg slot (ValidatedGenTx genTx) tickedSt =
-    Ledger.applyDiffs tickedSt . fst
-      <$> Ledger.applyTx cfg Ledger.DoNotIntervene slot genTx tickedSt
-
-  -- FIXME: it is ok to use 'DoNotIntervene' here?
+  -- Reapplication does /not/ route through 'applyTx' (which would pay the full
+  -- validation cost); it runs the ledger transition directly, paying only the
+  -- much cheaper 'reapplyCpuMicros'.
+  reapplyTx _cfg _slot (ValidatedGenTx (TestBlockGenTx tx)) tickedSt =
+    except $
+      Ledger.applyDiffs tickedSt . Ledger.trackingToDiffs
+        <$> applyDirectlyToPayloadDependentState tickedSt (burnCpuMicros reapplyCpuMicros tx)
 
   txForgetValidated (ValidatedGenTx tx) = tx
 

--- a/ouroboros-consensus/bench/mempool-bench/Bench/Consensus/Mempool/TestBlock.hs
+++ b/ouroboros-consensus/bench/mempool-bench/Bench/Consensus/Mempool/TestBlock.hs
@@ -247,11 +247,13 @@ txSize (TestBlockGenTx tx) =
       1 + length (consumed tx) + length (produced tx)
 
 -- | Simulated CPU cost, in microseconds, of /fully/ validating a transaction
--- (the script and signature checks a real ledger performs in 'applyTx').
--- Overridable via @MEMPOOL_APPLY_CPU_US@; defaults to @128@, the measured median
--- applyBlock cost (~128us/tx) on an nvme SSD (see
--- input-output-hk/ouroboros-leios#553). Set it to @0@ to remove the injected
--- cost (e.g. for the criterion @mempool-bench@).
+-- (the script and signature checks a real ledger performs in 'applyTx'). Set via
+-- @MEMPOOL_APPLY_CPU_US@; defaults to @0@ (no injected cost) so this shared
+-- 'TestBlock' does not slow down the criterion @mempool-bench@ that CI
+-- regression-gates. The @mempool-state-bench@ opts in — it sets the env var from
+-- its @--apply-us@ flag (default 128us, the measured median applyBlock cost on
+-- an nvme SSD, see input-output-hk/ouroboros-leios#553) before this CAF is
+-- forced.
 --
 -- Together with 'reapplyCpuMicros' this lets a benchmark reproduce the
 -- real-node relationship @reapply ≪ apply@: reapplication skips the expensive
@@ -260,16 +262,16 @@ txSize (TestBlockGenTx tx) =
 -- this for its sync-vs-ingest convergence to be faithful.
 {-# NOINLINE applyCpuMicros #-}
 applyCpuMicros :: Int
-applyCpuMicros = envInt "MEMPOOL_APPLY_CPU_US" 128
+applyCpuMicros = envInt "MEMPOOL_APPLY_CPU_US" 0
 
 -- | Simulated CPU cost, in microseconds, of /reapplying/ an already-validated
--- transaction. Overridable via @MEMPOOL_REAPPLY_CPU_US@; defaults to @20@. This
--- is an estimate — reapplyBlock was not measured in #553 — kept well below
--- 'applyCpuMicros' to model @reapply ≪ apply@ (reapply skips the expensive
--- script/signature checks).
+-- transaction. Set via @MEMPOOL_REAPPLY_CPU_US@; defaults to @0@ (see
+-- 'applyCpuMicros'). The @mempool-state-bench@ sets it from its @--reapply-us@
+-- flag (default 20us, an estimate kept well below @--apply-us@ to model
+-- @reapply ≪ apply@, as reapply skips the expensive script/signature checks).
 {-# NOINLINE reapplyCpuMicros #-}
 reapplyCpuMicros :: Int
-reapplyCpuMicros = envInt "MEMPOOL_REAPPLY_CPU_US" 20
+reapplyCpuMicros = envInt "MEMPOOL_REAPPLY_CPU_US" 0
 
 {-# NOINLINE envInt #-}
 envInt :: String -> Int -> Int

--- a/ouroboros-consensus/bench/mempool-state-bench/Main.hs
+++ b/ouroboros-consensus/bench/mempool-state-bench/Main.hs
@@ -1,0 +1,348 @@
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+-- | Concurrent benchmark of the __real__ mempool's shared-state access patterns
+-- under a Leios-scale transaction load.
+--
+-- It opens the actual mempool ('openMempoolWithoutSyncThread') over a mocked
+-- ledger interface whose forker reads inject a configurable latency to model
+-- on-disk UTxO reads. Three roles run concurrently against it, as in a node
+-- under tx-submission load:
+--
+-- * __Adders__ (tx-submission clients and local clients): each submits an
+--   independent chain of transactions via the real 'addTx', rate-limited to a
+--   target rate.
+--
+-- * __Readers__ (tx-submission servers / block forging): call the real
+--   'getSnapshot' (@readTMVar istate@) on a configurable per-peer cadence,
+--   measuring how long a read blocks.
+--
+-- * __Syncer__ (the mempool sync thread): periodically advances the ledger tip
+--   and runs the real 'testSyncWithLedger', which revalidates the mempool
+--   through the latency-injected forker.
+--
+-- With the mempool holding many transactions, this reproduces the contention
+-- between revalidation, ingestion and serving that the mempool sync targets.
+module Main (main) where
+
+import Bench.Consensus.Mempool.TestBlock
+  ( TestBlock
+  , Token (Token)
+  , advanceTip
+  , mkInitialLedgerState
+  , mkTx
+  , sampleLedgerConfig
+  )
+import qualified Control.Concurrent as Conc
+import Control.Concurrent.Async (async, wait)
+import Control.Exception (evaluate)
+import Control.Monad (forM, when)
+import Control.Monad.Class.MonadTime.SI (diffTime, getMonotonicTime)
+import Control.Tracer (nullTracer)
+import Data.IORef
+import qualified Data.Set as Set
+import Data.Time.Clock (DiffTime)
+import Ouroboros.Consensus.Ledger.Basics (LedgerState)
+import Ouroboros.Consensus.Ledger.SupportsMempool (ByteSize32 (ByteSize32))
+import Ouroboros.Consensus.Ledger.Tables
+  ( KeysMK (KeysMK)
+  , LedgerTables (LedgerTables)
+  , ValuesMK
+  , projectLedgerTables
+  )
+import Ouroboros.Consensus.Ledger.Tables.Utils
+  ( emptyLedgerTables
+  , forgetLedgerTables
+  , restrictValues'
+  )
+import Ouroboros.Consensus.Mempool
+  ( Mempool (addTx, getSnapshot, testSyncWithLedger)
+  , MempoolCapacityBytesOverride (MempoolCapacityBytesOverride)
+  , openMempoolWithoutSyncThread
+  , snapshotTxs
+  )
+import Ouroboros.Consensus.Mempool.API
+  ( AddTxOnBehalfOf (AddTxForLocalClient, AddTxForRemotePeer)
+  , isMempoolTxAdded
+  )
+import Ouroboros.Consensus.Mempool.Impl.Common
+  ( LedgerInterface (LedgerInterface, getCurrentLedgerState)
+  , MempoolLedgerDBView (MempoolLedgerDBView)
+  )
+import Ouroboros.Consensus.Storage.LedgerDB.Forker
+  ( ReadOnlyForker (..)
+  , Statistics (Statistics)
+  )
+import Ouroboros.Consensus.Util.IOLike
+  ( StrictTVar
+  , atomically
+  , newTVarIO
+  , readTVar
+  , writeTVar
+  )
+import System.Environment (lookupEnv)
+import System.IO.Unsafe (unsafePerformIO)
+import Test.Util.Orphans.IOLike ()
+import Text.Read (readMaybe)
+
+-- * Configuration (all overridable via environment variables)
+
+envInt :: String -> Int -> Int
+envInt k d = unsafePerformIO $ maybe d id . (>>= readMaybe) <$> lookupEnv k
+
+envDouble :: String -> Double -> Double
+envDouble k d = unsafePerformIO $ maybe d id . (>>= readMaybe) <$> lookupEnv k
+
+{-# NOINLINE durationSec #-}
+durationSec :: Double
+durationSec = envDouble "DURATION" 20
+
+-- | Number of N2N peers. Each peer contributes one tx-submission __server__ (a
+-- reader serving txs to that peer) and one tx-submission __client__ (a remote
+-- adder feeding txs received from that peer).
+{-# NOINLINE numPeers #-}
+numPeers :: Int
+numPeers = envInt "PEERS" 2
+
+-- | Number of local (N2C) clients. They add on behalf of a local client (higher
+-- fifo priority).
+{-# NOINLINE numLocalClients #-}
+numLocalClients :: Int
+numLocalClients = envInt "LOCAL_CLIENTS" 1
+
+-- | tx-submission servers = one per peer.
+numReaders :: Int
+numReaders = numPeers
+
+-- | tx-submission clients = one per peer (N2N) + the local clients (N2C).
+numAdders :: Int
+numAdders = numPeers + numLocalClients
+
+-- | Total target submission rate across all adders (tx/s). @TPS=0@ means
+-- unbounded (adders submit as fast as they can), to measure the mempool's max
+-- sustained rate.
+{-# NOINLINE targetTpsTotal #-}
+targetTpsTotal :: Double
+targetTpsTotal = envDouble "TPS" 100
+
+-- | How often the syncer advances the tip + revalidates. A chain adopts a block
+-- roughly every ~20 s; a shorter period here exercises the sync contention more
+-- often. This is strictly periodic, unlike real block adoption.
+{-# NOINLINE syncPeriodSec #-}
+syncPeriodSec :: Double
+syncPeriodSec = envDouble "SYNC_PERIOD" 5
+
+-- | Fixed cost of a forker table read (models one on-disk round-trip), microseconds.
+{-# NOINLINE readBaseMicros #-}
+readBaseMicros :: Int
+readBaseMicros = envInt "READ_BASE_US" 500
+
+-- | Additional per-key cost of a forker table read (models per-UTxO on-disk
+-- lookup), microseconds. This is what makes a full-mempool sync read scale with
+-- occupancy.
+{-# NOINLINE readPerKeyMicros #-}
+readPerKeyMicros :: Int
+readPerKeyMicros = envInt "READ_PERKEY_US" 200
+
+-- | Pause between successive 'getSnapshot's per reader, microseconds. A reader
+-- models the tx-submission /server/ for one downstream peer, which reads the
+-- mempool on request rather than in a spin. On a Leios testnet each downstream
+-- peer pulled ~3–4 tx-body requests/s from a relay, and with the txid requests
+-- on top a server reads roughly 5–8×/s per peer — a read every ~125–200ms. The
+-- default models ~7 reads/s/peer; set @0@ for a tight loop (only sensible for a
+-- handful of readers, else hundreds of spinning O(occupancy) readers just
+-- measure CPU saturation).
+{-# NOINLINE readPeriodMicros #-}
+readPeriodMicros :: Int
+readPeriodMicros = envInt "READ_PERIOD_US" 150000
+
+-- | Disjoint token namespace per adder so their chains never collide.
+chainStride :: Int
+chainStride = 1_000_000_000
+
+capacityOverride :: MempoolCapacityBytesOverride
+capacityOverride = MempoolCapacityBytesOverride (ByteSize32 100_000_000)
+
+-- * Main
+
+main :: IO ()
+main = do
+  putStr $
+    unlines
+      [ "Mempool shared-state concurrent benchmark (real mempool)"
+      , "  duration      : " <> show durationSec <> " s"
+      , "  peers         : " <> show numPeers <> " (=> " <> show numReaders <> " servers/readers)"
+      , "  clients       : "
+          <> show numAdders
+          <> " ("
+          <> show numPeers
+          <> " N2N + "
+          <> show numLocalClients
+          <> " local, target "
+          <> show targetTpsTotal
+          <> " tx/s total)"
+      , "  sync period   : " <> show syncPeriodSec <> " s"
+      , "  forker read   : " <> show readBaseMicros <> " us + " <> show readPerKeyMicros <> " us/key"
+      , ""
+      ]
+  let seeds = [Token (j * chainStride) | j <- [0 .. numAdders - 1]]
+      baseLedger = mkInitialLedgerState seeds
+  ledgerVar <- newTVarIO baseLedger
+  mempool <-
+    openMempoolWithoutSyncThread
+      (latencyLedgerInterface ledgerVar)
+      sampleLedgerConfig
+      capacityOverride
+      Nothing
+      nullTracer
+
+  addedRef <- newIORef (0 :: Int)
+  readRef <- newIORef (0 :: Int)
+  maxReadLatRef <- newIORef (0 :: DiffTime)
+  syncDursRef <- newIORef ([] :: [DiffTime])
+
+  start <- getMonotonicTime
+  let expired = do
+        now <- getMonotonicTime
+        pure (realToFrac (diffTime now start) >= durationSec)
+
+  syncer <- async (runSyncer expired mempool ledgerVar baseLedger syncDursRef)
+  readers <-
+    forM [1 .. numReaders] $ \_ ->
+      async (runReader expired mempool readRef maxReadLatRef)
+  adders <-
+    forM [0 .. numAdders - 1] $ \j -> do
+      let onBehalf = if j < numPeers then AddTxForRemotePeer else AddTxForLocalClient
+      async (runAdder expired mempool onBehalf j addedRef)
+
+  mapM_ wait adders
+  mapM_ wait readers
+  wait syncer
+  end <- getMonotonicTime
+
+  finalOccupancy <- length . snapshotTxs <$> atomically (getSnapshot mempool)
+  added <- readIORef addedRef
+  reads' <- readIORef readRef
+  maxReadLat <- readIORef maxReadLatRef
+  syncDurs <- readIORef syncDursRef
+  let elapsed = realToFrac (diffTime end start) :: Double
+  putStr $
+    unlines
+      [ "Results:"
+      , "  elapsed         : " <> showT (diffTime end start)
+      , "  txs added       : " <> show added
+      , "  final occupancy : " <> show finalOccupancy <> " txs in mempool"
+      , "  throughput      : " <> show (round (fromIntegral added / elapsed) :: Int) <> " tx/s"
+      , "  snapshot reads  : " <> show reads'
+      , "  max read stall  : " <> showT maxReadLat
+      , "  syncs           : " <> show (length syncDurs)
+      , "  max sync time   : " <> showT (if null syncDurs then 0 else maximum syncDurs)
+      , "  avg sync time   : "
+          <> showT (if null syncDurs then 0 else sum syncDurs / fromIntegral (length syncDurs))
+      ]
+
+-- * Roles
+
+-- | Adder @j@ submits its own chain: consume token @base+i@, produce @base+i+1@.
+runAdder :: IO Bool -> Mempool IO TestBlock -> AddTxOnBehalfOf -> Int -> IORef Int -> IO ()
+runAdder expired mempool onBehalf j addedRef = go 0
+ where
+  base = j * chainStride
+  intervalMicros =
+    if targetTpsTotal <= 0
+      then 0
+      else round (1_000_000 * fromIntegral numAdders / targetTpsTotal)
+  go :: Int -> IO ()
+  go i = do
+    done <- expired
+    if done
+      then pure ()
+      else do
+        let tx = mkTx [Token (base + i)] [Token (base + i + 1)]
+        r <- addTx mempool onBehalf tx
+        when (isMempoolTxAdded r) $ atomicModifyIORef' addedRef (\c -> (c + 1, ()))
+        when (intervalMicros > 0) $ Conc.threadDelay intervalMicros
+        go (i + 1)
+
+-- | Reader: real 'getSnapshot' on the configured per-reader cadence
+-- ('readPeriodMicros'), recording max read latency.
+runReader :: IO Bool -> Mempool IO TestBlock -> IORef Int -> IORef DiffTime -> IO ()
+runReader expired mempool readRef maxLatRef = go
+ where
+  go = do
+    done <- expired
+    if done
+      then pure ()
+      else do
+        t0 <- getMonotonicTime
+        snap <- atomically (getSnapshot mempool)
+        _ <- evaluate (length (snapshotTxs snap))
+        t1 <- getMonotonicTime
+        let lat = diffTime t1 t0
+        atomicModifyIORef' readRef (\c -> (c + 1, ()))
+        atomicModifyIORef' maxLatRef (\m -> (max m lat, ()))
+        when (readPeriodMicros > 0) $ Conc.threadDelay readPeriodMicros
+        go
+
+-- | Syncer: every 'syncPeriodSec', advance the tip and run the real sync.
+runSyncer ::
+  IO Bool ->
+  Mempool IO TestBlock ->
+  StrictTVar IO (LedgerState TestBlock ValuesMK) ->
+  LedgerState TestBlock ValuesMK ->
+  IORef [DiffTime] ->
+  IO ()
+runSyncer expired mempool ledgerVar baseLedger syncDursRef = go 1
+ where
+  go :: Int -> IO ()
+  go n = do
+    Conc.threadDelay (round (1_000_000 * syncPeriodSec))
+    done <- expired
+    if done
+      then pure ()
+      else do
+        atomically $ writeTVar ledgerVar (advanceTip (fromIntegral n) baseLedger)
+        t0 <- getMonotonicTime
+        _ <- testSyncWithLedger mempool
+        t1 <- getMonotonicTime
+        atomicModifyIORef' syncDursRef (\ds -> (diffTime t1 t0 : ds, ()))
+        go (n + 1)
+
+-- * Latency-injecting ledger interface
+
+latencyLedgerInterface ::
+  StrictTVar IO (LedgerState TestBlock ValuesMK) ->
+  LedgerInterface IO TestBlock
+latencyLedgerInterface ledgerVar =
+  LedgerInterface
+    { getCurrentLedgerState = do
+        st <- readTVar ledgerVar
+        pure $
+          MempoolLedgerDBView
+            (forgetLedgerTables st)
+            ( pure $
+                Right $
+                  ReadOnlyForker
+                    { roforkerClose = pure ()
+                    , roforkerGetLedgerState = pure (forgetLedgerTables st)
+                    , roforkerReadTables = \keys -> do
+                        Conc.threadDelay (readBaseMicros + readPerKeyMicros * keysCount keys)
+                        pure (projectLedgerTables st `restrictValues'` keys)
+                    , roforkerReadStatistics = pure (Statistics 0)
+                    , roforkerRangeReadTables = \_ -> pure (emptyLedgerTables, Nothing)
+                    }
+            )
+    }
+
+keysCount :: LedgerTables (LedgerState TestBlock) KeysMK -> Int
+keysCount (LedgerTables (KeysMK s)) = Set.size s
+
+-- * Formatting
+
+showT :: DiffTime -> String
+showT t
+  | s < 1e-3 = show (round (s * 1_000_000) :: Int) <> " us"
+  | s < 1 = show (round (s * 1_000) :: Int) <> " ms"
+  | otherwise = show (fromIntegral (round (s * 1000) :: Int) / 1000 :: Double) <> " s"
+ where
+  s = realToFrac t :: Double

--- a/ouroboros-consensus/bench/mempool-state-bench/Main.hs
+++ b/ouroboros-consensus/bench/mempool-state-bench/Main.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
@@ -377,7 +378,7 @@ runAdder cfg expired mempool onBehalf j addedRef = go 0
     if cfgTargetTpsTotal cfg <= 0
       then 0
       else round (1_000_000 * fromIntegral (numAdders cfg) / cfgTargetTpsTotal cfg)
-       
+
   go !i = do
     done <- expired
     if done
@@ -426,7 +427,7 @@ runSyncer cfg expired mempool ledgerVar baseLedger syncDursRef = go 1
     if done
       then pure ()
       else do
-        atomically $ writeTVar ledgerVar (advanceTip (fromIntegral n) baseLedger)
+        atomically $ writeTVar ledgerVar (advanceTip n baseLedger)
         t0 <- getMonotonicTime
         _ <- testSyncWithLedger mempool
         t1 <- getMonotonicTime

--- a/ouroboros-consensus/bench/mempool-state-bench/Main.hs
+++ b/ouroboros-consensus/bench/mempool-state-bench/Main.hs
@@ -1,0 +1,454 @@
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+-- | Concurrent benchmark of the __real__ mempool's shared-state access patterns
+-- under a Leios-scale transaction load.
+--
+-- It opens the actual mempool ('openMempoolWithoutSyncThread') over a mocked
+-- ledger interface whose forker reads inject a configurable latency to model
+-- on-disk UTxO reads. Three roles run concurrently against it, as in a node
+-- under tx-submission load:
+--
+-- * __Adders__ (tx-submission clients and local clients): each submits an
+--   independent chain of transactions via the real 'addTx', rate-limited to a
+--   target rate.
+--
+-- * __Readers__ (tx-submission servers / block forging): call the real
+--   'getSnapshot' (@readTMVar istate@) on a configurable per-peer cadence,
+--   measuring how long a read blocks.
+--
+-- * __Syncer__ (the mempool sync thread): periodically advances the ledger tip
+--   and runs the real 'testSyncWithLedger', which revalidates the mempool
+--   through the latency-injected forker.
+--
+-- With the mempool holding many transactions, this reproduces the contention
+-- between revalidation, ingestion and serving that the mempool sync targets.
+module Main (main) where
+
+import Bench.Consensus.Mempool.TestBlock
+  ( TestBlock
+  , Token (Token)
+  , advanceTip
+  , mkInitialLedgerState
+  , mkTx
+  , sampleLedgerConfig
+  )
+import qualified Control.Concurrent as Conc
+import Control.Concurrent.Async (async, wait)
+import Control.Exception (evaluate)
+import Control.Monad (forM, when)
+import Control.Monad.Class.MonadTime.SI (diffTime, getMonotonicTime)
+import Control.Tracer (nullTracer)
+import Data.IORef
+import qualified Data.Set as Set
+import Data.Time.Clock (DiffTime)
+import Data.Word (Word64)
+import GHC.Clock (getMonotonicTimeNSec)
+import Options.Applicative
+  ( Parser
+  , auto
+  , execParser
+  , fullDesc
+  , help
+  , helper
+  , info
+  , long
+  , metavar
+  , option
+  , progDesc
+  , showDefault
+  , value
+  , (<**>)
+  )
+import Ouroboros.Consensus.Ledger.Basics (LedgerState)
+import Ouroboros.Consensus.Ledger.SupportsMempool (ByteSize32 (ByteSize32))
+import Ouroboros.Consensus.Ledger.Tables
+  ( KeysMK (KeysMK)
+  , LedgerTables (LedgerTables)
+  , ValuesMK
+  , ltliftA2
+  , projectLedgerTables
+  )
+import Ouroboros.Consensus.Ledger.Tables.Utils
+  ( emptyLedgerTables
+  , forgetLedgerTables
+  , restrictValuesMK
+  )
+import Ouroboros.Consensus.Mempool
+  ( Mempool (addTx, getSnapshot, testSyncWithLedger)
+  , MempoolCapacityBytesOverride (MempoolCapacityBytesOverride)
+  , openMempoolWithoutSyncThread
+  , snapshotTxs
+  )
+import Ouroboros.Consensus.Mempool.API
+  ( AddTxOnBehalfOf (AddTxForLocalClient, AddTxForRemotePeer)
+  , isMempoolTxAdded
+  )
+import Ouroboros.Consensus.Mempool.Impl.Common
+  ( LedgerInterface (LedgerInterface, getCurrentLedgerState)
+  , MempoolLedgerDBView (MempoolLedgerDBView)
+  )
+import Ouroboros.Consensus.Storage.LedgerDB.Forker
+  ( ReadOnlyForker (..)
+  , Statistics (Statistics)
+  )
+import Ouroboros.Consensus.Util.IOLike
+  ( StrictTVar
+  , atomically
+  , newTVarIO
+  , readTVar
+  , writeTVar
+  )
+import Test.Util.Orphans.IOLike ()
+
+-- * Configuration (command-line options, each with a default)
+
+-- | Benchmark parameters, parsed from the command line by 'configParser'.
+data Config = Config
+  { cfgDurationSec :: !Double
+  , cfgNumPeers :: !Int
+  -- ^ Number of N2N peers. Each peer contributes one tx-submission __server__ (a
+  -- reader serving txs to that peer) and one tx-submission __client__ (a remote
+  -- adder feeding txs received from that peer).
+  , cfgNumLocalClients :: !Int
+  -- ^ Number of local (N2C) clients. They add on behalf of a local client
+  -- (higher fifo priority).
+  , cfgTargetTpsTotal :: !Double
+  -- ^ Total target submission rate across all adders (tx/s). @0@ means unbounded
+  -- (adders submit as fast as they can), to measure the mempool's max sustained
+  -- rate.
+  , cfgSyncPeriodSec :: !Double
+  -- ^ How often the syncer advances the tip + revalidates. A chain adopts a
+  -- block roughly every ~20 s; a shorter period here exercises the sync
+  -- contention more often. This is strictly periodic, unlike real block
+  -- adoption.
+  , cfgReadBaseMicros :: !Int
+  -- ^ Fixed cost of a forker table read (models one on-disk round-trip),
+  -- microseconds.
+  , cfgReadPerKeyMicros :: !Int
+  -- ^ Additional per-key cost of a forker table read (models per-UTxO on-disk
+  -- lookup), microseconds. This is what makes a full-mempool sync read scale
+  -- with occupancy.
+  , cfgReadPeriodMicros :: !Int
+  -- ^ Pause between successive 'getSnapshot's per reader, microseconds. A reader
+  -- models the tx-submission /server/ for one downstream peer, which reads the
+  -- mempool on request rather than in a spin. On a Leios testnet each downstream
+  -- peer pulled ~3–4 tx-body requests/s from a relay, and with the txid requests
+  -- on top a server reads roughly 5–8×/s per peer — a read every ~125–200ms. The
+  -- default models ~7 reads/s/peer; set @0@ for a tight loop (only sensible for a
+  -- handful of readers, else hundreds of spinning O(occupancy) readers just
+  -- measure CPU saturation).
+  }
+
+configParser :: Parser Config
+configParser =
+  Config
+    <$> option
+      auto
+      ( long "duration"
+          <> metavar "SECONDS"
+          <> value 20
+          <> showDefault
+          <> help "Benchmark duration"
+      )
+    <*> option
+      auto
+      ( long "peers"
+          <> metavar "N"
+          <> value 2
+          <> showDefault
+          <> help "Number of N2N peers (each => one tx-submission server/reader and one remote adder)"
+      )
+    <*> option
+      auto
+      ( long "local-clients"
+          <> metavar "N"
+          <> value 1
+          <> showDefault
+          <> help "Number of local (N2C) clients (higher fifo priority)"
+      )
+    <*> option
+      auto
+      ( long "tps"
+          <> metavar "TXS_PER_SEC"
+          <> value 100
+          <> showDefault
+          <> help "Total target submission rate across all adders; 0 = unbounded"
+      )
+    <*> option
+      auto
+      ( long "sync-period"
+          <> metavar "SECONDS"
+          <> value 5
+          <> showDefault
+          <> help "How often the syncer advances the tip and revalidates"
+      )
+    <*> option
+      auto
+      ( long "read-base-us"
+          <> metavar "US"
+          <> value 0
+          <> showDefault
+          <> help
+            "Fixed per-read cost. 0 by default: the measured LSM read cost scales \
+            \linearly with the number of txs (no batching — a round trip per tx), \
+            \so it is charged per key below, not as a fixed component."
+      )
+    <*> option
+      auto
+      ( long "read-per-key-us"
+          <> metavar "US"
+          <> value 60
+          <> showDefault
+          <> help
+            "Per-key cost of a forker table read. Default 60us, midpoint of the \
+            \~40-80us/tx measured on the LSM backend (see \
+            \input-output-hk/ouroboros-leios#553); this bench's txs have ~1 input \
+            \each, so per-key ~= per-tx here."
+      )
+    <*> option
+      auto
+      ( long "read-period-us"
+          <> metavar "US"
+          <> value 150000
+          <> showDefault
+          <> help "Pause between successive getSnapshots per reader; 0 = tight loop"
+      )
+
+-- | tx-submission servers = one per peer.
+numReaders :: Config -> Int
+numReaders cfg = cfgNumPeers cfg
+
+-- | tx-submission clients = one per peer (N2N) + the local clients (N2C).
+numAdders :: Config -> Int
+numAdders cfg = cfgNumPeers cfg + cfgNumLocalClients cfg
+
+-- | Disjoint token namespace per adder so their chains never collide.
+chainStride :: Int
+chainStride = 1_000_000_000
+
+capacityOverride :: MempoolCapacityBytesOverride
+capacityOverride = MempoolCapacityBytesOverride (ByteSize32 100_000_000)
+
+-- * Main
+
+main :: IO ()
+main = do
+  cfg <-
+    execParser $
+      info
+        (configParser <**> helper)
+        ( fullDesc
+            <> progDesc
+              "Concurrent benchmark of the real mempool's shared-state access under Leios-scale load"
+        )
+  putStr $
+    unlines
+      [ "Mempool shared-state concurrent benchmark (real mempool)"
+      , "  duration      : " <> show (cfgDurationSec cfg) <> " s"
+      , "  peers         : "
+          <> show (cfgNumPeers cfg)
+          <> " (=> "
+          <> show (numReaders cfg)
+          <> " servers/readers)"
+      , "  clients       : "
+          <> show (numAdders cfg)
+          <> " ("
+          <> show (cfgNumPeers cfg)
+          <> " N2N + "
+          <> show (cfgNumLocalClients cfg)
+          <> " local, target "
+          <> show (cfgTargetTpsTotal cfg)
+          <> " tx/s total)"
+      , "  sync period   : " <> show (cfgSyncPeriodSec cfg) <> " s"
+      , "  forker read   : "
+          <> show (cfgReadBaseMicros cfg)
+          <> " us + "
+          <> show (cfgReadPerKeyMicros cfg)
+          <> " us/key"
+      , ""
+      ]
+  let seeds = [Token (j * chainStride) | j <- [0 .. numAdders cfg - 1]]
+      baseLedger = mkInitialLedgerState seeds
+  ledgerVar <- newTVarIO baseLedger
+  mempool <-
+    openMempoolWithoutSyncThread
+      (latencyLedgerInterface cfg ledgerVar)
+      sampleLedgerConfig
+      capacityOverride
+      Nothing
+      nullTracer
+
+  addedRef <- newIORef (0 :: Int)
+  readRef <- newIORef (0 :: Int)
+  maxReadLatRef <- newIORef (0 :: DiffTime)
+  syncDursRef <- newIORef ([] :: [DiffTime])
+
+  start <- getMonotonicTime
+  let expired = do
+        now <- getMonotonicTime
+        pure (realToFrac (diffTime now start) >= cfgDurationSec cfg)
+
+  syncer <- async (runSyncer cfg expired mempool ledgerVar baseLedger syncDursRef)
+  readers <-
+    forM [1 .. numReaders cfg] $ \_ ->
+      async (runReader cfg expired mempool readRef maxReadLatRef)
+  adders <-
+    forM [0 .. numAdders cfg - 1] $ \j -> do
+      let onBehalf = if j < cfgNumPeers cfg then AddTxForRemotePeer else AddTxForLocalClient
+      async (runAdder cfg expired mempool onBehalf j addedRef)
+
+  mapM_ wait adders
+  mapM_ wait readers
+  wait syncer
+  end <- getMonotonicTime
+
+  finalOccupancy <- length . snapshotTxs <$> atomically (getSnapshot mempool)
+  added <- readIORef addedRef
+  reads' <- readIORef readRef
+  maxReadLat <- readIORef maxReadLatRef
+  syncDurs <- readIORef syncDursRef
+  let elapsed = realToFrac (diffTime end start) :: Double
+  putStr $
+    unlines
+      [ "Results:"
+      , "  elapsed         : " <> showT (diffTime end start)
+      , "  txs added       : " <> show added
+      , "  final occupancy : " <> show finalOccupancy <> " txs in mempool"
+      , "  throughput      : " <> show (round (fromIntegral added / elapsed) :: Int) <> " tx/s"
+      , "  snapshot reads  : " <> show reads'
+      , "  max read stall  : " <> showT maxReadLat
+      , "  syncs           : " <> show (length syncDurs)
+      , "  max sync time   : " <> showT (if null syncDurs then 0 else maximum syncDurs)
+      , "  avg sync time   : "
+          <> showT (if null syncDurs then 0 else sum syncDurs / fromIntegral (length syncDurs))
+      ]
+
+-- * Roles
+
+-- | Adder @j@ submits its own chain: consume token @base+i@, produce @base+i+1@.
+runAdder ::
+  Config -> IO Bool -> Mempool IO TestBlock -> AddTxOnBehalfOf -> Int -> IORef Int -> IO ()
+runAdder cfg expired mempool onBehalf j addedRef = go 0
+ where
+  base = j * chainStride
+  intervalMicros =
+    if cfgTargetTpsTotal cfg <= 0
+      then 0
+      else round (1_000_000 * fromIntegral (numAdders cfg) / cfgTargetTpsTotal cfg)
+  go :: Int -> IO ()
+  go i = do
+    done <- expired
+    if done
+      then pure ()
+      else do
+        let tx = mkTx [Token (base + i)] [Token (base + i + 1)]
+        r <- addTx mempool onBehalf tx
+        when (isMempoolTxAdded r) $ atomicModifyIORef' addedRef (\c -> (c + 1, ()))
+        when (intervalMicros > 0) $ Conc.threadDelay intervalMicros
+        go (i + 1)
+
+-- | Reader: real 'getSnapshot' on the configured per-reader cadence
+-- ('cfgReadPeriodMicros'), recording max read latency.
+runReader :: Config -> IO Bool -> Mempool IO TestBlock -> IORef Int -> IORef DiffTime -> IO ()
+runReader cfg expired mempool readRef maxLatRef = go
+ where
+  go = do
+    done <- expired
+    if done
+      then pure ()
+      else do
+        t0 <- getMonotonicTime
+        snap <- atomically (getSnapshot mempool)
+        _ <- evaluate (length (snapshotTxs snap))
+        t1 <- getMonotonicTime
+        let lat = diffTime t1 t0
+        atomicModifyIORef' readRef (\c -> (c + 1, ()))
+        atomicModifyIORef' maxLatRef (\m -> (max m lat, ()))
+        when (cfgReadPeriodMicros cfg > 0) $ Conc.threadDelay (cfgReadPeriodMicros cfg)
+        go
+
+-- | Syncer: every 'cfgSyncPeriodSec', advance the tip and run the real sync.
+runSyncer ::
+  Config ->
+  IO Bool ->
+  Mempool IO TestBlock ->
+  StrictTVar IO (LedgerState TestBlock ValuesMK) ->
+  LedgerState TestBlock ValuesMK ->
+  IORef [DiffTime] ->
+  IO ()
+runSyncer cfg expired mempool ledgerVar baseLedger syncDursRef = go 1
+ where
+  go :: Int -> IO ()
+  go n = do
+    Conc.threadDelay (round (1_000_000 * cfgSyncPeriodSec cfg))
+    done <- expired
+    if done
+      then pure ()
+      else do
+        atomically $ writeTVar ledgerVar (advanceTip (fromIntegral n) baseLedger)
+        t0 <- getMonotonicTime
+        _ <- testSyncWithLedger mempool
+        t1 <- getMonotonicTime
+        atomicModifyIORef' syncDursRef (\ds -> (diffTime t1 t0 : ds, ()))
+        go (n + 1)
+
+-- * Latency-injecting ledger interface
+
+latencyLedgerInterface ::
+  Config ->
+  StrictTVar IO (LedgerState TestBlock ValuesMK) ->
+  LedgerInterface IO TestBlock
+latencyLedgerInterface cfg ledgerVar =
+  LedgerInterface
+    { getCurrentLedgerState = do
+        st <- readTVar ledgerVar
+        pure $
+          MempoolLedgerDBView
+            (forgetLedgerTables st)
+            ( pure $
+                Right $
+                  ReadOnlyForker
+                    { roforkerClose = pure ()
+                    , roforkerGetLedgerState = pure (forgetLedgerTables st)
+                    , roforkerReadTables = \keys -> do
+                        -- Busy-wait, not 'threadDelay': the read latency here is
+                        -- often sub-millisecond, below 'threadDelay's timer
+                        -- granularity, and it is on the critical path (held under
+                        -- the mempool lock), so rounding it up to ~1ms would
+                        -- badly distort the results.
+                        spinMicros (cfgReadBaseMicros cfg + cfgReadPerKeyMicros cfg * keysCount keys)
+                        pure (ltliftA2 restrictValuesMK (projectLedgerTables st) keys)
+                    , roforkerReadStatistics = pure (Statistics 0)
+                    , roforkerRangeReadTables = \_ -> pure (emptyLedgerTables, Nothing)
+                    }
+            )
+    }
+
+keysCount :: LedgerTables TestBlock KeysMK -> Int
+keysCount (LedgerTables (KeysMK s)) = Set.size s
+
+-- | Busy-wait for the given number of microseconds. Unlike 'Conc.threadDelay',
+-- this honours sub-millisecond durations (which the RTS timer would round up),
+-- at the cost of burning a core — appropriate for modelling a latency that sits
+-- on the mempool's critical path.
+spinMicros :: Int -> IO ()
+spinMicros us
+  | us <= 0 = pure ()
+  | otherwise = do
+      let target = fromIntegral us * 1_000 :: Word64
+      start <- getMonotonicTimeNSec
+      let go = do
+            now <- getMonotonicTimeNSec
+            when (now - start < target) go
+      go
+
+-- * Formatting
+
+showT :: DiffTime -> String
+showT t
+  | s < 1e-3 = show (round (s * 1_000_000) :: Int) <> " us"
+  | s < 1 = show (round (s * 1_000) :: Int) <> " ms"
+  | otherwise = show (fromIntegral (round (s * 1000) :: Int) / 1000 :: Double) <> " s"
+ where
+  s = realToFrac t :: Double

--- a/ouroboros-consensus/bench/mempool-state-bench/Main.hs
+++ b/ouroboros-consensus/bench/mempool-state-bench/Main.hs
@@ -99,6 +99,7 @@ import Ouroboros.Consensus.Util.IOLike
   , readTVar
   , writeTVar
   )
+import System.Environment (setEnv)
 import Test.Util.Orphans.IOLike ()
 
 -- * Configuration (command-line options, each with a default)
@@ -138,6 +139,13 @@ data Config = Config
   -- default models ~7 reads/s/peer; set @0@ for a tight loop (only sensible for a
   -- handful of readers, else hundreds of spinning O(occupancy) readers just
   -- measure CPU saturation).
+  , cfgApplyCpuMicros :: !Int
+  -- ^ Simulated CPU cost of fully validating a tx (@applyTx@), microseconds.
+  -- Exported to the shared 'TestBlock' via @MEMPOOL_APPLY_CPU_US@ (see
+  -- 'Bench.Consensus.Mempool.TestBlock.applyCpuMicros').
+  , cfgReapplyCpuMicros :: !Int
+  -- ^ Simulated CPU cost of reapplying an already-validated tx (@reapplyTx@),
+  -- microseconds. Kept well below 'cfgApplyCpuMicros' to model @reapply ≪ apply@.
   }
 
 configParser :: Parser Config
@@ -214,6 +222,27 @@ configParser =
           <> showDefault
           <> help "Pause between successive getSnapshots per reader; 0 = tight loop"
       )
+    <*> option
+      auto
+      ( long "apply-us"
+          <> metavar "US"
+          <> value 128
+          <> showDefault
+          <> help
+            "Simulated CPU cost of fully validating a tx (applyTx). Default 128us, \
+            \the measured median applyBlock cost (see \
+            \input-output-hk/ouroboros-leios#553). Exported via MEMPOOL_APPLY_CPU_US."
+      )
+    <*> option
+      auto
+      ( long "reapply-us"
+          <> metavar "US"
+          <> value 20
+          <> showDefault
+          <> help
+            "Simulated CPU cost of reapplying an already-validated tx (reapplyTx). \
+            \Default 20us, kept well below --apply-us. Exported via MEMPOOL_REAPPLY_CPU_US."
+      )
 
 -- | tx-submission servers = one per peer.
 numReaders :: Config -> Int
@@ -242,6 +271,12 @@ main = do
             <> progDesc
               "Concurrent benchmark of the real mempool's shared-state access under Leios-scale load"
         )
+  -- Export the apply/reapply CPU costs to the shared 'TestBlock' before anything
+  -- forces its 'NOINLINE' CAFs (they read these env vars once via
+  -- 'unsafePerformIO'). The 'TestBlock' defaults to 0 so the criterion
+  -- 'mempool-bench' is unaffected; only this bench opts in.
+  setEnv "MEMPOOL_APPLY_CPU_US" (show (cfgApplyCpuMicros cfg))
+  setEnv "MEMPOOL_REAPPLY_CPU_US" (show (cfgReapplyCpuMicros cfg))
   putStr $
     unlines
       [ "Mempool shared-state concurrent benchmark (real mempool)"
@@ -266,6 +301,11 @@ main = do
           <> " us + "
           <> show (cfgReadPerKeyMicros cfg)
           <> " us/key"
+      , "  tx cpu cost   : "
+          <> show (cfgApplyCpuMicros cfg)
+          <> " us apply / "
+          <> show (cfgReapplyCpuMicros cfg)
+          <> " us reapply"
       , ""
       ]
   let seeds = [Token (j * chainStride) | j <- [0 .. numAdders cfg - 1]]

--- a/ouroboros-consensus/bench/mempool-state-bench/Main.hs
+++ b/ouroboros-consensus/bench/mempool-state-bench/Main.hs
@@ -372,12 +372,13 @@ runAdder ::
 runAdder cfg expired mempool onBehalf j addedRef = go 0
  where
   base = j * chainStride
+
   intervalMicros =
     if cfgTargetTpsTotal cfg <= 0
       then 0
       else round (1_000_000 * fromIntegral (numAdders cfg) / cfgTargetTpsTotal cfg)
-  go :: Int -> IO ()
-  go i = do
+       
+  go !i = do
     done <- expired
     if done
       then pure ()
@@ -419,8 +420,7 @@ runSyncer ::
   IO ()
 runSyncer cfg expired mempool ledgerVar baseLedger syncDursRef = go 1
  where
-  go :: Int -> IO ()
-  go n = do
+  go !n = do
     Conc.threadDelay (round (1_000_000 * cfgSyncPeriodSec cfg))
     done <- expired
     if done

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Impl/Common.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Impl/Common.hs
@@ -31,6 +31,7 @@ module Ouroboros.Consensus.Mempool.Impl.Common
   , RevalidateTxsResult (..)
   , computeSnapshot
   , revalidateTxsFor
+  , extendReapply
   , validateNewTransaction
 
     -- * Tracing
@@ -423,19 +424,100 @@ revalidateTxsFor ::
   [TxTicket (TxMeasureWithDiffTime blk) (ValidatedTxWithDiffs blk)] ->
   RevalidateTxsResult blk
 revalidateTxsFor capacityOverride cfg slot st values lastTicketNo txTickets =
-  let inputTxs = map wrap txTickets
-      inputKeys = Foldable.foldMap' (getTransactionKeySets . txForgetValidated . fst3) inputTxs
+  let inputTxs = map wrapTxTicket txTickets
+      inputKeys = Foldable.foldMap' (getTransactionKeySets . txForgetValidated . wtdTx) inputTxs
 
       ReapplyTxsResult err validTxs st' =
         reapplyTxs @blk @Collect cfg slot inputTxs $
           applyMempoolDiffs values inputKeys st
+   in buildRevalidatedIS capacityOverride cfg slot st values lastTicketNo err validTxs st'
 
-      outputKeys = Foldable.foldMap' (getTransactionKeySets . txForgetValidated . fst3) validTxs
-      outputDiffs = Foldable.foldl' rawPrependDiffs (DiffMK mempty) $ map (getLedgerTables . snd3) validTxs
+-- | Reapply an additional /delta/ of already-validated transactions on top of a
+-- previously revalidated 'InternalState' @cand@, without reprocessing @cand@'s
+-- transactions.
+--
+-- @cand@ must be the result of revalidating some prefix (by 'TicketNo') of the
+-- mempool against @st@ (the same ticked ledger state passed here), and
+-- @deltaTxTickets@ the transactions added since, in ascending ticket order,
+-- with @deltaValues@ their input values read at @st@'s tip. The result is
+-- /byte-identical/ to @'revalidateTxsFor' \@ (cand's txs ++ delta)@: the delta
+-- is reapplied against @cand@'s post-reapply ledger state (via
+-- 'applyMempoolDiffs' on 'isLedgerState'), and the final 'InternalState' is
+-- assembled by the /same/ 'buildRevalidatedIS' over the concatenated survivors.
+-- This lets a mempool sync shrink its outstanding work off the lock and take
+-- the lock only for a small, bounded final delta ('implSyncWithLedger').
+extendReapply ::
+  forall blk.
+  (LedgerSupportsMempool blk, HasTxId (GenTx blk)) =>
+  MempoolCapacityBytesOverride ->
+  LedgerConfig blk ->
+  SlotNo ->
+  -- | The ticked ledger state @cand@ was revalidated against.
+  TickedLedgerState blk DiffMK ->
+  -- | The already-revalidated state to extend.
+  InternalState blk ->
+  -- | Input values for the delta txs, read at @st@'s tip.
+  LedgerTables (LedgerState blk) ValuesMK ->
+  -- | The new 'isLastTicketNo' (the mempool's current ticket counter).
+  TicketNo ->
+  -- | The delta txs, in ascending 'TicketNo' order.
+  [TxTicket (TxMeasureWithDiffTime blk) (ValidatedTxWithDiffs blk)] ->
+  RevalidateTxsResult blk
+extendReapply capacityOverride cfg slot st cand deltaValues lastTicketNo deltaTxTickets =
+  let candTxs = map wrapTxTicket (TxSeq.toList (isTxs cand))
+      deltaTxs = map wrapTxTicket deltaTxTickets
+      deltaKeys = Foldable.foldMap' (getTransactionKeySets . txForgetValidated . wtdTx) deltaTxs
+
+      -- Seed the delta reapplication from @cand@'s post-reapply ledger state, so
+      -- a delta tx spending one of @cand@'s outputs sees it. This is exactly the
+      -- state a full reapplication would be in after processing @cand@'s txs.
+      ReapplyTxsResult errDelta validDelta st' =
+        reapplyTxs @blk @Collect cfg slot deltaTxs $
+          applyMempoolDiffs deltaValues deltaKeys (isLedgerState cand)
+
+      -- @cand@'s txs remain valid (reapplying more txs after them cannot
+      -- invalidate earlier ones), so the combined survivors are just @cand@'s
+      -- followed by the delta's, and the values cover both.
+      allValues = ltliftA2 unionValues (isTxValues cand) deltaValues
+   in buildRevalidatedIS
+        capacityOverride
+        cfg
+        slot
+        st
+        allValues
+        lastTicketNo
+        errDelta
+        (candTxs ++ validDelta)
+        st'
+
+-- | Assemble an 'InternalState' from the result of a (re)application: the base
+-- ticked ledger @st@, the input @values@, and the reapply's survivors and
+-- resulting ledger state. Shared by 'revalidateTxsFor' and 'extendReapply' so
+-- both produce identical states.
+buildRevalidatedIS ::
+  forall blk.
+  (LedgerSupportsMempool blk, HasTxId (GenTx blk)) =>
+  MempoolCapacityBytesOverride ->
+  LedgerConfig blk ->
+  SlotNo ->
+  TickedLedgerState blk DiffMK ->
+  LedgerTables (LedgerState blk) ValuesMK ->
+  TicketNo ->
+  [Invalidated blk] ->
+  [ ( Validated (GenTx blk)
+    , LedgerTables (TickedLedgerState blk) DiffMK
+    , (TicketNo, TxMeasureWithDiffTime blk)
+    )
+  ] ->
+  TickedLedgerState blk EmptyMK ->
+  RevalidateTxsResult blk
+buildRevalidatedIS capacityOverride cfg slot st values lastTicketNo err validTxs st' =
+  let outputKeys = Foldable.foldMap' (getTransactionKeySets . txForgetValidated . wtdTx) validTxs
+      outputDiffs = Foldable.foldl' rawPrependDiffs (DiffMK mempty) $ map (getLedgerTables . wtdDiffs) validTxs
    in RevalidateTxsResult
         ( IS
-            { isTxs = TxSeq.fromList $ map unwrap validTxs
-            , isTxIds = Set.fromList $ map (txId . txForgetValidated . fst3) validTxs
+            { isTxs = TxSeq.fromList $ map unwrapTxTicket validTxs
+            , isTxIds = Set.fromList $ map (txId . txForgetValidated . wtdTx) validTxs
             , isTxKeys = outputKeys
             , isTxValues = ltliftA2 restrictValuesMK values outputKeys
             , isLedgerState =
@@ -448,11 +530,28 @@ revalidateTxsFor capacityOverride cfg slot st values lastTicketNo txTickets =
             }
         )
         err
- where
-  wrap = \(TxTicket (ValidatedTxWithDiffs tx df) tk tz) -> (tx, df, (tk, tz))
-  unwrap = \(tx, df, (tk, tz)) -> TxTicket (ValidatedTxWithDiffs tx df) tk tz
-  fst3 (x, _, _) = x
-  snd3 (_, x, _) = x
+
+wrapTxTicket ::
+  TxTicket (TxMeasureWithDiffTime blk) (ValidatedTxWithDiffs blk) ->
+  ( Validated (GenTx blk)
+  , LedgerTables (TickedLedgerState blk) DiffMK
+  , (TicketNo, TxMeasureWithDiffTime blk)
+  )
+wrapTxTicket (TxTicket (ValidatedTxWithDiffs tx df) tk tz) = (tx, df, (tk, tz))
+
+unwrapTxTicket ::
+  ( Validated (GenTx blk)
+  , LedgerTables (TickedLedgerState blk) DiffMK
+  , (TicketNo, TxMeasureWithDiffTime blk)
+  ) ->
+  TxTicket (TxMeasureWithDiffTime blk) (ValidatedTxWithDiffs blk)
+unwrapTxTicket (tx, df, (tk, tz)) = TxTicket (ValidatedTxWithDiffs tx df) tk tz
+
+wtdTx :: (a, b, c) -> a
+wtdTx (x, _, _) = x
+
+wtdDiffs :: (a, b, c) -> b
+wtdDiffs (_, x, _) = x
 
 data RevalidateTxsResult blk
   = RevalidateTxsResult

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Impl/Common.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Impl/Common.hs
@@ -264,6 +264,15 @@ data MempoolEnv m blk = MempoolEnv
   , mpEnvForker :: StrictMVar m (ReadOnlyForker m (LedgerState blk))
   , mpEnvLedgerCfg :: LedgerConfig blk
   , mpEnvStateVar :: StrictTMVar m (InternalState blk)
+  -- ^ The single, authoritative internal state of the mempool, which doubles as
+  -- the /writer/ lock. Writers (adds, removes and the sync merge) 'takeTMVar'
+  -- it, do their work, and 'putTMVar' the new state; readers ('getSnapshot',
+  -- 'getCapacity', 'getSnapshotFor') 'readTMVar' it. Because it is a single
+  -- cell, the whole capacity accounting has one source of truth and cannot
+  -- diverge. A reader only ever blocks for the duration a writer holds the
+  -- lock; the sync keeps that short by doing its large LedgerDB read /before/
+  -- taking the lock (see 'implSyncWithLedger'), so only the (sub-second) merge
+  -- is under it.
   , mpEnvAddTxsRemoteFifo :: StrictMVar m ()
   , mpEnvAddTxsAllFifo :: StrictMVar m ()
   , mpEnvTracer :: Tracer m (TraceEventMempool blk)
@@ -293,9 +302,8 @@ initMempoolEnv ledgerInterface cfg capacityOverride mbTimeoutConfig tracer = do
     Right frk -> do
       frkMVar <- newMVar frk
       let (slot, st') = tickLedgerState cfg (ForgeInUnknownSlot st)
-      isVar <-
-        newTMVarIO $
-          initInternalState capacityOverride TxSeq.zeroTicketNo cfg slot st'
+          is0 = initInternalState capacityOverride TxSeq.zeroTicketNo cfg slot st'
+      isVar <- newTMVarIO is0
       addTxRemoteFifo <- newMVar ()
       addTxAllFifo <- newMVar ()
       return

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Impl/Common.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Impl/Common.hs
@@ -58,6 +58,7 @@ import Data.Set (Set)
 import qualified Data.Set as Set
 import qualified Data.Text as Text
 import Data.Typeable
+import Data.Word (Word64)
 import GHC.Generics (Generic)
 import NoThunks.Class
 import Ouroboros.Consensus.Block
@@ -279,6 +280,13 @@ data MempoolEnv m blk = MempoolEnv
   , mpEnvTracer :: Tracer m (TraceEventMempool blk)
   , mpEnvCapacityOverride :: MempoolCapacityBytesOverride
   , mpEnvTimeoutConfig :: Maybe MempoolTimeoutConfig
+  , mpEnvRemovalGen :: StrictTVar m Word64
+  -- ^ A monotonic counter bumped (under the state lock) whenever
+  -- 'implRemoveTxsEvenIfValid' actually drops a transaction. A sync captures it
+  -- alongside its snapshot and re-checks it before committing: a removal in that
+  -- window means the sync's candidate is stale (it may still contain a dropped
+  -- tx), so the sync restarts rather than resurrecting it. See
+  -- 'implSyncWithLedger'.
   }
 
 initMempoolEnv ::
@@ -307,6 +315,7 @@ initMempoolEnv ledgerInterface cfg capacityOverride mbTimeoutConfig tracer = do
       isVar <- newTMVarIO is0
       addTxRemoteFifo <- newMVar ()
       addTxAllFifo <- newMVar ()
+      removalGen <- newTVarIO 0
       return
         MempoolEnv
           { mpEnvLedger = ledgerInterface
@@ -318,6 +327,7 @@ initMempoolEnv ledgerInterface cfg capacityOverride mbTimeoutConfig tracer = do
           , mpEnvTracer = tracer
           , mpEnvCapacityOverride = capacityOverride
           , mpEnvTimeoutConfig = mbTimeoutConfig
+          , mpEnvRemovalGen = removalGen
           }
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Impl/Common.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Impl/Common.hs
@@ -502,19 +502,9 @@ revalidateTxsFor' frk capacityOverride cfg slot (RevalidateTxsResult cand remove
         { isTxs = Foldable.foldl' (:>) (isTxs cand) (map unwrap validDelta)
         , isTxIds = isTxIds cand <> Set.fromList (map (txId . txForgetValidated . fst3) validDelta)
         , isTxKeys = isTxKeys cand <> survivorKeys
-        , -- REVIEW(utxo-hd): incremental value cache. Equal to the from-scratch
-          -- @restrictValuesMK (isTxValues cand `union` deltaValues) (allKeys)@:
-          -- 'isTxValues cand' is already restricted to the candidate's keys and
-          -- 'deltaValues' covers the delta's keys, so the outer restrict is a
-          -- no-op; any key shared with the candidate (a reference input) carries
-          -- the same base value, so the union is unambiguous.
-          isTxValues =
+        , isTxValues =
             ltliftA2 unionValues (isTxValues cand) (ltliftA2 restrictValuesMK deltaValues survivorKeys)
-        , -- REVIEW(utxo-hd): incremental ledger tables. Prepends only the delta's
-          -- diffs onto the candidate's tables (base ⊕ cand-diffs). Equal to the
-          -- from-scratch @rawPrependDiffs base (candDiffs ⊕ deltaDiffs)@ iff
-          -- 'rawPrependDiffs' is associative over the (disjoint) per-tx diffs.
-          isLedgerState =
+        , isLedgerState =
             st'
               `withLedgerTables` ltliftA2 rawPrependDiffs (projectLedgerTables (isLedgerState cand)) (LedgerTables survivorDiffs)
         , isCapacity = computeMempoolCapacity cfg st' capacityOverride

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Impl/Common.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Impl/Common.hs
@@ -29,6 +29,7 @@ module Ouroboros.Consensus.Mempool.Impl.Common
   , RevalidateTxsResult (..)
   , computeSnapshot
   , revalidateTxsFor
+  , revalidateTxsFor'
   , validateNewTransaction
 
     -- * Tracing
@@ -56,6 +57,7 @@ import Data.Set (Set)
 import qualified Data.Set as Set
 import qualified Data.Text as Text
 import Data.Typeable
+import Data.Word (Word64)
 import GHC.Generics (Generic)
 import NoThunks.Class
 import Ouroboros.Consensus.Block
@@ -167,6 +169,12 @@ data InternalState blk = IS
   -- transactions will be in the next block. So any changes caused by that
   -- block will take effect after applying it and will only affect the
   -- next block.
+  , isRemovalGen :: !Word64
+  -- ^ A monotonic counter bumped each time 'implRemoveTxsEvenIfValid' drops a
+  -- transaction. A sync carries it along its (off-lock) candidate and re-checks
+  -- it against the committed state under the lock: a mismatch means a removal
+  -- raced the sync, whose candidate may have resurrected the dropped tx, so it
+  -- must retry. Preserved by adds and syncs, bumped only by removals.
   }
   deriving Generic
 
@@ -211,6 +219,7 @@ initInternalState capacityOverride lastTicketNo cfg slot st =
     , isTip = castPoint $ getTip st
     , isSlotNo = slot
     , isLastTicketNo = lastTicketNo
+    , isRemovalGen = 0
     , isCapacity = computeMempoolCapacity cfg st capacityOverride
     }
 
@@ -264,6 +273,15 @@ data MempoolEnv m blk = MempoolEnv
   , mpEnvForker :: StrictMVar m (ReadOnlyForker m LedgerState blk)
   , mpEnvLedgerCfg :: LedgerConfig blk
   , mpEnvStateVar :: StrictTMVar m (InternalState blk)
+  -- ^ The single, authoritative internal state of the mempool, which doubles as
+  -- the /writer/ lock. Writers (adds, removes and the sync merge) 'takeTMVar'
+  -- it, do their work, and 'putTMVar' the new state; readers ('getSnapshot',
+  -- 'getCapacity', 'getSnapshotFor') 'readTMVar' it. Because it is a single
+  -- cell, the whole capacity accounting has one source of truth and cannot
+  -- diverge. A reader only ever blocks for the duration a writer holds the
+  -- lock; the sync keeps that short by doing its large LedgerDB read /before/
+  -- taking the lock (see 'implSyncWithLedger'), so only the (sub-second) merge
+  -- is under it.
   , mpEnvAddTxsRemoteFifo :: StrictMVar m ()
   , mpEnvAddTxsAllFifo :: StrictMVar m ()
   , mpEnvTracer :: Tracer m (TraceEventMempool blk)
@@ -401,45 +419,104 @@ validateNewTransaction cfg wti tx txsz origValues st is =
 -- revalidating the whole set of transactions onto a new state, or if we remove
 -- some transactions and revalidate the remaining ones.
 revalidateTxsFor ::
-  forall blk.
-  (LedgerSupportsMempool blk, HasTxId (GenTx blk)) =>
+  forall m blk.
+  (Monad m, LedgerSupportsMempool blk, HasTxId (GenTx blk)) =>
+  -- | The forker to read the transactions' inputs from.
+  ReadOnlyForker m LedgerState blk ->
   MempoolCapacityBytesOverride ->
   LedgerConfig blk ->
   SlotNo ->
   -- | The ticked ledger state againt which txs will be revalidated
   TickedLedgerState blk DiffMK ->
-  -- | The tables with all the inputs for the transactions
-  LedgerTables blk ValuesMK ->
   -- | 'isLastTicketNo' and 'vrLastTicketNo'
   TicketNo ->
+  -- | The removal generation to stamp on the result (see 'isRemovalGen').
+  Word64 ->
   [TxTicket (TxMeasureWithDiffTime blk) (ValidatedTxWithDiffs blk)] ->
-  RevalidateTxsResult blk
-revalidateTxsFor capacityOverride cfg slot st values lastTicketNo txTickets =
-  let inputTxs = map wrap txTickets
-      inputKeys = Foldable.foldMap' (getTransactionKeySets . txForgetValidated . fst3) inputTxs
+  m (RevalidateTxsResult blk)
+revalidateTxsFor frk capacityOverride cfg slot st lastTicketNo removalGen txTickets =
+  -- A from-scratch revalidation is just 'revalidateTxsFor'' onto an empty candidate
+  -- at this base: no prior txs, ledger = @st@. Sharing the one implementation
+  -- keeps the two byte-identical by construction.
+  revalidateTxsFor' frk capacityOverride cfg slot emptyResult lastTicketNo txTickets
+ where
+  emptyResult =
+    RevalidateTxsResult
+      (initInternalState capacityOverride TxSeq.zeroTicketNo cfg slot st){isRemovalGen = removalGen}
+      []
 
-      ReapplyTxsResult err validTxs st' =
-        reapplyTxs @blk @Collect cfg slot inputTxs $
-          applyMempoolDiffs values inputKeys st
+-- | The general revalidation step: reapply a /delta/ of already-validated txs on
+-- top of the candidate carried in the given 'RevalidateTxsResult', without
+-- reprocessing what it already holds, appending any newly-removed txs to those
+-- carried in. 'revalidateTxsFor' is the special case that starts from an empty
+-- candidate.
+--
+-- @deltaTxTickets@ are the txs added since the candidate was revalidated, in
+-- ascending ticket order. Their inputs are read from @frk@ here rather than by
+-- the caller — the keys to read are derived from the txs anyway. Seeding the
+-- delta from the candidate's post-reapply ledger ('isLedgerState') lets a sync
+-- shrink its work off the lock and hold the lock only for a small final delta
+-- ('implSyncWithLedger').
+revalidateTxsFor' ::
+  forall m blk.
+  (Monad m, LedgerSupportsMempool blk, HasTxId (GenTx blk)) =>
+  -- | The forker to read the delta txs' inputs from.
+  ReadOnlyForker m LedgerState blk ->
+  MempoolCapacityBytesOverride ->
+  LedgerConfig blk ->
+  SlotNo ->
+  -- | The result so far: its state is extended in place with the delta (no full
+  -- rebuild), and its removed txs are carried forward so the loop accumulates
+  -- them without any bookkeeping of its own. The candidate already carries the
+  -- base it was revalidated against (via 'isLedgerState'/'isTip'), so the base
+  -- ledger need not be passed separately.
+  RevalidateTxsResult blk ->
+  -- | The new 'isLastTicketNo' (the mempool's current ticket counter).
+  TicketNo ->
+  -- | The delta txs, in ascending 'TicketNo' order.
+  [TxTicket (TxMeasureWithDiffTime blk) (ValidatedTxWithDiffs blk)] ->
+  m (RevalidateTxsResult blk)
+revalidateTxsFor' frk capacityOverride cfg slot (RevalidateTxsResult cand removedSoFar) lastTicketNo deltaTxTickets = do
+  let deltaTxs = map wrap deltaTxTickets
+      deltaKeys = Foldable.foldMap' (getTransactionKeySets . txForgetValidated . fst3) deltaTxs
+  deltaValues <- roforkerReadTables frk deltaKeys
+  let
+    -- Seed the delta reapplication from @cand@'s post-reapply ledger state, so
+    -- a delta tx spending one of @cand@'s outputs sees it. This is exactly the
+    -- state a full reapplication would be in after processing @cand@'s txs.
+    ReapplyTxsResult errDelta validDelta st' =
+      reapplyTxs @blk @Collect cfg slot deltaTxs $
+        applyMempoolDiffs deltaValues deltaKeys (isLedgerState cand)
 
-      outputKeys = Foldable.foldMap' (getTransactionKeySets . txForgetValidated . fst3) validTxs
-      outputDiffs = Foldable.foldl' rawPrependDiffs (DiffMK mempty) $ map (getLedgerTables . snd3) validTxs
-   in RevalidateTxsResult
-        ( IS
-            { isTxs = TxSeq.fromList $ map unwrap validTxs
-            , isTxIds = Set.fromList $ map (txId . txForgetValidated . fst3) validTxs
-            , isTxKeys = outputKeys
-            , isTxValues = ltliftA2 restrictValuesMK values outputKeys
-            , isLedgerState =
-                st'
-                  `withLedgerTables` (ltliftA2 rawPrependDiffs (projectLedgerTables st) (LedgerTables outputDiffs))
-            , isTip = castPoint $ getTip st
-            , isSlotNo = slot
-            , isLastTicketNo = lastTicketNo
-            , isCapacity = computeMempoolCapacity cfg st' capacityOverride
-            }
-        )
-        err
+    -- The delta's surviving txs' contributions — all O(delta), extending the
+    -- candidate in place rather than rebuilding from all survivors.
+    survivorKeys = Foldable.foldMap' (getTransactionKeySets . txForgetValidated . fst3) validDelta
+    survivorDiffs = Foldable.foldl' rawPrependDiffs (DiffMK mempty) $ map (getLedgerTables . snd3) validDelta
+
+    newIS =
+      cand
+        { isTxs = Foldable.foldl' (:>) (isTxs cand) (map unwrap validDelta)
+        , isTxIds = isTxIds cand <> Set.fromList (map (txId . txForgetValidated . fst3) validDelta)
+        , isTxKeys = isTxKeys cand <> survivorKeys
+        , -- REVIEW(utxo-hd): incremental value cache. Equal to the from-scratch
+          -- @restrictValuesMK (isTxValues cand `union` deltaValues) (allKeys)@:
+          -- 'isTxValues cand' is already restricted to the candidate's keys and
+          -- 'deltaValues' covers the delta's keys, so the outer restrict is a
+          -- no-op; any key shared with the candidate (a reference input) carries
+          -- the same base value, so the union is unambiguous.
+          isTxValues =
+            ltliftA2 unionValues (isTxValues cand) (ltliftA2 restrictValuesMK deltaValues survivorKeys)
+        , -- REVIEW(utxo-hd): incremental ledger tables. Prepends only the delta's
+          -- diffs onto the candidate's tables (base ⊕ cand-diffs). Equal to the
+          -- from-scratch @rawPrependDiffs base (candDiffs ⊕ deltaDiffs)@ iff
+          -- 'rawPrependDiffs' is associative over the (disjoint) per-tx diffs.
+          isLedgerState =
+            st'
+              `withLedgerTables` ltliftA2 rawPrependDiffs (projectLedgerTables (isLedgerState cand)) (LedgerTables survivorDiffs)
+        , isCapacity = computeMempoolCapacity cfg st' capacityOverride
+        , isLastTicketNo = lastTicketNo
+        }
+  pure $ RevalidateTxsResult newIS (removedSoFar ++ errDelta)
  where
   wrap = \(TxTicket (ValidatedTxWithDiffs tx df) tk tz) -> (tx, df, (tk, tz))
   unwrap = \(tx, df, (tk, tz)) -> TxTicket (ValidatedTxWithDiffs tx df) tk tz

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Impl/Common.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Impl/Common.hs
@@ -169,7 +169,7 @@ data InternalState blk = IS
   -- transactions will be in the next block. So any changes caused by that
   -- block will take effect after applying it and will only affect the
   -- next block.
-  , isRemovalGen :: !Word64
+  , isRemovalCounter :: !Word64
   -- ^ A monotonic counter bumped each time 'implRemoveTxsEvenIfValid' drops a
   -- transaction. A sync carries it along its (off-lock) candidate and re-checks
   -- it against the committed state under the lock: a mismatch means a removal
@@ -219,7 +219,7 @@ initInternalState capacityOverride lastTicketNo cfg slot st =
     , isTip = castPoint $ getTip st
     , isSlotNo = slot
     , isLastTicketNo = lastTicketNo
-    , isRemovalGen = 0
+    , isRemovalCounter = 0
     , isCapacity = computeMempoolCapacity cfg st capacityOverride
     }
 
@@ -430,7 +430,7 @@ revalidateTxsFor ::
   TickedLedgerState blk DiffMK ->
   -- | 'isLastTicketNo' and 'vrLastTicketNo'
   TicketNo ->
-  -- | The removal generation to stamp on the result (see 'isRemovalGen').
+  -- | The removal generation to stamp on the result (see 'isRemovalCounter').
   Word64 ->
   [TxTicket (TxMeasureWithDiffTime blk) (ValidatedTxWithDiffs blk)] ->
   m (RevalidateTxsResult blk)
@@ -446,7 +446,7 @@ revalidateTxsFor frk capacityOverride cfg slot st lastTicketNo removalGen txTick
   -- the mempool's ticket counter is preserved and the next add continues from it.
   emptyResult =
     RevalidateTxsResult
-      (initInternalState capacityOverride lastTicketNo cfg slot st){isRemovalGen = removalGen}
+      (initInternalState capacityOverride lastTicketNo cfg slot st){isRemovalCounter = removalGen}
       []
 
 -- | The general revalidation step: reapply a /delta/ of already-validated txs on

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Impl/Common.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Impl/Common.hs
@@ -440,9 +440,13 @@ revalidateTxsFor frk capacityOverride cfg slot st lastTicketNo removalGen txTick
   -- keeps the two byte-identical by construction.
   revalidateTxsFor' frk capacityOverride cfg slot emptyResult lastTicketNo txTickets
  where
+  -- Seed the empty candidate with the real 'lastTicketNo' (not zero): each
+  -- reapplied tx keeps its own 'TicketNo' (carried in its 'TxTicket'), and
+  -- 'revalidateTxsFor'' sets 'isLastTicketNo' to 'lastTicketNo' on the result, so
+  -- the mempool's ticket counter is preserved and the next add continues from it.
   emptyResult =
     RevalidateTxsResult
-      (initInternalState capacityOverride TxSeq.zeroTicketNo cfg slot st){isRemovalGen = removalGen}
+      (initInternalState capacityOverride lastTicketNo cfg slot st){isRemovalGen = removalGen}
       []
 
 -- | The general revalidation step: reapply a /delta/ of already-validated txs on

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Init.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Init.hs
@@ -113,7 +113,9 @@ mkMempool mpEnv =
   Mempool
     { addTx = fmap runIdentity .: implAddTx mpEnv ProductionAddTx
     , removeTxsEvenIfValid = implRemoveTxsEvenIfValid mpEnv
-    , getSnapshot = snapshotFromIS <$> readTMVar istate
+    , -- Readers 'readTMVar' the single state cell; they only block while a
+      -- writer holds it (see 'MempoolEnv').
+      getSnapshot = snapshotFromIS <$> readTMVar istate
     , getSnapshotFor = implGetSnapshotFor mpEnv
     , getSnapshotForNoCache = implGetSnapshotForNoCache mpEnv
     , getCapacity = isCapacity <$> readTMVar istate

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Update.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Update.hs
@@ -27,7 +27,7 @@ import qualified Data.Text as T
 import Ouroboros.Consensus.HeaderValidation
 import Ouroboros.Consensus.Ledger.Abstract
 import Ouroboros.Consensus.Ledger.SupportsMempool
-import Ouroboros.Consensus.Ledger.Tables.Utils (emptyLedgerTables)
+import Ouroboros.Consensus.Ledger.Tables.Utils (emptyLedgerTables, unionValues)
 import Ouroboros.Consensus.Mempool.API
 import Ouroboros.Consensus.Mempool.Capacity
 import Ouroboros.Consensus.Mempool.Impl.Common
@@ -259,7 +259,7 @@ doAddTx mpEnv caller wti tx = do
               -- in Conway.
               let txt = T.pack $ "MempoolTxTooSlow (" <> show dur <> ") " <> show (txId tx)
                in mkMempoolApplyTxError (isLedgerState is) txt
-        case mbX of
+        res <- case mbX of
           Nothing -> case (wti, mbTimeoutSoftTxErr) of
             (Intervene, Just txerr) -> do
               rejectBecauseOfTimeoutSoft txerr
@@ -291,6 +291,7 @@ doAddTx mpEnv caller wti tx = do
                     testDiffTime
                 TransactionProcessingResult is' _ _ = outcome
             pure (Right outcome, fromMaybe is is')
+        pure res
     case (caller, eRes) of
       (ProductionAddTx, _) -> either (doAddTx' . Just) (pure . Identity) eRes
       (TestingAddTx _, Left _) -> pure Nothing
@@ -531,74 +532,80 @@ implSyncWithLedger ::
   MempoolEnv m blk ->
   m r
 implSyncWithLedger projectResult mpEnv =
-  encloseTimedWith (TraceMempoolSynced >$< mpEnvTracer mpEnv) $ do
-    res <-
-      -- There could possibly be a race condition if we used there the state
-      -- that triggered the re-syncing in the background watcher, if a different
-      -- action acquired the state before the revalidation started.
-      --
-      -- For that reason, we read the state again here in the same STM
-      -- transaction in which we acquire the internal state of the mempool.
-      --
-      -- The following interleaving could happen:
-      --
-      -- - [ChainSel thread] We adopt a new block B at the tip of our selection.
-      --
-      -- - [Mempool sync thread] The Watcher wakes up, seeing that the tip has
-      --   changed to B, records it as the fingerprint, and invokes
-      --   implSyncWithLedger, but doesn't reach withTMVarAnd here.
-      --
-      -- - [ChainSel thread] Adopt a new block C.
-      --
-      -- - [Mempool thread] Execute withTMVarAnd here, obtaining the ledger
-      --   state for C and syncing the mempool with C.
-      --
-      -- - [Mempool thread] The Watcher wakes up again, seeing that the tip has
-      --   changed from B to C, and invokes implSyncWithLedger. This time,
-      --   nothing needs to be done, resulting in TraceMempoolSyncNotNeeded.
-      --
-      -- Just for performance reasons, we will avoid re-validating the mempool
-      -- if the state didn't change.
-      withTMVarAnd istate (const $ getCurrentLedgerState ldgrInterface) $
-        \is (MempoolLedgerDBView ls meFrk) -> do
-          let (slot, ls') = tickLedgerState cfg $ ForgeInUnknownSlot ls
-          if pointHash (isTip is) == castHash (getTipHash ls) && isSlotNo is == slot
-            then do
-              -- The tip didn't change, put the same state.
-              traceWith trcr $ TraceMempoolSyncNotNeeded (isTip is)
-              pure (Just (projectResult is), is)
-            else do
-              -- The tip changed, we have to revalidate
-              eFrk <- meFrk
-              case eFrk of
-                -- This case should happen only if the tip has moved again, this time
-                -- to a separate fork, since the background thread saw a change in the
-                -- tip, which should happen very rarely
-                Left{} -> do
-                  traceWith trcr TraceMempoolTipMovedBetweenSTMBlocks
-                  pure (Nothing, is)
-                Right frk -> do
-                  modifyMVar_
-                    forkerMVar
-                    ( \frkOld -> do
-                        roforkerClose frkOld
-                        pure frk
-                    )
-                  tbs <- castLedgerTables <$> roforkerReadTables frk (castLedgerTables $ isTxKeys is)
-                  let (is', mTrace) =
-                        pureSyncWithLedger
-                          capacityOverride
-                          cfg
-                          slot
-                          ls'
-                          tbs
-                          is
-                  whenJust mTrace (traceWith trcr)
-                  pure (Just (projectResult is'), is')
-    case res of
-      Nothing -> implSyncWithLedger projectResult mpEnv
-      Just res' -> pure res'
+  encloseTimedWith (TraceMempoolSynced >$< mpEnvTracer mpEnv) go
  where
+  -- The expensive part — reading all of the mempool's tx inputs from the
+  -- LedgerDB — is done /off the lock/, against a snapshot @is0@ taken with a
+  -- non-emptying 'readTMVar', while adds keep appending. We then 'takeTMVar'
+  -- only briefly: read the (small) input values for the txs added in the
+  -- meantime (the "delta", by 'TicketNo'), union them with the off-lock values,
+  -- and run 'pureSyncWithLedger' over the current txs. Since the union covers
+  -- exactly the current txs' input keys, the resulting state is identical to a
+  -- single under-lock revalidation. Only that (sub-second) merge holds the
+  -- lock, so readers block for the merge but not for the big LedgerDB read.
+  go = do
+    MempoolLedgerDBView ls0 meFrk0 <- atomically $ getCurrentLedgerState ldgrInterface
+    is0 <- atomically $ readTMVar istate
+    let (slot0, _ls0') = tickLedgerState cfg $ ForgeInUnknownSlot ls0
+    if pointHash (isTip is0) == castHash (getTipHash ls0) && isSlotNo is0 == slot0
+      then do
+        -- Looks like a no-op. Confirm under the lock (re-reading the ledger)
+        -- and return the /current/ committed state, so a concurrent add is not
+        -- lost from the returned snapshot.
+        outcome <-
+          withTMVarAnd istate (const $ getCurrentLedgerState ldgrInterface) $
+            \isNow (MempoolLedgerDBView ls _meFrk) -> do
+              let (slot, _ls') = tickLedgerState cfg $ ForgeInUnknownSlot ls
+              if pointHash (isTip isNow) == castHash (getTipHash ls) && isSlotNo isNow == slot
+                then do
+                  traceWith trcr $ TraceMempoolSyncNotNeeded (isTip isNow)
+                  pure (Just (projectResult isNow), isNow)
+                else
+                  -- The tip changed after our lock-free peek; retry via 'go',
+                  -- which will now take the sync path.
+                  pure (Nothing, isNow)
+        maybe go pure outcome
+      else do
+        eFrk <- meFrk0
+        case eFrk of
+          -- Tip moved to a separate fork between reading it and getting the
+          -- forker; very rare. Retry.
+          Left{} -> do
+            traceWith trcr TraceMempoolTipMovedBetweenSTMBlocks
+            go
+          Right frk -> do
+            -- OFF-LOCK: big read of the snapshot's input values at the new tip.
+            values0 <-
+              castLedgerTables <$> roforkerReadTables frk (castLedgerTables $ isTxKeys is0)
+            outcome <-
+              withTMVarAnd istate (const $ getCurrentLedgerState ldgrInterface) $
+                \isNow (MempoolLedgerDBView ls _meFrk) -> do
+                  let (slot, ls') = tickLedgerState cfg $ ForgeInUnknownSlot ls
+                  if getTipHash ls /= getTipHash ls0
+                    then
+                      -- Tip moved again during the off-lock read; retry.
+                      pure (Nothing, isNow)
+                    else do
+                      -- Read only the delta's input keys (small), union with the
+                      -- off-lock values, and revalidate /all/ current txs.
+                      let (_, deltaSeq) = TxSeq.splitAfterTicketNo (isTxs isNow) (isLastTicketNo is0)
+                          deltaKeys =
+                            Foldable.foldMap'
+                              (getTransactionKeySets . txForgetValidated . validatedTx . txTicketTx)
+                              (TxSeq.toList deltaSeq)
+                      valuesDelta <-
+                        castLedgerTables <$> roforkerReadTables frk (castLedgerTables deltaKeys)
+                      let allValues = ltliftA2 unionValues values0 valuesDelta
+                          (isFinal, mTrace) =
+                            pureSyncWithLedger capacityOverride cfg slot ls' allValues isNow
+                      modifyMVar_ forkerMVar (\frkOld -> roforkerClose frkOld >> pure frk)
+                      whenJust mTrace (traceWith trcr)
+                      pure (Just (projectResult isFinal), isFinal)
+            case outcome of
+              -- Retry: the forker we opened was never installed, so close it.
+              Nothing -> roforkerClose frk >> go
+              Just r -> pure r
+
   MempoolEnv
     { mpEnvStateVar = istate
     , mpEnvForker = forkerMVar

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Update.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Update.hs
@@ -27,7 +27,7 @@ import qualified Data.Text as T
 import Ouroboros.Consensus.HeaderValidation
 import Ouroboros.Consensus.Ledger.Abstract
 import Ouroboros.Consensus.Ledger.SupportsMempool
-import Ouroboros.Consensus.Ledger.Tables.Utils (emptyLedgerTables, unionValues)
+import Ouroboros.Consensus.Ledger.Tables.Utils (emptyLedgerTables)
 import Ouroboros.Consensus.Mempool.API
 import Ouroboros.Consensus.Mempool.Capacity
 import Ouroboros.Consensus.Mempool.Impl.Common
@@ -515,6 +515,21 @@ pureRemoveTxs capacityOverride lcfg slot lstate values tkt txs txIds =
   Sync with ledger
 -------------------------------------------------------------------------------}
 
+-- | Maximum number of delta transactions 'implSyncWithLedger' will reapply
+-- while holding the state lock. It shrinks its outstanding delta off the lock
+-- until at most this many txs remain, so the final under-lock reapply — and
+-- hence the time snapshot readers can be blocked — is bounded independently of
+-- mempool occupancy.
+syncDeltaCap :: Int
+syncDeltaCap = 256
+
+-- | Safety valve on the off-lock shrink loop: if the delta never falls below
+-- 'syncDeltaCap' (e.g. reapplication is not actually cheaper than ingestion),
+-- stop after this many rounds and finish anyway, degrading to a larger
+-- under-lock reapply rather than looping unboundedly.
+syncMaxIters :: Int
+syncMaxIters = 8
+
 -- | See 'Ouroboros.Consensus.Mempool.API.testSyncWithLedger' and
 -- and 'Ouroboros.Consensus.Mempool.Init.forkSyncStateOnTipPointChange'.
 implSyncWithLedger ::
@@ -534,15 +549,21 @@ implSyncWithLedger ::
 implSyncWithLedger projectResult mpEnv =
   encloseTimedWith (TraceMempoolSynced >$< mpEnvTracer mpEnv) go
  where
-  -- The expensive part — reading all of the mempool's tx inputs from the
-  -- LedgerDB — is done /off the lock/, against a snapshot @is0@ taken with a
-  -- non-emptying 'readTMVar', while adds keep appending. We then 'takeTMVar'
-  -- only briefly: read the (small) input values for the txs added in the
-  -- meantime (the "delta", by 'TicketNo'), union them with the off-lock values,
-  -- and run 'pureSyncWithLedger' over the current txs. Since the union covers
-  -- exactly the current txs' input keys, the resulting state is identical to a
-  -- single under-lock revalidation. Only that (sub-second) merge holds the
-  -- lock, so readers block for the merge but not for the big LedgerDB read.
+  -- Sync with a bounded lock hold. Everything expensive is done /off the lock/,
+  -- against a snapshot @is0@ taken with a non-emptying 'readTMVar' while adds
+  -- keep appending: the big LedgerDB read of @is0@'s inputs, the revalidation of
+  -- @is0@'s txs at the new tip (@cand0@), and then a converging loop that reads
+  -- the txs added in the meantime (the "delta", by 'TicketNo') and reapplies
+  -- them /on top/ via 'extendReapply' — never reprocessing what is already done.
+  --
+  -- The delta shrinks each iteration: adds are serialised (the fifo 'MVar's) and
+  -- pay full validation, whereas the sync only reapplies, which is cheaper per
+  -- tx, so fewer txs arrive during a round than it processes. Once the delta is
+  -- at most 'syncDeltaCap' (or we hit 'syncMaxIters'), we 'takeTMVar' and
+  -- reapply just that bounded residual before swapping. So the lock is held for
+  -- a near-constant time — O('syncDeltaCap') — independent of mempool occupancy,
+  -- rather than for a full O(n) revalidation. The committed state is byte-
+  -- identical to a single revalidation of all current txs ('extendReapply').
   go = do
     MempoolLedgerDBView ls0 meFrk0 <- atomically $ getCurrentLedgerState ldgrInterface
     is0 <- atomically $ readTMVar istate
@@ -574,33 +595,61 @@ implSyncWithLedger projectResult mpEnv =
             traceWith trcr TraceMempoolTipMovedBetweenSTMBlocks
             go
           Right frk -> do
-            -- OFF-LOCK: big read of the snapshot's input values at the new tip.
+            let (slot, ls') = tickLedgerState cfg $ ForgeInUnknownSlot ls0
+                deltaKeysOf =
+                  Foldable.foldMap'
+                    (getTransactionKeySets . txForgetValidated . validatedTx . txTicketTx)
+                readDeltaValues ts =
+                  castLedgerTables <$> roforkerReadTables frk (castLedgerTables $ deltaKeysOf ts)
+                deltaAfter cand is =
+                  TxSeq.toList . snd $ TxSeq.splitAfterTicketNo (isTxs is) (isLastTicketNo cand)
+                traceRemoved removed sz =
+                  if null removed
+                    then Nothing
+                    else
+                      Just $
+                        TraceMempoolRemoveTxs (map (\x -> (getInvalidated x, getReason x)) removed) sz
+                -- Shrink the outstanding delta off the lock, then finish under it
+                -- with a bounded residual reapply.
+                shrinkThenCommit cand removedAcc iterN = do
+                  isNow <- atomically $ readTMVar istate
+                  let deltaTickets = deltaAfter cand isNow
+                  if length deltaTickets > syncDeltaCap && iterN < syncMaxIters
+                    then do
+                      deltaValues <- readDeltaValues deltaTickets
+                      let RevalidateTxsResult cand' removed' =
+                            extendReapply capacityOverride cfg slot ls' cand deltaValues (isLastTicketNo isNow) deltaTickets
+                      shrinkThenCommit cand' (removedAcc ++ removed') (iterN + 1)
+                    else withTMVarAnd istate (const $ getCurrentLedgerState ldgrInterface) $
+                      \isLocked (MempoolLedgerDBView ls _meFrk) ->
+                        if getTipHash ls /= getTipHash ls0
+                          then -- Tip moved while we worked; retry the whole sync.
+                            pure (Nothing, isLocked)
+                          else do
+                            -- The lock is held, so no add can intervene: reapply
+                            -- only the residual delta (bounded by the cap plus any
+                            -- stragglers that landed while acquiring the lock).
+                            let resTickets = deltaAfter cand isLocked
+                            resValues <- readDeltaValues resTickets
+                            let RevalidateTxsResult isFinal removedF =
+                                  extendReapply capacityOverride cfg slot ls' cand resValues (isLastTicketNo isLocked) resTickets
+                                removed = removedAcc ++ removedF
+                            modifyMVar_ forkerMVar (\frkOld -> roforkerClose frkOld >> pure frk)
+                            whenJust (traceRemoved removed (isMempoolSize isFinal)) (traceWith trcr)
+                            pure (Just (projectResult isFinal), isFinal)
+            -- OFF-LOCK: big read of the snapshot's inputs and initial revalidation.
             values0 <-
               castLedgerTables <$> roforkerReadTables frk (castLedgerTables $ isTxKeys is0)
-            outcome <-
-              withTMVarAnd istate (const $ getCurrentLedgerState ldgrInterface) $
-                \isNow (MempoolLedgerDBView ls _meFrk) -> do
-                  let (slot, ls') = tickLedgerState cfg $ ForgeInUnknownSlot ls
-                  if getTipHash ls /= getTipHash ls0
-                    then
-                      -- Tip moved again during the off-lock read; retry.
-                      pure (Nothing, isNow)
-                    else do
-                      -- Read only the delta's input keys (small), union with the
-                      -- off-lock values, and revalidate /all/ current txs.
-                      let (_, deltaSeq) = TxSeq.splitAfterTicketNo (isTxs isNow) (isLastTicketNo is0)
-                          deltaKeys =
-                            Foldable.foldMap'
-                              (getTransactionKeySets . txForgetValidated . validatedTx . txTicketTx)
-                              (TxSeq.toList deltaSeq)
-                      valuesDelta <-
-                        castLedgerTables <$> roforkerReadTables frk (castLedgerTables deltaKeys)
-                      let allValues = ltliftA2 unionValues values0 valuesDelta
-                          (isFinal, mTrace) =
-                            pureSyncWithLedger capacityOverride cfg slot ls' allValues isNow
-                      modifyMVar_ forkerMVar (\frkOld -> roforkerClose frkOld >> pure frk)
-                      whenJust mTrace (traceWith trcr)
-                      pure (Just (projectResult isFinal), isFinal)
+            let RevalidateTxsResult cand0 removed0 =
+                  revalidateTxsFor
+                    capacityOverride
+                    cfg
+                    slot
+                    ls'
+                    values0
+                    (isLastTicketNo is0)
+                    (TxSeq.toList (isTxs is0))
+            outcome <- shrinkThenCommit cand0 removed0 (0 :: Int)
             case outcome of
               -- Retry: the forker we opened was never installed, so close it.
               Nothing -> roforkerClose frk >> go
@@ -614,37 +663,3 @@ implSyncWithLedger projectResult mpEnv =
     , mpEnvLedgerCfg = cfg
     , mpEnvCapacityOverride = capacityOverride
     } = mpEnv
-
--- | Create a 'SyncWithLedger' value representing the values that will need to
--- be stored for committing this synchronization with the Ledger.
---
--- See the documentation of 'runSyncWithLedger' for more context.
-pureSyncWithLedger ::
-  (LedgerSupportsMempool blk, HasTxId (GenTx blk)) =>
-  MempoolCapacityBytesOverride ->
-  LedgerConfig blk ->
-  SlotNo ->
-  TickedLedgerState blk DiffMK ->
-  LedgerTables (LedgerState blk) ValuesMK ->
-  InternalState blk ->
-  ( InternalState blk
-  , Maybe (TraceEventMempool blk)
-  )
-pureSyncWithLedger capacityOverride lcfg slot lstate values istate =
-  let RevalidateTxsResult is' removed =
-        revalidateTxsFor
-          capacityOverride
-          lcfg
-          slot
-          lstate
-          values
-          (isLastTicketNo istate)
-          (TxSeq.toList $ isTxs istate)
-      mTrace =
-        if null removed
-          then
-            Nothing
-          else
-            Just $
-              TraceMempoolRemoveTxs (map (\x -> (getInvalidated x, getReason x)) removed) (isMempoolSize is')
-   in (is', mTrace)

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Update.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Update.hs
@@ -573,11 +573,8 @@ implSyncWithLedger projectResult mpEnv =
             traceWith trcr TraceMempoolTipMovedBetweenSTMBlocks
             goSync
           Right frk -> do
-            -- OFF-LOCK, and the tall tent pole of the whole sync: read the
-            -- snapshot's inputs and revalidate the entire mempool against the new
-            -- tip. Everything after this ('revalidateDeltas') is just a bounded
-            -- catch-up loop reapplying whatever was added or removed while this
-            -- ran, so the state lock is held only briefly at the very end.
+            -- OFF-LOCK: read the snapshot's inputs and revalidate the entire
+            -- mempool against the new tip.
             seed <-
               revalidateTxsFor
                 frk
@@ -588,6 +585,9 @@ implSyncWithLedger projectResult mpEnv =
                 (isLastTicketNo is0)
                 (isRemovalCounter is0)
                 (TxSeq.toList (isTxs is0))
+            -- A bounded catch-up loop reapplying whatever was added or
+            -- removed while this ran, so the state lock is held only briefly at
+            -- the very end.
             revalidateDeltas frk tipHash0 slot seed (0 :: Int) >>= \case
               Nothing -> goSync -- Retry if the commit found the state stale.
               Just r -> pure r

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Update.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Update.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneKindSignatures #-}
 
@@ -12,11 +13,10 @@ module Ouroboros.Consensus.Mempool.Update
   , implSyncWithLedger
   ) where
 
-import Cardano.Slotting.Slot
+import Control.Monad (unless)
 import Control.Monad.Class.MonadTimer.SI (MonadTimer, timeout)
 import Control.Monad.Except (runExcept)
 import Control.Tracer
-import qualified Data.Foldable as Foldable
 import Data.Functor.Identity (Identity (Identity))
 import Data.Kind (Type)
 import qualified Data.List.NonEmpty as NE
@@ -34,7 +34,6 @@ import Ouroboros.Consensus.Mempool.Impl.Common
 import Ouroboros.Consensus.Mempool.TxSeq (TxTicket (..))
 import qualified Ouroboros.Consensus.Mempool.TxSeq as TxSeq
 import Ouroboros.Consensus.Storage.LedgerDB.Forker hiding (trace)
-import Ouroboros.Consensus.Util (whenJust)
 import Ouroboros.Consensus.Util.Enclose
 import Ouroboros.Consensus.Util.IOLike hiding (withMVar)
 import Ouroboros.Consensus.Util.NormalForm.StrictMVar
@@ -475,23 +474,25 @@ implRemoveTxsEvenIfValid mpEnv toRemove =
                   . txTicketTx
               )
               (TxSeq.toList $ isTxs is)
-          toKeep' =
-            Foldable.foldMap'
-              (getTransactionKeySets . txForgetValidated . validatedTx . TxSeq.txTicketTx)
-              toKeep
+          -- A tx actually leaves iff we kept fewer than we had; bump the removal
+          -- generation then, so an in-flight sync notices its snapshot is stale
+          -- (see 'isRemovalGen'). Carried on the state itself, under the lock.
+          newGen
+            | length toKeep < length (isTxs is) = isRemovalGen is + 1
+            | otherwise = isRemovalGen is
       frkr <- readMVar forker
-      tbs <- roforkerReadTables frkr toKeep'
-      let (is', t) =
-            pureRemoveTxs
-              capacityOverride
-              cfg
-              (isSlotNo is)
-              (isLedgerState is `withLedgerTables` emptyLedgerTables)
-              tbs
-              (isLastTicketNo is)
-              toKeep
-              toRemove
-      traceWith trcr t
+      RevalidateTxsResult is' removed <-
+        revalidateTxsFor
+          frkr
+          capacityOverride
+          cfg
+          (isSlotNo is)
+          (isLedgerState is `withLedgerTables` emptyLedgerTables)
+          (isLastTicketNo is)
+          newGen
+          toKeep
+      traceWith trcr $
+        TraceMempoolManuallyRemovedTxs toRemove (map getInvalidated removed) (isMempoolSize is')
       pure ((), is')
  where
   MempoolEnv
@@ -502,45 +503,26 @@ implRemoveTxsEvenIfValid mpEnv toRemove =
     , mpEnvCapacityOverride = capacityOverride
     } = mpEnv
 
--- | Craft a 'RemoveTxs' that manually removes the given transactions from the
--- mempool, returning inside it an updated InternalState.
-pureRemoveTxs ::
-  ( LedgerSupportsMempool blk
-  , HasTxId (GenTx blk)
-  ) =>
-  MempoolCapacityBytesOverride ->
-  LedgerConfig blk ->
-  SlotNo ->
-  TickedLedgerState blk DiffMK ->
-  LedgerTables blk ValuesMK ->
-  TicketNo ->
-  -- | Txs to keep
-  [TxTicket (TxMeasureWithDiffTime blk) (ValidatedTxWithDiffs blk)] ->
-  -- | IDs to remove
-  NE.NonEmpty (GenTxId blk) ->
-  (InternalState blk, TraceEventMempool blk)
-pureRemoveTxs capacityOverride lcfg slot lstate values tkt txs txIds =
-  let RevalidateTxsResult is' removed =
-        revalidateTxsFor
-          capacityOverride
-          lcfg
-          slot
-          lstate
-          values
-          tkt
-          txs
-      trace =
-        TraceMempoolManuallyRemovedTxs
-          txIds
-          (map getInvalidated removed)
-          (isMempoolSize is')
-   in (is', trace)
-
 {-------------------------------------------------------------------------------
   Sync with ledger
 -------------------------------------------------------------------------------}
 
--- | See 'Ouroboros.Consensus.Mempool.API.syncWithLedger'.
+-- | Maximum number of delta transactions 'implSyncWithLedger' will reapply
+-- while holding the state lock. It shrinks its outstanding delta off the lock
+-- until at most this many txs remain, so the final under-lock reapply — and
+-- hence the time snapshot readers can be blocked — is bounded independently of
+-- mempool occupancy.
+syncDeltaCap :: Int
+syncDeltaCap = 256
+
+-- | Safety valve on the off-lock shrink loop: if the delta never falls below
+-- 'syncDeltaCap' (e.g. reapplication is not actually cheaper than ingestion),
+-- stop after this many rounds and finish anyway, degrading to a larger
+-- under-lock reapply rather than looping unboundedly.
+syncMaxIters :: Int
+syncMaxIters = 8
+
+-- | See 'Ouroboros.Consensus.Mempool.API.syncWithLedger'
 implSyncWithLedger ::
   ( IOLike m
   , LedgerSupportsMempool blk
@@ -556,74 +538,125 @@ implSyncWithLedger ::
   MempoolEnv m blk ->
   m r
 implSyncWithLedger projectResult mpEnv =
-  encloseTimedWith (TraceMempoolSynced >$< mpEnvTracer mpEnv) $ do
-    res <-
-      -- There could possibly be a race condition if we used there the state
-      -- that triggered the re-syncing in the background watcher, if a different
-      -- action acquired the state before the revalidation started.
-      --
-      -- For that reason, we read the state again here in the same STM
-      -- transaction in which we acquire the internal state of the mempool.
-      --
-      -- The following interleaving could happen:
-      --
-      -- - [ChainSel thread] We adopt a new block B at the tip of our selection.
-      --
-      -- - [Mempool sync thread] The Watcher wakes up, seeing that the tip has
-      --   changed to B, records it as the fingerprint, and invokes
-      --   implSyncWithLedger, but doesn't reach withTMVarAnd here.
-      --
-      -- - [ChainSel thread] Adopt a new block C.
-      --
-      -- - [Mempool thread] Execute withTMVarAnd here, obtaining the ledger
-      --   state for C and syncing the mempool with C.
-      --
-      -- - [Mempool thread] The Watcher wakes up again, seeing that the tip has
-      --   changed from B to C, and invokes implSyncWithLedger. This time,
-      --   nothing needs to be done, resulting in TraceMempoolSyncNotNeeded.
-      --
-      -- Just for performance reasons, we will avoid re-validating the mempool
-      -- if the state didn't change.
-      withTMVarAnd istate (const $ getCurrentLedgerState ldgrInterface) $
-        \is (MempoolLedgerDBView ls meFrk) -> do
-          let (slot, ls') = tickLedgerState cfg $ ForgeInUnknownSlot ls
-          if pointHash (isTip is) == castHash (getTipHash ls) && isSlotNo is == slot
-            then do
-              -- The tip didn't change, put the same state.
-              traceWith trcr $ TraceMempoolSyncNotNeeded (isTip is)
-              pure (Just (projectResult is), is)
-            else do
-              -- The tip changed, we have to revalidate
-              eFrk <- meFrk
-              case eFrk of
-                -- This case should happen only if the tip has moved again, this time
-                -- to a separate fork, since the background thread saw a change in the
-                -- tip, which should happen very rarely
-                Left{} -> do
-                  traceWith trcr TraceMempoolTipMovedBetweenSTMBlocks
-                  pure (Nothing, is)
-                Right frk -> do
-                  modifyMVar_
-                    forkerMVar
-                    ( \frkOld -> do
-                        roforkerClose frkOld
-                        pure frk
-                    )
-                  tbs <- roforkerReadTables frk (isTxKeys is)
-                  let (is', mTrace) =
-                        pureSyncWithLedger
-                          capacityOverride
-                          cfg
-                          slot
-                          ls'
-                          tbs
-                          is
-                  whenJust mTrace (traceWith trcr)
-                  pure (Just (projectResult is'), is')
-    case res of
-      Nothing -> implSyncWithLedger projectResult mpEnv
-      Just res' -> pure res'
+  encloseTimedWith (TraceMempoolSynced >$< mpEnvTracer mpEnv) goSync
  where
+  -- Sync with a bounded lock hold. Everything expensive is done /off the lock/,
+  -- against a snapshot @is0@ taken with a non-emptying 'readTMVar' while adds
+  -- keep appending: the big LedgerDB read of @is0@'s inputs, the revalidation of
+  -- @is0@'s txs at the new tip (@cand0@), and then a converging loop that reads
+  -- the txs added in the meantime (the "delta", by 'TicketNo') and reapplies
+  -- them /on top/ via 'revalidateTxsFor'' — never reprocessing what is already done.
+  --
+  -- The delta shrinks each iteration: adds are serialised (the fifo 'MVar's) and
+  -- pay full validation, whereas the sync only reapplies, which is cheaper per
+  -- tx, so fewer txs arrive during a round than it processes. Once the delta is
+  -- at most 'syncDeltaCap' (or we hit 'syncMaxIters'), we 'takeTMVar' and
+  -- reapply just that bounded residual before swapping. So the lock is held for
+  -- a near-constant time — O('syncDeltaCap') — independent of mempool occupancy,
+  -- rather than for a full O(n) revalidation. The committed state is byte-
+  -- identical to a single revalidation of all current txs ('revalidateTxsFor'').
+  goSync =
+    checkTodo >>= \case
+      Left is0 -> do
+        -- The tip didn't change, put the same state.
+        traceWith trcr $ TraceMempoolSyncNotNeeded (isTip is0)
+        pure (projectResult is0)
+      Right (getForker, is0, slot, ls, tipHash0) ->
+        -- The tip changed, we have to revalidate.
+        -- TODO: leaking the forker on exceptions?
+        getForker >>= \case
+          -- This case should happen only if the tip has moved again, this time
+          -- to a separate fork, since the background thread saw a change in the
+          -- tip, which should happen very rarely
+          Left{} -> do
+            -- TODO: This is not really two STM blocks?
+            traceWith trcr TraceMempoolTipMovedBetweenSTMBlocks
+            goSync
+          Right frk -> do
+            -- OFF-LOCK, and the tall tent pole of the whole sync: read the
+            -- snapshot's inputs and revalidate the entire mempool against the new
+            -- tip. Everything after this ('shrinkThenCommit') is just a bounded
+            -- catch-up loop reapplying whatever was added or removed while this
+            -- ran, so the state lock is held only briefly at the very end.
+            --
+            -- TODO: this re-reads the entire working set from the LedgerDB on
+            -- every sync. The mempool already caches these values ('isTxValues')
+            -- at its last-synced tip; if the forker exposed the changelog diff
+            -- since that tip, we could forward the cache through it ('applyDiffs')
+            -- instead of re-reading — an O(occupancy) read becomes O(tip-diff).
+            -- Needs a LedgerDB/forker API change (discuss with UTxO-HD).
+            seed <-
+              revalidateTxsFor
+                frk
+                capacityOverride
+                cfg
+                slot
+                ls
+                (isLastTicketNo is0)
+                (isRemovalGen is0)
+                (TxSeq.toList (isTxs is0))
+            shrinkThenCommit frk tipHash0 slot seed (0 :: Int) >>= \case
+              Nothing -> goSync -- Retry if the commit found the state stale.
+              Just r -> pure r
+
+  checkTodo = atomically $ do
+    view <- getCurrentLedgerState ldgrInterface
+    is0 <- readTMVar istate
+    let ls0 = mldViewState view
+        tipHash0 = getTipHash ls0
+        (slot, ls') = tickLedgerState cfg $ ForgeInUnknownSlot ls0
+    pure $
+      if pointHash (isTip is0) == castHash tipHash0 && isSlotNo is0 == slot
+        then Left is0
+        else Right (mldViewGetForker view, is0, slot, ls', tipHash0)
+
+  deltaAfter cand is =
+    TxSeq.toList . snd $ TxSeq.splitAfterTicketNo (isTxs is) (isLastTicketNo cand)
+
+  -- Shrink the outstanding delta off the lock, then finish under it with a
+  -- bounded residual reapply. Returns Nothing (retry the whole sync) if the tip
+  -- moved or a tx was removed while we worked.
+  -- NOTE: Either closes the forker or updates it in the InternalState
+  shrinkThenCommit frk tipHash0 slot = goShrink
+   where
+    goShrink acc@(RevalidateTxsResult cand _) iterN = do
+      isNow <- atomically $ readTMVar istate
+      let deltaTickets = deltaAfter cand isNow
+      if length deltaTickets > syncDeltaCap && iterN < syncMaxIters
+        then do
+          next <- revalidateTxsFor' frk capacityOverride cfg slot acc (isLastTicketNo isNow) deltaTickets
+          goShrink next (iterN + 1)
+        else
+          -- Done with the shrink loop
+          withTMVarAnd istate (const $ getCurrentLedgerState ldgrInterface) $
+            \isLocked (MempoolLedgerDBView ls _getForker) -> do
+              -- ON-LOCK: Retry the whole sync if the tip moved or a tx was
+              -- removed while we worked off the lock. Committing anyway would
+              -- resurrect a dropped tx, or publish a snapshot for a tip that is
+              -- no longer current — which makes the sync non-linearizable (its
+              -- read and commit would straddle a concurrent tip change). The
+              -- removal generation rides along on the candidate ('isRemovalGen').
+              if getTipHash ls /= tipHash0 || isRemovalGen isLocked /= isRemovalGen cand
+                then do
+                  -- As we won't be keeping the forker in the internal state, we
+                  -- can close it.
+                  roforkerClose frk
+                  pure (Nothing, isLocked)
+                else do
+                  -- Lock held, so no add can intervene: reapply just the residual
+                  -- delta (the cap plus stragglers that landed while acquiring it).
+                  let resTickets = deltaAfter cand isLocked
+                  RevalidateTxsResult isFinal removed <-
+                    revalidateTxsFor' frk capacityOverride cfg slot acc (isLastTicketNo isLocked) resTickets
+                  unless (null removed) $
+                    traceWith trcr $
+                      TraceMempoolRemoveTxs
+                        (map (\x -> (getInvalidated x, getReason x)) removed)
+                        (isMempoolSize isFinal)
+                  -- Store the forker to be used with the new state
+                  modifyMVar_ forkerMVar (\frkOld -> roforkerClose frkOld >> pure frk)
+                  pure (Just (projectResult isFinal), isFinal)
+
   MempoolEnv
     { mpEnvStateVar = istate
     , mpEnvForker = forkerMVar
@@ -632,37 +665,3 @@ implSyncWithLedger projectResult mpEnv =
     , mpEnvLedgerCfg = cfg
     , mpEnvCapacityOverride = capacityOverride
     } = mpEnv
-
--- | Create a 'SyncWithLedger' value representing the values that will need to
--- be stored for committing this synchronization with the Ledger.
---
--- See the documentation of 'runSyncWithLedger' for more context.
-pureSyncWithLedger ::
-  (LedgerSupportsMempool blk, HasTxId (GenTx blk)) =>
-  MempoolCapacityBytesOverride ->
-  LedgerConfig blk ->
-  SlotNo ->
-  TickedLedgerState blk DiffMK ->
-  LedgerTables blk ValuesMK ->
-  InternalState blk ->
-  ( InternalState blk
-  , Maybe (TraceEventMempool blk)
-  )
-pureSyncWithLedger capacityOverride lcfg slot lstate values istate =
-  let RevalidateTxsResult is' removed =
-        revalidateTxsFor
-          capacityOverride
-          lcfg
-          slot
-          lstate
-          values
-          (isLastTicketNo istate)
-          (TxSeq.toList $ isTxs istate)
-      mTrace =
-        if null removed
-          then
-            Nothing
-          else
-            Just $
-              TraceMempoolRemoveTxs (map (\x -> (getInvalidated x, getReason x)) removed) (isMempoolSize is')
-   in (is', mTrace)

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Update.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Update.hs
@@ -575,7 +575,7 @@ implSyncWithLedger projectResult mpEnv =
           Right frk -> do
             -- OFF-LOCK, and the tall tent pole of the whole sync: read the
             -- snapshot's inputs and revalidate the entire mempool against the new
-            -- tip. Everything after this ('shrinkThenCommit') is just a bounded
+            -- tip. Everything after this ('revalidateDeltas') is just a bounded
             -- catch-up loop reapplying whatever was added or removed while this
             -- ran, so the state lock is held only briefly at the very end.
             --
@@ -595,7 +595,7 @@ implSyncWithLedger projectResult mpEnv =
                 (isLastTicketNo is0)
                 (isRemovalGen is0)
                 (TxSeq.toList (isTxs is0))
-            shrinkThenCommit frk tipHash0 slot seed (0 :: Int) >>= \case
+            revalidateDeltas frk tipHash0 slot seed (0 :: Int) >>= \case
               Nothing -> goSync -- Retry if the commit found the state stale.
               Just r -> pure r
 
@@ -613,49 +613,66 @@ implSyncWithLedger projectResult mpEnv =
   deltaAfter cand is =
     TxSeq.toList . snd $ TxSeq.splitAfterTicketNo (isTxs is) (isLastTicketNo cand)
 
-  -- Shrink the outstanding delta off the lock, then finish under it with a
-  -- bounded residual reapply. Returns Nothing (retry the whole sync) if the tip
-  -- moved or a tx was removed while we worked.
+  -- Revalidate the outstanding deltas off the lock until small enough, then
+  -- finish under it with a bounded residual reapply. Returns Nothing (retry the
+  -- whole sync) if the tip moved or a tx was removed while we worked.
   -- NOTE: Either closes the forker or updates it in the InternalState
-  shrinkThenCommit frk tipHash0 slot = goShrink
+  revalidateDeltas frk tipHash0 slot = go
    where
-    goShrink acc@(RevalidateTxsResult cand _) iterN = do
-      isNow <- atomically $ readTMVar istate
-      let deltaTickets = deltaAfter cand isNow
-      if length deltaTickets > syncDeltaCap && iterN < syncMaxIters
+    -- The candidate is doomed the moment the tip moves or a tx is force-removed
+    -- (the commit below would reject it, retrying the whole sync). This helper
+    -- checks that condition, run on each iteration.
+    stale cand isNow curTipHash =
+      curTipHash /= tipHash0 || isRemovalGen isNow /= isRemovalGen cand
+
+    go acc@(RevalidateTxsResult cand _) iterN = do
+      (isNow, curTipHash) <- atomically $ do
+        isNow <- readTMVar istate
+        view <- getCurrentLedgerState ldgrInterface
+        pure (isNow, getTipHash (mldViewState view))
+      if stale cand isNow curTipHash
         then do
-          next <- revalidateTxsFor' frk capacityOverride cfg slot acc (isLastTicketNo isNow) deltaTickets
-          goShrink next (iterN + 1)
-        else
-          -- Done with the shrink loop
-          withTMVarAnd istate (const $ getCurrentLedgerState ldgrInterface) $
-            \isLocked (MempoolLedgerDBView ls _getForker) -> do
-              -- ON-LOCK: Retry the whole sync if the tip moved or a tx was
-              -- removed while we worked off the lock. Committing anyway would
-              -- resurrect a dropped tx, or publish a snapshot for a tip that is
-              -- no longer current — which makes the sync non-linearizable (its
-              -- read and commit would straddle a concurrent tip change). The
-              -- removal generation rides along on the candidate ('isRemovalGen').
-              if getTipHash ls /= tipHash0 || isRemovalGen isLocked /= isRemovalGen cand
-                then do
-                  -- As we won't be keeping the forker in the internal state, we
-                  -- can close it.
-                  roforkerClose frk
-                  pure (Nothing, isLocked)
-                else do
-                  -- Lock held, so no add can intervene: reapply just the residual
-                  -- delta (the cap plus stragglers that landed while acquiring it).
-                  let resTickets = deltaAfter cand isLocked
-                  RevalidateTxsResult isFinal removed <-
-                    revalidateTxsFor' frk capacityOverride cfg slot acc (isLastTicketNo isLocked) resTickets
-                  unless (null removed) $
-                    traceWith trcr $
-                      TraceMempoolRemoveTxs
-                        (map (\x -> (getInvalidated x, getReason x)) removed)
-                        (isMempoolSize isFinal)
-                  -- Store the forker to be used with the new state
-                  modifyMVar_ forkerMVar (\frkOld -> roforkerClose frkOld >> pure frk)
-                  pure (Just (projectResult isFinal), isFinal)
+          -- Off-lock early abort: 'goSync' will retry from a fresh snapshot.
+          roforkerClose frk
+          pure Nothing
+        else do
+          let deltaTickets = deltaAfter cand isNow
+          if length deltaTickets > syncDeltaCap && iterN < syncMaxIters
+            then do
+              next <- revalidateTxsFor' frk capacityOverride cfg slot acc (isLastTicketNo isNow) deltaTickets
+              go next (iterN + 1)
+            else
+              -- Delta is small enough (or out of iterations); commit under the lock.
+              withTMVarAnd istate (const $ getCurrentLedgerState ldgrInterface) $
+                \isLocked (MempoolLedgerDBView ls _getForker) -> do
+                  -- ON-LOCK: the same staleness check, now atomic with the commit.
+                  -- The off-lock checks above cannot be final: the tip can still
+                  -- move between the last one and acquiring the lock. Re-reading
+                  -- the ledger state here (in the STM transaction that takes the
+                  -- lock) is what makes the tip-moved check atomic with the swap;
+                  -- committing a stale candidate would resurrect a dropped tx or
+                  -- publish a snapshot for a tip that is no longer current, i.e. be
+                  -- non-linearizable.
+                  if stale cand isLocked (getTipHash ls)
+                    then do
+                      -- As we won't be keeping the forker in the internal state, we
+                      -- can close it.
+                      roforkerClose frk
+                      pure (Nothing, isLocked)
+                    else do
+                      -- Lock held, so no add can intervene: reapply just the residual
+                      -- delta (the cap plus stragglers that landed while acquiring it).
+                      let resTickets = deltaAfter cand isLocked
+                      RevalidateTxsResult isFinal removed <-
+                        revalidateTxsFor' frk capacityOverride cfg slot acc (isLastTicketNo isLocked) resTickets
+                      unless (null removed) $
+                        traceWith trcr $
+                          TraceMempoolRemoveTxs
+                            (map (\x -> (getInvalidated x, getReason x)) removed)
+                            (isMempoolSize isFinal)
+                      -- Store the forker to be used with the new state
+                      modifyMVar_ forkerMVar (\frkOld -> roforkerClose frkOld >> pure frk)
+                      pure (Just (projectResult isFinal), isFinal)
 
   MempoolEnv
     { mpEnvStateVar = istate

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Update.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Update.hs
@@ -570,7 +570,6 @@ implSyncWithLedger projectResult mpEnv =
           -- to a separate fork, since the background thread saw a change in the
           -- tip, which should happen very rarely
           Left{} -> do
-            -- TODO: This is not really two STM blocks?
             traceWith trcr TraceMempoolTipMovedBetweenSTMBlocks
             goSync
           Right frk -> do

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Update.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Update.hs
@@ -574,7 +574,9 @@ implSyncWithLedger projectResult mpEnv =
   -- identical to a single revalidation of all current txs ('extendReapply').
   go = do
     MempoolLedgerDBView ls0 meFrk0 <- atomically $ getCurrentLedgerState ldgrInterface
-    is0 <- atomically $ readTMVar istate
+    -- Capture the removal generation together with the snapshot, so a removal
+    -- that races this sync is detected at commit (see 'mpEnvRemovalGen').
+    (is0, gen0) <- atomically $ (,) <$> readTMVar istate <*> readTVar removalGen
     let (slot0, _ls0') = tickLedgerState cfg $ ForgeInUnknownSlot ls0
     if pointHash (isTip is0) == castHash (getTipHash ls0) && isSlotNo is0 == slot0
       then do
@@ -629,9 +631,13 @@ implSyncWithLedger projectResult mpEnv =
                             extendReapply capacityOverride cfg slot ls' cand deltaValues (isLastTicketNo isNow) deltaTickets
                       shrinkThenCommit cand' (removedAcc ++ removed') (iterN + 1)
                     else withTMVarAnd istate (const $ getCurrentLedgerState ldgrInterface) $
-                      \isLocked (MempoolLedgerDBView ls _meFrk) ->
-                        if getTipHash ls /= getTipHash ls0
-                          then -- Tip moved while we worked; retry the whole sync.
+                      \isLocked (MempoolLedgerDBView ls _meFrk) -> do
+                        -- The lock is held, so a removal cannot bump the gen
+                        -- concurrently; this read is stable.
+                        genNow <- readTVarIO removalGen
+                        if getTipHash ls /= getTipHash ls0 || genNow /= gen0
+                          then -- Tip moved or a tx was removed while we worked;
+                          -- our candidate may be stale, so retry the whole sync.
                             pure (Nothing, isLocked)
                           else do
                             -- The lock is held, so no add can intervene: reapply
@@ -670,4 +676,5 @@ implSyncWithLedger projectResult mpEnv =
     , mpEnvTracer = trcr
     , mpEnvLedgerCfg = cfg
     , mpEnvCapacityOverride = capacityOverride
+    , mpEnvRemovalGen = removalGen
     } = mpEnv

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Update.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Update.hs
@@ -524,6 +524,7 @@ syncMaxIters = 8
 
 -- | See 'Ouroboros.Consensus.Mempool.API.syncWithLedger'
 implSyncWithLedger ::
+  forall m blk r.
   ( IOLike m
   , LedgerSupportsMempool blk
   , ValidateEnvelope blk
@@ -610,6 +611,13 @@ implSyncWithLedger projectResult mpEnv =
   -- finish under it with a bounded residual reapply. Returns Nothing (retry the
   -- whole sync) if the tip moved or a tx was removed while we worked.
   -- NOTE: Either closes the forker or updates it in the InternalState
+  revalidateDeltas ::
+    ReadOnlyForker m LedgerState blk ->
+    ChainHash (LedgerState blk) ->
+    SlotNo ->
+    RevalidateTxsResult blk ->
+    Int ->
+    m (Maybe r)
   revalidateDeltas frk tipHash0 slot = go
    where
     -- The candidate is doomed the moment the tip moves or a tx is force-removed

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Update.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Update.hs
@@ -649,7 +649,7 @@ implSyncWithLedger projectResult mpEnv =
                   if stale cand isLocked (getTipHash ls)
                     then do
                       -- As we won't be keeping the forker in the internal state, we
-                      -- can close it.
+                      -- must close it.
                       roforkerClose frk
                       pure (Nothing, isLocked)
                     else do

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Update.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Update.hs
@@ -553,8 +553,7 @@ implSyncWithLedger projectResult mpEnv =
   -- at most 'syncDeltaCap' (or we hit 'syncMaxIters'), we 'takeTMVar' and
   -- reapply just that bounded residual before swapping. So the lock is held for
   -- a near-constant time — O('syncDeltaCap') — independent of mempool occupancy,
-  -- rather than for a full O(n) revalidation. The committed state is byte-
-  -- identical to a single revalidation of all current txs ('revalidateTxsFor'').
+  -- rather than for a full O(n) revalidation.
   goSync =
     checkTodo >>= \case
       Left is0 -> do
@@ -563,7 +562,9 @@ implSyncWithLedger projectResult mpEnv =
         pure (projectResult is0)
       Right (getForker, is0, slot, ls, tipHash0) ->
         -- The tip changed, we have to revalidate.
-        -- TODO: leaking the forker on exceptions?
+        -- NOTE: The forker is closed in a bracket here because exceptions here
+        -- are fatal anyways. See also 'mldViewGetForker' (the function we call
+        -- here).
         getForker >>= \case
           -- This case should happen only if the tip has moved again, this time
           -- to a separate fork, since the background thread saw a change in the
@@ -578,13 +579,6 @@ implSyncWithLedger projectResult mpEnv =
             -- tip. Everything after this ('revalidateDeltas') is just a bounded
             -- catch-up loop reapplying whatever was added or removed while this
             -- ran, so the state lock is held only briefly at the very end.
-            --
-            -- TODO: this re-reads the entire working set from the LedgerDB on
-            -- every sync. The mempool already caches these values ('isTxValues')
-            -- at its last-synced tip; if the forker exposed the changelog diff
-            -- since that tip, we could forward the cache through it ('applyDiffs')
-            -- instead of re-reading — an O(occupancy) read becomes O(tip-diff).
-            -- Needs a LedgerDB/forker API change (discuss with UTxO-HD).
             seed <-
               revalidateTxsFor
                 frk

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Update.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Update.hs
@@ -476,10 +476,10 @@ implRemoveTxsEvenIfValid mpEnv toRemove =
               (TxSeq.toList $ isTxs is)
           -- A tx actually leaves iff we kept fewer than we had; bump the removal
           -- generation then, so an in-flight sync notices its snapshot is stale
-          -- (see 'isRemovalGen'). Carried on the state itself, under the lock.
+          -- (see 'isRemovalCounter'). Carried on the state itself, under the lock.
           newGen
-            | length toKeep < length (isTxs is) = isRemovalGen is + 1
-            | otherwise = isRemovalGen is
+            | length toKeep < length (isTxs is) = isRemovalCounter is + 1
+            | otherwise = isRemovalCounter is
       frkr <- readMVar forker
       RevalidateTxsResult is' removed <-
         revalidateTxsFor
@@ -593,7 +593,7 @@ implSyncWithLedger projectResult mpEnv =
                 slot
                 ls
                 (isLastTicketNo is0)
-                (isRemovalGen is0)
+                (isRemovalCounter is0)
                 (TxSeq.toList (isTxs is0))
             revalidateDeltas frk tipHash0 slot seed (0 :: Int) >>= \case
               Nothing -> goSync -- Retry if the commit found the state stale.
@@ -623,7 +623,7 @@ implSyncWithLedger projectResult mpEnv =
     -- (the commit below would reject it, retrying the whole sync). This helper
     -- checks that condition, run on each iteration.
     stale cand isNow curTipHash =
-      curTipHash /= tipHash0 || isRemovalGen isNow /= isRemovalGen cand
+      curTipHash /= tipHash0 || isRemovalCounter isNow /= isRemovalCounter cand
 
     go acc@(RevalidateTxsResult cand _) iterN = do
       (isNow, curTipHash) <- atomically $ do

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Update.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Mempool/Update.hs
@@ -13,6 +13,7 @@ module Ouroboros.Consensus.Mempool.Update
   ) where
 
 import Cardano.Slotting.Slot
+import Control.Monad (when)
 import Control.Monad.Class.MonadTimer.SI (MonadTimer, timeout)
 import Control.Monad.Except (runExcept)
 import Control.Tracer
@@ -466,6 +467,12 @@ implRemoveTxsEvenIfValid mpEnv toRemove =
               (isLastTicketNo is)
               toKeep
               toRemove
+      -- Signal any in-flight sync that its snapshot is now stale (see
+      -- 'mpEnvRemovalGen'). Only bump when a tx actually left, so a no-op
+      -- removal does not force a needless restart. Done under the state lock, so
+      -- it is ordered against the sync's commit re-check.
+      let nRemoved = length (TxSeq.toList (isTxs is)) - length (TxSeq.toList (isTxs is'))
+      when (nRemoved > 0) $ atomically $ modifyTVar removalGen (+ 1)
       traceWith trcr t
       pure ((), is')
  where
@@ -475,6 +482,7 @@ implRemoveTxsEvenIfValid mpEnv toRemove =
     , mpEnvTracer = trcr
     , mpEnvLedgerCfg = cfg
     , mpEnvCapacityOverride = capacityOverride
+    , mpEnvRemovalGen = removalGen
     } = mpEnv
 
 -- | Craft a 'RemoveTxs' that manually removes the given transactions from the

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/Mempool/StateMachine.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/Mempool/StateMachine.hs
@@ -777,7 +777,7 @@ prop_mempoolParallel ::
   MakeAtomic ->
   (Int -> LedgerState blk ValuesMK -> Gen [GenTx blk]) ->
   Property
-prop_mempoolParallel cfg capacity initialState ma gTxs = forAllParallelCommandsNTimes sm0 Nothing 100 $
+prop_mempoolParallel cfg capacity initialState ma gTxs = forAllParallelCommandsNTimes sm0 Nothing 10 $
   \cmds -> monadicIO $ do
     (sut, trcr) <- run $ mkSUT cfg initialState
     ior <- run $ newTVarIO sut
@@ -805,9 +805,8 @@ tests =
           -- More commands require exponentially more memory to explore.
           localOption (QuickCheckMaxSize 40) $
             testProperty "atomic" $
-              withMaxSuccess 10000 $
-                prop_mempoolParallel testLedgerConfigNoSizeLimits txMaxBytes' testInitLedger Atomic $
-                  \i -> fmap (fmap fst . fst) . genTxs i
+              prop_mempoolParallel testLedgerConfigNoSizeLimits txMaxBytes' testInitLedger Atomic $
+                \i -> fmap (fmap fst . fst) . genTxs i
         , testProperty "non atomic" $
             withMaxSuccess 10 $
               prop_mempoolParallel testLedgerConfigNoSizeLimits txMaxBytes' testInitLedger NonAtomic $

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/Mempool/StateMachine.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/Mempool/StateMachine.hs
@@ -28,11 +28,13 @@ module Test.Consensus.Mempool.StateMachine (tests) where
 import Cardano.Slotting.Slot
 import Control.Arrow (second)
 import Control.Concurrent.Class.MonadSTM.Strict.TChan
+import Control.Monad (when)
 import Control.Monad.Class.MonadTimer.SI (MonadTimer)
 import Control.Monad.Except (runExcept)
-import Control.Tracer (Tracer, mkTracer, traceWith)
+import Control.Tracer (Tracer, mkTracer, nullTracer, traceWith)
 import qualified Data.Foldable as Foldable
 import Data.Function (on)
+import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as Map
 import Data.Maybe (fromMaybe)
 import qualified Data.Measure as Measure
@@ -67,6 +69,7 @@ import Test.Cardano.Ledger.TreeDiff ()
 import Test.Consensus.Mempool.Util
   ( TestBlock
   , applyTxToLedger
+  , bumpTip
   , genTxs
   , genValidTxs
   , testInitLedger
@@ -80,6 +83,7 @@ import Test.StateMachine.Types (History (..), HistoryEvent (..))
 import qualified Test.StateMachine.Types as QC
 import qualified Test.StateMachine.Types.Rank2 as Rank2
 import Test.Tasty
+import Test.Tasty.HUnit (assertBool, testCase)
 import Test.Tasty.QuickCheck
 import Test.Util.Orphans.ToExpr ()
 import Test.Util.ToExpr ()
@@ -92,6 +96,11 @@ import Test.Util.ToExpr ()
 data Model blk r = Model
   { modelMempoolIntermediateState :: !(TickedLedgerState blk ValuesMK)
   -- ^ The current tip on the mempool
+  , modelMempoolBase :: !(LedgerState blk ValuesMK)
+  -- ^ The (unticked) ledger state the mempool is currently applied on top of,
+  -- i.e. the tip it last synced to. Needed to re-derive the mempool after a
+  -- 'RemoveTxs', which re-applies the kept txs on this same base rather than
+  -- syncing to a new one.
   , modelTxs :: ![(GenTx blk, TicketNo)]
   , modelAllValidTxs :: ![(GenTx blk, TicketNo)]
   -- ^ The current list of transactions
@@ -129,6 +138,8 @@ data Action blk r
     TryAddTxs ![GenTx blk]
   | -- | Unconditionally sync with the ledger db
     SyncLedger
+  | -- | Force-remove transactions (as the forge loop does on a rejected block).
+    RemoveTxs ![GenTxId blk]
   | -- | Ask for the current snapshot
     GetSnapshot
   -- TODO: maybe add 'GetSnapshotFor (Point blk)', but this requires to keep
@@ -196,6 +207,7 @@ generator ::
   , UnTick blk
   , StandardHash blk
   , GetTip (LedgerState blk)
+  , HasTxId (GenTx blk)
   ) =>
   MakeAtomic ->
   -- | Transaction generator based on an state
@@ -204,7 +216,7 @@ generator ::
   Maybe (Gen (Command blk Symbolic))
 generator ma gTxs model =
   Just $
-    frequency
+    frequency $
       [
         ( 100
         , Action . TryAddTxs <$> case ma of
@@ -239,11 +251,16 @@ generator ma gTxs model =
         )
       , (10, pure $ Action GetSnapshot)
       ]
+        -- Only remove when there is something to remove; races with SyncLedger.
+        ++ [ (10, Action . RemoveTxs <$> (sublistOf (map (txId . fst) modelTxs) `suchThat` (not . null)))
+           | not (null modelTxs)
+           ]
  where
   Model
     { modelMempoolIntermediateState
     , modelLedgerDBTip
     , modelLedgerDBOtherStates
+    , modelTxs
     } = model
 
 data Response blk r
@@ -271,6 +288,7 @@ initModel ::
 initModel cfg capacity initialState =
   Model
     { modelMempoolIntermediateState = ticked
+    , modelMempoolBase = initialState
     , modelLedgerDBOtherStates = Set.empty
     , modelLedgerDBTip = initialState
     , modelTxs = []
@@ -291,6 +309,7 @@ mock ::
 mock model = \case
   Action (TryAddTxs _) -> pure $ AddResult []
   Action SyncLedger -> pure $ Synced (genesisPoint, [])
+  Action (RemoveTxs _) -> pure Void
   Action GetSnapshot -> pure $ GotSnapshot $ modelTxs model
   Event (ChangeLedger _) -> pure Void
 
@@ -315,6 +334,7 @@ doSync model =
        in
         model
           { modelMempoolIntermediateState = st''
+          , modelMempoolBase = modelLedgerDBTip
           , modelTxs = validTxs
           , modelCurrentSize = newSize
           }
@@ -383,9 +403,41 @@ doTryAddTxs model txs =
     , modelCapacity
     } = model
 
+-- | Force-remove the given transactions, then re-derive the mempool by
+-- re-applying the /kept/ txs against the current base (mirrors
+-- 'removeTxsEvenIfValid'/'pureRemoveTxs': the base is unchanged, only the txs
+-- shrink).
+doRemoveTxs ::
+  ( LedgerSupportsMempool blk
+  , ValidateEnvelope blk
+  , HasTxId (GenTx blk)
+  ) =>
+  Model blk r ->
+  [GenTxId blk] ->
+  Model blk r
+doRemoveTxs model ids =
+  let toRemove = Set.fromList ids
+      kept = filter ((`Set.notMember` toRemove) . txId . fst) modelTxs
+      (validTxs, _tk, newSize, st'') =
+        foldTxs modelConfig zeroTicketNo modelCapacity Measure.zero (tick modelConfig modelMempoolBase) $
+          map (second Just) kept
+   in model
+        { modelMempoolIntermediateState = st''
+        , modelTxs = validTxs
+        , modelCurrentSize = newSize
+        }
+ where
+  Model
+    { modelMempoolBase
+    , modelTxs
+    , modelConfig
+    , modelCapacity
+    } = model
+
 transition ::
   ( Eq (TickedLedgerState blk ValuesMK)
   , LedgerSupportsMempool blk
+  , HasTxId (GenTx blk)
   , ToExpr (GenTx blk)
   , ValidateEnvelope blk
   , ToExpr (Command blk r)
@@ -399,6 +451,7 @@ transition model cmd resp = case (cmd, resp) of
   (Event (ChangeLedger l), Void) -> (doChangeLedger model l){modelIsSyncing = False}
   (Action GetSnapshot, GotSnapshot{}) -> model{modelIsSyncing = False}
   (Action SyncLedger, Synced{}) -> (doSync model){modelIsSyncing = True}
+  (Action (RemoveTxs ids), Void) -> (doRemoveTxs model ids){modelIsSyncing = False}
   _ ->
     error $
       "mismatched command "
@@ -597,6 +650,11 @@ semantics trcr cmd r = do
     Action SyncLedger -> do
       snap <- testSyncWithLedger m
       pure (Synced (snapshotPoint snap, [(txForgetValidated tt, tk) | (tt, tk, _) <- snapshotTxs snap]))
+    Action (RemoveTxs ids) -> do
+      case NE.nonEmpty ids of
+        Nothing -> pure ()
+        Just neids -> removeTxsEvenIfValid m neids
+      pure Void
     Action GetSnapshot -> do
       txs <- snapshotTxs <$> atomically (getSnapshot m)
       pure $ GotSnapshot [(txForgetValidated vtx, tk) | (vtx, tk, _) <- txs]
@@ -619,11 +677,13 @@ precondition :: Model blk Symbolic -> Command blk Symbolic -> Logic
 -- precondition cfg Model {modelCurrentSize} (Action (TryAddTxs txs)) =
 --   Boolean $ not (null txs) && modelCurrentSize > 0 && sum (map tSize rights $ init txs) < modelCurrentSize
 precondition m (Action SyncLedger) = Boolean $ not (modelIsSyncing m)
+precondition _ (Action (RemoveTxs ids)) = Boolean $ not (null ids)
 precondition _ _ = Top
 
 postcondition ::
   ( LedgerSupportsMempool blk
   , Eq (GenTx blk)
+  , HasTxId (GenTx blk)
   , --  , Show (TickedLedgerState blk ValuesMK)
     UnTick blk
   , ValidateEnvelope blk
@@ -668,6 +728,8 @@ shrinker ::
   [Command blk Symbolic]
 shrinker _ (Action (TryAddTxs txs)) =
   Action . TryAddTxs <$> shrinkList shrinkNothing txs
+shrinker _ (Action (RemoveTxs ids)) =
+  Action . RemoveTxs <$> filter (not . null) (shrinkList shrinkNothing ids)
 shrinker _ _ = []
 
 {-------------------------------------------------------------------------------
@@ -790,12 +852,127 @@ prop_mempoolParallel cfg capacity initialState ma gTxs = forAllParallelCommandsN
  where
   sm0 = smUnused cfg initialState capacity ma gTxs
 
+-- | A regression test for one specific interleaving that is hard to hit by
+-- random parallel testing, so we reproduce it deterministically.
+--
+-- Beware of this interleaving: the forge loop may 'removeTxsEvenIfValid' a
+-- transaction (to recover from forging a block that turns out to be invalid)
+-- while a mempool sync is in flight. A sync snapshots the mempool, does the
+-- expensive revalidation /off the lock/, and only then commits. If a removal
+-- lands in that window, a naive sync commits its now-stale snapshot and
+-- /resurrects/ the removed transaction.
+--
+-- Rather than race a second thread and hope to hit the window (which is exactly
+-- what the QSM parallel tests do — and miss), we interpose the removal at the
+-- one point that matters: from inside the sync's off-lock ledger read. That read
+-- happens after the snapshot and before the commit, so removing @x@ there
+-- reproduces the race with no threads and no blocking. The tip change to @base1@
+-- ('bumpTip') keeps @x@ valid, so the /only/ thing that can drop it is the
+-- removal.
+--
+-- The rest is an ordinary state-machine program run through 'semantics', with
+-- the 'Model' as the oracle:
+--
+-- > TryAddTxs [x]; ChangeLedger base1; SyncLedger; GetSnapshot
+--
+-- We advance the model as if the interposed removal happened just before the
+-- sync (the only sensible linearization), so the trailing 'GetSnapshot'
+-- 'postcondition' rejects a resurrected @x@.
+prop_removeDuringSyncSM :: IO ()
+prop_removeDuringSyncSM = do
+  let cfg = testLedgerConfigNoSizeLimits
+      capacity = txMaxBytes'
+      base0 = testInitLedger
+      base1 = bumpTip base0
+
+  (txs, _) <- generate $ genValidTxs 1 base0
+  assertBool "expected a valid tx" (not (null txs))
+  let x = head txs
+      xid = txId x
+
+  -- Reference to the mempool, filled once it exists so the ledger interface can
+  -- reach back into it to interpose the removal.
+  mempoolRef <- newEmptyMVar
+  removed <- newTVarIO False
+  ldb <- newTVarIO $ MockedLedgerDB base0 Set.empty
+  let interposeRemoval st =
+        -- Fire exactly once, and only in the sync's snapshot read: only the sync
+        -- serves 'base1' (setup reads serve 'base0', and the removal's own read
+        -- uses the stored 'base0' forker).
+        when (getTip st == getTip base1) $ do
+          firstTime <- atomically $ do
+            done <- readTVar removed
+            writeTVar removed True
+            pure (not done)
+          when firstTime $ do
+            mempool <- readMVar mempoolRef
+            removeTxsEvenIfValid mempool (NE.fromList [xid])
+      readTables st keys = do
+        interposeRemoval st
+        pure (projectLedgerTables st `restrictValues'` keys)
+      ledgerInterface =
+        LedgerInterface
+          { getCurrentLedgerState = do
+              st <- ldbTip <$> readTVar ldb
+              pure $
+                MempoolLedgerDBView
+                  (forgetLedgerTables st)
+                  ( pure $
+                      Right $
+                        ReadOnlyForker
+                          { roforkerClose = pure ()
+                          , roforkerReadStatistics = pure $ Statistics 0
+                          , roforkerReadTables = readTables st
+                          , roforkerRangeReadTables = const $ pure (emptyLedgerTables, Nothing)
+                          , roforkerGetLedgerState = pure $ forgetLedgerTables st
+                          }
+                  )
+          }
+  mempool <-
+    openMempoolWithoutSyncThread
+      ledgerInterface
+      cfg
+      (MempoolCapacityBytesOverride $ unIgnoringOverflow capacity)
+      (Nothing :: Maybe MempoolTimeoutConfig)
+      nullTracer
+  putMVar mempoolRef mempool
+  sutVar <- newTVarIO (SUT mempool ldb)
+
+  let model0 = initModel cfg capacity base0
+      -- Run one command through the state machine: execute it via 'semantics',
+      -- check its 'postcondition' against the model, and return the model
+      -- advanced by 'transition'.
+      step model cmd = do
+        resp <- semantics nullTracer cmd sutVar
+        assertBool ("postcondition violated by " <> show cmd) $
+          boolean (postcondition model cmd resp)
+        pure (transition model cmd resp)
+
+  -- Add x, then move the ledger tip so the sync does real work without
+  -- invalidating x ('ChangeLedger' goes through 'semantics', which writes the
+  -- same mocked ledger db the interface reads).
+  model1 <- step model0 (Action (TryAddTxs [x]))
+  model2 <- step model1 (Event (ChangeLedger base1))
+
+  -- The sync runs to completion; x is removed during its off-lock read.
+  syncResp <- semantics nullTracer (Action SyncLedger) sutVar
+
+  -- Advance the model as if the removal happened just before the sync.
+  let model3 = transition model2 (Action (RemoveTxs [xid])) Void
+      model4 = transition model3 (Action SyncLedger) syncResp
+
+  -- Observe: the snapshot must match the model, i.e. x is gone. Pre-fix the sync
+  -- resurrects x and this 'postcondition' fails.
+  _ <- step model4 (Action GetSnapshot)
+  pure ()
+
 -- | See 'MakeAtomic' on the reasoning behind having these tests.
 tests :: TestTree
 tests =
   testGroup
     "QSM"
-    [ testProperty "sequential" $
+    [ testCase "removal is not undone by a concurrent sync" prop_removeDuringSyncSM
+    , testProperty "sequential" $
         withMaxSuccess 1000 $
           prop_mempoolSequential testLedgerConfigNoSizeLimits txMaxBytes' testInitLedger $
             \i -> fmap (fmap fst . fst) . genTxs i
@@ -898,6 +1075,8 @@ instance ToExpr (Action TestBlock r) where
       ]
   toExpr SyncLedger = App "SyncLedger" []
   toExpr GetSnapshot = App "GetSnapshot" []
+  toExpr (RemoveTxs ids) =
+    App "RemoveTxs" [App (take 8 (tail $ init $ show i)) [] | i <- ids]
 
 instance ToExpr (LedgerState blk ValuesMK) => ToExpr (Event blk r) where
   toExpr (ChangeLedger ls) =

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/Mempool/StateMachine.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/Mempool/StateMachine.hs
@@ -27,11 +27,14 @@ module Test.Consensus.Mempool.StateMachine (tests) where
 import Cardano.Slotting.Slot
 import Control.Arrow (second)
 import Control.Concurrent.Class.MonadSTM.Strict.TChan
+import Control.Monad (when)
 import Control.Monad.Class.MonadTimer.SI (MonadTimer)
 import Control.Monad.Except (Except, runExcept)
+import Control.Tracer (nullTracer)
 import qualified Control.Tracer as CT (Tracer, mkTracer, traceWith)
 import qualified Data.Foldable as Foldable
 import Data.Function (on)
+import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as Map
 import Data.Maybe (fromMaybe)
 import qualified Data.Measure as Measure
@@ -67,6 +70,7 @@ import Test.Cardano.Ledger.TreeDiff ()
 import Test.Consensus.Mempool.Util
   ( TestBlock
   , applyTxToLedger
+  , bumpTip
   , genTxs
   , genValidTxs
   , testInitLedger
@@ -80,6 +84,7 @@ import Test.StateMachine.Types (History (..), HistoryEvent (..))
 import qualified Test.StateMachine.Types as QC
 import qualified Test.StateMachine.Types.Rank2 as Rank2
 import Test.Tasty
+import Test.Tasty.HUnit (assertBool, testCase)
 import Test.Tasty.QuickCheck
 import Test.Util.Orphans.ToExpr ()
 import qualified Test.Util.QuickCheck as QC
@@ -93,6 +98,11 @@ import Test.Util.ToExpr ()
 data Model blk r = Model
   { modelMempoolIntermediateState :: !(TickedLedgerState blk ValuesMK)
   -- ^ The current tip on the mempool
+  , modelMempoolBase :: !(LedgerState blk ValuesMK)
+  -- ^ The (unticked) ledger state the mempool is currently applied on top of,
+  -- i.e. the tip it last synced to. Needed to re-derive the mempool after a
+  -- 'RemoveTxs', which re-applies the kept txs on this same base rather than
+  -- syncing to a new one.
   , modelTxs :: ![(GenTx blk, TicketNo)]
   , modelAllValidTxs :: ![(GenTx blk, TicketNo)]
   -- ^ The current list of transactions
@@ -130,6 +140,8 @@ data Action blk r
     TryAddTxs ![GenTx blk]
   | -- | Unconditionally sync with the ledger db
     SyncLedger
+  | -- | Force-remove transactions (as the forge loop does on a rejected block).
+    RemoveTxs ![GenTxId blk]
   | -- | Ask for the current snapshot
     GetSnapshot
   -- TODO: maybe add 'GetSnapshotFor (Point blk)', but this requires to keep
@@ -197,6 +209,7 @@ generator ::
   , UnTick blk
   , StandardHash blk
   , GetTip (LedgerState blk)
+  , HasTxId (GenTx blk)
   ) =>
   MakeAtomic ->
   -- | Transaction generator based on an state
@@ -205,7 +218,7 @@ generator ::
   Maybe (Gen (Command blk Symbolic))
 generator ma gTxs model =
   Just $
-    frequency
+    frequency $
       [
         ( 100
         , Action . TryAddTxs <$> case ma of
@@ -240,11 +253,16 @@ generator ma gTxs model =
         )
       , (10, pure $ Action GetSnapshot)
       ]
+        -- Only remove when there is something to remove; races with SyncLedger.
+        ++ [ (10, Action . RemoveTxs <$> (sublistOf (map (txId . fst) modelTxs) `suchThat` (not . null)))
+           | not (null modelTxs)
+           ]
  where
   Model
     { modelMempoolIntermediateState
     , modelLedgerDBTip
     , modelLedgerDBOtherStates
+    , modelTxs
     } = model
 
 data Response blk r
@@ -272,6 +290,7 @@ initModel ::
 initModel cfg capacity initialState =
   Model
     { modelMempoolIntermediateState = ticked
+    , modelMempoolBase = initialState
     , modelLedgerDBOtherStates = Set.empty
     , modelLedgerDBTip = initialState
     , modelTxs = []
@@ -292,6 +311,7 @@ mock ::
 mock model = \case
   Action (TryAddTxs _) -> pure $ AddResult []
   Action SyncLedger -> pure $ Synced (genesisPoint, [])
+  Action (RemoveTxs _) -> pure Void
   Action GetSnapshot -> pure $ GotSnapshot $ modelTxs model
   Event (ChangeLedger _) -> pure Void
 
@@ -316,6 +336,7 @@ doSync model =
        in
         model
           { modelMempoolIntermediateState = st''
+          , modelMempoolBase = modelLedgerDBTip
           , modelTxs = validTxs
           , modelCurrentSize = newSize
           }
@@ -384,9 +405,41 @@ doTryAddTxs model txs =
     , modelCapacity
     } = model
 
+-- | Force-remove the given transactions, then re-derive the mempool by
+-- re-applying the /kept/ txs against the current base (mirrors
+-- 'removeTxsEvenIfValid'/'pureRemoveTxs': the base is unchanged, only the txs
+-- shrink).
+doRemoveTxs ::
+  ( LedgerSupportsMempool blk
+  , ValidateEnvelope blk
+  , HasTxId (GenTx blk)
+  ) =>
+  Model blk r ->
+  [GenTxId blk] ->
+  Model blk r
+doRemoveTxs model ids =
+  let toRemove = Set.fromList ids
+      kept = filter ((`Set.notMember` toRemove) . txId . fst) modelTxs
+      (validTxs, _tk, newSize, st'') =
+        foldTxs modelConfig zeroTicketNo modelCapacity Measure.zero (tick modelConfig modelMempoolBase) $
+          map (second Just) kept
+   in model
+        { modelMempoolIntermediateState = st''
+        , modelTxs = validTxs
+        , modelCurrentSize = newSize
+        }
+ where
+  Model
+    { modelMempoolBase
+    , modelTxs
+    , modelConfig
+    , modelCapacity
+    } = model
+
 transition ::
   ( Eq (TickedLedgerState blk ValuesMK)
   , LedgerSupportsMempool blk
+  , HasTxId (GenTx blk)
   , ToExpr (GenTx blk)
   , ValidateEnvelope blk
   , ToExpr (Command blk r)
@@ -400,6 +453,7 @@ transition model cmd resp = case (cmd, resp) of
   (Event (ChangeLedger l), Void) -> (doChangeLedger model l){modelIsSyncing = False}
   (Action GetSnapshot, GotSnapshot{}) -> model{modelIsSyncing = False}
   (Action SyncLedger, Synced{}) -> (doSync model){modelIsSyncing = True}
+  (Action (RemoveTxs ids), Void) -> (doRemoveTxs model ids){modelIsSyncing = False}
   _ ->
     error $
       "mismatched command "
@@ -609,6 +663,11 @@ semantics trcr cmd r = do
     Action SyncLedger -> do
       snap <- testSyncWithLedger m
       pure (Synced (snapshotPoint snap, [(txForgetValidated tt, tk) | (tt, tk, _) <- snapshotTxs snap]))
+    Action (RemoveTxs ids) -> do
+      case NE.nonEmpty ids of
+        Nothing -> pure ()
+        Just neids -> removeTxsEvenIfValid m neids
+      pure Void
     Action GetSnapshot -> do
       txs <- snapshotTxs <$> atomically (getSnapshot m)
       pure $ GotSnapshot [(txForgetValidated vtx, tk) | (vtx, tk, _) <- txs]
@@ -631,11 +690,13 @@ precondition :: Model blk Symbolic -> Command blk Symbolic -> Logic
 -- precondition cfg Model {modelCurrentSize} (Action (TryAddTxs txs)) =
 --   Boolean $ not (null txs) && modelCurrentSize > 0 && sum (map tSize rights $ init txs) < modelCurrentSize
 precondition m (Action SyncLedger) = Boolean $ not (modelIsSyncing m)
+precondition _ (Action (RemoveTxs ids)) = Boolean $ not (null ids)
 precondition _ _ = Top
 
 postcondition ::
   ( LedgerSupportsMempool blk
   , Eq (GenTx blk)
+  , HasTxId (GenTx blk)
   , --  , Show (TickedLedgerState blk ValuesMK)
     UnTick blk
   , ValidateEnvelope blk
@@ -682,6 +743,8 @@ shrinker ::
   [Command blk Symbolic]
 shrinker _ (Action (TryAddTxs txs)) =
   Action . TryAddTxs <$> shrinkList shrinkNothing txs
+shrinker _ (Action (RemoveTxs ids)) =
+  Action . RemoveTxs <$> filter (not . null) (shrinkList shrinkNothing ids)
 shrinker _ _ = []
 
 {-------------------------------------------------------------------------------
@@ -701,8 +764,6 @@ sm sm0 trcr ior = sm0{QC.semantics = \c -> semantics trcr c ior}
 
 smUnused ::
   ( blk ~ TestBlock
-  , LedgerSupportsMempool blk
-  , LedgerSupportsProtocol blk
   , Monad m
   ) =>
   LedgerConfig blk ->
@@ -737,8 +798,6 @@ prop_mempoolSequential ::
   forall blk.
   ( HasTxId (GenTx blk)
   , blk ~ TestBlock
-  , LedgerSupportsMempool blk
-  , LedgerSupportsProtocol blk
   ) =>
   LedgerConfig blk ->
   TxMeasure blk ->
@@ -782,8 +841,6 @@ prop_mempoolSequential cfg capacity initialState gTxs = forAllCommands sm0 Nothi
 prop_mempoolParallel ::
   ( HasTxId (GenTx blk)
   , blk ~ TestBlock
-  , LedgerSupportsMempool blk
-  , LedgerSupportsProtocol blk
   ) =>
   LedgerConfig blk ->
   TxMeasure blk ->
@@ -791,7 +848,7 @@ prop_mempoolParallel ::
   MakeAtomic ->
   (Int -> LedgerState blk ValuesMK -> Gen [GenTx blk]) ->
   Property
-prop_mempoolParallel cfg capacity initialState ma gTxs = forAllParallelCommandsNTimes sm0 Nothing 100 $
+prop_mempoolParallel cfg capacity initialState ma gTxs = forAllParallelCommandsNTimes sm0 Nothing 10 $
   \cmds -> monadicIO $ do
     (sut, trcr) <- run $ mkSUT cfg initialState
     ior <- run $ newTVarIO sut
@@ -804,21 +861,154 @@ prop_mempoolParallel cfg capacity initialState ma gTxs = forAllParallelCommandsN
  where
   sm0 = smUnused cfg initialState capacity ma gTxs
 
+-- | A regression test for one specific interleaving that random parallel
+-- testing is very unlikely to hit, so we reproduce it deterministically: while a
+-- mempool sync is in flight, the forge loop 'removeTxsEvenIfValid' drops a tx. A
+-- sync snapshots the mempool, revalidates /off the lock/, then commits; if a
+-- removal lands in that window a naive sync commits its now-stale snapshot and
+-- /resurrects/ the removed tx.
+--
+-- This function interleaves 'semantics' and 'transition' in a very atypical way.
+-- Normally one calls a QSM search function and it handles all of this, but the
+-- point here is to reach the rare interleaving deterministically, so there is no
+-- random search:
+--
+-- >        [X1]        -- TryAddTxs [x]
+-- >         |
+-- >        [X2]        -- ChangeLedger base1
+-- >       /    \
+-- >    [L1]    [R1]    -- L1: SyncLedger      R1: RemoveTxs [x]
+-- >     |       |
+-- >     |      [R2]    -- R2: SyncLedger
+-- >       \    /
+-- >        [X3]        -- GetSnapshot
+--
+-- Each node is an action this function performs:
+--
+--   * Each @X*@ is a 'step' (defined below): both a 'semantics' and a
+--     'transition' call, so it mutates the SUT (the real mempool) /and/ advances
+--     the model's pure state.
+--   * @L1@ is only a 'semantics' call — it does not touch the model.
+--   * @R1@ and @R2@ are only 'transition' calls — they do not touch the SUT.
+--   * @X3@ is a final 'step', the 'GetSnapshot' query, so we can check the model
+--     and the SUT still agree.
+--
+-- Crucially, @L1@ does /two/ things: its 'SyncLedger' /implicitly/ invokes
+-- 'interposeRemoval'. So @L1@ does to the SUT exactly what @R1@+@R2@ do to the
+-- model — but @L1@'s implicit 'RemoveTxs' is carefully arranged to happen
+-- \"during\" @L1@'s explicit 'SyncLedger', i.e. inside the sync's off-lock read,
+-- after its snapshot and before its commit. The tip change to @base1@ ('bumpTip')
+-- keeps @x@ valid, so the only thing that can drop it is that removal — and a
+-- correct sync must not bring it back.
+prop_removeDuringSyncSM :: IO ()
+prop_removeDuringSyncSM = do
+  let cfg = testLedgerConfigNoSizeLimits
+      capacity = txMaxBytes'
+      base0 = testInitLedger
+      base1 = bumpTip base0
+
+  (txs, _) <- generate $ genValidTxs 1 base0
+  assertBool "expected a valid tx" (not (null txs))
+  let x = head txs
+      xid = txId x
+
+  -- Reference to the mempool, filled once it exists so the ledger interface can
+  -- reach back into it to interpose the removal.
+  mempoolRef <- newEmptyMVar
+  removed <- newTVarIO False
+  ldb <- newTVarIO $ MockedLedgerDB base0 Set.empty
+  let interposeRemoval st =
+        -- Fire exactly once, and only in the sync's snapshot read: only the sync
+        -- serves 'base1' (setup reads serve 'base0', and the removal's own read
+        -- uses the stored 'base0' forker).
+        when (getTip st == getTip base1) $ do
+          firstTime <- atomically $ do
+            done <- readTVar removed
+            writeTVar removed True
+            pure (not done)
+          when firstTime $ do
+            mempool <- readMVar mempoolRef
+            removeTxsEvenIfValid mempool (NE.fromList [xid])
+      readTables st keys = do
+        interposeRemoval st
+        pure (ltliftA2 restrictValuesMK (projectLedgerTables st) keys)
+      ledgerInterface =
+        LedgerInterface
+          { getCurrentLedgerState = do
+              st <- ldbTip <$> readTVar ldb
+              pure $
+                MempoolLedgerDBView
+                  (forgetLedgerTables st)
+                  ( pure $
+                      Right $
+                        ReadOnlyForker
+                          { roforkerClose = pure ()
+                          , roforkerReadStatistics = pure $ Statistics 0
+                          , roforkerReadTables = readTables st
+                          , roforkerRangeReadTables = const $ pure (emptyLedgerTables, Nothing)
+                          , roforkerGetLedgerState = pure $ forgetLedgerTables st
+                          }
+                  )
+          }
+  mempool <-
+    openMempoolWithoutSyncThread
+      ledgerInterface
+      cfg
+      (MempoolCapacityBytesOverride $ unIgnoringOverflow $ tmPhase1 capacity)
+      (Nothing :: Maybe MempoolTimeoutConfig)
+      nullTracer
+  putMVar mempoolRef mempool
+  sutVar <- newTVarIO (SUT mempool ldb)
+
+  let model0 = initModel cfg capacity base0
+      -- Run one command through the state machine: execute it via 'semantics',
+      -- check its 'postcondition' against the model, and return the model
+      -- advanced by 'transition'.
+      step model cmd = do
+        resp <- semantics nullTracer cmd sutVar
+        assertBool ("postcondition violated by " <> show cmd) $
+          boolean (postcondition model cmd resp)
+        pure (transition model cmd resp)
+
+  -- X1, X2: add x, then move the ledger tip so the sync does real work without
+  -- invalidating x ('ChangeLedger' goes through 'semantics', which writes the
+  -- same mocked ledger db the interface reads).
+  model1 <- step model0 (Action (TryAddTxs [x]))
+  model2 <- step model1 (Event (ChangeLedger base1))
+
+  -- L1: the sync runs to completion, and 'interposeRemoval' drops x during its
+  -- off-lock read.
+  syncResp <- semantics nullTracer (Action SyncLedger) sutVar
+
+  -- R1, R2: mirror L1 on the model — remove, then sync, the only sensible
+  -- linearization.
+  let model3 = transition model2 (Action (RemoveTxs [xid])) Void
+      model4 = transition model3 (Action SyncLedger) syncResp
+
+  -- X3: the snapshot must match the model, i.e. x is gone. Pre-fix the sync
+  -- resurrects x and this 'postcondition' fails.
+  _ <- step model4 (Action GetSnapshot)
+  pure ()
+
 -- | See 'MakeAtomic' on the reasoning behind having these tests.
 tests :: TestTree
 tests =
   testGroup
     "QSM"
-    [ testProperty "sequential" $
+    [ testCase "removal is not undone by a concurrent sync" prop_removeDuringSyncSM
+    , testProperty "sequential" $
         QC.withNumTests 1000 $
           prop_mempoolSequential testLedgerConfigNoSizeLimits txMaxBytes' testInitLedger $
             \i -> fmap (fmap fst . fst) . genTxs i
     , testGroup
         "parallel"
-        [ testProperty "atomic" $
-            QC.withNumTests 10000 $
-              prop_mempoolParallel testLedgerConfigNoSizeLimits txMaxBytes' testInitLedger Atomic $
-                \i -> fmap (fmap fst . fst) . genTxs i
+        [ -- Restrict the length of the command list for QSM parallel testing.
+          -- More commands require exponentially more memory to explore.
+          localOption (QuickCheckMaxSize 40) $
+            testProperty "atomic" $
+              QC.withNumTests 1000 $
+                prop_mempoolParallel testLedgerConfigNoSizeLimits txMaxBytes' testInitLedger Atomic $
+                  \i -> fmap (fmap fst . fst) . genTxs i
         , testProperty "non atomic" $
             QC.withNumTests 10 $
               prop_mempoolParallel testLedgerConfigNoSizeLimits txMaxBytes' testInitLedger NonAtomic $
@@ -910,6 +1100,8 @@ instance ToExpr (Action TestBlock r) where
       ]
   toExpr SyncLedger = App "SyncLedger" []
   toExpr GetSnapshot = App "GetSnapshot" []
+  toExpr (RemoveTxs ids) =
+    App "RemoveTxs" [App (take 8 (tail $ init $ show i)) [] | i <- ids]
 
 instance ToExpr (LedgerState blk ValuesMK) => ToExpr (Event blk r) where
   toExpr (ChangeLedger ls) =

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/Mempool/Util.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/Mempool/Util.hs
@@ -9,6 +9,7 @@ module Test.Consensus.Mempool.Util
   , TestTxId
   , TheMeasure
   , applyTxToLedger
+  , bumpTip
   , genInvalidTx
   , genLargeInvalidTx
   , genTxs
@@ -210,6 +211,29 @@ genLargeInvalidTx (IgnoringOverflow sz) = go Set.empty
         tx = mkSimpleGenTx $ Tx DoNotExpire ins outs
     guard $ genTxSize tx > sz
     pure tx
+
+-- | Advance the ledger tip by one slot while keeping the UTxO unchanged.
+--
+-- Unlike 'applyTxToLedger', this consumes no inputs, so any transaction that was
+-- valid against the input state is still valid against the result. This is
+-- exactly the base change needed to make a mempool sync do real work without
+-- invalidating any of the transactions it already holds.
+bumpTip ::
+  LedgerState TestBlock ValuesMK ->
+  LedgerState TestBlock ValuesMK
+bumpTip (SimpleLedgerState mockState tbls) =
+  SimpleLedgerState mockState{mockTip = BlockPoint slot' hash'} tbls
+ where
+  slot' = case pointSlot $ mockTip mockState of
+    Origin -> 0
+    NotOrigin s -> succ s
+
+  -- See 'applyTxToLedger' for the phantom-parameter trick behind this hash.
+  hash' :: HeaderHash TestBlock
+  hash' = hashWithSerialiser fakeEncodeHeader (error "fake header")
+
+  fakeEncodeHeader :: Header TestBlock -> Encoding
+  fakeEncodeHeader _ = toCBOR slot'
 
 -- | Apply a transaction to the ledger
 --

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/Mempool/Util.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/Mempool/Util.hs
@@ -10,6 +10,7 @@ module Test.Consensus.Mempool.Util
   , TestTxId
   , TheMeasure
   , applyTxToLedger
+  , bumpTip
   , genInvalidTx
   , genLargeInvalidTx
   , genTxs
@@ -210,6 +211,29 @@ genLargeInvalidTx (IgnoringOverflow sz) = go Set.empty
         tx = mkSimpleGenTx $ Tx DoNotExpire ins outs
     guard $ genTxSize tx > sz
     pure tx
+
+-- | Advance the ledger tip by one slot while keeping the UTxO unchanged.
+--
+-- Unlike 'applyTxToLedger', this consumes no inputs, so any transaction that was
+-- valid against the input state is still valid against the result. This is
+-- exactly the base change needed to make a mempool sync do real work without
+-- invalidating any of the transactions it already holds.
+bumpTip ::
+  LedgerState TestBlock ValuesMK ->
+  LedgerState TestBlock ValuesMK
+bumpTip (SimpleLedgerState mockState tables) =
+  SimpleLedgerState mockState{mockTip = BlockPoint slot' hash'} tables
+ where
+  slot' = case pointSlot $ mockTip mockState of
+    Origin -> 0
+    NotOrigin s -> succ s
+
+  -- See 'applyTxToLedger' for the phantom-parameter trick behind this hash.
+  hash' :: HeaderHash TestBlock
+  hash' = hashWithSerialiser fakeEncodeHeader (error "fake header")
+
+  fakeEncodeHeader :: Header TestBlock -> Encoding
+  fakeEncodeHeader _ = toCBOR slot'
 
 -- | Apply a transaction to the ledger
 --


### PR DESCRIPTION
On every tip change the mempool sync revalidates the whole mempool under the state lock, blocking snapshot readers (forging, tx-submission) and adders for an `O(occupancy)` LedgerDB read + reapply. This double-buffers the sync: revalidate off the lock against a `readTMVar` snapshot, take the lock only for a bounded residual reapply (`≤ syncDeltaCap`) and commit. Committed state is byte-identical to a full revalidation; at commit the sync retries if the tip moved or a tx was force-removed while it worked off the lock.

Possible follow-up: moving ingestion off the lock is another idea, we can applyTx off the fifo and reapplyTx while holding the fifo / istate mvars. Done on a branch, but had a slightly worse change vs. benefit result so not incorporated here.

## Benchmarks

New `mempool-state-bench` drives the real mempool over a mocked, latency-injecting `LedgerInterface` (concurrent adders/readers/syncer) at measured LSM latencies (read ~60 µs/tx, apply ~128 µs/tx, [ouroboros-leios#553](https://github.com/input-output-hk/ouroboros-leios/issues/553)). `-N4`, 20 s. `stall` = max `getSnapshot` block a reader saw (a peak, the metric this change targets); `thr` = mean `addTx`/s over the run; `occ` = final occupancy. A/B is base (`main`, under-lock sync) vs this branch, same harness.

| peers | offered | stall (base → branch) | thr (base → branch) |    occ |
|------:|--------:|----------------------:|--------------------:|-------:|
|     2 |     100 |      10 ms → **1 ms** |             94 → 95 |   1.9k |
|     2 |    1000 |     900 ms → **8 ms** |           600 → 610 |    13k |
|     2 |   10000 |    2.76 s → **16 ms** |         1302 → 1490 | 34–41k |
|    20 |     100 |      23 ms → **2 ms** |             98 → 98 |   2.0k |
|    20 |    1000 |     1.22 s → **9 ms** |           745 → 805 | 17–18k |
|    20 |   10000 |    4.40 s → **52 ms** |         1722 → 2380 | 50–56k |
|   100 |     100 |      27 ms → **3 ms** |            99 → 100 |   2.0k |
|   100 |    1000 |    1.30 s → **65 ms** |           751 → 805 | 17–19k |
|   100 |   10000 |   2.40 s → **290 ms** |           904 → 959 | 23–24k |

Reader stall drops **10–85×** and is decoupled from occupancy: the base's stall tracks occupancy (up to seconds) because `getSnapshot` blocks for the whole under-lock revalidation, whereas the branch holds the lock only for the bounded residual. Throughput is equal-to-better: the base is noisy under contention (the 20p×10k row varied 1722–2535 tx/s across runs), and on the median the branch matches or exceeds it — this change buys reader/forge responsiveness at no ingestion cost. (Single-row figures above are one representative run; the 20p×10k row was sampled 3× — base 4.40 s / 1722 tx/s median, branch 52 ms / 2380 tx/s median.)

The 290 ms branch outlier (100 peers × 10k tx/s) is the shrink loop hitting `syncMaxIters` before the delta falls below `syncDeltaCap` under sustained ingest; a tuning knob, not an unbounded regression.

## Testing

QSM sequential (×1000), atomic linearizability (×100), a deterministic removal-during-sync resurrection regression test, and the timeout-precedence test.
