### PR TITLE
[Peras 43] Move Test.Consensus.Committee.Utils to Test.Util.Committee

### DIFF
--- a/ouroboros-consensus.cabal
+++ b/ouroboros-consensus.cabal
@@ -466,6 +466,7 @@ library unstable-consensus-testlib
     Test.Util.ChainDB
     Test.Util.ChainUpdates
     Test.Util.ChunkInfo
+    Test.Util.Committee
     Test.Util.Corruption
     Test.Util.FileLock
     Test.Util.HardFork.Future
@@ -659,7 +660,6 @@ test-suite consensus-test
     Test.Consensus.Committee.EveryoneVotes
     Test.Consensus.Committee.EveryoneVotes.Tests
     Test.Consensus.Committee.TestCrypto
-    Test.Consensus.Committee.Utils
     Test.Consensus.Committee.WFALS
     Test.Consensus.Committee.WFALS.Conformance
     Test.Consensus.Committee.WFALS.Model

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/Committee.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/Committee.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 
 -- | Utility functions for the voting committee tests.
-module Test.Consensus.Committee.Utils
+module Test.Util.Committee
   ( -- * General utilities
     mkPoolId
   , unfairWFATiebreaker

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/Committee/Class.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/Committee/Class.hs
@@ -25,7 +25,6 @@ import Ouroboros.Consensus.Committee.Crypto
   )
 import Test.Consensus.Committee.TestCrypto (TestCrypto)
 import qualified Test.Consensus.Committee.TestCrypto as TestCrypto
-import Test.Consensus.Committee.Utils (mkBucket)
 import Test.QuickCheck
   ( Arbitrary (..)
   , Gen
@@ -41,6 +40,7 @@ import Test.QuickCheck
   )
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.QuickCheck (Testable (..), testProperty)
+import Test.Util.Committee (mkBucket)
 import Test.Util.TestEnv (adjustQuickCheckTests)
 
 tests :: TestTree

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/Committee/EveryoneVotes/Tests.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/Committee/EveryoneVotes/Tests.hs
@@ -41,16 +41,6 @@ import Ouroboros.Consensus.Committee.WFA
   )
 import Test.Consensus.Committee.TestCrypto (TestCrypto)
 import qualified Test.Consensus.Committee.TestCrypto as TestCrypto
-import Test.Consensus.Committee.Utils
-  ( eqWithShowCmp
-  , genPools
-  , genPositiveStake
-  , mkBucket
-  , onError
-  , tabulateNumPools
-  , tabulatePoolStake
-  , unfairWFATiebreaker
-  )
 import Test.QuickCheck
   ( Gen
   , Property
@@ -65,6 +55,16 @@ import Test.QuickCheck
   )
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.QuickCheck (testProperty)
+import Test.Util.Committee
+  ( eqWithShowCmp
+  , genPools
+  , genPositiveStake
+  , mkBucket
+  , onError
+  , tabulateNumPools
+  , tabulatePoolStake
+  , unfairWFATiebreaker
+  )
 import Test.Util.TestEnv (adjustQuickCheckTests)
 
 tests :: TestTree

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/Committee/TestCrypto.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/Committee/TestCrypto.hs
@@ -63,7 +63,6 @@ import Ouroboros.Consensus.Committee.Crypto
   )
 import Ouroboros.Consensus.Committee.Crypto.BLS (KeyRole (..))
 import qualified Ouroboros.Consensus.Committee.Crypto.BLS as BLS
-import Test.Consensus.Committee.Utils (genEpochNonce)
 import Test.QuickCheck
   ( Arbitrary (..)
   , Gen
@@ -80,6 +79,7 @@ import Test.QuickCheck
   )
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.QuickCheck (testProperty)
+import Test.Util.Committee (genEpochNonce)
 import Test.Util.TestEnv (adjustQuickCheckTests)
 
 -- * Test crypto based on BLS signatures

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/Committee/WFALS.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/Committee/WFALS.hs
@@ -16,7 +16,6 @@ import Data.String (IsString (..))
 import qualified Ouroboros.Consensus.Committee.Types as WFA
 import Ouroboros.Consensus.Committee.WFA (WFATiebreaker (..))
 import qualified Ouroboros.Consensus.Committee.WFA as WFA
-import Test.Consensus.Committee.Utils (mkPoolId)
 import Test.Consensus.Committee.WFALS.Conformance (conformsToRustImplementation)
 import Test.Consensus.Committee.WFALS.Model
   ( NumSeats
@@ -38,6 +37,7 @@ import Test.QuickCheck
   )
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.QuickCheck (testProperty)
+import Test.Util.Committee (mkPoolId)
 import Test.Util.TestEnv (adjustQuickCheckTests)
 
 tests :: TestTree

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/Committee/WFALS/Model/Utils.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/Committee/WFALS/Model/Utils.hs
@@ -17,7 +17,6 @@ import qualified Data.Map.Strict as Map
 import Data.Ratio ((%))
 import qualified Data.Set as Set
 import Data.Word (Word64)
-import Test.Consensus.Committee.Utils (mkBucket)
 import Test.Consensus.Committee.WFALS.Model
   ( IsStake (..)
   , NumSeats
@@ -38,6 +37,7 @@ import Test.QuickCheck
   , tabulate
   , vectorOf
   )
+import Test.Util.Committee (mkBucket)
 
 -- * Generators
 

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/Committee/WFALS/Tests.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/Committee/WFALS/Tests.hs
@@ -52,16 +52,6 @@ import Ouroboros.Consensus.Committee.WFALS
   )
 import Test.Consensus.Committee.TestCrypto (TestCrypto)
 import qualified Test.Consensus.Committee.TestCrypto as TestCrypto
-import Test.Consensus.Committee.Utils
-  ( eqWithShowCmp
-  , genEpochNonce
-  , genPools
-  , mkBucket
-  , onError
-  , tabulateNumPools
-  , tabulatePoolStake
-  , unfairWFATiebreaker
-  )
 import Test.QuickCheck
   ( Gen
   , Property
@@ -76,6 +66,16 @@ import Test.QuickCheck
   )
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.QuickCheck (testProperty)
+import Test.Util.Committee
+  ( eqWithShowCmp
+  , genEpochNonce
+  , genPools
+  , mkBucket
+  , onError
+  , tabulateNumPools
+  , tabulatePoolStake
+  , unfairWFATiebreaker
+  )
 import Test.Util.TestEnv (adjustQuickCheckTests)
 
 tests :: TestTree


### PR DESCRIPTION
This commit relocates the voting committee test utilities from the consensus test suite into the unstable-consensus-testlib library so they can be reused outside the test suite.
