### PR TITLE
[Peras 52] Consolidate Peras vote collection types

### DIFF
--- a/changelog.d/20260811_090804_agustin.mista_vote_collection.md
+++ b/changelog.d/20260811_090804_agustin.mista_vote_collection.md
@@ -1,0 +1,20 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+### Breaking
+
+- Remove `ValidatedPerasVotesWithQuorum` in favor of `PerasVoteCollection` and `PerasVoteCollectionWithQuorum`.
+
+<!--
+### Non-Breaking
+
+
+-->
+### Patch
+
+- Simplify Peras vote aggregation state to use `PerasVoteCollection` and `PerasVoteCollectionWithQuorum` directly.
+

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Block/SupportsPeras.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Block/SupportsPeras.hs
@@ -10,6 +10,7 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilyDependencies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Ouroboros.Consensus.Block.SupportsPeras
@@ -28,8 +29,10 @@ module Ouroboros.Consensus.Block.SupportsPeras
   , PerasCert' (..)
   , PerasVote' (..)
 
-    -- * Types and functions related to Peras vote collection and quorum checking
+    -- * To be removed in favor of using a 'PerasEpochContext' directly
   , PerasVoteStakeDistr (..)
+
+    -- * To be removed in favor of 'PerasVoteCollection(WithQuorum)'
   , ValidatedPerasVotesWithQuorum
     ( vpvqTarget
     , vpvqVotes
@@ -43,6 +46,22 @@ module Ouroboros.Consensus.Block.SupportsPeras
 
     -- * Peras error types
   , IsPerasError (..)
+
+    -- * Types and functions related to Peras vote collection and quorum checking
+  , PerasVoteCollection
+    ( pvcTarget
+    , pvcVotes
+    , pvcTotalWeight
+    )
+  , perasVoteCollectionSingleton
+  , perasVoteCollectionAddVote
+  , unsafePerasVoteCollection
+  , PerasVoteCollectionWithQuorum
+    ( forgetQuorum
+    )
+  , unsafeAssumeQuorum
+  , perasVoteCollectionCheckQuorum
+  , toUniqueVotesWithSameTarget
 
     -- * Helpers
   , weightAboveThreshold
@@ -59,24 +78,34 @@ import Cardano.Binary (FromCBOR (..), ToCBOR (..))
 import Codec.Serialise (Serialise (..))
 import Codec.Serialise.Decoding (decodeListLenOf)
 import Codec.Serialise.Encoding (encodeListLen)
+import Control.Exception (assert)
+import Data.Containers.NonEmpty (HasNonEmpty (..))
 import Data.Kind (Type)
 import Data.List.NonEmpty (NonEmpty (..))
+import qualified Data.Map.NonEmpty as NEMap
 import Data.Map.Strict (Map)
 import Data.Proxy (Proxy (..))
 import Data.Typeable (Typeable)
 import GHC.Generics (Generic)
 import NoThunks.Class
 import Ouroboros.Consensus.Block.Abstract
+import Ouroboros.Consensus.BlockchainTime.WallClock.Types (WithArrivalTime (..))
 import Ouroboros.Consensus.Committee.Class
   ( CryptoSupportsVotingCommittee (..)
+  , UniqueVotesWithSameTarget
   , VotingCommittee
+  , unsafeUniqueVotesWithSameTarget
   )
+import Ouroboros.Consensus.Committee.Crypto (VoteCandidate)
 import Ouroboros.Consensus.Peras.Cert.Class
 import Ouroboros.Consensus.Peras.Params
 import Ouroboros.Consensus.Peras.Types
 import Ouroboros.Consensus.Peras.Void
 import Ouroboros.Consensus.Peras.Vote.Class
-import Ouroboros.Consensus.Peras.Voting.Adapter (PerasConversionError)
+import Ouroboros.Consensus.Peras.Voting.Adapter
+  ( PerasConversionError
+  , PerasVoteCompatibleWithVotingCommittee (..)
+  )
 import Ouroboros.Consensus.Util
 
 -- * Voting committee types for Peras
@@ -434,6 +463,198 @@ class IsPerasError err blk | err -> blk where
   injectVotingCommitteeError :: PerasVotingCommitteeError blk -> err
   injectConversionError :: PerasConversionError -> err
   injectQuorumNotReachedError :: VoteWeight -> err
+
+-- * Types and functions related to Peras vote collection and quorum checking
+
+-- | Collection of Peras votes for a given target.
+--
+-- NOTE: votes in this collection are uniquely identified by their vote ID.
+data PerasVoteCollection blk
+  = PerasVoteCollection
+  { pvcTarget :: !(PerasVoteTarget blk)
+  -- ^ The target of the votes in this collection
+  , pvcVotes :: !(NE (Map PerasVoteId (WithArrivalTime (ValidatedPerasVote blk))))
+  -- ^ Votes received for this target, indexed by vote ID
+  , pvcTotalWeight :: !VoteWeight
+  -- ^ Total weight of the votes received for this target
+  }
+
+deriving instance
+  ( StandardHash blk
+  , Show (PerasVote blk)
+  , Show (PerasCert blk)
+  ) =>
+  Show (PerasVoteCollection blk)
+deriving instance
+  ( StandardHash blk
+  , Eq (PerasVote blk)
+  , Eq (PerasCert blk)
+  ) =>
+  Eq (PerasVoteCollection blk)
+deriving instance
+  ( StandardHash blk
+  , NoThunks (PerasVote blk)
+  , NoThunks (PerasCert blk)
+  ) =>
+  NoThunks (PerasVoteCollection blk)
+deriving instance
+  Generic (PerasVoteCollection blk)
+
+-- | Construct a 'PerasVoteCollection' with a single vote.
+perasVoteCollectionSingleton ::
+  IsPerasVote (PerasVote blk) blk =>
+  WithArrivalTime (ValidatedPerasVote blk) ->
+  PerasVoteCollection blk
+perasVoteCollectionSingleton vote =
+  PerasVoteCollection
+    { pvcTarget = getPerasVoteTarget vote
+    , pvcVotes = NEMap.singleton (getPerasVoteId vote) vote
+    , pvcTotalWeight = vpvVoteWeight (forgetArrivalTime vote)
+    }
+
+-- | Add a vote to an existing vote collection if it isn't already present, and
+-- update the total weight accordingly.
+--
+-- PRECONDITION: the vote's target must match the collection's target.
+perasVoteCollectionAddVote ::
+  ( StandardHash blk
+  , IsPerasVote (PerasVote blk) blk
+  ) =>
+  WithArrivalTime (ValidatedPerasVote blk) ->
+  PerasVoteCollection blk ->
+  PerasVoteCollection blk
+perasVoteCollectionAddVote vote pvc =
+  assert (getPerasVoteTarget vote == pvcTarget pvc) $
+    pvc
+      { pvcVotes = pvcVotes'
+      , pvcTotalWeight = pvcTotalWeight'
+      }
+ where
+  swapVote =
+    NEMap.insertLookupWithKey
+      (\_k old _new -> old)
+      (getPerasVoteId vote)
+
+  (pvcVotes', pvcTotalWeight')
+    -- key WAS NOT present → vote inserted and weight updated
+    | (Nothing, votes') <- swapVote vote (pvcVotes pvc) =
+        ( votes'
+        , pvcTotalWeight pvc + vpvVoteWeight (forgetArrivalTime vote)
+        )
+    -- key WAS already present → votes and weight unchanged
+    | otherwise =
+        ( pvcVotes pvc
+        , pvcTotalWeight pvc
+        )
+
+-- | Unsafe constructor for 'PerasVoteCollection'.
+--
+-- The only recorded use at the moment is in the HFC implementation, to turn an
+-- existing 'PerasVoteCollection' for the HardForkBlock into a
+-- 'PerasVoteCollection' of a concrete era.
+unsafePerasVoteCollection ::
+  ( IsPerasVote (PerasVote blk) blk
+  , StandardHash blk
+  ) =>
+  (NE (Map PerasVoteId (WithArrivalTime (ValidatedPerasVote blk)))) ->
+  PerasVoteCollection blk
+unsafePerasVoteCollection votes =
+  -- NOTE: no need to check for ID uniqueness since the votes are stored in a
+  -- map keyed by vote ID.
+  assert
+    ( all
+        (\vote -> getPerasVoteTarget vote == firstVoteTarget)
+        (NEMap.elems votes)
+    )
+    $ PerasVoteCollection
+      { pvcTarget = firstVoteTarget
+      , pvcVotes = votes
+      , pvcTotalWeight = totalWeight
+      }
+ where
+  ((_, firstVote) :| _) = NEMap.toList votes
+  firstVoteTarget = getPerasVoteTarget firstVote
+  totalWeight = sum (vpvVoteWeight . forgetArrivalTime <$> NEMap.elems votes)
+
+-- | A collection of Peras votes for a given target that has reached quorum
+newtype PerasVoteCollectionWithQuorum blk
+  = PerasVoteCollectionWithQuorum
+  { forgetQuorum :: PerasVoteCollection blk
+  }
+
+deriving newtype instance
+  ( StandardHash blk
+  , Show (PerasVote blk)
+  , Show (PerasCert blk)
+  ) =>
+  Show (PerasVoteCollectionWithQuorum blk)
+deriving newtype instance
+  ( StandardHash blk
+  , Eq (PerasVote blk)
+  , Eq (PerasCert blk)
+  ) =>
+  Eq (PerasVoteCollectionWithQuorum blk)
+deriving newtype instance
+  ( StandardHash blk
+  , NoThunks (PerasVote blk)
+  , NoThunks (PerasCert blk)
+  ) =>
+  NoThunks (PerasVoteCollectionWithQuorum blk)
+deriving newtype instance
+  Generic (PerasVoteCollectionWithQuorum blk)
+
+-- | Transforms a 'PerasVoteCollection' into a 'PerasVoteCollectionWithQuorum'
+-- without actually checking the quorum condition.
+--
+-- NOTE: the only recorded use at the moment is in the HFC implementation, to
+-- turn an existing 'PerasVoteCollectionWithQuorum' for the HardForkBlock into
+-- a 'PerasVoteCollectionWithQuorum' of a concrete era.
+unsafeAssumeQuorum ::
+  PerasVoteCollection blk ->
+  PerasVoteCollectionWithQuorum blk
+unsafeAssumeQuorum =
+  PerasVoteCollectionWithQuorum
+
+-- | Smart constructor for 'PerasVoteCollectionWithQuorum'
+perasVoteCollectionCheckQuorum ::
+  PerasParams blk ->
+  PerasVoteCollection blk ->
+  Maybe (PerasVoteCollectionWithQuorum blk)
+perasVoteCollectionCheckQuorum params pvc =
+  case weightAboveThreshold params (pvcTotalWeight pvc) of
+    True -> Just (PerasVoteCollectionWithQuorum pvc)
+    False -> Nothing
+
+-- | Convert a collection of Peras votes that has reached quorum into the
+-- corresponding abstract representation of votes used by the voting committee
+-- to forge certificates.
+--
+-- 'UniqueVotesWithSameTarget' and 'PerasVoteCollection' enforce the same
+-- invariants, which are:
+-- - The collection is not empty
+-- - All votes have the same target
+-- - All votes have a unique vote ID (or unique seat index, which is equivalent
+--   assuming they also have the same target, see second point)
+-- In addition to that, 'PerasVoteCollectionWithQuorum' guarantees that the
+-- total weight of the votes is above the threshold.
+toUniqueVotesWithSameTarget ::
+  ( vote ~ PerasVote blk
+  , crypto ~ PerasCrypto blk
+  , committee ~ PerasVotingCommitteeScheme blk
+  , PerasVoteCompatibleWithVotingCommittee vote crypto committee
+  , Eq (VoteCandidate crypto)
+  ) =>
+  PerasVoteCollectionWithQuorum blk ->
+  Either
+    PerasConversionError
+    (UniqueVotesWithSameTarget (PerasCrypto blk) (PerasVotingCommitteeScheme blk))
+toUniqueVotesWithSameTarget (PerasVoteCollectionWithQuorum pvc) = do
+  fmap unsafeUniqueVotesWithSameTarget -- Skip redundant checks in production
+    . traverse fromPerasVote
+    . fmap (vpvVote . forgetArrivalTime)
+    . NEMap.elems
+    . pvcVotes
+    $ pvc
 
 -- * Helpers
 

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Block/SupportsPeras.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Block/SupportsPeras.hs
@@ -32,14 +32,6 @@ module Ouroboros.Consensus.Block.SupportsPeras
     -- * To be removed in favor of using a 'PerasEpochContext' directly
   , PerasVoteStakeDistr (..)
 
-    -- * To be removed in favor of 'PerasVoteCollection(WithQuorum)'
-  , ValidatedPerasVotesWithQuorum
-    ( vpvqTarget
-    , vpvqVotes
-    , vpvqPerasParams
-    )
-  , votesReachQuorum
-
     -- * Validated types
   , ValidatedPerasCert (..)
   , ValidatedPerasVote (..)
@@ -180,9 +172,7 @@ deriving instance
 deriving instance
   Generic (PerasEpochContext blk)
 
-{-------------------------------------------------------------------------------
 -- * Peras types
--------------------------------------------------------------------------------}
 
 -- TODO: to be removed in favor of using a 'PerasEpochContext' directly.
 newtype PerasVoteStakeDistr = PerasVoteStakeDistr
@@ -191,64 +181,7 @@ newtype PerasVoteStakeDistr = PerasVoteStakeDistr
   deriving newtype NoThunks
   deriving stock (Show, Eq, Generic)
 
--- ** Votes with enough stake to reach quorum for a given target
-
--- | A collection of validated Peras votes that:
--- 1. are all for the same target, and
--- 2. have total stake above the quorum threshold for a given 'PerasParams'.
-data ValidatedPerasVotesWithQuorum blk = ValidatedPerasVotesWithQuorum
-  { vpvqTarget :: !(PerasVoteTarget blk)
-  -- ^ The target that all the votes are for
-  , vpvqVotes :: !(NonEmpty (ValidatedPerasVote blk))
-  -- ^ The votes that reached quorum for the given target
-  , vpvqPerasParams :: !(PerasParams blk)
-  -- ^ The Peras configuration used to validate that the votes reach quorum
-  }
-  deriving stock (Show, Eq, Generic)
-  deriving anyclass NoThunks
-
--- | Smart constructor for 'ValidatedPerasVotesReachingQuorum'.
---
--- This function checks that all votes are for the same target, and that their
--- total stake is above the quorum threshold defined in the given 'PerasParams'.
--- It returns 'Nothing' if either of these conditions is not met.
-votesReachQuorum ::
-  ( StandardHash blk
-  , IsPerasVote (PerasVote blk) blk
-  ) =>
-  PerasParams blk ->
-  [ValidatedPerasVote blk] ->
-  Maybe (ValidatedPerasVotesWithQuorum blk)
-votesReachQuorum params votes =
-  case votes of
-    -- We need at least one vote to determine who these votes are for, so we
-    -- can't vacuously reach a quorum, even if the quorum threshold is 0.
-    [] -> Nothing
-    -- If we have at least one vote, we must check that all votes are for the
-    -- same target, and that their total stake of is above the quorum threshold.
-    (v0 : vs)
-      | not (allVotesMatchTarget v0 vs) ->
-          Nothing
-      | not votesHaveEnoughWeight ->
-          Nothing
-      | otherwise ->
-          Just
-            ValidatedPerasVotesWithQuorum
-              { vpvqTarget = getPerasVoteTarget v0
-              , vpvqVotes = v0 :| vs
-              , vpvqPerasParams = params
-              }
- where
-  totalVoteStake =
-    mconcat (vpvVoteWeight <$> votes)
-  votesHaveEnoughWeight =
-    weightAboveThreshold params totalVoteStake
-  allVotesMatchTarget target =
-    all ((== (getPerasVoteTarget target)) . getPerasVoteTarget)
-
-{-------------------------------------------------------------------------------
 -- * BlockSupportsPeras class
--------------------------------------------------------------------------------}
 
 class
   ( Show (PerasParams blk)
@@ -298,7 +231,7 @@ class
 
   forgePerasCert ::
     PerasParams blk ->
-    ValidatedPerasVotesWithQuorum blk ->
+    PerasVoteCollectionWithQuorum blk ->
     Either (PerasError blk) (ValidatedPerasCert blk)
 
   -- | Extract a Peras certificate optionally stored in a block.
@@ -338,8 +271,8 @@ instance StandardHash blk => BlockSupportsPeras blk where
       ValidatedPerasCert
         { vpcCert =
             PerasCert
-              { pcCertRound = pvtRoundNo (vpvqTarget votes)
-              , pcCertBoostedBlock = pvtBlock (vpvqTarget votes)
+              { pcCertRound = pvtRoundNo (pvcTarget (forgetQuorum votes))
+              , pcCertBoostedBlock = pvtBlock (pvcTarget (forgetQuorum votes))
               }
         , vpcCertBoost = perasWeight params
         }

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Peras/Vote/Aggregation.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Peras/Vote/Aggregation.hs
@@ -12,13 +12,14 @@
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE ViewPatterns #-}
 
 -- | Peras vote aggregation and certificate forging
 --
 -- This module implements the core voting logic for the Peras protocol, which
--- aggregates weighted votes on chain blocks and forges certificates when quorum
--- is reached.
+-- aggregates weighted votes on chain blocks and forges certificates when
+-- quorum is reached.
 --
 -- = Overview
 --
@@ -47,7 +48,7 @@
 -- = Quorum Threshold and Multiple Winners
 --
 -- The quorum threshold is parameterized via 'PerasParams'. Depending on this
--- configuration and the stake distribution, it may be theoretically possible
+-- configuration and the weight distribution, it may be theoretically possible
 -- for multiple targets to exceed the threshold within the same round.
 --
 -- This module treats multiple winners as an error condition and rejects votes
@@ -59,7 +60,7 @@
 -- With a correct threshold configuration (e.g., > 3/4 of total weight + a small
 -- safety margin to account for an unlucky local sortition when selecting
 -- non-persistent voters during committee selection), multiple winners should be
--- impossible given an honest stake distribution.
+-- impossible given honest weight distribution.
 --
 -- = Key Types
 --
@@ -67,7 +68,7 @@
 --      its logically split between separate 'NoQuorum' and 'Quorum' types
 --      representing the two states (1) and (2) described above, respectively.
 --   * 'PerasTargetVoteState': tracks votes for one specific block target
---   * 'PerasTargetVoteTally': raw vote count and weight accumulation
+--   * 'PerasVoteCollection': raw vote count and weight accumulation
 --   * 'PerasTargetVoteStatus': type-level status (Candidate/Winner/Loser)
 --   * 'UpdateRoundVoteStateError': errors from invalid state transitions
 --
@@ -91,16 +92,16 @@ module Ouroboros.Consensus.Peras.Vote.Aggregation
   , getPerasTargetVoteStateBlock
   ) where
 
-import Cardano.Prelude (fromMaybe)
 import Control.Exception (assert)
 import Data.Functor.Compose (Compose (..))
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
+import Data.Maybe (fromMaybe)
 import Data.Word (Word64)
 import GHC.Generics (Generic)
 import NoThunks.Class (NoThunks (..))
 import Ouroboros.Consensus.Block
-import Ouroboros.Consensus.BlockchainTime (WithArrivalTime, forgetArrivalTime)
+import Ouroboros.Consensus.BlockchainTime (WithArrivalTime)
 
 {-------------------------------------------------------------------------------
   Voting state for a given Peras round
@@ -111,15 +112,56 @@ data PerasRoundVoteState blk = PerasRoundVoteState
   { prvsRoundNo :: !PerasRoundNo
   , prvsState :: !(Either (NoQuorum blk) (Quorum blk))
   }
-  deriving stock (Generic, Eq, Show)
-  deriving anyclass NoThunks
+
+deriving instance
+  ( StandardHash blk
+  , Show (PerasVote blk)
+  , Show (PerasCert blk)
+  , Show (PerasVotingCommittee blk)
+  ) =>
+  Show (PerasRoundVoteState blk)
+deriving instance
+  ( StandardHash blk
+  , Eq (PerasVote blk)
+  , Eq (PerasCert blk)
+  , Eq (PerasVotingCommittee blk)
+  ) =>
+  Eq (PerasRoundVoteState blk)
+deriving instance
+  ( StandardHash blk
+  , NoThunks (PerasVote blk)
+  , NoThunks (PerasCert blk)
+  , NoThunks (PerasVotingCommittee blk)
+  ) =>
+  NoThunks (PerasRoundVoteState blk)
+deriving instance
+  Generic (PerasRoundVoteState blk)
 
 -- | Current vote state when a quorum has not yet been reached
 data NoQuorum blk = NoQuorum
   { candidateStates :: !(Map (Point blk) (PerasTargetVoteState blk 'Candidate))
   }
-  deriving stock (Generic, Eq, Show)
-  deriving anyclass NoThunks
+
+deriving instance
+  ( StandardHash blk
+  , Show (PerasVote blk)
+  , Show (PerasCert blk)
+  ) =>
+  Show (NoQuorum blk)
+deriving instance
+  ( StandardHash blk
+  , Eq (PerasVote blk)
+  , Eq (PerasCert blk)
+  ) =>
+  Eq (NoQuorum blk)
+deriving instance
+  ( StandardHash blk
+  , NoThunks (PerasVote blk)
+  , NoThunks (PerasCert blk)
+  ) =>
+  NoThunks (NoQuorum blk)
+deriving instance
+  Generic (NoQuorum blk)
 
 -- | Current vote state when a quorum has been reached
 data Quorum blk = Quorum
@@ -127,8 +169,27 @@ data Quorum blk = Quorum
   , loserStates :: !(Map (Point blk) (PerasTargetVoteState blk 'Loser))
   , winnerState :: !(PerasTargetVoteState blk 'Winner)
   }
-  deriving stock (Generic, Eq, Show)
-  deriving anyclass NoThunks
+
+deriving instance
+  ( StandardHash blk
+  , Show (PerasVote blk)
+  , Show (PerasCert blk)
+  ) =>
+  Show (Quorum blk)
+deriving instance
+  ( StandardHash blk
+  , Eq (PerasVote blk)
+  , Eq (PerasCert blk)
+  ) =>
+  Eq (Quorum blk)
+deriving instance
+  ( StandardHash blk
+  , NoThunks (PerasVote blk)
+  , NoThunks (PerasCert blk)
+  ) =>
+  NoThunks (Quorum blk)
+deriving instance
+  Generic (Quorum blk)
 
 -- | Get the round number of a round vote state
 getPerasRoundVoteStateRound :: PerasRoundVoteState blk -> PerasRoundNo
@@ -165,7 +226,7 @@ getPerasRoundVoteStateMaxTargetedSlot PerasRoundVoteState{prvsState} =
       maximumOrOrigin $ map pointSlot $ Map.keys candidateStates
     Right Quorum{winnerState, loserStates} ->
       maximumOrOrigin $
-        pointSlot (pvtBlock . ptvtTarget . ptvsVoteTally $ winnerState)
+        pointSlot (getPerasTargetVoteStateBlock winnerState)
           : (pointSlot <$> Map.keys loserStates)
  where
   maximumOrOrigin [] = Origin
@@ -218,21 +279,19 @@ updatePerasRoundVoteState vote params roundState =
               { candidateStates
               }
         } -> do
-          let oldCandidateState =
-                Map.findWithDefault
-                  (freshCandidateVoteState (getPerasVoteTarget vote))
-                  (getPerasVoteBlock vote)
-                  candidateStates
+          let updateMaybeCandidateState = \case
+                Nothing ->
+                  candidateOrWinnerVoteStateSingleton params vote
+                Just oldCandidateState ->
+                  updateCandidateVoteState params vote oldCandidateState
           candidateOrWinnerState <-
-            updateCandidateVoteState params vote oldCandidateState
-              `onErr` \err ->
-                RoundVoteStateForgingCertError err
+            updateMaybeCandidateState (Map.lookup (getPerasVotePoint vote) candidateStates)
           case candidateOrWinnerState of
             RemainedCandidate newCandidateState -> do
               -- Quorum still not reached for this round
               let prvsCandidateStates' =
                     Map.insert
-                      (getPerasVoteBlock vote)
+                      (getPerasVotePoint vote)
                       newCandidateState
                       candidateStates
               pure $
@@ -246,7 +305,7 @@ updatePerasRoundVoteState vote params roundState =
             BecameWinner winnerState -> do
               -- Quorum has been reached for the first time here for this round
               let winnerPoint =
-                    pvtBlock (ptvtTarget (ptvsVoteTally winnerState))
+                    pvtBlock (pvcTarget (ptvsVoteCollection winnerState))
                   loserStates =
                     candidateToLoser <$> Map.delete winnerPoint candidateStates
               pure $
@@ -273,9 +332,9 @@ updatePerasRoundVoteState vote params roundState =
               }
         } -> do
           let votePoint =
-                getPerasVoteBlock vote
+                getPerasVotePoint vote
               winnerPoint =
-                pvtBlock (ptvtTarget (ptvsVoteTally winnerState))
+                pvtBlock (pvcTarget (ptvsVoteCollection winnerState))
           if votePoint == winnerPoint
             -- The vote ratifies the winner => update winner state
             then do
@@ -294,14 +353,14 @@ updatePerasRoundVoteState vote params roundState =
 
             -- The vote is for a loser => update loser state
             else do
-              let existingOrFreshLoserVoteState =
-                    fromMaybe (freshLoserVoteState (getPerasVoteTarget vote))
-                  updateMaybeLoserVoteState mState =
-                    fmap Just $
-                      updateLoserVoteState params vote (existingOrFreshLoserVoteState mState)
-                        `onErr` \err ->
-                          RoundVoteStateLoserAboveQuorum winnerState err
-              loserStates' <- Map.alterF updateMaybeLoserVoteState votePoint loserStates
+              let updateMaybeLoserVoteState = \case
+                    Nothing ->
+                      loserVoteStateSingleton params winnerState vote
+                    Just oldLoserState ->
+                      updateLoserVoteState params winnerState vote oldLoserState
+
+              loserStates' <-
+                Map.alterF (\mState -> Just <$> updateMaybeLoserVoteState mState) votePoint loserStates
               pure $
                 state
                   { prvsState =
@@ -404,65 +463,6 @@ voteGeneratedCert = \case
     Nothing
 
 {-------------------------------------------------------------------------------
-  Peras target vote tally
--------------------------------------------------------------------------------}
-
--- | Tally of votes for a given target (round number and block point)
-data PerasTargetVoteTally blk = PerasTargetVoteTally
-  { ptvtTarget :: !(PerasVoteTarget blk)
-  -- ^ What we are tallying votes for
-  , ptvtVotes :: !(Map PerasVoteId (WithArrivalTime (ValidatedPerasVote blk)))
-  -- ^ Votes received for this target, indexed by vote ID
-  , ptvtTotalWeight :: !VoteWeight
-  -- ^ Total weight of the votes received for this target
-  }
-  deriving stock (Generic, Eq, Show)
-  deriving anyclass NoThunks
-
-freshTargetVoteTally :: PerasVoteTarget blk -> PerasTargetVoteTally blk
-freshTargetVoteTally target =
-  PerasTargetVoteTally
-    { ptvtTarget = target
-    , ptvtVotes = Map.empty
-    , ptvtTotalWeight = VoteWeight 0
-    }
-
--- | Add a vote to an existing target tally if it isn't already present,
--- and update the weight accordingly.
---
--- PRECONDITION: the vote's target must match the tally's target.
-updateTargetVoteTally ::
-  StandardHash blk =>
-  WithArrivalTime (ValidatedPerasVote blk) ->
-  PerasTargetVoteTally blk ->
-  PerasTargetVoteTally blk
-updateTargetVoteTally
-  vote
-  ptvt@PerasTargetVoteTally
-    { ptvtVotes
-    , ptvtTarget
-    , ptvtTotalWeight
-    } =
-    assert (getPerasVoteTarget vote == ptvtTarget) $ do
-      ptvt
-        { ptvtVotes = pvaVotes'
-        , ptvtTotalWeight = pvaTotalWeight'
-        }
-   where
-    swapVote =
-      Map.insertLookupWithKey
-        (\_k old _new -> old)
-        (getPerasVoteId vote)
-
-    (pvaVotes', pvaTotalWeight')
-      -- key WAS NOT present → vote inserted and weight updated
-      | (Nothing, votes') <- swapVote vote ptvtVotes =
-          (votes', ptvtTotalWeight + vpvVoteWeight (forgetArrivalTime vote))
-      -- key WAS already present → votes and weight unchanged
-      | otherwise =
-          (ptvtVotes, ptvtTotalWeight)
-
-{-------------------------------------------------------------------------------
   Peras target vote status
 -------------------------------------------------------------------------------}
 
@@ -479,36 +479,36 @@ data PerasTargetVoteStatus
 -- We indicate at type level the status of the target w.r.t the voting process.
 data PerasTargetVoteState blk (status :: PerasTargetVoteStatus) where
   PerasTargetVoteCandidate ::
-    !(PerasTargetVoteTally blk) ->
+    !(PerasVoteCollection blk) ->
     PerasTargetVoteState blk 'Candidate
   PerasTargetVoteLoser ::
-    !(PerasTargetVoteTally blk) ->
+    !(PerasVoteCollection blk) ->
     PerasTargetVoteState blk 'Loser
   PerasTargetVoteWinner ::
-    !(PerasTargetVoteTally blk) ->
+    !(PerasVoteCollection blk) ->
     !(ValidatedPerasCert blk) ->
     PerasTargetVoteState blk 'Winner
 
 deriving stock instance
-  ( Eq (PerasTargetVoteTally blk)
+  ( Eq (PerasVoteCollection blk)
   , Eq (ValidatedPerasCert blk)
   ) =>
   Eq (PerasTargetVoteState blk status)
 
 deriving stock instance
-  ( Ord (PerasTargetVoteTally blk)
+  ( Ord (PerasVoteCollection blk)
   , Ord (ValidatedPerasCert blk)
   ) =>
   Ord (PerasTargetVoteState blk status)
 
 deriving stock instance
-  ( Show (PerasTargetVoteTally blk)
+  ( Show (PerasVoteCollection blk)
   , Show (ValidatedPerasCert blk)
   ) =>
   Show (PerasTargetVoteState blk status)
 
 instance
-  ( NoThunks (PerasTargetVoteTally blk)
+  ( NoThunks (PerasVoteCollection blk)
   , NoThunks (ValidatedPerasCert blk)
   ) =>
   NoThunks (PerasTargetVoteState blk status)
@@ -519,35 +519,56 @@ instance
   -- we can just delegate wNoThunks to our custom noThunks
   wNoThunks = noThunks
 
-  noThunks ctx (PerasTargetVoteCandidate tally) =
-    noThunks ctx tally
-  noThunks ctx (PerasTargetVoteLoser tally) =
-    noThunks ctx tally
-  noThunks ctx (PerasTargetVoteWinner tally cert) =
-    noThunks ctx (tally, cert)
+  noThunks ctx (PerasTargetVoteCandidate voteCollection) =
+    noThunks ctx voteCollection
+  noThunks ctx (PerasTargetVoteLoser voteCollection) =
+    noThunks ctx voteCollection
+  noThunks ctx (PerasTargetVoteWinner voteCollection cert) =
+    noThunks ctx (voteCollection, cert)
 
 -- | Extract the total weight from a target vote state
 getPerasTargetVoteStateTotalWeight :: PerasTargetVoteState blk status -> VoteWeight
-getPerasTargetVoteStateTotalWeight = ptvtTotalWeight . ptvsVoteTally
+getPerasTargetVoteStateTotalWeight = pvcTotalWeight . ptvsVoteCollection
 
 -- | Extract the block point from a target vote state
 getPerasTargetVoteStateBlock :: PerasTargetVoteState blk status -> Point blk
-getPerasTargetVoteStateBlock = pvtBlock . ptvtTarget . ptvsVoteTally
+getPerasTargetVoteStateBlock = pvtBlock . pvcTarget . ptvsVoteCollection
 
--- | Extract the underlying vote tally from a target vote state
-ptvsVoteTally :: PerasTargetVoteState blk status -> PerasTargetVoteTally blk
-ptvsVoteTally = \case
-  PerasTargetVoteCandidate tally -> tally
-  PerasTargetVoteLoser tally -> tally
-  PerasTargetVoteWinner tally _ -> tally
+-- | Extract the underlying vote voteCollection from a target vote state
+ptvsVoteCollection :: PerasTargetVoteState blk status -> PerasVoteCollection blk
+ptvsVoteCollection = \case
+  PerasTargetVoteCandidate voteCollection -> voteCollection
+  PerasTargetVoteLoser voteCollection -> voteCollection
+  PerasTargetVoteWinner voteCollection _ -> voteCollection
 
-freshCandidateVoteState :: PerasVoteTarget blk -> PerasTargetVoteState blk 'Candidate
-freshCandidateVoteState target =
-  PerasTargetVoteCandidate (freshTargetVoteTally target)
+candidateOrWinnerVoteStateSingleton ::
+  BlockSupportsPeras blk =>
+  PerasParams blk ->
+  WithArrivalTime (ValidatedPerasVote blk) ->
+  Either
+    (UpdateRoundVoteStateError blk)
+    (PerasVoteStateCandidateOrWinner blk)
+candidateOrWinnerVoteStateSingleton params vote =
+  let voteCollection = perasVoteCollectionSingleton vote
+   in case perasVoteCollectionCheckQuorum params voteCollection of
+        Just votesWithQuorum -> do
+          cert <- forgePerasCert params votesWithQuorum `onErr` RoundVoteStateForgingCertError
+          pure $ BecameWinner $ PerasTargetVoteWinner voteCollection cert
+        Nothing ->
+          pure $ RemainedCandidate $ PerasTargetVoteCandidate voteCollection
 
-freshLoserVoteState :: PerasVoteTarget blk -> PerasTargetVoteState blk 'Loser
-freshLoserVoteState target =
-  PerasTargetVoteLoser (freshTargetVoteTally target)
+loserVoteStateSingleton ::
+  PerasParams blk ->
+  PerasTargetVoteState blk 'Winner ->
+  WithArrivalTime (ValidatedPerasVote blk) ->
+  Either (UpdateRoundVoteStateError blk) (PerasTargetVoteState blk 'Loser)
+loserVoteStateSingleton params winnerState vote =
+  let voteCollection = perasVoteCollectionSingleton vote
+   in case perasVoteCollectionCheckQuorum params voteCollection of
+        Just _ ->
+          Left $ RoundVoteStateLoserAboveQuorum winnerState (PerasTargetVoteLoser voteCollection)
+        Nothing ->
+          Right $ PerasTargetVoteLoser voteCollection
 
 -- | Convert a 'Candidate' state to a 'Loser' state.
 --
@@ -556,8 +577,8 @@ freshLoserVoteState target =
 candidateToLoser ::
   PerasTargetVoteState blk 'Candidate ->
   PerasTargetVoteState blk 'Loser
-candidateToLoser (PerasTargetVoteCandidate tally) =
-  PerasTargetVoteLoser tally
+candidateToLoser (PerasTargetVoteCandidate voteCollection) =
+  PerasTargetVoteLoser voteCollection
 
 -- | Subtype of 'PerasTargetVoteState' to indicate whether the target remains a
 -- candidate or has been elected winner
@@ -574,52 +595,55 @@ updateCandidateVoteState ::
   WithArrivalTime (ValidatedPerasVote blk) ->
   PerasTargetVoteState blk 'Candidate ->
   Either
-    (PerasError blk)
+    (UpdateRoundVoteStateError blk)
     (PerasVoteStateCandidateOrWinner blk)
-updateCandidateVoteState cfg vote oldState =
+updateCandidateVoteState params vote oldState =
   let
-    newVoteTally = updateTargetVoteTally vote (ptvsVoteTally oldState)
-    voteList = forgetArrivalTime <$> Map.elems (ptvtVotes newVoteTally)
+    newVoteCollection = perasVoteCollectionAddVote vote (ptvsVoteCollection oldState)
    in
-    case votesReachQuorum cfg voteList of
+    case perasVoteCollectionCheckQuorum params newVoteCollection of
       Just votesWithQuorum -> do
-        cert <- forgePerasCert cfg votesWithQuorum
-        pure $ BecameWinner (PerasTargetVoteWinner newVoteTally cert)
+        cert <- forgePerasCert params votesWithQuorum `onErr` RoundVoteStateForgingCertError
+        pure $ BecameWinner (PerasTargetVoteWinner newVoteCollection cert)
       Nothing -> do
-        pure $ RemainedCandidate (PerasTargetVoteCandidate newVoteTally)
+        pure $ RemainedCandidate (PerasTargetVoteCandidate newVoteCollection)
 
 -- | Add a vote to an existing target vote state if it isn't already present.
 --
--- PRECONDITION: the vote's target must match the underlying tally's target.
+-- PRECONDITION: the vote's target must match the underlying vote collection's target.
 --
 -- May fail if the loser goes above quorum by adding the vote.
 updateLoserVoteState ::
   StandardHash blk =>
   PerasParams blk ->
+  PerasTargetVoteState blk 'Winner ->
   WithArrivalTime (ValidatedPerasVote blk) ->
   PerasTargetVoteState blk 'Loser ->
-  Either (PerasTargetVoteState blk 'Loser) (PerasTargetVoteState blk 'Loser)
-updateLoserVoteState cfg vote oldState =
-  assert (getPerasVoteTarget vote == ptvtTarget (ptvsVoteTally oldState)) $ do
-    let newVoteTally = updateTargetVoteTally vote (ptvsVoteTally oldState)
-        aboveQuorum = weightAboveThreshold cfg (ptvtTotalWeight newVoteTally)
-     in if aboveQuorum
-          then Left $ PerasTargetVoteLoser newVoteTally
-          else Right $ PerasTargetVoteLoser newVoteTally
+  Either (UpdateRoundVoteStateError blk) (PerasTargetVoteState blk 'Loser)
+updateLoserVoteState params winnerState vote oldState =
+  assert (getPerasVoteTarget vote == pvcTarget (ptvsVoteCollection oldState)) $ do
+    let newVoteCollection = perasVoteCollectionAddVote vote (ptvsVoteCollection oldState)
+     in case perasVoteCollectionCheckQuorum params newVoteCollection of
+          Just _ ->
+            Left $ RoundVoteStateLoserAboveQuorum winnerState (PerasTargetVoteLoser newVoteCollection)
+          Nothing ->
+            Right $ PerasTargetVoteLoser newVoteCollection
 
 -- | Add a vote to an existing target vote state if it isn't already present.
 --
--- PRECONDITION: the vote's target must match the underlying tally's target.
+-- PRECONDITION: the vote's target must match the underlying vote collection's target.
 updateWinnerVoteState ::
-  StandardHash blk =>
+  ( StandardHash blk
+  , IsPerasVote (PerasVote blk) blk
+  ) =>
   WithArrivalTime (ValidatedPerasVote blk) ->
   PerasTargetVoteState blk 'Winner ->
   PerasTargetVoteState blk 'Winner
 updateWinnerVoteState vote oldState =
-  assert (getPerasVoteTarget vote == ptvtTarget (ptvsVoteTally oldState)) $ do
-    let newVoteTally = updateTargetVoteTally vote (ptvsVoteTally oldState)
+  assert (getPerasVoteTarget vote == pvcTarget (ptvsVoteCollection oldState)) $ do
+    let newVoteCollection = perasVoteCollectionAddVote vote (ptvsVoteCollection oldState)
         (PerasTargetVoteWinner _ cert) = oldState
-     in PerasTargetVoteWinner newVoteTally cert
+     in PerasTargetVoteWinner newVoteCollection cert
 
 {-------------------------------------------------------------------------------
   Helpers

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Util/Orphans.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Util/Orphans.hs
@@ -29,6 +29,8 @@ import Data.Array (Array)
 import qualified Data.Array as Array
 import Data.IntPSQ (IntPSQ)
 import qualified Data.IntPSQ as PSQ
+import Data.Map.NonEmpty (NEMap)
+import qualified Data.Map.NonEmpty as NEMap
 import Data.MultiSet (MultiSet)
 import qualified Data.MultiSet as MultiSet
 import Data.SOP.BasicFunctors
@@ -110,6 +112,10 @@ instance NoThunks a => NoThunks (K a b) where
 instance NoThunks a => NoThunks (MultiSet a) where
   showTypeOf _ = "MultiSet"
   wNoThunks ctxt = wNoThunks ctxt . MultiSet.toMap
+
+instance (NoThunks k, NoThunks v) => NoThunks (NEMap k v) where
+  showTypeOf _ = "NEMap"
+  wNoThunks ctxt = wNoThunks ctxt . NEMap.toMap
 
 instance NoThunks v => NoThunks (NESet v) where
   showTypeOf _ = "NESet"


### PR DESCRIPTION
This PR:

- Adds the `PerasVoteCollection` and `PerasVoteCollectionWithQuorum` container wrapper types, along with a minimal interface to construct and destruct them.

- Removes the old `ValidatedPerasVoteWithQuorum` container wrapper type, in favor of using the new `PerasVoteCollection` and `PerasVoteCollectionWithQuorum` in both the client-facing API, as well as in the internal state of the vote aggregation logic (by replacing the old `PerasTargetVoteTally` container type serving the same purpose).

NOTE: in this process, we also replaced some inline deriving clauses with standalone ones, as these will be needed soon when we extend the per-round vote aggregation state with a `PerasEpochContext` to allow for real validation.