### PR TITLE
[Peras 39] Tweak Peras parameters and add necessary instances

### DIFF
--- a/changelog.d/20260727_131349_agustin.mista_tweak_peras_params.md
+++ b/changelog.d/20260727_131349_agustin.mista_tweak_peras_params.md
@@ -1,0 +1,29 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+### Breaking
+
+- Add phantom `blk` type parameter to `PerasParams`.
+
+- Extract `PerasRoundLength` from the Peras parameter bundle.
+
+- Rename "stake" to "weight" terminology in:
+  - `PerasQuorumStakeThreshold` → `PerasQuorumWeightThreshold`, and
+  - `PerasQuorumStakeThresholdSafetyMargin` → `PerasQuorumWeightThresholdSafetyMargin`.
+
+- Rename `mkPerasParameters` into `defaultPerasParameters`.
+
+### Non-Breaking
+
+- Add new `TargetCommitteeSize` Peras parameter.
+
+<!--
+### Patch
+
+- A bullet item for the Patch category.
+
+-->

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator.hs
@@ -161,7 +161,7 @@ prop_simple_hfc_convergence testSetup@TestSetup{..} =
         (History.StandardSafeZone (safeFromTipA k))
         (safeZoneB k)
       <*> pure (GenesisWindow ((unNonZero $ maxRollbacks k) * 2))
-      <*> pure (History.PerasEnabled (perasRoundLength mkPerasParams))
+      <*> pure dijkstraPerasRoundLength
 
   shape :: History.Shape '[BlockA, BlockB]
   shape = History.Shape $ exactlyTwo eraParamsA eraParamsB

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Block/SupportsPeras.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Block/SupportsPeras.hs
@@ -112,18 +112,18 @@ newtype PerasVoteStake = PerasVoteStake
 -- both values are relative (normalized) values, so we should either normalize
 -- the 'PerasVoteStake' before calling this function, or change this function to
 -- accept a stake distribution and perform the normalization internally.
-stakeAboveThreshold :: PerasParams -> PerasVoteStake -> Bool
+stakeAboveThreshold :: PerasParams blk -> PerasVoteStake -> Bool
 stakeAboveThreshold params voteStake =
   stake >= quorumThreshold + safetyMargin
  where
   stake =
     unPerasVoteStake voteStake
   quorumThreshold =
-    unPerasQuorumStakeThreshold
-      (perasQuorumStakeThreshold params)
+    unPerasQuorumWeightThreshold
+      (perasQuorumWeightThreshold params)
   safetyMargin =
-    unPerasQuorumStakeThresholdSafetyMargin
-      (perasQuorumStakeThresholdSafetyMargin params)
+    unPerasQuorumWeightThresholdSafetyMargin
+      (perasQuorumWeightThresholdSafetyMargin params)
 
 newtype PerasVoteStakeDistr = PerasVoteStakeDistr
   { unPerasVoteStakeDistr :: Map PerasVoterId PerasVoteStake
@@ -228,6 +228,8 @@ class
   ) =>
   BlockSupportsPeras blk
   where
+  -- NOTE: this associated type will dissapear in favor of using
+  -- 'PerasParams blk' directly.
   type PerasCfg blk
 
   data PerasCert blk
@@ -265,7 +267,7 @@ class
 -- TODO: degenerate instance for all blks to get things to compile
 -- see https://github.com/tweag/cardano-peras/issues/73
 instance StandardHash blk => BlockSupportsPeras blk where
-  type PerasCfg blk = PerasParams
+  type PerasCfg blk = PerasParams blk
 
   data PerasCert blk = PerasCert
     { pcCertRound :: PerasRoundNo

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ObjectDiffusion/ObjectPool/PerasCert.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ObjectDiffusion/ObjectPool/PerasCert.hs
@@ -100,7 +100,7 @@ makePerasCertPoolWriterFromCertDB systemTime perasCertDB =
         processCerts
           systemTime
           (PerasCertDB.getCertIds perasCertDB)
-          (validatePerasCert mkPerasParams) -- TODO replace when actual plumbing is in place
+          (validatePerasCert defaultPerasParams) -- TODO replace when actual plumbing is in place
           (void . join . atomically . PerasCertDB.addCert perasCertDB)
           certs
     , opwHasObject = do
@@ -123,7 +123,7 @@ makePerasCertPoolWriterFromChainDB systemTime chainDB =
           systemTime
           (ChainDB.getPerasCertIds chainDB)
           -- TODO replace when actual plumbing is in place
-          (validatePerasCert mkPerasParams)
+          (validatePerasCert defaultPerasParams)
           -- We do not want to block the writer thread on waiting for ChainSel
           -- side-effects to complete, so we use the async version of adding
           -- certs to the ChainDB and ignore the returned promise.

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ObjectDiffusion/ObjectPool/PerasVote.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ObjectDiffusion/ObjectPool/PerasVote.hs
@@ -108,7 +108,7 @@ makePerasVotePoolWriterFromVoteDB systemTime getStakeDistrSTM perasVoteDB =
           -- TODO: in the future we won't need just the stake distribution for
           -- validating votes, but also the whole committee selection context
           -- (containing vote weights of committee members = voters)
-          (\vote -> getStakeDistrSTM >>= \sd -> pure $ validatePerasVote mkPerasParams sd vote)
+          (\vote -> getStakeDistrSTM >>= \sd -> pure $ validatePerasVote defaultPerasParams sd vote)
           (void . join . atomically . PerasVoteDB.addVote perasVoteDB)
           votes
     , opwHasObject = do
@@ -138,7 +138,7 @@ makePerasVotePoolWriterFromChainDB systemTime getStakeDistrSTM chainDB =
           -- TODO: in the future we won't need just the stake distribution for
           -- validating votes, but also the whole committee selection context
           -- (containing vote weights of committee members = voters)
-          (\vote -> getStakeDistrSTM >>= \sd -> pure $ validatePerasVote mkPerasParams sd vote)
+          (\vote -> getStakeDistrSTM >>= \sd -> pure $ validatePerasVote defaultPerasParams sd vote)
           -- We do not want to block the writer thread on waiting for ChainSel
           -- side-effects to complete, so we use the async version of adding
           -- votes to the ChainDB and ignore the returned promise.

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Peras/Cert/Inclusion.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Peras/Cert/Inclusion.hs
@@ -65,7 +65,7 @@ data LatestCertOnChainView cert
 
 -- | Interface needed to evaluate the Peras cert inclusion rules
 data PerasCertInclusionView cert blk = PerasCertInclusionView
-  { perasParams :: !PerasParams
+  { perasParams :: !(PerasParams blk)
   -- ^ Peras protocol parameters
   , currRoundNo :: !PerasRoundNo
   -- ^ The current Peras round number
@@ -90,7 +90,7 @@ mkPerasCertInclusionView ::
   forall cert blk.
   HasPerasCertRound cert =>
   -- | Peras protocol parameters
-  PerasParams ->
+  PerasParams blk ->
   -- | Current Peras round number
   PerasRoundNo ->
   -- | Most recent certificate seen by the voter

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Peras/Params.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Peras/Params.hs
@@ -3,9 +3,11 @@
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE StandaloneDeriving #-}
 
 -- | Peras protocol parameters
@@ -18,12 +20,16 @@ module Ouroboros.Consensus.Peras.Params
   , PerasCertArrivalThreshold (..)
   , PerasRoundLength (..)
   , PerasWeight (..)
-  , PerasQuorumStakeThreshold (..)
-  , PerasQuorumStakeThresholdSafetyMargin (..)
+  , PerasQuorumWeightThreshold (..)
+  , PerasQuorumWeightThresholdSafetyMargin (..)
 
     -- * Protocol parameters bundle
   , PerasParams (..)
-  , mkPerasParams
+  , castPerasParams
+  , defaultPerasParams
+
+    -- * Era-dependent default values
+  , dijkstraPerasRoundLength
 
     -- * 'PerasEnabled' wrapper
   , PerasEnabled
@@ -32,18 +38,26 @@ module Ouroboros.Consensus.Peras.Params
   , PerasEnabledT (..)
   , fromPerasEnabled
   , perasEnabledToMaybe
+
+    -- * Convenience re-exports
+  , Committee.TargetCommitteeSize (..)
   )
 where
 
 import Cardano.Binary
   ( FromCBOR (..)
   , ToCBOR (..)
+  , decodeListLenOf
+  , encodeListLen
   )
 import Control.Monad (ap, liftM)
 import Control.Monad.Trans.Class
+import Data.Coerce (coerce)
 import Data.Semigroup (Sum (..))
+import Data.Typeable (Typeable)
 import Data.Word (Word64)
 import GHC.Generics (Generic)
+import qualified Ouroboros.Consensus.Committee.Types as Committee
 import Ouroboros.Consensus.Util.Condense (Condense (..))
 import Ouroboros.Consensus.Util.IOLike (NoThunks)
 import Quiet (Quiet (..))
@@ -64,7 +78,7 @@ newtype PerasCooldownRounds
   = PerasCooldownRounds {unPerasCooldownRounds :: Word64}
   deriving Show via Quiet PerasCooldownRounds
   deriving stock Generic
-  deriving newtype (Enum, Eq, Ord, NoThunks, Condense)
+  deriving newtype (Enum, Eq, Ord, NoThunks, Condense, FromCBOR, ToCBOR)
 
 -- | Minimum age in slots of a block before it can be voted for in order to get
 -- a boost.
@@ -72,14 +86,14 @@ newtype PerasBlockMinSlots
   = PerasBlockMinSlots {unPerasBlockMinSlots :: Word64}
   deriving Show via Quiet PerasBlockMinSlots
   deriving stock Generic
-  deriving newtype (Enum, Eq, Ord, NoThunks, Condense)
+  deriving newtype (Enum, Eq, Ord, NoThunks, Condense, FromCBOR, ToCBOR)
 
 -- | Maximum age for a certificate to be included in a block, in rounds.
 newtype PerasCertMaxRounds
   = PerasCertMaxRounds {unPerasCertMaxRounds :: Word64}
   deriving Show via Quiet PerasCertMaxRounds
   deriving stock Generic
-  deriving newtype (Enum, Eq, Ord, NoThunks, Condense)
+  deriving newtype (Enum, Eq, Ord, NoThunks, Condense, FromCBOR, ToCBOR)
 
 -- | Maximum number of slots to wait for after the start of a round to consider
 -- a certificate valid for voting.
@@ -87,42 +101,42 @@ newtype PerasCertArrivalThreshold
   = PerasCertArrivalThreshold {unPerasCertArrivalThreshold :: Word64}
   deriving Show via Quiet PerasCertArrivalThreshold
   deriving stock Generic
-  deriving newtype (Enum, Eq, Ord, NoThunks, Condense)
+  deriving newtype (Enum, Eq, Ord, NoThunks, Condense, FromCBOR, ToCBOR)
 
 -- | Length of a Peras round in slots.
 newtype PerasRoundLength
   = PerasRoundLength {unPerasRoundLength :: Word64}
   deriving Show via Quiet PerasRoundLength
   deriving stock Generic
-  deriving newtype (Enum, Eq, Ord, NoThunks)
+  deriving newtype (Enum, Eq, Ord, NoThunks, Condense, FromCBOR, ToCBOR)
 
 -- | Weight assigned to a block when boosted by a Peras certificate.
 newtype PerasWeight
   = PerasWeight {unPerasWeight :: Word64}
   deriving Show via Quiet PerasWeight
   deriving stock Generic
-  deriving newtype (Enum, Eq, Ord, NoThunks, Condense)
+  deriving newtype (Enum, Eq, Ord, NoThunks, Condense, FromCBOR, ToCBOR)
 
 deriving via Sum Word64 instance Semigroup PerasWeight
 deriving via Sum Word64 instance Monoid PerasWeight
 
--- | Total stake needed to forge a Peras certificate.
-newtype PerasQuorumStakeThreshold
-  = PerasQuorumStakeThreshold {unPerasQuorumStakeThreshold :: Rational}
-  deriving Show via Quiet PerasQuorumStakeThreshold
+-- | Total vote weight needed to forge a Peras certificate.
+newtype PerasQuorumWeightThreshold
+  = PerasQuorumWeightThreshold {unPerasQuorumWeightThreshold :: Rational}
+  deriving Show via Quiet PerasQuorumWeightThreshold
   deriving stock Generic
-  deriving newtype (Eq, Ord, NoThunks, Condense)
+  deriving newtype (Eq, Ord, NoThunks, Condense, FromCBOR, ToCBOR)
 
 -- | Safety margin needed on top of the quorum vote weight threshold.
 --
 -- NOTE: this is needed to account for an extremely unlikely local sortition
 -- where not enough honest non-persistent parties decide to vote in a round.
 -- This mostly depend on the expected size of the voting committee.
-newtype PerasQuorumStakeThresholdSafetyMargin
-  = PerasQuorumStakeThresholdSafetyMargin {unPerasQuorumStakeThresholdSafetyMargin :: Rational}
-  deriving Show via Quiet PerasQuorumStakeThresholdSafetyMargin
+newtype PerasQuorumWeightThresholdSafetyMargin
+  = PerasQuorumWeightThresholdSafetyMargin {unPerasQuorumWeightThresholdSafetyMargin :: Rational}
+  deriving Show via Quiet PerasQuorumWeightThresholdSafetyMargin
   deriving stock Generic
-  deriving newtype (Eq, Ord, NoThunks, Condense)
+  deriving newtype (Eq, Ord, NoThunks, Condense, FromCBOR, ToCBOR)
 
 -- * Protocol parameters bundle
 
@@ -132,24 +146,55 @@ newtype PerasQuorumStakeThresholdSafetyMargin
 -- https://tweag.github.io/cardano-peras/peras-design.pdf#section.2.1
 --
 -- TODO: make fields strict when we have concrete default values for them.
-data PerasParams = PerasParams
+data PerasParams blk = PerasParams
   { perasIgnoranceRounds :: !PerasIgnoranceRounds
   , perasCooldownRounds :: !PerasCooldownRounds
   , perasBlockMinSlots :: !PerasBlockMinSlots
   , perasCertMaxRounds :: !PerasCertMaxRounds
   , perasCertArrivalThreshold :: !PerasCertArrivalThreshold
-  , perasRoundLength :: !PerasRoundLength
   , perasWeight :: !PerasWeight
-  , perasQuorumStakeThreshold :: !PerasQuorumStakeThreshold
-  , perasQuorumStakeThresholdSafetyMargin :: !PerasQuorumStakeThresholdSafetyMargin
+  , perasQuorumWeightThreshold :: !PerasQuorumWeightThreshold
+  , perasQuorumWeightThresholdSafetyMargin :: !PerasQuorumWeightThresholdSafetyMargin
+  , perasTargetCommitteeSize :: !Committee.TargetCommitteeSize
   }
   deriving (Show, Eq, Generic, NoThunks)
+
+instance Typeable blk => FromCBOR (PerasParams blk) where
+  fromCBOR = do
+    decodeListLenOf 9
+    PerasParams
+      <$> fromCBOR
+      <*> fromCBOR
+      <*> fromCBOR
+      <*> fromCBOR
+      <*> fromCBOR
+      <*> fromCBOR
+      <*> fromCBOR
+      <*> fromCBOR
+      <*> fromCBOR
+
+instance Typeable blk => ToCBOR (PerasParams blk) where
+  toCBOR params =
+    encodeListLen 9
+      <> toCBOR (perasIgnoranceRounds params)
+      <> toCBOR (perasCooldownRounds params)
+      <> toCBOR (perasBlockMinSlots params)
+      <> toCBOR (perasCertMaxRounds params)
+      <> toCBOR (perasCertArrivalThreshold params)
+      <> toCBOR (perasWeight params)
+      <> toCBOR (perasQuorumWeightThreshold params)
+      <> toCBOR (perasQuorumWeightThresholdSafetyMargin params)
+      <> toCBOR (perasTargetCommitteeSize params)
+
+-- | Retag a 'PerasParams' with a new phantom @blk@ type.
+castPerasParams :: forall blk' blk. PerasParams blk -> PerasParams blk'
+castPerasParams = coerce
 
 -- | Instantiate default Peras protocol parameters.
 --
 -- NOTE: in the future this will depend on a concrete 'BlockConfig'.
-mkPerasParams :: PerasParams
-mkPerasParams =
+defaultPerasParams :: PerasParams blk
+defaultPerasParams =
   -- Many of these parameters are provided with sensible default values for now,
   -- waiting for a final decision (in a future stage of the project) on the
   -- exact values to use. See https://github.com/tweag/cardano-peras/issues/97.
@@ -180,15 +225,21 @@ mkPerasParams =
         PerasCertMaxRounds 487
     , perasCertArrivalThreshold =
         PerasCertArrivalThreshold 30
-    , perasRoundLength =
-        PerasRoundLength 90
     , perasWeight =
         PerasWeight 15
-    , perasQuorumStakeThreshold =
-        PerasQuorumStakeThreshold (3 / 4)
-    , perasQuorumStakeThresholdSafetyMargin =
-        PerasQuorumStakeThresholdSafetyMargin (2 / 100)
+    , perasQuorumWeightThreshold =
+        PerasQuorumWeightThreshold (3 / 4)
+    , perasQuorumWeightThresholdSafetyMargin =
+        PerasQuorumWeightThresholdSafetyMargin (2 / 100)
+    , perasTargetCommitteeSize =
+        Committee.TargetCommitteeSize 800
     }
+
+-- * Era-dependent default values
+
+-- | Default value for 'PerasRoundLength' in the Dijkstra eras.
+dijkstraPerasRoundLength :: PerasEnabled PerasRoundLength
+dijkstraPerasRoundLength = PerasEnabled (PerasRoundLength 90)
 
 -- * 'PerasEnabled' wrapper
 

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Peras/Voting/Rules.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Peras/Voting/Rules.hs
@@ -77,7 +77,7 @@ instance Explainable PerasVotingRulesDecision where
 -- | Evaluate whether voting is allowed or not according to the voting rules
 isPerasVotingAllowed ::
   HasPerasCertRound cert =>
-  PerasVotingView cert ->
+  PerasVotingView cert blk ->
   PerasVotingRulesDecision
 isPerasVotingAllowed pvv =
   evalPred (perasVotingRules pvv) $ \e ->
@@ -128,7 +128,7 @@ instance Explainable PerasVotingRule where
 -- certificate was received in the first X slots after the start of the round.
 perasVR1A ::
   HasPerasCertRound cert =>
-  PerasVotingView cert ->
+  PerasVotingView cert blk ->
   Pred PerasVotingRule
 perasVR1A
   PerasVotingView
@@ -166,7 +166,7 @@ perasVR1A
 
 -- | VR-1B: the block being voted upon extends the most recently certified one.
 perasVR1B ::
-  PerasVotingView cert ->
+  PerasVotingView cert blk ->
   Pred PerasVotingRule
 perasVR1B
   PerasVotingView
@@ -191,7 +191,7 @@ perasVR1B
 -- cooldown period.
 perasVR2A ::
   HasPerasCertRound cert =>
-  PerasVotingView cert ->
+  PerasVotingView cert blk ->
   Pred PerasVotingRule
 perasVR2A
   PerasVotingView
@@ -224,7 +224,7 @@ perasVR2A
 -- period.
 perasVR2B ::
   HasPerasCertRound cert =>
-  PerasVotingView cert ->
+  PerasVotingView cert blk ->
   Pred PerasVotingRule
 perasVR2B
   PerasVotingView
@@ -268,7 +268,7 @@ perasVR2B
 -- the voting has regularly occurred in preceding rounds.
 perasVR1 ::
   HasPerasCertRound cert =>
-  PerasVotingView cert ->
+  PerasVotingView cert blk ->
   Pred PerasVotingRule
 perasVR1 pvv =
   perasVR1A pvv :/\: perasVR1B pvv
@@ -277,7 +277,7 @@ perasVR1 pvv =
 -- the chain is about to exit a cooldown period.
 perasVR2 ::
   HasPerasCertRound cert =>
-  PerasVotingView cert ->
+  PerasVotingView cert blk ->
   Pred PerasVotingRule
 perasVR2 pvv =
   perasVR2A pvv :/\: perasVR2B pvv
@@ -285,7 +285,7 @@ perasVR2 pvv =
 -- | Voting is allowed if either VR-1A and VR-1B hold, or VR-2A and VR-2B hold.
 perasVotingRules ::
   HasPerasCertRound cert =>
-  PerasVotingView cert ->
+  PerasVotingView cert blk ->
   Pred PerasVotingRule
 perasVotingRules pvv =
   perasVR1 pvv :\/: perasVR2 pvv

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Peras/Voting/View.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Peras/Voting/View.hs
@@ -189,8 +189,8 @@ newtype LatestCertOnChainView cert
 -- block or its point, but only whether the candidate block extends the block
 -- boosted by the most recent certificate seen by the voter, which is provided
 -- to the rules via 'lcsCandidateBlockExtendsCert' inside 'latestCertSeen'.
-data PerasVotingView cert = PerasVotingView
-  { perasParams :: !PerasParams
+data PerasVotingView cert blk = PerasVotingView
+  { perasParams :: !(PerasParams blk)
   -- ^ Peras protocol parameters
   , currRoundNo :: !PerasRoundNo
   -- ^ The current Peras round number
@@ -225,7 +225,7 @@ mkPerasVotingView ::
   , GetHeader blk
   ) =>
   -- | Peras protocol parameters
-  PerasParams ->
+  PerasParams blk ->
   -- | Current Peras round number
   PerasRoundNo ->
   -- | Most recent certificate seen by the voter
@@ -236,7 +236,7 @@ mkPerasVotingView ::
   -- preferred chain
   AnchoredFragment (Header blk) ->
   -- | Constructed voting view
-  PerasQry xs (PerasVotingView cert)
+  PerasQry xs (PerasVotingView cert blk)
 mkPerasVotingView
   perasParams
   currRoundNo

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Args.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Args.hs
@@ -228,7 +228,7 @@ completeChainDbArgs
       , cdbPerasVoteDbArgs =
           PerasVoteDB.PerasVoteDbArgs
             { PerasVoteDB.pvdbaTracer = PerasVoteDB.pvdbaTracer (cdbPerasVoteDbArgs defArgs)
-            , PerasVoteDB.pvdbaPerasCfg = mkPerasParams
+            , PerasVoteDB.pvdbaPerasCfg = defaultPerasParams
             }
       , cdbsArgs =
           (cdbsArgs defArgs)

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Storage/TestBlock.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Storage/TestBlock.hs
@@ -782,7 +782,7 @@ mkTestConfig k ChunkSize{chunkCanContainEBB, numRegularBlocks} =
       , eraSlotLength = slotLength
       , eraSafeZone = HardFork.StandardSafeZone (unNonZero (maxRollbacks k) * 2)
       , eraGenesisWin = GenesisWindow (unNonZero (maxRollbacks k) * 2)
-      , eraPerasRoundLength = HardFork.PerasEnabled (perasRoundLength mkPerasParams)
+      , eraPerasRoundLength = dijkstraPerasRoundLength
       }
 
 instance ImmutableEraParams TestBlock where

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/ChainDB.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/ChainDB.hs
@@ -21,7 +21,7 @@ import Ouroboros.Consensus.HardFork.History.EraParams (eraEpochSize)
 import Ouroboros.Consensus.Ledger.Abstract
 import Ouroboros.Consensus.Ledger.Extended (ExtLedgerState)
 import Ouroboros.Consensus.Ledger.SupportsProtocol
-import Ouroboros.Consensus.Peras.Params (mkPerasParams)
+import Ouroboros.Consensus.Peras.Params (defaultPerasParams)
 import Ouroboros.Consensus.Storage.ChainDB hiding
   ( TraceFollowerEvent (..)
   )
@@ -140,7 +140,7 @@ fromMinimalChainDbArgs MinimalChainDbArgs{..} =
     , cdbPerasVoteDbArgs =
         PerasVoteDbArgs
           { pvdbaTracer = nullTracer
-          , pvdbaPerasCfg = mkPerasParams
+          , pvdbaPerasCfg = defaultPerasParams
           }
     , cdbsArgs =
         ChainDbSpecificArgs

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/MiniProtocol/ObjectDiffusion/PerasCert/Smoke.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/MiniProtocol/ObjectDiffusion/PerasCert/Smoke.hs
@@ -76,7 +76,7 @@ genValidatedPerasCert :: Gen (ValidatedPerasCert TestBlock)
 genValidatedPerasCert =
   ValidatedPerasCert
     <$> genPerasCert
-    <*> pure (perasWeight mkPerasParams)
+    <*> pure (perasWeight defaultPerasParams)
 
 newCertDB ::
   (IOLike m, StandardHash blk) => [WithArrivalTime (ValidatedPerasCert blk)] -> m (PerasCertDB m blk)

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/MiniProtocol/ObjectDiffusion/PerasVote/Smoke.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/MiniProtocol/ObjectDiffusion/PerasVote/Smoke.hs
@@ -101,7 +101,7 @@ newVoteDB ::
   (IOLike m, StandardHash blk, Typeable blk) =>
   [WithArrivalTime (ValidatedPerasVote blk)] -> m (PerasVoteDB m blk)
 newVoteDB votes = do
-  db <- PerasVoteDB.createDB (PerasVoteDB.PerasVoteDbArgs nullTracer mkPerasParams)
+  db <- PerasVoteDB.createDB (PerasVoteDB.PerasVoteDbArgs nullTracer defaultPerasParams)
   mapM_
     ( \vote -> do
         result <- join $ atomically $ PerasVoteDB.addVote db vote

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/Peras/Cert/Inclusion.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/Peras/Cert/Inclusion.hs
@@ -33,7 +33,7 @@ import Ouroboros.Consensus.Peras.Cert.Inclusion
 import Ouroboros.Consensus.Peras.Params
   ( PerasCertMaxRounds (..)
   , PerasParams (..)
-  , mkPerasParams
+  , defaultPerasParams
   )
 import Ouroboros.Consensus.Util.Pred (Evidence (..))
 import Test.Tasty (TestTree, testGroup)
@@ -203,11 +203,11 @@ certInclusionDecisionTag = \case
 --  - 25% chance of being 2
 --  - 12.5% chance of being 3
 --  ... and so on
-genPerasParams :: Gen PerasParams
+genPerasParams :: Gen (PerasParams blk)
 genPerasParams = do
   _A <- fromIntegral . (+ 1) <$> geometric 0.5
   pure
-    mkPerasParams
+    defaultPerasParams
       { perasCertMaxRounds = PerasCertMaxRounds _A
       }
 

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/Peras/Voting/Rules.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/Peras/Voting/Rules.hs
@@ -32,7 +32,7 @@ import Ouroboros.Consensus.Peras.Params
   , PerasCooldownRounds (..)
   , PerasIgnoranceRounds (..)
   , PerasParams (..)
-  , mkPerasParams
+  , defaultPerasParams
   )
 import Ouroboros.Consensus.Peras.Voting.Rules
   ( PerasVotingRulesDecision (..)
@@ -59,6 +59,7 @@ import Test.Tasty.QuickCheck
   )
 import Test.Util.Orphans.Arbitrary (genNominalDiffTime50Years)
 import Test.Util.QuickCheck (geometric)
+import Test.Util.TestBlock (TestBlock)
 import Test.Util.TestEnv (adjustQuickCheckTests)
 
 {-------------------------------------------------------------------------------
@@ -93,7 +94,7 @@ data PerasVotingRulesDecisionModel
 --
 -- NOTE: this predicate could be lifted directly from the agda specification.
 isPerasVotingAllowedModel ::
-  PerasVotingView TestCert ->
+  PerasVotingView TestCert TestBlock ->
   PerasVotingRulesDecisionModel
 isPerasVotingAllowedModel
   PerasVotingView
@@ -216,14 +217,14 @@ prop_isPerasVotingAllowed = forAll genPerasVotingView $ \pvv -> do
 --  - 25% chance of being 2
 --  - 12.5% chance of being 3
 --  ... and so on
-genPerasParams :: Gen PerasParams
+genPerasParams :: Gen (PerasParams blk)
 genPerasParams = do
   _L <- fromIntegral . (+ 1) <$> geometric 0.5
   _X <- fromIntegral . (+ 1) <$> geometric 0.5
   _R <- fromIntegral . (+ 1) <$> geometric 0.5
   _K <- fromIntegral . (+ 1) <$> geometric 0.5
   pure
-    mkPerasParams
+    defaultPerasParams
       { perasBlockMinSlots = PerasBlockMinSlots _L
       , perasCertArrivalThreshold = PerasCertArrivalThreshold _X
       , perasIgnoranceRounds = PerasIgnoranceRounds _R
@@ -302,7 +303,7 @@ genLatestCertOnChain roundNo = do
       { lcocCert = cert
       }
 
-genPerasVotingView :: Gen (PerasVotingView TestCert)
+genPerasVotingView :: Gen (PerasVotingView TestCert TestBlock)
 genPerasVotingView = do
   perasParams <- genPerasParams
   currRoundNo <- genPerasRoundNo

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/Model.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/Model.hs
@@ -417,7 +417,7 @@ empty loe initLedger =
     { volatileDbBlocks = Map.empty
     , immutableDbChain = Chain.Genesis
     , perasCertModel = PerasCertDBModel.openDB PerasCertDBModel.initModel
-    , perasVoteModel = PerasVoteDBModel.openDB (PerasVoteDBModel.initModel mkPerasParams)
+    , perasVoteModel = PerasVoteDBModel.openDB (PerasVoteDBModel.initModel defaultPerasParams)
     , cps = CPS.initChainProducerState Chain.Genesis
     , currentLedger = initLedger
     , initLedger = initLedger
@@ -1186,7 +1186,7 @@ wipeVolatileDB cfg m =
     (closeDB m)
       { volatileDbBlocks = Map.empty
       , perasCertModel = PerasCertDBModel.openDB PerasCertDBModel.initModel
-      , perasVoteModel = PerasVoteDBModel.openDB (PerasVoteDBModel.initModel mkPerasParams)
+      , perasVoteModel = PerasVoteDBModel.openDB (PerasVoteDBModel.initModel defaultPerasParams)
       , cps = CPS.switchFork newChain (cps m)
       , currentLedger = newLedger
       , invalid = Map.empty

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
@@ -1316,8 +1316,8 @@ generator loe genBlock genPerasBlock m@Model{..} =
 
         voteParams = PerasVoteDBModel.params voteModel
         quorum =
-          unPerasQuorumStakeThreshold (perasQuorumStakeThreshold voteParams)
-            + unPerasQuorumStakeThresholdSafetyMargin (perasQuorumStakeThresholdSafetyMargin voteParams)
+          unPerasQuorumWeightThreshold (perasQuorumWeightThreshold voteParams)
+            + unPerasQuorumWeightThresholdSafetyMargin (perasQuorumWeightThresholdSafetyMargin voteParams)
         -- Maximum total vote stake per round: 2 * quorum - epsilon.
         -- Below this threshold it is impossible for two different blocks to
         -- both reach quorum in the same round.

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/PerasCertDB/StateMachine.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/PerasCertDB/StateMachine.hs
@@ -52,7 +52,7 @@ tests =
     ]
 
 perasTestCfg :: PerasCfg TestBlock
-perasTestCfg = mkPerasParams
+perasTestCfg = defaultPerasParams
 
 prop_qd :: Actions Model -> Property
 prop_qd actions = QC.monadic f $ property () <$ runActions actions

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/PerasVoteDB/Model.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/PerasVoteDB/Model.hs
@@ -66,7 +66,7 @@ data PerasVoteDbModelError = MultipleWinnersInRound PerasRoundNo
 data Model blk = Model
   { open :: Bool
   -- ^ Is the database open?
-  , params :: PerasParams
+  , params :: PerasParams blk
   -- ^ Configuration parameters
   , lastTicketNo :: PerasVoteTicketNo
   -- ^ The last issued ticket number

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/PerasVoteDB/StateMachine.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/PerasVoteDB/StateMachine.hs
@@ -52,7 +52,7 @@ import Ouroboros.Consensus.Block.SupportsPeras
   , PerasVoterId (..)
   , ValidatedPerasCert
   , ValidatedPerasVote (..)
-  , mkPerasParams
+  , defaultPerasParams
   )
 import Ouroboros.Consensus.BlockchainTime.WallClock.Types
   ( RelativeTime (..)
@@ -105,7 +105,7 @@ tests =
     ]
 
 perasTestCfg :: PerasCfg TestBlock
-perasTestCfg = mkPerasParams
+perasTestCfg = defaultPerasParams
 
 prop_qd :: Actions Model -> Property
 prop_qd actions = monadic runActualImplemMonad resultAsPropertyM


### PR DESCRIPTION
This commit tweak the Peras parameters module by:

* Adding the phantom `blk` type parameter to `PerasParas`. This will be
helpful later to enforce type family injectivity without an extra data
constructor. Note that, this will render the current `PerasCfg`
associated type unnecessary, and will be removed during the final
refactor of the `BlockSupportsPeras` type class.

* Renaming "stake" to "weight" terminology in:
  + `PerasQuorumStakeThreshold` → `PerasQuorumWeightThreshold`, and
  + `PerasQuorumStakeThresholdSafetyMargin` → `PerasQuorumWeightThresholdSafetyMargin`
to better reflect that quorum will be based on (relative) vote weights,
as opposed to (absolute) pool stakes.

* Adding necessary `FromCBOR`/`ToCBOR` instances to all parameters and the
parameter bundle.

* Adding a new `TargetCommitteeSize` parameter (needed by the wFA^LS
  committee selection algorithm).

* Extracting `PerasRoundLength` from the parameter bundle. For technical
reasons involving time/era resolution, this parameter will be
hardcoded (i.e., non-governable) on a per-era based for now.

* Renaming `mkPerasParameters` to `defaultPerasParameters`.

* Propagating all the changes across the codebase.