### PR TITLE
[Peras 45] Introduce Peras type family wrappers for the HFC

### DIFF
--- a/changelog.d/20260731_134424_agustin.mista_type_family_wrappers.md
+++ b/changelog.d/20260731_134424_agustin.mista_type_family_wrappers.md
@@ -1,0 +1,22 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+<!--
+### Breaking
+
+- A bullet item for the Breaking category.
+
+-->
+### Non-Breaking
+
+- Introduce Peras type family wrappers (`WrapPerasVote`, `WrapPerasCert`, `WrapPerasError`, `WrapPerasCrypto`, `WrapPerasVotingCommitteeScheme`, `WrapPerasPrivateKey` and `WrapPerasVotingCommittee`) for the HFC.
+<!--
+### Patch
+
+- A bullet item for the Patch category.
+
+-->

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/TypeFamilyWrappers.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/TypeFamilyWrappers.hs
@@ -1,5 +1,9 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -27,6 +31,13 @@ module Ouroboros.Consensus.TypeFamilyWrappers
   , WrapTxMeasurePhase2 (..)
   , WrapTxOut (..)
   , WrapValidatedGenTx (..)
+  , WrapPerasVote (..)
+  , WrapPerasCert (..)
+  , WrapPerasError (..)
+  , WrapPerasCrypto (..)
+  , WrapPerasVotingCommitteeScheme (..)
+  , WrapPerasPrivateKey (..)
+  , WrapPerasVotingCommittee (..)
 
     -- * Protocol based
   , WrapCanBeLeader (..)
@@ -48,9 +59,15 @@ module Ouroboros.Consensus.TypeFamilyWrappers
   , Ticked (..)
   ) where
 
+import Cardano.Binary (FromCBOR, ToCBOR)
 import Codec.Serialise (Serialise)
+import Control.Exception (Exception)
+import Data.Typeable (Typeable)
+import GHC.Generics (Generic)
 import NoThunks.Class (NoThunks)
 import Ouroboros.Consensus.Block
+import Ouroboros.Consensus.Committee.Class (VotingCommittee)
+import Ouroboros.Consensus.Committee.Crypto (PrivateKey)
 import Ouroboros.Consensus.HeaderValidation
 import Ouroboros.Consensus.Ledger.Abstract
 import Ouroboros.Consensus.Ledger.Inspect
@@ -111,6 +128,161 @@ newtype WrapValidateView blk = WrapValidateView {unwrapValidateView :: ValidateV
 newtype WrapValidationErr blk = WrapValidationErr {unwrapValidationErr :: ValidationErr (BlockProtocol blk)}
 
 newtype WrapReasonForSwitch blk = WrapReasonForSwitch {unwrapReasonForSwitch :: ReasonForSwitch (WrapTiebreakerView blk)}
+
+{-------------------------------------------------------------------------------
+  Peras
+-------------------------------------------------------------------------------}
+
+newtype WrapPerasVote blk
+  = WrapPerasVote
+  { unwrapPerasVote ::
+      PerasVote blk
+  }
+
+deriving instance
+  Show (PerasVote blk) =>
+  Show (WrapPerasVote blk)
+deriving instance
+  Eq (PerasVote blk) =>
+  Eq (WrapPerasVote blk)
+deriving instance
+  NoThunks (PerasVote blk) =>
+  NoThunks (WrapPerasVote blk)
+deriving instance
+  Generic (WrapPerasVote blk)
+
+newtype WrapPerasCert blk
+  = WrapPerasCert
+  { unwrapPerasCert ::
+      PerasCert blk
+  }
+
+deriving instance
+  Show (PerasCert blk) =>
+  Show (WrapPerasCert blk)
+deriving instance
+  Eq (PerasCert blk) =>
+  Eq (WrapPerasCert blk)
+deriving instance
+  NoThunks (PerasCert blk) =>
+  NoThunks (WrapPerasCert blk)
+deriving instance
+  Generic (WrapPerasCert blk)
+
+newtype WrapPerasError blk
+  = WrapPerasError
+  { unwrapPerasError ::
+      PerasError blk
+  }
+
+deriving instance
+  Show (PerasError blk) =>
+  Show (WrapPerasError blk)
+deriving instance
+  Eq (PerasError blk) =>
+  Eq (WrapPerasError blk)
+deriving instance
+  NoThunks (PerasError blk) =>
+  NoThunks (WrapPerasError blk)
+deriving instance
+  Generic (WrapPerasError blk)
+deriving instance
+  ( Typeable blk
+  , Exception (PerasError blk)
+  ) =>
+  Exception (WrapPerasError blk)
+
+instance
+  IsPerasError (PerasError blk) blk =>
+  IsPerasError (WrapPerasError blk) blk
+  where
+  injectVotingCommitteeError = WrapPerasError . injectVotingCommitteeError
+  injectConversionError = WrapPerasError . injectConversionError
+  injectQuorumNotReachedError = WrapPerasError . injectQuorumNotReachedError
+
+newtype WrapPerasCrypto blk
+  = WrapPerasCrypto
+  { unwrapPerasCrypto ::
+      PerasCrypto blk
+  }
+
+deriving instance
+  Show (PerasCrypto blk) =>
+  Show (WrapPerasCrypto blk)
+deriving instance
+  Eq (PerasCrypto blk) =>
+  Eq (WrapPerasCrypto blk)
+deriving instance
+  NoThunks (PerasCrypto blk) =>
+  NoThunks (WrapPerasCrypto blk)
+deriving instance
+  Generic (WrapPerasCrypto blk)
+
+newtype WrapPerasVotingCommitteeScheme blk
+  = WrapPerasVotingCommitteeScheme
+  { unwrapPerasVotingCommitteeScheme ::
+      PerasVotingCommitteeScheme blk
+  }
+
+deriving instance
+  Show (PerasVotingCommitteeScheme blk) =>
+  Show (WrapPerasVotingCommitteeScheme blk)
+deriving instance
+  Eq (PerasVotingCommitteeScheme blk) =>
+  Eq (WrapPerasVotingCommitteeScheme blk)
+deriving instance
+  NoThunks (PerasVotingCommitteeScheme blk) =>
+  NoThunks (WrapPerasVotingCommitteeScheme blk)
+deriving instance
+  Generic (WrapPerasVotingCommitteeScheme blk)
+
+newtype WrapPerasPrivateKey blk
+  = WrapPerasPrivateKey
+  { unwrapPerasPrivateKey ::
+      PrivateKey (PerasCrypto blk)
+  }
+
+deriving instance
+  Show (PrivateKey (PerasCrypto blk)) =>
+  Show (WrapPerasPrivateKey blk)
+deriving instance
+  Eq (PrivateKey (PerasCrypto blk)) =>
+  Eq (WrapPerasPrivateKey blk)
+deriving instance
+  NoThunks (PrivateKey (PerasCrypto blk)) =>
+  NoThunks (WrapPerasPrivateKey blk)
+deriving instance
+  Generic (WrapPerasPrivateKey blk)
+
+newtype WrapPerasVotingCommittee blk
+  = WrapPerasVotingCommittee
+  { unwrapPerasVotingCommittee ::
+      VotingCommittee (PerasCrypto blk) (PerasVotingCommitteeScheme blk)
+  }
+
+deriving instance
+  Show (VotingCommittee (PerasCrypto blk) (PerasVotingCommitteeScheme blk)) =>
+  Show (WrapPerasVotingCommittee blk)
+deriving instance
+  Eq (VotingCommittee (PerasCrypto blk) (PerasVotingCommitteeScheme blk)) =>
+  Eq (WrapPerasVotingCommittee blk)
+deriving instance
+  NoThunks (VotingCommittee (PerasCrypto blk) (PerasVotingCommitteeScheme blk)) =>
+  NoThunks (WrapPerasVotingCommittee blk)
+deriving instance
+  Generic (WrapPerasVotingCommittee blk)
+
+deriving newtype instance
+  ( Typeable blk
+  , FromCBOR (VotingCommittee (PerasCrypto blk) (PerasVotingCommitteeScheme blk))
+  ) =>
+  FromCBOR (WrapPerasVotingCommittee blk)
+
+deriving newtype instance
+  ( Typeable blk
+  , ToCBOR (VotingCommittee (PerasCrypto blk) (PerasVotingCommitteeScheme blk))
+  ) =>
+  ToCBOR (WrapPerasVotingCommittee blk)
 
 {-------------------------------------------------------------------------------
   Versioning


### PR DESCRIPTION
This PR adds newtype wrappers around the per-block Peras type families that need to interact with the HFC, mirroring the existing pattern used in TypeFamilyWrappers.