### PR TITLE
[Peras 47] Introduce OneEraPeras type wrappers 

### DIFF
--- a/changelog.d/20260731_160723_agustin.mista_across_eras_wrappers.md
+++ b/changelog.d/20260731_160723_agustin.mista_across_eras_wrappers.md
@@ -1,0 +1,31 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+<!--
+### Breaking
+
+- A bullet item for the Breaking category.
+
+-->
+<!--
+### Non-Breaking
+
+- A bullet item for the Non-Breaking category.
+
+-->
+### Non-Breaking
+
+- Introduce the `OneEraPeras` HFC wrapper types (`OneEraPerasVote`, `OneEraPerasCert`, `OneEraPerasError`, `OneEraPerasCrypto`, `OneEraPerasVotingCommitteeScheme`)
+- Introduce `PerEraPerasPrivateKey` type.
+- Introduce `HardForkPerasError` type.
+- Move n-ary sum serialisers `encodeNS`/`decodeNS` from `Ouroboros.Consensus.HardFork.Combinator.Serialisation.Common` to `Ouroboros.Consensus.HardFork.Combinator.AcrossEras` (still re-exported from `Common`).
+<!--
+### Patch
+
+- A bullet item for the Patch category.
+
+-->

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/AcrossEras.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/AcrossEras.hs
@@ -1,13 +1,17 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
@@ -20,6 +24,7 @@ module Ouroboros.Consensus.HardFork.Combinator.AcrossEras
   , PerEraConsensusConfig (..)
   , PerEraLedgerConfig (..)
   , PerEraStorageConfig (..)
+  , PerEraPerasPrivateKey (..)
 
     -- * Values for /some/ eras
   , SomeErasCanBeLeader (..)
@@ -48,6 +53,17 @@ module Ouroboros.Consensus.HardFork.Combinator.AcrossEras
   , OneEraValidateView (..)
   , OneEraValidatedGenTx (..)
   , OneEraValidationErr (..)
+  , OneEraPerasVote (..)
+  , OneEraPerasCert (..)
+  , OneEraPerasError (..)
+  , HardForkPerasError (..)
+  , OneEraPerasCrypto (..)
+  , OneEraPerasVotingCommitteeScheme (..)
+  , VotingCommittee (..)
+
+    -- * Serialisation of n-ary sums
+  , decodeNS
+  , encodeNS
 
     -- * Value for two /different/ eras
   , EraMismatch (..)
@@ -61,9 +77,14 @@ module Ouroboros.Consensus.HardFork.Combinator.AcrossEras
   , oneEraBlockHeader
   ) where
 
-import Cardano.Binary (FromCBOR (..), ToCBOR (..))
+import Cardano.Binary (FromCBOR (..), ToCBOR (..), enforceSize)
+import Codec.CBOR.Decoding (Decoder)
+import qualified Codec.CBOR.Decoding as Dec
+import Codec.CBOR.Encoding (Encoding)
+import qualified Codec.CBOR.Encoding as Enc
 import Codec.Serialise (Serialise (..))
 import Control.DeepSeq (NFData)
+import Control.Exception (Exception)
 import Control.Monad.Except (throwError)
 import qualified Data.ByteString.Base16 as B16
 import qualified Data.ByteString.Char8 as BSC
@@ -72,16 +93,20 @@ import qualified Data.ByteString.Short as Short
 import Data.Proxy
 import Data.SOP.BasicFunctors
 import Data.SOP.Constraint
+import Data.SOP.Index (Index, hizipWith, injectNS, nsFromIndex, nsToIndex)
 import Data.SOP.Match (Mismatch)
 import qualified Data.SOP.Match as Match
 import Data.SOP.OptNP (NonEmptyOptNP)
 import Data.SOP.Strict
 import Data.Text (Text)
+import Data.Typeable (Typeable)
 import Data.Void
 import GHC.Generics (Generic)
 import GHC.Stack
 import NoThunks.Class (NoThunks)
 import Ouroboros.Consensus.Block.Abstract
+import Ouroboros.Consensus.Committee.Class (VotingCommittee)
+import Ouroboros.Consensus.Committee.Crypto (PrivateKey)
 import Ouroboros.Consensus.HardFork.Combinator.Abstract
 import Ouroboros.Consensus.HardFork.Combinator.Info
 import Ouroboros.Consensus.HardFork.Combinator.Lifting
@@ -89,9 +114,48 @@ import Ouroboros.Consensus.HardFork.Combinator.PartialConfig
 import Ouroboros.Consensus.HardFork.Combinator.Protocol.ChainSel
 import Ouroboros.Consensus.Ledger.SupportsMempool
 import Ouroboros.Consensus.TypeFamilyWrappers
-import Ouroboros.Consensus.Util (allEqual)
+import Ouroboros.Consensus.Util (ShowProxy, allEqual)
 import Ouroboros.Consensus.Util.Assert
 import Ouroboros.Consensus.Util.Condense (Condense (..))
+
+{-------------------------------------------------------------------------------
+  Serialisation of n-ary sums ('NS')
+
+  Generic CBOR (de)serialisation of an 'NS': a length-2 list holding the 'Word8'
+  era index followed by the selected era's payload.
+-------------------------------------------------------------------------------}
+
+encodeNS ::
+  SListI xs =>
+  NP (f -.-> K Encoding) xs ->
+  NS f xs ->
+  Encoding
+encodeNS es ns =
+  mconcat
+    [ Enc.encodeListLen 2
+    , Enc.encodeWord8 (nsToIndex ns)
+    , hcollapse (hzipWith apFn es ns)
+    ]
+
+decodeNS ::
+  forall xs f s.
+  SListI xs =>
+  NP (Decoder s :.: f) xs ->
+  Decoder s (NS f xs)
+decodeNS ds = do
+  enforceSize "decodeNS" 2
+  i <- Dec.decodeWord8
+  case nsFromIndex i of
+    Nothing -> fail ("decodeNS: invalid index " <> show i)
+    Just ns -> hcollapse (hizipWith aux ds ns)
+ where
+  aux ::
+    Index xs blk ->
+    (Decoder s :.: f) blk ->
+    K () blk ->
+    K (Decoder s (NS f xs)) blk
+  aux index (Comp dec) (K ()) =
+    K (injectNS index <$> dec)
 
 {-------------------------------------------------------------------------------
   Value for /each/ era
@@ -103,6 +167,16 @@ newtype PerEraCodecConfig xs = PerEraCodecConfig {getPerEraCodecConfig :: NP Cod
 newtype PerEraConsensusConfig xs = PerEraConsensusConfig {getPerEraConsensusConfig :: NP WrapPartialConsensusConfig xs}
 newtype PerEraLedgerConfig xs = PerEraLedgerConfig {getPerEraLedgerConfig :: NP WrapPartialLedgerConfig xs}
 newtype PerEraStorageConfig xs = PerEraStorageConfig {getPerEraStorageConfig :: NP StorageConfig xs}
+
+-- * Peras-specific types
+
+newtype PerEraPerasPrivateKey xs
+  = PerEraPerasPrivateKey
+  { getPerEraPerasPrivateKey ::
+      NP WrapPerasPrivateKey xs
+  }
+
+type instance PrivateKey (OneEraPerasCrypto xs) = PerEraPerasPrivateKey xs
 
 {-------------------------------------------------------------------------------
   Values for /some/ eras
@@ -139,6 +213,214 @@ newtype OneEraTipInfo xs = OneEraTipInfo {getOneEraTipInfo :: NS WrapTipInfo xs}
 newtype OneEraValidateView xs = OneEraValidateView {getOneEraValidateView :: NS WrapValidateView xs}
 newtype OneEraValidatedGenTx xs = OneEraValidatedGenTx {getOneEraValidatedGenTx :: NS WrapValidatedGenTx xs}
 newtype OneEraValidationErr xs = OneEraValidationErr {getOneEraValidationErr :: NS WrapValidationErr xs}
+
+-- ** Peras-specific types
+
+newtype OneEraPerasVote xs
+  = OneEraPerasVote
+  { getOneEraPerasVote ::
+      NS WrapPerasVote xs
+  }
+
+deriving via
+  LiftNS WrapPerasVote xs
+  instance
+    CanHardFork xs =>
+    Show (OneEraPerasVote xs)
+deriving via
+  LiftNS WrapPerasVote xs
+  instance
+    CanHardFork xs =>
+    Eq (OneEraPerasVote xs)
+deriving via
+  LiftNamedNS "OneEraPerasVote" WrapPerasVote xs
+  instance
+    CanHardFork xs =>
+    NoThunks (OneEraPerasVote xs)
+deriving instance
+  Generic (OneEraPerasVote xs)
+instance
+  Typeable xs =>
+  ShowProxy (OneEraPerasVote xs)
+
+newtype OneEraPerasCert xs
+  = OneEraPerasCert
+  { getOneEraPerasCert ::
+      NS WrapPerasCert xs
+  }
+
+deriving via
+  LiftNS WrapPerasCert xs
+  instance
+    CanHardFork xs =>
+    Show (OneEraPerasCert xs)
+deriving via
+  LiftNS WrapPerasCert xs
+  instance
+    CanHardFork xs =>
+    Eq (OneEraPerasCert xs)
+deriving via
+  LiftNamedNS "OneEraPerasCert" WrapPerasCert xs
+  instance
+    CanHardFork xs =>
+    NoThunks (OneEraPerasCert xs)
+deriving instance
+  Generic (OneEraPerasCert xs)
+instance
+  Typeable xs =>
+  ShowProxy (OneEraPerasCert xs)
+
+newtype OneEraPerasError xs
+  = OneEraPerasError
+  { getOneEraPerasError ::
+      NS
+        WrapPerasError
+        xs
+  }
+
+deriving via
+  LiftNS WrapPerasError xs
+  instance
+    CanHardFork xs =>
+    Show (OneEraPerasError xs)
+deriving via
+  LiftNS WrapPerasError xs
+  instance
+    CanHardFork xs =>
+    Eq (OneEraPerasError xs)
+deriving via
+  LiftNamedNS "OneEraPerasError" WrapPerasError xs
+  instance
+    CanHardFork xs =>
+    NoThunks (OneEraPerasError xs)
+deriving instance
+  Generic (OneEraPerasError xs)
+instance
+  CanHardFork xs =>
+  Exception (OneEraPerasError xs)
+
+data HardForkPerasError xs
+  = HardForkPerasErrorEraMismatch
+  | HardForkPerasErrorOneEraPerasError (OneEraPerasError xs)
+  | -- | Should never be produced in practice, since we dispatch to a concrete
+    -- era before calling any fallible operation.
+    HardForkPerasErrorConversionError
+  | -- | Should never be produced in practice, since we dispatch to a concrete
+    -- era before calling any fallible operation.
+    HardForkPerasErrorQuorumNotReachedError
+  | -- | Should never be produced in practice, since we dispatch to a concrete
+    -- era before calling any fallible operation.
+    HardForkPerasErrorCommitteeError
+
+deriving instance
+  Show (OneEraPerasError xs) =>
+  Show (HardForkPerasError xs)
+deriving instance
+  Eq (OneEraPerasError xs) =>
+  Eq (HardForkPerasError xs)
+deriving instance
+  NoThunks (OneEraPerasError xs) =>
+  NoThunks (HardForkPerasError xs)
+deriving instance
+  Generic (HardForkPerasError xs)
+instance
+  CanHardFork xs =>
+  Exception (HardForkPerasError xs)
+
+newtype OneEraPerasCrypto xs
+  = OneEraPerasCrypto
+  { getOneEraPerasCrypto ::
+      NS WrapPerasCrypto xs
+  }
+
+deriving via
+  LiftNS WrapPerasCrypto xs
+  instance
+    CanHardFork xs =>
+    Show (OneEraPerasCrypto xs)
+deriving via
+  LiftNS WrapPerasCrypto xs
+  instance
+    CanHardFork xs =>
+    Eq (OneEraPerasCrypto xs)
+deriving via
+  LiftNamedNS "OneEraPerasCrypto" WrapPerasCrypto xs
+  instance
+    CanHardFork xs =>
+    NoThunks (OneEraPerasCrypto xs)
+deriving instance
+  Generic (OneEraPerasCrypto xs)
+
+newtype OneEraPerasVotingCommitteeScheme xs
+  = OneEraPerasVotingCommitteeScheme
+  { getOneEraPerasVotingCommitteeScheme ::
+      NS WrapPerasVotingCommitteeScheme xs
+  }
+
+deriving via
+  LiftNS WrapPerasVotingCommitteeScheme xs
+  instance
+    CanHardFork xs =>
+    Show (OneEraPerasVotingCommitteeScheme xs)
+deriving via
+  LiftNS WrapPerasVotingCommitteeScheme xs
+  instance
+    CanHardFork xs =>
+    Eq (OneEraPerasVotingCommitteeScheme xs)
+deriving via
+  LiftNamedNS "OneEraPerasVotingCommitteeScheme" WrapPerasVotingCommitteeScheme xs
+  instance
+    CanHardFork xs =>
+    NoThunks (OneEraPerasVotingCommitteeScheme xs)
+deriving instance
+  Generic (OneEraPerasVotingCommitteeScheme xs)
+
+newtype instance VotingCommittee (OneEraPerasCrypto xs) (OneEraPerasVotingCommitteeScheme xs)
+  = OneEraPerasVotingCommittee
+  { getOneEraPerasVotingCommittee ::
+      NS WrapPerasVotingCommittee xs
+  }
+
+deriving via
+  LiftNS WrapPerasVotingCommittee xs
+  instance
+    CanHardFork xs =>
+    Show (VotingCommittee (OneEraPerasCrypto xs) (OneEraPerasVotingCommitteeScheme xs))
+deriving via
+  LiftNS WrapPerasVotingCommittee xs
+  instance
+    CanHardFork xs =>
+    Eq (VotingCommittee (OneEraPerasCrypto xs) (OneEraPerasVotingCommitteeScheme xs))
+deriving via
+  LiftNamedNS "OneEraPerasVotingCommittee" WrapPerasVotingCommittee xs
+  instance
+    CanHardFork xs =>
+    NoThunks (VotingCommittee (OneEraPerasCrypto xs) (OneEraPerasVotingCommitteeScheme xs))
+deriving instance
+  Generic (VotingCommittee (OneEraPerasCrypto xs) (OneEraPerasVotingCommitteeScheme xs))
+
+-- | Hand-written rather than @deriving via SerialiseNS@: that derivation needs
+-- @All (Compose Serialise WrapPerasVotingCommittee) xs@, which GHC cannot solve
+-- from the @CanHardFork xs@ (i.e. @All SingleEraBlock xs@) context for an
+-- abstract @xs@. We instead build the per-era codecs with @hcpure proxySingle@,
+-- where each era's @Serialise (WrapPerasVotingCommittee blk)@ is reachable from
+-- @SingleEraBlock blk@ via its @StateSupportsPerasEpochContext@ superclass, and
+-- feed them to 'encodeNS' and 'decodeNS', producing the same wire format a
+-- @SerialiseNS@ derivation would.
+instance
+  CanHardFork xs =>
+  FromCBOR (VotingCommittee (OneEraPerasCrypto xs) (OneEraPerasVotingCommitteeScheme xs))
+  where
+  fromCBOR =
+    OneEraPerasVotingCommittee
+      <$> decodeNS (hcpure proxySingle (Comp fromCBOR))
+
+instance
+  CanHardFork xs =>
+  ToCBOR (VotingCommittee (OneEraPerasCrypto xs) (OneEraPerasVotingCommitteeScheme xs))
+  where
+  toCBOR (OneEraPerasVotingCommittee ns) =
+    encodeNS (hcpure proxySingle (fn (K . toCBOR))) ns
 
 {-------------------------------------------------------------------------------
   Hash

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Serialisation/Common.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Serialisation/Common.hs
@@ -409,29 +409,6 @@ decodeTelescope = \ds -> do
   Serialisation of sums
 -------------------------------------------------------------------------------}
 
-encodeNS :: SListI xs => NP (f -.-> K Encoding) xs -> NS f xs -> Encoding
-encodeNS es ns =
-  mconcat
-    [ Enc.encodeListLen 2
-    , Enc.encodeWord8 $ nsToIndex ns
-    , hcollapse $ hzipWith apFn es ns
-    ]
-
-decodeNS :: forall xs f s. SListI xs => NP (Decoder s :.: f) xs -> Decoder s (NS f xs)
-decodeNS ds = do
-  enforceSize "decodeNS" 2
-  i <- Dec.decodeWord8
-  case nsFromIndex i of
-    Nothing -> fail $ "decodeNS: invalid index " ++ show i
-    Just ns -> hcollapse $ hizipWith aux ds ns
- where
-  aux ::
-    Index xs blk ->
-    (Decoder s :.: f) blk ->
-    K () blk ->
-    K (Decoder s (NS f xs)) blk
-  aux index (Comp dec) (K ()) = K $ injectNS index <$> dec
-
 decodeAnnNS ::
   forall xs f.
   SListI xs =>


### PR DESCRIPTION
This PR introduces the `OneEraPeras*` HFC wrapper types that lift per-era Peras objects across eras: `OneEraPerasVote`, `OneEraPerasCert`, `OneEraPerasError`, `OneEraPerasCrypto` and `OneEraPerasVotingCommitteeScheme`, together with the `VotingCommittee` instance for `OneEraPerasCrypto`/`OneEraPerasVotingCommitteeScheme`, the `HardForkPerasError` sum type and the `PerEraPerasPrivateKey` type.

NOTE: we also moved the generic n-ary sum CBOR (de)serialisers
(`encodeNS` and `decodeNS`) from `O.C.HardFork.Combinator.Serialisation.Common` into
`O.C.HardFork.Combinator.AcrossEras` (still re-exported from `Common`), so that instances sitting upstream of `Common` (e.g. the `VotingCommittee` CBOR ones) can reuse them.