### PR TITLE
[Peras 41] Tweak PerasCertDB to return status of latest certificate seen

### DIFF
--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Peras/Voting/View.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Peras/Voting/View.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE TypeOperators #-}
@@ -60,6 +59,10 @@ import qualified Ouroboros.Consensus.HardFork.History.Summary as HF
 import Ouroboros.Consensus.Peras.Params
   ( PerasBlockMinSlots (..)
   , PerasParams (..)
+  )
+import Ouroboros.Consensus.Storage.PerasCertDB.API
+  ( WithBoostedBlockStatus (..)
+  , forgetBoostedBlockStatus
   )
 import Ouroboros.Network.AnchoredFragment (AnchoredFragment)
 import qualified Ouroboros.Network.AnchoredFragment as AF
@@ -201,21 +204,6 @@ data PerasVotingView cert blk = PerasVotingView
   }
   deriving Show
 
--- | Indicate the status of a block boosted by a certificate w.r.t. the
--- chain's immutable prefix and volatile suffix.
-data WithBoostedBlockStatus cert
-  = -- | Certificate boosting a block within the immutable prefix
-    CertWithImmutableBlock cert
-  | -- | Certificate boosting a block within the volatile suffix
-    CertWithVolatileBlock cert
-  deriving Show
-
--- | Deconstruct a certificate from its provenance wrapper
-forgetBoostedBlockStatus :: WithBoostedBlockStatus cert -> cert
-forgetBoostedBlockStatus = \case
-  CertWithVolatileBlock cert -> cert
-  CertWithImmutableBlock cert -> cert
-
 -- | Construct a 'PerasVotingView'.
 --
 -- NOTE: this assumes that the client code computes all the needed inputs
@@ -282,14 +270,16 @@ mkPerasVotingView
     --
     -- NOTE: the case of an extremely old certificate boosting a block beyond
     -- the volatile suffix is covered by also providing the status of the
-    -- boosted block w.r.t. the chain's immutable prefix and volatile suffix.
-    candidateBlockExtendsCert (CertWithImmutableBlock _) =
-      -- This case is vacuously true: an immutable block is always part of
-      -- any volatile suffix, so the candidate block trivially extends it.
+    -- boosted block w.r.t. the volatile suffix.
+    candidateBlockExtendsCert (CertBoostingBlockNoLongerInVolatileDB _) =
+      -- This case is vacuously true: the boosted block is from a slot that has
+      -- already been garbage collected from the volatile suffix, which implies
+      -- that it extends any volatile suffix.
       True
-    candidateBlockExtendsCert (CertWithVolatileBlock cert) =
-      -- Check whether the boosted block is within the volatile fragment leading
-      -- to the candidate block.
+    candidateBlockExtendsCert (CertBoostingBlockInVolatileDB cert) =
+      -- The block boosted by the latest certificate seen is still in the
+      -- VolatileDB, so we can check whether it is within the bounds of the
+      -- anchored fragment leading to the candidate block.
       AF.withinFragmentBounds
         (castPoint (getPerasCertBoostedBlock cert))
         chainAtCandidateBlock

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/API.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/API.hs
@@ -106,6 +106,7 @@ import Ouroboros.Consensus.Storage.LedgerDB
 import Ouroboros.Consensus.Storage.PerasCertDB.API
   ( AddPerasCertResult (..)
   , PerasCertTicketNo
+  , WithBoostedBlockStatus
   )
 import Ouroboros.Consensus.Storage.PerasVoteDB.API
   ( AddPerasVoteResult (..)
@@ -430,7 +431,8 @@ data ChainDB m blk = ChainDB
   , getPerasWeightSnapshot :: STM m (WithFingerprint (PerasWeightSnapshot blk))
   -- ^ Get the 'PerasWeightSnapshot', representing the Peras weight boosts for
   -- all blocks newer than the current immutable tip.
-  , getLatestPerasCertSeen :: STM m (Maybe (WithArrivalTime (ValidatedPerasCert blk)))
+  , getLatestPerasCertSeen ::
+      STM m (Maybe (WithBoostedBlockStatus (WithArrivalTime (ValidatedPerasCert blk))))
   -- ^ Get the latest Peras certificate that has been seen by this node.
   , getLatestPerasCertOnChainRound :: STM m (Maybe PerasRoundNo)
   -- ^ Get the round number of the latest Peras certificate on the currently

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Query.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Query.hs
@@ -78,6 +78,7 @@ import qualified Ouroboros.Consensus.Storage.LedgerDB as LedgerDB
 import qualified Ouroboros.Consensus.Storage.PerasCertDB as PerasCertDB
 import Ouroboros.Consensus.Storage.PerasCertDB.API
   ( PerasCertTicketNo
+  , WithBoostedBlockStatus
   )
 import Ouroboros.Consensus.Storage.PerasVoteDB.API
   ( PerasVoteTicketNo
@@ -346,7 +347,8 @@ getPerasWeightSnapshot ::
 getPerasWeightSnapshot CDB{..} = PerasCertDB.getWeightSnapshot cdbPerasCertDB
 
 getLatestPerasCertSeen ::
-  ChainDbEnv m blk -> STM m (Maybe (WithArrivalTime (ValidatedPerasCert blk)))
+  ChainDbEnv m blk ->
+  STM m (Maybe (WithBoostedBlockStatus (WithArrivalTime (ValidatedPerasCert blk))))
 getLatestPerasCertSeen CDB{..} = PerasCertDB.getLatestCertSeen cdbPerasCertDB
 
 getPerasCertsAfter ::

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/PerasCertDB/API.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/PerasCertDB/API.hs
@@ -3,9 +3,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase #-}
 
 module Ouroboros.Consensus.Storage.PerasCertDB.API
   ( PerasCertDB (..)
+  , WithBoostedBlockStatus (..)
+  , forgetBoostedBlockStatus
   , AddPerasCertResult (..)
   , PerasCertTicketNo
   , zeroPerasCertTicketNo
@@ -66,7 +69,7 @@ data PerasCertDB m blk = PerasCertDB
   -- The 'Fingerprint' is updated every time a new certificate is added, but it
   -- stays the same when certificates are garbage-collected.
   , getLatestCertSeen ::
-      STM m (Maybe (WithArrivalTime (ValidatedPerasCert blk)))
+      STM m (Maybe (WithBoostedBlockStatus (WithArrivalTime (ValidatedPerasCert blk))))
   -- ^ This field impacts voting directly because having seen a certificate is a
   -- precondition for voting in any round except for the very first one
   -- (at origin).
@@ -82,6 +85,34 @@ data PerasCertDB m blk = PerasCertDB
   -- NOTE: Use the `join . atomically` pattern to consume its output.
   }
   deriving NoThunks via OnlyCheckWhnfNamed "PerasCertDB" (PerasCertDB m blk)
+
+-- | Indicate whether the block being boosted by a certificate is expected to
+-- still be part of the volatile chain suffix or not.
+--
+-- This is relevant for Peras voting because we need to know if a candidate
+-- block extends the chain that contains the block being boosted by the latest
+-- certificate seen. For this purpose, we want to limit the voting rules to only
+-- look within the volatile chain suffix, and assume that, if the boosted block
+-- is no longer in the volatile suffix, then it trivially extends the candidate
+-- block (because it must have been copied into the immutable chain prefix). For
+-- this reason, we need to manually keep track of whether the boosted block of
+-- this certificate has already been garbage collected from the volatile suffix
+-- or not.
+data WithBoostedBlockStatus cert
+  = -- | Certificate boosting a block within the volatile chain suffix
+    CertBoostingBlockInVolatileDB cert
+  | -- | Certificate boosting a block that no longer belongs to the volatile
+    -- chain suffix. This typically means that the block has been copied to the
+    -- immutable prefix, and then garbage collected from the volatile suffix.
+    CertBoostingBlockNoLongerInVolatileDB cert
+  deriving stock (Show, Eq, Generic)
+  deriving anyclass NoThunks
+
+-- | Deconstruct a certificate from its provenance wrapper
+forgetBoostedBlockStatus :: WithBoostedBlockStatus cert -> cert
+forgetBoostedBlockStatus = \case
+  CertBoostingBlockInVolatileDB cert -> cert
+  CertBoostingBlockNoLongerInVolatileDB cert -> cert
 
 -- | A sequence number, incremented every time we receive a new certificate.
 --
@@ -169,7 +200,7 @@ prop_garbageCollectRemovesOldCerts db slotNo = do
     _ <- garbageCollect db slotNo
     getCertsAfter db zeroPerasCertTicketNo
   allCertValues <- sequence (Map.elems allCertActions)
-  let targetSlots = pointSlot . getPerasCertBoostedBlock . forgetArrivalTime <$> allCertValues
+  let targetSlots = pointSlot . getPerasCertBoostedBlock <$> allCertValues
   pure $
     all (>= NotOrigin slotNo) targetSlots
 
@@ -185,7 +216,7 @@ prop_addCertLatestCertSeenMonotonic db cert =
     prevLatest <- getLatestCertSeen db
     _ <- addCert db cert
     newLatest <- getLatestCertSeen db
-    let getRound = getPerasCertRound . forgetArrivalTime
+    let getRound = getPerasCertRound . forgetBoostedBlockStatus
     pure $ case (prevLatest, newLatest) of
       (_, Nothing) -> False -- after adding a cert, the latest cert seen should not go back to 'Nothing'
       (Nothing, Just _) -> True -- if there was no cert seen before, any new cert should be greater than or equal to it
@@ -193,7 +224,7 @@ prop_addCertLatestCertSeenMonotonic db cert =
 
 -- | 'getLatestCertSeen' is not affected by garbage collection.
 prop_garbageCollectPreservesLatestCertSeen ::
-  (MonadSTM m, StandardHash blk) =>
+  MonadSTM m =>
   PerasCertDB m blk ->
   SlotNo ->
   m Bool
@@ -202,4 +233,5 @@ prop_garbageCollectPreservesLatestCertSeen db slotNo =
     prevLatest <- getLatestCertSeen db
     _ <- garbageCollect db slotNo
     newLatest <- getLatestCertSeen db
-    pure $ prevLatest == newLatest
+    let getRound = getPerasCertRound . forgetBoostedBlockStatus
+    pure $ fmap getRound prevLatest == fmap getRound newLatest

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/PerasCertDB/Impl.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/PerasCertDB/Impl.hs
@@ -2,9 +2,11 @@
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneKindSignatures #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 module Ouroboros.Consensus.Storage.PerasCertDB.Impl
   ( -- * Opening
@@ -57,7 +59,7 @@ data PerasCertDbState blk = PerasCertDbState
   , pcdsLastTicketNo :: !PerasCertTicketNo
   -- ^ The most recent 'PerasCertTicketNo' (or 'zeroPerasCertTicketNo'
   -- otherwise).
-  , pcdsLatestCertSeen :: !(Maybe (WithArrivalTime (ValidatedPerasCert blk)))
+  , pcdsLatestCertSeen :: !(Maybe (WithBoostedBlockStatus (WithArrivalTime (ValidatedPerasCert blk))))
   -- ^ The certificate with the highest round number that has been added to the
   -- db since it has been opened.
   }
@@ -181,11 +183,16 @@ implAddCert PerasCertDbEnv{pcdbTracer, pcdbState} cert = do
         let pcdsLastTicketNo' = succ (pcdsLastTicketNo pcds)
             pcdsCertIds' = Set.insert roundNo (pcdsCertIds pcds)
             pcdsCertsByTicket' = Map.insert pcdsLastTicketNo' cert (pcdsCertsByTicket pcds)
-            pcdsLatestCertSeen' = case pcdsLatestCertSeen pcds of
-              Nothing -> Just cert
-              Just prev
-                | getPerasCertRound cert > getPerasCertRound prev -> Just cert
-                | otherwise -> Just prev
+            pcdsLatestCertSeen' =
+              case pcdsLatestCertSeen pcds of
+                Nothing ->
+                  Just (CertBoostingBlockInVolatileDB cert)
+                Just prev
+                  | getPerasCertRound cert
+                      > getPerasCertRound (forgetBoostedBlockStatus prev) ->
+                      Just (CertBoostingBlockInVolatileDB cert)
+                  | otherwise ->
+                      Just prev
         writeTVar pcdbState $
           WithFingerprint
             PerasCertDbState
@@ -236,7 +243,7 @@ implGetCertsAfter PerasCertDbEnv{pcdbState} ticketNo = do
 implGetLatestCertSeen ::
   IOLike m =>
   PerasCertDbEnv m blk ->
-  STM m (Maybe (WithArrivalTime (ValidatedPerasCert blk)))
+  STM m (Maybe (WithBoostedBlockStatus (WithArrivalTime (ValidatedPerasCert blk))))
 implGetLatestCertSeen PerasCertDbEnv{pcdbState} = do
   PerasCertDbState{pcdsLatestCertSeen} <-
     forgetFingerprint <$> readTVar pcdbState
@@ -267,9 +274,20 @@ implGarbageCollect PerasCertDbEnv{pcdbTracer, pcdbState} slotNo = do
               pcdsCertsByTicket
           pcdsCertIds' =
             Set.fromList (getPerasCertRound <$> Map.elems pcdsCertsByTicket')
+          pcdsLatestCertSeen' =
+            updateIfBoostingGarbageCollectedBlock <$> pcdsLatestCertSeen
+
+          -- Update the latest certificate seen status when its corresponding
+          -- boosted block gets garbage collected.
+          updateIfBoostingGarbageCollectedBlock cert
+            | pointSlot (getPerasCertBoostedBlock (forgetBoostedBlockStatus cert))
+                < NotOrigin slotNo =
+                CertBoostingBlockNoLongerInVolatileDB (forgetBoostedBlockStatus cert)
+            | otherwise =
+                cert
        in PerasCertDbState
             { pcdsCertIds = pcdsCertIds'
             , pcdsCertsByTicket = pcdsCertsByTicket'
             , pcdsLastTicketNo = pcdsLastTicketNo
-            , pcdsLatestCertSeen = pcdsLatestCertSeen
+            , pcdsLatestCertSeen = pcdsLatestCertSeen'
             }

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/Model.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/Model.hs
@@ -133,6 +133,7 @@ import Ouroboros.Consensus.Storage.ChainDB.API
   )
 import Ouroboros.Consensus.Storage.ChainDB.Impl.ChainSel (olderThanImmTip)
 import Ouroboros.Consensus.Storage.Common ()
+import Ouroboros.Consensus.Storage.PerasCertDB.API (forgetBoostedBlockStatus)
 import Ouroboros.Consensus.Storage.PerasVoteDB.API (AddPerasVoteResult (..))
 import Ouroboros.Consensus.Util (repeatedly)
 import qualified Ouroboros.Consensus.Util.AnchoredFragment as Fragment
@@ -401,7 +402,9 @@ perasWeights :: StandardHash blk => Model blk -> PerasWeightSnapshot blk
 perasWeights = PerasCertDBModel.getWeightSnapshot . perasCertModel
 
 roundNoOfLatestCertSeen :: Model blk -> Maybe PerasRoundNo
-roundNoOfLatestCertSeen m = getPerasCertRound <$> PerasCertDBModel.getLatestCertSeen (perasCertModel m)
+roundNoOfLatestCertSeen m =
+  getPerasCertRound . forgetBoostedBlockStatus
+    <$> PerasCertDBModel.getLatestCertSeen (perasCertModel m)
 
 {-------------------------------------------------------------------------------
   Construction

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/PerasCertDB/Model.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/PerasCertDB/Model.hs
@@ -18,16 +18,20 @@ import qualified Data.Set as Set
 import Data.TreeDiff (ToExpr (..), defaultExprViaShow)
 import GHC.Generics (Generic)
 import Ouroboros.Consensus.Block
-import Ouroboros.Consensus.BlockchainTime.WallClock.Types (WithArrivalTime)
+import Ouroboros.Consensus.BlockchainTime.WallClock.Types (WithArrivalTime (..))
 import Ouroboros.Consensus.Peras.Weight
   ( PerasWeightSnapshot
   , mkPerasWeightSnapshot
   )
-import Ouroboros.Consensus.Storage.PerasCertDB.API (AddPerasCertResult (..))
+import Ouroboros.Consensus.Storage.PerasCertDB.API
+  ( AddPerasCertResult (..)
+  , WithBoostedBlockStatus (..)
+  , forgetBoostedBlockStatus
+  )
 
 data Model blk = Model
   { certs :: Set (WithArrivalTime (ValidatedPerasCert blk))
-  , latestCertSeen :: Maybe (WithArrivalTime (ValidatedPerasCert blk))
+  , latestCertSeen :: Maybe (WithBoostedBlockStatus (WithArrivalTime (ValidatedPerasCert blk)))
   , open :: Bool
   }
   deriving Generic
@@ -51,11 +55,16 @@ addCert model@Model{certs, latestCertSeen} cert
   | otherwise = (AddedPerasCertToDB, model{certs = certs', latestCertSeen = latestCertSeen'})
  where
   certs' = Set.insert cert certs
-  latestCertSeen' = case latestCertSeen of
-    Nothing -> Just cert
-    Just prev
-      | getPerasCertRound cert > getPerasCertRound prev -> Just cert
-      | otherwise -> Just prev
+  latestCertSeen' =
+    case latestCertSeen of
+      Nothing ->
+        Just (CertBoostingBlockInVolatileDB cert)
+      Just prev
+        | getPerasCertRound cert
+            > getPerasCertRound (forgetBoostedBlockStatus prev) ->
+            Just (CertBoostingBlockInVolatileDB cert)
+        | otherwise ->
+            Just prev
 
 hasRoundNo ::
   Set (WithArrivalTime (ValidatedPerasCert blk)) ->
@@ -74,12 +83,23 @@ getWeightSnapshot Model{certs} =
     ]
 
 getLatestCertSeen ::
-  Model blk -> Maybe (WithArrivalTime (ValidatedPerasCert blk))
+  Model blk ->
+  Maybe (WithBoostedBlockStatus (WithArrivalTime (ValidatedPerasCert blk)))
 getLatestCertSeen Model{latestCertSeen} =
   latestCertSeen
 
 garbageCollect :: SlotNo -> Model blk -> Model blk
-garbageCollect slotNo model@Model{certs} =
-  model{certs = Set.filter keepCert certs}
+garbageCollect slotNo model@Model{certs, latestCertSeen} =
+  model
+    { certs = Set.filter keepCert certs
+    , latestCertSeen = updateIfBoostingGarbageCollectedBlock <$> latestCertSeen
+    }
  where
   keepCert cert = pointSlot (getPerasCertBoostedBlock cert) >= NotOrigin slotNo
+
+  updateIfBoostingGarbageCollectedBlock cert
+    | pointSlot (getPerasCertBoostedBlock (forgetBoostedBlockStatus cert))
+        < NotOrigin slotNo =
+        CertBoostingBlockNoLongerInVolatileDB (forgetBoostedBlockStatus cert)
+    | otherwise =
+        cert

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/PerasCertDB/StateMachine.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/PerasCertDB/StateMachine.hs
@@ -30,7 +30,11 @@ import Ouroboros.Consensus.BlockchainTime.WallClock.Types
   )
 import Ouroboros.Consensus.Peras.Weight (PerasWeightSnapshot)
 import qualified Ouroboros.Consensus.Storage.PerasCertDB as PerasCertDB
-import Ouroboros.Consensus.Storage.PerasCertDB.API (AddPerasCertResult (..), PerasCertDB)
+import Ouroboros.Consensus.Storage.PerasCertDB.API
+  ( AddPerasCertResult (..)
+  , PerasCertDB
+  , WithBoostedBlockStatus
+  )
 import Ouroboros.Consensus.Util.IOLike
 import Ouroboros.Consensus.Util.Orphans ()
 import Ouroboros.Consensus.Util.STM
@@ -67,7 +71,8 @@ instance StateModel Model where
     OpenDB :: Action Model ()
     AddCert :: WithArrivalTime (ValidatedPerasCert TestBlock) -> Action Model AddPerasCertResult
     GetWeightSnapshot :: Action Model (PerasWeightSnapshot TestBlock)
-    GetLatestCertSeen :: Action Model (Maybe (WithArrivalTime (ValidatedPerasCert TestBlock)))
+    GetLatestCertSeen ::
+      Action Model (Maybe (WithBoostedBlockStatus (WithArrivalTime (ValidatedPerasCert TestBlock))))
     GarbageCollect :: SlotNo -> Action Model ()
 
   arbitraryAction _ (Model model)


### PR DESCRIPTION
This commit extends the `PerasCertDB.getLatestCertSeen` method to return the status of the block being boosted by the certificate.

This is relevant for Peras voting because we need to know if a candidate block extends the chain that contains the block being boosted by the latest certificate seen. Since this block might no longer be part of the current volatile suffix, the PerasCertDB now keeps track of whether the certificate was garbage collected or not, which in turn would indicate that the block has entered the immutable prefix, thus rendering the ancestor check mentioned above vacuously true.

In addition, it updates the ChainDB model and state-machine tests to abide by the new requirement.