### PR TITLE
Fix kes-agent SRP

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -80,12 +80,11 @@ source-repository-package
     eras/conway/impl
     eras/dijkstra/impl
 
--- Points to f-f:f-f/allow-crypto-class-2.5
 source-repository-package
   type: git
-  location: https://github.com/f-f/kes-agent
-  tag: 32c1ed675d22a30735d9f22f7afa436a3ef3e64a
-  --sha256: sha256-o7hFX1JnraS6Xq0WoXQwd9Z8GsPPv0Ls2DWvZ08o0ZU=
+  location: https://github.com/input-output-hk/kes-agent
+  tag: 4e7ec7b5102a030587413f4af770e87a15c9cb9c
+  --sha256: sha256-OUnBy86ny2RHHJZoOXPHeHbYwvWBHmnXoVyQp0FZjEA=
   subdir:
     kes-agent
     kes-agent-crypto


### PR DESCRIPTION
Before

ouroboros-consensus on  leios-prototype via λ 9.6.7 via :snowflake:   impure (ghc-shell-for-packages-env) ❯ cabal build
fatal: Could not parse object '32c1ed675d22a30735d9f22f7afa436a3ef3e64a'.

-- Points to f-f:f-f/allow-crypto-class-2.5
source-repository-package
  type: git
  location: https://github.com/f-f/kes-agent
  tag: 32c1ed675d22a30735d9f22f7afa436a3ef3e64a
  --sha256: sha256-o7hFX1JnraS6Xq0WoXQwd9Z8GsPPv0Ls2DWvZ08o0ZU=
  subdir:
    kes-agent
    kes-agent-crypto