### PR TITLE
Leios: move vote validation outside the STM transaction

### DIFF
--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosVoteState.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosVoteState.hs
@@ -83,57 +83,65 @@ newLeiosVoteState getCommittee = do
   pointStates <- atomically $ newTVar (Map.empty :: Map RbHash PointState)
   pure
     LeiosVoteState
-      { addVote = \vote -> atomically $ do
-          seen <- readTVar seenVotes
-          if Set.member vote seen
+      { addVote = \vote -> do
+          -- Validate outside the transaction: the BLS pairing is ms-scale, and
+          -- inside 'atomically' every conflicting commit re-ran it. Worst case
+          -- now is one redundant verification per concurrently-received duplicate.
+          alreadySeen <- atomically $ Set.member vote <$> readTVar seenVotes
+          if alreadySeen
             then pure AlreadyKnown
             else do
               -- TODO: disallow votes from different epoch (than the committee is).
               -- Could use slot numbers or put epoch into votes to distinguish?
-              getCommittee >>= \case
+              mCommittee <- atomically getCommittee
+              case mCommittee of
                 Nothing -> pure NoCommittee
                 Just committee ->
                   case validateLeiosVote committee vote of
                     Left reason -> pure $ VoteInvalid reason
-                    Right weight -> do
-                      writeTVar seenVotes $! Set.insert vote seen
-                      writeTChan votesChan vote
+                    Right weight -> atomically $ do
+                      seen <- readTVar seenVotes
+                      if Set.member vote seen
+                        then pure AlreadyKnown
+                        else do
+                          writeTVar seenVotes $! Set.insert vote seen
+                          writeTChan votesChan vote
 
-                      -- FIXME: This code is not only ugly, but we need to also
-                      -- keep track of which committee the cert is for. We shall
-                      -- only use the cert (return on queryCert) if we are in
-                      -- the same epoch as when it was aggregated / the
-                      -- committee still the same.
+                          -- FIXME: This code is not only ugly, but we need to also
+                          -- keep track of which committee the cert is for. We shall
+                          -- only use the cert (return on queryCert) if we are in
+                          -- the same epoch as when it was aggregated / the
+                          -- committee still the same.
 
-                      -- Update the per-point tally, assembling (and
-                      -- caching) the certificate the first time the
-                      -- threshold is crossed.
-                      states <- readTVar pointStates
-                      let pst = Map.findWithDefault emptyPointState vote.announcingRbHash states
-                          pst' =
-                            pst
-                              { psVoters =
-                                  Map.insert vote.voterId (weight, vote.voteSignature) pst.psVoters
-                              }
-                          totalW = sum [w | (w, _) <- Map.elems pst'.psVoters]
-                          pst'' = case pst.psCert of
-                            Just _ -> pst'
-                            Nothing
-                              | totalW >= minCertificationThreshold ->
-                                  -- Voters were validated against this committee before
-                                  -- being added and the per-voter signatures already
-                                  -- passed individual verification, so aggregation must
-                                  -- succeed. TODO: replace 'error' with a tracer.
-                                  case aggregateLeiosCert committee (fmap snd pst'.psVoters) of
-                                    Left e ->
-                                      error $
-                                        "LeiosVoteState.addVote: aggregateLeiosCert "
-                                          <> "failed on validated votes; should not happen: "
-                                          <> show e
-                                    Right cert -> pst'{psCert = Just cert}
-                              | otherwise -> pst'
-                      writeTVar pointStates $! Map.insert vote.announcingRbHash pst'' states
-                      pure $ Added weight pst''.psCert
+                          -- Update the per-point tally, assembling (and
+                          -- caching) the certificate the first time the
+                          -- threshold is crossed.
+                          states <- readTVar pointStates
+                          let pst = Map.findWithDefault emptyPointState vote.announcingRbHash states
+                              pst' =
+                                pst
+                                  { psVoters =
+                                      Map.insert vote.voterId (weight, vote.voteSignature) pst.psVoters
+                                  }
+                              totalW = sum [w | (w, _) <- Map.elems pst'.psVoters]
+                              pst'' = case pst.psCert of
+                                Just _ -> pst'
+                                Nothing
+                                  | totalW >= minCertificationThreshold ->
+                                      -- Voters were validated against this committee before
+                                      -- being added and the per-voter signatures already
+                                      -- passed individual verification, so aggregation must
+                                      -- succeed. TODO: replace 'error' with a tracer.
+                                      case aggregateLeiosCert committee (fmap snd pst'.psVoters) of
+                                        Left e ->
+                                          error $
+                                            "LeiosVoteState.addVote: aggregateLeiosCert "
+                                              <> "failed on validated votes; should not happen: "
+                                              <> show e
+                                        Right cert -> pst'{psCert = Just cert}
+                                  | otherwise -> pst'
+                          writeTVar pointStates $! Map.insert vote.announcingRbHash pst'' states
+                          pure $ Added weight pst''.psCert
       , subscribeVotes = do
           chan <- atomically $ dupTChan votesChan
           pure $

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosVoteState.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosVoteState.hs
@@ -93,8 +93,7 @@ newLeiosVoteState getCommittee = do
             else do
               -- TODO: disallow votes from different epoch (than the committee is).
               -- Could use slot numbers or put epoch into votes to distinguish?
-              mCommittee <- atomically getCommittee
-              case mCommittee of
+              atomically getCommittee >>= \case
                 Nothing -> pure NoCommittee
                 Just committee ->
                   case validateLeiosVote committee vote of


### PR DESCRIPTION
## Problem

`addVote` runs the BLS pairing (`validateLeiosVote`) **inside** the `atomically` block that inserts into the shared vote state. Under gossip load every concurrently committing inbound vote aborts the transaction, and every retry re-executes the pairing. On a block producer this holds the node's **own, fully-ready vote** (EB closure downloaded and checked at ~+1.5s) for 5–10 seconds before casting — frequently missing the voting window.

## Change

Dedup peek (duplicates exit with zero crypto) → validate in plain IO (a retry can never re-run the pairing) → short insert transaction that re-checks membership. Worst case introduced: one redundant verification per *concurrently received* duplicate — bounded by receipts, not retries. `aggregateLeiosCert` deliberately stays inside (fires ~once per certified RB); the pre-existing committee-epoch TODO is unchanged and should be reviewed separately.

## Field evidence — reversible A/B/A on a live Musashi BP

Same node (NITEN, 4 vCPU KVM without ADX, `-N2`), same network, same measurement (closure-acquired → own-vote-cast per EB, from node.log timestamps):

| period | binary | votes | p90 | max | holds >5s |
|---|---|---|---|---|---|
| ~21 h | stock | 869 | 5.91s | 10.08s | **114** |
| ~18 h | patched | 901 | 2.14s | 3.12s | **0** |
| 30 min | stock (rollback) | 63 | 6.13s | 10.26s | **8** |
| post-restore | patched | 8+ | 2.51s | 2.51s | **0** |

Specimen from the rollback window: closure acquired at announce+1.0s, own vote cast at announce+11.1s — held 10.1s with everything in hand. The patched windows carried the heavier sustained load (574k inbound vote acquisitions over 18h).

A minimal, dependency-free reproduction of the retry re-execution (dedup-read + expensive step inside `atomically`, execution counter: 1 thread = 1.00×, 4 threads = 2.15×, 10 threads = 1.72×) and the full 1,841-vote dataset + measurement script are available in the field report (Musashi Slack thread).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
