### PR TITLE
Seed initial stake snapshots on epoch-0/1 hard fork

### DIFF
--- a/changelog.d/20260809_184924_sebastian.nagel_seed_stake_snapshots.md
+++ b/changelog.d/20260809_184924_sebastian.nagel_seed_stake_snapshots.md
@@ -1,0 +1,27 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+- Seed initial stake snapshots in experimental hard forks in epochs 0 or 1 (CardanoTriggerHardForkAtEpoch). This is useful for integration and end-to-end tests that otherwise need to wait for at least the third epoch, before the initial stake distribution comes into effect.
+
+<!--
+### Breaking
+
+- A bullet item for the Breaking category.
+
+-->
+<!--
+### Non-Breaking
+
+- A bullet item for the Non-Breaking category.
+
+-->
+<!--
+### Patch
+
+- A bullet item for the Patch category.
+
+-->

--- a/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/Node.hs
+++ b/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/Node.hs
@@ -52,6 +52,8 @@ import qualified Cardano.Ledger.Api.Era as L
 import qualified Cardano.Ledger.Api.Transition as L
 import qualified Cardano.Ledger.BaseTypes as SL
 import qualified Cardano.Ledger.Shelley.API as SL
+import Cardano.Ledger.Shelley.LedgerState (NewEpochState, esSnapshotsL, nesEsL)
+import Cardano.Ledger.State (ssStakeGoL, ssStakeMarkL, ssStakeSetL)
 import Cardano.Prelude (cborError)
 import qualified Cardano.Protocol.TPraos.OCert as Absolute (KESPeriod (..))
 import qualified Codec.CBOR.Decoding as CBOR
@@ -70,7 +72,7 @@ import Data.SOP.OptNP (NonEmptyOptNP, OptNP (OptSkip))
 import qualified Data.SOP.OptNP as OptNP
 import Data.SOP.Strict
 import Data.Word (Word16, Word64)
-import Lens.Micro ((^.))
+import Lens.Micro ((&), (.~), (^.))
 import Ouroboros.Consensus.Block
 import Ouroboros.Consensus.Byron.ByronHFC
 import Ouroboros.Consensus.Byron.Ledger (ByronBlock)
@@ -483,6 +485,30 @@ toTriggerHardFork = \case
       SL.getVersion (L.eraProtVerLow @(ShelleyBlockLedgerEra blk))
   CardanoTriggerHardForkAtEpoch epochNo ->
     TriggerHardForkAtEpoch epochNo
+
+-- | Warm the initial stake snapshots for early-bootstrap (test) networks, so the
+-- stake distribution -- and hence anything reading it at genesis, e.g. the Leios
+-- committee via @nesPd@ -- is active from the first epochs instead of only after
+-- the ~2-epoch snapshot pipeline has run. @ssStakeMark@ is already seeded from
+-- genesis staking by the ledger's 'L.injectIntoTestState'; here we backfill
+-- set\/go by how early the era boots. Only fires for
+-- 'CardanoTriggerHardForkAtEpoch' (test-only; real networks use
+-- 'CardanoTriggerHardForkAtDefaultVersion' and are left untouched):
+--
+--   * hard fork at epoch 0   -> go = set = mark
+--   * hard fork at epoch 1   -> set = mark
+--   * hard fork at epoch >=2 -> unchanged
+seedInitialStakeSnapshots ::
+  TriggerHardFork ->
+  NewEpochState era ->
+  NewEpochState era
+seedInitialStakeSnapshots trigger nes = case trigger of
+  TriggerHardForkAtEpoch (EpochNo 0) -> nes & setSnap ssStakeSetL & setSnap ssStakeGoL
+  TriggerHardForkAtEpoch (EpochNo 1) -> nes & setSnap ssStakeSetL
+  _ -> nes
+ where
+  mark = nes ^. nesEsL . esSnapshotsL . ssStakeMarkL
+  setSnap l = (nesEsL . esSnapshotsL . l) .~ mark
 
 newtype CardanoHardForkTriggers = CardanoHardForkTriggers
   { getCardanoHardForkTriggers ::
@@ -958,15 +984,34 @@ protocolInfoCardano (SomeHasFS hasFS) paramsCardano
         (CardanoEras c)
     perEraInjections =
       fn (Comp . pure)
-        :* hcmap (Proxy @IsShelleyBlock) shelleyInjection shelleyTcfgs
+        :* hczipWith
+          (Proxy @IsShelleyBlock)
+          (\(K trigger) -> shelleyInjection trigger)
+          perEraTriggers
+          shelleyTcfgs
+
+    -- Crypto-erased triggers per Shelley-based era, so 'shelleyInjection' can
+    -- warm the initial stake snapshots on an early ('AtEpoch') bootstrap. A K-NP
+    -- avoids the @c ~ StandardCrypto@ mismatch of the raw 'CardanoHardForkTriggers'.
+    perEraTriggers :: NP (K TriggerHardFork) (CardanoShelleyEras c)
+    perEraTriggers =
+      K (toTriggerHardFork triggerHardForkShelley)
+        :* K (toTriggerHardFork triggerHardForkAllegra)
+        :* K (toTriggerHardFork triggerHardForkMary)
+        :* K (toTriggerHardFork triggerHardForkAlonzo)
+        :* K (toTriggerHardFork triggerHardForkBabbage)
+        :* K (toTriggerHardFork triggerHardForkConway)
+        :* K (toTriggerHardFork triggerHardForkDijkstra)
+        :* Nil
 
     shelleyInjection ::
       forall proto era.
       Shelley.ShelleyCompatible proto era =>
+      TriggerHardFork ->
       WrapTransitionConfig (ShelleyBlock proto era) ->
       (Flip LedgerState ValuesMK -.-> (m :.: Flip LedgerState ValuesMK))
         (ShelleyBlock proto era)
-    shelleyInjection (WrapTransitionConfig tcfg) = fn $ \(Flip stIn) -> Comp $ do
+    shelleyInjection trigger (WrapTransitionConfig tcfg) = fn $ \(Flip stIn) -> Comp $ do
       let stowed = stowLedgerTables stIn
       newNES <-
         L.injectIntoTestState
@@ -974,7 +1019,10 @@ protocolInfoCardano (SomeHasFS hasFS) paramsCardano
           tcfg
           (Shelley.shelleyLedgerState stowed)
       pure . Flip . unstowLedgerTables $
-        stowed{Shelley.shelleyLedgerState = newNES}
+        stowed
+          { Shelley.shelleyLedgerState =
+              seedInitialStakeSnapshots trigger newNES
+          }
 
     shelleyTcfgs :: NP WrapTransitionConfig (CardanoShelleyEras c)
     shelleyTcfgs =


### PR DESCRIPTION
For early-bootstrap (test) networks that hard-fork into an era at epoch 0 or 1 (CardanoTriggerHardForkAtEpoch -- test-only; real networks use AtDefaultVersion), copy the genesis-seeded ssStakeMark into ssStakeSet/ssStakeGo so the stake distribution -- and hence the Leios committee, which reads nesPd -- is fully active from the first epochs instead of only after the ~2-epoch stake snapshot pipeline. hard fork at epoch 0 => go = set = mark; epoch 1 => set = mark; epoch >= 2 / mainnet => unchanged.

Benefits the Leios ThreadNet tests and any genesis-keyed devnet: the committee is stake-active from epoch 0, so voting and EB certification run immediately.
