### PR TITLE
[Peras 55] Refine Peras certificate inclusion view

### DIFF
--- a/changelog.d/20260811_131418_agustin.mista_tweak_cert_inclusion_rules.md
+++ b/changelog.d/20260811_131418_agustin.mista_tweak_cert_inclusion_rules.md
@@ -1,0 +1,21 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+### Breaking
+
+- Refine the Peras certificate inclusion API to require the latest seen certificate when constructing an inclusion view.
+
+### Non-Breaking
+
+- Add `PerasCertInclusionViewHandle` wrapper to compute Peras certificate inclusion views over STM.
+
+<!--
+### Patch
+
+- A bullet item for the Patch category.
+
+-->

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Peras/Cert/Inclusion.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Peras/Cert/Inclusion.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
@@ -17,23 +19,30 @@ module Ouroboros.Consensus.Peras.Cert.Inclusion
   , LatestCertOnChainView (..)
   , PerasCertInclusionView (..)
   , mkPerasCertInclusionView
+  , PerasCertInclusionViewHandle (..)
   , PerasCertInclusionRule (..)
   , PerasCertInclusionRulesDecision (..)
   , needCert
+  , needCertWithHandle
   , noCertsFromTwoRoundsAgo
   , needCertRules
   ) where
 
 import Data.Set (Set)
 import qualified Data.Set as Set
-import Ouroboros.Consensus.Block (WithOrigin (..), withOriginToMaybe)
-import Ouroboros.Consensus.Block.SupportsPeras
+import GHC.Generics (Generic)
+import NoThunks.Class (NoThunks)
+import Ouroboros.Consensus.Block
   ( IsPerasCert (..)
-  , PerasParams
+  , PerasCertMaxRounds (..)
+  , PerasParams (..)
   , PerasRoundNo (..)
+  , ValidatedPerasCert
+  , WithOrigin (..)
   )
-import Ouroboros.Consensus.Peras.Params (PerasCertMaxRounds (..), PerasParams (..))
+import Ouroboros.Consensus.BlockchainTime.WallClock.Types (WithArrivalTime)
 import Ouroboros.Consensus.Util.Condense (Condense (..))
+import Ouroboros.Consensus.Util.IOLike (MonadSTM (..))
 import Ouroboros.Consensus.Util.Pred
   ( Evidence (..)
   , Explainable (..)
@@ -81,10 +90,6 @@ data PerasCertInclusionView cert blk = PerasCertInclusionView
 
 -- | Construct a 'PerasCertInclusionView' from the given inputs.
 --
--- Returns 'Nothing' if we are trying to construct the view without having a
--- latest certificate seen, which is a precondition to being able to include it
--- in the block we are building.
---
 -- NOTE: this assumes that the client code computes all the needed inputs
 -- within the same STM transaction, or the results may be inconsistent.
 mkPerasCertInclusionView ::
@@ -95,41 +100,53 @@ mkPerasCertInclusionView ::
   -- | Current Peras round number
   PerasRoundNo ->
   -- | Most recent certificate seen by the voter
-  WithOrigin cert ->
+  cert ->
   -- | Round number of the latest certificate present in our preferred chain
   WithOrigin PerasRoundNo ->
   -- | Set of certificates (by their round number) present in our database
   Set PerasRoundNo ->
   -- | Constructed certificate inclusion view
-  Maybe (PerasCertInclusionView cert blk)
+  PerasCertInclusionView cert blk
 mkPerasCertInclusionView
   perasParams
   currRoundNo
   latestCertSeen
   latestCertOnChain
   certIds = do
-    latestCertSeenView <- withOriginToMaybe (mkLatestCertSeenView latestCertSeen)
-    latestCertOnChainView <- traverse mkLatestCertOnChainView latestCertOnChain
-    pure $
-      PerasCertInclusionView
-        { perasParams = perasParams
-        , currRoundNo = currRoundNo
-        , latestCertSeen = latestCertSeenView
-        , latestCertOnChain = latestCertOnChainView
-        , certIds = certIds
-        }
+    PerasCertInclusionView
+      { perasParams = perasParams
+      , currRoundNo = currRoundNo
+      , latestCertSeen = mkLatestCertSeenView latestCertSeen
+      , latestCertOnChain = mkLatestCertOnChainView <$> latestCertOnChain
+      , certIds = certIds
+      }
    where
-    mkLatestCertSeenView = fmap $ \cert ->
+    mkLatestCertSeenView cert =
       LatestCertSeenView
         { lcsCert = cert
         , lcsCertRound = getPerasCertRound cert
         }
 
     mkLatestCertOnChainView roundNo =
-      Just $
-        LatestCertOnChainView
-          { lcocRoundNo = roundNo
-          }
+      LatestCertOnChainView
+        { lcocRoundNo = roundNo
+        }
+
+-- | Handle for querying the Peras certificate inclusion rules via STM.
+newtype PerasCertInclusionViewHandle m blk
+  = PerasCertInclusionViewHandle
+      ( PerasRoundNo ->
+        STM m (Maybe (PerasCertInclusionView (WithArrivalTime (ValidatedPerasCert blk)) blk))
+      )
+
+-- | Query the Peras certificate inclusion rules via STM.
+needCertWithHandle ::
+  MonadSTM m =>
+  PerasCertInclusionViewHandle m blk ->
+  PerasRoundNo ->
+  STM m (Maybe (PerasCertInclusionRulesDecision (WithArrivalTime (ValidatedPerasCert blk))))
+needCertWithHandle (PerasCertInclusionViewHandle getPerasCertInclusionView) =
+  fmap (fmap needCert) . getPerasCertInclusionView
 
 {-------------------------------------------------------------------------------
   Certificate inclusion rules
@@ -145,7 +162,7 @@ mkPerasCertInclusionView
 data PerasCertInclusionRulesDecision cert
   = IncludeCert (Evidence True PerasCertInclusionRule) cert
   | DoNotIncludeCert (Evidence False PerasCertInclusionRule)
-  deriving Show
+  deriving (Show, Eq, Generic, NoThunks)
 
 instance
   IsPerasCert cert blk =>

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/Peras/Cert/Inclusion.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/Peras/Cert/Inclusion.hs
@@ -24,7 +24,10 @@ import Ouroboros.Consensus.Block (Point (..), WithOrigin (..))
 import Ouroboros.Consensus.Block.SupportsPeras
   ( BoostedBlock
   , IsPerasCert (..)
+  , PerasCertMaxRounds (..)
+  , PerasParams (..)
   , PerasRoundNo (..)
+  , defaultPerasParams
   )
 import Ouroboros.Consensus.Peras.Cert.Inclusion
   ( LatestCertOnChainView (..)
@@ -32,11 +35,6 @@ import Ouroboros.Consensus.Peras.Cert.Inclusion
   , PerasCertInclusionRulesDecision (..)
   , PerasCertInclusionView (..)
   , needCert
-  )
-import Ouroboros.Consensus.Peras.Params
-  ( PerasCertMaxRounds (..)
-  , PerasParams (..)
-  , defaultPerasParams
   )
 import Ouroboros.Consensus.Util.Pred (Evidence (..))
 import Test.Tasty (TestTree, testGroup)
@@ -87,7 +85,7 @@ data PerasCertInclusionRulesDecisionModel
 --
 -- NOTE: this predicate could be lifted directly from the agda specification.
 needCertModel ::
-  PerasCertInclusionView TestCert TestBlk ->
+  PerasCertInclusionView TestCert TestBlock ->
   PerasCertInclusionRulesDecisionModel
 needCertModel
   PerasCertInclusionView
@@ -265,13 +263,6 @@ genTestCert roundNo = do
       { tcRoundNo = roundNo'
       }
 
--- * Mocked block type
-
--- | A mocked block type for testing
-data TestBlk
-  = TestBlk
-  deriving (Show, Eq, Generic)
-
 -- * Certificate and inclusion views
 
 genLatestCertSeen :: PerasRoundNo -> Gen (LatestCertSeenView TestCert)
@@ -301,7 +292,7 @@ genPerasCertIds currRoundNo = do
       then Set.singleton (currRoundNo - 2)
       else Set.empty
 
-genPerasCertInclusionView :: Gen (PerasCertInclusionView TestCert TestBlk)
+genPerasCertInclusionView :: Gen (PerasCertInclusionView TestCert TestBlock)
 genPerasCertInclusionView = do
   perasParams <- genPerasParams
   currRoundNo <- genPerasRoundNo


### PR DESCRIPTION
In anticipation for the Peras voting thread implementation, this PR tweaks the Peras certificate inclusion logic to:

* Unconditionally require the latest seen certificate seen when constructing inclusion views,
* Add an STM-backed view handle with a query helper, and
* Support a couple of instances needed later for tracing.
