### PR TITLE
[Peras 54] Refine Peras voting view and decisions

### DIFF
--- a/changelog.d/20260811_125240_agustin.mista_tweak_voting_rules_cont.md
+++ b/changelog.d/20260811_125240_agustin.mista_tweak_voting_rules_cont.md
@@ -1,0 +1,21 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+### Breaking
+
+- Refine the Peras voting API to track the candidate block.
+
+### Non-Breaking
+
+- Add `PerasVotingViewHandle` wrapper to compute Peras voting views over STM.
+
+<!--
+### Patch
+
+- A bullet item for the Patch category.
+
+-->

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Peras/Voting/Rules.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Peras/Voting/Rules.hs
@@ -1,4 +1,7 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
@@ -16,6 +19,7 @@
 -- do not denote ignored variables.
 module Ouroboros.Consensus.Peras.Voting.Rules
   ( isPerasVotingAllowed
+  , isPerasVotingAllowedWithHandle
   , PerasVotingRule (..)
   , PerasVotingRulesDecision (..)
   , perasVR1A
@@ -28,27 +32,31 @@ module Ouroboros.Consensus.Peras.Voting.Rules
   )
 where
 
+import GHC.Generics (Generic)
+import NoThunks.Class (NoThunks)
 import Ouroboros.Consensus.Block (WithOrigin (..))
 import Ouroboros.Consensus.Block.Abstract
-  ( SlotNo (..)
+  ( Point
+  , SlotNo (..)
+  , StandardHash
   )
 import Ouroboros.Consensus.Block.SupportsPeras
-  ( IsPerasCert
-  , PerasRoundNo (..)
-  , getPerasCertRound
-  , onPerasRoundNo
-  )
-import Ouroboros.Consensus.Peras.Params
-  ( PerasCertArrivalThreshold (..)
+  ( IsPerasCert (..)
+  , PerasCertArrivalThreshold (..)
   , PerasCooldownRounds (..)
   , PerasIgnoranceRounds (..)
   , PerasParams (..)
+  , PerasRoundNo (..)
+  , ValidatedPerasCert
+  , onPerasRoundNo
   )
+import Ouroboros.Consensus.BlockchainTime.WallClock.Types (WithArrivalTime)
 import Ouroboros.Consensus.Peras.Voting.View
-  ( LatestCertOnChainView (..)
-  , LatestCertSeenView (..)
+  ( LatestCertSeenView (..)
   , PerasVotingView (..)
+  , PerasVotingViewHandle (..)
   )
+import Ouroboros.Consensus.Util.IOLike (MonadSTM (..))
 import Ouroboros.Consensus.Util.Pred
   ( Evidence (..)
   , Explainable (..)
@@ -64,26 +72,36 @@ import Ouroboros.Consensus.Util.Pred
 -- | Whether we are allowed to vote according to the rules.
 --
 -- This type additionally carries the evidence for the decision taken.
-data PerasVotingRulesDecision
-  = Vote (Evidence True PerasVotingRule)
+data PerasVotingRulesDecision blk
+  = Vote (Evidence True PerasVotingRule) (Point blk)
   | NoVote (Evidence False PerasVotingRule)
-  deriving Show
+  deriving (Show, Eq, Generic, NoThunks)
 
-instance Explainable PerasVotingRulesDecision where
+instance StandardHash blk => Explainable (PerasVotingRulesDecision blk) where
   explain mode = \case
-    Vote (ETrue e) -> "Vote(" <> explain mode e <> ")"
-    NoVote (EFalse e) -> "NoVote(" <> explain mode e <> ")"
+    Vote (ETrue e) candidate ->
+      "Vote(" <> show candidate <> "," <> explain mode e <> ")"
+    NoVote (EFalse e) ->
+      "NoVote(" <> explain mode e <> ")"
 
 -- | Evaluate whether voting is allowed or not according to the voting rules
 isPerasVotingAllowed ::
   IsPerasCert cert blk =>
   PerasVotingView cert blk ->
-  PerasVotingRulesDecision
+  PerasVotingRulesDecision blk
 isPerasVotingAllowed pvv =
   evalPred (perasVotingRules pvv) $ \e ->
     case e of
-      ETrue{} -> Vote e
+      ETrue{} -> Vote e (candidateBlock pvv)
       EFalse{} -> NoVote e
+
+isPerasVotingAllowedWithHandle ::
+  (IsPerasCert (WithArrivalTime (ValidatedPerasCert blk)) blk, MonadSTM m) =>
+  PerasVotingViewHandle m blk ->
+  PerasRoundNo ->
+  STM m (PerasVotingRulesDecision blk)
+isPerasVotingAllowedWithHandle (PerasVotingViewHandle getPerasVotingView) =
+  fmap isPerasVotingAllowed . getPerasVotingView
 
 -- | Voting rules
 --
@@ -223,26 +241,25 @@ perasVR2A
 -- This enforces chain quality and common prefix before leaving a cooldown
 -- period.
 perasVR2B ::
-  IsPerasCert cert blk =>
   PerasVotingView cert blk ->
   Pred PerasVotingRule
 perasVR2B
   PerasVotingView
     { perasParams
     , currRoundNo
-    , latestCertOnChain
+    , latestCertOnChainRound
     } =
     VR2B c := vr2b
    where
     vr2b =
-      case latestCertOnChain of
+      case latestCertOnChainRound of
         -- There is a certificate on chain ==> we must check its round number
-        NotOrigin cert ->
+        NotOrigin certRoundNo ->
           -- The certificate comes from a round older than the current one
-          (currRoundNo :>: getPerasCertRound (lcocCert cert))
+          (currRoundNo :>: certRoundNo)
             -- The certificate round is c⋅K rounds away from the current one
             :/\: ( (currRoundNo `rmod` _K)
-                     :==: (getPerasCertRound (lcocCert cert) `rmod` _K)
+                     :==: (certRoundNo `rmod` _K)
                  )
         -- There is no certificate on chain ==> check if we are recovering
         -- from an initial cooldown after having initially failed to

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Peras/Voting/View.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Peras/Voting/View.hs
@@ -25,9 +25,10 @@ module Ouroboros.Consensus.Peras.Voting.View
   , perasRoundStart
   , perasChainAtCandidateBlock
   , LatestCertSeenView (..)
-  , LatestCertOnChainView (..)
   , PerasVotingView (..)
+  , WithBoostedBlockStatus (..)
   , mkPerasVotingView
+  , PerasVotingViewHandle (..)
   )
 where
 
@@ -38,6 +39,7 @@ import Control.Monad.Reader (MonadReader (..), Reader, runReader)
 import Ouroboros.Consensus.Block.Abstract
   ( GetHeader (..)
   , Header
+  , Point
   , SlotNo (..)
   , castPoint
   )
@@ -46,7 +48,6 @@ import Ouroboros.Consensus.Block.SupportsPeras
   , IsPerasCert (..)
   , PerasRoundNo (..)
   , ValidatedPerasCert
-  , getPerasCertRound
   )
 import Ouroboros.Consensus.BlockchainTime.WallClock.Types
   ( WithArrivalTime (..)
@@ -65,6 +66,7 @@ import Ouroboros.Consensus.Storage.PerasCertDB.API
   ( WithBoostedBlockStatus (..)
   , forgetBoostedBlockStatus
   )
+import Ouroboros.Consensus.Util.IOLike (MonadSTM (..))
 import Ouroboros.Network.AnchoredFragment (AnchoredFragment)
 import qualified Ouroboros.Network.AnchoredFragment as AF
 
@@ -155,7 +157,7 @@ perasChainAtCandidateBlock blockMinSlots currRoundNo currChain = do
   Voting interface
 -------------------------------------------------------------------------------}
 
--- | View of the latest certificate seen by the voter
+-- | View of the latest certificate seen by the voter.
 --
 -- NOTE: the voting rules depend on the candidate block indirectly. This is
 -- reflected in the fact that the voting view does not contain the candidate
@@ -175,24 +177,12 @@ data LatestCertSeenView cert
   }
   deriving Show
 
--- | View of the latest certificate present in our preferred chain
---
--- NOTE: if we add more fields here in the future, do not forget to add
--- strictness annotations as needed.
-newtype LatestCertOnChainView cert
-  = LatestCertOnChainView
-  { lcocCert :: cert
-  -- ^ Latest certificate present in our preferred chain
-  }
-  deriving Show
-
 -- | Interface needed to evaluate the Peras voting rules
 --
--- NOTE: the voting rules depend on the candidate block indirectly. This is
--- reflected in the fact that the voting view does not contain the candidate
--- block or its point, but only whether the candidate block extends the block
--- boosted by the most recent certificate seen by the voter, which is provided
--- to the rules via 'lcsCandidateBlockExtendsCert' inside 'latestCertSeen'.
+-- NOTE: the voting rules depend on the candidate block only indirectly. The
+-- only reason to include the point of the block being voted for
+-- ('candidateBlock') here is to be able to return it as part of the result of
+-- 'isPerasVotingAllowed' in the positive case.
 data PerasVotingView cert blk = PerasVotingView
   { perasParams :: !(PerasParams blk)
   -- ^ Peras protocol parameters
@@ -200,8 +190,14 @@ data PerasVotingView cert blk = PerasVotingView
   -- ^ The current Peras round number
   , latestCertSeen :: !(WithOrigin (LatestCertSeenView cert))
   -- ^ The most recent certificate seen by the voter
-  , latestCertOnChain :: !(WithOrigin (LatestCertOnChainView cert))
-  -- ^ The most recent certificate present in our preferred chain
+  , latestCertOnChainRound :: !(WithOrigin PerasRoundNo)
+  -- ^ 'PerasRoundNo' of the latest certificate present in our preferred chain
+  -- (we don't actually need the whole certificate here).
+  , candidateBlock :: Point blk
+  -- ^ The candidate block being voted for.
+  --
+  -- NOTE: this is the tip of the 'chainAtCandidateBlock' used to initialize
+  -- the voting view.
   }
   deriving Show
 
@@ -220,8 +216,9 @@ mkPerasVotingView ::
   PerasRoundNo ->
   -- | Most recent certificate seen by the voter
   WithOrigin (WithBoostedBlockStatus cert) ->
-  -- | Most recent certificate included in some block in our preferred chain
-  WithOrigin cert ->
+  -- | 'PerasRoundNo' of the most recent certificate included in some block in
+  -- our preferred chain
+  WithOrigin PerasRoundNo ->
   -- | Prefix leading to the candidate block in the volatile suffix of our
   -- preferred chain
   AnchoredFragment (Header blk) ->
@@ -231,16 +228,16 @@ mkPerasVotingView
   perasParams
   currRoundNo
   latestCertSeen
-  latestCertOnChain
+  latestCertOnChainRound
   chainAtCandidateBlock = do
     latestCertSeenView <- traverse mkLatestCertSeenView latestCertSeen
-    latestCertOnChainView <- traverse mkLatestCertOnChainView latestCertOnChain
     pure $
       PerasVotingView
         { perasParams = perasParams
         , currRoundNo = currRoundNo
         , latestCertSeen = latestCertSeenView
-        , latestCertOnChain = latestCertOnChainView
+        , latestCertOnChainRound = latestCertOnChainRound
+        , candidateBlock = candidateBlock
         }
    where
     mkLatestCertSeenView certWithProvenance = do
@@ -254,12 +251,6 @@ mkPerasVotingView
           , lcsArrivalSlot
           , lcsRoundStartSlot
           , lcsCandidateBlockExtendsCert
-          }
-
-    mkLatestCertOnChainView lcocCert =
-      pure $
-        LatestCertOnChainView
-          { lcocCert
           }
 
     -- Does the candidate block extend the one boosted by a certificate?
@@ -285,3 +276,16 @@ mkPerasVotingView
       AF.withinFragmentBounds
         (castPoint (getPerasCertPoint cert))
         chainAtCandidateBlock
+
+    candidateBlock =
+      AF.anchorToPoint
+        . AF.castAnchor
+        . AF.headAnchor
+        $ chainAtCandidateBlock
+
+-- | Handle for querying the Peras voting view via STM.
+newtype PerasVotingViewHandle m blk
+  = PerasVotingViewHandle
+      ( PerasRoundNo ->
+        STM m (PerasVotingView (WithArrivalTime (ValidatedPerasCert blk)) blk)
+      )

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Util/Pred.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Util/Pred.hs
@@ -29,6 +29,7 @@ where
 
 import Data.Bifunctor (bimap)
 import Data.Typeable (Typeable, cast)
+import NoThunks.Class (NoThunks, OnlyCheckWhnfNamed (..))
 
 {-------------------------------------------------------------------------------
   Self-explaining boolean predicates
@@ -98,6 +99,11 @@ data Evidence (res :: Bool) a where
 
 deriving instance Show a => Show (Evidence res a)
 deriving instance Eq a => Eq (Evidence res a)
+
+deriving via
+  OnlyCheckWhnfNamed "Evidence" (Evidence res a)
+  instance
+    NoThunks (Evidence res a)
 
 -- | Forget the evidence payload, yielding just its corresponding boolean value
 forgetEvidence :: Evidence res a -> Bool

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/Peras/Voting/Rules.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/Peras/Voting/Rules.hs
@@ -15,6 +15,7 @@
 -- do not denote ignored variables.
 module Test.Consensus.Peras.Voting.Rules (tests) where
 
+import Data.Maybe (isJust)
 import GHC.Generics (Generic)
 import Ouroboros.Consensus.Block.Abstract
   ( Point (..)
@@ -24,27 +25,24 @@ import Ouroboros.Consensus.Block.Abstract
 import Ouroboros.Consensus.Block.SupportsPeras
   ( BoostedBlock
   , IsPerasCert (..)
-  , PerasRoundNo (..)
-  , onPerasRoundNo
-  )
-import Ouroboros.Consensus.BlockchainTime
-  ( RelativeTime (..)
-  )
-import Ouroboros.Consensus.Peras.Params
-  ( PerasBlockMinSlots (..)
+  , PerasBlockMinSlots (..)
   , PerasCertArrivalThreshold (..)
   , PerasCooldownRounds (..)
   , PerasIgnoranceRounds (..)
   , PerasParams (..)
+  , PerasRoundNo (..)
   , defaultPerasParams
+  , onPerasRoundNo
+  )
+import Ouroboros.Consensus.BlockchainTime
+  ( RelativeTime (..)
   )
 import Ouroboros.Consensus.Peras.Voting.Rules
   ( PerasVotingRulesDecision (..)
   , isPerasVotingAllowed
   )
 import Ouroboros.Consensus.Peras.Voting.View
-  ( LatestCertOnChainView (..)
-  , LatestCertSeenView (..)
+  ( LatestCertSeenView (..)
   , PerasVotingView (..)
   )
 import Ouroboros.Consensus.Util.Pred (Evidence (..), explainShallow)
@@ -62,6 +60,7 @@ import Test.Tasty.QuickCheck
   , testProperty
   )
 import Test.Util.Orphans.Arbitrary (genNominalDiffTime50Years)
+import Test.Util.Peras (genPointTestBlock)
 import Test.Util.QuickCheck (geometric)
 import Test.Util.TestBlock (TestBlock)
 import Test.Util.TestEnv (adjustQuickCheckTests)
@@ -84,7 +83,7 @@ tests =
 
 data PerasVotingRulesDecisionModel
   = PerasVotingDecisionModel
-  { shouldVote :: Bool
+  { shouldVote :: Maybe (Point TestBlock)
   , vr1a :: Bool
   , vr1b :: Bool
   , vr2a :: Bool
@@ -105,16 +104,21 @@ isPerasVotingAllowedModel
     { perasParams
     , currRoundNo
     , latestCertSeen
-    , latestCertOnChain
+    , latestCertOnChainRound
+    , candidateBlock
     } =
     PerasVotingDecisionModel
-      { shouldVote = vr1a && vr1b || vr2a && vr2b
-      , vr1a = vr1a
-      , vr1b = vr1b
-      , vr2a = vr2a
-      , vr2b = vr2b
+      { shouldVote
+      , vr1a
+      , vr1b
+      , vr2a
+      , vr2b
       }
    where
+    shouldVote
+      | (vr1a && vr1b) || (vr2a && vr2b) = Just candidateBlock
+      | otherwise = Nothing
+
     vr1a =
       vr1a1 && vr1a2
     vr1a1 =
@@ -142,11 +146,11 @@ isPerasVotingAllowedModel
         Origin ->
           _R <= currRoundNo
     vr2b =
-      case latestCertOnChain of
-        NotOrigin cert ->
-          (currRoundNo > getPerasCertRound (lcocCert cert))
+      case latestCertOnChainRound of
+        NotOrigin certRoundNo ->
+          (currRoundNo > certRoundNo)
             && ( (currRoundNo `rmod` _K)
-                   == (getPerasCertRound (lcocCert cert) `rmod` _K)
+                   == (certRoundNo `rmod` _K)
                )
         Origin ->
           currRoundNo `rmod` _K == _K - 1
@@ -185,7 +189,7 @@ prop_isPerasVotingAllowed = forAll genPerasVotingView $ \pvv -> do
           , tabulate "VR-2A" [show vr2a]
           , tabulate "VR-2B" [show vr2b]
           , tabulate "VR-(1A|1B|2A|2B)" [show (vr1a, vr1b, vr2a, vr2b)]
-          , tabulate "Should vote according to model" [show shouldVote]
+          , tabulate "Should vote according to model" [show (isJust shouldVote)]
           , tabulate "Actual result" [desc]
           ]
           $ property True
@@ -195,13 +199,21 @@ prop_isPerasVotingAllowed = forAll genPerasVotingView $ \pvv -> do
   -- Now check that the real implementation agrees with the model
   let votingDecision = isPerasVotingAllowed pvv
   case votingDecision of
-    Vote (ETrue voteReason)
-      | shouldVote ->
-          ok $ "Vote(" <> explainShallow voteReason <> ")"
+    Vote (ETrue voteReason) actualCandidate
+      | Just expectedCandidate <- shouldVote ->
+          if expectedCandidate == actualCandidate
+            then
+              ok $ "Vote(Point{..}," <> explainShallow voteReason <> ")"
+            else
+              failure $
+                "Expected to vote for "
+                  <> show expectedCandidate
+                  <> ", but got: "
+                  <> show actualCandidate
       | otherwise ->
           failure $ "Expected not to vote, but got: " <> show votingDecision
     NoVote (EFalse noVoteReason)
-      | not shouldVote ->
+      | Nothing <- shouldVote ->
           ok $ "NoVote(" <> explainShallow noVoteReason <> ")"
       | otherwise ->
           failure $ "Expected to vote, but got: " <> show votingDecision
@@ -290,8 +302,8 @@ genTestCert roundNo = do
 
 -- * Certificate and voting views
 
-genLatestCertSeen :: PerasRoundNo -> Gen (LatestCertSeenView TestCert)
-genLatestCertSeen roundNo = do
+genLatestCertSeenView :: PerasRoundNo -> Gen (LatestCertSeenView TestCert)
+genLatestCertSeenView roundNo = do
   cert <- genTestCert roundNo
   arrivalSlot <- genSlotNo
   roundStartSlot <- genSlotNo
@@ -304,26 +316,25 @@ genLatestCertSeen roundNo = do
       , lcsCandidateBlockExtendsCert = candidateBlockExtendsCert
       }
 
-genLatestCertOnChain :: PerasRoundNo -> Gen (LatestCertOnChainView TestCert)
-genLatestCertOnChain roundNo = do
+genLatestCertOnChainRound :: PerasRoundNo -> Gen PerasRoundNo
+genLatestCertOnChainRound roundNo = do
   cert <- genTestCert roundNo
-  pure $
-    LatestCertOnChainView
-      { lcocCert = cert
-      }
+  pure (getPerasCertRound cert)
 
 genPerasVotingView :: Gen (PerasVotingView TestCert TestBlock)
 genPerasVotingView = do
   perasParams <- genPerasParams
   currRoundNo <- genPerasRoundNo
-  latestCertSeen <- genWithOrigin (genLatestCertSeen currRoundNo)
-  latestCertOnChain <- genWithOrigin (genLatestCertOnChain currRoundNo)
+  latestCertSeen <- genWithOrigin (genLatestCertSeenView currRoundNo)
+  latestCertOnChainRound <- genWithOrigin (genLatestCertOnChainRound currRoundNo)
+  candidateBlock <- genPointTestBlock
   pure
     PerasVotingView
       { perasParams
       , currRoundNo
-      , latestCertSeen = latestCertSeen
-      , latestCertOnChain = latestCertOnChain
+      , latestCertSeen
+      , latestCertOnChainRound
+      , candidateBlock
       }
  where
   genWithOrigin gen =


### PR DESCRIPTION
In anticipation for the Peras voting thread implementation, this PR extends the Peras voting machinery to:

* Track the candidate block in successful voting decisions,
* Retain the latest on-chain certificate's round,
* Provide an STM-backed view handle, and
* Derive a couple of instances that will be needed for tracing later on.