### PR TITLE
Leios: fix error handling in block validation

### DIFF
--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoTypes.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoTypes.hs
@@ -766,6 +766,34 @@ data VoteInvalid
   | SignerNotInCommittee
   deriving (Eq, Show)
 
+-- | Why a CertRB was rejected during ledger validation of its Leios
+-- certificate.
+--
+-- Enumerated rather than rendered to a 'String' so each case is a distinct,
+-- monitorable outcome (e.g. for Grafana) and carries enough context to diagnose
+-- without extra forensics. Temporary prototype stand-in: once the ledger
+-- interface is Leios-aware an invalid cert becomes expressible as an ordinary
+-- 'LedgerError', at which point this type (and the 'ExtValidationErrorLeios'
+-- constructor that wraps it) can be removed.
+data LeiosExtValidationError
+  = -- | The block carries a Leios cert but its predecessor announced no EB, so
+    -- there is nothing for the cert to certify.
+    LeiosCertificateWithoutAnnouncement !LeiosCert
+  | -- | A CertRB reached ledger validation in an era/state with no Leios
+    -- committee to verify the cert against.
+    LeiosMissingCommittee !LeiosPoint !LeiosCert
+  | -- | A CertRB whose announcing ranking block could not be determined; it
+    -- would be certifying against genesis.
+    LeiosCertificateAfterGenesis !LeiosCert !LeiosPoint
+  | -- | The certificate failed committee / threshold / signature verification.
+    LeiosInvalidCertificate !LeiosCert !LeiosPoint !RbHash !VerificationError
+  deriving stock (Eq, Show, Generic)
+
+deriving via
+  OnlyCheckWhnfNamed "LeiosExtValidationError" LeiosExtValidationError
+  instance
+    NoThunks LeiosExtValidationError
+
 -- * Era-level Leios dispatch
 
 -- | Per-era hooks for Leios voting and CertRB admission. Default

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Dual.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Dual.hs
@@ -545,6 +545,7 @@ dualExtValidationErrorMain ::
 dualExtValidationErrorMain = \case
   ExtValidationErrorLedger e -> ExtValidationErrorLedger (dualLedgerErrorMain e)
   ExtValidationErrorHeader e -> ExtValidationErrorHeader (castHeaderError e)
+  ExtValidationErrorLeios e -> ExtValidationErrorLeios e
 
 {-------------------------------------------------------------------------------
   LedgerSupportsProtocol

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Extended.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Extended.hs
@@ -60,6 +60,10 @@ import Ouroboros.Consensus.Util.IndexedMemPack
 data ExtValidationError blk
   = ExtValidationErrorLedger !(LedgerError blk)
   | ExtValidationErrorHeader !(HeaderError blk)
+  | -- | An invalid Leios certificate on a CertRB (e.g. 'InvalidSignature').
+    -- Kept as a 'String' (the rendered 'VoteInvalid') so it stays independent
+    -- of @blk@ and needs no extra instances on the cert-failure type.
+    ExtValidationErrorLeios !String
   deriving Generic
 
 deriving instance LedgerSupportsProtocol blk => Eq (ExtValidationError blk)

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Extended.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Extended.hs
@@ -43,6 +43,7 @@ import Data.Proxy
 import Data.Typeable
 import GHC.Generics (Generic)
 import GHC.Stack (HasCallStack)
+import LeiosDemoTypes (LeiosExtValidationError (..))
 import NoThunks.Class (NoThunks (..))
 import Ouroboros.Consensus.Block
 import Ouroboros.Consensus.Config
@@ -60,10 +61,14 @@ import Ouroboros.Consensus.Util.IndexedMemPack
 data ExtValidationError blk
   = ExtValidationErrorLedger !(LedgerError blk)
   | ExtValidationErrorHeader !(HeaderError blk)
-  | -- | An invalid Leios certificate on a CertRB (e.g. 'InvalidSignature').
-    -- Kept as a 'String' (the rendered 'VoteInvalid') so it stays independent
-    -- of @blk@ and needs no extra instances on the cert-failure type.
-    ExtValidationErrorLeios !String
+  | -- | A CertRB rejected during ledger validation of its Leios certificate.
+    -- The payload is 'blk'-independent (it references only the monomorphic
+    -- Leios types), so it needs no extra instances here.
+    --
+    -- TODO: temporary prototype stand-in. Once the ledger interface is Leios
+    -- aware, an invalid cert will be expressible as an ordinary 'LedgerError'
+    -- 'blk' and this constructor can be removed.
+    ExtValidationErrorLeios !LeiosExtValidationError
   deriving Generic
 
 deriving instance LedgerSupportsProtocol blk => Eq (ExtValidationError blk)

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/Forker.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/Forker.hs
@@ -83,6 +83,7 @@ import LeiosDemoTypes
   , EbHash
   , HasLeiosVoting (..)
   , LeiosCert
+  , LeiosExtValidationError (..)
   , LeiosPoint (..)
   , RbHash
   , minCertificationThreshold
@@ -513,19 +514,10 @@ applyBlock leiosDb evs cfg ap fo doResolveBlock = case ap of
             tip = castPoint $ getTip extSt
         case protocolStateLeiosAnnouncement @blk cds of
           Nothing ->
-            -- A reapplied CertRB was validated before, so its predecessor must
-            -- have announced an EB; reaching this means the chain-dep state is
-            -- inconsistent. Reject as an InvalidBlock rather than crash the node
-            -- (mirrors the ApplyVal path); the alternative hard 'error' would
-            -- take the whole node down on chain selection with no restart path.
-            pure
-              ( Left
-                  ( AnnLedgerError
-                      tip
-                      (blockRealPoint b)
-                      (ExtValidationErrorLeios "applyBlock: reapplied CertRB but its predecessor announced no EB")
-                  )
-              )
+            -- TODO: Ideally make this impossible to reach.
+            -- NOTE: We deliberately keep the 'error' call here because this
+            -- would point us to a bug in our currently running implementation.
+            error $ "applyBlock ReapplyVal: nothing announced!?"
           Just (announcedPoint, _) -> do
             let bKeys = castLedgerTables (getBlockKeySets b :: LedgerTables l KeysMK)
                 readTables = fmap castLedgerTables . forkerReadTables fo . castLedgerTables
@@ -584,18 +576,22 @@ applyBlock leiosDb evs cfg ap fo doResolveBlock = case ap of
         -- rules because step 2 involves an IO read of the LeiosDB
         -- which can't be interleaved with the pure STS evaluation.
         --
-        -- Every failure below is reachable from an adversarial block on chain
-        -- selection, so each rejects the CertRB as an InvalidBlock (via
-        -- 'rejectLeios') instead of crashing the node with a hard 'error':
-        -- ChainSel marks the block InvalidBlock and carries on.
+        -- 'rejectLeios' rejects the CertRB as an InvalidBlock (ChainSel marks it
+        -- InvalidBlock and carries on) rather than crashing the node with a hard
+        -- 'error'. Most of these failures should already have caused our node to
+        -- reject the 'MsgRollForward' header that first informed us of this
+        -- CertRB, so catching them here is belt-and-suspenders — but worthwhile,
+        -- because not all headers arrive via 'MsgRollForward' (e.g. a bug in our
+        -- own forging logic). The invalid-cert case below is the only one that
+        -- header validation could not have caught.
         let tip = castPoint $ getTip extSt
-            rejectLeios msg =
+            rejectLeios err =
               pure
                 ( Left
                     ( AnnLedgerError
                         tip
                         (blockRealPoint b)
-                        (ExtValidationErrorLeios msg)
+                        (ExtValidationErrorLeios err)
                     )
                 )
         case protocolStateLeiosAnnouncement @blk cds of
@@ -603,23 +599,24 @@ applyBlock leiosDb evs cfg ap fo doResolveBlock = case ap of
             -- A CertRB certifies an EB announced by its predecessor; if the
             -- parent's chain-dep state announced none, there is nothing to
             -- certify, so the block is invalid.
-            rejectLeios "applyBlock: CertRB but its predecessor announced no EB"
+            rejectLeios (LeiosCertificateWithoutAnnouncement cert)
           Just (announcedPoint, _) ->
             case getLeiosCommittee (ledgerState extSt) of
               Nothing ->
                 -- CertRB on an era without a Leios committee is itself a protocol
                 -- violation: the era machinery shouldn't have let one through.
-                rejectLeios "applyBlock: CertRB but no Leios committee for this era"
+                rejectLeios (LeiosMissingCommittee announcedPoint cert)
               Just cm ->
                 case announcingRbHash b of
                   Nothing ->
                     -- A CertRB always has a (non-genesis) announcing parent; if
-                    -- we cannot determine one, the block is malformed.
-                    rejectLeios "applyBlock: CertRB with no determinable announcing RB hash"
+                    -- we cannot determine one, it would be certifying at genesis.
+                    rejectLeios (LeiosCertificateAfterGenesis cert announcedPoint)
                   Just announcingRbHashValue ->
                     case verifyLeiosCert cm minCertificationThreshold announcingRbHashValue cert of
                       Left invalid ->
-                        rejectLeios ("applyBlock: invalid Leios cert: " <> show invalid)
+                        rejectLeios
+                          (LeiosInvalidCertificate cert announcedPoint announcingRbHashValue invalid)
                       Right _weight -> do
                         -- get the UTXO-HD keys of the RB we are applying the cert onto
                         let bKeys = castLedgerTables (getBlockKeySets b :: LedgerTables l KeysMK)

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/Forker.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/Forker.hs
@@ -591,8 +591,16 @@ applyBlock leiosDb evs cfg ap fo doResolveBlock = case ap of
                     error "applyBlock: cannot determine announcing RB hash for CertRB"
             case verifyLeiosCert cm minCertificationThreshold announcingRbHashValue cert of
               Left invalid ->
-                -- TODO: make this less fatal. This is like a ledger error.
-                error $ "applyBlock: invalid Leios cert: " <> show invalid
+                -- Reject the CertRB as an invalid block instead of crashing the
+                -- node: ChainSel marks it InvalidBlock and carries on.
+                pure
+                  ( Left
+                      ( AnnLedgerError
+                          (castPoint $ getTip extSt)
+                          (blockRealPoint b)
+                          (ExtValidationErrorLeios ("invalid Leios cert: " <> show invalid))
+                      )
+                  )
               Right _weight -> do
                 -- get the UTXO-HD keys of the RB we are applying the cert onto
                 let bKeys = castLedgerTables (getBlockKeySets b :: LedgerTables l KeysMK)

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/Forker.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/Forker.hs
@@ -510,9 +510,22 @@ applyBlock leiosDb evs cfg ap fo doResolveBlock = case ap of
         -- where possible, since this is /reapplication/.
         extSt <- atomically (forkerGetLedgerState fo)
         let cds = headerStateChainDep (headerState extSt)
+            tip = castPoint $ getTip extSt
         case protocolStateLeiosAnnouncement @blk cds of
           Nothing ->
-            error $ "applyBlock ReapplyVal: nothing announced!?"
+            -- A reapplied CertRB was validated before, so its predecessor must
+            -- have announced an EB; reaching this means the chain-dep state is
+            -- inconsistent. Reject as an InvalidBlock rather than crash the node
+            -- (mirrors the ApplyVal path); the alternative hard 'error' would
+            -- take the whole node down on chain selection with no restart path.
+            pure
+              ( Left
+                  ( AnnLedgerError
+                      tip
+                      (blockRealPoint b)
+                      (ExtValidationErrorLeios "applyBlock: reapplied CertRB but its predecessor announced no EB")
+                  )
+              )
           Just (announcedPoint, _) -> do
             let bKeys = castLedgerTables (getBlockKeySets b :: LedgerTables l KeysMK)
                 readTables = fmap castLedgerTables . forkerReadTables fo . castLedgerTables
@@ -524,7 +537,6 @@ applyBlock leiosDb evs cfg ap fo doResolveBlock = case ap of
                 readTables
                 bKeys
                 (ledgerState extSt)
-            let tip = castPoint $ getTip extSt
             case res of
               Left lerr ->
                 pure
@@ -571,71 +583,77 @@ applyBlock leiosDb evs cfg ap fo doResolveBlock = case ap of
         -- Steps 1 and 2 happen here rather than as Dijkstra ledger
         -- rules because step 2 involves an IO read of the LeiosDB
         -- which can't be interleaved with the pure STS evaluation.
+        --
+        -- Every failure below is reachable from an adversarial block on chain
+        -- selection, so each rejects the CertRB as an InvalidBlock (via
+        -- 'rejectLeios') instead of crashing the node with a hard 'error':
+        -- ChainSel marks the block InvalidBlock and carries on.
+        let tip = castPoint $ getTip extSt
+            rejectLeios msg =
+              pure
+                ( Left
+                    ( AnnLedgerError
+                        tip
+                        (blockRealPoint b)
+                        (ExtValidationErrorLeios msg)
+                    )
+                )
         case protocolStateLeiosAnnouncement @blk cds of
           Nothing ->
-            -- TODO: make this less fatal or impossible to reach
-            error $ "applyBlock applyVal: nothing announced!?"
-          Just (announcedPoint, _) -> do
-            cm <- case getLeiosCommittee (ledgerState extSt) of
-              Just c -> pure c
+            -- A CertRB certifies an EB announced by its predecessor; if the
+            -- parent's chain-dep state announced none, there is nothing to
+            -- certify, so the block is invalid.
+            rejectLeios "applyBlock: CertRB but its predecessor announced no EB"
+          Just (announcedPoint, _) ->
+            case getLeiosCommittee (ledgerState extSt) of
               Nothing ->
                 -- CertRB on an era without a Leios committee is itself a protocol
                 -- violation: the era machinery shouldn't have let one through.
-                -- TODO: make this less fatal
-                error "applyBlock: CertRB seen but no Leios committee for this era"
-            let announcingRbHashValue = case announcingRbHash b of
-                  Just h -> h
+                rejectLeios "applyBlock: CertRB but no Leios committee for this era"
+              Just cm ->
+                case announcingRbHash b of
                   Nothing ->
-                    -- A CertRB always has a (non-genesis) announcing parent;
-                    -- the apply path shouldn't have produced one otherwise.
-                    error "applyBlock: cannot determine announcing RB hash for CertRB"
-            case verifyLeiosCert cm minCertificationThreshold announcingRbHashValue cert of
-              Left invalid ->
-                -- Reject the CertRB as an invalid block instead of crashing the
-                -- node: ChainSel marks it InvalidBlock and carries on.
-                pure
-                  ( Left
-                      ( AnnLedgerError
-                          (castPoint $ getTip extSt)
-                          (blockRealPoint b)
-                          (ExtValidationErrorLeios ("invalid Leios cert: " <> show invalid))
-                      )
-                  )
-              Right _weight -> do
-                -- get the UTXO-HD keys of the RB we are applying the cert onto
-                let bKeys = castLedgerTables (getBlockKeySets b :: LedgerTables l KeysMK)
-                let readTables = fmap castLedgerTables . forkerReadTables fo . castLedgerTables
-                -- Resolve the EB closure from disk and apply it onto the ledger state.
-                res <-
-                  resolveAndApplyLeiosClosure
-                    leiosDb
-                    (configLedger (getExtLedgerCfg cfg))
-                    (pointEbHash announcedPoint)
-                    readTables
-                    bKeys
-                    (ledgerState extSt)
-                let tip = castPoint $ getTip extSt
-                case res of
-                  Left lerr ->
-                    -- REVIEW: Better annotation than CertRB point possible?
-                    --
-                    -- TODO this should be unreachable, at least from
-                    -- ChainSel (maybe LeiosVoting calls it?)
-                    pure
-                      ( Left
-                          ( AnnLedgerError
-                              tip
-                              (blockRealPoint b)
-                              (ExtValidationErrorLedger lerr)
-                          )
-                      )
-                  Right LeiosClosureApplied{lcaStateAfterEB, lcaClosureDiff} ->
-                    let lsAfterEB = extSt{ledgerState = lcaStateAfterEB}
-                     in case runExcept $ tickThenApply evs cfg b lsAfterEB of
+                    -- A CertRB always has a (non-genesis) announcing parent; if
+                    -- we cannot determine one, the block is malformed.
+                    rejectLeios "applyBlock: CertRB with no determinable announcing RB hash"
+                  Just announcingRbHashValue ->
+                    case verifyLeiosCert cm minCertificationThreshold announcingRbHashValue cert of
+                      Left invalid ->
+                        rejectLeios ("applyBlock: invalid Leios cert: " <> show invalid)
+                      Right _weight -> do
+                        -- get the UTXO-HD keys of the RB we are applying the cert onto
+                        let bKeys = castLedgerTables (getBlockKeySets b :: LedgerTables l KeysMK)
+                        let readTables = fmap castLedgerTables . forkerReadTables fo . castLedgerTables
+                        -- Resolve the EB closure from disk and apply it onto the ledger state.
+                        res <-
+                          resolveAndApplyLeiosClosure
+                            leiosDb
+                            (configLedger (getExtLedgerCfg cfg))
+                            (pointEbHash announcedPoint)
+                            readTables
+                            bKeys
+                            (ledgerState extSt)
+                        case res of
                           Left lerr ->
-                            pure (Left (AnnLedgerError tip (blockRealPoint b) lerr))
-                          Right blockDiff ->
-                            pure (Right (prependDiffs lcaClosureDiff blockDiff))
+                            -- REVIEW: Better annotation than CertRB point possible?
+                            --
+                            -- TODO this should be unreachable, at least from
+                            -- ChainSel (maybe LeiosVoting calls it?)
+                            pure
+                              ( Left
+                                  ( AnnLedgerError
+                                      tip
+                                      (blockRealPoint b)
+                                      (ExtValidationErrorLedger lerr)
+                                  )
+                              )
+                          Right LeiosClosureApplied{lcaStateAfterEB, lcaClosureDiff} ->
+                            let lsAfterEB = extSt{ledgerState = lcaStateAfterEB}
+                             in case runExcept $ tickThenApply evs cfg b lsAfterEB of
+                                  Left lerr ->
+                                    pure (Left (AnnLedgerError tip (blockRealPoint b) lerr))
+                                  Right blockDiff ->
+                                    pure (Right (prependDiffs lcaClosureDiff blockDiff))
   ReapplyRef r -> do
     b <- doResolveBlock r
     applyBlock leiosDb evs cfg (ReapplyVal b) fo doResolveBlock

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/Orphans/ToExpr.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/Orphans/ToExpr.hs
@@ -16,6 +16,7 @@ module Test.Util.Orphans.ToExpr () where
 import qualified Control.Monad.Class.MonadTime.SI as SI
 import Data.TreeDiff
 import GHC.Generics (Generic)
+import LeiosDemoTypes (LeiosExtValidationError)
 import Ouroboros.Consensus.Block
 import Ouroboros.Consensus.BlockchainTime.WallClock.Types (RelativeTime, WithArrivalTime)
 import Ouroboros.Consensus.HeaderValidation
@@ -75,6 +76,9 @@ instance
   ToExpr (HeaderState blk)
 
 instance ToExpr SecurityParam where
+  toExpr = defaultExprViaShow
+
+instance ToExpr LeiosExtValidationError where
   toExpr = defaultExprViaShow
 
 instance ToExpr CRC


### PR DESCRIPTION
This makes errors when applying a block less fatal and have the chain selection / block adoption machinery treat these errors as `InvalidBlock` outcomes. These do not crash the node and are traced.

NOTE: I also thought about avoiding `error` calls in initial chain selection / when applying blocks from immutable db, but that does not do error handling at all - missing UTxOs from UTxO-HD would just trip the ledger and also `error` out. Follow-up here: https://github.com/input-output-hk/ouroboros-leios/issues/1018