### PR TITLE
[Peras 40] Introduce LedgerStateSupportsPeras auxiliary type class

### DIFF
--- a/changelog.d/20260727_154815_agustin.mista_ledger_state_supports_peras.md
+++ b/changelog.d/20260727_154815_agustin.mista_ledger_state_supports_peras.md
@@ -1,0 +1,23 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+<!--
+### Breaking
+
+- A bullet item for the Breaking category.
+
+-->
+### Non-Breaking
+
+- Add auxiliary `LedgerStateSupportsPeras` typeclass to extract `PoolDistr` and `PerasParams` from either ticked or unticked ledger states.
+
+<!--
+### Patch
+
+- A bullet item for the Patch category.
+
+-->

--- a/ouroboros-consensus-cardano/src/byron/Ouroboros/Consensus/Byron/Ledger/Ledger.hs
+++ b/ouroboros-consensus-cardano/src/byron/Ouroboros/Consensus/Byron/Ledger/Ledger.hs
@@ -88,6 +88,7 @@ import Ouroboros.Consensus.Ledger.CommonProtocolParams
 import Ouroboros.Consensus.Ledger.Extended
 import Ouroboros.Consensus.Ledger.Query
 import Ouroboros.Consensus.Ledger.SupportsPeerSelection
+import Ouroboros.Consensus.Ledger.SupportsPeras (LedgerStateSupportsPeras)
 import Ouroboros.Consensus.Ledger.SupportsProtocol
 import Ouroboros.Consensus.Ledger.Tables.Utils
 import Ouroboros.Consensus.Util (ShowProxy (..))
@@ -573,3 +574,11 @@ decodeByronResult query = case query of
 
 instance CanUpgradeLedgerTables LedgerState ByronBlock where
   upgradeTables _ _ = id
+
+{-------------------------------------------------------------------------------
+  Peras
+-------------------------------------------------------------------------------}
+
+instance LedgerStateSupportsPeras (LedgerState ByronBlock)
+
+instance LedgerStateSupportsPeras (Ticked LedgerState ByronBlock)

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Block.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Block.hs
@@ -67,8 +67,10 @@ import NoThunks.Class (NoThunks (..))
 import Ouroboros.Consensus.Block
 import Ouroboros.Consensus.HardFork.Combinator
   ( HasPartialConsensusConfig
+  , LedgerState
   )
 import Ouroboros.Consensus.HeaderValidation
+import Ouroboros.Consensus.Ledger.SupportsPeras (LedgerStateSupportsPeras)
 import Ouroboros.Consensus.Protocol.Abstract
 import Ouroboros.Consensus.Protocol.Praos.Common
   ( PraosTiebreakerView
@@ -131,11 +133,13 @@ class
   , -- Backwards compatibility
     Plain.FromCBOR (LegacyPParams era)
   , Plain.ToCBOR (LegacyPParams era)
-  , -- TODO: replace the two constraints below with:
+  , -- TODO: replace the four constraints below with:
     -- 'StateSupportsPerasEpochContext (ShelleyBlock proto er)' once that type
     -- class is in place.
     ChainDepStateSupportsPeras (ChainDepState (BlockProtocol (ShelleyBlock proto era)))
   , ChainDepStateSupportsPeras (Ticked (ChainDepState (BlockProtocol (ShelleyBlock proto era))))
+  , LedgerStateSupportsPeras (LedgerState (ShelleyBlock proto era))
+  , LedgerStateSupportsPeras (Ticked LedgerState (ShelleyBlock proto era))
   ) =>
   ShelleyCompatible proto era
 

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Ledger.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Ledger.hs
@@ -86,6 +86,7 @@ import Cardano.Ledger.Core
 import qualified Cardano.Ledger.Core as Core
 import qualified Cardano.Ledger.Shelley.API as SL
 import qualified Cardano.Ledger.Shelley.Governance as SL
+import Cardano.Ledger.Shelley.LedgerState (NewEpochState (..))
 import qualified Cardano.Ledger.Shelley.LedgerState as SL
 import qualified Cardano.Ledger.State as SL
 import Cardano.Slotting.EpochInfo
@@ -122,7 +123,10 @@ import Ouroboros.Consensus.HeaderValidation
 import Ouroboros.Consensus.Ledger.Abstract
 import Ouroboros.Consensus.Ledger.CommonProtocolParams
 import Ouroboros.Consensus.Ledger.Extended
-import Ouroboros.Consensus.Ledger.SupportsPeras (LedgerSupportsPeras (..))
+import Ouroboros.Consensus.Ledger.SupportsPeras
+  ( LedgerStateSupportsPeras (..)
+  , LedgerSupportsPeras (..)
+  )
 import Ouroboros.Consensus.Ledger.Tables.Utils
 import Ouroboros.Consensus.Protocol.Ledger.Util (isNewEpoch)
 import Ouroboros.Consensus.Shelley.Ledger.Block
@@ -919,3 +923,11 @@ instance LedgerSupportsPeras (ShelleyBlock proto era) where
   getLatestPerasCertRound =
     strictMaybeToMaybe
       . shelleyLedgerLatestPerasCertRound
+
+instance LedgerStateSupportsPeras (LedgerState (ShelleyBlock proto era)) where
+  getPoolDistr =
+    nesPd . shelleyLedgerState
+
+instance LedgerStateSupportsPeras (Ticked LedgerState (ShelleyBlock proto era)) where
+  getPoolDistr =
+    nesPd . tickedShelleyLedgerState

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator/A.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator/A.hs
@@ -80,7 +80,7 @@ import Ouroboros.Consensus.Ledger.Inspect
 import Ouroboros.Consensus.Ledger.Query
 import Ouroboros.Consensus.Ledger.SupportsMempool
 import Ouroboros.Consensus.Ledger.SupportsPeerSelection
-import Ouroboros.Consensus.Ledger.SupportsPeras (LedgerSupportsPeras)
+import Ouroboros.Consensus.Ledger.SupportsPeras (LedgerStateSupportsPeras, LedgerSupportsPeras)
 import Ouroboros.Consensus.Ledger.SupportsProtocol
 import Ouroboros.Consensus.Ledger.Tables.Utils
 import Ouroboros.Consensus.Node.InitStorage
@@ -308,6 +308,10 @@ instance LedgerSupportsProtocol BlockA where
   ledgerViewForecastAt _ = trivialForecast
 
 instance LedgerSupportsPeras BlockA
+
+instance LedgerStateSupportsPeras (LedgerState BlockA)
+
+instance LedgerStateSupportsPeras (Ticked LedgerState BlockA)
 
 instance HasPartialConsensusConfig ProtocolA
 

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator/B.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator/B.hs
@@ -64,7 +64,7 @@ import Ouroboros.Consensus.Ledger.Inspect
 import Ouroboros.Consensus.Ledger.Query
 import Ouroboros.Consensus.Ledger.SupportsMempool
 import Ouroboros.Consensus.Ledger.SupportsPeerSelection
-import Ouroboros.Consensus.Ledger.SupportsPeras (LedgerSupportsPeras)
+import Ouroboros.Consensus.Ledger.SupportsPeras (LedgerStateSupportsPeras, LedgerSupportsPeras)
 import Ouroboros.Consensus.Ledger.SupportsProtocol
 import Ouroboros.Consensus.Ledger.Tables.Utils
 import Ouroboros.Consensus.Node.InitStorage
@@ -264,6 +264,10 @@ instance LedgerSupportsProtocol BlockB where
   ledgerViewForecastAt _ = trivialForecast
 
 instance LedgerSupportsPeras BlockB
+
+instance LedgerStateSupportsPeras (LedgerState BlockB)
+
+instance LedgerStateSupportsPeras (Ticked LedgerState BlockB)
 
 instance HasPartialConsensusConfig ProtocolB
 

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Abstract/SingleEraBlock.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Abstract/SingleEraBlock.hs
@@ -45,7 +45,7 @@ import Ouroboros.Consensus.Ledger.Inspect
 import Ouroboros.Consensus.Ledger.Query
 import Ouroboros.Consensus.Ledger.SupportsMempool
 import Ouroboros.Consensus.Ledger.SupportsPeerSelection
-import Ouroboros.Consensus.Ledger.SupportsPeras (LedgerSupportsPeras)
+import Ouroboros.Consensus.Ledger.SupportsPeras (LedgerStateSupportsPeras, LedgerSupportsPeras)
 import Ouroboros.Consensus.Ledger.SupportsProtocol
 import Ouroboros.Consensus.Node.InitStorage
 import Ouroboros.Consensus.Node.Serialisation
@@ -80,10 +80,12 @@ class
   , BlockSupportsDiffusionPipelining blk
   , BlockSupportsMetrics blk
   , SerialiseNodeToClient blk (PartialLedgerConfig blk)
-  , -- TODO: replace the two constraints below with:
+  , -- TODO: replace the four constraints below with:
     -- 'StateSupportsPerasEpochContext blk' once that type class is in place.
     ChainDepStateSupportsPeras (ChainDepState (BlockProtocol blk))
   , ChainDepStateSupportsPeras (Ticked (ChainDepState (BlockProtocol blk)))
+  , LedgerStateSupportsPeras (LedgerState blk)
+  , LedgerStateSupportsPeras (Ticked LedgerState blk)
   , -- LedgerTables
     CanStowLedgerTables (LedgerState blk)
   , HasLedgerTables LedgerState blk

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Basics.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Basics.hs
@@ -56,7 +56,10 @@ import Ouroboros.Consensus.HardFork.Combinator.State.Instances ()
 import Ouroboros.Consensus.HardFork.Combinator.State.Types
 import qualified Ouroboros.Consensus.HardFork.History as History
 import Ouroboros.Consensus.Ledger.Abstract
-import Ouroboros.Consensus.Ledger.SupportsPeras (LedgerSupportsPeras (..))
+import Ouroboros.Consensus.Ledger.SupportsPeras
+  ( LedgerStateSupportsPeras (..)
+  , LedgerSupportsPeras (..)
+  )
 import Ouroboros.Consensus.Protocol.Abstract
 import Ouroboros.Consensus.TypeFamilyWrappers
 import Ouroboros.Consensus.Util (ShowProxy)
@@ -256,5 +259,12 @@ instance CanHardFork xs => LedgerSupportsPeras (HardForkBlock xs) where
   getLatestPerasCertRound =
     hcollapse
       . hcmap proxySingle (K . getLatestPerasCertRound . unFlip)
+      . State.tip
+      . hardForkLedgerStatePerEra
+
+instance CanHardFork xs => LedgerStateSupportsPeras (LedgerState (HardForkBlock xs)) where
+  getPoolDistr =
+    hcollapse
+      . hcmap proxySingle (K . getPoolDistr . unFlip)
       . State.tip
       . hardForkLedgerStatePerEra

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Ledger.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Ledger.hs
@@ -97,6 +97,7 @@ import qualified Ouroboros.Consensus.HardFork.History as History
 import Ouroboros.Consensus.HeaderValidation
 import Ouroboros.Consensus.Ledger.Abstract
 import Ouroboros.Consensus.Ledger.Inspect
+import Ouroboros.Consensus.Ledger.SupportsPeras (LedgerStateSupportsPeras (..))
 import Ouroboros.Consensus.Ledger.SupportsProtocol
 import Ouroboros.Consensus.Ledger.Tables.Utils
 import Ouroboros.Consensus.TypeFamilyWrappers
@@ -321,6 +322,23 @@ instance All SingleEraBlock xs => HasHardForkHistory (HardForkBlock xs) where
   hardForkSummary cfg =
     State.reconstructSummaryLedger cfg
       . hardForkLedgerStatePerEra
+
+{-------------------------------------------------------------------------------
+  Peras
+-------------------------------------------------------------------------------}
+
+-- | 'LedgerStateSupportsPeras' for the /ticked/ hard fork ledger state,
+-- mirroring the instance for the unticked ledger state in
+-- @Ouroboros.Consensus.HardFork.Combinator.Basics@.
+instance
+  CanHardFork xs =>
+  LedgerStateSupportsPeras (Ticked LedgerState (HardForkBlock xs))
+  where
+  getPoolDistr =
+    hcollapse
+      . hcmap proxySingle (K . getPoolDistr . getFlipTickedLedgerState)
+      . State.tip
+      . tickedHardForkLedgerStatePerEra
 
 {-------------------------------------------------------------------------------
   HeaderValidation

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Dual.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Dual.hs
@@ -90,6 +90,7 @@ import Ouroboros.Consensus.Ledger.Inspect
 import Ouroboros.Consensus.Ledger.Query
 import Ouroboros.Consensus.Ledger.SupportsMempool
 import Ouroboros.Consensus.Ledger.SupportsPeerSelection
+import Ouroboros.Consensus.Ledger.SupportsPeras (LedgerStateSupportsPeras)
 import Ouroboros.Consensus.Ledger.SupportsProtocol
 import Ouroboros.Consensus.Ledger.Tables.Utils
 import Ouroboros.Consensus.Storage.Serialisation
@@ -1197,3 +1198,11 @@ instance
       , dualLedgerStateAux
       , dualLedgerStateBridge
       } = dls
+
+{-------------------------------------------------------------------------------
+  Peras
+-------------------------------------------------------------------------------}
+
+instance LedgerStateSupportsPeras (LedgerState (DualBlock m a))
+
+instance LedgerStateSupportsPeras (Ticked LedgerState (DualBlock m a))

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/SupportsPeras.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/SupportsPeras.hs
@@ -1,14 +1,31 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DefaultSignatures #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications #-}
 
 module Ouroboros.Consensus.Ledger.SupportsPeras
   ( LedgerSupportsPeras (..)
+  , LedgerStateSupportsPeras (..)
   )
 where
 
-import Ouroboros.Consensus.Block.SupportsPeras (PerasRoundNo)
-import Ouroboros.Consensus.Ledger.Abstract (LedgerState)
+import qualified Cardano.Crypto.Hash as Hash
+import Cardano.Ledger.Coin (Coin (..), compactCoinOrError, knownNonZeroCoin)
+import Cardano.Ledger.Keys (KeyHash (..), toVRFVerKeyHash)
+import Cardano.Ledger.State (IndividualPoolStake (..), PoolDistr (..))
+import qualified Data.Map as Map
+import Ouroboros.Consensus.Block.SupportsPeras
+  ( PerasParams
+  , PerasRoundNo
+  , defaultPerasParams
+  )
+import Ouroboros.Consensus.Ledger.Abstract (EmptyMK, LedgerState)
 
--- | Extract Peras information stored in the ledger state
+-- | Extract Peras information stored in the ledger state (deprecated).
+--
+-- IMPORTANT: we are moving the cached latest Peras cert round from the
+-- (non-extended) ledger state into the extended one, so we will remove this
+-- type class during that refactor.
 class LedgerSupportsPeras blk where
   -- | Extract the round number of the latest Peras certificate stored in the
   -- given ledger state (if any). This is needed to coordinate the end of a
@@ -16,3 +33,48 @@ class LedgerSupportsPeras blk where
   getLatestPerasCertRound :: LedgerState blk mk -> Maybe PerasRoundNo
   default getLatestPerasCertRound :: LedgerState blk mk -> Maybe PerasRoundNo
   getLatestPerasCertRound _ = Nothing
+
+-- | Extract Peras information stored in the ledger state.
+class LedgerStateSupportsPeras ledgerState where
+  -- | Extract the stake distribution from the given ledger state.
+  --
+  -- PRECONDITION: this function will only return a meaningful result if the
+  -- ledger state is from a block that supports Peras.
+  getPoolDistr :: ledgerState EmptyMK -> PoolDistr
+  default getPoolDistr :: ledgerState EmptyMK -> PoolDistr
+  getPoolDistr _ = dummyPoolDistr
+
+  -- | Extract the Peras parameters from the given ledger state.
+  --
+  -- TODO: when Peras params go on chain, update this.
+  getPerasParams :: proxy blk -> ledgerState EmptyMK -> PerasParams blk
+  default getPerasParams :: proxy blk -> ledgerState EmptyMK -> PerasParams blk
+  getPerasParams _ _ = defaultPerasParams
+
+-- NOTE: this is a bit of a hack for blocks that do not really support Peras.
+-- We return a single dummy stake pool holding all of the active stake, so that
+-- consumers relying on a non-empty stake distribution (e.g. the mock voting
+-- committee) do not fail.
+dummyPoolDistr :: PoolDistr
+dummyPoolDistr =
+  PoolDistr
+    { unPoolDistr = Map.singleton dummyPoolId dummyPoolStake
+    , pdTotalActiveStake = knownNonZeroCoin @1
+    }
+ where
+  dummyPoolId =
+    KeyHash
+      . Hash.castHash
+      . Hash.hashWith id
+      $ "peras-mock-pool"
+  dummyPoolVrf =
+    toVRFVerKeyHash
+      . Hash.castHash
+      . Hash.hashWith id
+      $ "peras-mock-pool-vrf"
+  dummyPoolStake =
+    IndividualPoolStake
+      { individualPoolStake = 1
+      , individualTotalPoolStake = compactCoinOrError (Coin 1)
+      , individualPoolStakeVrf = dummyPoolVrf
+      }

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Storage/TestBlock.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Storage/TestBlock.hs
@@ -108,7 +108,10 @@ import Ouroboros.Consensus.HeaderValidation
 import Ouroboros.Consensus.Ledger.Abstract
 import Ouroboros.Consensus.Ledger.Extended
 import Ouroboros.Consensus.Ledger.Inspect
-import Ouroboros.Consensus.Ledger.SupportsPeras (LedgerSupportsPeras (..))
+import Ouroboros.Consensus.Ledger.SupportsPeras
+  ( LedgerStateSupportsPeras (..)
+  , LedgerSupportsPeras (..)
+  )
 import Ouroboros.Consensus.Ledger.SupportsProtocol
 import Ouroboros.Consensus.Ledger.Tables.Utils
 import Ouroboros.Consensus.Node.ProtocolInfo
@@ -724,6 +727,10 @@ instance LedgerSupportsProtocol TestBlock where
 
 instance LedgerSupportsPeras TestBlock where
   getLatestPerasCertRound = latestPerasCertRound
+
+instance LedgerStateSupportsPeras (LedgerState TestBlock)
+
+instance LedgerStateSupportsPeras (Ticked LedgerState TestBlock)
 
 instance HasHardForkHistory TestBlock where
   type HardForkIndices TestBlock = '[TestBlock]

--- a/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Ledger/Block.hs
+++ b/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Ledger/Block.hs
@@ -101,7 +101,10 @@ import Ouroboros.Consensus.Ledger.Inspect
 import Ouroboros.Consensus.Ledger.Query
 import Ouroboros.Consensus.Ledger.SupportsMempool
 import Ouroboros.Consensus.Ledger.SupportsPeerSelection
-import Ouroboros.Consensus.Ledger.SupportsPeras (LedgerSupportsPeras)
+import Ouroboros.Consensus.Ledger.SupportsPeras
+  ( LedgerStateSupportsPeras
+  , LedgerSupportsPeras
+  )
 import Ouroboros.Consensus.Ledger.Tables.Utils
 import Ouroboros.Consensus.Mock.Ledger.Address
 import Ouroboros.Consensus.Mock.Ledger.State
@@ -525,6 +528,10 @@ instance LedgerSupportsPeerSelection (SimpleBlock c ext) where
   getPeers = const []
 
 instance LedgerSupportsPeras (SimpleBlock c ext)
+
+instance LedgerStateSupportsPeras (LedgerState (SimpleBlock c ext))
+
+instance LedgerStateSupportsPeras (Ticked LedgerState (SimpleBlock c ext))
 
 {-------------------------------------------------------------------------------
   LedgerTables


### PR DESCRIPTION
This commit introduces an auxiliary `LedgerStateSupportsPeras` type class to aid with extracting the stake distribution and Peras parameters from either a ticked or unticked `LedgerState` in a consistent manner across the codebase.

NOTE: until the Peras parameters can be defined via on-chain governance, the default `getPerasParams` implementation returns `defaultPerasParams`.

NOTE: the existing `LedgerSupportsPeras` class is flagged for removal, as the cached latest Peras cert round is being moved from the (non-extended) ledger state into the extended one.