### PR TITLE
[Peras 53] Refactor Peras test utilities into unstable testlib

### DIFF
--- a/ouroboros-consensus.cabal
+++ b/ouroboros-consensus.cabal
@@ -485,6 +485,10 @@ library unstable-consensus-testlib
     Test.Util.Orphans.SignableRepresentation
     Test.Util.Orphans.ToExpr
     Test.Util.Paths
+    Test.Util.Peras
+    Test.Util.Peras.Common
+    Test.Util.Peras.Mock
+    Test.Util.Peras.V1
     Test.Util.QSM
     Test.Util.QuickCheck
     Test.Util.Range
@@ -688,7 +692,6 @@ test-suite consensus-test
     Test.Consensus.MiniProtocol.ObjectDiffusion.Smoke
     Test.Consensus.Peras.Cert.Inclusion
     Test.Consensus.Peras.Serialisation
-    Test.Consensus.Peras.Util
     Test.Consensus.Peras.Voting.Adapter
     Test.Consensus.Peras.Voting.Rules
     Test.Consensus.Peras.WeightSnapshot

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/Peras.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/Peras.hs
@@ -1,0 +1,6 @@
+-- | Test utilities for Peras.
+module Test.Util.Peras (module X) where
+
+import Test.Util.Peras.Common as X
+import Test.Util.Peras.Mock as X
+import Test.Util.Peras.V1 as X

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/Peras/Common.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/Peras/Common.hs
@@ -1,0 +1,170 @@
+{-# LANGUAGE TypeApplications #-}
+
+-- | Common test utilities for Peras tests.
+module Test.Util.Peras.Common
+  ( genPerasParams
+  , genRoundNo
+  , genSeatIndex
+  , genPoolId
+  , genLedgerStake
+  , ListWithUniqueIds (..)
+  , NonEmptyListWithUniqueIds (..)
+  , genListWithUniqueIds
+  , genNonEmptyListWithUniqueIds
+  , nonEmptyListOf
+  , genRelativeTime
+  , genWithArrivalTime
+  , genPointTestBlock
+  , mockSystemTime
+  , mkBucket
+  , divisorClosestToTarget
+  , divisorClosestToQuotient
+  ) where
+
+import Cardano.Prelude (comparing)
+import Data.Containers.ListUtils (nubOrdOn)
+import Data.List (sortBy)
+import Data.List.NonEmpty (NonEmpty)
+import qualified Data.List.NonEmpty as NonEmpty
+import Data.Word (Word64)
+import Ouroboros.Consensus.Block.SupportsPeras
+  ( PerasParams
+  , PerasRoundNo (..)
+  , defaultPerasParams
+  )
+import Ouroboros.Consensus.BlockchainTime
+  ( RelativeTime (..)
+  , SystemTime (..)
+  , WithArrivalTime (..)
+  )
+import Ouroboros.Consensus.Committee.Types (LedgerStake (..), PoolId)
+import Ouroboros.Consensus.Peras.Types (PerasSeatIndex (..))
+import Ouroboros.Network.Block (Point (..), SlotNo (..))
+import Ouroboros.Network.Point (Block (..), WithOrigin (..))
+import Test.QuickCheck (Arbitrary (..), Gen, NonEmptyList (..), choose)
+import Test.QuickCheck.Gen (frequency, listOf, listOf1)
+import Test.Util.Committee (mkPoolId)
+import Test.Util.TestBlock (TestBlock, TestHash (..))
+
+genPerasParams :: Gen (PerasParams blk)
+genPerasParams = pure defaultPerasParams
+
+genRoundNo :: Gen PerasRoundNo
+genRoundNo = PerasRoundNo <$> arbitrary
+
+genSeatIndex :: Gen PerasSeatIndex
+genSeatIndex = PerasSeatIndex <$> arbitrary
+
+genPoolId :: Gen PoolId
+genPoolId = mkPoolId <$> arbitrary
+
+genLedgerStake :: Gen LedgerStake
+genLedgerStake = LedgerStake . toRational <$> choose @Int (1, 100)
+
+newtype ListWithUniqueIds a = ListWithUniqueIds [a]
+  deriving (Eq, Show, Ord)
+
+newtype NonEmptyListWithUniqueIds a = NonEmptyListWithUniqueIds (NonEmpty a)
+  deriving (Eq, Show, Ord)
+
+genListWithUniqueIds ::
+  Ord idTy =>
+  (a -> idTy) ->
+  Gen a ->
+  Gen (ListWithUniqueIds a)
+genListWithUniqueIds getId genObject =
+  ListWithUniqueIds . nubOrdOn getId <$> listOf genObject
+
+genNonEmptyListWithUniqueIds ::
+  Ord idTy =>
+  (a -> idTy) ->
+  Gen a ->
+  Gen (NonEmptyListWithUniqueIds a)
+genNonEmptyListWithUniqueIds getId genObject =
+  NonEmptyListWithUniqueIds . NonEmpty.fromList . nubOrdOn getId
+    <$> listOf1 genObject
+
+nonEmptyListOf :: Gen a -> Gen (NonEmpty a)
+nonEmptyListOf genObject =
+  NonEmpty.fromList <$> listOf1 genObject
+
+-- | Find the whole divisor of 'a' that is the closest to 'a/b'.
+--
+-- If there are multiple divisors with the same distance, the smallest one is
+-- returned.
+--
+-- >>> divisorClosestToQuotient 10 3
+-- 2
+-- >>> divisorClosestToQuotient 10 5
+-- 2
+-- >>> divisorClosestToQuotient 6 10
+-- 1
+divisorClosestToQuotient :: Integral a => a -> a -> a
+divisorClosestToQuotient num denom =
+  divisorClosestToTarget
+    num
+    ( (fromIntegral num :: Double)
+        / (fromIntegral denom :: Double)
+    )
+
+-- | Find the whole divisor of 'num' that is the closest to 'target'.
+divisorClosestToTarget :: Integral a => a -> Double -> a
+divisorClosestToTarget num target =
+  case sortBy (comparing snd) (addDistance <$> divisors) of
+    [] -> error "impossible: divisorClosestToTarget found no divisors"
+    (closestDivisor, _dist) : _ -> closestDivisor
+ where
+  divisors = filter (\x -> num `mod` x == 0) [1 .. num]
+  addDistance divisor = (divisor, getDistance divisor)
+  getDistance divisor = abs (target - fromIntegral divisor)
+
+-- * Shared generators for Peras smoke tests
+
+genRelativeTime :: Gen RelativeTime
+genRelativeTime =
+  RelativeTime . fromIntegral
+    <$> arbitrary @Word64
+
+genWithArrivalTime :: Gen a -> Gen (WithArrivalTime a)
+genWithArrivalTime genA =
+  WithArrivalTime
+    <$> genRelativeTime
+    <*> genA
+
+genPointTestBlock :: Gen (Point TestBlock)
+genPointTestBlock =
+  frequency
+    [
+      ( 1
+      , pure (Point Origin)
+      )
+    ,
+      ( 50
+      , do
+          slotNo <- SlotNo <$> arbitrary
+          hash <- TestHash . NonEmpty.fromList . getNonEmpty <$> arbitrary
+          pure (Point (At (Block slotNo hash)))
+      )
+    ]
+
+-- | A static 'SystemTime' returning a constant time. The canonical mock system
+-- time lives in 'Test.Util.LogicalClock.mockSystemTime', but it is a field of
+-- 'LogicalClock' which requires a 'ResourceRegistry' and a background tick
+-- thread — too heavyweight for simple property tests that don't need time
+-- progression.
+mockSystemTime :: Applicative m => SystemTime m
+mockSystemTime =
+  SystemTime
+    { systemTimeCurrent = pure (RelativeTime 0)
+    , systemTimeWait = pure ()
+    }
+
+-- * Tabulators
+
+mkBucket :: Int -> Int -> String -> String
+mkBucket bucketSize x suffix
+  | lower == upper = show lower <> suffix
+  | otherwise = show lower <> "-" <> show upper <> suffix
+ where
+  lower = (x `div` bucketSize) * bucketSize
+  upper = lower + bucketSize

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/Peras/Mock.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/Peras/Mock.hs
@@ -1,0 +1,145 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections #-}
+
+-- | Test utilities for the mock Peras implementation.
+module Test.Util.Peras.Mock
+  ( genMockPerasVotingCommitteeInput
+  , genMockPerasVotingCommittee
+  , genMockPerasVote
+  , genMockPerasCert
+  , genMockPerasCertFullCommittee
+  , genMockPerasVoterIndices
+  , pickSeatIndexFromCommittee
+  , genVotersSubset
+  ) where
+
+import Data.Containers.NonEmpty (NE)
+import Data.Either (fromRight)
+import qualified Data.List.NonEmpty as NonEmpty
+import Data.Set (Set)
+import qualified Data.Set.NonEmpty as NESet
+import Ouroboros.Consensus.Committee.Class
+import Ouroboros.Consensus.Peras.Cert.Mock (MockPerasCert (..))
+import Ouroboros.Consensus.Peras.Crypto.Mock
+  ( MockPerasCrypto
+  , MockPerasVotingCommitteeScheme
+  , VotingCommittee (..)
+  , VotingCommitteeInput (..)
+  , unsafeIntToSeatIndex
+  )
+import Ouroboros.Consensus.Peras.Types (PerasSeatIndex (..))
+import Ouroboros.Consensus.Peras.Vote.Mock (MockPerasVote (..))
+import Test.QuickCheck (Gen, choose)
+import Test.Util.Peras.Common
+  ( NonEmptyListWithUniqueIds (..)
+  , genLedgerStake
+  , genNonEmptyListWithUniqueIds
+  , genPointTestBlock
+  , genPoolId
+  , genRoundNo
+  )
+import Test.Util.TestBlock (TestBlock)
+
+genMockPerasVotingCommitteeInput ::
+  Gen
+    ( VotingCommitteeInput
+        (MockPerasCrypto TestBlock)
+        (MockPerasVotingCommitteeScheme TestBlock)
+    )
+genMockPerasVotingCommitteeInput = do
+  NonEmptyListWithUniqueIds poolIds <- genNonEmptyListWithUniqueIds id genPoolId
+  poolIdsWithStakes <- traverse (\poolId -> (poolId,) <$> genLedgerStake) poolIds
+  pure (MockPerasVotingCommitteeInput poolIdsWithStakes)
+
+genMockPerasVotingCommittee ::
+  Gen
+    ( VotingCommittee
+        (MockPerasCrypto TestBlock)
+        (MockPerasVotingCommitteeScheme TestBlock)
+    )
+genMockPerasVotingCommittee =
+  fromRight (error "mkVotingCommittee cannot fail for the mock committee")
+    . mkVotingCommittee
+    <$> genMockPerasVotingCommitteeInput
+
+pickSeatIndexFromCommittee ::
+  VotingCommittee
+    (MockPerasCrypto TestBlock)
+    (MockPerasVotingCommitteeScheme TestBlock) ->
+  Gen PerasSeatIndex
+pickSeatIndexFromCommittee committee = do
+  let maxIndex = length (weightDistr committee) - 1
+  unsafeIntToSeatIndex <$> choose (0, maxIndex)
+
+genVotersSubset ::
+  VotingCommittee
+    (MockPerasCrypto TestBlock)
+    (MockPerasVotingCommitteeScheme TestBlock) ->
+  Gen (NE (Set PerasSeatIndex))
+genVotersSubset committee = do
+  NonEmptyListWithUniqueIds seatIndices <-
+    genNonEmptyListWithUniqueIds id $
+      pickSeatIndexFromCommittee committee
+  pure (NESet.fromList seatIndices)
+
+genMockPerasVoterIndices :: Gen (NE (Set PerasSeatIndex))
+genMockPerasVoterIndices = do
+  NonEmptyListWithUniqueIds seatIndices <-
+    genNonEmptyListWithUniqueIds id
+      . fmap unsafeIntToSeatIndex
+      $ choose (0, 100)
+  pure (NESet.fromList seatIndices)
+
+genMockPerasVote ::
+  VotingCommittee
+    (MockPerasCrypto TestBlock)
+    (MockPerasVotingCommitteeScheme TestBlock) ->
+  Gen (MockPerasVote TestBlock)
+genMockPerasVote committee = do
+  seatIndex <- pickSeatIndexFromCommittee committee
+  roundNo <- genRoundNo
+  block <- genPointTestBlock
+  pure
+    MockPerasVote
+      { mockVoteSeatIndex = seatIndex
+      , mockVoteRound = roundNo
+      , mockVoteBlock = block
+      }
+
+genMockPerasCert ::
+  VotingCommittee
+    (MockPerasCrypto TestBlock)
+    (MockPerasVotingCommitteeScheme TestBlock) ->
+  Gen (MockPerasCert TestBlock)
+genMockPerasCert committee = do
+  votersSubset <- genVotersSubset committee
+  roundNo <- genRoundNo
+  block <- genPointTestBlock
+  pure
+    MockPerasCert
+      { mockCertVoters = votersSubset
+      , mockCertRound = roundNo
+      , mockCertBlock = block
+      }
+
+genMockPerasCertFullCommittee ::
+  VotingCommittee
+    (MockPerasCrypto TestBlock)
+    (MockPerasVotingCommitteeScheme TestBlock) ->
+  Gen (MockPerasCert TestBlock)
+genMockPerasCertFullCommittee committee = do
+  let maxIndex =
+        length (weightDistr committee) - 1
+  let voters =
+        NESet.fromList
+          . NonEmpty.fromList
+          . fmap unsafeIntToSeatIndex
+          $ [0 .. maxIndex]
+  roundNo <- genRoundNo
+  block <- genPointTestBlock
+  pure
+    MockPerasCert
+      { mockCertVoters = voters
+      , mockCertRound = roundNo
+      , mockCertBlock = block
+      }

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/Peras/V1.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/Peras/V1.hs
@@ -6,18 +6,12 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 
--- | Common utilities for writing tests for Peras types.
-module Test.Consensus.Peras.Util
-  ( -- * Predicates
-    perasVoteIsPersistent
+-- | Test utilities for the V1 (production) Peras implementation.
+module Test.Util.Peras.V1
+  ( perasVoteIsPersistent
   , perasCertContainsOnlyPersistentVotes
-
-    -- * Generators
   , genPerasVote
   , genPerasCert
-
-    -- * Tabulators
-  , mkBucket
   , tabulatePerasCert
   , tabulatePerasVote
   ) where
@@ -26,9 +20,7 @@ import Cardano.Crypto.Hash (ByteString)
 import Cardano.Ledger.BaseTypes (SlotNo (..))
 import Control.Monad (forM)
 import qualified Data.ByteString as ByteString
-import Data.ByteString.Short (ShortByteString)
 import qualified Data.ByteString.Short as ShortByteString
-import qualified Data.ByteString.Short as ShortBytesString
 import qualified Data.List.NonEmpty as NonEmpty
 import qualified Data.Map.NonEmpty as NEMap
 import Data.Maybe (catMaybes, fromMaybe)
@@ -37,20 +29,18 @@ import Data.String (IsString (..))
 import Data.Traversable (mapAccumM)
 import Data.Word (Word8)
 import GHC.Word (Word16)
-import Ouroboros.Consensus.Block (ConvertRawHash, HeaderHash)
-import Ouroboros.Consensus.Block.Abstract (ConvertRawHash (..), WithOrigin (..))
+import Ouroboros.Consensus.Block.Abstract (WithOrigin (..))
 import Ouroboros.Consensus.Block.RealPoint (Bytes32RealPoint (..))
-import Ouroboros.Consensus.Block.SupportsPeras
-  ( PerasBoostedBlock (..)
-  , PerasRoundNo (..)
-  , PerasSeatIndex (..)
-  )
 import qualified Ouroboros.Consensus.Committee.Crypto.BLS as BLS
 import qualified Ouroboros.Consensus.Peras.Cert.V1 as V1
 import Ouroboros.Consensus.Peras.Crypto.BLS
   ( PerasBLSCryptoAggregateVoteSignature (..)
   , VRFOutput (..)
   , VoteSignature (..)
+  )
+import Ouroboros.Consensus.Peras.Types
+  ( PerasBoostedBlock (..)
+  , PerasSeatIndex (..)
   )
 import qualified Ouroboros.Consensus.Peras.Vote.V1 as V1
 import Test.QuickCheck
@@ -63,8 +53,11 @@ import Test.QuickCheck
   , tabulate
   , vectorOf
   )
-
--- * Predicates
+import Test.Util.Peras.Common
+  ( genRoundNo
+  , genSeatIndex
+  , mkBucket
+  )
 
 -- | Whether a Peras vote is a persistent one
 perasVoteIsPersistent :: V1.PerasVote tag -> Bool
@@ -72,7 +65,7 @@ perasVoteIsPersistent vote
   | V1.PersistentPerasVoteEligibilityProof{} <- V1.pvEligibilityProof vote = True
   | otherwise = False
 
--- | Whether a Peras certifcate only contains persistent votes
+-- | Whether a Peras certificate only contains persistent votes
 perasCertContainsOnlyPersistentVotes :: V1.PerasCert tag -> Bool
 perasCertContainsOnlyPersistentVotes cert =
   all
@@ -86,21 +79,9 @@ perasCertContainsOnlyPersistentVotes cert =
         $ cert
     )
 
--- * Generators
-
-genRoundNo :: Gen PerasRoundNo
-genRoundNo = PerasRoundNo <$> arbitrary
-
-data BlockWith32BytesHeaderHash
-type instance HeaderHash BlockWith32BytesHeaderHash = ShortByteString
-
-instance ConvertRawHash BlockWith32BytesHeaderHash where
-  type HashSize BlockWith32BytesHeaderHash = 32
-  toRawHash _ = ShortBytesString.fromShort
-  unsafeFromRawHash _ = ShortBytesString.toShort
-
 genBoostedBlock :: Gen PerasBoostedBlock
-genBoostedBlock = PerasBoostedBlock <$> genWithOrigin genBytes32RealPoint
+genBoostedBlock =
+  PerasBoostedBlock <$> genWithOrigin genBytes32RealPoint
  where
   genWithOrigin gen =
     frequency
@@ -112,9 +93,6 @@ genBoostedBlock = PerasBoostedBlock <$> genWithOrigin genBytes32RealPoint
     hash <- ShortByteString.pack <$> vectorOf 32 arbitrary
     pure $ Bytes32RealPoint slotNo hash
 
-genSeatIndex :: Gen PerasSeatIndex
-genSeatIndex = PerasSeatIndex <$> arbitrary
-
 genPrivateKey :: Proxy r -> Gen (BLS.PrivateKey r)
 genPrivateKey _ =
   fromMaybe (error "genPrivateKey: invalid key bytes")
@@ -122,11 +100,7 @@ genPrivateKey _ =
     . ByteString.pack
     <$> vectorOf 32 (arbitrary @Word8)
 
-genSignature ::
-  forall r.
-  BLS.HasBLSContext r =>
-  Proxy r ->
-  Gen (BLS.Signature r)
+genSignature :: forall r. BLS.HasBLSContext r => Proxy r -> Gen (BLS.Signature r)
 genSignature _ = do
   key <- genPrivateKey (Proxy @r)
   msg <- fromString @ByteString <$> arbitrary
@@ -224,16 +198,6 @@ genPerasCert shouldGenNonPersistent = do
       , V1.pcVoters
       , V1.pcSignature
       }
-
--- * Tabulators
-
-mkBucket :: Int -> Int -> String -> String
-mkBucket bucketSize x suffix
-  | lower == upper = show lower <> suffix
-  | otherwise = show lower <> "-" <> show upper <> suffix
- where
-  lower = (x `div` bucketSize) * bucketSize
-  upper = lower + bucketSize
 
 tabulatePerasCert :: V1.PerasCert tag -> Property -> Property
 tabulatePerasCert cert =

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/MiniProtocol/ObjectDiffusion/PerasCert/Smoke.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/MiniProtocol/ObjectDiffusion/PerasCert/Smoke.hs
@@ -1,14 +1,11 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TypeApplications #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Test.Consensus.MiniProtocol.ObjectDiffusion.PerasCert.Smoke
   ( tests
-  , genPerasCert
-  , genValidatedPerasCert
   ) where
 
 import Control.Monad (join)
@@ -38,19 +35,20 @@ import Ouroboros.Network.Protocol.ObjectDiffusion.Inbound
   )
 import Ouroboros.Network.Protocol.ObjectDiffusion.Outbound (objectDiffusionOutboundPeer)
 import Test.Consensus.MiniProtocol.ObjectDiffusion.Smoke
-  ( ListWithUniqueIds (..)
-  , WithId
-  , genListWithUniqueIds
-  , genPointTestBlock
-  , genProtocolConstants
-  , genWithArrivalTime
-  , getId
-  , mockSystemTime
+  ( genProtocolConstants
   , prop_smoke_object_diffusion
   )
 import Test.QuickCheck
 import Test.Tasty
 import Test.Tasty.QuickCheck (testProperty)
+import Test.Util.Peras
+  ( ListWithUniqueIds (..)
+  , genListWithUniqueIds
+  , genPointTestBlock
+  , genRoundNo
+  , genWithArrivalTime
+  , mockSystemTime
+  )
 import Test.Util.TestBlock
 
 tests :: TestTree
@@ -60,23 +58,19 @@ tests =
     [ testProperty "PerasCertDiffusion smoke test" prop_smoke
     ]
 
-genPerasCert :: Gen (PerasCert TestBlock)
-genPerasCert = do
-  pcCertRound <- PerasRoundNo <$> arbitrary
-  pcCertBoostedBlock <- genPointTestBlock
-  pure $ PerasCert{pcCertRound, pcCertBoostedBlock}
-
-instance WithId (PerasCert' blk) PerasRoundNo where
-  getId = pcCertRound
-
-instance WithId (WithArrivalTime (ValidatedPerasCert blk)) PerasRoundNo where
-  getId = pcCertRound . vpcCert . forgetArrivalTime
-
 genValidatedPerasCert :: Gen (ValidatedPerasCert TestBlock)
 genValidatedPerasCert =
   ValidatedPerasCert
     <$> genPerasCert
-    <*> pure (perasWeight defaultPerasParams)
+    <*> genPerasWeight
+ where
+  genPerasCert =
+    PerasCert
+      <$> genRoundNo
+      <*> genPointTestBlock
+  genPerasWeight =
+    PerasWeight
+      <$> choose (1, 15)
 
 newCertDB ::
   (IOLike m, StandardHash blk) => [WithArrivalTime (ValidatedPerasCert blk)] -> m (PerasCertDB m blk)
@@ -95,7 +89,7 @@ newCertDB certs = do
 prop_smoke :: Property
 prop_smoke =
   forAll genProtocolConstants $ \protocolConstants ->
-    forAll (genListWithUniqueIds (genWithArrivalTime genValidatedPerasCert)) $
+    forAll (genListWithUniqueIds getPerasCertRound (genWithArrivalTime genValidatedPerasCert)) $
       \(ListWithUniqueIds watValidatedCerts) ->
         let
           mkPoolInterfaces ::

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/MiniProtocol/ObjectDiffusion/PerasVote/Smoke.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/MiniProtocol/ObjectDiffusion/PerasVote/Smoke.hs
@@ -1,13 +1,9 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE NamedFieldPuns #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Test.Consensus.MiniProtocol.ObjectDiffusion.PerasVote.Smoke
   ( tests
-  , genPerasVoteWeight
-  , genPerasVote
-  , genValidatedPerasVote
   ) where
 
 import Control.Monad (join)
@@ -38,19 +34,21 @@ import Ouroboros.Network.Protocol.ObjectDiffusion.Inbound
   )
 import Ouroboros.Network.Protocol.ObjectDiffusion.Outbound (objectDiffusionOutboundPeer)
 import Test.Consensus.MiniProtocol.ObjectDiffusion.Smoke
-  ( ListWithUniqueIds (..)
-  , WithId
-  , genListWithUniqueIds
-  , genPointTestBlock
-  , genProtocolConstants
-  , genWithArrivalTime
-  , getId
-  , mockSystemTime
+  ( genProtocolConstants
   , prop_smoke_object_diffusion
   )
 import Test.QuickCheck
 import Test.Tasty
 import Test.Tasty.QuickCheck (testProperty)
+import Test.Util.Peras
+  ( ListWithUniqueIds (..)
+  , genListWithUniqueIds
+  , genPointTestBlock
+  , genRoundNo
+  , genSeatIndex
+  , genWithArrivalTime
+  , mockSystemTime
+  )
 import Test.Util.TestBlock
 
 tests :: TestTree
@@ -60,32 +58,20 @@ tests =
     [ testProperty "PerasVoteDiffusion smoke test" prop_smoke
     ]
 
-genPerasSeatIndex :: Gen PerasSeatIndex
-genPerasSeatIndex = PerasSeatIndex <$> choose (0, 99)
-
-genPerasVoteWeight :: Gen VoteWeight
-genPerasVoteWeight = do
-  weight <- (1 %) <$> choose (2, 10)
-  pure (VoteWeight weight)
-
-genPerasVote :: Gen (PerasVote TestBlock)
-genPerasVote = do
-  pvVoteRound <- PerasRoundNo <$> arbitrary
-  pvVoteBlock <- genPointTestBlock
-  pvVoteVoterId <- genPerasSeatIndex
-  pure $ PerasVote{pvVoteRound, pvVoteBlock, pvVoteVoterId}
-
-instance WithId (PerasVote' blk) PerasVoteId where
-  getId = getPerasVoteId
-
-instance WithId (WithArrivalTime (ValidatedPerasVote blk)) PerasVoteId where
-  getId = getPerasVoteId . vpvVote . forgetArrivalTime
-
 genValidatedPerasVote :: Gen (ValidatedPerasVote TestBlock)
 genValidatedPerasVote =
   ValidatedPerasVote
     <$> genPerasVote
-    <*> genPerasVoteWeight
+    <*> genVoteWeight
+ where
+  genPerasVote =
+    PerasVote
+      <$> genRoundNo
+      <*> genPointTestBlock
+      <*> genSeatIndex
+  genVoteWeight =
+    VoteWeight . (1 %)
+      <$> choose (1, 100)
 
 newVoteDB ::
   (IOLike m, StandardHash blk, Typeable blk) =>
@@ -106,7 +92,7 @@ newVoteDB votes = do
 prop_smoke :: Property
 prop_smoke =
   forAll genProtocolConstants $ \protocolConstants ->
-    forAll (genListWithUniqueIds (genWithArrivalTime genValidatedPerasVote)) $
+    forAll (genListWithUniqueIds getPerasVoteRound (genWithArrivalTime genValidatedPerasVote)) $
       \(ListWithUniqueIds watValidatedVotes) ->
         let
           mkPoolInterfaces ::

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/MiniProtocol/ObjectDiffusion/Smoke.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/MiniProtocol/ObjectDiffusion/Smoke.hs
@@ -1,46 +1,27 @@
-{-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE TypeApplications #-}
 
 -- | Smoke tests for the object diffusion protocol. This uses a trivial object
 -- pool and checks that a few objects can indeed be transferred from the
 -- outbound to the inbound peer.
 module Test.Consensus.MiniProtocol.ObjectDiffusion.Smoke
   ( tests
-  , WithId (..)
-  , ListWithUniqueIds (..)
-  , ProtocolConstants
-  , mockSystemTime
   , prop_smoke_object_diffusion
-  , genSmokeObjectId
-  , genSmokeObject
-  , genListWithUniqueIds
+  , ProtocolConstants
   , genProtocolConstants
-  , genRelativeTime
-  , genWithArrivalTime
-  , genPointTestBlock
   ) where
 
 import Cardano.Network.NodeToNode.Version (NodeToNodeVersion (..))
 import Control.Monad.IOSim (runSimStrictShutdown)
 import Control.ResourceRegistry (forkLinkedThread, waitAnyThread, withRegistry)
 import Control.Tracer (Tracer, nullTracer, traceWith)
-import Data.Containers.ListUtils (nubOrdOn)
 import Data.Data (Typeable)
 import Data.Functor.Contravariant (contramap)
-import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as Map
-import Data.Word (Word64)
 import Network.TypedProtocol.Channel (Channel, createConnectedChannels)
 import Network.TypedProtocol.Codec (AnyMessage)
 import Network.TypedProtocol.Driver.Simple (runPeer, runPipelinedPeer)
 import NoThunks.Class (NoThunks)
-import Ouroboros.Consensus.BlockchainTime.WallClock.Types
-  ( RelativeTime (..)
-  , SystemTime (..)
-  , WithArrivalTime (..)
-  )
 import Ouroboros.Consensus.MiniProtocol.ObjectDiffusion.Inbound
   ( objectDiffusionInbound
   )
@@ -59,9 +40,7 @@ import Ouroboros.Consensus.Util.IOLike
   , uncheckedNewTVarM
   , writeTVar
   )
-import Ouroboros.Network.Block (Point (..), SlotNo (SlotNo))
 import Ouroboros.Network.ControlMessage (ControlMessage (..))
-import Ouroboros.Network.Point (Block (Block), WithOrigin (..))
 import Ouroboros.Network.Protocol.ObjectDiffusion.Codec (codecObjectDiffusionId)
 import Ouroboros.Network.Protocol.ObjectDiffusion.Inbound
   ( ObjectDiffusionInboundPipelined
@@ -82,7 +61,7 @@ import Test.Tasty
 import Test.Tasty.QuickCheck
 import Test.Util.Orphans.Arbitrary ()
 import Test.Util.Orphans.IOLike ()
-import Test.Util.TestBlock
+import Test.Util.Peras (ListWithUniqueIds (..), genListWithUniqueIds)
 
 tests :: TestTree
 tests =
@@ -92,22 +71,6 @@ tests =
         "ObjectDiffusion smoke test with mock objects"
         prop_smoke
     ]
-
-{-------------------------------------------------------------------------------
-  Provides a way to generate lists composed of objects with no duplicate ids,
-  with an Arbitrary instance
--------------------------------------------------------------------------------}
-
-class WithId a idTy | a -> idTy where
-  getId :: a -> idTy
-
-newtype ListWithUniqueIds a idTy = ListWithUniqueIds [a]
-  deriving (Eq, Show, Ord)
-
-genListWithUniqueIds :: (Ord idTy, WithId a idTy) => Gen a -> Gen (ListWithUniqueIds a idTy)
-genListWithUniqueIds genObject = ListWithUniqueIds . nubOrdOn getId <$> listOf genObject
-
-instance WithId SmokeObject SmokeObjectId where getId = getSmokeObjectId
 
 {-------------------------------------------------------------------------------
   Mock objectPools
@@ -178,10 +141,8 @@ mkMockPoolInterfaces objects = do
   return (outboundPoolReader, inboundPoolWriter, atomically $ readTVar tvar)
 
 {-------------------------------------------------------------------------------
-  Main properties
+  Protocol constants
 -------------------------------------------------------------------------------}
-
--- Protocol constants
 
 newtype ProtocolConstants
   = ProtocolConstants (NumObjectsUnacknowledged, NumObjectIdsReq, NumObjectsReq)
@@ -203,51 +164,20 @@ nodeToNodeVersion :: NodeToNodeVersion
 nodeToNodeVersion = NodeToNodeV_14
 
 {-------------------------------------------------------------------------------
-  Shared generators for Peras smoke tests
+  Main properties
 -------------------------------------------------------------------------------}
-
-genRelativeTime :: Gen RelativeTime
-genRelativeTime = RelativeTime . fromIntegral <$> arbitrary @Word64
-
-genWithArrivalTime :: Gen a -> Gen (WithArrivalTime a)
-genWithArrivalTime genA = WithArrivalTime <$> genRelativeTime <*> genA
-
-genPointTestBlock :: Gen (Point TestBlock)
-genPointTestBlock =
-  -- Sometimes pick the genesis point
-  frequency
-    [ (1, pure $ Point Origin)
-    ,
-      ( 50
-      , do
-          slotNo <- SlotNo <$> arbitrary
-          hash <- TestHash . NE.fromList . getNonEmpty <$> arbitrary
-          pure $ Point (At (Block slotNo hash))
-      )
-    ]
-
--- | A static 'SystemTime' returning a constant time. The canonical mock
--- system time lives in 'Test.Util.LogicalClock.mockSystemTime', but it
--- is a field of 'LogicalClock' which requires a 'ResourceRegistry' and
--- a background tick thread — too heavyweight for simple property tests
--- that don't need time progression.
-mockSystemTime :: Applicative m => SystemTime m
-mockSystemTime =
-  SystemTime
-    { systemTimeCurrent = pure (RelativeTime 0)
-    , systemTimeWait = pure ()
-    }
 
 prop_smoke :: Property
 prop_smoke =
   forAll genProtocolConstants $ \protocolConstants ->
-    forAll (genListWithUniqueIds genSmokeObject) $ \(ListWithUniqueIds objects) ->
-      prop_smoke_object_diffusion
-        protocolConstants
-        objects
-        runOutboundPeer
-        runInboundPeer
-        (mkMockPoolInterfaces objects)
+    forAll (genListWithUniqueIds getSmokeObjectId genSmokeObject) $
+      \(ListWithUniqueIds objects) ->
+        prop_smoke_object_diffusion
+          protocolConstants
+          objects
+          runOutboundPeer
+          runInboundPeer
+          (mkMockPoolInterfaces objects)
  where
   runOutboundPeer outbound outboundChannel tracer =
     runPeer

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/Peras/Serialisation.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/Peras/Serialisation.hs
@@ -11,13 +11,6 @@ import Cardano.Binary (FromCBOR (..), ToCBOR (..), decodeFull, serialize)
 import qualified Data.ByteString.Lazy as LazyByteString
 import qualified Ouroboros.Consensus.Peras.Cert.V1 as V1
 import qualified Ouroboros.Consensus.Peras.Vote.V1 as V1
-import Test.Consensus.Peras.Util
-  ( genPerasCert
-  , genPerasVote
-  , mkBucket
-  , tabulatePerasCert
-  , tabulatePerasVote
-  )
 import Test.QuickCheck
   ( Gen
   , Property
@@ -28,6 +21,13 @@ import Test.QuickCheck
   )
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.QuickCheck (testProperty)
+import Test.Util.Peras
+  ( genPerasCert
+  , genPerasVote
+  , mkBucket
+  , tabulatePerasCert
+  , tabulatePerasVote
+  )
 import Test.Util.TestEnv (adjustQuickCheckTests)
 
 tests :: TestTree

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/Peras/Voting/Adapter.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/Peras/Voting/Adapter.hs
@@ -15,14 +15,6 @@ import Ouroboros.Consensus.Peras.Voting.Adapter
   ( PerasCertCompatibleWithVotingCommittee (..)
   , PerasVoteCompatibleWithVotingCommittee (..)
   )
-import Test.Consensus.Peras.Util
-  ( genPerasCert
-  , genPerasVote
-  , perasCertContainsOnlyPersistentVotes
-  , perasVoteIsPersistent
-  , tabulatePerasCert
-  , tabulatePerasVote
-  )
 import Test.QuickCheck
   ( Gen
   , Property
@@ -35,6 +27,14 @@ import Test.QuickCheck
   )
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.QuickCheck (testProperty)
+import Test.Util.Peras
+  ( genPerasCert
+  , genPerasVote
+  , perasCertContainsOnlyPersistentVotes
+  , perasVoteIsPersistent
+  , tabulatePerasCert
+  , tabulatePerasVote
+  )
 import Test.Util.TestEnv (adjustQuickCheckTests)
 
 tests :: TestTree


### PR DESCRIPTION
This PR moves the shared Peras generators, mocks, predicates, and tabulation helpers from the consensus test suite into exposed unstable-consensus-testlib modules. In addition, it provides a couple of extra helpers that will be needed used soon.

Moreover, it refactors the smoke, serialization, and voting-adapter tests to use the new utilities.