### PR TITLE
[Peras 38] Introduce ChainDepStateSupportsPeras auxiliary class 

### DIFF
--- a/changelog.d/20260724_152724_agustin.mista_chaindep_state_supports_peras.md
+++ b/changelog.d/20260724_152724_agustin.mista_chaindep_state_supports_peras.md
@@ -1,0 +1,23 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+<!--
+### Breaking
+
+- A bullet item for the Breaking category.
+
+-->
+### Non-Breaking
+
+- Add auxiliary `ChainDepStateSupportsPeras` typeclass to extract epoch nonce from either ticked or unticked chain dependent states.
+
+<!--
+### Patch
+
+- A bullet item for the Patch category.
+
+-->

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Block.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Block.hs
@@ -131,6 +131,11 @@ class
   , -- Backwards compatibility
     Plain.FromCBOR (LegacyPParams era)
   , Plain.ToCBOR (LegacyPParams era)
+  , -- TODO: replace the two constraints below with:
+    -- 'StateSupportsPerasEpochContext (ShelleyBlock proto er)' once that type
+    -- class is in place.
+    ChainDepStateSupportsPeras (ChainDepState (BlockProtocol (ShelleyBlock proto era)))
+  , ChainDepStateSupportsPeras (Ticked (ChainDepState (BlockProtocol (ShelleyBlock proto era))))
   ) =>
   ShelleyCompatible proto era
 

--- a/ouroboros-consensus-protocol/src/ouroboros-consensus-protocol/Ouroboros/Consensus/Protocol/Praos.hs
+++ b/ouroboros-consensus-protocol/src/ouroboros-consensus-protocol/Ouroboros/Consensus/Protocol/Praos.hs
@@ -388,6 +388,12 @@ deriving instance PraosCrypto c => NoThunks (PraosValidationErr c)
 
 deriving instance PraosCrypto c => Show (PraosValidationErr c)
 
+instance ChainDepStateSupportsPeras PraosState where
+  getEpochNonce = praosStateEpochNonce
+
+instance ChainDepStateSupportsPeras (Ticked PraosState) where
+  getEpochNonce = praosStateEpochNonce . tickedPraosStateChainDepState
+
 instance PraosCrypto c => ConsensusProtocol (Praos c) where
   type ChainDepState (Praos c) = PraosState
   type IsLeader (Praos c) = PraosIsLeader c

--- a/ouroboros-consensus-protocol/src/ouroboros-consensus-protocol/Ouroboros/Consensus/Protocol/TPraos.hs
+++ b/ouroboros-consensus-protocol/src/ouroboros-consensus-protocol/Ouroboros/Consensus/Protocol/TPraos.hs
@@ -300,6 +300,10 @@ data instance Ticked TPraosState = TickedChainDepState
   , tickedTPraosStateLedgerView :: SL.TPraosLedgerView
   }
 
+instance ChainDepStateSupportsPeras TPraosState
+
+instance ChainDepStateSupportsPeras (Ticked TPraosState)
+
 instance SL.PraosCrypto c => ConsensusProtocol (TPraos c) where
   type ChainDepState (TPraos c) = TPraosState
   type IsLeader (TPraos c) = TPraosIsLeader c

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Abstract/SingleEraBlock.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Abstract/SingleEraBlock.hs
@@ -80,6 +80,10 @@ class
   , BlockSupportsDiffusionPipelining blk
   , BlockSupportsMetrics blk
   , SerialiseNodeToClient blk (PartialLedgerConfig blk)
+  , -- TODO: replace the two constraints below with:
+    -- 'StateSupportsPerasEpochContext blk' once that type class is in place.
+    ChainDepStateSupportsPeras (ChainDepState (BlockProtocol blk))
+  , ChainDepStateSupportsPeras (Ticked (ChainDepState (BlockProtocol blk)))
   , -- LedgerTables
     CanStowLedgerTables (LedgerState blk)
   , HasLedgerTables LedgerState blk

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Protocol.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Protocol.hs
@@ -2,13 +2,16 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Ouroboros.Consensus.HardFork.Combinator.Protocol
@@ -28,6 +31,7 @@ module Ouroboros.Consensus.HardFork.Combinator.Protocol
   , Ticked (..)
   ) where
 
+import Cardano.Ledger.BaseTypes (Nonce)
 import Control.Monad.Except
 import Data.Functor.Product
 import Data.SOP.BasicFunctors
@@ -127,6 +131,28 @@ instance CanHardFork xs => ConsensusProtocol (HardForkProtocol xs) where
 
   -- Security parameter must be equal across /all/ eras
   protocolSecurityParam = hardForkConsensusConfigK
+
+instance CanHardFork xs => ChainDepStateSupportsPeras (HardForkChainDepState xs) where
+  getEpochNonce =
+    hcollapse
+      . hcmap proxySingle getEpochNonce'
+      . State.tip
+   where
+    getEpochNonce' :: forall blk. SingleEraBlock blk => WrapChainDepState blk -> K Nonce blk
+    getEpochNonce' (WrapChainDepState st) =
+      K (getEpochNonce st)
+
+instance CanHardFork xs => ChainDepStateSupportsPeras (Ticked (HardForkChainDepState xs)) where
+  getEpochNonce =
+    hcollapse
+      . hcmap proxySingle getEpochNonce'
+      . State.tip
+      . tickedHardForkChainDepStatePerEra
+   where
+    getEpochNonce' ::
+      forall blk. SingleEraBlock blk => (Ticked :.: WrapChainDepState) blk -> K Nonce blk
+    getEpochNonce' (Comp (WrapTickedChainDepState st)) =
+      K (getEpochNonce st)
 
 {-------------------------------------------------------------------------------
   BlockSupportsProtocol

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HeaderValidation.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HeaderValidation.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -186,6 +187,18 @@ data HeaderState blk = HeaderState
   , headerStateChainDep :: !(ChainDepState (BlockProtocol blk))
   }
   deriving Generic
+
+instance
+  ChainDepStateSupportsPeras (ChainDepState (BlockProtocol blk)) =>
+  ChainDepStateSupportsPeras (HeaderState blk)
+  where
+  getEpochNonce = getEpochNonce . headerStateChainDep
+
+instance
+  ChainDepStateSupportsPeras (Ticked (ChainDepState (BlockProtocol blk))) =>
+  ChainDepStateSupportsPeras (Ticked (HeaderState blk))
+  where
+  getEpochNonce = getEpochNonce . tickedHeaderStateChainDep
 
 castHeaderState ::
   ( Coercible

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Protocol/Abstract.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Protocol/Abstract.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DefaultSignatures #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingVia #-}
@@ -30,10 +32,14 @@ module Ouroboros.Consensus.Protocol.Abstract
   , shouldSwitchToMaybe
   , Comparing (..)
 
+    -- * Peras support
+  , ChainDepStateSupportsPeras (..)
+
     -- * Convenience re-exports
   , SecurityParam (..)
   ) where
 
+import Cardano.Ledger.BaseTypes (Nonce (NeutralNonce))
 import Cardano.Slotting.Slot (WithOrigin (At))
 import Control.Monad.Except
 import Data.Function (on)
@@ -306,6 +312,26 @@ data NoTiebreaker = NoTiebreaker
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass NoThunks
   deriving ChainOrder via SimpleChainOrder NoTiebreaker
+
+-- * Peras support
+
+-- | Projections of the chain-dependent state required to support Peras.
+class ChainDepStateSupportsPeras chainDepState where
+  -- | Extract the epoch nonce from the given 'ChainDepState'.
+  --
+  -- PRECONDITION: this function will only return a meaningful result if the
+  -- 'ChainDepState' is from a protocol of a block that supports Peras.
+  getEpochNonce :: chainDepState -> Nonce
+  default getEpochNonce :: chainDepState -> Nonce
+  getEpochNonce _ = NeutralNonce
+
+-- | Protocols with a trivial (unit) 'ChainDepState' do not contribute an epoch
+-- nonce, so they use the default 'NeutralNonce'. These canonical instances
+-- cover all such protocols (e.g. BFT, leader schedules), which would otherwise
+-- each need an (overlapping) instance for @()@.
+instance ChainDepStateSupportsPeras ()
+
+instance ChainDepStateSupportsPeras (Ticked ())
 
 {-------------------------------------------------------------------------------
   Helpers

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Protocol/PBFT.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Protocol/PBFT.hs
@@ -1,21 +1,20 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeFamilyDependencies #-}
 {-# LANGUAGE UndecidableInstances #-}
-
-#if __GLASGOW_HASKELL__ >= 908
--- GHC is a bit pickier for data family instances, but trying to remove this
--- one forces us to reorganize the Protocol.* modules. TODO eventually.
+-- We have a few orphan instances here: the @Ticked (PBftState c)@ data family
+-- instance, and the Peras @ChainDepStateSupportsPeras@ instances for @PBftState@
+-- (whose type lives in Protocol.PBFT.State) and its ticked form. Removing them
+-- would force us to reorganize the Protocol.* modules. TODO eventually.
 {-# OPTIONS_GHC -Wno-orphans #-}
-#endif
 
 module Ouroboros.Consensus.Protocol.PBFT
   ( PBft
@@ -285,6 +284,10 @@ data instance Ticked (PBftState c) = TickedPBftState
   { getPBftLedgerView :: LedgerView (PBft c)
   , getTickedPBftState :: PBftState c
   }
+
+instance ChainDepStateSupportsPeras (PBftState c)
+
+instance ChainDepStateSupportsPeras (Ticked (PBftState c))
 
 instance PBftCrypto c => ConsensusProtocol (PBft c) where
   type ValidationErr (PBft c) = PBftValidationErr c

--- a/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Protocol/Praos.hs
+++ b/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Protocol/Praos.hs
@@ -568,6 +568,10 @@ instance PraosCrypto c => ConsensusProtocol (Praos c) where
               }
        in PraosChainDepState $ bi : praosHistory cds
 
+instance ChainDepStateSupportsPeras (PraosChainDepState c)
+
+instance ChainDepStateSupportsPeras (Ticked (PraosChainDepState c))
+
 -- (Standard) Praos uses the standard chain selection rule, so no need to
 -- override (though see note regarding clock skew).
 

--- a/ouroboros-consensus/src/unstable-tutorials/Ouroboros/Consensus/Tutorial/WithEpoch.lhs
+++ b/ouroboros-consensus/src/unstable-tutorials/Ouroboros/Consensus/Tutorial/WithEpoch.lhs
@@ -95,6 +95,7 @@ And imports, of course:
 > import Ouroboros.Consensus.Ledger.Tables.Utils
 
 > import Ouroboros.Consensus.Util.IndexedMemPack
+> import Ouroboros.Consensus.Protocol.Abstract (ChainDepStateSupportsPeras)
 
 Epochs
 ------
@@ -519,6 +520,8 @@ of `ConsensusProtocol PrtclD` we will represent the epoch snapshot using the
 
 Now we can instantiate `ConsensusProtocol PrtclD` proper with the types and
 functions defined above:
+
+> instance ChainDepStateSupportsPeras ChainDepStateD
 
 > instance ConsensusProtocol PrtclD where
 


### PR DESCRIPTION
This PR introduces an auxiliary `ChainDepStateSupportsPeras` type class to aid with extracting the current epoch nonce from either a ticked or unticked `ChainDepState` in a consistent manner across the codebase.