### PR TITLE
Take Mithril snapshots every 40*k slots with no offset (forward-port)

### DIFF
--- a/changelog.d/20260807_165141_javier.sagredo_mithril_snapshot_policy_40k.md
+++ b/changelog.d/20260807_165141_javier.sagredo_mithril_snapshot_policy_40k.md
@@ -1,0 +1,32 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+### Breaking
+
+- The Mithril snapshot policy (which is also the default policy) now takes a
+  snapshot every `40 * k` slots with no offset, instead of every 432,000 slots
+  with an offset of 388,800. On mainnet this is one snapshot a day, one of every
+  five landing on a Shelley epoch boundary.
+- `sfaInterval` is now a `SnapshotInterval`, which is either
+  `DefaultSnapshotInterval` (`40 * k` slots, resolved via
+  `resolveSnapshotInterval` once the `SecurityParam` is known) or an explicit
+  `RequestedSnapshotInterval`.
+- `defaultSnapshotPolicy` and `sanityCheckSnapshotPolicyArgs` now take a
+  `SecurityParam`.
+
+<!--
+### Non-Breaking
+
+- A bullet item for the Non-Breaking category.
+
+-->
+<!--
+### Patch
+
+- A bullet item for the Patch category.
+
+-->

--- a/docs/website/contents/references/consensus_configuration.md
+++ b/docs/website/contents/references/consensus_configuration.md
@@ -230,14 +230,13 @@ The LedgerDB periodically writes a **snapshot** of the ledger state to disk so
 that a restarting node can resume from a recent state instead of replaying the
 whole chain. Only states that are older than `k` blocks (i.e. immutable) are
 snapshotted. The policy is configured by `SnapshotPolicyArgs`
-(`srnSnapshotPolicyArgs`); every field can be left as `UseDefault` or
-overridden. Defaults from `defaultSnapshotPolicy` in
+(`srnSnapshotPolicyArgs`). Defaults from `defaultSnapshotPolicyArgs` in
 `Ouroboros.Consensus.Storage.LedgerDB.Snapshots`:
 
 | Knob | Default | Meaning / implication |
 |---|---|---|
 | `spaNum` (snapshots kept on disk) | **2** | When a new snapshot is written, the oldest is deleted, always leaving one intact snapshot in case the write is interrupted (snapshot files are not `fsync`ed). `1` is dangerous for that reason; `0` would delete the snapshot right after writing it. |
-| `sfaInterval` | **`2·k` slots** (43,200 on mainnet ≈ 72 min of slots) | Snapshots are taken for the most recent immutable state before each slot in `offset, offset + interval, offset + 2·interval, …`. Nodes with the same interval/offset therefore snapshot *the same slots*, which matters for tools like Mithril that compare snapshots across nodes. Smaller interval = less replay on restart, more snapshot I/O. |
+| `sfaInterval` | **`DefaultSnapshotInterval` = `40·k` slots** (86,400 on mainnet ≈ one day of slots) | Snapshots are taken for the most recent immutable state before each slot in `offset, offset + interval, offset + 2·interval, …`. Nodes with the same interval/offset therefore snapshot *the same slots*, which matters for tools like Mithril that compare snapshots across nodes. Smaller interval = less replay on restart, more snapshot I/O. A `RequestedSnapshotInterval` gives an explicit number of slots instead; either way the interval is turned into slots by `resolveSnapshotInterval`, using the `SecurityParam` of the LedgerDB configuration. |
 | `sfaOffset` | **0** | Shifts the grid of snapshot slots, see above. |
 | `sfaRateLimit` | **10 minutes** | Skip a snapshot if less than this much time passed since the previous one finished. Mainly relevant while syncing, when eligible slots stream past quickly. Non-positive values disable the limit. Should be well below the wall-clock duration of the interval, or snapshots get skipped even when caught up. |
 | `sfaDelaySnapshotRange` | **5–10 minutes** | Once a snapshot is due, the node waits a random delay drawn from this range before writing it, so that the network's nodes don't all hit the disk (and slow down) simultaneously. |
@@ -245,15 +244,23 @@ overridden. Defaults from `defaultSnapshotPolicy` in
 Additional points:
 
 - `spaFrequency = DisableSnapshots` turns snapshotting off entirely.
-- `mithrilSnapshotPolicyArgs` is a ready-made policy for Mithril: interval
-  **432,000** (one Shelley epoch) and offset **388,800**, chosen so that
-  snapshots land on Shelley epoch boundaries even while still syncing Byron.
+- `mithrilSnapshotPolicyArgs` is a ready-made policy for Mithril, and is what
+  `defaultSnapshotPolicyArgs` is defined to be: interval `40·k` and offset
+  **0**. On mainnet that is 86,400 slots, one fifth of the 432,000-slot Shelley
+  epoch, so one snapshot a day and one of every five landing exactly on an
+  epoch boundary (86,400 divides both 432,000 and the 4,492,800-slot start of
+  Shelley). The epoch boundary itself is not made busier by this: only
+  immutable states are snapshotted, so the write happens once the state is `k`
+  blocks deep, and `sfaDelaySnapshotRange` defers it by a further 5–10 minutes.
 - Snapshots whose directory name carries a suffix (e.g. `4492799_last_Byron`)
   are **never deleted** by the retention policy — useful for pinning a state.
 - `sanityCheckSnapshotPolicyArgs` runs at startup and traces a warning for
-  suspicious overrides: 0 snapshots on disk, a negative or inverted delay
+  suspicious configurations: 0 snapshots on disk, a negative or inverted delay
   range, a disabled or very large rate limit, or an interval incompatible with
-  Mithril (not dividing the 432,000-slot epoch).
+  Mithril (not dividing the 432,000-slot epoch). The interval check is applied
+  to the *resolved* interval, so it depends on `k`: `40·k` divides 432,000 for
+  mainnet's `k = 2160` and for the usual testnet values, but a network whose
+  `k` does not divide 10,800 will be warned about even with the default.
 
 ## Mempool
 

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Node.hs
@@ -524,7 +524,7 @@ runWith RunNodeArgs{..} encAddrNtN decAddrNtN LowLevelRunNodeArgs{..} =
             traceWith (consensusSanityCheckTracer rnTraceConsensus) issue
           let snapshotPolicyArgs =
                 lgrSnapshotPolicyArgs $ ChainDB.cdbLgrDbArgs llrnChainDbArgsDefaults
-          forM_ (sanityCheckSnapshotPolicyArgs snapshotPolicyArgs) $ \issue ->
+          forM_ (sanityCheckSnapshotPolicyArgs (configSecurityParam cfg) snapshotPolicyArgs) $ \issue ->
             traceWith (consensusSanityCheckTracer rnTraceConsensus) issue
 
           (chainDB, finalArgs) <-

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/Snapshots.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/Snapshots.hs
@@ -4,7 +4,6 @@
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
-{-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE RankNTypes #-}
@@ -80,6 +79,8 @@ module Ouroboros.Consensus.Storage.LedgerDB.Snapshots
   , SnapshotSelectorContext (..)
   , SnapshotFrequency (..)
   , SnapshotFrequencyArgs (..)
+  , SnapshotInterval (..)
+  , resolveSnapshotInterval
   , defaultSnapshotPolicy
   , mithrilEpochSize
   , sanityCheckSnapshotPolicyArgs
@@ -124,6 +125,7 @@ import Data.Word
 import GHC.Generics
 import NoThunks.Class
 import Ouroboros.Consensus.Block
+import Ouroboros.Consensus.Config.SecurityParam
 import Ouroboros.Consensus.Ledger.Abstract (EmptyMK)
 import Ouroboros.Consensus.Ledger.Extended
 import Ouroboros.Consensus.Util (Flag (..), lastMaybe)
@@ -595,7 +597,7 @@ data SnapshotSelectorContext = SnapshotSelectorContext
 -- 'sfaRateLimit' to something significantly smaller than the wall-clock duration
 -- of 'sfaInterval'.
 data SnapshotFrequencyArgs = SnapshotFrequencyArgs
-  { sfaInterval :: NonZero Word64
+  { sfaInterval :: SnapshotInterval
   -- ^ Try to write snapshots every 'sfaInterval' many slots.
   , sfaOffset :: SlotNo
   -- ^ An offset for when to write snapshots, see 'SnapshotFrequency'.
@@ -612,6 +614,23 @@ data SnapshotFrequency
   | DisableSnapshots
   deriving stock (Show, Eq)
 
+-- | How many slots to leave between snapshots, see 'SnapshotFrequencyArgs'.
+--
+-- The interval is only resolved into a concrete number of slots once the
+-- 'SecurityParam' is known, see 'resolveSnapshotInterval'.
+data SnapshotInterval
+  = -- | @40k@ slots, see 'mithrilSnapshotPolicyArgs'.
+    DefaultSnapshotInterval
+  | -- | An explicit number of slots.
+    RequestedSnapshotInterval (NonZero Word64)
+  deriving stock (Show, Eq)
+
+-- | Resolve a 'SnapshotInterval' into a concrete number of slots.
+resolveSnapshotInterval :: SecurityParam -> SnapshotInterval -> NonZero Word64
+resolveSnapshotInterval k = \case
+  DefaultSnapshotInterval -> unsafeNonZero $ 40 * unNonZero (maxRollbacks k)
+  RequestedSnapshotInterval interval -> interval
+
 data SnapshotPolicyArgs = SnapshotPolicyArgs
   { spaFrequency :: SnapshotFrequency
   , spaNum :: NumOfDiskSnapshots
@@ -626,24 +645,20 @@ defaultSnapshotPolicyArgs = mithrilSnapshotPolicyArgs
 -- | Snapshot Policy arguments to be used by Mithril
 --
 -- The snapshot interval is derived as follows:
---   * The epoch in Shelley is 432,000 slots long.
+--   * The epoch in Shelley is 432,000 (10k/f) slots long, which corresponds to 5 days.
+--   * We want to take a snapshot a day, so that is 40*k.
 --
--- The snapshot offset is derived as follows:
---   * 21,600 slots per epoch in Byron
---   * The Byron era was 208 epochs long
---   * The Shelley era starts at 208 * 21,600 = 4,492,800 slots
---   * Half of a Shelley epoch is 432,000 / 2 = 216,000
---   * The resulting offset of the first snapshot in Shelley is 4,492,800 + 216,000 = 4,708,800
---   * Finally, if we want to start taking snapshot while still syncing Byron,
---     we must start at slot 4,708,800 % 432,000 = 388,800
+-- Note that we will take a snapshot at the beginning of each epoch too, but we
+-- won't write it immediately, instead we will write it 5 - 10 minutes later, so
+-- we don't risk imposing more work on the epoch boundary.
 mithrilSnapshotPolicyArgs :: SnapshotPolicyArgs
 mithrilSnapshotPolicyArgs =
   SnapshotPolicyArgs
     { spaFrequency =
         SnapshotFrequency $
           SnapshotFrequencyArgs
-            { sfaInterval = unsafeNonZero 432_000
-            , sfaOffset = 388_800
+            { sfaInterval = DefaultSnapshotInterval
+            , sfaOffset = 0
             , sfaRateLimit = secondsToDiffTime $ 10 * 60
             , sfaDelaySnapshotRange = SnapshotDelayRange fiveMinutes tenMinutes
             }
@@ -658,9 +673,10 @@ mithrilSnapshotPolicyArgs =
 
 -- | Default on-disk policy suitable to use with cardano-node
 defaultSnapshotPolicy ::
+  SecurityParam ->
   SnapshotPolicyArgs ->
   SnapshotPolicy
-defaultSnapshotPolicy args =
+defaultSnapshotPolicy k args =
   SnapshotPolicy
     { onDiskNumSnapshots = spaNum
     , onDiskSnapshotSelector
@@ -692,6 +708,8 @@ defaultSnapshotPolicy args =
                   (sscSnapshotSlots ctx)
                   (drop 1 (sscSnapshotSlots ctx))
            where
+            interval = unNonZero $ resolveSnapshotInterval k sfaInterval
+
             -- Test whether there is a non-negative integer @n@ such that
             --
             -- > candidateSlot < offset + n * interval <= nextSlot
@@ -703,10 +721,10 @@ defaultSnapshotPolicy args =
               Maybe SlotNo
             shouldTakeSnapshot candidateSlot nextSlot
               | nextSlot < sfaOffset = Nothing
-              | candidateSlot < sfaOffset + n * SlotNo (unNonZero sfaInterval) = Just candidateSlot
+              | candidateSlot < sfaOffset + n * SlotNo interval = Just candidateSlot
               | otherwise = Nothing
              where
-              n = SlotNo $ unSlotNo (nextSlot - sfaOffset) `div` (unNonZero sfaInterval)
+              n = SlotNo $ unSlotNo (nextSlot - sfaOffset) `div` interval
 
             -- When rate limiting is enabled, only return at most one (the last)
             -- of the slots satisfying 'shouldTakeSnapshot'.
@@ -737,8 +755,8 @@ mithrilEpochSize = 432000
 -- Only 'Override' values are checked — 'UseDefault' values are known-good and
 -- are never flagged. Checks that are specific to 'SnapshotFrequency' are
 -- skipped entirely when 'spaFrequency' is 'DisableSnapshots'.
-sanityCheckSnapshotPolicyArgs :: SnapshotPolicyArgs -> [SanityCheckIssue]
-sanityCheckSnapshotPolicyArgs SnapshotPolicyArgs{spaFrequency, spaNum} =
+sanityCheckSnapshotPolicyArgs :: SecurityParam -> SnapshotPolicyArgs -> [SanityCheckIssue]
+sanityCheckSnapshotPolicyArgs k SnapshotPolicyArgs{spaFrequency, spaNum} =
   catMaybes $
     checkNumZero spaNum
       : case spaFrequency of
@@ -768,10 +786,12 @@ sanityCheckSnapshotPolicyArgs SnapshotPolicyArgs{spaFrequency, spaNum} =
     | rl > 86400 = Just (SnapshotRateLimitSuspiciouslyLarge rl)
     | otherwise = Nothing
 
-  checkMithrilDivisibility interval
-    | mithrilEpochSize `mod` unNonZero interval /= 0 =
-        Just (SnapshotIntervalNotDivisorOfEpoch (unNonZero interval))
+  checkMithrilDivisibility sfaInterval
+    | mithrilEpochSize `mod` interval /= 0 =
+        Just (SnapshotIntervalNotDivisorOfEpoch interval)
     | otherwise = Nothing
+   where
+    interval = unNonZero $ resolveSnapshotInterval k sfaInterval
 
 {-------------------------------------------------------------------------------
   Tracing snapshot events

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/V2.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/V2.hs
@@ -110,7 +110,10 @@ mkInitDb args getBlock snapManager getVolatileSuffix res = do
                 { ldbSeq = varDB
                 , ldbPrevApplied = prevApplied
                 , ldbNextForkerKey = nextForkerKey
-                , ldbSnapshotPolicy = defaultSnapshotPolicy lgrSnapshotPolicyArgs
+                , ldbSnapshotPolicy =
+                    defaultSnapshotPolicy
+                      (ledgerDbCfgSecParam lgrConfig)
+                      lgrSnapshotPolicyArgs
                 , ldbTracer = tr
                 , ldbCfg = lgrConfig
                 , ldbHasFS = lgrHasFS

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/LedgerSnapshots.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/LedgerSnapshots.hs
@@ -274,7 +274,7 @@ tsSnapshotPolicyArgs TestSetup{tsTestSnapshotPolicyArgs} =
   spaFrequency =
     SnapshotFrequency
       SnapshotFrequencyArgs
-        { sfaInterval = tspaInterval tsTestSnapshotPolicyArgs
+        { sfaInterval = RequestedSnapshotInterval $ tspaInterval tsTestSnapshotPolicyArgs
         , sfaOffset = tspaOffset tsTestSnapshotPolicyArgs
         , sfaRateLimit = tspaRateLimit tsTestSnapshotPolicyArgs
         , sfaDelaySnapshotRange = tspaDelaySnapshotRange tsTestSnapshotPolicyArgs

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/LedgerDB/SnapshotPolicySanityCheck.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/LedgerDB/SnapshotPolicySanityCheck.hs
@@ -1,9 +1,10 @@
 module Test.Ouroboros.Storage.LedgerDB.SnapshotPolicySanityCheck (tests) where
 
-import Cardano.Ledger.BaseTypes (unsafeNonZero)
+import Cardano.Ledger.BaseTypes (unNonZero, unsafeNonZero)
 import Data.Time.Clock (DiffTime, secondsToDiffTime)
 import Data.Word (Word64)
 import Ouroboros.Consensus.Block.SupportsSanityCheck
+import Ouroboros.Consensus.Config.SecurityParam
 import Ouroboros.Consensus.Storage.LedgerDB.Snapshots
 import Test.QuickCheck
 import Test.Tasty
@@ -27,6 +28,8 @@ tests =
         $ prop_rate_limit_large_iff
     , testProperty "SnapshotIntervalNotDivisorOfEpoch fires iff 432000 mod interval /= 0" $
         prop_mithril_divisibility_iff
+    , testProperty "DefaultSnapshotInterval resolves to 40k" $
+        prop_default_interval_is_40k
     , testProperty "no frequency issues emitted under DisableSnapshots" $
         prop_disable_snapshots_no_frequency_issues
     ]
@@ -42,6 +45,7 @@ prop_num_zero_iff =
   forAll (arbitrary :: Gen Word) $ \n ->
     let issues =
           sanityCheckSnapshotPolicyArgs
+            testSecurityParam
             SnapshotPolicyArgs{spaFrequency = DisableSnapshots, spaNum = NumOfDiskSnapshots n}
      in (SnapshotNumZero `elem` issues) === (n == 0)
 
@@ -51,7 +55,7 @@ prop_delay_range_inverted_iff :: Property
 prop_delay_range_inverted_iff =
   forAll genNonNegativeDiffTime $ \mn ->
     forAll genDiffTime $ \mx ->
-      let issues = sanityCheckSnapshotPolicyArgs (withDelayRange (SnapshotDelayRange mn mx))
+      let issues = sanityCheckSnapshotPolicyArgs testSecurityParam (withDelayRange (SnapshotDelayRange mn mx))
           fired = any isInverted issues
        in fired === (mn > mx)
  where
@@ -62,7 +66,7 @@ prop_delay_range_inverted_iff =
 prop_delay_range_negative_minimum_iff :: Property
 prop_delay_range_negative_minimum_iff =
   forAll genDiffTime $ \mn ->
-    let issues = sanityCheckSnapshotPolicyArgs (withDelayRange (SnapshotDelayRange mn 0))
+    let issues = sanityCheckSnapshotPolicyArgs testSecurityParam (withDelayRange (SnapshotDelayRange mn 0))
         fired = any isNegativeMin issues
      in fired === (mn < 0)
  where
@@ -74,7 +78,7 @@ prop_delay_range_negative_minimum_iff =
 prop_rate_limit_disabled_iff :: Property
 prop_rate_limit_disabled_iff =
   forAll genDiffTime $ \rl ->
-    let issues = sanityCheckSnapshotPolicyArgs (withRateLimit rl)
+    let issues = sanityCheckSnapshotPolicyArgs testSecurityParam (withRateLimit rl)
      in (SnapshotRateLimitDisabled `elem` issues) === (rl <= 0)
 
 -- | 'SnapshotRateLimitSuspiciouslyLarge' fires if and only if 'sfaRateLimit' is
@@ -83,7 +87,7 @@ prop_rate_limit_disabled_iff =
 prop_rate_limit_large_iff :: Property
 prop_rate_limit_large_iff =
   forAll genPositiveDiffTime $ \rl ->
-    let issues = sanityCheckSnapshotPolicyArgs (withRateLimit rl)
+    let issues = sanityCheckSnapshotPolicyArgs testSecurityParam (withRateLimit rl)
         fired = any isLarge issues
      in fired === (rl > 86400)
  where
@@ -95,12 +99,19 @@ prop_rate_limit_large_iff =
 prop_mithril_divisibility_iff :: Property
 prop_mithril_divisibility_iff =
   forAll genNonZeroWord64 $ \n ->
-    let issues = sanityCheckSnapshotPolicyArgs (withInterval n)
+    let issues = sanityCheckSnapshotPolicyArgs testSecurityParam (withInterval n)
         fired = any isMithrilIssue issues
      in fired === (mithrilEpochSize `mod` n /= 0)
  where
   isMithrilIssue (SnapshotIntervalNotDivisorOfEpoch _) = True
   isMithrilIssue _ = False
+
+-- | 'DefaultSnapshotInterval' resolves to @40k@ slots.
+prop_default_interval_is_40k :: Property
+prop_default_interval_is_40k =
+  forAll genNonZeroWord64 $ \k ->
+    let secParam = SecurityParam (unsafeNonZero k)
+     in unNonZero (resolveSnapshotInterval secParam DefaultSnapshotInterval) === 40 * k
 
 -- | With 'DisableSnapshots', no frequency-related issues are ever emitted,
 -- regardless of what 'spaNum' is set to.
@@ -109,6 +120,7 @@ prop_disable_snapshots_no_frequency_issues =
   forAll (arbitrary :: Gen Word) $ \n ->
     let issues =
           sanityCheckSnapshotPolicyArgs
+            testSecurityParam
             SnapshotPolicyArgs{spaFrequency = DisableSnapshots, spaNum = NumOfDiskSnapshots n}
      in filter isFrequencyIssue issues === []
  where
@@ -142,6 +154,11 @@ genNonZeroWord64 = getPositive <$> arbitrary
 -- Helpers
 -------------------------------------------------------------------------------
 
+-- | Cardano mainnet @k@. As @40k = 86,400@ divides 'mithrilEpochSize',
+-- 'DefaultSnapshotInterval' never contributes an issue of its own here.
+testSecurityParam :: SecurityParam
+testSecurityParam = SecurityParam (unsafeNonZero 2160)
+
 -- | Build a 'SnapshotPolicyArgs' with a specific 'SnapshotDelayRange' override.
 withDelayRange :: SnapshotDelayRange -> SnapshotPolicyArgs
 withDelayRange sdr =
@@ -166,5 +183,5 @@ withInterval n =
   defaultSnapshotPolicyArgs
     { spaFrequency = case spaFrequency defaultSnapshotPolicyArgs of
         DisableSnapshots -> DisableSnapshots
-        SnapshotFrequency sfa -> SnapshotFrequency (sfa{sfaInterval = unsafeNonZero n})
+        SnapshotFrequency sfa -> SnapshotFrequency (sfa{sfaInterval = RequestedSnapshotInterval (unsafeNonZero n)})
     }


### PR DESCRIPTION
Forward-port of #2194 

The Mithril snapshot policy (which is also the default policy) used an interval of one Shelley epoch with an offset of half an epoch. Take a snapshot every 40*k slots instead, with no offset: on mainnet that is one snapshot a day, and one of every five lands on an epoch boundary, as 40*k = 86,400 divides both the 432,000-slot epoch and the 4,492,800-slot start of Shelley.

As the interval now depends on k, 'sfaInterval' becomes a 'SnapshotInterval': either 'DefaultSnapshotInterval', resolved to 40*k once the 'SecurityParam' is known, or an explicit
'RequestedSnapshotInterval'. 'SnapshotPolicyArgs' therefore stays plain data, and the security parameter is only needed by 'defaultSnapshotPolicy', which takes it from the LedgerDB configuration, and by 'sanityCheckSnapshotPolicyArgs', which checks the resolved interval.

# Description

Please include a meaningful description of the PR and link the relevant issues
this PR might resolve.

Also note that:

- New code should be properly tested (even if it does not add new features).
- The fix for a regression should include a test that reproduces said regression.

# WARNING

To update your feature branch if it's stale, please rebase it manually on top of `main`. Don't update your feature branch by merging `main` into it. Your pull request will not pass CI if you do.
