### PR TITLE
[Peras 51] Replace old types and type families

### DIFF
--- a/changelog.d/20260810_145547_agustin.mista_replace_old_data_types.md
+++ b/changelog.d/20260810_145547_agustin.mista_replace_old_data_types.md
@@ -1,0 +1,24 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+### Breaking
+
+- Remove `PerasCfg` associated type of `BlockSupportsPeras` in favor of using `PerasParams` directly.
+- Remove `HasPerasCert*` and `HasPerasVote*` type classes in favor or `IsPerasCert` and `IsPerasVote`.
+- Remove `PerasValidationErr` and `PerasForgeErr` in favor of `PerasError`.
+- Remove `PerasVoteStake` in favor of `VoteWeight`.
+
+### Non-Breaking
+
+- Remove old KeyHash-based `PerasVoterId` (all call sites were already updated to use `PerasSeatIndex`).
+
+<!--
+### Patch
+
+- A bullet item for the Patch category.
+
+-->

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Block/SupportsPeras.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Block/SupportsPeras.hs
@@ -322,27 +322,21 @@ class
 
   type PerasVotingCommitteeScheme blk = VoidPerasVotingCommitteeScheme
 
-  -- NOTE: to be removed in favor of 'PerasError'.
-  data PerasValidationErr blk
-
-  -- NOTE: to be removed in favor of 'PerasError'.
-  data PerasForgeErr blk
-
   validatePerasCert ::
     PerasParams blk ->
     PerasCert blk ->
-    Either (PerasValidationErr blk) (ValidatedPerasCert blk)
+    Either (PerasError blk) (ValidatedPerasCert blk)
 
   validatePerasVote ::
     PerasParams blk ->
     PerasVoteStakeDistr ->
     PerasVote blk ->
-    Either (PerasValidationErr blk) (ValidatedPerasVote blk)
+    Either (PerasError blk) (ValidatedPerasVote blk)
 
   forgePerasCert ::
     PerasParams blk ->
     ValidatedPerasVotesWithQuorum blk ->
-    Either (PerasForgeErr blk) (ValidatedPerasCert blk)
+    Either (PerasError blk) (ValidatedPerasCert blk)
 
   -- | Extract a Peras certificate optionally stored in a block.
   --
@@ -362,21 +356,6 @@ instance StandardHash blk => BlockSupportsPeras blk where
   type PerasCert blk = PerasCert' blk
   type PerasVote blk = PerasVote' blk
 
-  -- TODO: enrich with actual error types
-  -- see https://github.com/tweag/cardano-peras/issues/120
-  data PerasValidationErr blk
-    = PerasValidationErr
-    deriving stock (Show, Eq)
-
-  -- TODO: enrich with actual error types
-  -- see https://github.com/tweag/cardano-peras/issues/120
-  data PerasForgeErr blk
-    = PerasForgeErr
-    deriving stock (Show, Eq)
-
-  -- TODO: perform actual validation against all
-  -- possible 'PerasValidationErr' variants
-  -- see https://github.com/tweag/cardano-peras/issues/120
   validatePerasCert params cert =
     Right
       ValidatedPerasCert
@@ -384,24 +363,15 @@ instance StandardHash blk => BlockSupportsPeras blk where
         , vpcCertBoost = perasWeight params
         }
 
-  -- TODO: perform actual validation against all
-  -- possible 'PerasValidationErr' variants
-  -- see https://github.com/tweag/cardano-peras/issues/120
-  validatePerasVote _params stakeDistr vote
-    | Just stake <- lookupPerasVoteStake vote stakeDistr =
-        Right
-          ValidatedPerasVote
-            { vpvVote = vote
-            , vpvVoteStake = stake
-            }
-    | otherwise =
-        Left PerasValidationErr
+  validatePerasVote _params _stakeDistr vote =
+    Right
+      ValidatedPerasVote
+        { vpvVote = vote
+        , vpvVoteStake = PerasVoteStake 0
+        }
 
-  -- TODO: perform actual validation against all
-  -- possible 'PerasForgeErr' variants
-  -- see https://github.com/tweag/cardano-peras/issues/120
   forgePerasCert params votes =
-    return $
+    Right $
       ValidatedPerasCert
         { vpcCert =
             PerasCert
@@ -411,8 +381,6 @@ instance StandardHash blk => BlockSupportsPeras blk where
         , vpcCertBoost = perasWeight params
         }
 
-  -- TODO: extract actual Peras certificates from blocks when the HFC plumbing
-  -- is in place.
   getPerasCertInBlock _ = Nothing
 
 -- | NOTE: to be removed in favor of using per-blk definitions.

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Block/SupportsPeras.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Block/SupportsPeras.hs
@@ -24,18 +24,9 @@ module Ouroboros.Consensus.Block.SupportsPeras
     -- * BlockSupportsPeras class
   , BlockSupportsPeras (..)
 
-    -- * To be removed in favor of using 'IsPerasCert'/'IsPerasVote'
+    -- * To be removed in favor of using per-blk definitions
   , PerasCert' (..)
   , PerasVote' (..)
-  , HasPerasCertRound (..)
-  , HasPerasCertBoostedBlock (..)
-  , HasPerasCertBoost (..)
-  , HasPerasVoteRound (..)
-  , HasPerasVoteBlock (..)
-  , HasPerasVoteVoterId (..)
-  , HasPerasVoteStake (..)
-  , HasPerasVoteTarget (..)
-  , HasPerasVoteId (..)
 
     -- * Types and functions related to Peras vote collection and quorum checking
   , PerasVoteId (..)
@@ -61,9 +52,11 @@ module Ouroboros.Consensus.Block.SupportsPeras
   , stakeAboveThreshold
 
     -- * Convenience re-exports
+  , module Ouroboros.Consensus.Peras.Cert.Class
   , module Ouroboros.Consensus.Peras.Params
   , module Ouroboros.Consensus.Peras.Types
   , module Ouroboros.Consensus.Peras.Void
+  , module Ouroboros.Consensus.Peras.Vote.Class
   ) where
 
 import Cardano.Binary (FromCBOR (..), ToCBOR (..))
@@ -81,14 +74,15 @@ import Data.Typeable (Typeable)
 import GHC.Generics (Generic)
 import NoThunks.Class
 import Ouroboros.Consensus.Block.Abstract
-import Ouroboros.Consensus.BlockchainTime.WallClock.Types (WithArrivalTime (..))
 import Ouroboros.Consensus.Committee.Class
   ( CryptoSupportsVotingCommittee (..)
   , VotingCommittee
   )
+import Ouroboros.Consensus.Peras.Cert.Class
 import Ouroboros.Consensus.Peras.Params
 import Ouroboros.Consensus.Peras.Types
 import Ouroboros.Consensus.Peras.Void
+import Ouroboros.Consensus.Peras.Vote.Class
 import Ouroboros.Consensus.Peras.Voting.Adapter (PerasConversionError)
 import Ouroboros.Consensus.Util
 import Quiet (Quiet (..))
@@ -234,22 +228,6 @@ lookupPerasVoteStake vote distr =
     (pvVoteVoterId vote)
     (unPerasVoteStakeDistr distr)
 
--- ** Validated types
-
-data ValidatedPerasCert blk = ValidatedPerasCert
-  { vpcCert :: !(PerasCert blk)
-  , vpcCertBoost :: !PerasWeight
-  }
-  deriving stock (Show, Eq, Ord, Generic)
-  deriving anyclass NoThunks
-
-data ValidatedPerasVote blk = ValidatedPerasVote
-  { vpvVote :: !(PerasVote blk)
-  , vpvVoteStake :: !PerasVoteStake
-  }
-  deriving stock (Show, Eq, Ord, Generic)
-  deriving anyclass NoThunks
-
 -- ** Votes with enough stake to reach quorum for a given target
 
 -- | A collection of validated Peras votes that:
@@ -272,7 +250,9 @@ data ValidatedPerasVotesWithQuorum blk = ValidatedPerasVotesWithQuorum
 -- total stake is above the quorum threshold defined in the given 'PerasParams'.
 -- It returns 'Nothing' if either of these conditions is not met.
 votesReachQuorum ::
-  StandardHash blk =>
+  ( StandardHash blk
+  , IsPerasVote (PerasVote blk) blk
+  ) =>
   PerasParams blk ->
   [ValidatedPerasVote blk] ->
   Maybe (ValidatedPerasVotesWithQuorum blk)
@@ -484,151 +464,66 @@ instance Serialise (HeaderHash blk) => Serialise (PerasVote' blk) where
     pvVoteVoterId <- fromCBOR
     pure $ PerasVote{pvVoteRound, pvVoteBlock, pvVoteVoterId}
 
--- | Extract the certificate round from a Peras certificate container
-class HasPerasCertRound cert where
-  getPerasCertRound :: cert -> PerasRoundNo
+type instance BoostedBlock (PerasCert' blk) = Point blk
+type instance BoostedBlock (PerasVote' blk) = Point blk
 
-instance HasPerasCertRound (PerasCert' blk) where
+instance IsPerasCert (PerasCert' blk) blk where
   getPerasCertRound = pcCertRound
+  getPerasCertBlock = pcCertBoostedBlock
 
-instance HasPerasCertRound (ValidatedPerasCert blk) where
-  getPerasCertRound = getPerasCertRound . vpcCert
-
-instance
-  HasPerasCertRound cert =>
-  HasPerasCertRound (WithArrivalTime cert)
-  where
-  getPerasCertRound = getPerasCertRound . forgetArrivalTime
-
--- | Extract the boosted block point from a Peras certificate container
-class HasPerasCertBoostedBlock cert blk | cert -> blk where
-  getPerasCertBoostedBlock :: cert -> Point blk
-
-instance HasPerasCertBoostedBlock (PerasCert' blk) blk where
-  getPerasCertBoostedBlock = pcCertBoostedBlock
-
-instance HasPerasCertBoostedBlock (ValidatedPerasCert blk) blk where
-  getPerasCertBoostedBlock = getPerasCertBoostedBlock . vpcCert
-
-instance
-  HasPerasCertBoostedBlock cert blk =>
-  HasPerasCertBoostedBlock (WithArrivalTime cert) blk
-  where
-  getPerasCertBoostedBlock = getPerasCertBoostedBlock . forgetArrivalTime
-
--- | Extract the certificate boost from a Peras certificate container
-class HasPerasCertBoost cert where
-  getPerasCertBoost :: cert -> PerasWeight
-
-instance HasPerasCertBoost (ValidatedPerasCert blk) where
-  getPerasCertBoost = vpcCertBoost
-
-instance
-  HasPerasCertBoost cert =>
-  HasPerasCertBoost (WithArrivalTime cert)
-  where
-  getPerasCertBoost = getPerasCertBoost . forgetArrivalTime
-
--- | Extract the vote round from a Peras vote container
-class HasPerasVoteRound vote where
-  getPerasVoteRound :: vote -> PerasRoundNo
-
-instance HasPerasVoteRound (PerasVote' blk) where
+instance IsPerasVote (PerasVote' blk) blk where
   getPerasVoteRound = pvVoteRound
-
-instance HasPerasVoteRound (ValidatedPerasVote blk) where
-  getPerasVoteRound = getPerasVoteRound . vpvVote
-
-instance
-  HasPerasVoteRound vote =>
-  HasPerasVoteRound (WithArrivalTime vote)
-  where
-  getPerasVoteRound = getPerasVoteRound . forgetArrivalTime
-
--- | Extract the vote block point from a Peras vote container
-class HasPerasVoteBlock vote blk | vote -> blk where
-  getPerasVoteBlock :: vote -> Point blk
-
-instance HasPerasVoteBlock (PerasVote' blk) blk where
   getPerasVoteBlock = pvVoteBlock
+  getPerasVoteSeatIndex = pvVoteVoterId
 
-instance HasPerasVoteBlock (ValidatedPerasVote blk) blk where
+-- * Validated types
+
+data ValidatedPerasVote blk
+  = ValidatedPerasVote
+  { vpvVote :: !(PerasVote blk)
+  , vpvVoteStake :: !PerasVoteStake
+  }
+
+deriving instance Show (PerasVote blk) => Show (ValidatedPerasVote blk)
+deriving instance Eq (PerasVote blk) => Eq (ValidatedPerasVote blk)
+deriving instance Ord (PerasVote blk) => Ord (ValidatedPerasVote blk)
+deriving instance NoThunks (PerasVote blk) => NoThunks (ValidatedPerasVote blk)
+deriving instance Generic (ValidatedPerasVote blk)
+
+data ValidatedPerasCert blk
+  = ValidatedPerasCert
+  { vpcCert :: !(PerasCert blk)
+  , vpcCertBoost :: !PerasWeight
+  }
+
+type instance BoostedBlock (ValidatedPerasVote blk) = BoostedBlock (PerasVote blk)
+
+instance
+  ( IsPerasVote (PerasVote blk) blk
+  , BoostedBlockCompatibleWithPoint (BoostedBlock (PerasVote blk)) blk
+  ) =>
+  IsPerasVote (ValidatedPerasVote blk) blk
+  where
+  getPerasVoteRound = getPerasVoteRound . vpvVote
   getPerasVoteBlock = getPerasVoteBlock . vpvVote
+  getPerasVoteSeatIndex = getPerasVoteSeatIndex . vpvVote
+
+deriving instance Show (PerasCert blk) => Show (ValidatedPerasCert blk)
+deriving instance Eq (PerasCert blk) => Eq (ValidatedPerasCert blk)
+deriving instance Ord (PerasCert blk) => Ord (ValidatedPerasCert blk)
+deriving instance NoThunks (PerasCert blk) => NoThunks (ValidatedPerasCert blk)
+deriving instance Generic (ValidatedPerasCert blk)
+
+type instance BoostedBlock (ValidatedPerasCert blk) = BoostedBlock (PerasCert blk)
 
 instance
-  HasPerasVoteBlock vote blk =>
-  HasPerasVoteBlock (WithArrivalTime vote) blk
+  ( IsPerasCert (PerasCert blk) blk
+  , BoostedBlockCompatibleWithPoint (BoostedBlock (PerasCert blk)) blk
+  ) =>
+  IsPerasCert (ValidatedPerasCert blk) blk
   where
-  getPerasVoteBlock = getPerasVoteBlock . forgetArrivalTime
-
--- | Extract the stake pool ID from a Peras vote container
-class HasPerasVoteVoterId vote where
-  getPerasVoteVoterId :: vote -> PerasSeatIndex
-
-instance HasPerasVoteVoterId (PerasVote' blk) where
-  getPerasVoteVoterId = pvVoteVoterId
-
-instance HasPerasVoteVoterId (ValidatedPerasVote blk) where
-  getPerasVoteVoterId = getPerasVoteVoterId . vpvVote
-
-instance
-  HasPerasVoteVoterId vote =>
-  HasPerasVoteVoterId (WithArrivalTime vote)
-  where
-  getPerasVoteVoterId = getPerasVoteVoterId . forgetArrivalTime
-
--- | Extract the vote stake from a validated Peras vote container
-class HasPerasVoteStake vote where
-  getPerasVoteStake :: vote -> PerasVoteStake
-
-instance HasPerasVoteStake (ValidatedPerasVote blk) where
-  getPerasVoteStake = vpvVoteStake
-
-instance
-  HasPerasVoteStake vote =>
-  HasPerasVoteStake (WithArrivalTime vote)
-  where
-  getPerasVoteStake = getPerasVoteStake . forgetArrivalTime
-
--- | Extract the vote target from a Peras vote container
-class HasPerasVoteTarget vote blk | vote -> blk where
-  getPerasVoteTarget :: vote -> PerasVoteTarget blk
-
-instance HasPerasVoteTarget (PerasVote' blk) blk where
-  getPerasVoteTarget vote =
-    PerasVoteTarget
-      { pvtRoundNo = pvVoteRound vote
-      , pvtBlock = pvVoteBlock vote
-      }
-
-instance HasPerasVoteTarget (ValidatedPerasVote blk) blk where
-  getPerasVoteTarget = getPerasVoteTarget . vpvVote
-
-instance
-  HasPerasVoteTarget vote blk =>
-  HasPerasVoteTarget (WithArrivalTime vote) blk
-  where
-  getPerasVoteTarget = getPerasVoteTarget . forgetArrivalTime
-
--- | Extract the vote ID from a Peras vote container
-class HasPerasVoteId vote blk | vote -> blk where
-  getPerasVoteId :: vote -> PerasVoteId
-
-instance HasPerasVoteId (PerasVote' blk) blk where
-  getPerasVoteId vote =
-    PerasVoteId
-      { pviRoundNo = pvVoteRound vote
-      , pviSeatIndex = pvVoteVoterId vote
-      }
-
-instance HasPerasVoteId (ValidatedPerasVote blk) blk where
-  getPerasVoteId = getPerasVoteId . vpvVote
-
-instance
-  HasPerasVoteId vote blk =>
-  HasPerasVoteId (WithArrivalTime vote) blk
-  where
-  getPerasVoteId = getPerasVoteId . forgetArrivalTime
+  getPerasCertRound = getPerasCertRound . vpcCert
+  getPerasCertBlock = getPerasCertBlock . vpcCert
 
 --- * Peras error types
 

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Block/SupportsPeras.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Block/SupportsPeras.hs
@@ -29,8 +29,6 @@ module Ouroboros.Consensus.Block.SupportsPeras
   , PerasVote' (..)
 
     -- * Types and functions related to Peras vote collection and quorum checking
-  , PerasVoteId (..)
-  , PerasVoterId (..)
   , PerasVoteStake (..)
   , PerasVoteStakeDistr (..)
   , ValidatedPerasVotesWithQuorum
@@ -60,7 +58,6 @@ module Ouroboros.Consensus.Block.SupportsPeras
   ) where
 
 import Cardano.Binary (FromCBOR (..), ToCBOR (..))
-import Cardano.Ledger.Hashes (KeyHash, KeyRole (..))
 import Codec.Serialise (Serialise (..))
 import Codec.Serialise.Decoding (decodeListLenOf)
 import Codec.Serialise.Encoding (encodeListLen)
@@ -164,14 +161,6 @@ deriving instance
 -------------------------------------------------------------------------------}
 
 -- ** Stake pool distributions
-
--- NOTE: to be removed in favor of the one in 'Ouroboros.Consensus.Peras.Types'
-newtype PerasVoterId = PerasVoterId
-  { unPerasVoterId :: KeyHash StakePool
-  }
-  deriving newtype NoThunks
-  deriving stock (Eq, Ord, Generic)
-  deriving Show via Quiet PerasVoterId
 
 -- NOTE: At the moment there is no consensus from researchers/engineers on how
 -- we go from the absolute stake of a voter in the ledger to the relative stake

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Block/SupportsPeras.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Block/SupportsPeras.hs
@@ -45,7 +45,7 @@ module Ouroboros.Consensus.Block.SupportsPeras
   , ValidatedPerasVotesWithQuorum
     ( vpvqTarget
     , vpvqVotes
-    , vpvqPerasCfg
+    , vpvqPerasParams
     )
   , lookupPerasVoteStake
   , votesReachQuorum
@@ -254,13 +254,13 @@ data ValidatedPerasVote blk = ValidatedPerasVote
 
 -- | A collection of validated Peras votes that:
 -- 1. are all for the same target, and
--- 2. have total stake above the quorum threshold for a given 'PerasCfg'.
+-- 2. have total stake above the quorum threshold for a given 'PerasParams'.
 data ValidatedPerasVotesWithQuorum blk = ValidatedPerasVotesWithQuorum
   { vpvqTarget :: !(PerasVoteTarget blk)
   -- ^ The target that all the votes are for
   , vpvqVotes :: !(NonEmpty (ValidatedPerasVote blk))
   -- ^ The votes that reached quorum for the given target
-  , vpvqPerasCfg :: !(PerasCfg blk)
+  , vpvqPerasParams :: !(PerasParams blk)
   -- ^ The Peras configuration used to validate that the votes reach quorum
   }
   deriving stock (Show, Eq, Generic)
@@ -269,14 +269,14 @@ data ValidatedPerasVotesWithQuorum blk = ValidatedPerasVotesWithQuorum
 -- | Smart constructor for 'ValidatedPerasVotesReachingQuorum'.
 --
 -- This function checks that all votes are for the same target, and that their
--- total stake is above the quorum threshold defined in the given 'PerasCfg'.
+-- total stake is above the quorum threshold defined in the given 'PerasParams'.
 -- It returns 'Nothing' if either of these conditions is not met.
 votesReachQuorum ::
   StandardHash blk =>
-  PerasCfg blk ->
+  PerasParams blk ->
   [ValidatedPerasVote blk] ->
   Maybe (ValidatedPerasVotesWithQuorum blk)
-votesReachQuorum cfg votes =
+votesReachQuorum params votes =
   case votes of
     -- We need at least one vote to determine who these votes are for, so we
     -- can't vacuously reach a quorum, even if the quorum threshold is 0.
@@ -293,13 +293,13 @@ votesReachQuorum cfg votes =
             ValidatedPerasVotesWithQuorum
               { vpvqTarget = getPerasVoteTarget v0
               , vpvqVotes = v0 :| vs
-              , vpvqPerasCfg = cfg
+              , vpvqPerasParams = params
               }
  where
   totalVoteStake =
     mconcat (vpvVoteStake <$> votes)
   votesHaveEnoughStake =
-    stakeAboveThreshold cfg totalVoteStake
+    stakeAboveThreshold params totalVoteStake
   allVotesMatchTarget target =
     all ((== (getPerasVoteTarget target)) . getPerasVoteTarget)
 
@@ -308,7 +308,7 @@ votesReachQuorum cfg votes =
 -------------------------------------------------------------------------------}
 
 class
-  ( Show (PerasCfg blk)
+  ( Show (PerasParams blk)
   , NoThunks (PerasCert blk)
   ) =>
   BlockSupportsPeras blk
@@ -342,9 +342,6 @@ class
 
   type PerasVotingCommitteeScheme blk = VoidPerasVotingCommitteeScheme
 
-  -- NOTE: to be removed in favor of 'PerasParams'.
-  type PerasCfg blk
-
   -- NOTE: to be removed in favor of 'PerasError'.
   data PerasValidationErr blk
 
@@ -352,18 +349,18 @@ class
   data PerasForgeErr blk
 
   validatePerasCert ::
-    PerasCfg blk ->
+    PerasParams blk ->
     PerasCert blk ->
     Either (PerasValidationErr blk) (ValidatedPerasCert blk)
 
   validatePerasVote ::
-    PerasCfg blk ->
+    PerasParams blk ->
     PerasVoteStakeDistr ->
     PerasVote blk ->
     Either (PerasValidationErr blk) (ValidatedPerasVote blk)
 
   forgePerasCert ::
-    PerasCfg blk ->
+    PerasParams blk ->
     ValidatedPerasVotesWithQuorum blk ->
     Either (PerasForgeErr blk) (ValidatedPerasCert blk)
 
@@ -382,7 +379,6 @@ instance StandardHash blk => BlockSupportsPeras blk where
   type PerasVotingCommitteeScheme blk = VoidPerasVotingCommitteeScheme
   type PerasError blk = VoidPerasError blk
 
-  type PerasCfg blk = PerasParams blk
   type PerasCert blk = PerasCert' blk
   type PerasVote blk = PerasVote' blk
 

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Block/SupportsPeras.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Block/SupportsPeras.hs
@@ -29,14 +29,12 @@ module Ouroboros.Consensus.Block.SupportsPeras
   , PerasVote' (..)
 
     -- * Types and functions related to Peras vote collection and quorum checking
-  , PerasVoteStake (..)
   , PerasVoteStakeDistr (..)
   , ValidatedPerasVotesWithQuorum
     ( vpvqTarget
     , vpvqVotes
     , vpvqPerasParams
     )
-  , lookupPerasVoteStake
   , votesReachQuorum
 
     -- * Validated types
@@ -47,7 +45,7 @@ module Ouroboros.Consensus.Block.SupportsPeras
   , IsPerasError (..)
 
     -- * Helpers
-  , stakeAboveThreshold
+  , weightAboveThreshold
 
     -- * Convenience re-exports
   , module Ouroboros.Consensus.Peras.Cert.Class
@@ -63,9 +61,7 @@ import Codec.Serialise.Decoding (decodeListLenOf)
 import Codec.Serialise.Encoding (encodeListLen)
 import Data.Kind (Type)
 import Data.List.NonEmpty (NonEmpty (..))
-import qualified Data.Map as Map
 import Data.Map.Strict (Map)
-import Data.Monoid (Sum (..))
 import Data.Proxy (Proxy (..))
 import Data.Typeable (Typeable)
 import GHC.Generics (Generic)
@@ -82,7 +78,6 @@ import Ouroboros.Consensus.Peras.Void
 import Ouroboros.Consensus.Peras.Vote.Class
 import Ouroboros.Consensus.Peras.Voting.Adapter (PerasConversionError)
 import Ouroboros.Consensus.Util
-import Quiet (Quiet (..))
 
 -- * Voting committee types for Peras
 
@@ -160,62 +155,12 @@ deriving instance
 -- * Peras types
 -------------------------------------------------------------------------------}
 
--- ** Stake pool distributions
-
--- NOTE: At the moment there is no consensus from researchers/engineers on how
--- we go from the absolute stake of a voter in the ledger to the relative stake
--- of their vote in the voting commitee (given that the quorum is expressed as
--- a relative value of the voting commitee total stake).
---
--- So, for now you can consider this 'Rational' as the best approximation we
--- have at the moment of the concrete type for a relative vote stake that can be
--- compared to the quorum threshold value (also currently a 'Rational').
-newtype PerasVoteStake = PerasVoteStake
-  { unPerasVoteStake :: Rational
-  }
-  deriving newtype (Eq, Ord, Num, Fractional, NoThunks, Serialise)
-  deriving stock Generic
-  deriving Show via Quiet PerasVoteStake
-  deriving Semigroup via Sum Rational
-  deriving Monoid via Sum Rational
-
--- | Check whether a given vote stake is above the quorum threshold.
---
--- TODO: this function assumes that the 'PerasVoteStake' and the quorum
--- threshold used in 'PerasParams' are expressed in the same units. That is,
--- both are either absolute or relative (normalized) values. Under the current
--- current implementation of 'PerasParams', this function only makes sense when
--- both values are relative (normalized) values, so we should either normalize
--- the 'PerasVoteStake' before calling this function, or change this function to
--- accept a stake distribution and perform the normalization internally.
-stakeAboveThreshold :: PerasParams blk -> PerasVoteStake -> Bool
-stakeAboveThreshold params voteStake =
-  stake >= quorumThreshold + safetyMargin
- where
-  stake =
-    unPerasVoteStake voteStake
-  quorumThreshold =
-    unPerasQuorumWeightThreshold
-      (perasQuorumWeightThreshold params)
-  safetyMargin =
-    unPerasQuorumWeightThresholdSafetyMargin
-      (perasQuorumWeightThresholdSafetyMargin params)
-
+-- TODO: to be removed in favor of using a 'PerasEpochContext' directly.
 newtype PerasVoteStakeDistr = PerasVoteStakeDistr
-  { unPerasVoteStakeDistr :: Map PerasSeatIndex PerasVoteStake
+  { unPerasVoteStakeDistr :: Map PerasSeatIndex VoteWeight
   }
   deriving newtype NoThunks
   deriving stock (Show, Eq, Generic)
-
--- | Lookup the stake of a vote cast by a member of a given stake distribution.
-lookupPerasVoteStake ::
-  PerasVote blk ->
-  PerasVoteStakeDistr ->
-  Maybe PerasVoteStake
-lookupPerasVoteStake vote distr =
-  Map.lookup
-    (pvVoteVoterId vote)
-    (unPerasVoteStakeDistr distr)
 
 -- ** Votes with enough stake to reach quorum for a given target
 
@@ -255,7 +200,7 @@ votesReachQuorum params votes =
     (v0 : vs)
       | not (allVotesMatchTarget v0 vs) ->
           Nothing
-      | not votesHaveEnoughStake ->
+      | not votesHaveEnoughWeight ->
           Nothing
       | otherwise ->
           Just
@@ -266,9 +211,9 @@ votesReachQuorum params votes =
               }
  where
   totalVoteStake =
-    mconcat (vpvVoteStake <$> votes)
-  votesHaveEnoughStake =
-    stakeAboveThreshold params totalVoteStake
+    mconcat (vpvVoteWeight <$> votes)
+  votesHaveEnoughWeight =
+    weightAboveThreshold params totalVoteStake
   allVotesMatchTarget target =
     all ((== (getPerasVoteTarget target)) . getPerasVoteTarget)
 
@@ -356,7 +301,7 @@ instance StandardHash blk => BlockSupportsPeras blk where
     Right
       ValidatedPerasVote
         { vpvVote = vote
-        , vpvVoteStake = PerasVoteStake 0
+        , vpvVoteWeight = VoteWeight 0
         }
 
   forgePerasCert params votes =
@@ -438,7 +383,7 @@ instance IsPerasVote (PerasVote' blk) blk where
 data ValidatedPerasVote blk
   = ValidatedPerasVote
   { vpvVote :: !(PerasVote blk)
-  , vpvVoteStake :: !PerasVoteStake
+  , vpvVoteWeight :: !VoteWeight
   }
 
 deriving instance Show (PerasVote blk) => Show (ValidatedPerasVote blk)
@@ -489,3 +434,25 @@ class IsPerasError err blk | err -> blk where
   injectVotingCommitteeError :: PerasVotingCommitteeError blk -> err
   injectConversionError :: PerasConversionError -> err
   injectQuorumNotReachedError :: VoteWeight -> err
+
+-- * Helpers
+
+-- | Check whether a given vote weight is above the quorum threshold.
+--
+-- NOTE: this function assumes that the 'VoteWeight' and the quorum
+-- threshold used in 'PerasParams' are expressed in the same units. That is,
+-- both are either absolute or relative (normalized) values. Under the current
+-- current implementation of 'PerasParams', this function only makes sense when
+-- both values are relative (normalized) values.
+weightAboveThreshold :: PerasParams blk -> VoteWeight -> Bool
+weightAboveThreshold params voteWeight =
+  weight >= quorumThreshold + safetyMargin
+ where
+  weight =
+    unVoteWeight voteWeight
+  quorumThreshold =
+    unPerasQuorumWeightThreshold
+      (perasQuorumWeightThreshold params)
+  safetyMargin =
+    unPerasQuorumWeightThresholdSafetyMargin
+      (perasQuorumWeightThresholdSafetyMargin params)

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ObjectDiffusion/ObjectPool/PerasCert.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ObjectDiffusion/ObjectPool/PerasCert.hs
@@ -137,7 +137,7 @@ makePerasCertPoolWriterFromChainDB systemTime chainDB =
     }
 
 data PerasCertInboundException
-  = forall blk. PerasCertValidationError [PerasValidationErr blk]
+  = forall blk. PerasCertValidationError [PerasError blk]
 
 deriving instance Show PerasCertInboundException
 
@@ -157,7 +157,7 @@ processCerts ::
   MonadSTM m =>
   SystemTime m ->
   STM m (Set PerasRoundNo) ->
-  (PerasCert blk -> Either (PerasValidationErr blk) (ValidatedPerasCert blk)) ->
+  (PerasCert blk -> Either (PerasError blk) (ValidatedPerasCert blk)) ->
   (WithArrivalTime (ValidatedPerasCert blk) -> m ()) ->
   [PerasCert blk] ->
   m ()

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ObjectDiffusion/ObjectPool/PerasVote.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ObjectDiffusion/ObjectPool/PerasVote.hs
@@ -152,7 +152,7 @@ makePerasVotePoolWriterFromChainDB systemTime getStakeDistrSTM chainDB =
     }
 
 data PerasVoteInboundException
-  = forall blk. PerasVoteValidationError [PerasValidationErr blk]
+  = forall blk. PerasVoteValidationError [PerasError blk]
 
 deriving instance Show PerasVoteInboundException
 
@@ -171,7 +171,7 @@ processVotes ::
   MonadSTM m =>
   SystemTime m ->
   STM m (Set PerasVoteId) ->
-  (PerasVote blk -> STM m (Either (PerasValidationErr blk) (ValidatedPerasVote blk))) ->
+  (PerasVote blk -> STM m (Either (PerasError blk) (ValidatedPerasVote blk))) ->
   (WithArrivalTime (ValidatedPerasVote blk) -> m ()) ->
   [PerasVote blk] ->
   m ()

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Node/Serialisation.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Node/Serialisation.hs
@@ -37,7 +37,6 @@ module Ouroboros.Consensus.Node.Serialisation
   ) where
 
 import Cardano.Binary (FromCBOR (..), ToCBOR (..))
-import qualified Cardano.Binary as KeyHash
 import Codec.CBOR.Decoding (Decoder, decodeListLenOf)
 import Codec.CBOR.Encoding (Encoding, encodeListLen)
 import Codec.Serialise (Serialise (decode, encode))
@@ -227,10 +226,6 @@ instance ConvertRawHash blk => SerialiseNodeToNode blk (PerasVote' blk) where
     pvVoteBlock <- decodeNodeToNode ccfg version
     pvVoteVoterId <- decodeNodeToNode ccfg version
     pure $ PerasVote pvVoteRound pvVoteBlock pvVoteVoterId
-
-instance SerialiseNodeToNode blk PerasVoterId where
-  encodeNodeToNode _ccfg _version = KeyHash.toCBOR . unPerasVoterId
-  decodeNodeToNode _ccfg _version = PerasVoterId <$> KeyHash.fromCBOR
 
 instance SerialiseNodeToNode blk PerasVoteId where
   -- Consistent with the 'Serialise' instance for 'PerasVoteId' defined in Ouroboros.Consensus.Block.SupportsPeras

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Peras/Cert/Inclusion.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Peras/Cert/Inclusion.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 -- | This module defines the logic needed to evaluate when a Peras certificate
 -- must be included in a block.
@@ -27,7 +28,7 @@ import Data.Set (Set)
 import qualified Data.Set as Set
 import Ouroboros.Consensus.Block (WithOrigin (..), withOriginToMaybe)
 import Ouroboros.Consensus.Block.SupportsPeras
-  ( HasPerasCertRound (..)
+  ( IsPerasCert (..)
   , PerasParams
   , PerasRoundNo (..)
   )
@@ -88,7 +89,7 @@ data PerasCertInclusionView cert blk = PerasCertInclusionView
 -- within the same STM transaction, or the results may be inconsistent.
 mkPerasCertInclusionView ::
   forall cert blk.
-  HasPerasCertRound cert =>
+  IsPerasCert cert blk =>
   -- | Peras protocol parameters
   PerasParams blk ->
   -- | Current Peras round number
@@ -147,7 +148,7 @@ data PerasCertInclusionRulesDecision cert
   deriving Show
 
 instance
-  HasPerasCertRound cert =>
+  IsPerasCert cert blk =>
   Explainable (PerasCertInclusionRulesDecision cert)
   where
   explain mode = \case

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Peras/Vote/Aggregation.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Peras/Vote/Aggregation.hs
@@ -192,7 +192,7 @@ data UpdateRoundVoteStateError blk
       (PerasTargetVoteState blk 'Winner)
       (PerasTargetVoteState blk 'Loser)
   | RoundVoteStateForgingCertError
-      (PerasForgeErr blk)
+      (PerasError blk)
 
 -- | Add a vote to an existing round vote aggregate.
 --
@@ -574,7 +574,7 @@ updateCandidateVoteState ::
   WithArrivalTime (ValidatedPerasVote blk) ->
   PerasTargetVoteState blk 'Candidate ->
   Either
-    (PerasForgeErr blk)
+    (PerasError blk)
     (PerasVoteStateCandidateOrWinner blk)
 updateCandidateVoteState cfg vote oldState =
   let

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Peras/Vote/Aggregation.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Peras/Vote/Aggregation.hs
@@ -79,13 +79,16 @@
 -- freshly forged (as opposed to voting on an already-won target).
 module Ouroboros.Consensus.Peras.Vote.Aggregation
   ( PerasRoundVoteState
-  , ptvsTotalStake
+  , getPerasRoundVoteStateRound
+  , getPerasRoundVoteStateCertMaybe
+  , getPerasRoundVoteStateMaxTargetedSlot
   , pattern VoteGeneratedNewCert
   , pattern VoteDidntGenerateNewCert
   , updatePerasRoundVoteStates
-  , getPerasRoundVoteStateCertMaybe
-  , getPerasRoundVoteStateMaxTargetedSlot
   , UpdateRoundVoteStateError (..)
+  , PerasTargetVoteState
+  , getPerasTargetVoteStateTotalWeight
+  , getPerasTargetVoteStateBlock
   ) where
 
 import Cardano.Prelude (fromMaybe)
@@ -111,9 +114,6 @@ data PerasRoundVoteState blk = PerasRoundVoteState
   deriving stock (Generic, Eq, Show)
   deriving anyclass NoThunks
 
-instance HasPerasVoteRound (PerasRoundVoteState blk) where
-  getPerasVoteRound = prvsRoundNo
-
 -- | Current vote state when a quorum has not yet been reached
 data NoQuorum blk = NoQuorum
   { candidateStates :: !(Map (Point blk) (PerasTargetVoteState blk 'Candidate))
@@ -129,6 +129,10 @@ data Quorum blk = Quorum
   }
   deriving stock (Generic, Eq, Show)
   deriving anyclass NoThunks
+
+-- | Get the round number of a round vote state
+getPerasRoundVoteStateRound :: PerasRoundVoteState blk -> PerasRoundNo
+getPerasRoundVoteStateRound = prvsRoundNo
 
 -- | Get the certificate if quorum was reached for the given round
 getPerasRoundVoteStateCertMaybe ::
@@ -161,7 +165,7 @@ getPerasRoundVoteStateMaxTargetedSlot PerasRoundVoteState{prvsState} =
       maximumOrOrigin $ map pointSlot $ Map.keys candidateStates
     Right Quorum{winnerState, loserStates} ->
       maximumOrOrigin $
-        pointSlot (getPerasVoteBlock winnerState)
+        pointSlot (pvtBlock . ptvtTarget . ptvsVoteTally $ winnerState)
           : (pointSlot <$> Map.keys loserStates)
  where
   maximumOrOrigin [] = Origin
@@ -204,7 +208,7 @@ updatePerasRoundVoteState ::
   PerasRoundVoteState blk ->
   Either (UpdateRoundVoteStateError blk) (PerasRoundVoteState blk)
 updatePerasRoundVoteState vote params roundState =
-  assert (getPerasVoteRound vote == getPerasVoteRound roundState) $ do
+  assert (getPerasVoteRound vote == prvsRoundNo roundState) $ do
     case roundState of
       -- Quorum not yet reached
       state@PerasRoundVoteState
@@ -522,11 +526,13 @@ instance
   noThunks ctx (PerasTargetVoteWinner tally cert) =
     noThunks ctx (tally, cert)
 
-instance HasPerasVoteRound (PerasTargetVoteState blk status) where
-  getPerasVoteRound = pvtRoundNo . ptvtTarget . ptvsVoteTally
+-- | Extract the total weight from a target vote state
+getPerasTargetVoteStateTotalWeight :: PerasTargetVoteState blk status -> PerasVoteStake
+getPerasTargetVoteStateTotalWeight = ptvtTotalStake . ptvsVoteTally
 
-instance HasPerasVoteBlock (PerasTargetVoteState blk status) blk where
-  getPerasVoteBlock = pvtBlock . ptvtTarget . ptvsVoteTally
+-- | Extract the block point from a target vote state
+getPerasTargetVoteStateBlock :: PerasTargetVoteState blk status -> Point blk
+getPerasTargetVoteStateBlock = pvtBlock . ptvtTarget . ptvsVoteTally
 
 -- | Extract the underlying vote tally from a target vote state
 ptvsVoteTally :: PerasTargetVoteState blk status -> PerasTargetVoteTally blk
@@ -534,10 +540,6 @@ ptvsVoteTally = \case
   PerasTargetVoteCandidate tally -> tally
   PerasTargetVoteLoser tally -> tally
   PerasTargetVoteWinner tally _ -> tally
-
--- | Extract the total stake from a target vote state
-ptvsTotalStake :: PerasTargetVoteState blk status -> PerasVoteStake
-ptvsTotalStake = ptvtTotalStake . ptvsVoteTally
 
 freshCandidateVoteState :: PerasVoteTarget blk -> PerasTargetVoteState blk 'Candidate
 freshCandidateVoteState target =

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Peras/Vote/Aggregation.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Peras/Vote/Aggregation.hs
@@ -46,7 +46,7 @@
 --
 -- = Quorum Threshold and Multiple Winners
 --
--- The quorum threshold is parameterized via 'PerasCfg'. Depending on this
+-- The quorum threshold is parameterized via 'PerasParams'. Depending on this
 -- configuration and the stake distribution, it may be theoretically possible
 -- for multiple targets to exceed the threshold within the same round.
 --
@@ -200,10 +200,10 @@ updatePerasRoundVoteState ::
   forall blk.
   StandardHash blk =>
   WithArrivalTime (ValidatedPerasVote blk) ->
-  PerasCfg blk ->
+  PerasParams blk ->
   PerasRoundVoteState blk ->
   Either (UpdateRoundVoteStateError blk) (PerasRoundVoteState blk)
-updatePerasRoundVoteState vote cfg roundState =
+updatePerasRoundVoteState vote params roundState =
   assert (getPerasVoteRound vote == getPerasVoteRound roundState) $ do
     case roundState of
       -- Quorum not yet reached
@@ -220,7 +220,7 @@ updatePerasRoundVoteState vote cfg roundState =
                   (getPerasVoteBlock vote)
                   candidateStates
           candidateOrWinnerState <-
-            updateCandidateVoteState cfg vote oldCandidateState
+            updateCandidateVoteState params vote oldCandidateState
               `onErr` \err ->
                 RoundVoteStateForgingCertError err
           case candidateOrWinnerState of
@@ -294,7 +294,7 @@ updatePerasRoundVoteState vote cfg roundState =
                     fromMaybe (freshLoserVoteState (getPerasVoteTarget vote))
                   updateMaybeLoserVoteState mState =
                     fmap Just $
-                      updateLoserVoteState cfg vote (existingOrFreshLoserVoteState mState)
+                      updateLoserVoteState params vote (existingOrFreshLoserVoteState mState)
                         `onErr` \err ->
                           RoundVoteStateLoserAboveQuorum winnerState err
               loserStates' <- Map.alterF updateMaybeLoserVoteState votePoint loserStates
@@ -320,12 +320,12 @@ updatePerasRoundVoteStates ::
   forall blk.
   StandardHash blk =>
   WithArrivalTime (ValidatedPerasVote blk) ->
-  PerasCfg blk ->
+  PerasParams blk ->
   Map PerasRoundNo (PerasRoundVoteState blk) ->
   Either
     (UpdateRoundVoteStateError blk)
     (PerasRoundVoteState blk, Map PerasRoundNo (PerasRoundVoteState blk))
-updatePerasRoundVoteStates vote cfg =
+updatePerasRoundVoteStates vote params =
   alterMapAndReturnUpdatedValue
     updateMaybePerasRoundVoteState
     (getPerasVoteRound vote)
@@ -358,7 +358,7 @@ updatePerasRoundVoteStates vote cfg =
       (PerasRoundVoteState blk, PerasRoundVoteState blk)
   updateMaybePerasRoundVoteState mRoundState = do
     let roundState = existingOrFreshRoundVoteState mRoundState
-    newRoundState <- updatePerasRoundVoteState vote cfg roundState
+    newRoundState <- updatePerasRoundVoteState vote params roundState
     pure (newRoundState, newRoundState)
 
 {-------------------------------------------------------------------------------
@@ -568,7 +568,7 @@ data PerasVoteStateCandidateOrWinner blk
 -- May fail if the candidate is elected winner but forging the certificate fails.
 updateCandidateVoteState ::
   StandardHash blk =>
-  PerasCfg blk ->
+  PerasParams blk ->
   WithArrivalTime (ValidatedPerasVote blk) ->
   PerasTargetVoteState blk 'Candidate ->
   Either
@@ -593,7 +593,7 @@ updateCandidateVoteState cfg vote oldState =
 -- May fail if the loser goes above quorum by adding the vote.
 updateLoserVoteState ::
   StandardHash blk =>
-  PerasCfg blk ->
+  PerasParams blk ->
   WithArrivalTime (ValidatedPerasVote blk) ->
   PerasTargetVoteState blk 'Loser ->
   Either (PerasTargetVoteState blk 'Loser) (PerasTargetVoteState blk 'Loser)

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Peras/Vote/Aggregation.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Peras/Vote/Aggregation.hs
@@ -17,19 +17,19 @@
 -- | Peras vote aggregation and certificate forging
 --
 -- This module implements the core voting logic for the Peras protocol, which
--- aggregates stake-weighted votes on chain blocks and forges certificates when
--- quorum is reached.
+-- aggregates weighted votes on chain blocks and forges certificates when quorum
+-- is reached.
 --
 -- = Overview
 --
 -- In Peras, validators vote on specific blocks during designated voting rounds.
--- Each vote carries a stake weight, and votes are aggregated by:
+-- Each vote carries a weight, and votes are aggregated by:
 --
 --   * __Round__: each vote belongs to a specific 'PerasRoundNo'
 --   * __Target__: within a round, votes are cast for different block 'Point's
 --
--- As votes arrive, the system tracks the total stake backing each candidate
--- block. When one target accumulates enough stake to exceed the configured
+-- As votes arrive, the system tracks the total weight backing each candidate
+-- block. When one target accumulates enough weight to exceed the configured
 -- quorum threshold, a certificate is automatically forged for that block,
 -- making it a winner for that round.
 --
@@ -38,7 +38,7 @@
 -- For every round being voted for, the aggregation follows a state machine:
 --
 -- 1. __Quorum not reached__: multiple block targets are candidates, each
---    accumulating votes and stake. All targets compete to reach quorum first.
+--    accumulating votes and weight. All targets compete to reach quorum first.
 --
 -- 2. __Quorum reached__: once a target reaches quorum, it becomes the winner
 --    and a certificate is forged. All other targets become losers and continue
@@ -56,10 +56,10 @@
 --   * The quorum threshold is misconfigured, or that
 --   * We were extremely unlucky when randomly selecting the voting committee.
 --
--- With a correct threshold configuration (e.g., > 3/4 of total stake + a small
+-- With a correct threshold configuration (e.g., > 3/4 of total weight + a small
 -- safety margin to account for an unlucky local sortition when selecting
 -- non-persistent voters during committee selection), multiple winners should be
--- impossible given honest stake distribution.
+-- impossible given an honest stake distribution.
 --
 -- = Key Types
 --
@@ -67,7 +67,7 @@
 --      its logically split between separate 'NoQuorum' and 'Quorum' types
 --      representing the two states (1) and (2) described above, respectively.
 --   * 'PerasTargetVoteState': tracks votes for one specific block target
---   * 'PerasTargetVoteTally': raw vote count and stake accumulation
+--   * 'PerasTargetVoteTally': raw vote count and weight accumulation
 --   * 'PerasTargetVoteStatus': type-level status (Candidate/Winner/Loser)
 --   * 'UpdateRoundVoteStateError': errors from invalid state transitions
 --
@@ -413,8 +413,8 @@ data PerasTargetVoteTally blk = PerasTargetVoteTally
   -- ^ What we are tallying votes for
   , ptvtVotes :: !(Map PerasVoteId (WithArrivalTime (ValidatedPerasVote blk)))
   -- ^ Votes received for this target, indexed by vote ID
-  , ptvtTotalStake :: !PerasVoteStake
-  -- ^ Total stake of the votes received for this target
+  , ptvtTotalWeight :: !VoteWeight
+  -- ^ Total weight of the votes received for this target
   }
   deriving stock (Generic, Eq, Show)
   deriving anyclass NoThunks
@@ -424,11 +424,11 @@ freshTargetVoteTally target =
   PerasTargetVoteTally
     { ptvtTarget = target
     , ptvtVotes = Map.empty
-    , ptvtTotalStake = PerasVoteStake 0
+    , ptvtTotalWeight = VoteWeight 0
     }
 
 -- | Add a vote to an existing target tally if it isn't already present,
--- and update the stake accordingly.
+-- and update the weight accordingly.
 --
 -- PRECONDITION: the vote's target must match the tally's target.
 updateTargetVoteTally ::
@@ -441,12 +441,12 @@ updateTargetVoteTally
   ptvt@PerasTargetVoteTally
     { ptvtVotes
     , ptvtTarget
-    , ptvtTotalStake
+    , ptvtTotalWeight
     } =
     assert (getPerasVoteTarget vote == ptvtTarget) $ do
       ptvt
         { ptvtVotes = pvaVotes'
-        , ptvtTotalStake = pvaTotalStake'
+        , ptvtTotalWeight = pvaTotalWeight'
         }
    where
     swapVote =
@@ -454,13 +454,13 @@ updateTargetVoteTally
         (\_k old _new -> old)
         (getPerasVoteId vote)
 
-    (pvaVotes', pvaTotalStake')
-      -- key WAS NOT present → vote inserted and stake updated
+    (pvaVotes', pvaTotalWeight')
+      -- key WAS NOT present → vote inserted and weight updated
       | (Nothing, votes') <- swapVote vote ptvtVotes =
-          (votes', ptvtTotalStake + vpvVoteStake (forgetArrivalTime vote))
-      -- key WAS already present → votes and stake unchanged
+          (votes', ptvtTotalWeight + vpvVoteWeight (forgetArrivalTime vote))
+      -- key WAS already present → votes and weight unchanged
       | otherwise =
-          (ptvtVotes, ptvtTotalStake)
+          (ptvtVotes, ptvtTotalWeight)
 
 {-------------------------------------------------------------------------------
   Peras target vote status
@@ -527,8 +527,8 @@ instance
     noThunks ctx (tally, cert)
 
 -- | Extract the total weight from a target vote state
-getPerasTargetVoteStateTotalWeight :: PerasTargetVoteState blk status -> PerasVoteStake
-getPerasTargetVoteStateTotalWeight = ptvtTotalStake . ptvsVoteTally
+getPerasTargetVoteStateTotalWeight :: PerasTargetVoteState blk status -> VoteWeight
+getPerasTargetVoteStateTotalWeight = ptvtTotalWeight . ptvsVoteTally
 
 -- | Extract the block point from a target vote state
 getPerasTargetVoteStateBlock :: PerasTargetVoteState blk status -> Point blk
@@ -602,7 +602,7 @@ updateLoserVoteState ::
 updateLoserVoteState cfg vote oldState =
   assert (getPerasVoteTarget vote == ptvtTarget (ptvsVoteTally oldState)) $ do
     let newVoteTally = updateTargetVoteTally vote (ptvsVoteTally oldState)
-        aboveQuorum = stakeAboveThreshold cfg (ptvtTotalStake newVoteTally)
+        aboveQuorum = weightAboveThreshold cfg (ptvtTotalWeight newVoteTally)
      in if aboveQuorum
           then Left $ PerasTargetVoteLoser newVoteTally
           else Right $ PerasTargetVoteLoser newVoteTally

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Peras/Voting/Rules.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Peras/Voting/Rules.hs
@@ -33,7 +33,7 @@ import Ouroboros.Consensus.Block.Abstract
   ( SlotNo (..)
   )
 import Ouroboros.Consensus.Block.SupportsPeras
-  ( HasPerasCertRound (..)
+  ( IsPerasCert
   , PerasRoundNo (..)
   , getPerasCertRound
   , onPerasRoundNo
@@ -76,7 +76,7 @@ instance Explainable PerasVotingRulesDecision where
 
 -- | Evaluate whether voting is allowed or not according to the voting rules
 isPerasVotingAllowed ::
-  HasPerasCertRound cert =>
+  IsPerasCert cert blk =>
   PerasVotingView cert blk ->
   PerasVotingRulesDecision
 isPerasVotingAllowed pvv =
@@ -127,7 +127,7 @@ instance Explainable PerasVotingRule where
 -- | VR-1A: the voter has seen the certificate for the previous round, and the
 -- certificate was received in the first X slots after the start of the round.
 perasVR1A ::
-  HasPerasCertRound cert =>
+  IsPerasCert cert blk =>
   PerasVotingView cert blk ->
   Pred PerasVotingRule
 perasVR1A
@@ -190,7 +190,7 @@ perasVR1B
 -- This enforces the chain-healing period that must occur before leaving a
 -- cooldown period.
 perasVR2A ::
-  HasPerasCertRound cert =>
+  IsPerasCert cert blk =>
   PerasVotingView cert blk ->
   Pred PerasVotingRule
 perasVR2A
@@ -223,7 +223,7 @@ perasVR2A
 -- This enforces chain quality and common prefix before leaving a cooldown
 -- period.
 perasVR2B ::
-  HasPerasCertRound cert =>
+  IsPerasCert cert blk =>
   PerasVotingView cert blk ->
   Pred PerasVotingRule
 perasVR2B
@@ -267,7 +267,7 @@ perasVR2B
 -- | Both VR-1A and VR-1B hold, which is the situation typically occurring when
 -- the voting has regularly occurred in preceding rounds.
 perasVR1 ::
-  HasPerasCertRound cert =>
+  IsPerasCert cert blk =>
   PerasVotingView cert blk ->
   Pred PerasVotingRule
 perasVR1 pvv =
@@ -276,7 +276,7 @@ perasVR1 pvv =
 -- | Both VR-2A and VR-2B hold, which is the situation typically occurring when
 -- the chain is about to exit a cooldown period.
 perasVR2 ::
-  HasPerasCertRound cert =>
+  IsPerasCert cert blk =>
   PerasVotingView cert blk ->
   Pred PerasVotingRule
 perasVR2 pvv =
@@ -284,7 +284,7 @@ perasVR2 pvv =
 
 -- | Voting is allowed if either VR-1A and VR-1B hold, or VR-2A and VR-2B hold.
 perasVotingRules ::
-  HasPerasCertRound cert =>
+  IsPerasCert cert blk =>
   PerasVotingView cert blk ->
   Pred PerasVotingRule
 perasVotingRules pvv =

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Peras/Voting/View.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Peras/Voting/View.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE NamedFieldPuns #-}
@@ -41,10 +42,10 @@ import Ouroboros.Consensus.Block.Abstract
   , castPoint
   )
 import Ouroboros.Consensus.Block.SupportsPeras
-  ( HasPerasCertRound (..)
+  ( BlockSupportsPeras (..)
+  , IsPerasCert (..)
   , PerasRoundNo (..)
   , ValidatedPerasCert
-  , getPerasCertBoostedBlock
   , getPerasCertRound
   )
 import Ouroboros.Consensus.BlockchainTime.WallClock.Types
@@ -211,6 +212,7 @@ data PerasVotingView cert blk = PerasVotingView
 mkPerasVotingView ::
   ( cert ~ WithArrivalTime (ValidatedPerasCert blk)
   , GetHeader blk
+  , IsPerasCert (PerasCert blk) blk
   ) =>
   -- | Peras protocol parameters
   PerasParams blk ->
@@ -281,5 +283,5 @@ mkPerasVotingView
       -- VolatileDB, so we can check whether it is within the bounds of the
       -- anchored fragment leading to the candidate block.
       AF.withinFragmentBounds
-        (castPoint (getPerasCertBoostedBlock cert))
+        (castPoint (getPerasCertPoint cert))
         chainAtCandidateBlock

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Args.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Args.hs
@@ -228,7 +228,7 @@ completeChainDbArgs
       , cdbPerasVoteDbArgs =
           PerasVoteDB.PerasVoteDbArgs
             { PerasVoteDB.pvdbaTracer = PerasVoteDB.pvdbaTracer (cdbPerasVoteDbArgs defArgs)
-            , PerasVoteDB.pvdbaPerasCfg = defaultPerasParams
+            , PerasVoteDB.pvdbaPerasParams = defaultPerasParams
             }
       , cdbsArgs =
           (cdbsArgs defArgs)

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Background.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Background.hs
@@ -616,7 +616,7 @@ addBlockRunner fuse cdb@CDB{..} = forever $ do
             ChainSelAddPerasCert cert _varProcessed ->
               traceWith cdbTracer $
                 TraceAddPerasCertEvent $
-                  PoppedPerasCertFromQueue (getPerasCertRound cert) (getPerasCertBoostedBlock cert)
+                  PoppedPerasCertFromQueue (getPerasCertRound cert) (getPerasCertPoint cert)
           chainSelSync cdb message
           lift $ atomically $ processedChainSelMessage cdbChainSelQueue message
       )

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/ChainSel.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/ChainSel.hs
@@ -540,7 +540,7 @@ chainSelSync cdb@CDB{..} (ChainSelAddPerasCert cert varProcessed) = do
   certRound = getPerasCertRound cert
 
   boostedBlock :: Point blk
-  boostedBlock = getPerasCertBoostedBlock cert
+  boostedBlock = getPerasCertPoint cert
 
   -- \| Run a block that can exit early with a result value.
   withEarlyExitId :: ExceptT a (Electric m) a -> Electric m a

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Types.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Types.hs
@@ -655,7 +655,7 @@ addPerasCertToQueue tracer ChainSelQueue{varChainSelQueue} cert = do
       { waitPerasCertProcessed = atomically $ readTMVar varProcessed
       }
  where
-  addedToQueue = AddedPerasCertToQueue (getPerasCertRound cert) (getPerasCertBoostedBlock cert)
+  addedToQueue = AddedPerasCertToQueue (getPerasCertRound cert) (getPerasCertPoint cert)
 
 -- | Try to add blocks again that were postponed due to the LoE.
 addReprocessLoEBlocks ::

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/PerasCertDB/API.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/PerasCertDB/API.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase #-}
 
@@ -200,7 +201,7 @@ prop_garbageCollectRemovesOldCerts db slotNo = do
     _ <- garbageCollect db slotNo
     getCertsAfter db zeroPerasCertTicketNo
   allCertValues <- sequence (Map.elems allCertActions)
-  let targetSlots = pointSlot . getPerasCertBoostedBlock <$> allCertValues
+  let targetSlots = pointSlot . getPerasCertPoint <$> allCertValues
   pure $
     all (>= NotOrigin slotNo) targetSlots
 

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/PerasCertDB/Impl.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/PerasCertDB/Impl.hs
@@ -79,7 +79,8 @@ initialPerasCertDbState =
 
 -- | Check that the fields of 'PerasCertDbState' are in sync.
 invariantForPerasCertDbState ::
-  WithFingerprint (PerasCertDbState blk) -> Either String ()
+  WithFingerprint (PerasCertDbState blk) ->
+  Either String ()
 invariantForPerasCertDbState pcds = do
   checkEqual
     "pcdsCertsByTicket"
@@ -208,14 +209,16 @@ implAddCert PerasCertDbEnv{pcdbTracer, pcdbState} cert = do
     pure addPerasCertRes
 
 implGetWeightSnapshot ::
-  (IOLike m, StandardHash blk) =>
+  ( IOLike m
+  , StandardHash blk
+  ) =>
   PerasCertDbEnv m blk ->
   STM m (WithFingerprint (PerasWeightSnapshot blk))
 implGetWeightSnapshot PerasCertDbEnv{pcdbState} = do
   WithFingerprint pcds fp <- readTVar pcdbState
   let weights =
         mkPerasWeightSnapshot
-          [ (getPerasCertBoostedBlock cert, getPerasCertBoost cert)
+          [ (getPerasCertPoint cert, vpcCertBoost (forgetArrivalTime cert))
           | cert <- Map.elems (pcdsCertsByTicket pcds)
           ]
   pure (WithFingerprint weights fp)
@@ -270,7 +273,7 @@ implGarbageCollect PerasCertDbEnv{pcdbTracer, pcdbState} slotNo = do
       } =
       let pcdsCertsByTicket' =
             Map.filter
-              (\cert -> pointSlot (getPerasCertBoostedBlock cert) >= NotOrigin slotNo)
+              (\cert -> pointSlot (getPerasCertPoint cert) >= NotOrigin slotNo)
               pcdsCertsByTicket
           pcdsCertIds' =
             Set.fromList (getPerasCertRound <$> Map.elems pcdsCertsByTicket')
@@ -280,7 +283,7 @@ implGarbageCollect PerasCertDbEnv{pcdbTracer, pcdbState} slotNo = do
           -- Update the latest certificate seen status when its corresponding
           -- boosted block gets garbage collected.
           updateIfBoostingGarbageCollectedBlock cert
-            | pointSlot (getPerasCertBoostedBlock (forgetBoostedBlockStatus cert))
+            | pointSlot (getPerasCertPoint (forgetBoostedBlockStatus cert))
                 < NotOrigin slotNo =
                 CertBoostingBlockNoLongerInVolatileDB (forgetBoostedBlockStatus cert)
             | otherwise =

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/PerasVoteDB/API.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/PerasVoteDB/API.hs
@@ -91,11 +91,11 @@ data AddPerasVoteResult blk
 -------------------------------------------------------------------------------}
 
 newtype ExistingPerasRoundWinner blk
-  = ExistingPerasRoundWinner (Point blk, PerasVoteStake)
+  = ExistingPerasRoundWinner (Point blk, VoteWeight)
   deriving stock (Show, Eq)
 
 newtype BlockedPerasRoundWinner blk
-  = BlockedPerasRoundWinner (Point blk, PerasVoteStake)
+  = BlockedPerasRoundWinner (Point blk, VoteWeight)
   deriving stock (Show, Eq)
 
 data PerasVoteDbError blk

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/PerasVoteDB/API.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/PerasVoteDB/API.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase #-}
 
@@ -168,7 +169,11 @@ prop_garbageCollectRemovesOldVotes db slotNo =
   atomically $ do
     _ <- garbageCollect db slotNo
     allVotes <- getVotesAfter db zeroPerasVoteTicketNo
-    let targetSlots = pointSlot . getPerasVoteBlock . forgetArrivalTime <$> Map.elems allVotes
+    let targetSlots =
+          pointSlot
+            . getPerasVotePoint
+            . forgetArrivalTime
+            <$> Map.elems allVotes
     pure $
       all (>= NotOrigin slotNo) targetSlots
 

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/PerasVoteDB/API.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/PerasVoteDB/API.hs
@@ -106,7 +106,7 @@ data PerasVoteDbError blk
       (ExistingPerasRoundWinner blk)
       (BlockedPerasRoundWinner blk)
   | -- | An error occurred while forging a certificate
-    ForgingCertError (PerasForgeErr blk)
+    ForgingCertError (PerasError blk)
   deriving stock Show
   deriving anyclass Exception
 

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/PerasVoteDB/Impl.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/PerasVoteDB/Impl.hs
@@ -80,7 +80,10 @@ invariantForPerasVoteDbState ::
   WithFingerprint (PerasVoteDbState blk) -> Either String ()
 invariantForPerasVoteDbState pvs = do
   for_ (Map.toList pvdsRoundVoteStates) $ \(roundNo, prvs) ->
-    checkEqual "pvcRoundVoteStates rounds" roundNo (getPerasVoteRound prvs)
+    checkEqual
+      "pvcRoundVoteStates rounds"
+      roundNo
+      (getPerasRoundVoteStateRound prvs)
   checkEqual
     "pvcsVotesByTicket"
     (Set.fromList (getPerasVoteRound <$> Map.elems pvdsVotesByTicket))
@@ -221,13 +224,13 @@ implAddVote perasParams PerasVoteDbEnv{pvdeTracer, pvdeState} vote = do
             MultipleWinnersInRound
               (getPerasVoteRound vote)
               ( ExistingPerasRoundWinner
-                  ( getPerasVoteBlock winnerState
-                  , ptvsTotalStake winnerState
+                  ( getPerasTargetVoteStateBlock winnerState
+                  , getPerasTargetVoteStateTotalWeight winnerState
                   )
               )
               ( BlockedPerasRoundWinner
-                  ( getPerasVoteBlock loserState
-                  , ptvsTotalStake loserState
+                  ( getPerasTargetVoteStateBlock loserState
+                  , getPerasTargetVoteStateTotalWeight loserState
                   )
               )
         -- Reached quorum but failed to forge a certificate

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/PerasVoteDB/Impl.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/PerasVoteDB/Impl.hs
@@ -124,14 +124,14 @@ data TraceEvent blk
 type PerasVoteDbArgs :: (Type -> Type) -> (Type -> Type) -> Type -> Type
 data PerasVoteDbArgs f m blk = PerasVoteDbArgs
   { pvdbaTracer :: Tracer m (TraceEvent blk)
-  , pvdbaPerasCfg :: HKD f (PerasCfg blk)
+  , pvdbaPerasParams :: HKD f (PerasParams blk)
   }
 
 defaultArgs :: Monad m => Incomplete PerasVoteDbArgs m blk
 defaultArgs =
   PerasVoteDbArgs
     { pvdbaTracer = nullTracer
-    , pvdbaPerasCfg = noDefault
+    , pvdbaPerasParams = noDefault
     }
 
 createDB ::
@@ -142,7 +142,7 @@ createDB ::
   ) =>
   Complete PerasVoteDbArgs m blk ->
   m (PerasVoteDB m blk)
-createDB args@PerasVoteDbArgs{pvdbaPerasCfg} = do
+createDB args@PerasVoteDbArgs{pvdbaPerasParams} = do
   pvdeState <-
     newTVarWithInvariantIO
       (either Just (const Nothing) . invariantForPerasVoteDbState)
@@ -154,7 +154,7 @@ createDB args@PerasVoteDbArgs{pvdbaPerasCfg} = do
           }
   pure
     PerasVoteDB
-      { addVote = implAddVote pvdbaPerasCfg env
+      { addVote = implAddVote pvdbaPerasParams env
       , getVoteIds = implGetVoteIds env
       , getVotesAfter = implGetVotesAfter env
       , getForgedCertForRound = implGetForgedCertForRound env
@@ -176,11 +176,11 @@ implAddVote ::
   , StandardHash blk
   , Typeable blk
   ) =>
-  PerasCfg blk ->
+  PerasParams blk ->
   PerasVoteDbEnv m blk ->
   WithArrivalTime (ValidatedPerasVote blk) ->
   STM m (m (AddPerasVoteResult blk))
-implAddVote perasCfg PerasVoteDbEnv{pvdeTracer, pvdeState} vote = do
+implAddVote perasParams PerasVoteDbEnv{pvdeTracer, pvdeState} vote = do
   let voteId = getPerasVoteId vote
   addPerasVoteRes <- do
     WithFingerprint pvds fp <- readTVar pvdeState
@@ -205,7 +205,7 @@ implAddVote perasCfg PerasVoteDbEnv{pvdeTracer, pvdeState} vote = do
         pvsVotesByTicket' = Map.insert pvsLastTicketNo' vote (pvdsVotesByTicket pvds)
 
     (addPerasVoteRes, pvsRoundVoteStates') <-
-      case updatePerasRoundVoteStates vote perasCfg (pvdsRoundVoteStates pvds) of
+      case updatePerasRoundVoteStates vote perasParams (pvdsRoundVoteStates pvds) of
         -- Added vote and reached a quorum, forging a new certificate
         Right (VoteGeneratedNewCert cert, pvsRoundVoteStates') ->
           pure (AddedPerasVoteAndGeneratedNewCert cert, pvsRoundVoteStates')

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/ChainDB.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/ChainDB.hs
@@ -140,7 +140,7 @@ fromMinimalChainDbArgs MinimalChainDbArgs{..} =
     , cdbPerasVoteDbArgs =
         PerasVoteDbArgs
           { pvdbaTracer = nullTracer
-          , pvdbaPerasCfg = defaultPerasParams
+          , pvdbaPerasParams = defaultPerasParams
           }
     , cdbsArgs =
         ChainDbSpecificArgs

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/MiniProtocol/ObjectDiffusion/PerasVote/Smoke.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/MiniProtocol/ObjectDiffusion/PerasVote/Smoke.hs
@@ -5,7 +5,7 @@
 
 module Test.Consensus.MiniProtocol.ObjectDiffusion.PerasVote.Smoke
   ( tests
-  , genPerasVoteStake
+  , genPerasVoteWeight
   , genPerasVote
   , genValidatedPerasVote
   ) where
@@ -63,10 +63,10 @@ tests =
 genPerasSeatIndex :: Gen PerasSeatIndex
 genPerasSeatIndex = PerasSeatIndex <$> choose (0, 99)
 
-genPerasVoteStake :: Gen PerasVoteStake
-genPerasVoteStake = do
-  stake <- (1 %) <$> choose (2, 10)
-  pure (PerasVoteStake stake)
+genPerasVoteWeight :: Gen VoteWeight
+genPerasVoteWeight = do
+  weight <- (1 %) <$> choose (2, 10)
+  pure (VoteWeight weight)
 
 genPerasVote :: Gen (PerasVote TestBlock)
 genPerasVote = do
@@ -85,7 +85,7 @@ genValidatedPerasVote :: Gen (ValidatedPerasVote TestBlock)
 genValidatedPerasVote =
   ValidatedPerasVote
     <$> genPerasVote
-    <*> genPerasVoteStake
+    <*> genPerasVoteWeight
 
 newVoteDB ::
   (IOLike m, StandardHash blk, Typeable blk) =>
@@ -124,7 +124,7 @@ prop_smoke =
                 stakeDistr =
                   PerasVoteStakeDistr $
                     Map.fromList
-                      [ (pvVoteVoterId (vpvVote v), vpvVoteStake v)
+                      [ (pvVoteVoterId (vpvVote v), vpvVoteWeight v)
                       | WithArrivalTime _ v <- watValidatedVotes
                       ]
                 inboundPoolWriter =

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/Peras/Cert/Inclusion.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/Peras/Cert/Inclusion.hs
@@ -1,8 +1,11 @@
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 -- | Test that the Peras certificate inclusion rules can correctly decide when
@@ -17,11 +20,11 @@ module Test.Consensus.Peras.Cert.Inclusion (tests) where
 import Data.Set (Set)
 import qualified Data.Set as Set
 import GHC.Generics (Generic)
-import Ouroboros.Consensus.Block (WithOrigin (..))
+import Ouroboros.Consensus.Block (Point (..), WithOrigin (..))
 import Ouroboros.Consensus.Block.SupportsPeras
-  ( HasPerasCertRound (..)
+  ( BoostedBlock
+  , IsPerasCert (..)
   , PerasRoundNo (..)
-  , getPerasCertRound
   )
 import Ouroboros.Consensus.Peras.Cert.Inclusion
   ( LatestCertOnChainView (..)
@@ -50,6 +53,7 @@ import Test.Tasty.QuickCheck
   , testProperty
   )
 import Test.Util.QuickCheck (geometric)
+import Test.Util.TestBlock (TestBlock)
 import Test.Util.TestEnv (adjustQuickCheckTests)
 
 {-------------------------------------------------------------------------------
@@ -235,8 +239,13 @@ data TestCert
   }
   deriving (Show, Eq, Generic)
 
-instance HasPerasCertRound TestCert where
+type instance BoostedBlock TestCert = Point TestBlock
+
+instance IsPerasCert TestCert TestBlock where
   getPerasCertRound = tcRoundNo
+
+  -- We don't really care about the block being boosted for the inclusion rules
+  getPerasCertBlock = const GenesisPoint
 
 -- | Generate a test certificate
 --

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/Peras/Voting/Rules.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/Peras/Voting/Rules.hs
@@ -1,7 +1,10 @@
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 -- | Test that the Peras voting rules can correctly decide when to vote.
@@ -14,13 +17,14 @@ module Test.Consensus.Peras.Voting.Rules (tests) where
 
 import GHC.Generics (Generic)
 import Ouroboros.Consensus.Block.Abstract
-  ( SlotNo (..)
+  ( Point (..)
+  , SlotNo (..)
   , WithOrigin (..)
   )
 import Ouroboros.Consensus.Block.SupportsPeras
-  ( HasPerasCertRound (..)
+  ( BoostedBlock
+  , IsPerasCert (..)
   , PerasRoundNo (..)
-  , getPerasCertRound
   , onPerasRoundNo
   )
 import Ouroboros.Consensus.BlockchainTime
@@ -256,8 +260,13 @@ data TestCert
   }
   deriving (Show, Eq, Generic)
 
-instance HasPerasCertRound TestCert where
+type instance BoostedBlock (TestCert) = Point TestBlock
+
+instance IsPerasCert TestCert TestBlock where
   getPerasCertRound = tcRoundNo
+
+  -- We don't really care about the block being boosted for the voting rules
+  getPerasCertBlock = const GenesisPoint
 
 -- | Generate a test certificate
 --

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/Model.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/Model.hs
@@ -468,7 +468,7 @@ addPerasCert ::
   Model blk ->
   (AddPerasCertChainSelOutcome, Model blk)
 addPerasCert cfg cert m
-  | pointSlot (getPerasCertBoostedBlock cert) < Chain.headSlot (immutableChain secParam m) =
+  | pointSlot (getPerasCertPoint cert) < Chain.headSlot (immutableChain secParam m) =
       (PerasCertIgnoredTooOld, m)
   | otherwise =
       let (certRes, perasCertModel') = PerasCertDBModel.addCert (perasCertModel m) cert

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
@@ -1307,7 +1307,7 @@ generator loe genBlock genPerasBlock m@Model{..} =
             (+)
             [ ( pvtRoundNo target
               , sum
-                  [ unPerasVoteStake (getPerasVoteStake (PerasVoteDBModel.veVote ve))
+                  [ unPerasVoteStake (vpvVoteStake (forgetArrivalTime (PerasVoteDBModel.veVote ve)))
                   | ve <- Set.toList entries
                   ]
               )
@@ -1812,7 +1812,7 @@ addPerasCertOutcomes = concatMap classifyEvent
   classifyEvent :: Event Blk m Symbolic -> [String]
   classifyEvent ev = case unAt (eventCmd ev) of
     AddPerasCert certWithTime _ ->
-      let targetPt = pcCertBoostedBlock (vpcCert (forgetArrivalTime certWithTime))
+      let targetPt = getPerasCertPoint (vpcCert (forgetArrivalTime certWithTime))
        in case (isBlockConnected targetPt (dbModel (eventBefore ev))) of
             False ->
               assert (chainSelOutcome ev == "no chain selection change") $
@@ -1830,7 +1830,7 @@ addPerasVoteOutcomes = concatMap classifyEvent
   classifyEvent :: Event Blk m Symbolic -> [String]
   classifyEvent ev = case unAt (eventCmd ev) of
     AddPerasVote voteWithTime _ ->
-      let targetPt = pvVoteBlock (vpvVote (forgetArrivalTime voteWithTime))
+      let targetPt = getPerasVotePoint (vpvVote (forgetArrivalTime voteWithTime))
           certsBefore = numCerts (eventBefore ev)
           certsAfter = numCerts (eventAfter ev)
           certProduced = certsAfter > certsBefore

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
@@ -1294,20 +1294,20 @@ generator loe genBlock genPerasBlock m@Model{..} =
   genAddPerasVote :: Gen (Cmd blk it flr)
   genAddPerasVote = do
     (blk, gapBlks) <- genPerasBlock m
-    -- Pick a round based on the remaining capacity (maxRoundVoteStake -
-    -- currentTotalStake) of existing rounds, with a flat probability for
+    -- Pick a round based on the remaining capacity (maxRoundVoteWeight -
+    -- currentTotalWeight) of existing rounds, with a flat probability for
     -- selecting a fresh new round. This ensures we never exceed the quorum
     -- threshold for multiple different blocks in the same round, avoiding the
     -- MultipleWinnersInRound error.
     let voteModel = Model.perasVoteModel dbModel
-        -- Compute total stake per round from the vote model
-        stakePerRound :: Map.Map PerasRoundNo Rational
-        stakePerRound =
+        -- Compute total weight per round from the vote model
+        weightPerRound :: Map.Map PerasRoundNo Rational
+        weightPerRound =
           Map.fromListWith
             (+)
             [ ( pvtRoundNo target
               , sum
-                  [ unPerasVoteStake (vpvVoteStake (forgetArrivalTime (PerasVoteDBModel.veVote ve)))
+                  [ unVoteWeight (vpvVoteWeight (forgetArrivalTime (PerasVoteDBModel.veVote ve)))
                   | ve <- Set.toList entries
                   ]
               )
@@ -1318,49 +1318,49 @@ generator loe genBlock genPerasBlock m@Model{..} =
         quorum =
           unPerasQuorumWeightThreshold (perasQuorumWeightThreshold voteParams)
             + unPerasQuorumWeightThresholdSafetyMargin (perasQuorumWeightThresholdSafetyMargin voteParams)
-        -- Maximum total vote stake per round: 2 * quorum - epsilon.
+        -- Maximum total vote weight per round: 2 * quorum - epsilon.
         -- Below this threshold it is impossible for two different blocks to
         -- both reach quorum in the same round.
         -- It would be more realistic to use just 'quorum', but by doing so we
         -- would only have very few voting rounds succeeding with a cert
         -- creation, because we can't concentrate votes on a few distinct
         -- candidates easily as we would observe in real world.
-        maxRoundVoteStake :: Rational
-        maxRoundVoteStake = 2 * quorum - (1 % 100)
-        -- Minimum vote stake
-        minVoteStake :: Rational
-        minVoteStake = 1 % 10
-        -- Maximum vote stake
-        maxVoteStake :: Rational
-        maxVoteStake = 1 % 2
+        maxRoundVoteWeight :: Rational
+        maxRoundVoteWeight = 2 * quorum - (1 % 100)
+        -- Minimum vote weight
+        minVoteWeight :: Rational
+        minVoteWeight = 1 % 10
+        -- Maximum vote weight
+        maxVoteWeight :: Rational
+        maxVoteWeight = 1 % 2
         -- Remaining capacity for each existing round
         roundCapacities :: [(PerasRoundNo, Rational)]
         roundCapacities =
           [ (r, cap)
-          | (r, totalStake) <- Map.toList stakePerRound
-          , let cap = maxRoundVoteStake - totalStake
-          , cap >= minVoteStake
+          | (r, totalWeight) <- Map.toList weightPerRound
+          , let cap = maxRoundVoteWeight - totalWeight
+          , cap >= minVoteWeight
           ]
         -- The next fresh round number
         freshRound :: PerasRoundNo
-        freshRound = case Map.lookupMax stakePerRound of
+        freshRound = case Map.lookupMax weightPerRound of
           Nothing -> PerasRoundNo 0
           Just (PerasRoundNo r, _) -> PerasRoundNo (r + 1)
-        -- Weight for a fresh round (same as a round with 0.25 * maxRoundVoteStake capacity remaining)
+        -- Weight for a fresh round (same as a round with 0.25 * maxRoundVoteWeight capacity remaining)
         freshWeight :: Int
-        freshWeight = max 1 $ floor (25 * maxRoundVoteStake)
+        freshWeight = max 1 $ floor (25 * maxRoundVoteWeight)
         -- Weighted choices: existing rounds by remaining capacity + fresh round
         choices :: [(Int, Gen (PerasRoundNo, Rational))]
         choices =
           [ (max 1 (floor (cap * 100)), pure (r, cap))
           | (r, cap) <- roundCapacities
           ]
-            ++ [(freshWeight, pure (freshRound, maxRoundVoteStake))]
+            ++ [(freshWeight, pure (freshRound, maxRoundVoteWeight))]
     (roundNo, capacity) <- frequency choices
-    -- Pick a vote stake between minVoteStake and min(capacity, maxVoteStake)
-    let upperBound = min capacity maxVoteStake
-    stakeNumerator <- choose (ceiling (minVoteStake * 100), floor (upperBound * 100)) :: Gen Int
-    let stake = PerasVoteStake (fromIntegral stakeNumerator % 100)
+    -- Pick a vote weight between minVoteWeight and min(capacity, maxVoteWeight)
+    let upperBound = min capacity maxVoteWeight
+    weightNumerator <- choose (ceiling (minVoteWeight * 100), floor (upperBound * 100)) :: Gen Int
+    let weight = VoteWeight (fromIntegral weightNumerator % 100)
     seatIndex <- PerasVoteDB.SM.genPerasSeatIndex
     -- Include the voted block itself in the persisted seenBlocks
     let seenBlks = fmap (blk :) gapBlks
@@ -1375,7 +1375,7 @@ generator loe genBlock genPerasBlock m@Model{..} =
                     , pvVoteBlock = blockPoint blk
                     , pvVoteVoterId = seatIndex
                     }
-              , vpvVoteStake = stake
+              , vpvVoteWeight = weight
               }
     pure $ AddPerasVote voteWithTime seenBlks
 

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/PerasCertDB/Model.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/PerasCertDB/Model.hs
@@ -78,7 +78,7 @@ getWeightSnapshot ::
   Model blk -> PerasWeightSnapshot blk
 getWeightSnapshot Model{certs} =
   mkPerasWeightSnapshot
-    [ (getPerasCertBoostedBlock cert, getPerasCertBoost cert)
+    [ (getPerasCertPoint cert, vpcCertBoost (forgetArrivalTime cert))
     | cert <- Set.toList certs
     ]
 
@@ -95,10 +95,10 @@ garbageCollect slotNo model@Model{certs, latestCertSeen} =
     , latestCertSeen = updateIfBoostingGarbageCollectedBlock <$> latestCertSeen
     }
  where
-  keepCert cert = pointSlot (getPerasCertBoostedBlock cert) >= NotOrigin slotNo
+  keepCert cert = pointSlot (getPerasCertPoint cert) >= NotOrigin slotNo
 
   updateIfBoostingGarbageCollectedBlock cert
-    | pointSlot (getPerasCertBoostedBlock (forgetBoostedBlockStatus cert))
+    | pointSlot (getPerasCertPoint (forgetBoostedBlockStatus cert))
         < NotOrigin slotNo =
         CertBoostingBlockNoLongerInVolatileDB (forgetBoostedBlockStatus cert)
     | otherwise =

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/PerasCertDB/StateMachine.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/PerasCertDB/StateMachine.hs
@@ -142,7 +142,7 @@ instance StateModel Model where
           -- So we should enforce: round = round' => boostedBlock = boostedBlock'
           p cert' =
             getPerasCertRound cert /= getPerasCertRound cert'
-              || getPerasCertBoostedBlock cert == getPerasCertBoostedBlock cert'
+              || getPerasCertPoint cert == getPerasCertPoint cert'
         GetWeightSnapshot -> True
         GetLatestCertSeen -> True
         GarbageCollect _slotNo -> True
@@ -197,7 +197,7 @@ instance RunModel Model (StateT (PerasCertDB IO TestBlock) IO) where
         "Certificate block collision"
         [ show $
             Set.member
-              (getPerasCertBoostedBlock cert)
-              (Set.map getPerasCertBoostedBlock model.certs)
+              (getPerasCertPoint cert)
+              (Set.map getPerasCertPoint model.certs)
         ]
   monitoring _ _ _ _ prop = prop

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/PerasCertDB/StateMachine.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/PerasCertDB/StateMachine.hs
@@ -55,8 +55,8 @@ tests =
     [ adjustQuickCheckTests (* 100) $ testProperty "q-d" $ prop_qd
     ]
 
-perasTestCfg :: PerasCfg TestBlock
-perasTestCfg = defaultPerasParams
+perasTestParams :: PerasParams TestBlock
+perasTestParams = defaultPerasParams
 
 prop_qd :: Actions Model -> Property
 prop_qd actions = QC.monadic f $ property () <$ runActions actions
@@ -100,7 +100,7 @@ instance StateModel Model where
                       { pcCertRound = roundNo
                       , pcCertBoostedBlock = boostedBlock
                       }
-                , vpcCertBoost = perasWeight perasTestCfg
+                , vpcCertBoost = perasWeight perasTestParams
                 }
       pure (AddCert certWithTime)
 

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/PerasVoteDB/Model.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/PerasVoteDB/Model.hs
@@ -27,7 +27,6 @@ import Ouroboros.Consensus.Block.SupportsPeras
   ( HasPerasVoteBlock (..)
   , HasPerasVoteRound (..)
   , PerasCert' (..)
-  , PerasCfg
   , PerasParams (..)
   , PerasRoundNo
   , PerasVoteId (..)
@@ -80,11 +79,11 @@ data Model blk = Model
 instance StandardHash blk => ToExpr (Model blk) where
   toExpr = defaultExprViaShow
 
-initModel :: PerasCfg blk -> Model blk
-initModel cfg =
+initModel :: PerasParams blk -> Model blk
+initModel perasParams =
   Model
     { open = False
-    , params = cfg
+    , params = perasParams
     , lastTicketNo = zeroPerasVoteTicketNo
     , votes = Map.empty
     , certs = Map.empty

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/PerasVoteDB/Model.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/PerasVoteDB/Model.hs
@@ -29,12 +29,12 @@ import Ouroboros.Consensus.Block.SupportsPeras
   , PerasParams (..)
   , PerasRoundNo
   , PerasVoteId (..)
-  , PerasVoteStake (..)
   , PerasVoteTarget (..)
   , ValidatedPerasCert (..)
   , ValidatedPerasVote (..)
+  , VoteWeight (..)
   , getPerasCertPoint
-  , stakeAboveThreshold
+  , weightAboveThreshold
   )
 import Ouroboros.Consensus.BlockchainTime.WallClock.Types
   ( WithArrivalTime (..)
@@ -220,11 +220,11 @@ addVote vote model
     Set.insert voteEntry existingVotes
   -- Get the total stake of a set of votes
   getTotalStake =
-    PerasVoteStake
+    VoteWeight
       . sum
       . fmap
-        ( unPerasVoteStake
-            . vpvVoteStake
+        ( unVoteWeight
+            . vpvVoteWeight
             . forgetArrivalTime
             . veVote
         )
@@ -237,10 +237,10 @@ addVote vote model
     getTotalStake extendedVotes
   -- Did we already have a quorum before adding this new vote?
   hadQuorum =
-    stakeAboveThreshold (params model) existingVotesStake
+    weightAboveThreshold (params model) existingVotesStake
   -- Did we reach the quorum threshold with this new vote?
   reachedQuorum =
-    stakeAboveThreshold (params model) extendedVotesStake
+    weightAboveThreshold (params model) extendedVotesStake
   -- The existing certificate (if any) for this round
   certAtRound =
     Map.lookup roundNo (certs model)

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/PerasVoteDB/Model.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/PerasVoteDB/Model.hs
@@ -24,8 +24,7 @@ import GHC.Generics (Generic)
 import Ouroboros.Consensus.Block (SlotNo, WithOrigin (..), pointSlot)
 import Ouroboros.Consensus.Block.Abstract (StandardHash)
 import Ouroboros.Consensus.Block.SupportsPeras
-  ( HasPerasVoteBlock (..)
-  , HasPerasVoteRound (..)
+  ( IsPerasVote (..)
   , PerasCert' (..)
   , PerasParams (..)
   , PerasRoundNo
@@ -33,10 +32,8 @@ import Ouroboros.Consensus.Block.SupportsPeras
   , PerasVoteStake (..)
   , PerasVoteTarget (..)
   , ValidatedPerasCert (..)
-  , ValidatedPerasVote
-  , getPerasCertBoostedBlock
-  , getPerasVoteStake
-  , getPerasVoteVoterId
+  , ValidatedPerasVote (..)
+  , getPerasCertPoint
   , stakeAboveThreshold
   )
 import Ouroboros.Consensus.BlockchainTime.WallClock.Types
@@ -158,7 +155,7 @@ addVote vote model
   -- block in this round => integrity violation (shouldn't happen in practice)
   | reachedQuorum
   , Just existingCert <- certAtRound
-  , getPerasCertBoostedBlock freshCert /= getPerasCertBoostedBlock existingCert =
+  , getPerasCertPoint freshCert /= getPerasCertPoint existingCert =
       ( Left $
           MultipleWinnersInRound roundNo
       , model
@@ -200,7 +197,7 @@ addVote vote model
   votedBlock =
     getPerasVoteBlock vote
   voter =
-    getPerasVoteVoterId vote
+    getPerasVoteSeatIndex vote
   -- Compute the next ticket number associated to this vote.
   -- NOTE: This is a 64-bit counter, so there's no practical risk of overflow.
   nextTicketNo =
@@ -227,7 +224,7 @@ addVote vote model
       . sum
       . fmap
         ( unPerasVoteStake
-            . getPerasVoteStake
+            . vpvVoteStake
             . forgetArrivalTime
             . veVote
         )

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/PerasVoteDB/StateMachine.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/PerasVoteDB/StateMachine.hs
@@ -12,7 +12,7 @@ module Test.Ouroboros.Storage.PerasVoteDB.StateMachine
 
     -- * Reusable generators
   , genPerasSeatIndex
-  , genVoteStake
+  , genVoteWeight
   ) where
 
 import Control.Concurrent.Class.MonadSTM (MonadSTM (..))
@@ -42,10 +42,10 @@ import Ouroboros.Consensus.Block.SupportsPeras
   , PerasSeatIndex (..)
   , PerasVote' (..)
   , PerasVoteId
-  , PerasVoteStake (..)
   , PerasVoteTarget (..)
   , ValidatedPerasCert
   , ValidatedPerasVote (..)
+  , VoteWeight (..)
   , defaultPerasParams
   )
 import Ouroboros.Consensus.BlockchainTime.WallClock.Types
@@ -173,7 +173,7 @@ instance StateModel Model where
       roundNo <- genRoundNo
       point <- genPoint
       seatIndex <- genPerasSeatIndex
-      stake <- genVoteStake
+      weight <- genVoteWeight
       now <- genRelativeTime
       let voteWithTime =
             WithArrivalTime now $
@@ -184,7 +184,7 @@ instance StateModel Model where
                       , pvVoteBlock = point
                       , pvVoteVoterId = seatIndex
                       }
-                , vpvVoteStake = stake
+                , vpvVoteWeight = weight
                 }
       return (AddVote voteWithTime)
 
@@ -352,15 +352,15 @@ instance RunModel Model (StateT (PerasVoteDB IO TestBlock) IO) where
 genPerasSeatIndex :: Gen PerasSeatIndex
 genPerasSeatIndex = PerasSeatIndex <$> choose (0, 99)
 
--- | Generate a random 'PerasVoteStake'.
+-- | Generate a random 'VoteWeight'.
 --
 -- Make it so that we always require multiple votes to reach a quorum.
 -- This is assuming a quorum threshold strictly larger than 50%, which is
 -- a very conservative assumption for Peras.
-genVoteStake :: Gen PerasVoteStake
-genVoteStake = do
-  stake <- (1 %) <$> choose (2, 10) -- stake between 1/2 and 1/10
-  pure (PerasVoteStake stake)
+genVoteWeight :: Gen VoteWeight
+genVoteWeight = do
+  weight <- (1 %) <$> choose (2, 10) -- weight between 1/2 and 1/10
+  pure (VoteWeight weight)
 
 -- * Helpers
 

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/PerasVoteDB/StateMachine.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/PerasVoteDB/StateMachine.hs
@@ -36,9 +36,9 @@ import Data.Word (Word64)
 import GHC.Generics (Generic)
 import Ouroboros.Consensus.Block.Abstract (Point (..), SlotNo (..))
 import Ouroboros.Consensus.Block.SupportsPeras
-  ( BlockSupportsPeras (..)
-  , HasPerasVoteBlock (..)
+  ( HasPerasVoteBlock (..)
   , HasPerasVoteRound (..)
+  , PerasParams
   , PerasRoundNo (..)
   , PerasSeatIndex (..)
   , PerasVote' (..)
@@ -98,8 +98,8 @@ tests =
             prop_qd
     ]
 
-perasTestCfg :: PerasCfg TestBlock
-perasTestCfg = defaultPerasParams
+perasTestParams :: PerasParams TestBlock
+perasTestParams = defaultPerasParams
 
 prop_qd :: Actions Model -> Property
 prop_qd actions = monadic runActualImplemMonad resultAsPropertyM
@@ -228,7 +228,7 @@ instance StateModel Model where
       pure (RelativeTime time)
 
   initialState =
-    Model (Model.initModel perasTestCfg)
+    Model (Model.initModel perasTestParams)
 
   nextState (Model m) action _ =
     case action of
@@ -258,7 +258,7 @@ instance RunModel Model (StateT (PerasVoteDB IO TestBlock) IO) where
   perform _ action _ =
     case action of
       CreateDB -> do
-        let args = PerasVoteDB.PerasVoteDbArgs nullTracer perasTestCfg
+        let args = PerasVoteDB.PerasVoteDbArgs nullTracer perasTestParams
         voteDB <- lift $ PerasVoteDB.createDB args
         put voteDB
       AddVote vote -> do

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/PerasVoteDB/StateMachine.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/PerasVoteDB/StateMachine.hs
@@ -36,8 +36,7 @@ import Data.Word (Word64)
 import GHC.Generics (Generic)
 import Ouroboros.Consensus.Block.Abstract (Point (..), SlotNo (..))
 import Ouroboros.Consensus.Block.SupportsPeras
-  ( HasPerasVoteBlock (..)
-  , HasPerasVoteRound (..)
+  ( IsPerasVote (..)
   , PerasParams
   , PerasRoundNo (..)
   , PerasSeatIndex (..)
@@ -400,6 +399,6 @@ votesToReachQuorum model vote res =
       Set.empty
       PerasVoteTarget
         { pvtRoundNo = getPerasVoteRound vote
-        , pvtBlock = getPerasVoteBlock vote
+        , pvtBlock = getPerasVotePoint vote
         }
       (Model.votes model)


### PR DESCRIPTION
This PR replaces five old definitions:

* The associated `PerasCfg` type from `BlockSupportsPeras`, in favor of using `PerasParams` directly.
* The `HasPeras(Cert|Vote)*` projection type classes, in favor of the consolidated `IsPerasCert` and `IsPerasVote` ones.
* The associated `PerasValidationErr` and `PerasForgeErr` type from `BlockSupportsPeras` in favor of a single `PerasError`.
* The `PerasVoteStake` type, in favor of `VoteWeight`.
* The old KeyHash-based `PerasVoterId` (all call sites were already adapted to `PerasSeatIndex` in a previous PR).
 