### PR TITLE
[Peras 49] Use injective type families for associated BlockSupportsPeras types

### DIFF
--- a/changelog.d/20260806_121453_agustin.mista_use_injective_type_families.md
+++ b/changelog.d/20260806_121453_agustin.mista_use_injective_type_families.md
@@ -1,0 +1,23 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+<!--
+### Breaking
+
+- A bullet item for the Breaking category.
+
+-->
+<!--
+### Non-Breaking
+
+- A bullet item for the Non-Breaking category.
+
+-->
+### Patch
+
+- The associated types in `BlockSupportsPeras` (`PerasCert`, `PerasVote`, and the new `PerasError`) are now injective type families.
+

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Block/SupportsPeras.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Block/SupportsPeras.hs
@@ -9,7 +9,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeFamilyDependencies #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Ouroboros.Consensus.Block.SupportsPeras
@@ -25,8 +25,8 @@ module Ouroboros.Consensus.Block.SupportsPeras
   , BlockSupportsPeras (..)
 
     -- * To be removed in favor of using 'IsPerasCert'/'IsPerasVote'
-  , PerasCert (..)
-  , PerasVote (..)
+  , PerasCert' (..)
+  , PerasVote' (..)
   , HasPerasCertRound (..)
   , HasPerasCertBoostedBlock (..)
   , HasPerasCertBoost (..)
@@ -72,6 +72,7 @@ import Cardano.Ledger.Hashes (KeyHash, KeyRole (..))
 import Codec.Serialise (Serialise (..))
 import Codec.Serialise.Decoding (decodeListLenOf)
 import Codec.Serialise.Encoding (encodeListLen)
+import Data.Kind (Type)
 import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.Map as Map
 import Data.Map.Strict (Map)
@@ -321,21 +322,42 @@ class
   ) =>
   BlockSupportsPeras blk
   where
-  -- NOTE: these will be updated during the upcoming 'BlockSupportsPeras' refactor
-  type PerasCrypto blk
-  type PerasVotingCommitteeScheme blk
-  type PerasError blk
+  -- | The concrete Peras vote type for this block type.
+  type PerasVote blk = (vote :: Type) | vote -> blk
 
-  -- NOTE: this associated type will dissapear in favor of using
-  -- 'PerasParams blk' directly.
+  type PerasVote blk = VoidPerasVote blk
+
+  -- | The concrete Peras certificate type for this block type.
+  type PerasCert blk = (cert :: Type) | cert -> blk
+
+  type PerasCert blk = VoidPerasCert blk
+
+  -- | The concrete Peras error type for this block type.
+  type PerasError blk = (err :: Type) | err -> blk
+
+  type PerasError blk = VoidPerasError blk
+
+  -- | The crypto scheme used for Peras votes and certificates.
+  --
+  -- Used to dispatch a block type to a its corresponding voting crypto scheme.
+  type PerasCrypto blk :: Type
+
+  type PerasCrypto blk = VoidPerasCrypto blk
+
+  -- | The voting committee scheme used for Peras.
+  --
+  -- Used to dispatch a block type to a its corresponding voting committee scheme.
+  type PerasVotingCommitteeScheme blk :: Type
+
+  type PerasVotingCommitteeScheme blk = VoidPerasVotingCommitteeScheme
+
+  -- NOTE: to be removed in favor of 'PerasParams'.
   type PerasCfg blk
 
-  data PerasCert blk
-
-  data PerasVote blk
-
+  -- NOTE: to be removed in favor of 'PerasError'.
   data PerasValidationErr blk
 
+  -- NOTE: to be removed in favor of 'PerasError'.
   data PerasForgeErr blk
 
   validatePerasCert ::
@@ -370,21 +392,8 @@ instance StandardHash blk => BlockSupportsPeras blk where
   type PerasError blk = VoidPerasError blk
 
   type PerasCfg blk = PerasParams blk
-
-  data PerasCert blk = PerasCert
-    { pcCertRound :: PerasRoundNo
-    , pcCertBoostedBlock :: Point blk
-    }
-    deriving stock (Generic, Eq, Ord, Show)
-    deriving anyclass NoThunks
-
-  data PerasVote blk = PerasVote
-    { pvVoteRound :: PerasRoundNo
-    , pvVoteBlock :: Point blk
-    , pvVoteVoterId :: PerasVoterId
-    }
-    deriving stock (Generic, Eq, Ord, Show)
-    deriving anyclass NoThunks
+  type PerasCert blk = PerasCert' blk
+  type PerasVote blk = PerasVote' blk
 
   -- TODO: enrich with actual error types
   -- see https://github.com/tweag/cardano-peras/issues/120
@@ -439,16 +448,35 @@ instance StandardHash blk => BlockSupportsPeras blk where
   -- is in place.
   getPerasCertInBlock _ = Nothing
 
-instance ShowProxy blk => ShowProxy (PerasCert blk) where
+-- | NOTE: to be removed in favor of using per-blk definitions.
+data PerasCert' blk
+  = PerasCert
+  { pcCertRound :: PerasRoundNo
+  , pcCertBoostedBlock :: Point blk
+  }
+  deriving stock (Generic, Eq, Ord, Show)
+  deriving anyclass NoThunks
+
+-- | NOTE: to be removed in favor of using per-blk definitions.
+data PerasVote' blk
+  = PerasVote
+  { pvVoteRound :: PerasRoundNo
+  , pvVoteBlock :: Point blk
+  , pvVoteVoterId :: PerasVoterId
+  }
+  deriving stock (Generic, Eq, Ord, Show)
+  deriving anyclass NoThunks
+
+instance ShowProxy blk => ShowProxy (PerasCert' blk) where
   showProxy _ = "PerasCert " <> showProxy (Proxy @blk)
 
-instance ShowProxy blk => ShowProxy (PerasVote blk) where
+instance ShowProxy blk => ShowProxy (PerasVote' blk) where
   showProxy _ = "PerasVote " <> showProxy (Proxy @blk)
 
 instance ShowProxy blk => ShowProxy (PerasVoteId blk) where
   showProxy _ = "PerasVoteId " <> showProxy (Proxy @blk)
 
-instance Serialise (HeaderHash blk) => Serialise (PerasCert blk) where
+instance Serialise (HeaderHash blk) => Serialise (PerasCert' blk) where
   encode PerasCert{pcCertRound, pcCertBoostedBlock} =
     encodeListLen 2
       <> encode pcCertRound
@@ -459,7 +487,7 @@ instance Serialise (HeaderHash blk) => Serialise (PerasCert blk) where
     pcCertBoostedBlock <- decode
     pure $ PerasCert{pcCertRound, pcCertBoostedBlock}
 
-instance Serialise (HeaderHash blk) => Serialise (PerasVote blk) where
+instance Serialise (HeaderHash blk) => Serialise (PerasVote' blk) where
   encode PerasVote{pvVoteRound, pvVoteBlock, pvVoteVoterId} =
     encodeListLen 3
       <> encode pvVoteRound
@@ -487,7 +515,7 @@ instance Serialise (PerasVoteId blk) where
 class HasPerasCertRound cert where
   getPerasCertRound :: cert -> PerasRoundNo
 
-instance HasPerasCertRound (PerasCert blk) where
+instance HasPerasCertRound (PerasCert' blk) where
   getPerasCertRound = pcCertRound
 
 instance HasPerasCertRound (ValidatedPerasCert blk) where
@@ -503,7 +531,7 @@ instance
 class HasPerasCertBoostedBlock cert blk | cert -> blk where
   getPerasCertBoostedBlock :: cert -> Point blk
 
-instance HasPerasCertBoostedBlock (PerasCert blk) blk where
+instance HasPerasCertBoostedBlock (PerasCert' blk) blk where
   getPerasCertBoostedBlock = pcCertBoostedBlock
 
 instance HasPerasCertBoostedBlock (ValidatedPerasCert blk) blk where
@@ -532,7 +560,7 @@ instance
 class HasPerasVoteRound vote where
   getPerasVoteRound :: vote -> PerasRoundNo
 
-instance HasPerasVoteRound (PerasVote blk) where
+instance HasPerasVoteRound (PerasVote' blk) where
   getPerasVoteRound = pvVoteRound
 
 instance HasPerasVoteRound (ValidatedPerasVote blk) where
@@ -548,7 +576,7 @@ instance
 class HasPerasVoteBlock vote blk | vote -> blk where
   getPerasVoteBlock :: vote -> Point blk
 
-instance HasPerasVoteBlock (PerasVote blk) blk where
+instance HasPerasVoteBlock (PerasVote' blk) blk where
   getPerasVoteBlock = pvVoteBlock
 
 instance HasPerasVoteBlock (ValidatedPerasVote blk) blk where
@@ -564,7 +592,7 @@ instance
 class HasPerasVoteVoterId vote where
   getPerasVoteVoterId :: vote -> PerasVoterId
 
-instance HasPerasVoteVoterId (PerasVote blk) where
+instance HasPerasVoteVoterId (PerasVote' blk) where
   getPerasVoteVoterId = pvVoteVoterId
 
 instance HasPerasVoteVoterId (ValidatedPerasVote blk) where
@@ -593,7 +621,7 @@ instance
 class HasPerasVoteTarget vote blk | vote -> blk where
   getPerasVoteTarget :: vote -> PerasVoteTarget blk
 
-instance HasPerasVoteTarget (PerasVote blk) blk where
+instance HasPerasVoteTarget (PerasVote' blk) blk where
   getPerasVoteTarget vote =
     PerasVoteTarget
       { pvtRoundNo = pvVoteRound vote
@@ -613,7 +641,7 @@ instance
 class HasPerasVoteId vote blk | vote -> blk where
   getPerasVoteId :: vote -> PerasVoteId blk
 
-instance HasPerasVoteId (PerasVote blk) blk where
+instance HasPerasVoteId (PerasVote' blk) blk where
   getPerasVoteId vote =
     PerasVoteId
       { pviRoundNo = pvVoteRound vote

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Node/Serialisation.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Node/Serialisation.hs
@@ -202,7 +202,7 @@ instance SerialiseNodeToNode blk PerasSeatIndex where
   encodeNodeToNode _ccfg _version = toCBOR . unPerasSeatIndex
   decodeNodeToNode _ccfg _version = PerasSeatIndex <$> fromCBOR
 
-instance ConvertRawHash blk => SerialiseNodeToNode blk (PerasCert blk) where
+instance ConvertRawHash blk => SerialiseNodeToNode blk (PerasCert' blk) where
   -- Consistent with the 'Serialise' instance for 'PerasCert' defined in Ouroboros.Consensus.Block.SupportsPeras
   encodeNodeToNode ccfg version PerasCert{..} =
     encodeListLen 2
@@ -214,7 +214,7 @@ instance ConvertRawHash blk => SerialiseNodeToNode blk (PerasCert blk) where
     pcCertBoostedBlock <- decodeNodeToNode ccfg version
     pure $ PerasCert pcCertRound pcCertBoostedBlock
 
-instance ConvertRawHash blk => SerialiseNodeToNode blk (PerasVote blk) where
+instance ConvertRawHash blk => SerialiseNodeToNode blk (PerasVote' blk) where
   -- Consistent with the 'Serialise' instance for 'PerasVote' defined in Ouroboros.Consensus.Block.SupportsPeras
   encodeNodeToNode ccfg version PerasVote{..} =
     encodeListLen 3

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/Orphans/ToExpr.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/Orphans/ToExpr.hs
@@ -124,7 +124,7 @@ deriving anyclass instance ToExpr PerasRoundNo
 
 deriving anyclass instance ToExpr PerasWeight
 
-deriving anyclass instance ToExpr (HeaderHash blk) => ToExpr (PerasCert blk)
+deriving anyclass instance ToExpr (HeaderHash blk) => ToExpr (PerasCert' blk)
 
 deriving anyclass instance ToExpr (HeaderHash blk) => ToExpr (ValidatedPerasCert blk)
 

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/MiniProtocol/ObjectDiffusion/PerasCert/Smoke.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/MiniProtocol/ObjectDiffusion/PerasCert/Smoke.hs
@@ -66,7 +66,7 @@ genPerasCert = do
   pcCertBoostedBlock <- genPointTestBlock
   pure $ PerasCert{pcCertRound, pcCertBoostedBlock}
 
-instance WithId (PerasCert blk) PerasRoundNo where
+instance WithId (PerasCert' blk) PerasRoundNo where
   getId = pcCertRound
 
 instance WithId (WithArrivalTime (ValidatedPerasCert blk)) PerasRoundNo where

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/MiniProtocol/ObjectDiffusion/PerasVote/Smoke.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/MiniProtocol/ObjectDiffusion/PerasVote/Smoke.hs
@@ -85,7 +85,7 @@ genPerasVote = do
   pvVoteVoterId <- genPerasVoterId
   pure $ PerasVote{pvVoteRound, pvVoteBlock, pvVoteVoterId}
 
-instance WithId (PerasVote blk) (PerasVoteId blk) where
+instance WithId (PerasVote' blk) (PerasVoteId blk) where
   getId = getPerasVoteId
 
 instance WithId (WithArrivalTime (ValidatedPerasVote blk)) (PerasVoteId blk) where

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/PerasVoteDB/Model.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/PerasVoteDB/Model.hs
@@ -26,7 +26,7 @@ import Ouroboros.Consensus.Block.Abstract (StandardHash)
 import Ouroboros.Consensus.Block.SupportsPeras
   ( HasPerasVoteBlock (..)
   , HasPerasVoteRound (..)
-  , PerasCert (..)
+  , PerasCert' (..)
   , PerasCfg
   , PerasParams (..)
   , PerasRoundNo

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/PerasVoteDB/StateMachine.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/PerasVoteDB/StateMachine.hs
@@ -45,7 +45,7 @@ import Ouroboros.Consensus.Block.SupportsPeras
   , HasPerasVoteBlock (..)
   , HasPerasVoteRound (..)
   , PerasRoundNo (..)
-  , PerasVote (..)
+  , PerasVote' (..)
   , PerasVoteId
   , PerasVoteStake (..)
   , PerasVoteTarget (..)


### PR DESCRIPTION
This commit tweaks the `BlockSupportsPeras` class to use injective type families for `PerasVote`, `PerasCert`, and `PerasError` (to soon replace `PerasForgeErr` and `PerasValidationErr`).

The main idea is to allow us to avoid some of the necessary boilerplate we would require if used data families by providing a default (void) implementation for all these types, while still being able to take advantage of blk-based injectivity.

NOTE: for now, we turned associated `PerasCert` and `PerasVote` data instances into standalone types, but these will be ultimately removed after we get rid of the degenerate `BlockSupportsPeras` instance.