### PR TITLE
[Peras 56] Add Peras vote forging and certificate inclusion tracers

### DIFF
--- a/changelog.d/20260811_170336_agustin.mista_add_voting_cert_inclusion_tracers.md
+++ b/changelog.d/20260811_170336_agustin.mista_add_voting_cert_inclusion_tracers.md
@@ -1,0 +1,24 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+<!--
+### Breaking
+
+- A bullet item for the Breaking category.
+
+-->
+### Non-Breaking
+
+- Add tracer for Peras vote forging events `TracePerasVoteForgingEvent`.
+- Add tracer for Peras certificate inclusion events `TracePerasCertInclusionEvent`.
+
+<!--
+### Patch
+
+- A bullet item for the Patch category.
+
+-->

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Node/Tracers.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Node/Tracers.hs
@@ -15,6 +15,7 @@ module Ouroboros.Consensus.Node.Tracers
     -- * Specific tracers
   , TraceForgeEvent (..)
   , TraceLabelCreds (..)
+  , TracePerasCertInclusionEvent (..)
   ) where
 
 import Control.Exception (SomeException)
@@ -46,6 +47,10 @@ import Ouroboros.Consensus.MiniProtocol.LocalTxSubmission.Server
 import Ouroboros.Consensus.MiniProtocol.ObjectDiffusion.PerasCert
 import Ouroboros.Consensus.MiniProtocol.ObjectDiffusion.PerasVote
 import Ouroboros.Consensus.Node.GSM (TraceGsmEvent)
+import Ouroboros.Consensus.Peras.Cert.Inclusion.Trace
+  ( TracePerasCertInclusionEvent (..)
+  )
+import Ouroboros.Consensus.Peras.Voting.Trace (TracePerasVoteForgingEvent)
 import Ouroboros.Consensus.Protocol.Praos.AgentClient
   ( KESAgentClientTrace (..)
   )
@@ -89,6 +94,9 @@ data Tracers' remotePeer localPeer blk f = Tracers
       f (TraceLabelPeer remotePeer (TracePerasVoteDiffusionInbound blk))
   , perasVoteDiffusionOutboundTracer ::
       f (TraceLabelPeer remotePeer (TracePerasVoteDiffusionOutbound blk))
+  , perasCertInclusionTracer ::
+      f (TracePerasCertInclusionEvent blk)
+  , perasVoteForgingTracer :: f (TracePerasVoteForgingEvent blk)
   , forgeTracer :: f (TraceLabelCreds (TraceForgeEvent blk))
   , blockchainTimeTracer :: f (TraceBlockchainTimeEvent UTCTime)
   , forgeStateInfoTracer :: f (TraceLabelCreds (ForgeStateInfo blk))
@@ -125,6 +133,8 @@ instance
       , perasCertDiffusionOutboundTracer = f perasCertDiffusionOutboundTracer
       , perasVoteDiffusionInboundTracer = f perasVoteDiffusionInboundTracer
       , perasVoteDiffusionOutboundTracer = f perasVoteDiffusionOutboundTracer
+      , perasCertInclusionTracer = f perasCertInclusionTracer
+      , perasVoteForgingTracer = f perasVoteForgingTracer
       , forgeTracer = f forgeTracer
       , blockchainTimeTracer = f blockchainTimeTracer
       , forgeStateInfoTracer = f forgeStateInfoTracer
@@ -165,7 +175,9 @@ nullTracers =
     , perasCertDiffusionInboundTracer = nullTracer
     , perasCertDiffusionOutboundTracer = nullTracer
     , perasVoteDiffusionInboundTracer = nullTracer
+    , perasVoteForgingTracer = nullTracer
     , perasVoteDiffusionOutboundTracer = nullTracer
+    , perasCertInclusionTracer = nullTracer
     , forgeTracer = nullTracer
     , blockchainTimeTracer = nullTracer
     , forgeStateInfoTracer = nullTracer
@@ -194,6 +206,8 @@ showTracers ::
   , Show (CannotForge blk)
   , Show (TxMeasurePhase1 blk)
   , Show (TxMeasurePhase2 blk)
+  , Show (PerasVote blk)
+  , Show (PerasCert blk)
   , Show remotePeer
   , HasRawTxId (GenTxId blk)
   , LedgerSupportsProtocol blk
@@ -217,6 +231,8 @@ showTracers tr =
     , perasCertDiffusionOutboundTracer = show >$< tr
     , perasVoteDiffusionInboundTracer = show >$< tr
     , perasVoteDiffusionOutboundTracer = show >$< tr
+    , perasCertInclusionTracer = show >$< tr
+    , perasVoteForgingTracer = show >$< tr
     , forgeTracer = show >$< tr
     , blockchainTimeTracer = show >$< tr
     , forgeStateInfoTracer = show >$< tr

--- a/ouroboros-consensus.cabal
+++ b/ouroboros-consensus.cabal
@@ -237,6 +237,7 @@ library
     Ouroboros.Consensus.NodeId
     Ouroboros.Consensus.Peras.Cert.Class
     Ouroboros.Consensus.Peras.Cert.Inclusion
+    Ouroboros.Consensus.Peras.Cert.Inclusion.Trace
     Ouroboros.Consensus.Peras.Cert.V1
     Ouroboros.Consensus.Peras.Context
     Ouroboros.Consensus.Peras.Crypto.BLS
@@ -249,6 +250,7 @@ library
     Ouroboros.Consensus.Peras.Vote.V1
     Ouroboros.Consensus.Peras.Voting.Adapter
     Ouroboros.Consensus.Peras.Voting.Rules
+    Ouroboros.Consensus.Peras.Voting.Trace
     Ouroboros.Consensus.Peras.Voting.View
     Ouroboros.Consensus.Peras.Weight
     Ouroboros.Consensus.Protocol.Abstract

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Peras/Cert/Inclusion/Trace.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Peras/Cert/Inclusion/Trace.hs
@@ -1,0 +1,44 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Ouroboros.Consensus.Peras.Cert.Inclusion.Trace
+  ( TracePerasCertInclusionEvent (..)
+  ) where
+
+import GHC.Generics (Generic)
+import NoThunks.Class (NoThunks)
+import Ouroboros.Consensus.Block.Abstract (SlotNo)
+import Ouroboros.Consensus.Block.SupportsPeras (PerasCert, ValidatedPerasCert)
+import Ouroboros.Consensus.BlockchainTime.WallClock.Types (WithArrivalTime)
+import Ouroboros.Consensus.Peras.Cert.Inclusion (PerasCertInclusionRulesDecision)
+import Ouroboros.Consensus.Peras.Types (PerasRoundNo)
+
+-- | Peras certificate inclusion events.
+data TracePerasCertInclusionEvent blk
+  = -- | There is no latest certificate seen available to include in a block
+    TracePerasCertInclusionNoCertToInclude
+      -- | The current slot number
+      SlotNo
+  | -- | The decision made by the inclusion rules for a certificate
+    TracePerasCertInclusionRulesDecision
+      -- | The current slot number
+      SlotNo
+      -- | The current round number
+      PerasRoundNo
+      -- | The reason to include or not include a certificate
+      (PerasCertInclusionRulesDecision (WithArrivalTime (ValidatedPerasCert blk)))
+
+deriving instance
+  Show (PerasCert blk) =>
+  Show (TracePerasCertInclusionEvent blk)
+deriving instance
+  Eq (PerasCert blk) =>
+  Eq (TracePerasCertInclusionEvent blk)
+deriving instance
+  NoThunks (PerasCert blk) =>
+  NoThunks (TracePerasCertInclusionEvent blk)
+deriving instance
+  Generic (TracePerasCertInclusionEvent blk)

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Peras/Voting/Trace.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Peras/Voting/Trace.hs
@@ -1,0 +1,86 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Ouroboros.Consensus.Peras.Voting.Trace
+  ( TracePerasVoteForgingEvent (..)
+  ) where
+
+import Data.Word (Word64)
+import GHC.Generics (Generic)
+import NoThunks.Class (NoThunks)
+import Ouroboros.Consensus.Block
+  ( PerasCert
+  , PerasRoundNo
+  , PerasVote
+  , StandardHash
+  , ValidatedPerasVote
+  )
+import Ouroboros.Consensus.BlockchainTime (WithArrivalTime)
+import Ouroboros.Consensus.Peras.Voting.Rules (PerasVotingRulesDecision)
+import Ouroboros.Consensus.Storage.ChainDB
+  ( AddPerasCertChainSelOutcome
+  , AddPerasVoteResult
+  )
+
+-- | Peras vote forging events.
+data TracePerasVoteForgingEvent blk
+  = -- | We do nothing unless we are on the first slot of a round
+    TracePerasVotingNoVoteAfterFirstSlotInRound
+      -- | The current round number
+      PerasRoundNo
+      -- | The current slot number within the round
+      Word64
+  | -- | We do nothing if we are not eligible to vote in the current round
+    TracePerasVotingNotAVoterInRound
+      -- | The current round number
+      PerasRoundNo
+  | -- | The decision made by the voting rules for a given round
+    TracePerasVotingRulesDecision
+      -- | The current round number
+      PerasRoundNo
+      -- | The reason to forge or not forge a vote
+      (PerasVotingRulesDecision blk)
+  | -- | We forged a vote for the current round
+    TracePerasVotingForgedVote
+      -- | The current round number
+      PerasRoundNo
+      -- | The forged vote
+      (WithArrivalTime (ValidatedPerasVote blk))
+  | -- | The result of adding the vote to the PerasVoteDB
+    TracePerasVotingAddVoteResult
+      -- | The current round number
+      PerasRoundNo
+      -- | The result of adding the vote to the chain
+      (AddPerasVoteResult blk)
+  | -- | The result of adding the certificate to the PerasCertDB
+    TracePerasVotingAddCertChainSelOutcome
+      -- | The current round number
+      PerasRoundNo
+      -- | The result of adding the certificate to the chain
+      AddPerasCertChainSelOutcome
+  | -- | TODO: get rid of this when we no longer read stuff from env variables
+    TracePerasVotingCantReadEnv String
+
+deriving instance
+  ( StandardHash blk
+  , Show (PerasVote blk)
+  , Show (PerasCert blk)
+  ) =>
+  Show (TracePerasVoteForgingEvent blk)
+deriving instance
+  ( StandardHash blk
+  , Eq (PerasVote blk)
+  , Eq (PerasCert blk)
+  ) =>
+  Eq (TracePerasVoteForgingEvent blk)
+deriving instance
+  ( StandardHash blk
+  , NoThunks (PerasVote blk)
+  , NoThunks (PerasCert blk)
+  ) =>
+  NoThunks (TracePerasVoteForgingEvent blk)
+deriving instance
+  Generic (TracePerasVoteForgingEvent blk)


### PR DESCRIPTION
This PR adds tracing events for Peras vote forging and certificate inclusion events, including vote and certificate database outcomes. In addition, it wires them into node tracer configuration and adds the required instances.