### PR TITLE
[Peras 57] Introduce PerasState type

### DIFF
--- a/changelog.d/20260812_131141_agustin.mista_add_peras_state.md
+++ b/changelog.d/20260812_131141_agustin.mista_add_peras_state.md
@@ -1,0 +1,23 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+<!--
+### Breaking
+
+- A bullet item for the Breaking category.
+
+-->
+### Non-Breaking
+
+- Define `PerasState` type containing a `PerasEpochContextResolver` and the round number of the latest certificate on chain.
+
+<!--
+### Patch
+
+- A bullet item for the Patch category.
+
+-->

--- a/ouroboros-consensus.cabal
+++ b/ouroboros-consensus.cabal
@@ -189,6 +189,7 @@ library
     Ouroboros.Consensus.Ledger.Dual
     Ouroboros.Consensus.Ledger.Extended
     Ouroboros.Consensus.Ledger.Inspect
+    Ouroboros.Consensus.Ledger.Peras
     Ouroboros.Consensus.Ledger.Query
     Ouroboros.Consensus.Ledger.Query.Version
     Ouroboros.Consensus.Ledger.SupportsMempool

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Peras.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Peras.hs
@@ -1,0 +1,133 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+-- | Peras state to be stored in the extended ledger state.
+module Ouroboros.Consensus.Ledger.Peras
+  ( PerasState (..)
+  , initPerasState
+  , decodePerasState
+  , encodePerasState
+  ) where
+
+import Cardano.Binary (FromCBOR (..), ToCBOR (..))
+import Codec.CBOR.Decoding (Decoder, decodeListLenOf)
+import Codec.CBOR.Encoding (Encoding, encodeListLen)
+import Data.Maybe.Strict (StrictMaybe (..))
+import Data.SOP (All)
+import Data.SOP.Constraint (Top)
+import Data.Typeable (Typeable)
+import GHC.Generics (Generic)
+import NoThunks.Class (NoThunks (..))
+import Ouroboros.Consensus.Block.SupportsPeras (PerasVotingCommittee)
+import Ouroboros.Consensus.HardFork.Abstract (HasHardForkHistory (..))
+import Ouroboros.Consensus.HeaderValidation (HeaderState)
+import Ouroboros.Consensus.Ledger.Basics (LedgerCfg, LedgerState)
+import Ouroboros.Consensus.Ledger.Tables (HasLedgerTables)
+import Ouroboros.Consensus.Ledger.Tables.Utils (forgetLedgerTables)
+import Ouroboros.Consensus.Peras.Context
+  ( PerasEpochContextResolver
+  , StateSupportsPerasEpochContext
+  , initPerasEpochContextResolver
+  )
+import Ouroboros.Consensus.Peras.Types (PerasRoundNo)
+import Ouroboros.Consensus.Storage.Serialisation
+import Ouroboros.Consensus.Util.CBOR (decodeStrictMaybe, encodeStrictMaybe)
+
+-- | Peras state to be stored in the extended ledger state.
+data PerasState blk
+  = PerasState
+  { perasEpochContextResolver :: !(PerasEpochContextResolver blk)
+  , latestPerasCertOnChainRound :: !(StrictMaybe PerasRoundNo)
+  }
+
+deriving instance Eq (PerasVotingCommittee blk) => Eq (PerasState blk)
+deriving instance Show (PerasVotingCommittee blk) => Show (PerasState blk)
+deriving instance NoThunks (PerasVotingCommittee blk) => NoThunks (PerasState blk)
+deriving instance Generic (PerasState blk)
+
+initPerasState ::
+  ( All Top (HardForkIndices blk)
+  , StateSupportsPerasEpochContext blk
+  , HasLedgerTables LedgerState blk
+  ) =>
+  LedgerCfg LedgerState blk ->
+  LedgerState blk mk ->
+  HeaderState blk ->
+  PerasState blk
+initPerasState ledgerConfig ledgerState headerState =
+  PerasState
+    { perasEpochContextResolver =
+        initPerasEpochContextResolver
+          ledgerConfig
+          (forgetLedgerTables ledgerState)
+          headerState
+    , latestPerasCertOnChainRound =
+        SNothing
+    }
+
+encodePerasState ::
+  (PerasEpochContextResolver blk -> Encoding) ->
+  PerasState blk ->
+  Encoding
+encodePerasState
+  encodeResolver
+  PerasState
+    { perasEpochContextResolver
+    , latestPerasCertOnChainRound
+    } =
+    encodeListLen 2
+      <> encodeResolver perasEpochContextResolver
+      <> encodeStrictMaybe toCBOR latestPerasCertOnChainRound
+
+decodePerasState ::
+  (forall s. Decoder s (PerasEpochContextResolver blk)) ->
+  forall s. Decoder s (PerasState blk)
+decodePerasState decodeResolver = do
+  decodeListLenOf 2
+  perasEpochContextResolver <- decodeResolver
+  latestPerasCertOnChainRound <- decodeStrictMaybe fromCBOR
+  pure
+    PerasState
+      { perasEpochContextResolver
+      , latestPerasCertOnChainRound
+      }
+
+instance
+  ( Typeable blk
+  , FromCBOR (PerasVotingCommittee blk)
+  ) =>
+  FromCBOR (PerasState blk)
+  where
+  fromCBOR = decodePerasState fromCBOR
+
+instance
+  ( Typeable blk
+  , ToCBOR (PerasVotingCommittee blk)
+  ) =>
+  ToCBOR (PerasState blk)
+  where
+  toCBOR = encodePerasState toCBOR
+
+instance
+  ( Typeable blk
+  , FromCBOR (PerasVotingCommittee blk)
+  ) =>
+  DecodeDisk blk (PerasState blk)
+  where
+  decodeDisk cfg = decodePerasState (decodeDisk cfg)
+
+instance
+  ( Typeable blk
+  , ToCBOR (PerasVotingCommittee blk)
+  ) =>
+  EncodeDisk blk (PerasState blk)
+  where
+  encodeDisk cfg = encodePerasState (encodeDisk cfg)


### PR DESCRIPTION
This PR adds a new `PerasState` type to store the data needed by Peras on the extended ledger state at runtime. Currently, this contains an `PerasEpochContextResolver` and the round number of the latest certificate on chain, both of which evolve over time when applying new blocks.