### PR TITLE
[Peras 50] Use SeatIndex-based PerasVoteId

### DIFF
--- a/changelog.d/20260806_105059_agustin.mista_tweak_peras_vote_id.md
+++ b/changelog.d/20260806_105059_agustin.mista_tweak_peras_vote_id.md
@@ -1,0 +1,23 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+### Breaking
+
+- `PerasVoteId` now uses a `SeatIndex`-based voter ID and no longer has a phantom `blk` index.
+
+<!--
+### Non-Breaking
+
+- A bullet item for the Non-Breaking category.
+
+-->
+<!--
+### Patch
+
+- A bullet item for the Patch category.
+
+-->

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Block/SupportsPeras.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Block/SupportsPeras.hs
@@ -67,7 +67,6 @@ module Ouroboros.Consensus.Block.SupportsPeras
   ) where
 
 import Cardano.Binary (FromCBOR (..), ToCBOR (..))
-import qualified Cardano.Binary as KeyHash
 import Cardano.Ledger.Hashes (KeyHash, KeyRole (..))
 import Codec.Serialise (Serialise (..))
 import Codec.Serialise.Decoding (decodeListLenOf)
@@ -88,7 +87,7 @@ import Ouroboros.Consensus.Committee.Class
   , VotingCommittee
   )
 import Ouroboros.Consensus.Peras.Params
-import Ouroboros.Consensus.Peras.Types hiding (PerasVoteId (..))
+import Ouroboros.Consensus.Peras.Types
 import Ouroboros.Consensus.Peras.Void
 import Ouroboros.Consensus.Peras.Voting.Adapter (PerasConversionError)
 import Ouroboros.Consensus.Util
@@ -220,18 +219,10 @@ stakeAboveThreshold params voteStake =
       (perasQuorumWeightThresholdSafetyMargin params)
 
 newtype PerasVoteStakeDistr = PerasVoteStakeDistr
-  { unPerasVoteStakeDistr :: Map PerasVoterId PerasVoteStake
+  { unPerasVoteStakeDistr :: Map PerasSeatIndex PerasVoteStake
   }
   deriving newtype NoThunks
   deriving stock (Show, Eq, Generic)
-
--- NOTE: to be removed in favor of the one in 'Ouroboros.Consensus.Peras.Types'
-data PerasVoteId blk = PerasVoteId
-  { pviRoundNo :: !PerasRoundNo
-  , pviVoterId :: !PerasVoterId
-  }
-  deriving stock (Show, Eq, Ord, Generic)
-  deriving anyclass NoThunks
 
 -- | Lookup the stake of a vote cast by a member of a given stake distribution.
 lookupPerasVoteStake ::
@@ -462,7 +453,7 @@ data PerasVote' blk
   = PerasVote
   { pvVoteRound :: PerasRoundNo
   , pvVoteBlock :: Point blk
-  , pvVoteVoterId :: PerasVoterId
+  , pvVoteVoterId :: PerasSeatIndex
   }
   deriving stock (Generic, Eq, Ord, Show)
   deriving anyclass NoThunks
@@ -472,9 +463,6 @@ instance ShowProxy blk => ShowProxy (PerasCert' blk) where
 
 instance ShowProxy blk => ShowProxy (PerasVote' blk) where
   showProxy _ = "PerasVote " <> showProxy (Proxy @blk)
-
-instance ShowProxy blk => ShowProxy (PerasVoteId blk) where
-  showProxy _ = "PerasVoteId " <> showProxy (Proxy @blk)
 
 instance Serialise (HeaderHash blk) => Serialise (PerasCert' blk) where
   encode PerasCert{pcCertRound, pcCertBoostedBlock} =
@@ -492,24 +480,13 @@ instance Serialise (HeaderHash blk) => Serialise (PerasVote' blk) where
     encodeListLen 3
       <> encode pvVoteRound
       <> encode pvVoteBlock
-      <> KeyHash.toCBOR (unPerasVoterId pvVoteVoterId)
+      <> toCBOR pvVoteVoterId
   decode = do
     decodeListLenOf 3
     pvVoteRound <- decode
     pvVoteBlock <- decode
-    pvVoteVoterId <- PerasVoterId <$> KeyHash.fromCBOR
+    pvVoteVoterId <- fromCBOR
     pure $ PerasVote{pvVoteRound, pvVoteBlock, pvVoteVoterId}
-
-instance Serialise (PerasVoteId blk) where
-  encode PerasVoteId{pviRoundNo, pviVoterId} =
-    encodeListLen 2
-      <> encode pviRoundNo
-      <> KeyHash.toCBOR (unPerasVoterId pviVoterId)
-  decode = do
-    decodeListLenOf 2
-    pviRoundNo <- decode
-    pviVoterId <- PerasVoterId <$> KeyHash.fromCBOR
-    pure $ PerasVoteId{pviRoundNo, pviVoterId}
 
 -- | Extract the certificate round from a Peras certificate container
 class HasPerasCertRound cert where
@@ -590,7 +567,7 @@ instance
 
 -- | Extract the stake pool ID from a Peras vote container
 class HasPerasVoteVoterId vote where
-  getPerasVoteVoterId :: vote -> PerasVoterId
+  getPerasVoteVoterId :: vote -> PerasSeatIndex
 
 instance HasPerasVoteVoterId (PerasVote' blk) where
   getPerasVoteVoterId = pvVoteVoterId
@@ -639,13 +616,13 @@ instance
 
 -- | Extract the vote ID from a Peras vote container
 class HasPerasVoteId vote blk | vote -> blk where
-  getPerasVoteId :: vote -> PerasVoteId blk
+  getPerasVoteId :: vote -> PerasVoteId
 
 instance HasPerasVoteId (PerasVote' blk) blk where
   getPerasVoteId vote =
     PerasVoteId
       { pviRoundNo = pvVoteRound vote
-      , pviVoterId = pvVoteVoterId vote
+      , pviSeatIndex = pvVoteVoterId vote
       }
 
 instance HasPerasVoteId (ValidatedPerasVote blk) blk where

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ObjectDiffusion/ObjectPool/PerasVote.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ObjectDiffusion/ObjectPool/PerasVote.hs
@@ -49,7 +49,7 @@ makePerasVotePoolReader ::
   ( PerasVoteTicketNo ->
     STM m (Map PerasVoteTicketNo (WithArrivalTime (ValidatedPerasVote blk)))
   ) ->
-  ObjectPoolReader (PerasVoteId blk) (PerasVote blk) PerasVoteTicketNo m
+  ObjectPoolReader PerasVoteId (PerasVote blk) PerasVoteTicketNo m
 makePerasVotePoolReader getVotesAfterSTM =
   ObjectPoolReader
     { oprObjectId = getPerasVoteId
@@ -66,7 +66,7 @@ makePerasVotePoolReader getVotesAfterSTM =
 makePerasVotePoolReaderFromVoteDB ::
   IOLike m =>
   PerasVoteDB m blk ->
-  ObjectPoolReader (PerasVoteId blk) (PerasVote blk) PerasVoteTicketNo m
+  ObjectPoolReader PerasVoteId (PerasVote blk) PerasVoteTicketNo m
 makePerasVotePoolReaderFromVoteDB perasVoteDB =
   makePerasVotePoolReader
     (PerasVoteDB.getVotesAfter perasVoteDB)
@@ -74,7 +74,7 @@ makePerasVotePoolReaderFromVoteDB perasVoteDB =
 makePerasVotePoolReaderFromChainDB ::
   IOLike m =>
   ChainDB m blk ->
-  ObjectPoolReader (PerasVoteId blk) (PerasVote blk) PerasVoteTicketNo m
+  ObjectPoolReader PerasVoteId (PerasVote blk) PerasVoteTicketNo m
 makePerasVotePoolReaderFromChainDB chainDB =
   makePerasVotePoolReader
     (ChainDB.getPerasVotesAfter chainDB)
@@ -97,7 +97,7 @@ makePerasVotePoolWriterFromVoteDB ::
   -- from the stake distr directly, but rather use the committee selection data)
   STM m PerasVoteStakeDistr ->
   PerasVoteDB m blk ->
-  ObjectPoolWriter (PerasVoteId blk) (PerasVote blk) m
+  ObjectPoolWriter PerasVoteId (PerasVote blk) m
 makePerasVotePoolWriterFromVoteDB systemTime getStakeDistrSTM perasVoteDB =
   ObjectPoolWriter
     { opwObjectId = getPerasVoteId
@@ -127,7 +127,7 @@ makePerasVotePoolWriterFromChainDB ::
   -- from the stake distr directly, but rather use the committee selection data)
   STM m PerasVoteStakeDistr ->
   ChainDB m blk ->
-  ObjectPoolWriter (PerasVoteId blk) (PerasVote blk) m
+  ObjectPoolWriter PerasVoteId (PerasVote blk) m
 makePerasVotePoolWriterFromChainDB systemTime getStakeDistrSTM chainDB =
   ObjectPoolWriter
     { opwObjectId = getPerasVoteId
@@ -170,7 +170,7 @@ instance Exception PerasVoteInboundException
 processVotes ::
   MonadSTM m =>
   SystemTime m ->
-  STM m (Set (PerasVoteId blk)) ->
+  STM m (Set PerasVoteId) ->
   (PerasVote blk -> STM m (Either (PerasValidationErr blk) (ValidatedPerasVote blk))) ->
   (WithArrivalTime (ValidatedPerasVote blk) -> m ()) ->
   [PerasVote blk] ->

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ObjectDiffusion/PerasVote.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ObjectDiffusion/PerasVote.hs
@@ -20,22 +20,22 @@ import Ouroboros.Network.Protocol.ObjectDiffusion.Outbound (ObjectDiffusionOutbo
 import Ouroboros.Network.Protocol.ObjectDiffusion.Type (ObjectDiffusion)
 
 type TracePerasVoteDiffusionInbound blk =
-  TraceObjectDiffusionInbound (PerasVoteId blk) (PerasVote blk)
+  TraceObjectDiffusionInbound PerasVoteId (PerasVote blk)
 
 type TracePerasVoteDiffusionOutbound blk =
-  TraceObjectDiffusionOutbound (PerasVoteId blk) (PerasVote blk)
+  TraceObjectDiffusionOutbound PerasVoteId (PerasVote blk)
 
 type PerasVotePoolReader blk m =
-  ObjectPoolReader (PerasVoteId blk) (PerasVote blk) PerasVoteTicketNo m
+  ObjectPoolReader PerasVoteId (PerasVote blk) PerasVoteTicketNo m
 
 type PerasVotePoolWriter blk m =
-  ObjectPoolWriter (PerasVoteId blk) (PerasVote blk) m
+  ObjectPoolWriter PerasVoteId (PerasVote blk) m
 
 type PerasVoteDiffusionInboundPipelined blk m a =
-  ObjectDiffusionInboundPipelined (PerasVoteId blk) (PerasVote blk) m a
+  ObjectDiffusionInboundPipelined PerasVoteId (PerasVote blk) m a
 
 type PerasVoteDiffusionOutbound blk m a =
-  ObjectDiffusionOutbound (PerasVoteId blk) (PerasVote blk) m a
+  ObjectDiffusionOutbound PerasVoteId (PerasVote blk) m a
 
 type PerasVoteDiffusion blk =
-  ObjectDiffusion (PerasVoteId blk) (PerasVote blk)
+  ObjectDiffusion PerasVoteId (PerasVote blk)

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Node/Serialisation.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Node/Serialisation.hs
@@ -232,17 +232,17 @@ instance SerialiseNodeToNode blk PerasVoterId where
   encodeNodeToNode _ccfg _version = KeyHash.toCBOR . unPerasVoterId
   decodeNodeToNode _ccfg _version = PerasVoterId <$> KeyHash.fromCBOR
 
-instance SerialiseNodeToNode blk (PerasVoteId blk) where
+instance SerialiseNodeToNode blk PerasVoteId where
   -- Consistent with the 'Serialise' instance for 'PerasVoteId' defined in Ouroboros.Consensus.Block.SupportsPeras
   encodeNodeToNode ccfg version PerasVoteId{..} =
     encodeListLen 2
       <> encodeNodeToNode ccfg version pviRoundNo
-      <> encodeNodeToNode ccfg version pviVoterId
+      <> encodeNodeToNode ccfg version pviSeatIndex
   decodeNodeToNode ccfg version = do
     decodeListLenOf 2
     pviRoundNo <- decodeNodeToNode ccfg version
-    pviVoterId <- decodeNodeToNode ccfg version
-    pure $ PerasVoteId pviRoundNo pviVoterId
+    pviSeatIndex <- decodeNodeToNode ccfg version
+    pure $ PerasVoteId pviRoundNo pviSeatIndex
 
 deriving newtype instance
   SerialiseNodeToClient blk (GenTxId blk) =>

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Peras/Vote/Aggregation.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Peras/Vote/Aggregation.hs
@@ -407,7 +407,7 @@ voteGeneratedCert = \case
 data PerasTargetVoteTally blk = PerasTargetVoteTally
   { ptvtTarget :: !(PerasVoteTarget blk)
   -- ^ What we are tallying votes for
-  , ptvtVotes :: !(Map (PerasVoteId blk) (WithArrivalTime (ValidatedPerasVote blk)))
+  , ptvtVotes :: !(Map PerasVoteId (WithArrivalTime (ValidatedPerasVote blk)))
   -- ^ Votes received for this target, indexed by vote ID
   , ptvtTotalStake :: !PerasVoteStake
   -- ^ Total stake of the votes received for this target

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/API.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/API.hs
@@ -464,7 +464,7 @@ data ChainDB m blk = ChainDB
       STM m (Map PerasVoteTicketNo (WithArrivalTime (ValidatedPerasVote blk)))
   -- ^ Get all known Peras votes with a ticket number strictly greater than the
   -- given one, in ascending order.
-  , getPerasVoteIds :: STM m (Set (PerasVoteId blk))
+  , getPerasVoteIds :: STM m (Set PerasVoteId)
   -- ^ Get the set of all Peras vote IDs currently in the database.
   , waitForImmutableBlock :: RealPoint blk -> m (Either SeekBlockError (RealPoint blk))
   -- ^ Wait until the immutable tip's slot is equal or greater than the given slot:

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Query.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Query.hs
@@ -368,7 +368,7 @@ getPerasVotesAfter ::
 getPerasVotesAfter CDB{..} = PerasVoteDB.getVotesAfter cdbPerasVoteDB
 
 getPerasVoteIds ::
-  ChainDbEnv m blk -> STM m (Set (PerasVoteId blk))
+  ChainDbEnv m blk -> STM m (Set PerasVoteId)
 getPerasVoteIds CDB{..} = PerasVoteDB.getVoteIds cdbPerasVoteDB
 
 -- | Wait until the slot of the given point is smaller or equal than the immutable tip slot,

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/PerasVoteDB/API.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/PerasVoteDB/API.hs
@@ -48,7 +48,7 @@ data PerasVoteDB m blk = PerasVoteDB
   -- NOTE: the resulting computation over 'm' is there solely for tracing
   -- purposes. Use the `join . atomically` pattern to consume its output.
   , getVoteIds ::
-      STM m (Set (PerasVoteId blk))
+      STM m (Set PerasVoteId)
   -- ^ Get the set of all vote IDs currently in the database.
   , getVotesAfter ::
       PerasVoteTicketNo ->

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/PerasVoteDB/Impl.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/PerasVoteDB/Impl.hs
@@ -52,7 +52,7 @@ data PerasVoteDbEnv m blk = PerasVoteDbEnv
 
 -- INVARIANT: See 'invariantForPerasVoteDbState'.
 data PerasVoteDbState blk = PerasVoteDbState
-  { pvdsVoteIds :: !(Set (PerasVoteId blk))
+  { pvdsVoteIds :: !(Set PerasVoteId)
   , pvdsRoundVoteStates :: !(Map PerasRoundNo (PerasRoundVoteState blk))
   , pvdsVotesByTicket :: !(Map PerasVoteTicketNo (WithArrivalTime (ValidatedPerasVote blk)))
   -- ^ The votes by 'PerasVoteTicketNo'.
@@ -110,7 +110,7 @@ invariantForPerasVoteDbState pvs = do
 
 data TraceEvent blk
   = AddVote
-      (PerasVoteId blk)
+      PerasVoteId
       (WithArrivalTime (ValidatedPerasVote blk))
       (AddPerasVoteResult blk)
   | GarbageCollected
@@ -248,7 +248,7 @@ implAddVote perasCfg PerasVoteDbEnv{pvdeTracer, pvdeState} vote = do
 implGetVoteIds ::
   IOLike m =>
   PerasVoteDbEnv m blk ->
-  STM m (Set (PerasVoteId blk))
+  STM m (Set PerasVoteId)
 implGetVoteIds PerasVoteDbEnv{pvdeState} = do
   PerasVoteDbState{pvdsVoteIds} <-
     forgetFingerprint <$> readTVar pvdeState

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/MiniProtocol/ObjectDiffusion/PerasVote/Smoke.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/MiniProtocol/ObjectDiffusion/PerasVote/Smoke.hs
@@ -5,21 +5,16 @@
 
 module Test.Consensus.MiniProtocol.ObjectDiffusion.PerasVote.Smoke
   ( tests
-  , genPerasVoterId
   , genPerasVoteStake
   , genPerasVote
   , genValidatedPerasVote
   ) where
 
-import qualified Cardano.Crypto.DSIGN.Class as SL
-import qualified Cardano.Crypto.Seed as SL
-import qualified Cardano.Ledger.Keys as SL
 import Control.Monad (join)
 import Control.Tracer (contramap, nullTracer)
 import Data.Data (Typeable)
 import qualified Data.Map as Map
 import Data.Ratio ((%))
-import Data.String (IsString (..))
 import Network.TypedProtocol.Driver.Simple (runPeer, runPipelinedPeer)
 import Ouroboros.Consensus.Block.SupportsPeras
 import Ouroboros.Consensus.BlockchainTime.WallClock.Types
@@ -65,13 +60,8 @@ tests =
     [ testProperty "PerasVoteDiffusion smoke test" prop_smoke
     ]
 
-genPerasVoterId :: Gen PerasVoterId
-genPerasVoterId = do
-  bytes <- fromString <$> vectorOf 32 arbitrary
-  let signKey = SL.genKeyDSIGN (SL.mkSeedFromBytes bytes)
-      verKey = SL.deriveVerKeyDSIGN signKey
-      keyHash = SL.hashKey (SL.VKey verKey)
-  pure (PerasVoterId keyHash)
+genPerasSeatIndex :: Gen PerasSeatIndex
+genPerasSeatIndex = PerasSeatIndex <$> choose (0, 99)
 
 genPerasVoteStake :: Gen PerasVoteStake
 genPerasVoteStake = do
@@ -82,13 +72,13 @@ genPerasVote :: Gen (PerasVote TestBlock)
 genPerasVote = do
   pvVoteRound <- PerasRoundNo <$> arbitrary
   pvVoteBlock <- genPointTestBlock
-  pvVoteVoterId <- genPerasVoterId
+  pvVoteVoterId <- genPerasSeatIndex
   pure $ PerasVote{pvVoteRound, pvVoteBlock, pvVoteVoterId}
 
-instance WithId (PerasVote' blk) (PerasVoteId blk) where
+instance WithId (PerasVote' blk) PerasVoteId where
   getId = getPerasVoteId
 
-instance WithId (WithArrivalTime (ValidatedPerasVote blk)) (PerasVoteId blk) where
+instance WithId (WithArrivalTime (ValidatedPerasVote blk)) PerasVoteId where
   getId = getPerasVoteId . vpvVote . forgetArrivalTime
 
 genValidatedPerasVote :: Gen (ValidatedPerasVote TestBlock)
@@ -122,8 +112,8 @@ prop_smoke =
           mkPoolInterfaces ::
             IOLike m =>
             m
-              ( ObjectPoolReader (PerasVoteId TestBlock) (PerasVote TestBlock) PerasVoteTicketNo m
-              , ObjectPoolWriter (PerasVoteId TestBlock) (PerasVote TestBlock) m
+              ( ObjectPoolReader PerasVoteId (PerasVote TestBlock) PerasVoteTicketNo m
+              , ObjectPoolWriter PerasVoteId (PerasVote TestBlock) m
               , m [PerasVote TestBlock]
               )
           mkPoolInterfaces = do

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
@@ -1361,7 +1361,7 @@ generator loe genBlock genPerasBlock m@Model{..} =
     let upperBound = min capacity maxVoteStake
     stakeNumerator <- choose (ceiling (minVoteStake * 100), floor (upperBound * 100)) :: Gen Int
     let stake = PerasVoteStake (fromIntegral stakeNumerator % 100)
-    voterId <- PerasVoteDB.SM.genVoterId
+    seatIndex <- PerasVoteDB.SM.genPerasSeatIndex
     -- Include the voted block itself in the persisted seenBlocks
     let seenBlks = fmap (blk :) gapBlks
     -- Build the vote
@@ -1373,7 +1373,7 @@ generator loe genBlock genPerasBlock m@Model{..} =
                   PerasVote
                     { pvVoteRound = roundNo
                     , pvVoteBlock = blockPoint blk
-                    , pvVoteVoterId = voterId
+                    , pvVoteVoterId = seatIndex
                     }
               , vpvVoteStake = stake
               }

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/PerasVoteDB/Model.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/PerasVoteDB/Model.hs
@@ -33,7 +33,6 @@ import Ouroboros.Consensus.Block.SupportsPeras
   , PerasVoteId (..)
   , PerasVoteStake (..)
   , PerasVoteTarget (..)
-  , PerasVoterId
   , ValidatedPerasCert (..)
   , ValidatedPerasVote
   , getPerasCertBoostedBlock
@@ -44,6 +43,7 @@ import Ouroboros.Consensus.Block.SupportsPeras
 import Ouroboros.Consensus.BlockchainTime.WallClock.Types
   ( WithArrivalTime (..)
   )
+import Ouroboros.Consensus.Peras.Types (PerasSeatIndex)
 import Ouroboros.Consensus.Storage.PerasVoteDB.API
   ( AddPerasVoteResult (..)
   , PerasVoteTicketNo
@@ -53,7 +53,7 @@ import Ouroboros.Consensus.Storage.PerasVoteDB.API
 data VoteEntry blk = VoteEntry
   { veTicketNo :: PerasVoteTicketNo
   -- ^ The ticket number assigned to this vote
-  , veVoter :: PerasVoterId
+  , veVoter :: PerasSeatIndex
   -- ^ The voter ID
   , veVote :: WithArrivalTime (ValidatedPerasVote blk)
   -- ^ The vote itself
@@ -97,7 +97,7 @@ initModel cfg =
 -- collection to track this information efficienty, at the cost of added
 -- complexity.
 hasVote ::
-  PerasVoteId blk ->
+  PerasVoteId ->
   Model blk ->
   Bool
 hasVote voteId model =
@@ -109,7 +109,7 @@ hasVote voteId model =
           ( \ve ->
               PerasVoteId
                 { pviRoundNo = pvtRoundNo voteTarget
-                , pviVoterId = veVoter ve
+                , pviSeatIndex = veVoter ve
                 }
           )
           votesForTarget
@@ -208,7 +208,7 @@ addVote vote model
     succ (lastTicketNo model)
   -- Prepare various data structures needed to update the model
   voteId =
-    PerasVoteId{pviRoundNo = roundNo, pviVoterId = voter}
+    PerasVoteId{pviRoundNo = roundNo, pviSeatIndex = voter}
   voteTarget =
     PerasVoteTarget{pvtRoundNo = roundNo, pvtBlock = votedBlock}
   voteEntry =
@@ -261,14 +261,14 @@ addVote vote model
 
 getVoteIds ::
   Model blk ->
-  Set (PerasVoteId blk)
+  Set PerasVoteId
 getVoteIds model =
   Set.unions $
     [ Set.map
         ( \ve ->
             PerasVoteId
               { pviRoundNo = pvtRoundNo voteTarget
-              , pviVoterId = veVoter ve
+              , pviSeatIndex = veVoter ve
               }
         )
         votesForTarget

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/PerasVoteDB/StateMachine.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/PerasVoteDB/StateMachine.hs
@@ -11,13 +11,10 @@ module Test.Ouroboros.Storage.PerasVoteDB.StateMachine
   ( tests
 
     -- * Reusable generators
-  , genVoterId
+  , genPerasSeatIndex
   , genVoteStake
   ) where
 
-import qualified Cardano.Crypto.DSIGN.Class as SL
-import qualified Cardano.Crypto.Seed as SL
-import qualified Cardano.Ledger.Keys as SL
 import Control.Concurrent.Class.MonadSTM (MonadSTM (..))
 import Control.Monad (join)
 import Control.Monad.Class.MonadThrow (MonadCatch (..))
@@ -28,7 +25,6 @@ import Control.Monad.State
   , evalStateT
   )
 import Control.Tracer (nullTracer)
-import Data.Char (chr)
 import Data.Functor (($>))
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map as Map
@@ -36,7 +32,6 @@ import Data.Map.Strict (Map)
 import Data.Ratio ((%))
 import Data.Set (Set)
 import qualified Data.Set as Set
-import Data.String (IsString (..))
 import Data.Word (Word64)
 import GHC.Generics (Generic)
 import Ouroboros.Consensus.Block.Abstract (Point (..), SlotNo (..))
@@ -45,11 +40,11 @@ import Ouroboros.Consensus.Block.SupportsPeras
   , HasPerasVoteBlock (..)
   , HasPerasVoteRound (..)
   , PerasRoundNo (..)
+  , PerasSeatIndex (..)
   , PerasVote' (..)
   , PerasVoteId
   , PerasVoteStake (..)
   , PerasVoteTarget (..)
-  , PerasVoterId (..)
   , ValidatedPerasCert
   , ValidatedPerasVote (..)
   , defaultPerasParams
@@ -74,7 +69,6 @@ import Test.QuickCheck
   , Gen
   , Property
   , choose
-  , elements
   , frequency
   , ioProperty
   , tabulate
@@ -145,7 +139,7 @@ instance StateModel Model where
             (AddPerasVoteResult TestBlock)
         )
     GetVoteIds ::
-      Action Model (Set (PerasVoteId TestBlock))
+      Action Model (Set PerasVoteId)
     GetVotesAfter ::
       PerasVoteTicketNo ->
       Action
@@ -179,7 +173,7 @@ instance StateModel Model where
     genAddVote = do
       roundNo <- genRoundNo
       point <- genPoint
-      voterId <- genVoterId
+      seatIndex <- genPerasSeatIndex
       stake <- genVoteStake
       now <- genRelativeTime
       let voteWithTime =
@@ -189,7 +183,7 @@ instance StateModel Model where
                     PerasVote
                       { pvVoteRound = roundNo
                       , pvVoteBlock = point
-                      , pvVoteVoterId = voterId
+                      , pvVoteVoterId = seatIndex
                       }
                 , vpvVoteStake = stake
                 }
@@ -351,19 +345,13 @@ instance RunModel Model (StateT (PerasVoteDB IO TestBlock) IO) where
 
 -- * Reusable generators
 
--- | Generate a random 'PerasVoterId'.
+-- | Generate a random 'PerasSeatIndex'.
 --
 -- We want to force collisions when adding votes, so we need to restrict
 -- the key space a lot here. Otherwise we might never hit the case where
 -- the same voter casts two votes for the same round/block.
-genVoterId :: Gen PerasVoterId
-genVoterId = do
-  let mkVoterKey = fromString . replicate 32
-  bytes <- mkVoterKey <$> elements [chr c | c <- [0 .. 99]]
-  let signKey = SL.genKeyDSIGN (SL.mkSeedFromBytes bytes)
-  let verKey = SL.deriveVerKeyDSIGN signKey
-  let keyHash = SL.hashKey (SL.VKey verKey)
-  pure (PerasVoterId keyHash)
+genPerasSeatIndex :: Gen PerasSeatIndex
+genPerasSeatIndex = PerasSeatIndex <$> choose (0, 99)
 
 -- | Generate a random 'PerasVoteStake'.
 --


### PR DESCRIPTION
This commit replaces the old `PerasVoteId` type from `Ouroboros.Consensus.Block.SupportsPeras` with the (monomorphic) one defined in `Ouroboros.Consensus.Peras.Types`.

Notably, this new type uses the seat index in the voting committee to identify voters, as opposed to the previous `KeyHash StakePool`.