### PR TITLE
LeiosNotify: remove stale-OCIN timing attack vector

### DIFF
--- a/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/Block.hs
+++ b/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/Block.hs
@@ -254,7 +254,7 @@ import Ouroboros.Consensus.Shelley.Ledger.Ledger
 import Ouroboros.Consensus.Shelley.Ledger.Leios ()
 import Ouroboros.Consensus.Shelley.Protocol.Praos ()
 import Ouroboros.Consensus.Shelley.Protocol.TPraos ()
-import Ouroboros.Consensus.Storage.LedgerDB (ResolveLeiosBlock (..))
+import Ouroboros.Consensus.Storage.LedgerDB (OCINStaleness (..), ResolveLeiosBlock (..))
 import Ouroboros.Consensus.TypeFamilyWrappers
 
 {-------------------------------------------------------------------------------
@@ -1645,7 +1645,7 @@ update ::
   OneEraValidateView xs ->
   SlotNo ->
   Ticked (HardForkChainDepState xs) ->
-  Except (HardForkValidationErr xs) ()
+  Except (HardForkValidationErr xs) OCINStaleness
 update
   HardForkConsensusConfig{..}
   (OneEraValidateView view)
@@ -1676,7 +1676,7 @@ updateEra ::
   Index xs blk ->
   WrapPartialConsensusConfig blk ->
   Product WrapValidateView (Ticked :.: WrapChainDepState) blk ->
-  K (Except (HardForkValidationErr xs) ()) blk
+  K (Except (HardForkValidationErr xs) OCINStaleness) blk
 updateEra
   ei
   slot

--- a/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/Block.hs
+++ b/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/Block.hs
@@ -253,7 +253,7 @@ import Ouroboros.Consensus.Shelley.Ledger.Ledger
 import Ouroboros.Consensus.Shelley.Ledger.Leios ()
 import Ouroboros.Consensus.Shelley.Protocol.Praos ()
 import Ouroboros.Consensus.Shelley.Protocol.TPraos ()
-import Ouroboros.Consensus.Storage.LedgerDB (ResolveLeiosBlock (..))
+import Ouroboros.Consensus.Storage.LedgerDB (OCINStaleness (..), ResolveLeiosBlock (..))
 import Ouroboros.Consensus.TypeFamilyWrappers
 
 {-------------------------------------------------------------------------------
@@ -1644,7 +1644,7 @@ update ::
   OneEraValidateView xs ->
   SlotNo ->
   Ticked (HardForkChainDepState xs) ->
-  Except (HardForkValidationErr xs) ()
+  Except (HardForkValidationErr xs) OCINStaleness
 update
   HardForkConsensusConfig{..}
   (OneEraValidateView view)
@@ -1675,7 +1675,7 @@ updateEra ::
   Index xs blk ->
   WrapPartialConsensusConfig blk ->
   Product WrapValidateView (Ticked :.: WrapChainDepState) blk ->
-  K (Except (HardForkValidationErr xs) ()) blk
+  K (Except (HardForkValidationErr xs) OCINStaleness) blk
 updateEra
   ei
   slot

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Leios.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Leios.hs
@@ -24,6 +24,7 @@ import Cardano.Ledger.Shelley.Rules (ledgerPpL)
 import qualified Cardano.Ledger.Shelley.UTxO as SL
 import Cardano.Slotting.Slot (SlotNo (..), fromWithOrigin)
 import Control.Monad (foldM)
+import Control.Monad.Except (catchError, throwError)
 import qualified Control.State.Transition as STS
 import Data.Bifunctor (first)
 import qualified Data.ByteString as BS
@@ -52,9 +53,8 @@ import Ouroboros.Consensus.Protocol.Praos
   , PraosState (..)
   , Ticked (..)
   , WhetherToUpperBoundOCERT (..)
-  , doValidateKESSignatureWorker
-  , doValidateVRFSignature
   )
+import qualified Ouroboros.Consensus.Protocol.Praos as PP
 import Ouroboros.Consensus.Protocol.Praos.Header
   ( Header (..)
   , HeaderBody (..)
@@ -83,7 +83,10 @@ import Ouroboros.Consensus.Shelley.Ledger.Ledger
   , shelleyLedgerGlobals
   )
 import Ouroboros.Consensus.Shelley.Ledger.Mempool (GenTx (ShelleyTx), mkShelleyTx)
-import Ouroboros.Consensus.Storage.LedgerDB.Forker (ResolveLeiosBlock (..))
+import Ouroboros.Consensus.Storage.LedgerDB.Forker
+  ( OCINStaleness (..)
+  , ResolveLeiosBlock (..)
+  )
 
 {-------------------------------------------------------------------------------
   ResolveLeiosBlock
@@ -221,29 +224,40 @@ instance
     Header{headerBody} = shelleyHeaderRaw hdr
 
   -- The announcement is validated out-of-context against a (possibly lagging)
-  -- immutable tip, so we skip the OCERT counter's upper bound
-  -- ('DoNotUpperBoundOCERT'): a counter ahead of our recorded view is honestly
-  -- explained by that lag. The election proof (VRF) and the signature (KES +
-  -- opcert, including the counter's revocation lower bound) are checked in full.
+  -- immutable tip. We skip the OCERT counter's upper bound
+  -- ('DoNotUpperBoundOCERT') — a counter ahead of our recorded view is honest
+  -- lag — and we /reinterpret/ its lower-bound failure ('CounterTooSmallOCERT'),
+  -- and the absence of any recorded counter ('NoCounterForKeyHashOCERT'), as
+  -- 'StaleOCIN' rather than a rejection: under this lagging view either is
+  -- honestly explained by the lag. The election proof (VRF) and the signature
+  -- (KES + opcert) are still checked in full; any other failure is a genuine
+  -- rejection. See 'LeiosDemoLogic.Announcements.Validate.validateAnnouncementHeader'
+  -- for why accepting-but-not-propagating a 'StaleOCIN' announcement is safe.
   validateAnnouncementChainDepState cfg hv _slot tcs = do
     -- validate the claimed election
-    doValidateVRFSignature
+    PP.doValidateVRFSignature
       (praosStateEpochNonce cs)
       pd
       (praosLeaderF prms)
       hv
-    -- authenticate the message
-    doValidateKESSignatureWorker
-      DoNotUpperBoundOCERT
-      (praosMaxKESEvo prms)
-      (praosSlotsPerKESPeriod prms)
-      pd
-      (praosStateOCertCounters cs)
-      hv
+    -- authenticate the message; the OCIN counter checks report staleness rather
+    -- than reject
+    (FreshOCIN <$ authenticate) `catchError` \err -> case err of
+      PP.CounterTooSmallOCERT{} -> pure StaleOCIN
+      PP.NoCounterForKeyHashOCERT{} -> pure StaleOCIN
+      _ -> throwError err
    where
     prms = praosParams cfg
     cs = tickedPraosStateChainDepState tcs
     SL.PoolDistr pd _ = plvPoolDistr (tickedPraosStateLedgerView tcs)
+    authenticate =
+      PP.doValidateKESSignatureWorker
+        DoNotUpperBoundOCERT
+        (praosMaxKESEvo prms)
+        (praosSlotsPerKESPeriod prms)
+        pd
+        (praosStateOCertCounters cs)
+        hv
 
   protocolStateLeiosAnnouncement st = do
     ann <- strictMaybeToMaybe $ praosStateLeiosAnnouncement st

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic.hs
@@ -53,7 +53,16 @@ import LeiosDemoDb
   , leiosDbInsertTxs
   , leiosDbLookupEbBody
   )
-import qualified LeiosDemoLogic.Announcements as Announcements
+import LeiosDemoLogic.Announcements
+  ( AnnouncementVerdict (..)
+  , ElState (..)
+  , ErrAnnouncement
+  , PeerState
+  , ShouldRelay (..)
+  , TraceLeiosNotifyEvent (..)
+  , TraceLeiosNotifyPeerEvent (..)
+  , prunePeerState
+  )
 import LeiosDemoLogic.Announcements.ElBimap (ElId)
 import LeiosDemoLogic.Announcements.Validate
   ( AnnouncementInvalidity
@@ -990,14 +999,14 @@ leiosCertRbCallback kernelVars peerVars hdr cds =
 -----
 
 -- The pure logic for handling an inbound 'MsgLeiosBlockAnnouncement'. The
--- effectful glue (reading the immutable tip, the 'Announcements.PeerState' ref,
+-- effectful glue (reading the immutable tip, the 'PeerState' ref,
 -- 'MVar' updates, tracing, and 'throwIO') lives in the NodeToNode client, which
--- invokes 'Announcements.onAnnouncement' with these pieces.
+-- invokes 'onAnnouncement' with these pieces.
 
 -- | 'Header blk' as a relayed LeiosNotify announcement, paired with the
 -- announcement data parsed from it (see 'mkAnnouncingHeader'). The 'Eq' instance
 -- compares by header hash: that is the one identity used for announcement dedup
--- and equivocation counting (see 'Announcements.onAnnouncement').
+-- and equivocation counting (see 'onAnnouncement').
 data AnnouncingHeader blk
   = -- | INVARIANT: 'ancHeader' includes an announcement whose fields are
     -- 'ancAnnouncementFields'
@@ -1023,13 +1032,13 @@ ancElId = announcementElection . ancAnnouncementFields
 
 -- | Thrown when a peer misbehaves on the announcement protocol; the ensuing
 -- thread death disconnects the peer. It carries the
--- 'Announcements.ErrAnnouncement' verbatim (the @blk@ is existential); every
+-- 'ErrAnnouncement' verbatim (the @blk@ is existential); every
 -- such error is a disconnect, since the only invalidities that used to be
 -- tolerated — opcert issue numbers ahead of the immutable tip — are now
 -- accepted outright by 'validateAnnouncementHeader'.
 data ExnInvalidLeiosAnnouncement
   = forall blk.
-    ReactToAnnouncementError (Announcements.ErrAnnouncement (AnnouncementInvalidity blk))
+    ReactToAnnouncementError (ErrAnnouncement (AnnouncementInvalidity blk))
 
 deriving instance Show ExnInvalidLeiosAnnouncement
 
@@ -1043,7 +1052,7 @@ data ExnLeiosBlockAnnouncementMissing = ExnLeiosBlockAnnouncementMissing
 
 instance Exception ExnLeiosBlockAnnouncementMissing
 
--- | The @validate@ callback for 'Announcements.onAnnouncement'.
+-- | The @validate@ callback for 'onAnnouncement'.
 --
 -- First apply ChainSync's in-future check to the announced slot's wall-clock
 -- onset (reusing the node's own 'InFutureCheck.SomeHeaderInFutureCheck'):
@@ -1052,14 +1061,13 @@ instance Exception ExnLeiosBlockAnnouncementMissing
 -- Chronos) — blocking the per-peer handler is acceptable, as a (near-)future
 -- announcement is the peer's fault.
 --
--- If the announcement is valid and 'FreshOCIN', returns its data and whether to
--- relay it downstream (see 'Announcements.ShouldRelay' and
+-- If the announcement is valid and 'FreshOCIN', the verdict carries its data and
+-- whether to relay it downstream (see 'ShouldRelay' and
 -- 'maxAnnouncementAgeSend'). If it is valid but 'StaleOCIN' (its opcert counter
--- was revoked by /our/ immutable tip; see 'validateAnnouncementHeader'),
--- returns @Right Nothing@, so that 'Announcements.onAnnouncement' accepts it
--- from the peer without processing or relaying it. Per that contract, 'Left
--- Nothing' signals the too-old rejection (see 'maxAnnouncementAgeRecv') and
--- 'Left Just' any other invalidity.
+-- was revoked by /our/ immutable tip; see 'validateAnnouncementHeader'), the
+-- verdict is 'VerdictIgnore', so that
+-- 'onAnnouncement' accepts it from the peer without processing or
+-- relaying it.
 announcementValidity ::
   (IOLike m, LedgerSupportsProtocol blk, ResolveLeiosBlock blk) =>
   SystemTime m ->
@@ -1068,9 +1076,9 @@ announcementValidity ::
   ExtLedgerState blk EmptyMK ->
   Header blk ->
   m
-    ( Either
-        (Maybe (AnnouncementInvalidity blk))
-        (Maybe (Announcements.ShouldRelay, NominalDiffTime, (LeiosPoint, BytesSize)))
+    ( AnnouncementVerdict
+        (AnnouncementInvalidity blk)
+        (ShouldRelay, NominalDiffTime, (LeiosPoint, BytesSize))
     )
 announcementValidity systemTime futureCheck cfg immLedger hdr = do
   onset <- case futureCheck of
@@ -1092,20 +1100,18 @@ announcementValidity systemTime futureCheck cfg immLedger hdr = do
   now <- systemTimeCurrent systemTime
   let age = diffRelTime now onset
   pure $
-    -- 'Left Nothing' signals the too-old rejection to 'Announcements.onAnnouncement'
-    -- (which raises 'Announcements.ErrTooOld'); only this function holds the wall
-    -- clock, so it owns that check.
+    -- Only this function holds the wall clock, so it owns the too-old check.
     if age > maxAnnouncementAgeRecv
-      then Left Nothing
+      then VerdictTooOld
       else
         let shouldRelay =
               if age <= maxAnnouncementAgeSend
-                then Announcements.DoRelay
-                else Announcements.DoNotRelay
+                then DoRelay
+                else DoNotRelay
          in case validateAnnouncementHeader cfg immLedger hdr of
-              Left inv -> Left (Just inv)
-              Right (StaleOCIN, _v) -> Right Nothing
-              Right (FreshOCIN, v) -> Right (Just (shouldRelay, age, v))
+              Left inv -> VerdictInvalid inv
+              Right (StaleOCIN, _v) -> VerdictIgnore
+              Right (FreshOCIN, v) -> VerdictProcess (shouldRelay, age, v)
 
 -- | Record a validated, newly-announced EB body as missing, with its
 -- authoritative (forger-signed) size. First-seen wins: a no-op if the body is
@@ -1138,39 +1144,39 @@ prunePeerStateToImmTip ::
   LedgerSupportsProtocol blk =>
   ExtLedgerState blk EmptyMK ->
   SlotNo ->
-  Announcements.PeerState anc ->
-  (SlotNo, Announcements.PeerState anc)
+  PeerState anc ->
+  (SlotNo, PeerState anc)
 prunePeerStateToImmTip immLedger latestPruneSlot peerSt =
   case getTipSlot (ledgerState immLedger) of
     NotOrigin immTipSlot
-      | latestPruneSlot < immTipSlot -> (immTipSlot, Announcements.prunePeerState immTipSlot peerSt)
+      | latestPruneSlot < immTipSlot -> (immTipSlot, prunePeerState immTipSlot peerSt)
     _ -> (latestPruneSlot, peerSt)
 
 -- | The just-counted announcement's fields, and whether it equivocates a prior
 -- header announcing the same election.
 announcementTraceFields ::
-  Announcements.ElState (AnnouncingHeader blk) ->
+  ElState (AnnouncingHeader blk) ->
   (AnnouncementEquivocation, AnnouncementFields)
 announcementTraceFields = \case
-  Announcements.OneAnnouncement a ->
+  OneAnnouncement a ->
     (NoEquivocation, ancAnnouncementFields a)
-  Announcements.TwoAnnouncements _a1 a2 ->
+  TwoAnnouncements _a1 a2 ->
     (Equivocation, ancAnnouncementFields a2)
 
 -- | Render an 'Announcements' per-peer announcement event as a 'TraceLeiosPeer'.
 tracePeerAnnouncement ::
-  Announcements.TraceLeiosNotifyPeerEvent (AnnouncingHeader blk) ->
+  TraceLeiosNotifyPeerEvent (AnnouncingHeader blk) ->
   TraceLeiosPeer
-tracePeerAnnouncement (Announcements.TracePeerAnnouncement elSt) =
+tracePeerAnnouncement (TracePeerAnnouncement elSt) =
   let (equivocation, fields) = announcementTraceFields elSt
    in TraceLeiosPeerAnnouncement equivocation fields
 
 -- | Render an 'Announcements' node-wide announcement event as a
 -- 'TraceLeiosKernel'.
 traceNewAnnouncement ::
-  Announcements.TraceLeiosNotifyEvent peer (AnnouncingHeader blk) ->
+  TraceLeiosNotifyEvent peer (AnnouncingHeader blk) ->
   TraceLeiosKernel
-traceNewAnnouncement (Announcements.TraceNewAnnouncement mbPeer _elId elSt age) =
+traceNewAnnouncement (TraceNewAnnouncement mbPeer _elId elSt age) =
   let (equivocation, fields) = announcementTraceFields elSt
    in TraceLeiosAnnouncementAccepted
         (maybe ForgedLocally (const ReceivedFromPeer) mbPeer)
@@ -1179,7 +1185,7 @@ traceNewAnnouncement (Announcements.TraceNewAnnouncement mbPeer _elId elSt age) 
         age
 
 -- | Do not relay (to downstream peers) an announcement whose slot's wall-clock
--- onset is older than this. See 'Announcements.ShouldRelay'.
+-- onset is older than this. See 'ShouldRelay'.
 --
 -- Must be comfortably less than 'maxAnnouncementAgeRecv', so that an
 -- announcement an honest node relays just before this bound still arrives at
@@ -1191,7 +1197,7 @@ maxAnnouncementAgeSend :: NominalDiffTime
 maxAnnouncementAgeSend = 300 -- 5 minutes
 
 -- | Disconnect an upstream peer that relays an announcement whose slot's
--- wall-clock onset is older than this. See 'Announcements.ErrTooOld'.
+-- wall-clock onset is older than this. See 'ErrTooOld'.
 --
 -- Comfortably greater than 'maxAnnouncementAgeSend', so that an honest peer
 -- (which stops relaying at that smaller bound) is never disconnected on account

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic.hs
@@ -104,7 +104,10 @@ import Ouroboros.Consensus.Ledger.Extended (ExtLedgerState, ledgerState)
 import Ouroboros.Consensus.Ledger.SupportsProtocol (LedgerSupportsProtocol)
 import qualified Ouroboros.Consensus.MiniProtocol.ChainSync.Client.InFutureCheck as InFutureCheck
 import Ouroboros.Consensus.Protocol.Abstract (ChainDepState)
-import Ouroboros.Consensus.Storage.LedgerDB.Forker (ResolveLeiosBlock (..))
+import Ouroboros.Consensus.Storage.LedgerDB.Forker
+  ( OCINStaleness (..)
+  , ResolveLeiosBlock (..)
+  )
 import Ouroboros.Consensus.Util.IOLike (IOLike)
 
 -- | Wrap an action with exception tracing. Catches the exception,
@@ -1049,11 +1052,14 @@ instance Exception ExnLeiosBlockAnnouncementMissing
 -- Chronos) — blocking the per-peer handler is acceptable, as a (near-)future
 -- announcement is the peer's fault.
 --
--- Returns the announcement's data and whether to relay it downstream (see
--- 'Announcements.ShouldRelay' and 'maxAnnouncementAgeSend'), if the announcement
--- is valid. Per the 'Announcements.onAnnouncement' contract, 'Left Nothing'
--- signals the too-old rejection (see 'maxAnnouncementAgeRecv') and 'Left Just'
--- any other invalidity.
+-- If the announcement is valid and 'FreshOCIN', returns its data and whether to
+-- relay it downstream (see 'Announcements.ShouldRelay' and
+-- 'maxAnnouncementAgeSend'). If it is valid but 'StaleOCIN' (its opcert counter
+-- was revoked by /our/ immutable tip; see 'validateAnnouncementHeader'),
+-- returns @Right Nothing@, so that 'Announcements.onAnnouncement' accepts it
+-- from the peer without processing or relaying it. Per that contract, 'Left
+-- Nothing' signals the too-old rejection (see 'maxAnnouncementAgeRecv') and
+-- 'Left Just' any other invalidity.
 announcementValidity ::
   (IOLike m, LedgerSupportsProtocol blk, ResolveLeiosBlock blk) =>
   SystemTime m ->
@@ -1064,7 +1070,7 @@ announcementValidity ::
   m
     ( Either
         (Maybe (AnnouncementInvalidity blk))
-        (Announcements.ShouldRelay, NominalDiffTime, (LeiosPoint, BytesSize))
+        (Maybe (Announcements.ShouldRelay, NominalDiffTime, (LeiosPoint, BytesSize)))
     )
 announcementValidity systemTime futureCheck cfg immLedger hdr = do
   onset <- case futureCheck of
@@ -1098,7 +1104,8 @@ announcementValidity systemTime futureCheck cfg immLedger hdr = do
                 else Announcements.DoNotRelay
          in case validateAnnouncementHeader cfg immLedger hdr of
               Left inv -> Left (Just inv)
-              Right v -> Right (shouldRelay, age, v)
+              Right (StaleOCIN, _v) -> Right Nothing
+              Right (FreshOCIN, v) -> Right (Just (shouldRelay, age, v))
 
 -- | Record a validated, newly-announced EB body as missing, with its
 -- authoritative (forger-signed) size. First-seen wins: a no-op if the body is

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic/Announcements.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic/Announcements.hs
@@ -168,8 +168,15 @@ onAnnouncement ::
   -- restriction (its election's wall-clock age exceeds what a client
   -- tolerates); 'onAnnouncement' then raises 'ErrTooOld'. This callback owns
   -- that check because only it holds the wall clock. Return @Left (Just inv)@
-  -- for any other rejection (raised as 'ErrInvalid'), and @Right@ when valid.
-  (anc -> m (Either (Maybe invalidity) validated)) ->
+  -- for any other rejection (raised as 'ErrInvalid').
+  --
+  -- Return @Right (Just v)@ when the announcement is valid and should be
+  -- processed (via the next argument) and relayed. Return @Right Nothing@ when
+  -- it is valid but should be accepted from the peer /without/ processing or
+  -- relaying it — currently a stale-OCIN announcement (see
+  -- 'LeiosDemoLogic.Announcements.Validate.validateAnnouncementHeader'). Either
+  -- way the peer is not disconnected and its per-peer dedup state is updated.
+  (anc -> m (Either (Maybe invalidity) (Maybe validated))) ->
   -- | How this central logic should react to a new announcement from
   -- this peer
   --
@@ -189,7 +196,10 @@ onAnnouncement tracer getEl validate process st anc = do
   lift (validate anc) >>= \case
     Left Nothing -> throwError ErrTooOld
     Left (Just err) -> throwError $ ErrInvalid err
-    Right x -> do
+    -- Valid but not to be processed/relayed (e.g. a stale OCIN): the peer's
+    -- dedup state was already updated by 'extendLive' above, so just keep it.
+    Right Nothing -> pure st'
+    Right (Just x) -> do
       lift $ process anc x
       pure st'
 

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic/Announcements.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic/Announcements.hs
@@ -116,7 +116,7 @@ data ErrAnnouncement invalidity
     -- what a client tolerates from an upstream peer). Unlike 'ErrInvalid', this
     -- verdict depends on the wall clock rather than on the announcement itself,
     -- so 'onAnnouncement' cannot decide it directly; it is signalled by the
-    -- validation callback returning @Left Nothing@ (see 'onAnnouncement').
+    -- validation callback returning 'VerdictTooOld' (see 'onAnnouncement').
     ErrTooOld
   deriving Show
 
@@ -158,25 +158,32 @@ extendLive elId anc st =
 data TraceLeiosNotifyPeerEvent anc
   = TracePeerAnnouncement !(ElState anc)
 
+-- | The verdict of 'onAnnouncement'\'s validation callback
+data AnnouncementVerdict invalidity validated
+  = -- | Reject: the election's wall-clock age exceeds what a client tolerates
+    --
+    -- Raised as 'ErrTooOld'. The callback owns this check because only it holds
+    -- the wall clock.
+    VerdictTooOld
+  | -- | Reject: the announcement is invalid; raised as 'ErrInvalid'
+    VerdictInvalid !invalidity
+  | -- | Accept from the peer, but neither process nor relay the announcement
+    --
+    -- Currently only a stale-OCIN announcement (see
+    -- 'LeiosDemoLogic.Announcements.Validate.validateAnnouncementHeader').
+    VerdictIgnore
+  | -- | Accept, process, and relay
+    VerdictProcess !validated
+
 onAnnouncement ::
   (Eq anc, Monad m) =>
   Tracer m (TraceLeiosNotifyPeerEvent anc) ->
   (anc -> ElId) ->
   -- | How to validate the announcement
   --
-  -- Return @Left Nothing@ when the announcement violates the too-old
-  -- restriction (its election's wall-clock age exceeds what a client
-  -- tolerates); 'onAnnouncement' then raises 'ErrTooOld'. This callback owns
-  -- that check because only it holds the wall clock. Return @Left (Just inv)@
-  -- for any other rejection (raised as 'ErrInvalid').
-  --
-  -- Return @Right (Just v)@ when the announcement is valid and should be
-  -- processed (via the next argument) and relayed. Return @Right Nothing@ when
-  -- it is valid but should be accepted from the peer /without/ processing or
-  -- relaying it — currently a stale-OCIN announcement (see
-  -- 'LeiosDemoLogic.Announcements.Validate.validateAnnouncementHeader'). Either
-  -- way the peer is not disconnected and its per-peer dedup state is updated.
-  (anc -> m (Either (Maybe invalidity) (Maybe validated))) ->
+  -- The peer is disconnected only for a rejecting verdict; both accepting
+  -- verdicts also update its per-peer dedup state.
+  (anc -> m (AnnouncementVerdict invalidity validated)) ->
   -- | How this central logic should react to a new announcement from
   -- this peer
   --
@@ -194,12 +201,12 @@ onAnnouncement tracer getEl validate process st anc = do
   -- do the more expensive validation only after the trivial
   -- counting checks
   lift (validate anc) >>= \case
-    Left Nothing -> throwError ErrTooOld
-    Left (Just err) -> throwError $ ErrInvalid err
-    -- Valid but not to be processed/relayed (e.g. a stale OCIN): the peer's
-    -- dedup state was already updated by 'extendLive' above, so just keep it.
-    Right Nothing -> pure st'
-    Right (Just x) -> do
+    VerdictTooOld -> throwError ErrTooOld
+    VerdictInvalid err -> throwError $ ErrInvalid err
+    -- The peer's dedup state was already updated by 'extendLive' above, so just
+    -- keep it.
+    VerdictIgnore -> pure st'
+    VerdictProcess x -> do
       lift $ process anc x
       pure st'
 

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic/Announcements/Validate.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic/Announcements/Validate.hs
@@ -51,7 +51,8 @@ import Ouroboros.Consensus.Ledger.SupportsProtocol
   )
 import Ouroboros.Consensus.Protocol.Abstract (ValidationErr)
 import Ouroboros.Consensus.Storage.LedgerDB.Forker
-  ( ResolveLeiosBlock
+  ( OCINStaleness (..)
+  , ResolveLeiosBlock
   , headerLeiosAnnouncement
   , validateAnnouncementChainDepState
   )
@@ -113,38 +114,82 @@ instance Show (AnnouncementInvalidity blk) where
 -- tip's ledger state (forecast to the header's slot). Envelope check skipped;
 -- see the module header.
 --
--- The operational certficiate (opcert) issue number (OCIN) is checked only as a
--- lower bound: any number at least the immutable tip's counter is accepted (the
--- over-increment upper bound, which the strict protocol check would enforce, is
--- skipped — see 'validateAnnouncementChainDepState' and
--- 'WhetherToUpperBoundOCERT'), and a lower one is rejected as a revoked key.
+-- The operational certificate (opcert) issue number (OCIN) governs only relay,
+-- not acceptance. We cannot soundly constrain it as strictly as genuine header
+-- validation does because we're using merely the immutable ledger state, which
+-- may be out of date. Only a non-OCIN failure — a bad election proof or
+-- signature, a slot before the immutable tip, an oversized header — rejects and
+-- disconnects. But even if an announcement is not considered invalid, it might
+-- otherwise be ignored. An announcement whose OCIN is at least our immutable
+-- tip's recorded counter is 'FreshOCIN': processed and relayed as usual. A
+-- lower one, or one from a key we have no recorded counter for, is 'StaleOCIN'
+-- (see 'validateAnnouncementChainDepState'): accepted from the peer — updating
+-- that peer's dedup state, never disconnecting — but not processed, published,
+-- or relayed.
 --
--- OCINs are otherwise ignored. In effect, this logic is assuming that all OCINs
--- are controlled by the pool owner. That's patentedly contrary the intended
--- purpose of OCINs, so it needs justification; hence this comment.
+-- Skipping OCIN validation effectively treats every one of a pool's OCINs as
+-- the pool owner's, which is contrary to the intended purpose of OCINs, so
+-- omitting the two checks that strict header validation would make needs
+-- justification.
 --
--- The crux is a Catch 22 if we consider different OCINs as different
--- identities. We must either treat all of those identities
--- _independently_ (ie as distinct elections) or _prioritize_ the
--- greater OCINs (which seems intuitive). The problem is that the
--- adversary can create arbitrarily many OCINs for its own pools. And
--- then it can abuse either choice we make: either it gets to multiply
--- the Leios load on the network per election, or it can cause
--- arbitrary "partitions" of the network, with one clique certifying a
--- lower OCIN's announcement but the other clique completely ignoring
--- that announcement.
+-- We do not enforce the counter's /upper/ bound: we accept that the true OCIN
+-- may have run ahead of our imm tip's view. In fact, this logic treats distinct
+-- OCINs as the same identity. The crux is a Catch 22 if we were to distinguish
+-- them: we would have to either treat those identities /independently/ (as
+-- distinct elections) or /prioritize/ the greater OCIN (which seems
+-- intuitive). But an adversary can mint arbitrarily many OCINs for its own
+-- pools and abuse either choice. The former lets them multiply the Leios load
+-- per election; the latter lets them "partition" the network, one clique
+-- certifying a lower OCIN's announcement while the other ignores it. So
+-- elections are keyed merely on @(slot, pool)@ alone (see
+-- 'LeiosDemoLogic.Announcements.ElBimap.ElId').
 --
--- The current behavior is to accept (and relay!) any OCIN at least as
--- great as the counter in our immutable tip's ledger state. The only
--- downside to this is that an increment OCIN doesn't revoke the old
--- opcert _for Leios_ until the increment is on the immutable tip
--- (Praos is still immediate). So a leaked hot key means the attacker
--- can equivocate all of the victim's announcements until the victim
--- notices, lands a new opcert on chain, and then waits for that
--- opcert to become immutable (~12 hr, <= ~36 hr). Not ideal, but
+-- We do not /promptly/ enforce the counter's /lower/ bound. An OCIN increment
+-- revokes the old opcert immediately for Praos (at header validation/chain
+-- adoption), but for Leios only once the increment reaches our immutable tip.
+-- Until then our recorded counter is still the old one, so an announcement
+-- bearing it (or greater) is 'FreshOCIN' and we process and relay it as
+-- usual. The downside of not being prompt is that a leaked hot key lets the
+-- attacker equivocate the victim's announcements until the victim notices,
+-- lands a new opcert, and waits for it to become immutable (~12 hr, <= ~36 hr)
+-- — and during that window announcements using the revoked OCIN are fresh, so
+-- they can even be voted for\/part of equivocation proofs\/etc. Not ideal, but
 -- tolerable.
 --
--- Returns the output of 'headerLeiosAnnouncement'.
+-- Once the increment /is/ immutable for us, an announcement bearing the old
+-- counter is 'StaleOCIN'. But even then we must not /reject/ it, only decline
+-- to process or relay it. Different honest nodes might have different immutable
+-- tips, so honest nodes can briefly disagree on whether the increment is yet
+-- immutable. An adversary who bumps a pool's OCIN and then sends a ~on-time
+-- announcement using the /revoked/ OCIN, timed to straddle that boundary, would
+-- otherwise make \"fast\" nodes (increment immutable, so 'StaleOCIN')
+-- disconnect the \"slow\" honest peers (increment not yet immutable, so still
+-- 'FreshOCIN') that legitimately relay it — an OCIN-timed partition.
+--
+-- That results in a diffusion asymmetry — the slow peers relay the old-counter
+-- announcement, the fast ones do not — but it is not the certify/ignore
+-- partition the upper-bound Catch 22 warned about, because once the increment
+-- is immutable even just /for/ /us/ the announcement can never be voted for,
+-- hence never certified:
+--
+--   * Once the increment is immutable for /any/ honest node then, by the Praos
+--     Common Prefix property, it is in every healthy honest node's selection now
+--     and forever, so every honest node's up-to-date view records the incremented
+--     counter.
+--
+--   * A vote follows selection, and selection is driven by ChainSync
+--     @MsgRollForward@ headers. Those are /not/ dangling: they extend the node's
+--     current chain and undergo full header validation with the exact
+--     chain-dependent OCIN bounds. Only announcements are dangling, which is
+--     precisely why only they fall back to the immutable-tip ledger view and this
+--     relaxed, report-don't-reject OCIN check.
+--
+-- So the old-counter RB fails @MsgRollForward@ validation on every healthy honest
+-- node — even the slow ones still relaying its announcement — never becomes a
+-- selected tip, and is never voted for; the asymmetry never yields a certified
+-- EB, so it is no Linear Leios availability violation.
+--
+-- Returns the OCIN staleness and the output of 'headerLeiosAnnouncement'.
 validateAnnouncementHeader ::
   forall blk.
   ( LedgerSupportsProtocol blk
@@ -153,7 +198,7 @@ validateAnnouncementHeader ::
   TopLevelConfig blk ->
   ExtLedgerState blk EmptyMK ->
   Header blk ->
-  Either (AnnouncementInvalidity blk) (LeiosPoint, BytesSize)
+  Either (AnnouncementInvalidity blk) (OCINStaleness, (LeiosPoint, BytesSize))
 validateAnnouncementHeader cfg extLedger hdr =
   runExcept $ do
     x <- case headerLeiosAnnouncement hdr of
@@ -184,12 +229,13 @@ validateAnnouncementHeader cfg extLedger hdr =
     -- rejection.
     let tickedHeaderState =
           tickHeaderState (configConsensus cfg) ledgerView slot (headerState extLedger)
-    withExcept HeaderInvalid $
-      validateAnnouncementChainDepState @blk
-        (configConsensus cfg)
-        (validateView (configBlock cfg) hdr)
-        slot
-        (tickedHeaderStateChainDep tickedHeaderState)
-    pure x
+    staleness <-
+      withExcept HeaderInvalid $
+        validateAnnouncementChainDepState @blk
+          (configConsensus cfg)
+          (validateView (configBlock cfg) hdr)
+          slot
+          (tickedHeaderStateChainDep tickedHeaderState)
+    pure (staleness, x)
  where
   slot = blockSlot hdr

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/Forker.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/Forker.hs
@@ -50,6 +50,7 @@ module Ouroboros.Consensus.Storage.LedgerDB.Forker
   , ResolveBlock
   , LeiosClosureApplied (..)
   , ResolveLeiosBlock (..)
+  , OCINStaleness (..)
   , applyBlockToForker
   , resolveAndApplyLeiosClosure
   , resolveLeiosBlock
@@ -774,6 +775,19 @@ applyThenPushMany leiosDb trace evs cfg aps fo doResolveBlock = pushAndTrace aps
 -- validation mode.
 type ResolveBlock m blk = RealPoint blk -> m blk
 
+-- | Whether a relayed Leios announcement's operational-certificate issue number
+-- (OCIN) is /stale/ relative to the (possibly-lagging) immutable-tip ledger view
+-- it was validated against: at or ahead of our recorded counter ('FreshOCIN'),
+-- versus below it or from an as-yet-unknown key ('StaleOCIN').
+--
+-- Only 'validateAnnouncementChainDepState' produces this, and only because an
+-- announcement is validated out-of-context (\"dangling\") against the immutable
+-- tip. A 'StaleOCIN' announcement is accepted from the peer (never a disconnect)
+-- and counted in its per-peer state, but is not processed, published, or
+-- relayed. See 'validateAnnouncementHeader' for why that is safe.
+data OCINStaleness = FreshOCIN | StaleOCIN
+  deriving (Eq, Show)
+
 -- | Resolve a block before it is applied to the ledger.
 --
 -- In Leios, a Dijkstra-era block may carry only a 'LeiosCert' on its body
@@ -871,20 +885,21 @@ class ResolveLeiosBlock blk where
   --
   -- Mirrors 'updateChainDepState' (its strict behaviour is the default), but is
   -- run out-of-context against a possibly-lagging immutable tip, so eras that
-  -- relay announcements override it to skip the checks that such lag spuriously
-  -- trips — currently just the OCERT counter's upper bound (see
-  -- 'WhetherToUpperBoundOCERT'). Unlike a full header validation it also omits
-  -- the RB-header-specific checks (body size etc.) that a bare EB announcement
-  -- would not carry. Any error it returns is therefore a genuine rejection.
+  -- relay announcements override it to relax the checks that such lag spuriously
+  -- trips.
+  --
+  -- Called by
+  -- 'LeiosDemoLogic.Announcements.Validate.validateAnnouncementHeader', which
+  -- has a large Haddock comment motivating the 'OCINStaleness' return type.
   validateAnnouncementChainDepState ::
     ConsensusProtocol (BlockProtocol blk) =>
     ConsensusConfig (BlockProtocol blk) ->
     ValidateView (BlockProtocol blk) ->
     SlotNo ->
     Ticked (ChainDepState (BlockProtocol blk)) ->
-    Except (ValidationErr (BlockProtocol blk)) ()
+    Except (ValidationErr (BlockProtocol blk)) OCINStaleness
   validateAnnouncementChainDepState cfg vv slot tcs =
-    () <$ updateChainDepState cfg vv slot tcs
+    FreshOCIN <$ updateChainDepState cfg vv slot tcs
 
   -- | The EB most recent announcement in the 'HeaderState', if any. 'Nothing'
   -- for headers in eras that don't carry Leios announcements.

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/Forker.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/Forker.hs
@@ -49,6 +49,7 @@ module Ouroboros.Consensus.Storage.LedgerDB.Forker
   , ResolveBlock
   , LeiosClosureApplied (..)
   , ResolveLeiosBlock (..)
+  , OCINStaleness (..)
   , resolveAndApplyLeiosClosure
   , resolveLeiosBlock
   , SuccessForkerAction (..)
@@ -733,6 +734,19 @@ applyThenPushMany leiosDb trace evs cfg aps fo doResolveBlock = pushAndTrace aps
 -- validation mode.
 type ResolveBlock m blk = RealPoint blk -> m blk
 
+-- | Whether a relayed Leios announcement's operational-certificate issue number
+-- (OCIN) is /stale/ relative to the (possibly-lagging) immutable-tip ledger view
+-- it was validated against: at or ahead of our recorded counter ('FreshOCIN'),
+-- versus below it or from an as-yet-unknown key ('StaleOCIN').
+--
+-- Only 'validateAnnouncementChainDepState' produces this, and only because an
+-- announcement is validated out-of-context (\"dangling\") against the immutable
+-- tip. A 'StaleOCIN' announcement is accepted from the peer (never a disconnect)
+-- and counted in its per-peer state, but is not processed, published, or
+-- relayed. See 'validateAnnouncementHeader' for why that is safe.
+data OCINStaleness = FreshOCIN | StaleOCIN
+  deriving (Eq, Show)
+
 -- | Resolve a block before it is applied to the ledger.
 --
 -- In Leios, a Dijkstra-era block may carry only a 'LeiosCert' on its body
@@ -830,20 +844,21 @@ class ResolveLeiosBlock blk where
   --
   -- Mirrors 'updateChainDepState' (its strict behaviour is the default), but is
   -- run out-of-context against a possibly-lagging immutable tip, so eras that
-  -- relay announcements override it to skip the checks that such lag spuriously
-  -- trips — currently just the OCERT counter's upper bound (see
-  -- 'WhetherToUpperBoundOCERT'). Unlike a full header validation it also omits
-  -- the RB-header-specific checks (body size etc.) that a bare EB announcement
-  -- would not carry. Any error it returns is therefore a genuine rejection.
+  -- relay announcements override it to relax the checks that such lag spuriously
+  -- trips.
+  --
+  -- Called by
+  -- 'LeiosDemoLogic.Announcements.Validate.validateAnnouncementHeader', which
+  -- has a large Haddock comment motivating the 'OCINStaleness' return type.
   validateAnnouncementChainDepState ::
     ConsensusProtocol (BlockProtocol blk) =>
     ConsensusConfig (BlockProtocol blk) ->
     ValidateView (BlockProtocol blk) ->
     SlotNo ->
     Ticked (ChainDepState (BlockProtocol blk)) ->
-    Except (ValidationErr (BlockProtocol blk)) ()
+    Except (ValidationErr (BlockProtocol blk)) OCINStaleness
   validateAnnouncementChainDepState cfg vv slot tcs =
-    () <$ updateChainDepState cfg vv slot tcs
+    FreshOCIN <$ updateChainDepState cfg vv slot tcs
 
   -- | The EB most recent announcement in the 'HeaderState', if any. 'Nothing'
   -- for headers in eras that don't carry Leios announcements.

--- a/ouroboros-consensus/test/consensus-test/Test/LeiosDemoLogic/Announcements.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/LeiosDemoLogic/Announcements.hs
@@ -164,6 +164,7 @@ onAnnouncementTests =
     [ testCase "invalid announcement surfaces as ErrInvalid" test_oaInvalid
     , testCase "too-old announcement (Left Nothing) surfaces as ErrTooOld" test_oaTooOld
     , testCase "valid announcement runs process and returns new state" test_oaProcess
+    , testCase "valid-but-stale (Right Nothing) accepts without running process" test_oaAcceptNoProcess
     , testCase "repeat is rejected without running process" test_oaRepeat
     ]
 
@@ -174,7 +175,7 @@ test_oaInvalid = do
       onAnnouncement
         nullTracer
         ancEl
-        (\_ -> pure (Left (Just "bad")) :: IO (Either (Maybe String) ()))
+        (\_ -> pure (Left (Just "bad")) :: IO (Either (Maybe String) (Maybe ())))
         (\_ _ -> pure ())
         emptyPeerState
         (Anc el0 0)
@@ -189,7 +190,7 @@ test_oaTooOld = do
       onAnnouncement
         nullTracer
         ancEl
-        (\_ -> pure (Left Nothing) :: IO (Either (Maybe String) ()))
+        (\_ -> pure (Left Nothing) :: IO (Either (Maybe String) (Maybe ())))
         (\_ _ -> pure ())
         emptyPeerState
         (Anc el0 0)
@@ -205,7 +206,7 @@ test_oaProcess = do
       onAnnouncement
         nullTracer
         ancEl
-        (\_ -> pure (Right ()))
+        (\_ -> pure (Right (Just ())))
         (\a () -> modifyIORef' ref (a :))
         emptyPeerState
         (Anc el0 0)
@@ -214,10 +215,27 @@ test_oaProcess = do
     Right _ -> pure ()
     Left _ -> assertFailure "expected success"
 
+test_oaAcceptNoProcess :: Assertion
+test_oaAcceptNoProcess = do
+  ref <- newIORef []
+  res <-
+    runExceptT $
+      onAnnouncement
+        nullTracer
+        ancEl
+        (\_ -> pure (Right Nothing) :: IO (Either (Maybe String) (Maybe ())))
+        (\a () -> modifyIORef' ref (a :))
+        emptyPeerState
+        (Anc el0 0)
+  readIORef ref >>= (@?= []) -- valid-but-stale: process must not run
+  case res of
+    Right _ -> pure ()
+    Left _ -> assertFailure "expected success"
+
 test_oaRepeat :: Assertion
 test_oaRepeat = do
   ref <- newIORef (0 :: Int)
-  let validate = \_ -> pure (Right ())
+  let validate = \_ -> pure (Right (Just ()))
       process = \_ _ -> modifyIORef' ref (+ 1) :: IO ()
       go st = runExceptT $ onAnnouncement nullTracer ancEl validate process st (Anc el0 0)
   Right st1 <- go emptyPeerState

--- a/ouroboros-consensus/test/consensus-test/Test/LeiosDemoLogic/Announcements.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/LeiosDemoLogic/Announcements.hs
@@ -162,9 +162,9 @@ onAnnouncementTests =
   testGroup
     "onAnnouncement"
     [ testCase "invalid announcement surfaces as ErrInvalid" test_oaInvalid
-    , testCase "too-old announcement (Left Nothing) surfaces as ErrTooOld" test_oaTooOld
+    , testCase "too-old announcement (VerdictTooOld) surfaces as ErrTooOld" test_oaTooOld
     , testCase "valid announcement runs process and returns new state" test_oaProcess
-    , testCase "valid-but-stale (Right Nothing) accepts without running process" test_oaAcceptNoProcess
+    , testCase "valid-but-stale (VerdictIgnore) accepts without running process" test_oaAcceptNoProcess
     , testCase "repeat is rejected without running process" test_oaRepeat
     ]
 
@@ -175,7 +175,7 @@ test_oaInvalid = do
       onAnnouncement
         nullTracer
         ancEl
-        (\_ -> pure (Left (Just "bad")) :: IO (Either (Maybe String) (Maybe ())))
+        (\_ -> pure (VerdictInvalid "bad") :: IO (AnnouncementVerdict String ()))
         (\_ _ -> pure ())
         emptyPeerState
         (Anc el0 0)
@@ -190,7 +190,7 @@ test_oaTooOld = do
       onAnnouncement
         nullTracer
         ancEl
-        (\_ -> pure (Left Nothing) :: IO (Either (Maybe String) (Maybe ())))
+        (\_ -> pure VerdictTooOld :: IO (AnnouncementVerdict String ()))
         (\_ _ -> pure ())
         emptyPeerState
         (Anc el0 0)
@@ -206,7 +206,7 @@ test_oaProcess = do
       onAnnouncement
         nullTracer
         ancEl
-        (\_ -> pure (Right (Just ())))
+        (\_ -> pure (VerdictProcess ()))
         (\a () -> modifyIORef' ref (a :))
         emptyPeerState
         (Anc el0 0)
@@ -223,7 +223,7 @@ test_oaAcceptNoProcess = do
       onAnnouncement
         nullTracer
         ancEl
-        (\_ -> pure (Right Nothing) :: IO (Either (Maybe String) (Maybe ())))
+        (\_ -> pure VerdictIgnore :: IO (AnnouncementVerdict String ()))
         (\a () -> modifyIORef' ref (a :))
         emptyPeerState
         (Anc el0 0)
@@ -235,7 +235,7 @@ test_oaAcceptNoProcess = do
 test_oaRepeat :: Assertion
 test_oaRepeat = do
   ref <- newIORef (0 :: Int)
-  let validate = \_ -> pure (Right (Just ()))
+  let validate = \_ -> pure (VerdictProcess ())
       process = \_ _ -> modifyIORef' ref (+ 1) :: IO ()
       go st = runExceptT $ onAnnouncement nullTracer ancEl validate process st (Anc el0 0)
   Right st1 <- go emptyPeerState

--- a/ouroboros-consensus/test/consensus-test/Test/LeiosVoteState.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/LeiosVoteState.hs
@@ -183,10 +183,10 @@ prop_signerNotInCommittee :: Property
 prop_signerNotInCommittee =
   forAll genCommittee $ \testCommittee ->
     forAll (genKeyNotIn testCommittee) $ \key ->
-      forAll genRbHash $ \announcingRbHash -> property $ runSimOrThrow $ do
+      forAll genRbHash $ \announcement -> property $ runSimOrThrow $ do
         -- VoterId must be outside of committe, otherwise this is just a bad signature
         let n = leiosCommitteeSize testCommittee.committee
-        let vote = signLeiosVote key (LeiosSeatId $ fromIntegral n) announcingRbHash
+        let vote = signLeiosVote key (LeiosSeatId $ fromIntegral n) announcement
         st <- newLeiosVoteState (pure (Just testCommittee.committee))
         sub <- subscribeVotes st
         r <- addVote st vote


### PR DESCRIPTION
Fixes Issue https://github.com/input-output-hk/ouroboros-leios/issues/1029

This PR's commit eliminates that attack vector.

Key change: we don't disconnect when the announcement has an OCIN that our imm tip has revoked; we now accept that message, since it's possible the honest peer's imm tip is a bit behind ours and so has _not_ revoked that OCIN. However, despite allowing the peer to send that message to us, we otherwise ignore it, since _we do_ know its OCIN was revoked.

The main idea: OCINs are irrelevant to which elections the adversary could send us _some_ message for. They're only relevant to what the contents of that message could be. It's the election itself that must be valid in order for our resource usage to remain bounded, and that is unrelated to the OCIN.