### PR TITLE
nix: keep the dev shell available on non-Linux platforms

### DIFF
--- a/changelog.d/20260731_230000_russoul_macos_nix_develop_devshell.md
+++ b/changelog.d/20260731_230000_russoul_macos_nix_develop_devshell.md
@@ -1,0 +1,24 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+<!--
+### Breaking
+
+- A bullet item for the Breaking category.
+
+-->
+
+<!--
+### Non-Breaking
+
+- A bullet item for the Non-Breaking category.
+
+-->
+
+### Patch
+
+- Fixed `nix develop` (and `devShells.default`/`ghc96` in general) being broken on non-Linux platforms (e.g. macOS/`aarch64-darwin`). The `exesOnly` CI-cost-reduction path in `nix/ci.nix` was accidentally also removing the `devShell` output on those platforms. The dev shell is now always available, while Hydra's `required` aggregate still excludes it on non-Linux platforms exactly as before, so CI build cost is unaffected.

--- a/nix/ci.nix
+++ b/nix/ci.nix
@@ -8,7 +8,9 @@ let
   # When `exesOnly` is set, only the (distributed) executables are built. This
   # is used for non-Linux platforms (macOS and the Windows cross), where we only
   # want to ensure that the executables we distribute are buildable, and skip
-  # the libraries, tests, benchmarks and dev shells to reduce CI load.
+  # the libraries, tests and benchmarks to reduce CI load. The dev shell is
+  # still made available here (for `nix develop` on those platforms), but is
+  # excluded from `required` below so Hydra doesn't build it there.
   mkHaskellJobsFor = { exesOnly ? false }: hsPkgs:
     let
       projectHsPkgs =
@@ -30,7 +32,7 @@ let
             (lib.filterAttrs (_: isCardanoExe)
               (haskellLib.mkFlakePackages projectHsPkgsNoAsserts)));
     in
-    if exesOnly then {
+    (if exesOnly then {
       inherit exesNoAsserts;
     } else {
       build =
@@ -38,7 +40,7 @@ let
       checks =
         haskellLib.mkFlakeChecks (haskellLib.collectChecks' projectHsPkgs);
       inherit exesNoAsserts;
-    } // lib.optionalAttrs noCross {
+    }) // lib.optionalAttrs noCross {
       devShell =
         import ./shell.nix { inherit inputs pkgs hsPkgs; };
     };
@@ -48,7 +50,8 @@ let
   jobs = lib.filterAttrsRecursive (n: v: n != "recurseForDerivations") ({
     native = {
       # On Linux we build everything; on other platforms (i.e. macOS) we only
-      # build the distributed executables.
+      # build the distributed executables (the dev shell is still exposed for
+      # local use, see `mkHaskellJobsFor` above and `jobsForRequired` below).
       haskell96 = mkHaskellJobsFor { exesOnly = !isLinux; } pkgs.hsPkgs;
     } // lib.optionalAttrs isLinux {
       formattingLinting = import ./formatting-linting.nix pkgs;
@@ -67,11 +70,23 @@ let
     };
   });
 
+  # `required` (below) drives what Hydra actually forces the build of. Where
+  # `exesOnly` is set we don't want that to include the dev shell: it's
+  # exposed in `jobs` purely so `nix develop` resolves on those platforms
+  # (e.g. macOS), not so CI builds it too — that's exactly the cost `exesOnly`
+  # exists to avoid. So strip it back out for the purposes of `required` only.
+  jobsForRequired =
+    jobs // lib.optionalAttrs (!isLinux) {
+      native = jobs.native // {
+        haskell96 = removeAttrs jobs.native.haskell96 [ "devShell" ];
+      };
+    };
+
   require = jobs: pkgs.releaseTools.aggregate {
     name = "required-consensus";
     constituents = lib.collect lib.isDerivation jobs;
   };
 in
 jobs // {
-  required = lib.mapAttrs (_: require) jobs;
+  required = lib.mapAttrs (_: require) jobsForRequired;
 }


### PR DESCRIPTION
## Summary

`nix develop` (and `devShells.default`/`ghc96`) is currently broken on non-Linux platforms (e.g. macOS/`aarch64-darwin`):

```
error: attribute 'devShell' missing
at flake.nix:79:19:
    78|           default = ghc96;
    79|           ghc96 = hydraJobs.native.haskell96.devShell;
      |                   ^
```

This was introduced by the `exesOnly` CI-cost-reduction path added in `nix/ci.nix` (to only build the distributed executables on macOS/Windows-cross and skip libraries/tests/benchmarks). As written, `exesOnly` also happened to drop the `devShell` output entirely, but `flake.nix` unconditionally references `hydraJobs.native.haskell96.devShell`, so the flake fails to evaluate a dev shell at all on those platforms.

## Fix

- `mkHaskellJobsFor` now always attaches `devShell` when not cross-compiling, regardless of `exesOnly`.
- Since `exesOnly` exists specifically to reduce what Hydra is forced to build on non-Linux, a new `jobsForRequired` strips `devShell` back out of the `required` aggregate on non-Linux platforms, so Hydra's build set is unchanged from before this PR. The dev shell is only ever *evaluated*, not built by CI, on those platforms — same as today.

Verified via `nix eval` that on `aarch64-darwin`:
- `hydraJobs.native.haskell96` still contains `devShell`.
- `hydraJobs.required.native.constituents` is unchanged (still just the distributed executables, no dev shell).

And via `nix develop` locally on macOS, which now succeeds instead of failing at evaluation.