### PR TITLE
[Peras 60] Introduce default StateSupportsPerasEpochContext instances

### DIFF
--- a/changelog.d/20260819_091107_agustin.mista_state_supports_epoch_context_instances.md
+++ b/changelog.d/20260819_091107_agustin.mista_state_supports_epoch_context_instances.md
@@ -1,0 +1,23 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+<!--
+### Breaking
+
+- A bullet item for the Breaking category.
+
+-->
+### Non-Breaking
+
+- Add empty `StateSupportsPerasEpochContext` instances for Byron, Shelley and the HFC blocks.
+
+<!--
+### Patch
+
+- A bullet item for the Patch category.
+
+-->

--- a/ouroboros-consensus-cardano/src/byron/Ouroboros/Consensus/Byron/Ledger/Ledger.hs
+++ b/ouroboros-consensus-cardano/src/byron/Ouroboros/Consensus/Byron/Ledger/Ledger.hs
@@ -81,6 +81,7 @@ import Ouroboros.Consensus.Byron.Ledger.Serialisation
 import Ouroboros.Consensus.Config
 import Ouroboros.Consensus.Forecast
 import Ouroboros.Consensus.HardFork.Abstract
+import Ouroboros.Consensus.HardFork.History (EpochToPerasRoundInfo, forgetEraIndex)
 import qualified Ouroboros.Consensus.HardFork.History as HardFork
 import Ouroboros.Consensus.HeaderValidation
 import Ouroboros.Consensus.Ledger.Abstract
@@ -91,6 +92,7 @@ import Ouroboros.Consensus.Ledger.SupportsPeerSelection
 import Ouroboros.Consensus.Ledger.SupportsPeras (LedgerStateSupportsPeras)
 import Ouroboros.Consensus.Ledger.SupportsProtocol
 import Ouroboros.Consensus.Ledger.Tables.Utils
+import Ouroboros.Consensus.Peras.Context (StateSupportsPerasEpochContext (..))
 import Ouroboros.Consensus.Util (ShowProxy (..))
 import Ouroboros.Consensus.Util.IndexedMemPack
 
@@ -582,3 +584,9 @@ instance CanUpgradeLedgerTables LedgerState ByronBlock where
 instance LedgerStateSupportsPeras (LedgerState ByronBlock)
 
 instance LedgerStateSupportsPeras (Ticked LedgerState ByronBlock)
+
+instance StateSupportsPerasEpochContext ByronBlock where
+  type MaybeEraIndexedEpochToPerasRoundInfo ByronBlock = EpochToPerasRoundInfo
+  toMaybeEraIndexedEpochToPerasRoundInfo _ = forgetEraIndex
+  fromMaybeEraIndexedEpochToPerasRoundInfo _ = id
+  mkBoundedPerasEpochContext = error "mkBoundedPerasEpochContext: ByronBlock does not support Peras"

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Block.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Block.hs
@@ -69,8 +69,10 @@ import Ouroboros.Consensus.HardFork.Combinator
   ( HasPartialConsensusConfig
   , LedgerState
   )
+import Ouroboros.Consensus.HardFork.History (EpochToPerasRoundInfo)
 import Ouroboros.Consensus.HeaderValidation
 import Ouroboros.Consensus.Ledger.SupportsPeras (LedgerStateSupportsPeras)
+import Ouroboros.Consensus.Peras.Context (StateSupportsPerasEpochContext (..))
 import Ouroboros.Consensus.Protocol.Abstract
 import Ouroboros.Consensus.Protocol.Praos.Common
   ( PraosTiebreakerView
@@ -130,14 +132,12 @@ class
     HasPartialConsensusConfig proto
   , DecCBOR (SL.PState era)
   , Crypto (ProtoCrypto proto)
+  , -- Peras constraints
+    StateSupportsPerasEpochContext (ShelleyBlock proto era)
+  , MaybeEraIndexedEpochToPerasRoundInfo (ShelleyBlock proto era) ~ EpochToPerasRoundInfo
   , -- Backwards compatibility
     Plain.FromCBOR (LegacyPParams era)
   , Plain.ToCBOR (LegacyPParams era)
-  , -- TODO: replace the four constraints below with:
-    -- 'StateSupportsPerasEpochContext (ShelleyBlock proto er)' once that type
-    -- class is in place.
-    ChainDepStateSupportsPeras (ChainDepState (BlockProtocol (ShelleyBlock proto era)))
-  , ChainDepStateSupportsPeras (Ticked (ChainDepState (BlockProtocol (ShelleyBlock proto era))))
   , LedgerStateSupportsPeras (LedgerState (ShelleyBlock proto era))
   , LedgerStateSupportsPeras (Ticked LedgerState (ShelleyBlock proto era))
   ) =>

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Node/Peras.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Node/Peras.hs
@@ -1,0 +1,131 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+-- | Peras support for Shelley.
+--
+-- NOTE: this module exists solely because the orphan module
+-- 'Ouroboros.Consensus.Shelley.Node.Serialisation' needs some of these
+-- instances, but defining them there would be too confusing.
+module Ouroboros.Consensus.Shelley.Node.Peras () where
+
+import Cardano.Ledger.Api
+import Data.Typeable (Typeable)
+import Ouroboros.Consensus.HardFork.History (EpochToPerasRoundInfo, forgetEraIndex)
+import Ouroboros.Consensus.Peras.Context (StateSupportsPerasEpochContext (..))
+import Ouroboros.Consensus.Protocol.Abstract
+  ( ChainDepStateSupportsPeras
+  , ConsensusProtocol (..)
+  )
+import Ouroboros.Consensus.Shelley.Ledger.Block (ShelleyBlock (..))
+import Ouroboros.Consensus.Shelley.Ledger.Ledger ()
+import Ouroboros.Consensus.Ticked (Ticked)
+
+{-------------------------------------------------------------------------------
+  StateSupportsPerasEpochContext
+-------------------------------------------------------------------------------}
+
+instance
+  ( Typeable proto
+  , ChainDepStateSupportsPeras (ChainDepState proto)
+  , ChainDepStateSupportsPeras (Ticked (ChainDepState proto))
+  ) =>
+  StateSupportsPerasEpochContext (ShelleyBlock proto ShelleyEra)
+  where
+  type
+    MaybeEraIndexedEpochToPerasRoundInfo (ShelleyBlock proto ShelleyEra) =
+      EpochToPerasRoundInfo
+  toMaybeEraIndexedEpochToPerasRoundInfo _ = forgetEraIndex
+  fromMaybeEraIndexedEpochToPerasRoundInfo _ = id
+  mkBoundedPerasEpochContext = error "mkBoundedPerasEpochContext: ShelleyEra does not support Peras"
+
+instance
+  ( Typeable proto
+  , ChainDepStateSupportsPeras (ChainDepState proto)
+  , ChainDepStateSupportsPeras (Ticked (ChainDepState proto))
+  ) =>
+  StateSupportsPerasEpochContext (ShelleyBlock proto AllegraEra)
+  where
+  type
+    MaybeEraIndexedEpochToPerasRoundInfo (ShelleyBlock proto AllegraEra) =
+      EpochToPerasRoundInfo
+  toMaybeEraIndexedEpochToPerasRoundInfo _ = forgetEraIndex
+  fromMaybeEraIndexedEpochToPerasRoundInfo _ = id
+  mkBoundedPerasEpochContext = error "mkBoundedPerasEpochContext: AllegraEra does not support Peras"
+
+instance
+  ( Typeable proto
+  , ChainDepStateSupportsPeras (ChainDepState proto)
+  , ChainDepStateSupportsPeras (Ticked (ChainDepState proto))
+  ) =>
+  StateSupportsPerasEpochContext (ShelleyBlock proto MaryEra)
+  where
+  type
+    MaybeEraIndexedEpochToPerasRoundInfo (ShelleyBlock proto MaryEra) =
+      EpochToPerasRoundInfo
+  toMaybeEraIndexedEpochToPerasRoundInfo _ = forgetEraIndex
+  fromMaybeEraIndexedEpochToPerasRoundInfo _ = id
+  mkBoundedPerasEpochContext = error "mkBoundedPerasEpochContext: MaryEra does not support Peras"
+
+instance
+  ( Typeable proto
+  , ChainDepStateSupportsPeras (ChainDepState proto)
+  , ChainDepStateSupportsPeras (Ticked (ChainDepState proto))
+  ) =>
+  StateSupportsPerasEpochContext (ShelleyBlock proto AlonzoEra)
+  where
+  type
+    MaybeEraIndexedEpochToPerasRoundInfo (ShelleyBlock proto AlonzoEra) =
+      EpochToPerasRoundInfo
+  toMaybeEraIndexedEpochToPerasRoundInfo _ = forgetEraIndex
+  fromMaybeEraIndexedEpochToPerasRoundInfo _ = id
+  mkBoundedPerasEpochContext = error "mkBoundedPerasEpochContext: AlonzoEra does not support Peras"
+
+instance
+  ( Typeable proto
+  , ChainDepStateSupportsPeras (ChainDepState proto)
+  , ChainDepStateSupportsPeras (Ticked (ChainDepState proto))
+  ) =>
+  StateSupportsPerasEpochContext (ShelleyBlock proto BabbageEra)
+  where
+  type
+    MaybeEraIndexedEpochToPerasRoundInfo (ShelleyBlock proto BabbageEra) =
+      EpochToPerasRoundInfo
+  toMaybeEraIndexedEpochToPerasRoundInfo _ = forgetEraIndex
+  fromMaybeEraIndexedEpochToPerasRoundInfo _ = id
+  mkBoundedPerasEpochContext = error "mkBoundedPerasEpochContext: BabbageEra does not support Peras"
+
+instance
+  ( Typeable proto
+  , ChainDepStateSupportsPeras (ChainDepState proto)
+  , ChainDepStateSupportsPeras (Ticked (ChainDepState proto))
+  ) =>
+  StateSupportsPerasEpochContext (ShelleyBlock proto ConwayEra)
+  where
+  type
+    MaybeEraIndexedEpochToPerasRoundInfo (ShelleyBlock proto ConwayEra) =
+      EpochToPerasRoundInfo
+  toMaybeEraIndexedEpochToPerasRoundInfo _ = forgetEraIndex
+  fromMaybeEraIndexedEpochToPerasRoundInfo _ = id
+  mkBoundedPerasEpochContext = error "mkBoundedPerasEpochContext: ConwayEra does not support Peras"
+
+-- TODO: this instance will have a real implementation as soon as we remove the
+-- degenerate 'BlockSupportsPeras' instance. That's why we don't have a global
+-- instance for all eras :)
+instance
+  ( Typeable proto
+  , ChainDepStateSupportsPeras (ChainDepState proto)
+  , ChainDepStateSupportsPeras (Ticked (ChainDepState proto))
+  ) =>
+  StateSupportsPerasEpochContext (ShelleyBlock proto DijkstraEra)
+  where
+  type
+    MaybeEraIndexedEpochToPerasRoundInfo (ShelleyBlock proto DijkstraEra) =
+      EpochToPerasRoundInfo
+  toMaybeEraIndexedEpochToPerasRoundInfo _ = forgetEraIndex
+  fromMaybeEraIndexedEpochToPerasRoundInfo _ = id
+  mkBoundedPerasEpochContext = error "mkBoundedPerasEpochContext: DijkstraEra does not support Peras (yet)"

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Node/Serialisation.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Node/Serialisation.hs
@@ -45,6 +45,7 @@ import Ouroboros.Consensus.Protocol.TPraos
 import Ouroboros.Consensus.Shelley.Eras
 import Ouroboros.Consensus.Shelley.Ledger
 import Ouroboros.Consensus.Shelley.Ledger.NetworkProtocolVersion ()
+import Ouroboros.Consensus.Shelley.Node.Peras ()
 import Ouroboros.Consensus.Shelley.Protocol.Abstract
   ( pHeaderBlockSize
   , pHeaderSize

--- a/ouroboros-consensus-cardano/src/unstable-cardano-testlib/Test/ThreadNet/Infra/ShelleyBasedHardFork.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-testlib/Test/ThreadNet/Infra/ShelleyBasedHardFork.hs
@@ -183,6 +183,8 @@ type ShelleyBasedHardForkConstraints proto1 era1 proto2 era2 =
   , ShelleyCompatible proto2 era2
   , LedgerSupportsProtocol (ShelleyBlock proto1 era1)
   , LedgerSupportsProtocol (ShelleyBlock proto2 era2)
+  , SerialiseConstraintsHFC (ShelleyBlock proto1 era1)
+  , SerialiseConstraintsHFC (ShelleyBlock proto2 era2)
   , TxLimits (ShelleyBlock proto1 era1)
   , TxLimits (ShelleyBlock proto2 era2)
   , TranslateTxMeasure

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator/A.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator/A.hs
@@ -65,12 +65,15 @@ import Ouroboros.Consensus.BlockchainTime
 import Ouroboros.Consensus.Config
 import Ouroboros.Consensus.Config.SupportsNode
 import Ouroboros.Consensus.Forecast
+import Ouroboros.Consensus.HardFork.Abstract (HasHardForkHistory (..))
 import Ouroboros.Consensus.HardFork.Combinator
 import Ouroboros.Consensus.HardFork.Combinator.Condense
 import Ouroboros.Consensus.HardFork.Combinator.Serialisation.Common
 import Ouroboros.Consensus.HardFork.History
   ( Bound (..)
+  , EpochToPerasRoundInfo
   , EraParams (..)
+  , forgetEraIndex
   )
 import qualified Ouroboros.Consensus.HardFork.History as History
 import Ouroboros.Consensus.HeaderValidation
@@ -87,6 +90,7 @@ import Ouroboros.Consensus.Node.InitStorage
 import Ouroboros.Consensus.Node.NetworkProtocolVersion
 import Ouroboros.Consensus.Node.Run
 import Ouroboros.Consensus.Node.Serialisation
+import Ouroboros.Consensus.Peras.Context (StateSupportsPerasEpochContext (..))
 import Ouroboros.Consensus.Protocol.Abstract
 import Ouroboros.Consensus.Storage.ImmutableDB (simpleChunkInfo)
 import Ouroboros.Consensus.Storage.Serialisation
@@ -310,6 +314,19 @@ instance LedgerSupportsProtocol BlockA where
 instance LedgerStateSupportsPeras (LedgerState BlockA)
 
 instance LedgerStateSupportsPeras (Ticked LedgerState BlockA)
+
+-- NOTE: BlockA is only ever used wrapped in the
+-- hard fork combinator (which implements 'hardForkSummary' directly and never
+-- delegates to the underlying era), so this method is never actually called.
+instance HasHardForkHistory BlockA where
+  type HardForkIndices BlockA = '[BlockA]
+  hardForkSummary = error "BlockA being used as a SingleEraBlock"
+
+instance StateSupportsPerasEpochContext BlockA where
+  type MaybeEraIndexedEpochToPerasRoundInfo BlockA = EpochToPerasRoundInfo
+  toMaybeEraIndexedEpochToPerasRoundInfo _ = forgetEraIndex
+  fromMaybeEraIndexedEpochToPerasRoundInfo _ = id
+  mkBoundedPerasEpochContext = error "mkBoundedPerasEpochContext: BlockA does not support Peras"
 
 instance HasPartialConsensusConfig ProtocolA
 

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator/B.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator/B.hs
@@ -53,9 +53,11 @@ import Ouroboros.Consensus.BlockchainTime
 import Ouroboros.Consensus.Config
 import Ouroboros.Consensus.Config.SupportsNode
 import Ouroboros.Consensus.Forecast
+import Ouroboros.Consensus.HardFork.Abstract (HasHardForkHistory (..))
 import Ouroboros.Consensus.HardFork.Combinator
 import Ouroboros.Consensus.HardFork.Combinator.Condense
 import Ouroboros.Consensus.HardFork.Combinator.Serialisation.Common
+import Ouroboros.Consensus.HardFork.History (EpochToPerasRoundInfo, forgetEraIndex)
 import qualified Ouroboros.Consensus.HardFork.History as History
 import Ouroboros.Consensus.HeaderValidation
 import Ouroboros.Consensus.Ledger.Abstract
@@ -71,6 +73,7 @@ import Ouroboros.Consensus.Node.InitStorage
 import Ouroboros.Consensus.Node.NetworkProtocolVersion
 import Ouroboros.Consensus.Node.Run
 import Ouroboros.Consensus.Node.Serialisation
+import Ouroboros.Consensus.Peras.Context (StateSupportsPerasEpochContext (..))
 import Ouroboros.Consensus.Protocol.Abstract
 import Ouroboros.Consensus.Storage.ImmutableDB (simpleChunkInfo)
 import Ouroboros.Consensus.Storage.Serialisation
@@ -266,6 +269,19 @@ instance LedgerSupportsProtocol BlockB where
 instance LedgerStateSupportsPeras (LedgerState BlockB)
 
 instance LedgerStateSupportsPeras (Ticked LedgerState BlockB)
+
+-- NOTE: BlockA is only ever used wrapped in the
+-- hard fork combinator (which implements 'hardForkSummary' directly and never
+-- delegates to the underlying era), so this method is never actually called.
+instance HasHardForkHistory BlockB where
+  type HardForkIndices BlockB = '[BlockB]
+  hardForkSummary = error "BlockB being used as a SingleEraBlock"
+
+instance StateSupportsPerasEpochContext BlockB where
+  type MaybeEraIndexedEpochToPerasRoundInfo BlockB = EpochToPerasRoundInfo
+  toMaybeEraIndexedEpochToPerasRoundInfo _ = forgetEraIndex
+  fromMaybeEraIndexedEpochToPerasRoundInfo _ = id
+  mkBoundedPerasEpochContext = error "mkBoundedPerasEpochContext: BlockB does not support Peras"
 
 instance HasPartialConsensusConfig ProtocolB
 

--- a/ouroboros-consensus.cabal
+++ b/ouroboros-consensus.cabal
@@ -598,6 +598,7 @@ library unstable-mock-block
     Ouroboros.Consensus.Mock.Node.Abstract
     Ouroboros.Consensus.Mock.Node.BFT
     Ouroboros.Consensus.Mock.Node.PBFT
+    Ouroboros.Consensus.Mock.Node.Peras
     Ouroboros.Consensus.Mock.Node.Praos
     Ouroboros.Consensus.Mock.Node.PraosRule
     Ouroboros.Consensus.Mock.Node.Serialisation
@@ -1381,6 +1382,7 @@ library cardano
     Ouroboros.Consensus.Shelley.Node
     Ouroboros.Consensus.Shelley.Node.Common
     Ouroboros.Consensus.Shelley.Node.DiffusionPipelining
+    Ouroboros.Consensus.Shelley.Node.Peras
     Ouroboros.Consensus.Shelley.Node.Praos
     Ouroboros.Consensus.Shelley.Node.Serialisation
     Ouroboros.Consensus.Shelley.Node.TPraos

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Block/SupportsPeras.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Block/SupportsPeras.hs
@@ -397,6 +397,14 @@ class IsPerasError err blk | err -> blk where
   injectConversionError :: PerasConversionError -> err
   injectQuorumNotReachedError :: VoteWeight -> err
 
+instance IsPerasError (VoidPerasError blk) blk where
+  injectVotingCommitteeError _ =
+    error "injectVotingCommitteeError: VoidPerasError cannot be inhabited"
+  injectConversionError _ =
+    error "injectConversionError: VoidPerasError cannot be inhabited"
+  injectQuorumNotReachedError _ =
+    error "injectQuorumNotReachedError: VoidPerasError cannot be inhabited"
+
 -- * Types and functions related to Peras vote collection and quorum checking
 
 -- | Collection of Peras votes for a given target.

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Abstract/SingleEraBlock.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Abstract/SingleEraBlock.hs
@@ -38,17 +38,17 @@ import Ouroboros.Consensus.Block
 import Ouroboros.Consensus.Config.SupportsNode
 import Ouroboros.Consensus.HardFork.Combinator.Info
 import Ouroboros.Consensus.HardFork.Combinator.PartialConfig
-import Ouroboros.Consensus.HardFork.History (Bound, EraParams)
+import Ouroboros.Consensus.HardFork.History (Bound, EpochToPerasRoundInfo, EraParams)
 import Ouroboros.Consensus.Ledger.Abstract
 import Ouroboros.Consensus.Ledger.CommonProtocolParams
 import Ouroboros.Consensus.Ledger.Inspect
 import Ouroboros.Consensus.Ledger.Query
 import Ouroboros.Consensus.Ledger.SupportsMempool
 import Ouroboros.Consensus.Ledger.SupportsPeerSelection
-import Ouroboros.Consensus.Ledger.SupportsPeras (LedgerStateSupportsPeras)
 import Ouroboros.Consensus.Ledger.SupportsProtocol
 import Ouroboros.Consensus.Node.InitStorage
 import Ouroboros.Consensus.Node.Serialisation
+import Ouroboros.Consensus.Peras.Context (StateSupportsPerasEpochContext (..))
 import Ouroboros.Consensus.Protocol.Abstract
 import Ouroboros.Consensus.Storage.Serialisation
 import Ouroboros.Consensus.Ticked
@@ -77,14 +77,10 @@ class
   , ConfigSupportsNode blk
   , NodeInitStorage blk
   , BlockSupportsDiffusionPipelining blk
+  , StateSupportsPerasEpochContext blk
+  , MaybeEraIndexedEpochToPerasRoundInfo blk ~ EpochToPerasRoundInfo
   , BlockSupportsMetrics blk
   , SerialiseNodeToClient blk (PartialLedgerConfig blk)
-  , -- TODO: replace the four constraints below with:
-    -- 'StateSupportsPerasEpochContext blk' once that type class is in place.
-    ChainDepStateSupportsPeras (ChainDepState (BlockProtocol blk))
-  , ChainDepStateSupportsPeras (Ticked (ChainDepState (BlockProtocol blk)))
-  , LedgerStateSupportsPeras (LedgerState blk)
-  , LedgerStateSupportsPeras (Ticked LedgerState blk)
   , -- LedgerTables
     CanStowLedgerTables (LedgerState blk)
   , HasLedgerTables LedgerState blk

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Ledger.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Ledger.hs
@@ -90,8 +90,11 @@ import Ouroboros.Consensus.HardFork.Combinator.State.Types
 import Ouroboros.Consensus.HardFork.Combinator.Translation
 import Ouroboros.Consensus.HardFork.History
   ( Bound (..)
+  , EpochToPerasRoundInfo
+  , EraIndexed
   , EraParams
   , SafeZone (..)
+  , forgetEraIndex
   )
 import qualified Ouroboros.Consensus.HardFork.History as History
 import Ouroboros.Consensus.HeaderValidation
@@ -100,6 +103,7 @@ import Ouroboros.Consensus.Ledger.Inspect
 import Ouroboros.Consensus.Ledger.SupportsPeras (LedgerStateSupportsPeras (..))
 import Ouroboros.Consensus.Ledger.SupportsProtocol
 import Ouroboros.Consensus.Ledger.Tables.Utils
+import Ouroboros.Consensus.Peras.Context (StateSupportsPerasEpochContext (..))
 import Ouroboros.Consensus.TypeFamilyWrappers
 import Ouroboros.Consensus.Util.Condense
 import Ouroboros.Consensus.Util.IndexedMemPack (IndexedMemPack)
@@ -339,6 +343,20 @@ instance
       . hcmap proxySingle (K . getPoolDistr . getFlipTickedLedgerState)
       . State.tip
       . tickedHardForkLedgerStatePerEra
+
+-- TODO: this instance will have a full implementation as soon as we remove the
+-- degenerate 'BlockSupportsPeras' instance.
+instance
+  CanHardFork xs =>
+  StateSupportsPerasEpochContext (HardForkBlock xs)
+  where
+  type
+    MaybeEraIndexedEpochToPerasRoundInfo (HardForkBlock xs) =
+      EraIndexed xs EpochToPerasRoundInfo
+
+  fromMaybeEraIndexedEpochToPerasRoundInfo _ = forgetEraIndex
+  toMaybeEraIndexedEpochToPerasRoundInfo _ = id
+  mkBoundedPerasEpochContext = error "mkBoundedPerasEpochContext: HardForkBlock does not support Peras (yet)"
 
 {-------------------------------------------------------------------------------
   HeaderValidation

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Dual.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Dual.hs
@@ -82,6 +82,7 @@ import Ouroboros.Consensus.Config
 import Ouroboros.Consensus.Config.SupportsNode
 import Ouroboros.Consensus.HardFork.Abstract
 import Ouroboros.Consensus.HardFork.Combinator.PartialConfig
+import Ouroboros.Consensus.HardFork.History (EpochToPerasRoundInfo, forgetEraIndex)
 import Ouroboros.Consensus.HeaderValidation
 import Ouroboros.Consensus.Ledger.Abstract
 import Ouroboros.Consensus.Ledger.CommonProtocolParams
@@ -93,6 +94,8 @@ import Ouroboros.Consensus.Ledger.SupportsPeerSelection
 import Ouroboros.Consensus.Ledger.SupportsPeras (LedgerStateSupportsPeras)
 import Ouroboros.Consensus.Ledger.SupportsProtocol
 import Ouroboros.Consensus.Ledger.Tables.Utils
+import Ouroboros.Consensus.Peras.Context (StateSupportsPerasEpochContext (..))
+import Ouroboros.Consensus.Protocol.Abstract (ChainDepStateSupportsPeras, ConsensusProtocol (..))
 import Ouroboros.Consensus.Storage.Serialisation
 import Ouroboros.Consensus.Util (ShowProxy (..))
 import Ouroboros.Consensus.Util.Condense
@@ -1206,3 +1209,17 @@ instance
 instance LedgerStateSupportsPeras (LedgerState (DualBlock m a))
 
 instance LedgerStateSupportsPeras (Ticked LedgerState (DualBlock m a))
+
+instance
+  ( Bridge m a
+  , Typeable m
+  , Typeable a
+  , ChainDepStateSupportsPeras (ChainDepState (BlockProtocol m))
+  , ChainDepStateSupportsPeras (Ticked (ChainDepState (BlockProtocol m)))
+  ) =>
+  StateSupportsPerasEpochContext (DualBlock m a)
+  where
+  type MaybeEraIndexedEpochToPerasRoundInfo (DualBlock m a) = EpochToPerasRoundInfo
+  toMaybeEraIndexedEpochToPerasRoundInfo _ = forgetEraIndex
+  fromMaybeEraIndexedEpochToPerasRoundInfo _ = id
+  mkBoundedPerasEpochContext = error "mkBoundedPerasEpochContext: DualBlock does not support Peras"

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Peras/Context.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Peras/Context.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DefaultSignatures #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DeriveTraversable #-}
@@ -98,7 +97,6 @@ import Ouroboros.Consensus.HardFork.History.Qry
   , PastHorizonException
   , Qry
   , epochToPerasRoundInfo
-  , forgetEraIndex
   , runQuery
   , runQueryEraIndexed
   , slotToEpoch'
@@ -493,10 +491,6 @@ withResolvedRoundNo handle roundNo k = do
 
 -- | Type-class for blocks that support constructing a Peras epoch contexts from
 -- their corresponding ledger and chain-dep states.
---
--- NOTE: the default implementation of this class is enough for block that do
--- not support Peras and never try to resolve a 'PerasRoundNo' into a
--- 'PerasEpochContext'.
 class
   ( HasHardForkHistory blk
   , LedgerStateSupportsPeras (LedgerState blk)
@@ -530,21 +524,12 @@ class
   -- implementation.
   type MaybeEraIndexedEpochToPerasRoundInfo blk :: Type
 
-  type MaybeEraIndexedEpochToPerasRoundInfo blk = EpochToPerasRoundInfo
-
   -- | Extract a 'EpochToPerasRoundInfo' the opaque
   -- 'MaybeEraIndexedEpochToPerasRoundInfo' of this block.
   fromMaybeEraIndexedEpochToPerasRoundInfo ::
     proxy blk ->
     MaybeEraIndexedEpochToPerasRoundInfo blk ->
     EpochToPerasRoundInfo
-  default fromMaybeEraIndexedEpochToPerasRoundInfo ::
-    MaybeEraIndexedEpochToPerasRoundInfo blk ~ EpochToPerasRoundInfo =>
-    proxy blk ->
-    MaybeEraIndexedEpochToPerasRoundInfo blk ->
-    EpochToPerasRoundInfo
-  fromMaybeEraIndexedEpochToPerasRoundInfo _ =
-    id
 
   -- | Inject an era-indexed 'EpochToPerasRoundInfo' into an opaque
   -- 'MaybeEraIndexedEpochToPerasRoundInfo' of this block.
@@ -553,13 +538,6 @@ class
     proxy blk ->
     EraIndexed (HardForkIndices blk) EpochToPerasRoundInfo ->
     MaybeEraIndexedEpochToPerasRoundInfo blk
-  default toMaybeEraIndexedEpochToPerasRoundInfo ::
-    MaybeEraIndexedEpochToPerasRoundInfo blk ~ EpochToPerasRoundInfo =>
-    proxy blk ->
-    EraIndexed (HardForkIndices blk) EpochToPerasRoundInfo ->
-    MaybeEraIndexedEpochToPerasRoundInfo blk
-  toMaybeEraIndexedEpochToPerasRoundInfo _ =
-    forgetEraIndex
 
   -- | Create a bounded epoch context from a given epoch-to-round info.
   mkBoundedPerasEpochContext ::
@@ -572,16 +550,6 @@ class
     Either
       (PerasError blk)
       (BoundedPerasEpochContext blk)
-  default mkBoundedPerasEpochContext ::
-    MaybeEraIndexedEpochToPerasRoundInfo blk ->
-    ledgerState EmptyMK ->
-    chainDepState ->
-    Either
-      (PerasError blk)
-      (BoundedPerasEpochContext blk)
-  mkBoundedPerasEpochContext _ _ _ =
-    error
-      "mkBoundedPerasEpochContext: should never be called for this block type since it does not support Peras"
 
 -- | Helper to build a 'BoundedPerasEpochContext' using a function that produces
 -- a 'PerasVotingCommitteeInput' from a ledger and chain-dep state.

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Storage/TestBlock.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Storage/TestBlock.hs
@@ -100,6 +100,7 @@ import Ouroboros.Consensus.HardFork.Abstract
 import Ouroboros.Consensus.HardFork.Combinator.Abstract
   ( ImmutableEraParams (immutableEraParams)
   )
+import Ouroboros.Consensus.HardFork.History (EpochToPerasRoundInfo, forgetEraIndex)
 import qualified Ouroboros.Consensus.HardFork.History as HardFork
 import Ouroboros.Consensus.HardFork.History.EraParams
   ( EraParams (eraGenesisWin)
@@ -114,6 +115,7 @@ import Ouroboros.Consensus.Ledger.Tables.Utils
 import Ouroboros.Consensus.Node.ProtocolInfo
 import Ouroboros.Consensus.Node.Run
 import Ouroboros.Consensus.NodeId
+import Ouroboros.Consensus.Peras.Context (StateSupportsPerasEpochContext (..))
 import Ouroboros.Consensus.Protocol.Abstract
 import Ouroboros.Consensus.Protocol.BFT
 import Ouroboros.Consensus.Protocol.ModChainSel
@@ -729,6 +731,12 @@ instance LedgerStateSupportsPeras (Ticked LedgerState TestBlock)
 instance HasHardForkHistory TestBlock where
   type HardForkIndices TestBlock = '[TestBlock]
   hardForkSummary = neverForksHardForkSummary id
+
+instance StateSupportsPerasEpochContext TestBlock where
+  type MaybeEraIndexedEpochToPerasRoundInfo TestBlock = EpochToPerasRoundInfo
+  toMaybeEraIndexedEpochToPerasRoundInfo _ = forgetEraIndex
+  fromMaybeEraIndexedEpochToPerasRoundInfo _ = id
+  mkBoundedPerasEpochContext = error "mkBoundedPerasEpochContext: TestBlock does not support Peras"
 
 instance InspectLedger TestBlock
 

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/TestBlock.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/TestBlock.hs
@@ -130,17 +130,20 @@ import Ouroboros.Consensus.HardFork.Abstract
 import Ouroboros.Consensus.HardFork.Combinator.Abstract
   ( ImmutableEraParams (immutableEraParams)
   )
+import Ouroboros.Consensus.HardFork.History (EpochToPerasRoundInfo, forgetEraIndex)
 import qualified Ouroboros.Consensus.HardFork.History as HardFork
 import Ouroboros.Consensus.HeaderValidation
 import Ouroboros.Consensus.Ledger.Abstract
 import Ouroboros.Consensus.Ledger.Extended
 import Ouroboros.Consensus.Ledger.Inspect
 import Ouroboros.Consensus.Ledger.Query
+import Ouroboros.Consensus.Ledger.SupportsPeras (LedgerStateSupportsPeras)
 import Ouroboros.Consensus.Ledger.SupportsProtocol
 import Ouroboros.Consensus.Ledger.Tables.Utils
 import Ouroboros.Consensus.Node.NetworkProtocolVersion
 import Ouroboros.Consensus.Node.ProtocolInfo
 import Ouroboros.Consensus.NodeId
+import Ouroboros.Consensus.Peras.Context (StateSupportsPerasEpochContext (..))
 import Ouroboros.Consensus.Peras.SelectView (weightedSelectView)
 import Ouroboros.Consensus.Peras.Weight (PerasWeightSnapshot)
 import Ouroboros.Consensus.Protocol.Abstract
@@ -736,6 +739,26 @@ instance ImmutableEraParams (TestBlockWith ptype) where
   immutableEraParams = tblcHardForkParams . topLevelConfigLedger
 
 {-------------------------------------------------------------------------------
+  Peras
+-------------------------------------------------------------------------------}
+
+instance LedgerStateSupportsPeras (LedgerState (TestBlockWith ptype))
+
+instance LedgerStateSupportsPeras (Ticked LedgerState (TestBlockWith ptype))
+
+instance HasHardForkHistory (TestBlockWith ptype) where
+  type HardForkIndices (TestBlockWith ptype) = '[TestBlockWith ptype]
+  hardForkSummary = neverForksHardForkSummary tblcHardForkParams
+
+-- TODO: this instance will have a full (mocked) implementation as soon as we
+-- remove the degenerate 'BlockSupportsPeras' instance.
+instance Typeable ptype => StateSupportsPerasEpochContext (TestBlockWith ptype) where
+  type MaybeEraIndexedEpochToPerasRoundInfo (TestBlockWith ptype) = EpochToPerasRoundInfo
+  toMaybeEraIndexedEpochToPerasRoundInfo _ = forgetEraIndex
+  fromMaybeEraIndexedEpochToPerasRoundInfo _ = id
+  mkBoundedPerasEpochContext = error "mkBoundedPerasEpochContext: TestBlockWith does not support Peras"
+
+{-------------------------------------------------------------------------------
   Test blocks without payload
 -------------------------------------------------------------------------------}
 
@@ -749,10 +772,6 @@ data instance CodecConfig TestBlock = TestBlockCodecConfig
 -- | The 'TestBlock' does not need any storage config
 data instance StorageConfig TestBlock = TestBlockStorageConfig
   deriving (Show, Generic, NoThunks)
-
-instance HasHardForkHistory TestBlock where
-  type HardForkIndices TestBlock = '[TestBlock]
-  hardForkSummary = neverForksHardForkSummary tblcHardForkParams
 
 data instance BlockQuery TestBlock fp result where
   QueryLedgerTip :: BlockQuery TestBlock QFNoTables (Point TestBlock)

--- a/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Node/Peras.hs
+++ b/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Node/Peras.hs
@@ -1,0 +1,36 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+-- | Empty Peras support for the mock block.
+--
+-- NOTE: this module exists solely because the orphan module
+-- 'Ouroboros.Consensus.Mock.Node.Serialisation' needs some of the these
+-- instances, but defining them there would be too confusing.
+module Ouroboros.Consensus.Mock.Node.Peras () where
+
+import Data.Typeable (Typeable)
+import Ouroboros.Consensus.Block (BlockProtocol)
+import Ouroboros.Consensus.HardFork.History (EpochToPerasRoundInfo, forgetEraIndex)
+import Ouroboros.Consensus.Mock.Ledger.Block (SimpleBlock, SimpleCrypto)
+import Ouroboros.Consensus.Peras.Context (StateSupportsPerasEpochContext (..))
+import Ouroboros.Consensus.Protocol.Abstract
+  ( ChainDepState
+  , ChainDepStateSupportsPeras
+  )
+import Ouroboros.Consensus.Ticked (Ticked)
+
+instance
+  ( SimpleCrypto c
+  , Typeable ext
+  , ChainDepStateSupportsPeras (ChainDepState (BlockProtocol (SimpleBlock c ext)))
+  , ChainDepStateSupportsPeras (Ticked (ChainDepState (BlockProtocol (SimpleBlock c ext))))
+  ) =>
+  StateSupportsPerasEpochContext (SimpleBlock c ext)
+  where
+  type MaybeEraIndexedEpochToPerasRoundInfo (SimpleBlock c ext) = EpochToPerasRoundInfo
+  toMaybeEraIndexedEpochToPerasRoundInfo _ = forgetEraIndex
+  fromMaybeEraIndexedEpochToPerasRoundInfo _ = id
+  mkBoundedPerasEpochContext = error "mkBoundedPerasEpochContext: SimpleBlock does not support Peras"

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/LedgerDB/StateMachine/TestBlock.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/LedgerDB/StateMachine/TestBlock.hs
@@ -45,7 +45,6 @@ import Data.Word
 import GHC.Generics (Generic)
 import Ouroboros.Consensus.Block
 import Ouroboros.Consensus.Config
-import Ouroboros.Consensus.HardFork.Abstract
 import Ouroboros.Consensus.Ledger.Abstract
 import Ouroboros.Consensus.Ledger.Extended
 import Ouroboros.Consensus.Ledger.Tables.Utils
@@ -268,10 +267,6 @@ instance ToExpr (ExtLedgerState TestBlock ValuesMK) where
 
 instance ToExpr (LedgerState (TestBlockWith Tx) ValuesMK) where
   toExpr = genericToExpr
-
-instance HasHardForkHistory TestBlock where
-  type HardForkIndices TestBlock = '[TestBlock]
-  hardForkSummary = neverForksHardForkSummary tblcHardForkParams
 
 {-------------------------------------------------------------------------------
   TestBlock generation


### PR DESCRIPTION
This commit introduces the necessary `StateSupportsPerasEpochContext` instances for the different block types in the codebase.

NOTE: some of these instances currently use the default empty implementation until we get rid of the degenerate `BlockSupportsPeras` instance in the near future.