### PR TITLE
[Peras 44] Introduce Peras epoch context resolution machinery

### DIFF
--- a/changelog.d/20260730_144257_agustin.mista_epoch_context_resolution.md
+++ b/changelog.d/20260730_144257_agustin.mista_epoch_context_resolution.md
@@ -1,0 +1,27 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+<!--
+### Breaking
+
+- A bullet item for the Breaking category.
+
+-->
+### Non-Breaking
+
+- Introduce the `Ouroboros.Consensus.Peras.Context` module, providing the machinery to resolve Peras round numbers into their epoch-dependent context (voting committee and Peras parameters).
+- Add `BoundedPerasEpochContext`, `PerasEpochContextResolver` (a two-epoch sliding window), and their `PerasEpochContextResolverHandle`, together with `initPerasEpochContextResolver`, `tickPerasEpochContextResolver`, `resolveRoundNo` and `withResolvedRoundNo`.
+- Add the `StateSupportsPerasEpochContext` typeclass and `mkBoundedPerasEpochContextWith` to extract epoch contexts from the node state.
+- Add `TimeResolutionContext` and the `runQueryWithContext`/`runQueryEraIndexedWithContext` helpers to run hard fork history queries against the ledger state.
+- Add the `PerasEpochContext` type and the `PerasCrypto`, `PerasVotingCommitteeScheme` and `PerasError` associated types to `BlockSupportsPeras`, in anticipation of an upcoming refactor of the type class.
+
+<!--
+### Patch
+
+- A bullet item for the Patch category.
+
+-->

--- a/ouroboros-consensus.cabal
+++ b/ouroboros-consensus.cabal
@@ -238,6 +238,7 @@ library
     Ouroboros.Consensus.Peras.Cert.Class
     Ouroboros.Consensus.Peras.Cert.Inclusion
     Ouroboros.Consensus.Peras.Cert.V1
+    Ouroboros.Consensus.Peras.Context
     Ouroboros.Consensus.Peras.Crypto.BLS
     Ouroboros.Consensus.Peras.Params
     Ouroboros.Consensus.Peras.SelectView

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Block/SupportsPeras.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Block/SupportsPeras.hs
@@ -7,32 +7,26 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Ouroboros.Consensus.Block.SupportsPeras
-  ( PerasRoundNo (..)
-  , PerasBoostedBlock (..)
-  , PerasSeatIndex (..)
-  , PerasVoteId (..)
-  , PerasVoteTarget (..)
-  , PerasVoterId (..)
-  , PerasVoteStake (..)
-  , stakeAboveThreshold
-  , PerasVoteStakeDistr (..)
-  , lookupPerasVoteStake
+  ( -- * Voting committee types for Peras
+    PerasVotingCommittee
+  , PerasVotingCommitteeError
+  , PerasVotingCommitteeInput
+
+    -- * Epoch-dependent context for Peras
+  , PerasEpochContext (..)
+
+    -- * BlockSupportsPeras class
   , BlockSupportsPeras (..)
+
+    -- * To be removed in favor of using 'IsPerasCert'/'IsPerasVote'
   , PerasCert (..)
   , PerasVote (..)
-  , ValidatedPerasCert (..)
-  , ValidatedPerasVote (..)
-  , ValidatedPerasVotesWithQuorum
-    ( vpvqTarget
-    , vpvqVotes
-    , vpvqPerasCfg
-    )
-  , votesReachQuorum
   , HasPerasCertRound (..)
   , HasPerasCertBoostedBlock (..)
   , HasPerasCertBoost (..)
@@ -43,15 +37,35 @@ module Ouroboros.Consensus.Block.SupportsPeras
   , HasPerasVoteTarget (..)
   , HasPerasVoteId (..)
 
+    -- * Types and functions related to Peras vote collection and quorum checking
+  , PerasVoteId (..)
+  , PerasVoterId (..)
+  , PerasVoteStake (..)
+  , PerasVoteStakeDistr (..)
+  , ValidatedPerasVotesWithQuorum
+    ( vpvqTarget
+    , vpvqVotes
+    , vpvqPerasCfg
+    )
+  , lookupPerasVoteStake
+  , votesReachQuorum
+
+    -- * Validated types
+  , ValidatedPerasCert (..)
+  , ValidatedPerasVote (..)
+
     -- * Peras error types
   , IsPerasError (..)
-  , PerasVotingCommitteeError
+
+    -- * Helpers
+  , stakeAboveThreshold
 
     -- * Convenience re-exports
   , module Ouroboros.Consensus.Peras.Params
   , module Ouroboros.Consensus.Peras.Types
   ) where
 
+import Cardano.Binary (FromCBOR (..), ToCBOR (..))
 import qualified Cardano.Binary as KeyHash
 import Cardano.Ledger.Hashes (KeyHash, KeyRole (..))
 import Codec.Serialise (Serialise (..))
@@ -62,15 +76,93 @@ import qualified Data.Map as Map
 import Data.Map.Strict (Map)
 import Data.Monoid (Sum (..))
 import Data.Proxy (Proxy (..))
+import Data.Typeable (Typeable)
+import Data.Void (Void)
 import GHC.Generics (Generic)
 import NoThunks.Class
 import Ouroboros.Consensus.Block.Abstract
 import Ouroboros.Consensus.BlockchainTime.WallClock.Types (WithArrivalTime (..))
+import Ouroboros.Consensus.Committee.Class
+  ( CryptoSupportsVotingCommittee (..)
+  , VotingCommittee
+  )
 import Ouroboros.Consensus.Peras.Params
 import Ouroboros.Consensus.Peras.Types hiding (PerasVoteId (..))
 import Ouroboros.Consensus.Peras.Voting.Adapter (PerasConversionError)
 import Ouroboros.Consensus.Util
 import Quiet (Quiet (..))
+
+-- * Voting committee types for Peras
+
+-- | Voting committee for Peras indexed by block type
+type PerasVotingCommittee blk =
+  VotingCommittee
+    (PerasCrypto blk)
+    (PerasVotingCommitteeScheme blk)
+
+-- | Error type for Peras voting committee errors
+type PerasVotingCommitteeError blk =
+  VotingCommitteeError
+    (PerasCrypto blk)
+    (PerasVotingCommitteeScheme blk)
+
+-- | Input needed to build a Peras voting committee
+type PerasVotingCommitteeInput blk =
+  VotingCommitteeInput
+    (PerasCrypto blk)
+    (PerasVotingCommitteeScheme blk)
+
+-- * Epoch-dependent context for Peras
+
+-- | Epoch-dependent context used for forging and validation of objects.
+data PerasEpochContext blk
+  = PerasEpochContext
+  { pecCommittee :: PerasVotingCommittee blk
+  , pecParams :: PerasParams blk
+  }
+
+instance
+  ( Typeable blk
+  , FromCBOR (PerasVotingCommittee blk)
+  ) =>
+  FromCBOR (PerasEpochContext blk)
+  where
+  fromCBOR = do
+    decodeListLenOf 2
+    pecCommittee <- fromCBOR
+    pecParams <- fromCBOR
+    pure
+      PerasEpochContext
+        { pecCommittee
+        , pecParams
+        }
+
+instance
+  ( Typeable blk
+  , ToCBOR (PerasVotingCommittee blk)
+  ) =>
+  ToCBOR (PerasEpochContext blk)
+  where
+  toCBOR
+    PerasEpochContext
+      { pecCommittee
+      , pecParams
+      } =
+      encodeListLen 2
+        <> toCBOR pecCommittee
+        <> toCBOR pecParams
+
+deriving instance
+  Show (PerasVotingCommittee blk) =>
+  Show (PerasEpochContext blk)
+deriving instance
+  Eq (PerasVotingCommittee blk) =>
+  Eq (PerasEpochContext blk)
+deriving instance
+  NoThunks (PerasVotingCommittee blk) =>
+  NoThunks (PerasEpochContext blk)
+deriving instance
+  Generic (PerasEpochContext blk)
 
 {-------------------------------------------------------------------------------
 -- * Peras types
@@ -228,6 +320,11 @@ class
   ) =>
   BlockSupportsPeras blk
   where
+  -- NOTE: these will be updated during the upcoming 'BlockSupportsPeras' refactor
+  type PerasCrypto blk
+  type PerasVotingCommitteeScheme blk
+  type PerasError blk
+
   -- NOTE: this associated type will dissapear in favor of using
   -- 'PerasParams blk' directly.
   type PerasCfg blk
@@ -267,6 +364,10 @@ class
 -- TODO: degenerate instance for all blks to get things to compile
 -- see https://github.com/tweag/cardano-peras/issues/73
 instance StandardHash blk => BlockSupportsPeras blk where
+  type PerasCrypto blk = Void
+  type PerasVotingCommitteeScheme blk = Void
+  type PerasError blk = Void
+
   type PerasCfg blk = PerasParams blk
 
   data PerasCert blk = PerasCert
@@ -528,9 +629,6 @@ instance
   getPerasVoteId = getPerasVoteId . forgetArrivalTime
 
 --- * Peras error types
-
--- NOTE: this will be replaced by an associated type in 'BlockSupportsPeras'.
-data PerasVotingCommitteeError blk
 
 -- | Error types that support injecting certain types of Peras errors
 class IsPerasError err blk | err -> blk where

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Peras/Context.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Peras/Context.hs
@@ -1,0 +1,963 @@
+{-# LANGUAGE DefaultSignatures #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveTraversable #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE MultiWayIf #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Ouroboros.Consensus.Peras.Context
+  ( -- * Bounded Peras epoch context
+    BoundedPerasEpochContext (..)
+  , withinEpochContext
+
+    -- * Peras epoch context resolver and handle
+  , PerasEpochContextResolver (..)
+  , PerasEpochContextNotFoundForRound (..)
+  , resolveRoundNo
+  , perasEpochContextResolverBounds
+  , PerasEpochContextResolverHandle (..)
+  , mockPerasEpochContextResolverHandle
+  , withResolvedRoundNo
+
+    -- * Extracting and resolving Peras epoch contexts from the node state
+  , StateSupportsPerasEpochContext (..)
+  , mkBoundedPerasEpochContextWith
+  , initPerasEpochContextResolver
+  , tickPerasEpochContextResolver
+
+    -- * Time resolution
+  , TimeResolutionContext (..)
+  , runQueryWithContext
+  , runQueryEraIndexedWithContext
+  , TimeResolutionContextHandle (..)
+  , runQueryWithContextHandle
+
+    -- * Next-epoch detection
+  , EpochCrossing (..)
+  , DetectNextEpochError
+  , isNextEpoch
+  )
+where
+
+import Cardano.Binary
+  ( FromCBOR (..)
+  , ToCBOR (..)
+  , decodeListLen
+  , decodeListLenOf
+  , encodeListLen
+  )
+import Cardano.Prelude (maybeToEither)
+import Control.Exception (Exception)
+import Control.Monad.Class.MonadSTM (STM)
+import Data.Bifunctor (Bifunctor (..))
+import qualified Data.ByteString.Char8 as ByteString
+import Data.Data (Proxy (..))
+import Data.Kind (Type)
+import Data.SOP (HCollapse (..), K (..))
+import Data.SOP.Constraint (All, Top)
+import Data.SOP.Index (himap, injectNS)
+import Data.Typeable (Typeable)
+import Data.Word (Word8)
+import GHC.Generics (Generic)
+import Ouroboros.Consensus.Block.Abstract
+  ( BlockProtocol
+  , EpochNo (..)
+  , SlotNo
+  , WithOrigin (..)
+  )
+import Ouroboros.Consensus.Block.SupportsPeras
+  ( BlockSupportsPeras (..)
+  , IsPerasError (..)
+  , PerasEpochContext (..)
+  , PerasRoundNo
+  , PerasVotingCommittee
+  , PerasVotingCommitteeInput
+  )
+import Ouroboros.Consensus.Committee.Class (CryptoSupportsVotingCommittee)
+import qualified Ouroboros.Consensus.Committee.Class as Committee
+import Ouroboros.Consensus.HardFork.Abstract (HasHardForkHistory (..))
+import Ouroboros.Consensus.HardFork.History.Qry
+  ( EpochToPerasRoundInfo (..)
+  , EraIndexed (..)
+  , PastHorizonException
+  , Qry
+  , epochToPerasRoundInfo
+  , forgetEraIndex
+  , runQuery
+  , runQueryEraIndexed
+  , slotToEpoch'
+  )
+import Ouroboros.Consensus.HeaderValidation
+  ( HeaderState
+  , Ticked
+  , annTipSlotNo
+  , headerStateTip
+  )
+import Ouroboros.Consensus.Ledger.Abstract (EmptyMK, LedgerConfig, LedgerState)
+import Ouroboros.Consensus.Ledger.SupportsPeras (LedgerStateSupportsPeras (..))
+import Ouroboros.Consensus.Peras.Params
+  ( PerasEnabled
+  , perasEnabledToMaybe
+  , pattern NoPerasEnabled
+  , pattern PerasEnabled
+  )
+import Ouroboros.Consensus.Protocol.Abstract
+  ( ChainDepStateSupportsPeras
+  , ConsensusProtocol (..)
+  )
+import Ouroboros.Consensus.Storage.Serialisation
+  ( DecodeDisk (..)
+  , EncodeDisk (..)
+  )
+import Ouroboros.Consensus.Util.IOLike
+  ( IOLike
+  , MonadSTM
+  , MonadThrow
+  , NoThunks (..)
+  , newTVarIO
+  , readTVar
+  , throwSTM
+  )
+
+-- * Bounded Peras epoch context
+
+-- | A 'PerasEpochContext' that is valid only in a given range of round numbers
+data BoundedPerasEpochContext blk
+  = BoundedPerasEpochContext
+  { startPerasRoundNo :: PerasRoundNo
+  -- ^ Inclusive lower bound
+  , endPerasRoundNo :: PerasRoundNo
+  -- ^ Exclusive upper bound
+  , epochContext :: PerasEpochContext blk
+  -- ^ Epcoh context that is valid within the given bounds
+  }
+
+deriving instance
+  Show (PerasEpochContext blk) =>
+  Show (BoundedPerasEpochContext blk)
+deriving instance
+  Eq (PerasEpochContext blk) =>
+  Eq (BoundedPerasEpochContext blk)
+deriving instance
+  NoThunks (PerasEpochContext blk) =>
+  NoThunks (BoundedPerasEpochContext blk)
+deriving instance
+  Generic (BoundedPerasEpochContext blk)
+
+instance
+  ( Typeable blk
+  , FromCBOR (PerasVotingCommittee blk)
+  ) =>
+  FromCBOR (BoundedPerasEpochContext blk)
+  where
+  fromCBOR = do
+    decodeListLenOf 3
+    startPerasRoundNo <- fromCBOR
+    endPerasRoundNo <- fromCBOR
+    epochContext <- fromCBOR
+    pure
+      BoundedPerasEpochContext
+        { startPerasRoundNo
+        , endPerasRoundNo
+        , epochContext
+        }
+
+instance
+  ( Typeable blk
+  , ToCBOR (PerasVotingCommittee blk)
+  ) =>
+  ToCBOR (BoundedPerasEpochContext blk)
+  where
+  toCBOR
+    BoundedPerasEpochContext
+      { startPerasRoundNo
+      , endPerasRoundNo
+      , epochContext
+      } =
+      encodeListLen 3
+        <> toCBOR startPerasRoundNo
+        <> toCBOR endPerasRoundNo
+        <> toCBOR epochContext
+
+instance
+  FromCBOR (BoundedPerasEpochContext blk) =>
+  DecodeDisk blk (BoundedPerasEpochContext blk)
+  where
+  decodeDisk _ccfg = fromCBOR
+
+instance
+  ToCBOR (BoundedPerasEpochContext blk) =>
+  EncodeDisk blk (BoundedPerasEpochContext blk)
+  where
+  encodeDisk _ccfg = toCBOR
+
+-- | Check whether a given 'PerasRoundNo' is within the bounds of a
+-- 'BoundedPerasEpochContext'.
+--
+-- Returns the corresponding 'PerasEpochContext' if the round number is within
+-- the bounds, or 'Nothing' otherwise.
+withinEpochContext ::
+  PerasRoundNo ->
+  BoundedPerasEpochContext blk ->
+  Maybe (PerasEpochContext blk)
+withinEpochContext roundNo boundedContext
+  | roundNo >= startPerasRoundNo boundedContext
+      && roundNo < endPerasRoundNo boundedContext =
+      Just (epochContext boundedContext)
+  | otherwise =
+      Nothing
+
+-- * Peras epoch context resolver (and handle)
+
+-- | A two-epoch window of Peras epoch contexts, which can be used to resolve
+-- round numbers into their corresponding Peras contexts.
+data PerasEpochContextResolver blk
+  = -- | The resolver is in an error state, and cannot resolve any round number.
+    --
+    -- NOTE: this exists to allow for recoverable errors during resolver
+    -- initialisation or ticking caused, e.g., by incorrect parameterization.
+    PerasEpochContextResolverError
+      !String
+  | -- | The resolver has a two-epoch window of Peras epoch contexts, which may
+    -- be empty if Peras is not enabled in either of these epochs.
+    PerasEpochContextResolver
+      -- | Current epoch context
+      !(PerasEnabled (BoundedPerasEpochContext blk))
+      -- | Previous epoch context
+      !(PerasEnabled (BoundedPerasEpochContext blk))
+
+deriving instance
+  Show (PerasEpochContext blk) =>
+  Show (PerasEpochContextResolver blk)
+deriving instance
+  Eq (PerasEpochContext blk) =>
+  Eq (PerasEpochContextResolver blk)
+deriving instance
+  NoThunks (PerasEpochContext blk) =>
+  NoThunks (PerasEpochContextResolver blk)
+deriving instance
+  Generic (PerasEpochContextResolver blk)
+
+instance
+  ( Typeable blk
+  , FromCBOR (PerasVotingCommittee blk)
+  ) =>
+  FromCBOR (PerasEpochContextResolver blk)
+  where
+  fromCBOR = do
+    len <- decodeListLen
+    tag <- fromCBOR @Word8
+    case (len, tag) of
+      (2, 0) -> do
+        reason <- ByteString.unpack <$> fromCBOR
+        pure $ PerasEpochContextResolverError reason
+      (3, 1) -> do
+        curr <- fromCBOR
+        prev <- fromCBOR
+        pure $ PerasEpochContextResolver curr prev
+      _ ->
+        fail $
+          "PerasEpochContextResolver: unexpected list length and tag: "
+            <> show (len, tag)
+
+instance
+  ( Typeable blk
+  , ToCBOR (PerasVotingCommittee blk)
+  ) =>
+  ToCBOR (PerasEpochContextResolver blk)
+  where
+  toCBOR = \case
+    PerasEpochContextResolverError reason ->
+      encodeListLen 2
+        <> toCBOR (0 :: Word8)
+        <> toCBOR (ByteString.pack reason)
+    PerasEpochContextResolver curr prev ->
+      encodeListLen 3
+        <> toCBOR (1 :: Word8)
+        <> toCBOR curr
+        <> toCBOR prev
+
+instance
+  FromCBOR (PerasEpochContextResolver blk) =>
+  DecodeDisk blk (PerasEpochContextResolver blk)
+  where
+  decodeDisk _ccfg = fromCBOR
+
+instance
+  ToCBOR (PerasEpochContextResolver blk) =>
+  EncodeDisk blk (PerasEpochContextResolver blk)
+  where
+  encodeDisk _ccfg = toCBOR
+
+-- | An error indicating that a 'PerasEpochContext' could not be found for a
+-- given 'PerasRoundNo' in a 'PerasEpochContextResolver'.
+data PerasEpochContextNotFoundForRound
+  = PerasEpochContextNotFoundForRound
+      -- | The round number for which the context could not be found.
+      !PerasRoundNo
+      -- | Detailed reason for the failure.
+      !String
+  deriving (Eq, Show, Generic, NoThunks, Exception)
+
+-- | Initialise a 'PerasEpochContextResolver' using a bounded context.
+--
+-- NOTE: regarding why this function uses a hardcoded 'NoPerasEnabled' for the
+-- epoch prior to the one being used to initialize this bounded context: please
+-- notice that this function is only used in cases where we don't have
+-- information about the previous epoch:
+--
+--  * When creating a new context resolver from scratch, where we don't have any
+--    information about Peras for the previous epoch (there might not even be a
+--    previous epoch if we are boostrapping from Genesis).
+--
+--  * When ticking the resolver out of an error state. This could occur due to
+--    bad parameterization leading to an error while creating a voting committee
+--    for a given epoch.
+--
+--  * When ticking the resolver more than one epoch at a time, in which case we
+--    cannot faitfully build a context for the previous (gap) epoch. This only
+--    happens in tests, though.
+--
+-- In all these cases, using 'NoPerasEnabled' for the previous epoch is the only
+-- safe option, although in the future we might want to make each of the cases
+-- mentioned above more explicitly representable.
+newPerasEpochContextResolver ::
+  PerasEnabled (BoundedPerasEpochContext blk) ->
+  PerasEpochContextResolver blk
+newPerasEpochContextResolver currEpochContext =
+  PerasEpochContextResolver
+    currEpochContext
+    NoPerasEnabled
+
+-- | Advance a 'PerasEpochContextResolver' to the next epoch, given a new
+-- bounded context for the next epoch.
+--
+-- NOTE: this will recover from an error state, but it will leave the previous
+-- epoch context disabled.
+advancePerasEpochContextResolver ::
+  PerasEpochContextResolver blk ->
+  PerasEnabled (BoundedPerasEpochContext blk) ->
+  PerasEpochContextResolver blk
+advancePerasEpochContextResolver resolver newEpochContext =
+  case resolver of
+    -- The previous resolver is in a valid state => slide the window forward
+    PerasEpochContextResolver currEpochContext _prevEpochContext ->
+      PerasEpochContextResolver
+        newEpochContext
+        currEpochContext
+    -- The previous resolver is in an error state => re-initialise the window
+    PerasEpochContextResolverError{} ->
+      newPerasEpochContextResolver
+        newEpochContext
+
+-- | Resolve a 'PerasRoundNo' into its corresponding 'PerasEpochContext' using a
+-- 'PerasEpochContextResolver'.
+--
+-- Fails with 'PerasEpochContextNotFoundForRound' if the round number is not
+-- within the bounds of either the current or previous epoch context, or if the
+-- resolver is in an error state.
+resolveRoundNo ::
+  PerasEpochContextResolver blk ->
+  PerasRoundNo ->
+  Either PerasEpochContextNotFoundForRound (PerasEpochContext blk)
+resolveRoundNo resolver roundNo = case resolver of
+  PerasEpochContextResolverError reason ->
+    Left $
+      PerasEpochContextNotFoundForRound roundNo reason
+  PerasEpochContextResolver curr prev ->
+    case (lookupBounded "current" curr, lookupBounded "previous" prev) of
+      -- The round number is within the bounds of the current epoch context
+      (Right context, _) ->
+        Right context
+      -- The round number is within the bounds of the previous epoch context
+      (_, Right context) ->
+        Right context
+      -- The round number is not within the bounds of either epoch context
+      (Left reason1, Left reason2) ->
+        Left $
+          PerasEpochContextNotFoundForRound roundNo (reason1 <> "; " <> reason2)
+ where
+  lookupBounded name mbContext = do
+    boundedContext <-
+      maybeToEither
+        ("no " <> name <> " epoch context available because Peras isn't enabled")
+        (perasEnabledToMaybe mbContext)
+    maybeToEither
+      ( name
+          <> " epoch context available, but roundNo "
+          <> show roundNo
+          <> " not within "
+          <> name
+          <> " epoch context bounds ["
+          <> show (startPerasRoundNo boundedContext)
+          <> ", "
+          <> show (endPerasRoundNo boundedContext)
+          <> ")"
+      )
+      (withinEpochContext roundNo boundedContext)
+
+-- | Compute the bounds of the Peras round numbers that are covered by the
+-- given 'PerasEpochContextResolver'.
+--
+-- NOTE: the upper bound is exclusive, thus we return an empty range [0,0) when
+-- the resolver doesn't cover any Peras round.
+perasEpochContextResolverBounds ::
+  PerasEpochContextResolver blk ->
+  (PerasRoundNo, PerasRoundNo)
+perasEpochContextResolverBounds = \case
+  PerasEpochContextResolverError _ ->
+    ( 0
+    , 0
+    )
+  PerasEpochContextResolver NoPerasEnabled NoPerasEnabled ->
+    ( 0
+    , 0
+    )
+  PerasEpochContextResolver (PerasEnabled curr) NoPerasEnabled ->
+    ( startPerasRoundNo curr
+    , endPerasRoundNo curr
+    )
+  PerasEpochContextResolver NoPerasEnabled (PerasEnabled prev) ->
+    ( startPerasRoundNo prev
+    , endPerasRoundNo prev
+    )
+  PerasEpochContextResolver (PerasEnabled curr) (PerasEnabled prev) ->
+    ( min (startPerasRoundNo curr) (startPerasRoundNo prev)
+    , max (endPerasRoundNo curr) (endPerasRoundNo prev)
+    )
+
+-- | A handle to a 'PerasEpochContextResolver' that can be used in 'STM' to
+-- resolve round numbers into their corresponding 'PerasEpochContext's.
+newtype PerasEpochContextResolverHandle m blk
+  = PerasEpochContextResolverHandle
+  { getPerasEpochContextResolver :: STM m (PerasEpochContextResolver blk)
+  }
+
+-- | A mocked 'PerasEpochContextResolverHandle' that always succeeds by
+-- resolving every round number to a fixed given (fixed) 'PerasEpochContext'.
+mockPerasEpochContextResolverHandle ::
+  ( IOLike m
+  , NoThunks (PerasEpochContext blk)
+  ) =>
+  PerasEpochContext blk ->
+  m (PerasEpochContextResolverHandle m blk)
+mockPerasEpochContextResolverHandle context = do
+  resolverVar <-
+    newTVarIO
+      ( PerasEpochContextResolver
+          (PerasEnabled (BoundedPerasEpochContext minBound maxBound context))
+          NoPerasEnabled
+      )
+  pure $ PerasEpochContextResolverHandle (readTVar resolverVar)
+
+-- | Helper to resolve the epoch context for a given round a pass it to a
+-- continuation for further processing.
+--
+-- NOTE: this function will throw an STM exception if round number cannot be
+-- resolved, or if the continuation fails.
+withResolvedRoundNo ::
+  ( MonadSTM m
+  , MonadThrow (STM m)
+  , Exception err
+  ) =>
+  PerasEpochContextResolverHandle m blk ->
+  PerasRoundNo ->
+  (PerasEpochContext blk -> Either err a) ->
+  STM m a
+withResolvedRoundNo handle roundNo k = do
+  resolver <- getPerasEpochContextResolver handle
+  case resolveRoundNo resolver roundNo of
+    Left err -> throwSTM err
+    Right context ->
+      case k context of
+        Left err -> throwSTM err
+        Right a -> pure a
+
+-- * Extracting and resolving Peras epoch contexts from the node state
+
+-- | Type-class for blocks that support constructing a Peras epoch contexts from
+-- their corresponding ledger and chain-dep states.
+--
+-- NOTE: the default implementation of this class is enough for block that do
+-- not support Peras and never try to resolve a 'PerasRoundNo' into a
+-- 'PerasEpochContext'.
+class
+  ( HasHardForkHistory blk
+  , LedgerStateSupportsPeras (LedgerState blk)
+  , LedgerStateSupportsPeras (Ticked LedgerState blk)
+  , ChainDepStateSupportsPeras (ChainDepState (BlockProtocol blk))
+  , ChainDepStateSupportsPeras (Ticked (ChainDepState (BlockProtocol blk)))
+  , IsPerasError (PerasError blk) blk
+  , Show (PerasError blk)
+  , Show (PerasVotingCommittee blk)
+  , Eq (PerasVotingCommittee blk)
+  , NoThunks (PerasVotingCommittee blk)
+  , Typeable (PerasVotingCommittee blk)
+  , FromCBOR (PerasVotingCommittee blk)
+  , ToCBOR (PerasVotingCommittee blk)
+  , Show (PerasEpochContextResolver blk)
+  , Eq (PerasEpochContextResolver blk)
+  , NoThunks (PerasEpochContextResolver blk)
+  , Typeable (PerasEpochContextResolver blk)
+  , FromCBOR (PerasEpochContextResolver blk)
+  , ToCBOR (PerasEpochContextResolver blk)
+  , EncodeDisk blk (PerasEpochContextResolver blk)
+  , DecodeDisk blk (PerasEpochContextResolver blk)
+  ) =>
+  StateSupportsPerasEpochContext blk
+  where
+  -- | Epoch-dependent information needed to resolve a 'PerasRoundNo' into its
+  -- corresponding 'PerasEpochContext'. In practice, this is always an
+  -- 'EpochToPerasRoundInfo', with the exception of the 'HardForkBlock', which
+  -- additionally takes advantage of the era index returned by
+  -- 'runQueryEraIndexed' to be able to dispatch to the correct era-specific
+  -- implementation.
+  type MaybeEraIndexedEpochToPerasRoundInfo blk :: Type
+
+  type MaybeEraIndexedEpochToPerasRoundInfo blk = EpochToPerasRoundInfo
+
+  -- | Extract a 'EpochToPerasRoundInfo' the opaque
+  -- 'MaybeEraIndexedEpochToPerasRoundInfo' of this block.
+  fromMaybeEraIndexedEpochToPerasRoundInfo ::
+    proxy blk ->
+    MaybeEraIndexedEpochToPerasRoundInfo blk ->
+    EpochToPerasRoundInfo
+  default fromMaybeEraIndexedEpochToPerasRoundInfo ::
+    MaybeEraIndexedEpochToPerasRoundInfo blk ~ EpochToPerasRoundInfo =>
+    proxy blk ->
+    MaybeEraIndexedEpochToPerasRoundInfo blk ->
+    EpochToPerasRoundInfo
+  fromMaybeEraIndexedEpochToPerasRoundInfo _ =
+    id
+
+  -- | Inject an era-indexed 'EpochToPerasRoundInfo' into an opaque
+  -- 'MaybeEraIndexedEpochToPerasRoundInfo' of this block.
+  toMaybeEraIndexedEpochToPerasRoundInfo ::
+    All Top (HardForkIndices blk) =>
+    proxy blk ->
+    EraIndexed (HardForkIndices blk) EpochToPerasRoundInfo ->
+    MaybeEraIndexedEpochToPerasRoundInfo blk
+  default toMaybeEraIndexedEpochToPerasRoundInfo ::
+    MaybeEraIndexedEpochToPerasRoundInfo blk ~ EpochToPerasRoundInfo =>
+    proxy blk ->
+    EraIndexed (HardForkIndices blk) EpochToPerasRoundInfo ->
+    MaybeEraIndexedEpochToPerasRoundInfo blk
+  toMaybeEraIndexedEpochToPerasRoundInfo _ =
+    forgetEraIndex
+
+  -- | Create a bounded epoch context from a given epoch-to-round info.
+  mkBoundedPerasEpochContext ::
+    ( LedgerStateSupportsPeras ledgerState
+    , ChainDepStateSupportsPeras chainDepState
+    ) =>
+    MaybeEraIndexedEpochToPerasRoundInfo blk ->
+    ledgerState EmptyMK ->
+    chainDepState ->
+    Either
+      (PerasError blk)
+      (BoundedPerasEpochContext blk)
+  default mkBoundedPerasEpochContext ::
+    MaybeEraIndexedEpochToPerasRoundInfo blk ->
+    ledgerState EmptyMK ->
+    chainDepState ->
+    Either
+      (PerasError blk)
+      (BoundedPerasEpochContext blk)
+  mkBoundedPerasEpochContext _ _ _ =
+    error
+      "mkBoundedPerasEpochContext: should never be called for this block type since it does not support Peras"
+
+-- | Helper to build a 'BoundedPerasEpochContext' using a function that produces
+-- a 'PerasVotingCommitteeInput' from a ledger and chain-dep state.
+--
+-- NOTE: this is useful to define instances for 'StateSupportsPerasEpochContext'
+-- where 'mkBoundedPerasEpochContext' is instantiated to either:
+--   * @mkBoundedPerasEpochContextWith mkMockPerasVotingCommitteeInput@ for test
+--     types with limited Peras support, and
+--   * @mkBoundedPerasEpochContextWith V1.mkPerasVotingCommitteeInput@ for
+--     production types.
+mkBoundedPerasEpochContextWith ::
+  ( LedgerStateSupportsPeras ledgerState
+  , ChainDepStateSupportsPeras chainDepState
+  , CryptoSupportsVotingCommittee (PerasCrypto blk) (PerasVotingCommitteeScheme blk)
+  , MaybeEraIndexedEpochToPerasRoundInfo blk ~ EpochToPerasRoundInfo
+  , IsPerasError (PerasError blk) blk
+  ) =>
+  ( ( LedgerStateSupportsPeras ledgerState
+    , ChainDepStateSupportsPeras chainDepState
+    ) =>
+    ledgerState EmptyMK ->
+    chainDepState ->
+    Either
+      (PerasError blk)
+      (PerasVotingCommitteeInput blk)
+  ) ->
+  MaybeEraIndexedEpochToPerasRoundInfo blk ->
+  ledgerState EmptyMK ->
+  chainDepState ->
+  Either
+    (PerasError blk)
+    (BoundedPerasEpochContext blk)
+mkBoundedPerasEpochContextWith
+  mkPerasVotingCommitteeInput
+  epochToRoundInfo
+  ledgerState
+  headerState = do
+    committeeInput <-
+      mkPerasVotingCommitteeInput ledgerState headerState
+    committee <-
+      bimap injectVotingCommitteeError id $
+        Committee.mkVotingCommittee committeeInput
+    let params =
+          getPerasParams Proxy ledgerState
+    pure
+      BoundedPerasEpochContext
+        { startPerasRoundNo =
+            etpriEpochStartPerasRound epochToRoundInfo
+        , endPerasRoundNo =
+            etpriEpochEndPerasRound epochToRoundInfo
+        , epochContext =
+            PerasEpochContext
+              { pecParams =
+                  params
+              , pecCommittee =
+                  committee
+              }
+        }
+
+-- | Initialize a 'PerasEpochContextResolver' from a ledger and header state.
+--
+-- NOTES:
+--   1. We may later decide that a 'PerasEpochContextResolver' is always
+--      initiated with empty/error value, and rely on the first ticking to
+--      properly initialize it. In the current architecture, however, that would
+--      work only if the first ticking happens when the previous slot is either
+--      'Origin', or a slot from a previous epoch compared to the target slot.
+--   2. Given that we have no assumption that (1) would work, we made a
+--      polymorphic system where a 'BoundedEpochContext' can be created from
+--      either a ticked or unticked ledger+header state
+--      (see 'LedgerStateSupportsPeras' and 'ChainDepStateSupportsPeras'
+--      helper classes). This way, a 'PerasEpochContextResolver' can be
+--      initialized from unticked 'LedgerState' and 'HeaderState', but then
+--      ticked by using the 'Ticked LedgerState' and 'Ticked HeaderState'.
+--   3. If in the future we move on to a system where the resolver is always
+--      initialized with empty/error value, we can remove the polymorphic system
+--      and only create a 'BoundedPerasEpochContext' from 'Ticked LedgerState'
+--      and 'Ticked HeaderState'.
+initPerasEpochContextResolver ::
+  ( All Top (HardForkIndices blk)
+  , StateSupportsPerasEpochContext blk
+  ) =>
+  LedgerConfig blk ->
+  LedgerState blk EmptyMK ->
+  HeaderState blk ->
+  PerasEpochContextResolver blk
+initPerasEpochContextResolver ledgerConfig ledgerState headerState =
+  case chainTipSlot of
+    Origin ->
+      newPerasEpochContextResolver NoPerasEnabled
+    NotOrigin slotNo ->
+      case resolveEpochToRoundInfo slotNo of
+        Left err ->
+          PerasEpochContextResolverError (show err)
+        Right eraIndexedEpochToPerasRoundInfo ->
+          embedBoundedEpochContext
+            newPerasEpochContextResolver
+            ledgerState
+            headerState
+            eraIndexedEpochToPerasRoundInfo
+ where
+  chainTipSlot =
+    fmap annTipSlotNo (headerStateTip headerState)
+  timeResolutionContext =
+    TimeResolutionContext ledgerConfig ledgerState
+  resolveEpochToRoundInfo slotNo = do
+    (epochNo, _) <-
+      runQueryWithContext
+        timeResolutionContext
+        (slotToEpoch' slotNo)
+    runQueryEraIndexedWithContext
+      timeResolutionContext
+      (epochToPerasRoundInfo epochNo)
+
+-- | Tick a 'PerasEpochContextResolver' to a target 'SlotNo'.
+--
+-- NOTES:
+--   1. To avoid circular dependencies, this function uses a deconstructed
+--      'ExtLedgerState' instead of the 'ExtLedgerState' itself.
+--   2. It doesn't seem to bring much to differentiate a
+--      'PerasEpochContextResolver' from a ticked one at type level, since they
+--      need to carry exactly the same information. We tried, and it didn't
+--      improve readability.
+tickPerasEpochContextResolver ::
+  ( All Top (HardForkIndices blk)
+  , StateSupportsPerasEpochContext blk
+  ) =>
+  LedgerConfig blk ->
+  -- | The fields needed from the previous 'ExtLedgerState' (before ticking)
+  (PerasEpochContextResolver blk, LedgerState blk EmptyMK, HeaderState blk) ->
+  -- | Target 'SlotNo' and fields of the 'Ticked ExtLedgerState' ticked to it
+  (SlotNo, Ticked LedgerState blk EmptyMK, Ticked (HeaderState blk)) ->
+  PerasEpochContextResolver blk
+tickPerasEpochContextResolver
+  ledgerConfig
+  (perasEpochContextResolver, ledgerState, headerState)
+  (targetSlot, tickedLedger, tickedHeader) =
+    case ( isNextEpoch
+             timeResolutionContext
+             chainTipSlot
+             targetSlot
+         ) of
+      Left err ->
+        error (show err)
+      Right SameEpoch ->
+        -- No epoch boundary was crossed: keep the current resolver as is.
+        perasEpochContextResolver
+      Right (NextEpoch eraIndexedEpochToPerasRoundInfo) ->
+        -- Exactly one epoch boundary was crossed: advance the two-epoch window
+        -- incrementally (the current context becomes the previous one).
+        embedBoundedEpochContext
+          (advancePerasEpochContextResolver perasEpochContextResolver)
+          tickedLedger
+          tickedHeader
+          eraIndexedEpochToPerasRoundInfo
+      Right (ManyEpochsCrossed eraIndexedEpochToPerasRoundInfo) ->
+        -- More than one epoch boundary was crossed at once, which is only
+        -- possible when the chain skips one or more entire epochs (e.g. a
+        -- sparse/empty chain, or a node ticking its ledger far ahead of its
+        -- tip). The two-epoch window cannot be advanced incrementally
+        -- across the gap, so we re-initialise it at the target epoch.
+        --
+        -- NOTE: this should be an impossible case in production, as we
+        -- expect at least one block per epoch. However, we still need to
+        -- handle this case in a way that doesn't break the more lenient
+        -- test suites, where we might tick the ledger far ahead of its tip.
+        -- See: https://github.com/tweag/cardano-peras/issues/260
+        embedBoundedEpochContext
+          newPerasEpochContextResolver
+          tickedLedger
+          tickedHeader
+          eraIndexedEpochToPerasRoundInfo
+   where
+    chainTipSlot =
+      fmap annTipSlotNo (headerStateTip headerState)
+    timeResolutionContext =
+      TimeResolutionContext ledgerConfig ledgerState
+
+-- | Build a 'PerasEpochContextResolver' from the per-era Peras info for an
+-- epoch, given a ledger and chain-dep state to derive the bounded epoch context
+-- from and a way to embed that context into the resolver.
+--
+-- NOTE: this captures the logic shared between initialising the resolver
+-- ('initPerasEpochContextResolver') and re-initialising or advancing it while
+-- ticking ('tickPerasEpochContextResolver').
+embedBoundedEpochContext ::
+  forall blk ledgerState chainDepState.
+  ( All Top (HardForkIndices blk)
+  , LedgerStateSupportsPeras ledgerState
+  , ChainDepStateSupportsPeras chainDepState
+  , StateSupportsPerasEpochContext blk
+  ) =>
+  -- | How to embed the (optional) fresh bounded epoch context into a resolver.
+  ( PerasEnabled (BoundedPerasEpochContext blk) ->
+    PerasEpochContextResolver blk
+  ) ->
+  ledgerState EmptyMK ->
+  chainDepState ->
+  EraIndexed (HardForkIndices blk) (PerasEnabled EpochToPerasRoundInfo) ->
+  PerasEpochContextResolver blk
+embedBoundedEpochContext
+  embed
+  ledgerState
+  chainDepState
+  eraIndexedEpochToRoundInfo =
+    case collapseEraIndexed eraIndexedEpochToRoundInfo of
+      PerasEnabled eiEpochToPerasRoundInfo ->
+        case ( mkBoundedPerasEpochContext
+                 ( toMaybeEraIndexedEpochToPerasRoundInfo
+                     (Proxy @blk)
+                     eiEpochToPerasRoundInfo
+                 )
+                 ledgerState
+                 chainDepState
+             ) of
+          Left err ->
+            PerasEpochContextResolverError (show err)
+          Right boundedContext ->
+            embed (PerasEnabled boundedContext)
+      NoPerasEnabled ->
+        embed NoPerasEnabled
+   where
+    -- Swap the positions of the 'EraIndexed' and 'PerasEnabled' wrappers, so we
+    -- can directly pattern-match on the 'PerasEnabled' information.
+    collapseEraIndexed ::
+      All Top xs =>
+      EraIndexed xs (PerasEnabled a) ->
+      PerasEnabled (EraIndexed xs a)
+    collapseEraIndexed (EraIndexed ns) =
+      hcollapse $
+        himap
+          ( \idx (K pea) ->
+              case pea of
+                PerasEnabled a ->
+                  K (PerasEnabled (EraIndexed (injectNS idx (K a))))
+                NoPerasEnabled ->
+                  K NoPerasEnabled
+          )
+          ns
+
+-- * Time resolution
+
+-- | Data needed to run time-dependent queries.
+--
+-- NOTE: this is existential on the 'MapKind' of the ledger state, as we really
+-- don't care about it for the purpose of time resolution.
+data TimeResolutionContext blk where
+  TimeResolutionContext ::
+    forall blk mk.
+    LedgerConfig blk ->
+    LedgerState blk mk ->
+    TimeResolutionContext blk
+
+-- | Wrapper over 'runQuery' that uses a 'TimeResolutionContext' to build a
+-- 'Summary'.
+runQueryWithContext ::
+  HasHardForkHistory blk =>
+  TimeResolutionContext blk ->
+  Qry a ->
+  Either PastHorizonException a
+runQueryWithContext (TimeResolutionContext cfg state) qry =
+  runQuery qry (hardForkSummary cfg state)
+
+-- | Wrapper over 'runQueryEraIndexed' that uses a 'TimeResolutionContext' to
+-- build a 'Summary'.
+runQueryEraIndexedWithContext ::
+  HasHardForkHistory blk =>
+  TimeResolutionContext blk ->
+  Qry a ->
+  Either PastHorizonException (EraIndexed (HardForkIndices blk) a)
+runQueryEraIndexedWithContext (TimeResolutionContext cfg state) qry =
+  runQueryEraIndexed qry (hardForkSummary cfg state)
+
+-- | A handle to an STM action that returns a 'TimeResolutionContext'.
+newtype TimeResolutionContextHandle m blk
+  = TimeResolutionContextHandle
+  { getTimeResolutionContext :: STM m (TimeResolutionContext blk)
+  }
+
+-- | Helper to run a time-dependent query using a 'TimeResolutionContextHandle'.
+runQueryWithContextHandle ::
+  (HasHardForkHistory blk, MonadSTM m) =>
+  TimeResolutionContextHandle m blk ->
+  Qry a ->
+  STM m (Either PastHorizonException a)
+runQueryWithContextHandle handle qry = do
+  context <- getTimeResolutionContext handle
+  pure (runQueryWithContext context qry)
+
+-- * Next-epoch detection
+
+-- | The outcome of comparing the epoch of a previous slot with the epoch of a
+-- target slot when ticking the ledger, discriminated by how many epoch
+-- boundaries were crossed. This drives how the Peras epoch-context resolver is
+-- updated.
+data EpochCrossing a
+  = -- | The target slot is in the same epoch as the previous slot: no epoch
+    -- boundary was crossed.
+    SameEpoch
+  | -- | Exactly one epoch boundary was crossed. The resolver can be advanced
+    -- incrementally (the current context becomes the previous one).
+    NextEpoch !a
+  | -- | More than one epoch boundary was crossed at once, i.e. the chain
+    -- skipped one or more entire epochs. This is only possible for a
+    -- sparse/empty chain, or when ticking the ledger far ahead of its tip. The
+    -- two-epoch window cannot be advanced incrementally across the gap, so the
+    -- resolver must be re-initialised at the target epoch instead.
+    ManyEpochsCrossed !a
+  deriving (Show, Functor, Foldable, Traversable)
+
+-- | Errors that can occur when detecting whether a target slot is in the next
+-- epoch compared to a previous slot.
+data DetectNextEpochError
+  = -- | Target slot is past the horizon of the given time resolution context.
+    DetectNextEpochPastHorizonError
+      PastHorizonException
+  | -- | Target slot is in the past compared to the previous slot.
+    DetectNextEpochNewSlotInPast
+      -- Previous slot.
+      !SlotNo
+      -- Epoch of the previous slot.
+      !EpochNo
+      -- Target slot.
+      !SlotNo
+      -- Epoch of the target slot.
+      !EpochNo
+  deriving (Show, Exception)
+
+-- | Determine whether a target slot is in the next epoch compared to a previous
+-- slot, and if so, how many epoch boundaries were crossed.
+isNextEpoch ::
+  HasHardForkHistory blk =>
+  TimeResolutionContext blk ->
+  WithOrigin SlotNo ->
+  SlotNo ->
+  Either
+    DetectNextEpochError
+    ( EpochCrossing
+        ( EraIndexed
+            (HardForkIndices blk)
+            (PerasEnabled EpochToPerasRoundInfo)
+        )
+    )
+isNextEpoch context mbPrevSlot nextSlot = do
+  resolveEpochCrossing >>= traverse resolvePerasInfoForEpoch
+ where
+  slotToEpochOrError slot =
+    bimap DetectNextEpochPastHorizonError fst $
+      runQueryWithContext context $
+        slotToEpoch' slot
+
+  resolvePerasInfoForEpoch epochNo =
+    bimap DetectNextEpochPastHorizonError id $
+      runQueryEraIndexedWithContext context (epochToPerasRoundInfo epochNo)
+
+  resolveEpochCrossing =
+    case mbPrevSlot of
+      Origin -> do
+        nextEpoch <- slotToEpochOrError nextSlot
+        if
+          | EpochNo 0 <- nextEpoch ->
+              Right (NextEpoch nextEpoch)
+          | otherwise ->
+              Right (ManyEpochsCrossed nextEpoch)
+      NotOrigin prevSlot -> do
+        prevEpoch <- slotToEpochOrError prevSlot
+        nextEpoch <- slotToEpochOrError nextSlot
+        if
+          | prevEpoch == nextEpoch ->
+              Right SameEpoch
+          | prevEpoch < nextEpoch ->
+              if EpochNo (unEpochNo prevEpoch + 1) == nextEpoch
+                then Right (NextEpoch nextEpoch)
+                else Right (ManyEpochsCrossed nextEpoch)
+          | otherwise ->
+              Left
+                ( DetectNextEpochNewSlotInPast
+                    prevSlot
+                    prevEpoch
+                    nextSlot
+                    nextEpoch
+                )


### PR DESCRIPTION
This PR introduces the `Ouroboros.Consensus.Peras.Context` module, providing the machinery needed to resolve Peras round numbers into their epoch-dependent context (voting committee and Peras parameters):

- `BoundedPerasEpochContext`: a `PerasEpochContext` tagged with the range of round numbers over which it is valid, plus the `withinEpochContext` lookup.
- `PerasEpochContextResolver`: a two-epoch (current + previous) sliding window of epoch contexts that resolves a round number to its context, with a dedicated error state for recoverable failures. `initPerasEpochContextResolver` and `tickPerasEpochContextResolver` build and advance the window (at most one epoch per step), and `StateSupportsPerasEpochContext` / `mkBoundedPerasEpochContextWith` extract contexts from the node state.
- `PerasEpochContextResolverHandle` (with a mock implementation) and `resolveRoundNo` / `withResolvedRoundNo` for consuming resolved contexts in `STM`.
- `TimeResolutionContext` and helpers (`runQueryWithContext`, `runQueryEraIndexedWithContext`, and their handle-based variants) to run hard fork history queries against the ledger state.

The changes in `Block.SupportsPeras` reorganise the module exports and introduce the `PerasEpochContext` type together with the `PerasCrypto`/`PerasVotingCommitteeScheme`/`PerasError` associated types in anticipation of an upcoming refactor of the `BlockSupportsPeras` type class.