### PR TITLE
Leios prototype: EB validation in vote logic

### DIFF
--- a/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/Block.hs
+++ b/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/Block.hs
@@ -1621,6 +1621,18 @@ instance
       protocolStateLeiosAnnouncement @(ShelleyBlock (Praos c) DijkstraEra) praosSt
     _ -> Nothing
 
+  assumeValidatedClosureTx tx = case tx of
+    GenTxDijkstra inner ->
+      HardForkValidatedGenTx
+        . OneEraValidatedGenTx
+        . TagDijkstra
+        . WrapValidatedGenTx
+        $ assumeValidatedClosureTx inner
+    _ ->
+      -- Only Dijkstra has a Leios closure to validate, so only Dijkstra txs
+      -- ever reach here (see 'resolveLeiosClosure' above).
+      error "assumeValidatedClosureTx: closure tx from a non-Dijkstra era"
+
   leiosClosureTxKeySets tx = case tx of
     GenTxDijkstra inner ->
       injectLedgerTables

--- a/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/Block.hs
+++ b/ouroboros-consensus-cardano/src/ouroboros-consensus-cardano/Ouroboros/Consensus/Cardano/Block.hs
@@ -1550,7 +1550,7 @@ instance
   ResolveLeiosBlock (HardForkBlock (CardanoEras c))
   where
   resolveLeiosClosure db ebHash =
-    fmap GenTxDijkstra
+    fmap (fmap GenTxDijkstra)
       <$> resolveLeiosClosure db ebHash
 
   inlineLeiosClosure blk txs = case blk of

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Leios.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Leios.hs
@@ -7,6 +7,11 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
+-- 'SL.unsafeMakeValidated' is deprecated in favour of the ledger's newer
+-- 'ValidatedTx', which consensus has not moved to yet (see the same FIXME in
+-- "Ouroboros.Consensus.Shelley.Ledger.Mempool"). Suppressed here the way the
+-- sibling Shelley modules do.
+{-# OPTIONS_GHC -Wno-deprecations #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Ouroboros.Consensus.Shelley.Ledger.Leios () where
@@ -85,7 +90,11 @@ import Ouroboros.Consensus.Shelley.Ledger.Ledger
   , ShelleyBasedEra
   , shelleyLedgerGlobals
   )
-import Ouroboros.Consensus.Shelley.Ledger.Mempool (GenTx (ShelleyTx), mkShelleyTx)
+import Ouroboros.Consensus.Shelley.Ledger.Mempool
+  ( GenTx (ShelleyTx)
+  , mkShelleyTx
+  , mkShelleyValidatedTx
+  )
 import Ouroboros.Consensus.Storage.LedgerDB.Forker
   ( OCINStaleness (..)
   , ResolveLeiosBlock (..)
@@ -144,6 +153,12 @@ instance
             <> "Refusing to apply as empty (would diverge UTxO)."
       Just closureEntries ->
         pure $ fmap (mkShelleyTx . deserialiseLeiosTx) <$> closureEntries
+
+  -- The ledger's 'Validated' is a bare newtype over the tx, so rebuilding the
+  -- token costs only the tx-id hash; 'SL.reapplyTx' derives the state-dependent
+  -- annotation itself, so nothing stale rides along.
+  assumeValidatedClosureTx (ShelleyTx _ tx) =
+    mkShelleyValidatedTx (SL.unsafeMakeValidated tx)
 
   leiosClosureTxKeySets = getTransactionKeySets
 

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Leios.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Leios.hs
@@ -143,7 +143,7 @@ instance
             <> "; chain-sel selected a cert-RB without its EB closure. "
             <> "Refusing to apply as empty (would diverge UTxO)."
       Just closureEntries ->
-        pure $ mkShelleyTx . deserialiseLeiosTx . snd <$> closureEntries
+        pure $ fmap (mkShelleyTx . deserialiseLeiosTx) <$> closureEntries
 
   leiosClosureTxKeySets = getTransactionKeySets
 

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Leios.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Leios.hs
@@ -217,7 +217,7 @@ readEbClosure leiosConn ebHash = do
   -- EB closure". Report the absence here.
   ebBody <- leiosDbLookupEbBody leiosConn ebHash
   when (null ebBody) $ error (missingEbBodyError ebHash)
-  txs <- resolveLeiosClosure leiosConn ebHash
+  txs <- map snd <$> resolveLeiosClosure leiosConn ebHash
   pure (txs, sum (snd <$> ebBody))
 
 missingEbBodyError :: EbHash -> String

--- a/ouroboros-consensus-cardano/test/cardano-test/Test/ThreadNet/Leios.hs
+++ b/ouroboros-consensus-cardano/test/cardano-test/Test/ThreadNet/Leios.hs
@@ -370,14 +370,21 @@ prop_leios seed =
       & counterexample ("announced-and-certified slots: " <> show announcedAndCertifiedSlots)
 
   -- In an honest net every acquired closure must apply against the announcing
-  -- RB's ledger state. A rejection here means the voting thread validates
-  -- against the wrong state or the wrong slot, not that anything was invalid.
+  -- RB's ledger state, because 'partitionMempool' cuts both the RB's and the
+  -- EB's transactions out of a single mempool snapshot: the snapshot is
+  -- internally consistent, so its transactions apply in sequence against the
+  -- state it was taken for, and the announcing RB /is/ that state plus its own
+  -- share of the split. The EB's share therefore applies against the RB's
+  -- post-state by construction. So a rejection here cannot mean a transaction
+  -- was bad; it means the voting thread validated against the wrong state or
+  -- the wrong slot.
   propClosuresValidate =
     null closureRejections
       & counterexample "a voter rejected an honestly-produced EB's transactions"
       & prettyCounterexampleList "rejections" 240 closureRejections
       -- The reapply-vs-apply split: how much full validation the LeiosTxCache
-      -- spared us. A forger's own EB should be entirely reapplied.
+      -- spared us. Tabulated only for visibility -- nothing here requires any
+      -- particular ratio.
       & tabulate
         "EB closure validation (reapplied/total)"
         [show reapplied <> "/" <> show (reapplied + applied) | (reapplied, applied) <- validatedSplits]
@@ -817,13 +824,14 @@ endorseInvalidTx adversary nid tni
 -- behaviour we care about. This tx is unsigned for the same reason — the
 -- signature is irrelevant to the check that has to catch it.
 --
--- Forced, because 'ForgedLeiosEb' and the forge path run 'NoThunks'
--- invariants over what they are handed.
 -- 'assumeValidatedClosureTx' is how the adversary lies: it stamps the tx as
 -- mempool-validated so the forge will endorse it, which is exactly the claim a
 -- voter is now supposed to disbelieve.
 invalidEbTx :: Validated (GenTx (CardanoBlock StandardCrypto))
-invalidEbTx = assumeValidatedClosureTx (GenTxDijkstra (mkShelleyTx (force tx)))
+invalidEbTx =
+  -- 'force'd because 'ForgedLeiosEb' and the forge path run 'NoThunks'
+  -- invariants over what they are handed, as the mempool does in 'respendTx'.
+  assumeValidatedClosureTx (GenTxDijkstra (mkShelleyTx (force tx)))
  where
   tx :: Tx TopTx DijkstraEra
   tx = mkBasicTx (mkBasicTxBody & inputsTxBodyL .~ Set.singleton phantomInput)

--- a/ouroboros-consensus-cardano/test/cardano-test/Test/ThreadNet/Leios.hs
+++ b/ouroboros-consensus-cardano/test/cardano-test/Test/ThreadNet/Leios.hs
@@ -74,6 +74,7 @@ import LeiosDemoTypes
   ( LeiosNotVotedReason (..)
   , LeiosPoint (..)
   , LeiosVote (..)
+  , RbHash (..)
   , TraceLeiosKernel (..)
   , hashLeiosEb
   , minCertificationGap
@@ -304,9 +305,10 @@ prop_leios seed =
         -- counts shrugs off the spurious 'TraceLeiosVoteAcquired's emitted
         -- by 'NodeToNode' for relay-redelivered votes that 'addVote'
         -- already classified 'AlreadyKnown'.
-        Set.size acquiredVotePairs === numNodes * Set.size castVotes
+        Set.size votePairsToDiffuse === numNodes * Set.size votesToDiffuse
           & counterexample "created votes not diffused"
           & counterexample ("cast votes: " <> show (Set.size castVotes))
+          & counterexample ("votes required to diffuse: " <> show (Set.size votesToDiffuse))
           & counterexample
             ( "acquired (node, vote) pairs: "
                 <> show (Set.size acquiredVotePairs)
@@ -329,6 +331,23 @@ prop_leios seed =
 
   -- Which EB slot each announcing RB hash announced, so that a vote can be
   -- dated: 'LeiosVote' carries only the hash it signed.
+  -- Which EB each announcing RB hash announced, so that a vote can be dated:
+  -- 'LeiosVote' carries only the hash it signed.
+  announcedPoints :: Map RbHash LeiosPoint
+  announcedPoints = Map.fromList . flip mapMaybe leiosTraces $ \case
+    TraceLeiosBlockAnnounced{announcingRbHashBytes, announcedEbPoint} ->
+      Just (MkRbHash announcingRbHashBytes, announcedEbPoint)
+    _ -> Nothing
+
+  -- Same requirement the EB diffusion properties make, one step further along:
+  -- a vote is required to have diffused iff its EB had 'minCertificationGap'
+  -- slots left to propagate. A vote cast near the end of the sim can still be
+  -- in flight when it stops, which says nothing about diffusion.
+  votesToDiffuse =
+    flip Set.filter castVotes $ \vote ->
+      maybe False diffusionRequired (Map.lookup vote.announcingRbHash announcedPoints)
+
+  votePairsToDiffuse = Set.filter ((`Set.member` votesToDiffuse) . snd) acquiredVotePairs
 
   -- Distinct (node, vote) pairs from 'TraceLeiosVoteAcquired'. A vote
   -- received multiple times by the same node (e.g. relayed back via a

--- a/ouroboros-consensus-cardano/test/cardano-test/Test/ThreadNet/Leios.hs
+++ b/ouroboros-consensus-cardano/test/cardano-test/Test/ThreadNet/Leios.hs
@@ -329,8 +329,6 @@ prop_leios seed =
     TraceLeiosVoted{vote} -> Just vote
     _ -> Nothing
 
-  -- Which EB slot each announcing RB hash announced, so that a vote can be
-  -- dated: 'LeiosVote' carries only the hash it signed.
   -- Which EB each announcing RB hash announced, so that a vote can be dated:
   -- 'LeiosVote' carries only the hash it signed.
   announcedPoints :: Map RbHash LeiosPoint
@@ -775,6 +773,7 @@ prop_leios_invalid_eb seed
     ChainTipDoesNotAnnounce -> "ChainTipDoesNotAnnounce"
     TooLate -> "TooLate"
     NotOnCommittee -> "NotOnCommittee"
+    VoteRejected{} -> "VoteRejected"
 
 -- | The EB points certified by a chain's CertRBs. A CertRB carries no
 -- announcement of its own for the EB it certifies; the announcement lives on

--- a/ouroboros-consensus-cardano/test/cardano-test/Test/ThreadNet/Leios.hs
+++ b/ouroboros-consensus-cardano/test/cardano-test/Test/ThreadNet/Leios.hs
@@ -71,7 +71,8 @@ import LeiosDemoDb
   , withLeiosDb
   )
 import LeiosDemoTypes
-  ( LeiosPoint (..)
+  ( LeiosNotVotedReason (..)
+  , LeiosPoint (..)
   , LeiosVote (..)
   , TraceLeiosKernel (..)
   , hashLeiosEb
@@ -79,8 +80,13 @@ import LeiosDemoTypes
   , prettyEbHash
   , prettyLeiosPoint
   )
-import Lens.Micro ((%~), (^.))
+import Lens.Micro ((%~), (.~), (^.))
 import Ouroboros.Consensus.Block (SlotNo (..), blockSlot, getHeader)
+import Ouroboros.Consensus.Block.Forging
+  ( BlockForging (..)
+  , ForgeBlockArgs (..)
+  , MkBlockForging (..)
+  )
 import Ouroboros.Consensus.Cardano
   ( CardanoBlock
   , Nonce (NeutralNonce)
@@ -88,7 +94,11 @@ import Ouroboros.Consensus.Cardano
   , ProtocolParamsShelleyBased (..)
   , ShelleyGenesis (..)
   )
-import Ouroboros.Consensus.Cardano.Block (pattern BlockDijkstra, pattern LedgerStateDijkstra)
+import Ouroboros.Consensus.Cardano.Block
+  ( pattern BlockDijkstra
+  , pattern GenTxDijkstra
+  , pattern LedgerStateDijkstra
+  )
 import Ouroboros.Consensus.Cardano.Node (CardanoProtocolParams (..), protocolInfoCardano)
 import Ouroboros.Consensus.Config (SecurityParam (..), TopLevelConfig, configLedger)
 import Ouroboros.Consensus.HeaderValidation (headerStateChainDep)
@@ -103,7 +113,7 @@ import Ouroboros.Consensus.Ledger.Extended
   , ExtLedgerState (..)
   , ledgerState
   )
-import Ouroboros.Consensus.Ledger.SupportsMempool (extractTxs)
+import Ouroboros.Consensus.Ledger.SupportsMempool (GenTx, extractTxs)
 import Ouroboros.Consensus.Ledger.Tables.MapKind (EmptyMK, ValuesMK)
 import Ouroboros.Consensus.Ledger.Tables.Utils (applyDiffs, forgetLedgerTables)
 import Ouroboros.Consensus.Mempool (TraceEventMempool (..))
@@ -115,6 +125,7 @@ import Ouroboros.Consensus.Shelley.Ledger.Ledger
   , shelleyLedgerState
   , shelleyLedgerTip
   )
+import Ouroboros.Consensus.Shelley.Ledger.Mempool (mkShelleyTx)
 import Ouroboros.Consensus.Shelley.Ledger.SupportsProtocol ()
 import Ouroboros.Consensus.Storage.LedgerDB (ResolveLeiosBlock (..))
 import qualified Ouroboros.Network.Mock.Chain as Chain
@@ -133,6 +144,7 @@ import Test.QuickCheck
   , choose
   , conjoin
   , counterexample
+  , discard
   , forAll
   , ioProperty
   , property
@@ -188,6 +200,8 @@ tests =
         testProperty "basic functionality" prop_leios
     , adjustQuickCheckTests (`div` 10) $
         testProperty "late join" prop_leios_late_join
+    , adjustQuickCheckTests (`div` 10) $
+        testProperty "invalid endorsed tx is not certified" prop_leios_invalid_eb
     ]
 
 -- | Verify a suite of basic Leios ThreadNet invariants in a single run:
@@ -310,6 +324,9 @@ prop_leios seed =
   castVotes = Set.fromList . flip mapMaybe leiosTraces $ \case
     TraceLeiosVoted{vote} -> Just vote
     _ -> Nothing
+
+  -- Which EB slot each announcing RB hash announced, so that a vote can be
+  -- dated: 'LeiosVote' carries only the hash it signed.
 
   -- Distinct (node, vote) pairs from 'TraceLeiosVoteAcquired'. A vote
   -- received multiple times by the same node (e.g. relayed back via a
@@ -573,6 +590,214 @@ prop_leios_late_join seed =
  where
   numSlots = 200 :: Word64
 
+-- | An EB whose closure cannot apply must never be certified: the committee is
+-- supposed to validate the endorsed transactions before signing a vote.
+--
+-- 4 nodes, 200 slots, node 1 adversarial. Only the EBs it announces carry the
+-- bogus tx — its RBs stay honest — so the chain keeps growing and the honest
+-- nodes' own EBs still certify, which is what makes 'poisonedNeverCertified'
+-- more than a statement about a stalled network.
+prop_leios_invalid_eb :: Seed -> Property
+prop_leios_invalid_eb seed
+  -- An unlucky seed where the adversary never led early enough to announce an
+  -- EB with time to diffuse. There is nothing to conclude either way, so don't
+  -- count the run rather than passing it vacuously.
+  | Set.null poisonedPointsToDiffuse = discard
+  -- Whether any honest EB reaches quorum is seed-dependent: votes scatter
+  -- across forks, so a 4-node run can finish with nothing certified at all.
+  -- Such a run cannot tell "the poisoned EB was rejected" apart from "nothing
+  -- was certified", so it is no evidence either -- discard rather than fail.
+  | Set.null honestCertifiedPoints = discard
+  | otherwise =
+      conjoin
+        [ adversaryWasEffective
+            & counterexample "[failed] adversaryWasEffective"
+        , poisonedNeverCertified
+            & counterexample "[failed] poisonedNeverCertified"
+        , poisonedNeverValidated
+            & counterexample "[failed] poisonedNeverValidated"
+        , validationDidRun
+            & counterexample "[failed] validationDidRun"
+        , isNothing testOutput.exceptionThrown
+            & counterexample "[failed] test threw an exception"
+            & prettyCounterexampleList "all traces" 120 (show <$> traces)
+        ]
+        & tabulate "poisoned EB turned down on" poisonedNotVotedReasons
+ where
+  adversary = CoreNodeId 1
+
+  numCoreNodes = NumCoreNodes 4
+
+  numSlots = 200 :: Word64
+
+  (testOutput, _) =
+    runThreadNet'
+      seed
+      (NumSlots numSlots)
+      numCoreNodes
+      (trivialNodeJoinPlan numCoreNodes)
+      (endorseInvalidTx adversary)
+
+  traces = testOutput.allTraces
+
+  -- 'TraceLeiosBlockForged' is emitted by the forger only, so the emitting
+  -- node id attributes each EB to whoever made it.
+  forgedBy nid = Set.fromList $ flip mapMaybe traces $ \case
+    FromNode nid' (FromLeios TraceLeiosBlockForged{slot, eb})
+      | nid' == nid ->
+          Just (MkLeiosPoint slot (hashLeiosEb eb))
+    _ -> Nothing
+
+  poisonedPoints = forgedBy adversary
+
+  -- Only EBs forged early enough to have 'minCertificationGap' slots left can
+  -- be expected to reach an honest node at all — the same bound 'prop_leios'
+  -- uses for diffusion.
+  poisonedPointsToDiffuse =
+    Set.filter
+      (\p -> unSlotNo p.pointSlotNo + minCertificationGap <= numSlots)
+      poisonedPoints
+
+  acquiredByHonest = Set.fromList $ flip mapMaybe traces $ \case
+    FromNode nid (FromLeios (TraceLeiosBlockTxsAcquired point _age))
+      | nid /= adversary -> Just point
+    _ -> Nothing
+
+  -- Ground truth from the adopted chains rather than from vote traces: a
+  -- CertRB certifies the EB that its parent's header announced.
+  certifiedPoints = foldMap certifiedEbPoints nodeChains
+
+  nodeChains = Chain.toOldestFirst . nodeOutputFinalChain <$> testOutput.testOutputNodes
+
+  -- Guard against a vacuous pass: a poisoned EB must actually have reached an
+  -- honest node's closure, or nobody was ever in a position to vote on one.
+  adversaryWasEffective =
+    not (Set.null (Set.intersection poisonedPointsToDiffuse acquiredByHonest))
+      & counterexample "no honest node acquired a poisoned EB's closure"
+      & prettyCounterexampleList "poisoned EBs (diffusion required)" 120 poisonedPointsToDiffuse
+      & prettyCounterexampleList "acquired by honest nodes" 120 acquiredByHonest
+
+  poisonedNeverCertified =
+    Set.intersection poisonedPoints certifiedPoints === Set.empty
+      & counterexample "a poisoned EB was certified"
+      & prettyCounterexampleList "poisoned EBs" 120 poisonedPoints
+      & prettyCounterexampleList "certified EBs" 120 certifiedPoints
+
+  -- The EBs certified in this run that were not the adversary's. Empty means
+  -- the run proves nothing, which is a discard above rather than a failure.
+  honestCertifiedPoints = Set.difference certifiedPoints poisonedPoints
+
+  -- A poisoned closure cannot apply, so no node may ever report it validated.
+  -- Unlike 'poisonedNeverCertified' this holds even when the vote never got
+  -- close — it is the invariant, not the outcome.
+  poisonedNeverValidated =
+    Set.null (Set.intersection poisonedPoints validatedPoints)
+      & counterexample "an EB carrying the bogus tx was reported as validated"
+      & prettyCounterexampleList "validated EBs" 120 validatedPoints
+
+  -- Non-vacuity for the validation path itself: some honest EB must have gone
+  -- through it. Without this the property would also pass on a build where
+  -- voting never validates anything.
+  validationDidRun =
+    not (Set.null (Set.difference validatedPoints poisonedPoints))
+      & counterexample "no EB's transactions were ever validated"
+      & prettyCounterexampleList "validated EBs" 120 validatedPoints
+
+  validatedPoints = Set.fromList $ flip mapMaybe leiosTraces $ \case
+    TraceLeiosEbValidated{ebPoint} -> Just ebPoint
+    _ -> Nothing
+
+  leiosTraces = [ev | FromNode _ (FromLeios ev) <- traces]
+
+  -- How the poisoned EBs were actually turned down: on their transactions, or
+  -- earlier on one of the cheap gates. Only the former exercises validation,
+  -- and which one happens depends on chain-tip timing, so report it rather
+  -- than requiring it.
+  poisonedNotVotedReasons =
+    [ reasonLabel reason
+    | FromNode _ (FromLeios TraceLeiosNotVoted{ebPoint, reason}) <- traces
+    , Set.member ebPoint poisonedPoints
+    ]
+
+  reasonLabel = \case
+    EbTxsInvalid{} -> "EbTxsInvalid"
+    ChainTipDoesNotAnnounce -> "ChainTipDoesNotAnnounce"
+    TooLate -> "TooLate"
+    NotOnCommittee -> "NotOnCommittee"
+
+-- | The EB points certified by a chain's CertRBs. A CertRB carries no
+-- announcement of its own for the EB it certifies; the announcement lives on
+-- its parent's header, so walk the chain carrying the previous announcement —
+-- the same traversal 'sumChainTxBytes' uses to resolve closures.
+certifiedEbPoints :: [CardanoBlock StandardCrypto] -> Set.Set LeiosPoint
+certifiedEbPoints = go Nothing
+ where
+  go _ [] = Set.empty
+  go prevAnn (blk : rest) =
+    here <> go (fst <$> headerLeiosAnnouncement (getHeader blk)) rest
+   where
+    here = case (blockLeiosCert blk, prevAnn) of
+      (Just _, Just point) -> Set.singleton point
+      _ -> Set.empty
+
+-- * Misbehaving nodes
+
+-- | Make one node endorse a transaction that can never apply, by appending
+-- 'invalidEbTx' to the txs it draws for the EB it is about to announce.
+-- 'fbRbTxs' is untouched, so the announcing RB itself stays valid.
+endorseInvalidTx ::
+  Functor m =>
+  -- | Which node misbehaves; every other node is left alone.
+  CoreNodeId ->
+  CoreNodeId ->
+  TestNodeInitialization m (CardanoBlock StandardCrypto) ->
+  TestNodeInitialization m (CardanoBlock StandardCrypto)
+endorseInvalidTx adversary nid tni
+  | nid /= adversary = tni
+  | otherwise =
+      tni{tniBlockForging = map (mapMkBlockForging poison) <$> tniBlockForging tni}
+ where
+  poison bf =
+    bf
+      { forgeBlock = \args ->
+          forgeBlock bf args{fbEbTxs = fbEbTxs args <> [invalidEbTx]}
+      }
+
+-- | A Dijkstra transaction that spends an output which does not exist: its
+-- input names the id of a transaction that is never applied anywhere, so the
+-- UTxO rule must reject it with 'BadInputsUTxO'.
+--
+-- Deliberately a /state-dependent/ failure rather than a missing-witness one:
+-- a missing witness is a static check, which is exactly what the reapply path
+-- is allowed to skip, so a witness-only failure would not pin down the
+-- behaviour we care about. This tx is unsigned for the same reason — the
+-- signature is irrelevant to the check that has to catch it.
+--
+-- Forced, because 'ForgedLeiosEb' and the forge path run 'NoThunks'
+-- invariants over what they are handed.
+-- 'assumeValidatedClosureTx' is how the adversary lies: it stamps the tx as
+-- mempool-validated so the forge will endorse it, which is exactly the claim a
+-- voter is now supposed to disbelieve.
+invalidEbTx :: Validated (GenTx (CardanoBlock StandardCrypto))
+invalidEbTx = assumeValidatedClosureTx (GenTxDijkstra (mkShelleyTx (force tx)))
+ where
+  tx :: Tx TopTx DijkstraEra
+  tx = mkBasicTx (mkBasicTxBody & inputsTxBodyL .~ Set.singleton phantomInput)
+
+  phantomInput = TxIn (txIdTx phantomTx) (TxIx 0)
+
+  -- Never submitted, never forged: its id therefore never appears in any UTxO.
+  phantomTx :: Tx TopTx DijkstraEra
+  phantomTx = mkBasicTx mkBasicTxBody
+
+-- | Rewrap the 'BlockForging' a 'MkBlockForging' allocates.
+mapMkBlockForging ::
+  Functor m =>
+  (BlockForging m blk -> BlockForging m blk) ->
+  MkBlockForging m blk ->
+  MkBlockForging m blk
+mapMkBlockForging f (MkBlockForging alloc) = MkBlockForging (f <$> alloc)
+
 -- | Independently compute cumulative tx bytes by resolving each block in the
 -- chain (filling in EB closures from the LeiosDB via 'inlineLeiosClosure')
 -- and summing individual 'sizeTxF' values per transaction.
@@ -684,19 +909,39 @@ runThreadNet ::
   NodeJoinPlan ->
   (TestOutput (CardanoBlock StandardCrypto), ProtocolInfo (CardanoBlock StandardCrypto))
 runThreadNet initSeed numSlots numCoreNodes joinPlan =
+  runThreadNet' initSeed numSlots numCoreNodes joinPlan (\_nid -> id)
+
+-- | 'runThreadNet' with a per-node tweak of the node's initialization, for
+-- tests that need one node to misbehave. Tweaking the whole
+-- 'TestNodeInitialization' rather than just its 'BlockForging' means a test can
+-- reach the protocol info and the crucial txs too; see 'endorseInvalidTx'.
+runThreadNet' ::
+  Seed ->
+  NumSlots ->
+  NumCoreNodes ->
+  NodeJoinPlan ->
+  ( forall m.
+    Functor m =>
+    CoreNodeId ->
+    TestNodeInitialization m (CardanoBlock StandardCrypto) ->
+    TestNodeInitialization m (CardanoBlock StandardCrypto)
+  ) ->
+  (TestOutput (CardanoBlock StandardCrypto), ProtocolInfo (CardanoBlock StandardCrypto))
+runThreadNet' initSeed numSlots numCoreNodes joinPlan tweakNodeInit =
   ( runTestNetwork
       testConfig
       testConfigB
       TestConfigMB
-        { nodeInfo = \(CoreNodeId nid) -> do
+        { nodeInfo = \coreNodeId@(CoreNodeId nid) -> do
             fs <- SomeHasFS <$> Sim.simHasFS' MockFS.empty
             (protocolInfo, blockForging) <- protocolInfoCardano fs (cardanoProtocolParams nid)
-            pure
-              TestNodeInitialization
-                { tniProtocolInfo = protocolInfo
-                , tniCrucialTxs = []
-                , tniBlockForging = blockForging Tracer.nullTracer
-                }
+            pure $
+              tweakNodeInit coreNodeId $
+                TestNodeInitialization
+                  { tniProtocolInfo = protocolInfo
+                  , tniCrucialTxs = []
+                  , tniBlockForging = blockForging Tracer.nullTracer
+                  }
         , mkRekeyM = Nothing
         }
   , protocolInfo0

--- a/ouroboros-consensus-cardano/test/cardano-test/Test/ThreadNet/Leios.hs
+++ b/ouroboros-consensus-cardano/test/cardano-test/Test/ThreadNet/Leios.hs
@@ -238,6 +238,8 @@ prop_leios seed =
         & counterexample "[failed] propCertifying"
     , propCertifyAndAnnounce
         & counterexample "[failed] propCertifyAndAnnounce"
+    , propClosuresValidate
+        & counterexample "[failed] propClosuresValidate"
     ]
  where
   numNodes = 3 :: Int
@@ -347,6 +349,29 @@ prop_leios seed =
       & counterexample "no block both certified and announced"
       & counterexample ("certifying block slots: " <> show certificateBlocks)
       & counterexample ("announced-and-certified slots: " <> show announcedAndCertifiedSlots)
+
+  -- In an honest net every acquired closure must apply against the announcing
+  -- RB's ledger state. A rejection here means the voting thread validates
+  -- against the wrong state or the wrong slot, not that anything was invalid.
+  propClosuresValidate =
+    null closureRejections
+      & counterexample "a voter rejected an honestly-produced EB's transactions"
+      & prettyCounterexampleList "rejections" 240 closureRejections
+      -- The reapply-vs-apply split: how much full validation the LeiosTxCache
+      -- spared us. A forger's own EB should be entirely reapplied.
+      & tabulate
+        "EB closure validation (reapplied/total)"
+        [show reapplied <> "/" <> show (reapplied + applied) | (reapplied, applied) <- validatedSplits]
+
+  closureRejections =
+    [ (nid, ebPoint, err)
+    | FromNode nid (FromLeios TraceLeiosNotVoted{ebPoint, reason = EbTxsInvalid err}) <- traces
+    ]
+
+  validatedSplits =
+    flip mapMaybe leiosTraces $ \case
+      TraceLeiosEbValidated{reapplied, applied} -> Just (reapplied, applied)
+      _ -> Nothing
 
   propCertifying =
     conjoin

--- a/ouroboros-consensus-cardano/test/cardano-test/Test/ThreadNet/Leios.hs
+++ b/ouroboros-consensus-cardano/test/cardano-test/Test/ThreadNet/Leios.hs
@@ -599,7 +599,7 @@ sumChainTxBytes _topConfig _initLedger node = runSimOrThrow $ do
   foldChain leiosDb prevAnn !total (blk : rest) = do
     blk' <- case (blockLeiosCert blk, prevAnn) of
       (Just _, Just point) ->
-        inlineLeiosClosure blk
+        inlineLeiosClosure blk . map snd
           <$> resolveLeiosClosure leiosDb (pointEbHash point)
       _ -> pure blk
     let nextAnn = fst <$> headerLeiosAnnouncement (getHeader blk)
@@ -665,7 +665,7 @@ foldWithResolution leiosDb cfg blks initState =
         Nothing ->
           error "foldWithResolution: CertRB but no announcement on parent chain-dep state"
         Just (point, _) -> do
-          closureTxs <- resolveLeiosClosure leiosDb (pointEbHash point)
+          closureTxs <- map snd <$> resolveLeiosClosure leiosDb (pointEbHash point)
           let ls = ledgerState state
               lcfg = configLedger (getExtLedgerCfg cfg)
           case applyLeiosClosure lcfg closureTxs ls of

--- a/ouroboros-consensus-cardano/test/cardano-test/Test/ThreadNet/Leios.hs
+++ b/ouroboros-consensus-cardano/test/cardano-test/Test/ThreadNet/Leios.hs
@@ -811,8 +811,13 @@ endorseInvalidTx adversary nid tni
   poison bf =
     bf
       { forgeBlock = \args ->
-          forgeBlock bf args{fbEbTxs = fbEbTxs args <> [invalidEbTx]}
+          forgeBlock bf args{fbEbTxs = fbEbTxs args <> [lie invalidEbTx]}
       }
+  -- The lie is told here and only here: 'assumeValidatedClosureTx' stamps the tx
+  -- as mempool-validated so the forge will endorse it, which is exactly the
+  -- claim a voter is now supposed to disbelieve. Applying it at the use site
+  -- keeps 'invalidEbTx' an ordinary, plainly invalid transaction.
+  lie = assumeValidatedClosureTx
 
 -- | A Dijkstra transaction that spends an output which does not exist: its
 -- input names the id of a transaction that is never applied anywhere, so the
@@ -823,15 +828,11 @@ endorseInvalidTx adversary nid tni
 -- is allowed to skip, so a witness-only failure would not pin down the
 -- behaviour we care about. This tx is unsigned for the same reason — the
 -- signature is irrelevant to the check that has to catch it.
---
--- 'assumeValidatedClosureTx' is how the adversary lies: it stamps the tx as
--- mempool-validated so the forge will endorse it, which is exactly the claim a
--- voter is now supposed to disbelieve.
-invalidEbTx :: Validated (GenTx (CardanoBlock StandardCrypto))
+invalidEbTx :: GenTx (CardanoBlock StandardCrypto)
 invalidEbTx =
   -- 'force'd because 'ForgedLeiosEb' and the forge path run 'NoThunks'
   -- invariants over what they are handed, as the mempool does in 'respendTx'.
-  assumeValidatedClosureTx (GenTxDijkstra (mkShelleyTx (force tx)))
+  GenTxDijkstra (mkShelleyTx (force tx))
  where
   tx :: Tx TopTx DijkstraEra
   tx = mkBasicTx (mkBasicTxBody & inputsTxBodyL .~ Set.singleton phantomInput)

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToNode.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToNode.hs
@@ -565,6 +565,7 @@ mkHandlers
                     traceWith tracer $ MkTraceLeiosPeer $ "MsgLeiosVotes " <> show vs
                     forM_ vs $ \vote -> do
                       result <- addVote vote
+                      -- TODO: Keep track of the running tally (even after certification)
                       traceWith kernelTracer TraceLeiosVoteAcquired{vote}
                       -- A remote vote can be the one that tips this
                       -- node's tally past 'minCertificationThreshold';

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
@@ -322,6 +322,7 @@ initNodeKernel
     , initChainDB
     , blockFetchConfiguration
     , btime
+    , systemTime
     , gsmArgs
     , peerSharingRng
     , publicPeerSelectionStateVar
@@ -582,7 +583,7 @@ initNodeKernel
           (leiosKernelTracer tracers)
           cfg
           chainDB
-          btime
+          systemTime
           leiosDB
           getLeiosTxCache
           leiosVoteState

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
@@ -581,7 +581,7 @@ initNodeKernel
       forkLinkedThread registry "NodeKernel.leiosVoting" $
         runLeiosVoting
           (leiosKernelTracer tracers)
-          cfg
+          (configLedger cfg)
           chainDB
           systemTime
           leiosDB

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
@@ -580,9 +580,11 @@ initNodeKernel
       forkLinkedThread registry "NodeKernel.leiosVoting" $
         runLeiosVoting
           (leiosKernelTracer tracers)
+          cfg
           chainDB
           btime
           leiosDB
+          getLeiosTxCache
           leiosVoteState
           (topLevelConfigVotingKey cfg)
 

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel/Forge.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel/Forge.hs
@@ -753,8 +753,8 @@ partitionMempool leiosConn leiosVoteState leiosTracer pmCtrace pmCallCtx cfg mem
               (ledgerState unticked)
         case res of
           Left err ->
-            -- Should not happen: each closure tx was validated
-            -- when inserted into the LeiosDb. Fail loudly.
+            -- Should not happen: we are certifying this EB, so a quorum of
+            -- the committee applied its closure before signing. Fail loudly.
             error $ "forkBlockForging: applyLeiosClosure failed, announcing no EB. " <> show err
           Right LeiosClosureApplied{lcaStateAfterEB, lcaClosureDiff} -> do
             -- Compose the EB closure diff (relative to the unticked

--- a/ouroboros-consensus.cabal
+++ b/ouroboros-consensus.cabal
@@ -770,6 +770,7 @@ test-suite consensus-test
     Test.LeiosTxCache.Reference
     Test.LeiosUtils.CallTrace
     Test.LeiosVoteState
+    Test.LeiosVoting
 
   build-depends:
     QuickCheck,

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoTypes.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoTypes.hs
@@ -1373,7 +1373,7 @@ data TraceLeiosKernel
   | TraceLeiosVoted {vote :: LeiosVote, weight :: Weight}
   | TraceLeiosVoteAcquired {vote :: LeiosVote}
   | TraceLeiosCertified {rbHash :: RbHash}
-  | -- \| A vote is scheduled to happen.
+  | -- | A vote is scheduled to happen.
     TraceLeiosVoteScheduled
       {ebPoint :: LeiosPoint, voteIn :: NominalDiffTime, deadlineIn :: NominalDiffTime}
   | -- | An 'AcquiredEbTxs' notification arrived but 'runLeiosVoting' chose
@@ -1485,6 +1485,9 @@ data LeiosNotVotedReason
     -- state, so this EB must not be certified. Carries the ledger's rendered
     -- rejection.
     EbTxsInvalid !Text
+  | -- | The vote we signed was not accepted into the tally. Carries the
+    -- rendered 'AddVoteResult'.
+    VoteRejected !Text
   deriving Show
 
 deriving instance Show TraceLeiosKernel
@@ -1705,6 +1708,7 @@ notVotedReasonText = \case
   TooLate -> Aeson.String "tooLate"
   NotOnCommittee -> Aeson.String "notOnCommittee"
   EbTxsInvalid err -> Aeson.String $ "ebTxsInvalid: " <> err
+  VoteRejected err -> Aeson.String $ "voteRejected: " <> err
 
 data TraceLeiosPeer
   = MkTraceLeiosPeer String

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoTypes.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoTypes.hs
@@ -1373,6 +1373,9 @@ data TraceLeiosKernel
   | TraceLeiosVoted {vote :: LeiosVote, weight :: Weight}
   | TraceLeiosVoteAcquired {vote :: LeiosVote}
   | TraceLeiosCertified {rbHash :: RbHash}
+  | -- \| A vote is scheduled to happen.
+    TraceLeiosVoteScheduled
+      {ebPoint :: LeiosPoint, voteIn :: NominalDiffTime, deadlineIn :: NominalDiffTime}
   | -- | An 'AcquiredEbTxs' notification arrived but 'runLeiosVoting' chose
     -- not to cast a vote; the reason identifies which precondition failed.
     TraceLeiosNotVoted {ebPoint :: LeiosPoint, reason :: LeiosNotVotedReason}
@@ -1626,6 +1629,15 @@ traceLeiosKernelToObject = \case
       , "ebHash" .= prettyEbHash ebHash
       , "ebSlot" .= ebSlot
       , "reason" .= notVotedReasonText reason
+      ]
+  TraceLeiosVoteScheduled{ebPoint = MkLeiosPoint (SlotNo ebSlot) ebHash, voteIn, deadlineIn} ->
+    mconcat
+      [ "kind" .= Aeson.String "LeiosVoteScheduled"
+      , "ebHash" .= prettyEbHash ebHash
+      , "ebSlot" .= ebSlot
+      , -- Aeson renders 'NominalDiffTime' as a number of seconds, exactly.
+        "voteIn" .= voteIn
+      , "deadlineIn" .= deadlineIn
       ]
   TraceLeiosEbValidated{ebPoint = MkLeiosPoint (SlotNo ebSlot) ebHash, reapplied, applied} ->
     mconcat

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoTypes.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoTypes.hs
@@ -95,6 +95,7 @@ import qualified Data.Set as Set
 import Data.Set.NonEmpty (NESet)
 import qualified Data.Set.NonEmpty as NESet
 import Data.String (fromString)
+import Data.Text (Text)
 import Data.Time.Clock (NominalDiffTime)
 import Data.Vector.Strict (Vector)
 import qualified Data.Vector.Strict as V
@@ -1375,6 +1376,9 @@ data TraceLeiosKernel
   | -- | An 'AcquiredEbTxs' notification arrived but 'runLeiosVoting' chose
     -- not to cast a vote; the reason identifies which precondition failed.
     TraceLeiosNotVoted {ebPoint :: LeiosPoint, reason :: LeiosNotVotedReason}
+  | -- | An EB's endorsed transactions all applied, so we are about to vote for
+    -- it. The split says how many txs the LeiosTxCache spared full validation.
+    TraceLeiosEbValidated {ebPoint :: LeiosPoint, reapplied :: Int, applied :: Int}
   | TraceLeiosDbException LeiosDbException
   | TraceLeiosDb TraceLeiosDb
   | -- | A forged RB both certifies an EB and announce a new one
@@ -1474,6 +1478,10 @@ data LeiosNotVotedReason
     TooLate
   | -- | We are not part of the current voting committee.
     NotOnCommittee
+  | -- | The endorsed transactions do not apply to the announcing RB's ledger
+    -- state, so this EB must not be certified. Carries the ledger's rendered
+    -- rejection.
+    EbTxsInvalid !Text
   deriving Show
 
 deriving instance Show TraceLeiosKernel
@@ -1619,6 +1627,14 @@ traceLeiosKernelToObject = \case
       , "ebSlot" .= ebSlot
       , "reason" .= notVotedReasonText reason
       ]
+  TraceLeiosEbValidated{ebPoint = MkLeiosPoint (SlotNo ebSlot) ebHash, reapplied, applied} ->
+    mconcat
+      [ "kind" .= Aeson.String "LeiosEbValidated"
+      , "ebHash" .= prettyEbHash ebHash
+      , "ebSlot" .= ebSlot
+      , "reapplied" .= reapplied
+      , "applied" .= applied
+      ]
   TraceLeiosDbException e ->
     jsonLeiosDbException e
   TraceLeiosDb (TraceLeiosDbInsertCollision table key) ->
@@ -1676,6 +1692,7 @@ notVotedReasonText = \case
   ChainTipDoesNotAnnounce -> Aeson.String "chainTipDoesNotAnnounce"
   TooLate -> Aeson.String "tooLate"
   NotOnCommittee -> Aeson.String "notOnCommittee"
+  EbTxsInvalid err -> Aeson.String $ "ebTxsInvalid: " <> err
 
 data TraceLeiosPeer
   = MkTraceLeiosPeer String

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosVoteState.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosVoteState.hs
@@ -32,6 +32,7 @@ import LeiosDemoTypes
   , validateLeiosVote
   )
 
+-- FIXME: Garbage collection of vote state
 data LeiosVoteState m = LeiosVoteState
   { addVote :: LeiosVote -> m AddVoteResult
   -- ^ Add a new vote to the LeiosVoteState. Adding the same vote multiple

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosVoting.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosVoting.hs
@@ -206,14 +206,12 @@ newVoteTimers tracer lcfg chainDB systemTime = do
                   }
               timer <-
                 registerDelay
-                  -- An EB whose window is already open gives a non-positive
-                  -- delay; 1us keeps 'registerDelay' in its intended range and
-                  -- fires on the next tick, which is the behaviour wanted here.
-                  . max 1
                   . diffTimeToMicrosecondsAsInt
                   $ nominalDelay voteIn
-              atomically . modifyTVar pendingVotes . Map.insert point $
-                (timer, voteDeadline)
+              atomically
+                . modifyTVar pendingVotes
+                . Map.insert point
+                $ (timer, voteDeadline)
       , -- Reading every armed timer puts them all in this transaction's read
         -- set, so it wakes on any of them, and 'Map.toList' is in point order,
         -- so simultaneous firings break towards the earlier slot.
@@ -312,7 +310,11 @@ runLeiosVoting tracer lcfg chainDB systemTime leiosDB txCache voteState = \case
   goVote leiosConn sk point deadline = do
     let vk = deriveVerKeyDSIGN sk
     withForkerAt VolatileTip $ \case
-      Nothing -> pure $ Left ChainTipDoesNotAnnounce
+      Nothing ->
+        -- Should not happen: VolatileTip target never fails to open. It's safe
+        -- to interpret this non-typed corner case the same way as if we were
+        -- not on the announcing chain.
+        pure $ Left ChainTipDoesNotAnnounce
       Just forker -> runExceptT $ do
         -- One consistent view of the selection: the header state that has
         -- to announce this EB and the ledger state its closure has to apply
@@ -328,7 +330,7 @@ runLeiosVoting tracer lcfg chainDB systemTime leiosDB txCache voteState = \case
 
         lift (validateEbClosure lcfg leiosConn txCache readTables point ls) >>= \case
           EbClosureInvalid err ->
-            -- XXX: Text in error
+            -- TODO: Text in error
             throwE . EbTxsInvalid . Text.pack $ show err
           EbClosureValid reapplied applied ->
             lift $ traceWith tracer TraceLeiosEbValidated{ebPoint = point, reapplied, applied}
@@ -352,7 +354,7 @@ runLeiosVoting tracer lcfg chainDB systemTime leiosDB txCache voteState = \case
                   Just _ -> traceWith tracer TraceLeiosCertified{rbHash}
                   Nothing -> pure ()
               err ->
-                -- XXX: Make this a NotVoted error / trace
+                -- TODO: Make this a NotVoted error / trace
                 error $ "runLeiosVoting: unexpected error on addVote: " <> show err
 
   LeiosVoteState{addVote} = voteState
@@ -372,7 +374,8 @@ data EbClosureVerdict blk
     -- tx-cache. Carries how many were reapplied versus validated in full — the
     -- cache's hit rate.
     EbClosureValid !Int !Int
-  | -- | A tx did not apply, so this EB must not be certified.
+  | -- | A tx did not apply, so this EB must not be certified. Any valid prefix
+    -- of txs is recorded as valid in the tx-cache.
     EbClosureInvalid !(ApplyTxErr blk)
 
 -- | Apply an EB's endorsed transactions to the announcing RB's ledger state,
@@ -380,9 +383,7 @@ data EbClosureVerdict blk
 --
 -- Each tx is validated in full, except where the LeiosTxCache reports it
 -- already validated: then only the state-dependent checks re-run
--- ('LedgerSupportsMempool.reapplyTx' rather than 'applyTx'). That is where the
--- cache earns its keep — consecutive EBs overlap heavily, and a forger's own EB
--- is entirely pre-validated by its mempool.
+-- ('LedgerSupportsMempool.reapplyTx' rather than 'applyTx').
 validateEbClosure ::
   forall m blk.
   ( IOLike m
@@ -403,10 +404,14 @@ validateEbClosure lcfg leiosConn txCache resolveValues point lsBase = do
   -- Load txs from disk
   closure <- resolveLeiosClosure leiosConn (pointEbHash point)
   -- Resolve their input UTxOs
+  -- TODO: This collects ALL inputs, but we would just need the inputs of the
+  -- transitive closure. That is, any chained txs would only require inputs not
+  -- internal to the chain.
   let keys = foldMap (getTransactionKeySets . snd) closure
   values <- resolveValues keys
   -- Determine which txs we can just reapply (the cache hits)
   decided <- withLookupTx txCache $ \look -> mapM (decide look) closure
+  -- TODO: Temporarily use the Mempool API until we have a dedicated one
   let st0 = applyMempoolDiffs values keys (applyChainTick OmitLedgerEvents lcfg slot lsBase)
   goValidate st0 decided 0 0 []
  where

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosVoting.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosVoting.hs
@@ -116,13 +116,18 @@ import Ouroboros.Network.Protocol.LocalStateQuery.Type (Target (VolatileTip))
 -- described in the Leios protocol specification. Real values should come
 -- from the protocol parameters once wired in.
 
--- TODO: Fetching and validating an EB's closure should start when the closure
--- arrives, streamed, rather than after this wait. Validation is linear in the
--- closure -- a full ~13.5k-tx closure takes ~1.5s even when every tx is a
--- tx-cache hit -- so doing it inside the vote window spends the window on work
--- that could have been done while waiting for it to open. A devnet run showed
--- exactly that: as closures filled up, the time from votable to validated grew
--- past the window and voting stopped entirely.
+-- Validation is linear in the closure -- a full ~13.5k-tx closure takes ~1.5s
+-- even when every tx is a tx-cache hit -- so doing it inside the vote window
+-- spends the window on work that could have been done before it opened. A devnet
+-- run showed exactly that: as closures filled up, the time from votable to
+-- validated grew past the window and voting stopped entirely. Two independent
+-- ways to stop paying for it here:
+--
+-- TODO: validate as soon as the whole closure has arrived, rather than waiting
+-- for the vote window to open.
+--
+-- TODO: validate the closure as it streams in, rather than waiting for all of
+-- it. Subsumes the above, and is considerably more involved.
 
 -- | How long after its announcing slot /begins/ before an EB's voters may cast
 -- a vote. Serves as the equivocation-detection window: if a peer equivocates by

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosVoting.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosVoting.hs
@@ -88,7 +88,7 @@ import Ouroboros.Consensus.Ledger.Extended (headerState, ledgerState)
 import Ouroboros.Consensus.Ledger.SupportsMempool
   ( ApplyTxErr
   , LedgerSupportsMempool (..)
-  , WhetherToIntervene (DoNotIntervene)
+  , WhetherToIntervene (Intervene)
   )
 import Ouroboros.Consensus.Ledger.Tables.Utils (applyDiffs)
 import Ouroboros.Consensus.Storage.ChainDB (ChainDB)
@@ -442,7 +442,19 @@ validateEbClosure lcfg leiosConn txCache resolveValues point lsBase = do
           Left err -> abandon newly err
           Right st' -> goValidate st' rest (reapplied + 1) applied newly
       Left tx ->
-        case runExcept $ applyTx lcfg DoNotIntervene slot tx st of
+        -- 'Intervene', despite the mempool's framing of it as a courtesy to
+        -- local clients. What it actually selects is whether the era's applyTx
+        -- may rewrite the tx's 'isValid' flag: 'DoNotIntervene' forces the flag
+        -- true and, on a tag mismatch, retries with it false, so a Plutus tx
+        -- whose scripts fail would be validated here as a collateral-only tx
+        -- and voted for. The apply path does not do that -- it runs with
+        -- 'ValidateNone' and branches on the /declared/ flag -- so it would
+        -- consume the tx's whole input set instead. Rewriting the flag here
+        -- would mean voting for a closure the chain never applies, which is
+        -- exactly the trust 'applyLeiosClosure' cites the certificate for.
+        -- 'Intervene' leaves the flag alone and lets the mismatch escape as an
+        -- error, so we fail closed on precisely those txs.
+        case runExcept $ applyTx lcfg Intervene slot tx st of
           Left err -> abandon newly err
           Right (st', _vtx) ->
             goValidate (applyDiffs st st') rest reapplied (applied + 1) (txh : newly)

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosVoting.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosVoting.hs
@@ -15,23 +15,24 @@ module LeiosVoting
 
 import Cardano.Crypto.DSIGN (DSIGNAlgorithm (deriveVerKeyDSIGN))
 import Cardano.Slotting.Slot (SlotNo (..))
-import Control.Applicative ((<|>))
 import Control.Concurrent.Class.MonadSTM.Strict
   ( modifyTVar
   , newTVar
   , readTChan
   , readTVar
-  , retry
-  , writeTVar
+  , tryReadTChan
   )
-import Control.Monad (forever)
+import Control.Monad (forM_, forever)
+import qualified Control.Monad.Class.MonadSTM.Internal as TVar
+import Control.Monad.Class.MonadTimer (MonadTimer, registerDelay)
+import Control.Monad.Class.MonadTimer.SI (diffTimeToMicrosecondsAsInt)
 import Control.Monad.Except (runExcept)
 import Control.Tracer (Tracer, traceWith)
 import Data.Proxy (Proxy (..))
 import Data.Set (Set)
 import qualified Data.Set as Set
 import qualified Data.Text as Text
-import Data.Word (Word64)
+import Data.Time.Clock (NominalDiffTime)
 import LeiosDemoDb
   ( LeiosDbConnection
   , LeiosDbHandle (..)
@@ -42,11 +43,13 @@ import LeiosDemoTypes
   ( HasLeiosVoting (..)
   , LeiosNotVotedReason (..)
   , LeiosPoint (..)
+  , LeiosSeatId
   , LeiosSigningKey
   , RbHash (..)
   , SerializedEbBody
   , TraceLeiosKernel (..)
   , getLeiosSeatId
+  , prettyLeiosPoint
   , signLeiosVote
   )
 import LeiosTxCache (LeiosTxCache (..))
@@ -56,10 +59,14 @@ import Ouroboros.Consensus.Block
   , WithOrigin (..)
   )
 import Ouroboros.Consensus.BlockchainTime
-  ( BlockchainTime (..)
-  , CurrentSlot (..)
+  ( RelativeTime
+  , SystemTime (..)
+  , addRelTime
+  , diffRelTime
   )
 import Ouroboros.Consensus.Config (TopLevelConfig, configLedger)
+import Ouroboros.Consensus.HardFork.Abstract (HasHardForkHistory (..))
+import qualified Ouroboros.Consensus.HardFork.History.Qry as Qry
 import Ouroboros.Consensus.HeaderValidation
   ( HasAnnTip
   , HeaderState
@@ -99,6 +106,7 @@ import Ouroboros.Consensus.Util.IOLike
   , atomically
   , bracket
   )
+import Ouroboros.Consensus.Util.Time (nominalDelay)
 import Ouroboros.Network.Protocol.LocalStateQuery.Type (Target (SpecificPoint))
 
 -- * Voting timing constants
@@ -108,19 +116,31 @@ import Ouroboros.Network.Protocol.LocalStateQuery.Type (Target (SpecificPoint))
 -- described in the Leios protocol specification. Real values should come
 -- from the protocol parameters once wired in.
 
--- | Number of slots after an EB's announcement before its voters are
--- allowed to cast a vote. Serves as the equivocation-detection window: if
--- a peer equivocates by announcing two different EBs on the same slot, we
--- want to observe the second announcement (and drop the vote) before
--- committing. Stub for '3 * L_hdr'.
-lHdrWaitSlots :: Word64
-lHdrWaitSlots = 3
+-- | How long after its announcing slot /begins/ before an EB's voters may cast
+-- a vote. Serves as the equivocation-detection window: if a peer equivocates by
+-- announcing two different EBs on the same slot, we want to observe the second
+-- announcement (and drop the vote) before committing. Stub for '3 * L_hdr'.
+lHdrWait :: NominalDiffTime
+lHdrWait = 3
 
--- | Number of slots after the vote-eligibility slot ('announcedSlot +
--- lHdrWaitSlots') during which votes are still accepted. Stub for
--- 'L_vote'.
-lVoteWindowSlots :: Word64
-lVoteWindowSlots = 4
+-- | How long after 'lHdrWait' votes are still accepted. Stub for 'L_vote'.
+lVoteWindow :: NominalDiffTime
+lVoteWindow = 4
+
+-- | When a slot begins, in wall-clock terms.
+--
+-- Both gates are measured from here rather than counted in slots: the node's
+-- notion of the current slot only advances as blocks are adopted, so slot
+-- arithmetic would judge the deadline against a clock that stops whenever the
+-- chain does.
+slotOnset ::
+  HasHardForkHistory blk =>
+  LedgerConfig blk ->
+  LedgerState blk mk ->
+  SlotNo ->
+  Either Qry.PastHorizonException RelativeTime
+slotOnset lcfg lst slot =
+  fst <$> Qry.runQuery (Qry.slotToWallclock slot) (hardForkSummary lcfg lst)
 
 -- * Voting loop
 
@@ -134,17 +154,19 @@ runLeiosVoting ::
   , ConvertRawHash blk
   , HasAnnTip blk
   , LedgerSupportsMempool blk
+  , HasHardForkHistory blk
+  , MonadTimer m
   ) =>
   Tracer m TraceLeiosKernel ->
   TopLevelConfig blk ->
   ChainDB m blk ->
-  BlockchainTime m ->
+  SystemTime m ->
   LeiosDbHandle m ->
   LeiosTxCache m () () SerializedEbBody ->
   LeiosVoteState m ->
   Maybe LeiosSigningKey ->
   m ()
-runLeiosVoting tracer cfg chainDB btime leiosDB txCache voteState = \case
+runLeiosVoting tracer cfg chainDB systemTime leiosDB txCache voteState = \case
   Nothing ->
     traceWith tracer $
       MkTraceLeiosKernel
@@ -175,87 +197,149 @@ runLeiosVoting tracer cfg chainDB btime leiosDB txCache voteState = \case
           AcquiredEb{} -> pure ()
           AcquiredEbTxs point -> modifyTVar pendingVar (Set.insert point)
 
-      -- Take the earliest pending point whose L_hdr wait has
-      -- elapsed. Retries if the set is empty or the earliest deadline
-      -- hasn't opened yet.
-      takeReady = do
+      -- Move whatever has already arrived into the pending set, blocking only
+      -- when there is nothing pending to act on at all.
+      ingest :: STM m ()
+      ingest = do
         pending <- readTVar pendingVar
-        case Set.minView pending of
-          Nothing -> retry
-          Just (point, rest) -> do
-            let SlotNo aw = pointSlotNo point
-                earliestVoteSlot = SlotNo (aw + lHdrWaitSlots)
-            s <- knownSlot btime
-            if s < earliestVoteSlot
-              then retry
-              else do
-                writeTVar pendingVar rest
-                extLedger <- ChainDB.getCurrentLedger chainDB
-                pure (point, s, extLedger)
+        if Set.null pending then takeAcquisition else drain
+       where
+        drain =
+          tryReadTChan chan >>= \case
+            Nothing -> pure ()
+            Just AcquiredEb{} -> drain
+            Just (AcquiredEbTxs point) -> do
+              modifyTVar pendingVar (Set.insert point)
+              drain
 
-    -- Wake on whichever fires first: a ready pending, or a new
-    -- acquisition. 'orElse' gives priority to voting over ingesting,
-    -- so we can't stall a due vote behind a chan drain.
+      -- Everything the node has to be asked about before we can decide, read
+      -- as one consistent view of the selected chain.
+      readTip = atomically $ ChainDB.getCurrentLedger chainDB
+
+      -- Validate an EB's closure against the announcing RB's ledger state.
+      -- Losing that state to chain-sel is not the EB's fault, so it reads as
+      -- 'ChainTipDoesNotAnnounce' rather than a rejection.
+      validateClosure extLedger point =
+        -- REVIEW: How expensive is it to open a forker - should we re-use
+        -- one for the whole vote logic?
+        -- TODO: refactor: withForker announcerPoint $ \(ls, forker) ->
+        bracket
+          (ChainDB.openReadOnlyForkerAtPoint chainDB (SpecificPoint (ledgerTipPoint (ledgerState extLedger))))
+          (either (\_ -> pure ()) roforkerClose)
+          $ \case
+            Left _ -> pure $ Left ChainTipDoesNotAnnounce
+            Right extForker -> do
+              let forker = ledgerStateReadOnlyForker extForker
+              lsBase <- atomically $ roforkerGetLedgerState forker
+              validateEbClosure
+                (configLedger cfg)
+                leiosConn
+                txCache
+                (roforkerReadTables forker)
+                point
+                lsBase
+                >>= \case
+                  -- XXX: Text in error
+                  EbClosureInvalid err -> pure $ Left $ EbTxsInvalid $ Text.pack $ show err
+                  EbClosureValid reapplied applied -> pure $ Right (reapplied, applied)
+
+      -- Decide and, if we may, cast the vote.
+      voteOn point extLedger deadline = do
+        let notVoted r = traceWith tracer TraceLeiosNotVoted{ebPoint = point, reason = r}
+        decideVote
+          (getLeiosCommittee (ledgerState extLedger) >>= getLeiosSeatId vk)
+          (tipAnnouncerFor @blk (headerState extLedger) point)
+          (validateClosure extLedger point)
+          (systemTimeCurrent systemTime)
+          deadline
+          >>= \case
+            Left reason -> notVoted reason
+            Right (rbHash, voterId, (reapplied, applied)) -> do
+              traceWith tracer TraceLeiosEbValidated{ebPoint = point, reapplied, applied}
+              let vote = signVote voterId rbHash
+              addVote vote >>= \case
+                Added weight mCert -> do
+                  traceWith tracer TraceLeiosVoted{vote, weight}
+                  traceWith tracer TraceLeiosVoteAcquired{vote}
+                  -- Trace certification whenever the tally crosses
+                  -- 'minCertificationThreshold'. May fire more than once
+                  -- per point if subsequent votes also come in; consumers
+                  -- (e.g. ThreadNet's 'propCertifying') dedupe.
+                  case mCert of
+                    Just _ -> traceWith tracer TraceLeiosCertified{rbHash}
+                    Nothing -> pure ()
+                err ->
+                  error $ "runLeiosVoting: unexpected error on addVote: " <> show err
+
     forever $ do
-      mWork <- atomically $ (Just <$> takeReady) <|> (Nothing <$ takeAcquisition)
-      case mWork of
-        Nothing -> pure ()
-        Just (point, currentSlot, extLedger) -> do
-          let SlotNo aw = pointSlotNo point
-              deadlineSlot = SlotNo (aw + lHdrWaitSlots + lVoteWindowSlots)
-              notVoted r = traceWith tracer TraceLeiosNotVoted{ebPoint = point, reason = r}
-              mVoterId = getLeiosCommittee (ledgerState extLedger) >>= getLeiosSeatId vk
-              mAnnouncer = tipAnnouncerFor @blk (headerState extLedger) point
-          -- FIXME: Check the deadline against wall clock not the ledger
-          -- state. The latter is only advancing whenever a block is
-          -- adopted.
-          case (currentSlot > deadlineSlot, mAnnouncer, mVoterId) of
-            (True, _, _) -> notVoted TooLate
-            (_, Nothing, _) -> notVoted ChainTipDoesNotAnnounce
-            (_, _, Nothing) -> notVoted NotOnCommittee
-            -- Only now, with every cheap check passed, is it worth paying for
-            -- ledger work: we never validate an EB we would not vote for.
-            (_, Just rbHash, Just voterId) -> do
-              let announcerPoint = ledgerTipPoint (ledgerState extLedger)
-              -- REVIEW: How expensive is it to open a forker - should we re-use
-              -- one for the whole vote logic?
-              -- TODO: refactor: withForker announcerPoint $ \(ls, forker) ->
-              bracket
-                (ChainDB.openReadOnlyForkerAtPoint chainDB (SpecificPoint announcerPoint))
-                (either (\_ -> pure ()) roforkerClose)
-                $ \case
-                  -- Chain-sel moved off the announcer before we could read
-                  -- its ledger state. No vote, but nothing is wrong with the EB.
-                  Left _ -> notVoted ChainTipDoesNotAnnounce
-                  Right extForker -> do
-                    let forker = ledgerStateReadOnlyForker extForker
-                    lsBase <- atomically $ roforkerGetLedgerState forker
-                    validateEbClosure
-                      (configLedger cfg)
-                      leiosConn
-                      txCache
-                      (roforkerReadTables forker)
-                      point
-                      lsBase
-                      >>= \case
-                        -- XXX: Text in error
-                        EbClosureInvalid err -> notVoted $ EbTxsInvalid (Text.pack $ show err)
-                        EbClosureValid reapplied applied -> do
-                          traceWith tracer TraceLeiosEbValidated{ebPoint = point, reapplied, applied}
-                          let vote = signVote voterId rbHash
-                          addVote vote >>= \case
-                            Added weight mCert -> do
-                              traceWith tracer TraceLeiosVoted{vote, weight}
-                              traceWith tracer TraceLeiosVoteAcquired{vote}
-                              -- Trace certification whenever the tally crosses
-                              -- 'minCertificationThreshold'. May fire more than once
-                              -- per point if subsequent votes also come in; consumers
-                              -- (e.g. ThreadNet's 'propCertifying') dedupe.
-                              case mCert of
-                                Just _ -> traceWith tracer TraceLeiosCertified{rbHash}
-                                Nothing -> pure ()
-                            err ->
-                              error $ "runLeiosVoting: unexpected error on addVote: " <> show err
+      atomically ingest
+      mNext <- atomically $ fmap fst . Set.minView <$> readTVar pendingVar
+      forM_ mNext $ \point -> do
+        extLedger <- readTip
+        now <- systemTimeCurrent systemTime
+        case slotOnset (configLedger cfg) (ledgerState extLedger) (pointSlotNo point) of
+          Left horizon -> do
+            -- Cannot happen for an EB announced on our own chain: its slot is
+            -- at or behind the tip whose summary we just read. Drop it rather
+            -- than spin on it, and say so.
+            atomically $ modifyTVar pendingVar (Set.delete point)
+            traceWith tracer . MkTraceLeiosKernel $
+              "runLeiosVoting: no wall-clock onset for "
+                <> prettyLeiosPoint point
+                <> ": "
+                <> show horizon
+          Right onset -> do
+            let votableAt = addRelTime lHdrWait onset
+            if now < votableAt
+              then do
+                -- Wait until it is votable, but wake early if something
+                -- arrives: an EB turning up late with an older slot must not
+                -- have to sit out this one's wait. Never register a zero
+                -- delay.
+                varTimeout <-
+                  registerDelay . max 1 . diffTimeToMicrosecondsAsInt . nominalDelay $
+                    diffRelTime votableAt now
+                atomically $
+                  (TVar.check =<< TVar.readTVar varTimeout) `TVar.orElse` takeAcquisition
+              else do
+                atomically $ modifyTVar pendingVar (Set.delete point)
+                voteOn point extLedger (addRelTime lVoteWindow votableAt)
+
+-- * The vote decision
+
+-- | Whether to vote for an acquired EB, and why not when we don't.
+--
+-- Validation runs /before/ the deadline is checked, deliberately: applying a
+-- closure takes real time, so whether we are still inside the vote window has
+-- to be judged by the clock as it reads when we are ready to sign, not by a
+-- reading taken before the work. The cheap checks still come first, so an EB we
+-- would not vote for is never validated.
+decideVote ::
+  Monad m =>
+  -- | Our seat on the voting committee, if we hold one.
+  Maybe LeiosSeatId ->
+  -- | The announcing RB's hash, if our tip announces this EB.
+  Maybe RbHash ->
+  -- | Validate the EB's closure.
+  m (Either LeiosNotVotedReason a) ->
+  -- | Read the wall clock. Called after validation.
+  m RelativeTime ->
+  -- | The moment after which a vote is too late.
+  RelativeTime ->
+  m (Either LeiosNotVotedReason (RbHash, LeiosSeatId, a))
+decideVote mSeat mAnnouncer validate readNow deadline =
+  case (mAnnouncer, mSeat) of
+    (Nothing, _) -> pure $ Left ChainTipDoesNotAnnounce
+    (_, Nothing) -> pure $ Left NotOnCommittee
+    (Just rbHash, Just seatId) ->
+      validate >>= \case
+        Left reason -> pure $ Left reason
+        Right a -> do
+          now <- readNow
+          pure $
+            if now > deadline
+              then Left TooLate
+              else Right (rbHash, seatId, a)
 
 -- * Validating the endorsed transactions
 
@@ -336,13 +420,6 @@ validateEbClosure lcfg leiosConn txCache resolveValues point lsBase = do
 
   recordValidated txh =
     withLockedInsertAppliedTx txCache $ \w0 step -> step w0 txh ()
-
--- | Read the current wall-clock slot, retrying until it is known.
-knownSlot :: IOLike m => BlockchainTime m -> STM m SlotNo
-knownSlot btime =
-  getCurrentSlot btime >>= \case
-    CurrentSlot s -> pure s
-    CurrentSlotUnknown -> retry
 
 -- | The 'RbHash' of the currently-selected chain's tip iff its most
 -- recently applied announcing header announces the given EB and is

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosVoting.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosVoting.hs
@@ -127,11 +127,17 @@ import Ouroboros.Network.Protocol.LocalStateQuery.Type (Target (VolatileTip))
 -- | How long after its announcing slot /begins/ before an EB's voters may cast
 -- a vote. Serves as the equivocation-detection window: if a peer equivocates by
 -- announcing two different EBs on the same slot, we want to observe the second
--- announcement (and drop the vote) before committing. Stub for '3 * L_hdr'.
+-- announcement (and drop the vote) before issuing our vote. Stub for
+-- '3 * L_hdr'.
+--
+-- TODO: read from the ledger state, once the Leios protocol parameters are
+-- there; a constant cannot follow an on-chain change.
 lHdrWait :: NominalDiffTime
 lHdrWait = 3
 
 -- | How long after 'lHdrWait' votes are still accepted. Stub for 'L_vote'.
+--
+-- TODO: read from the ledger state, as for 'lHdrWait'.
 lVoteWindow :: NominalDiffTime
 lVoteWindow = 4
 
@@ -195,6 +201,9 @@ newVoteTimers tracer lcfg chainDB systemTime = do
                   }
               timer <-
                 registerDelay
+                  -- An EB whose window is already open gives a non-positive
+                  -- delay; 1us keeps 'registerDelay' in its intended range and
+                  -- fires on the next tick, which is the behaviour wanted here.
                   . max 1
                   . diffTimeToMicrosecondsAsInt
                   $ nominalDelay voteIn
@@ -214,10 +223,9 @@ newVoteTimers tracer lcfg chainDB systemTime = do
 
 -- | When a slot begins, in wall-clock terms.
 --
--- Both gates are measured from here rather than counted in slots: the node's
--- notion of the current slot only advances as blocks are adopted, so slot
--- arithmetic would judge the deadline against a clock that stops whenever the
--- chain does.
+-- Both gates are durations -- the protocol parameters they stub for are diff
+-- times, not slot counts -- so they are measured from the announcing slot's
+-- onset rather than counted against the current slot.
 slotOnset ::
   HasHardForkHistory blk =>
   LedgerConfig blk ->

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosVoting.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosVoting.hs
@@ -22,7 +22,7 @@ import Control.Concurrent.Class.MonadSTM.Strict
   , readTChan
   , readTVar
   )
-import Control.Monad (filterM, forever, when)
+import Control.Monad (filterM, foldM, forever, when)
 import qualified Control.Monad.Class.MonadSTM.Internal as TVar
 import Control.Monad.Class.MonadTimer (MonadTimer, registerDelay)
 import Control.Monad.Class.MonadTimer.SI (diffTimeToMicrosecondsAsInt)
@@ -408,7 +408,7 @@ validateEbClosure lcfg leiosConn txCache resolveValues point lsBase = do
   -- Determine which txs we can just reapply (the cache hits)
   decided <- withLookupTx txCache $ \look -> mapM (decide look) closure
   let st0 = applyMempoolDiffs values keys (applyChainTick OmitLedgerEvents lcfg slot lsBase)
-  goValidate st0 decided 0 0
+  goValidate st0 decided 0 0 []
  where
   -- The EB's slot is also its announcer's, so ticking to it mirrors what the
   -- apply path does when a later RB certifies this EB.
@@ -422,27 +422,40 @@ validateEbClosure lcfg leiosConn txCache resolveValues point lsBase = do
       Just Right{} -> pure (txh, Right (assumeValidatedClosureTx tx))
       _ -> pure (txh, Left tx)
 
-  -- Apply or reapply txs and tag the former as validated in the cache
-  goValidate _ [] !reapplied !applied =
+  -- Apply or reapply txs, accumulating the ones we newly validated so the cache
+  -- is written once for the whole closure rather than once per tx.
+  goValidate _ [] !reapplied !applied newly = do
+    recordValidated newly
     pure $ EbClosureValid reapplied applied
-  goValidate !st ((txh, decision) : rest) !reapplied !applied =
+  goValidate !st ((txh, decision) : rest) !reapplied !applied newly =
     case decision of
       Right vtx ->
         -- Already validated once, so only the state-dependent checks re-run. A
         -- failure here is state-dependent (a spent input, say) and says nothing
         -- about the static checks, so the tx keeps the tag it already has.
         case runExcept $ reapplyTx lcfg slot vtx st of
-          Left err -> pure $ EbClosureInvalid err
-          Right st' -> goValidate st' rest (reapplied + 1) applied
+          Left err -> abandon newly err
+          Right st' -> goValidate st' rest (reapplied + 1) applied newly
       Left tx ->
         case runExcept $ applyTx lcfg DoNotIntervene slot tx st of
-          Left err -> pure $ EbClosureInvalid err
-          Right (st', _vtx) -> do
-            recordValidated txh
-            goValidate (applyDiffs st st') rest reapplied (applied + 1)
+          Left err -> abandon newly err
+          Right (st', _vtx) ->
+            goValidate (applyDiffs st st') rest reapplied (applied + 1) (txh : newly)
 
-  recordValidated txh =
-    withLockedInsertAppliedTx txCache $ \w0 step -> step w0 txh ()
+  -- A closure that fails part-way still validated everything before the failure,
+  -- against a real ledger state, so those tags are kept: the work holds
+  -- regardless of the tx that sank the EB.
+  abandon newly err = do
+    recordValidated newly
+    pure $ EbClosureInvalid err
+
+  -- One lock acquisition per closure. Order is irrelevant -- each entry is an
+  -- independent tag -- so the accumulator is not reversed.
+  recordValidated newly
+    | null newly = pure ()
+    | otherwise =
+        withLockedInsertAppliedTx txCache $ \w0 step ->
+          foldM (\w txh -> step w txh ()) w0 newly
 
 -- | The 'RbHash' of the currently-selected chain's tip iff its most
 -- recently applied announcing header announces the given EB and is

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosVoting.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosVoting.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
@@ -23,31 +24,42 @@ import Control.Concurrent.Class.MonadSTM.Strict
   , writeTVar
   )
 import Control.Monad (forever)
+import Control.Monad.Except (runExcept)
 import Control.Tracer (Tracer, traceWith)
 import Data.Proxy (Proxy (..))
 import Data.Set (Set)
 import qualified Data.Set as Set
+import qualified Data.Text as Text
 import Data.Word (Word64)
-import LeiosDemoDb (LeiosDbHandle (..), LeiosEbNotification (..))
+import LeiosDemoDb
+  ( LeiosDbConnection
+  , LeiosDbHandle (..)
+  , LeiosEbNotification (..)
+  , withLeiosDb
+  )
 import LeiosDemoTypes
   ( HasLeiosVoting (..)
   , LeiosNotVotedReason (..)
   , LeiosPoint (..)
   , LeiosSigningKey
   , RbHash (..)
+  , SerializedEbBody
   , TraceLeiosKernel (..)
   , getLeiosSeatId
   , signLeiosVote
   )
+import LeiosTxCache (LeiosTxCache (..))
 import LeiosVoteState (AddVoteResult (..), LeiosVoteState (..))
 import Ouroboros.Consensus.Block
   ( ConvertRawHash (..)
+  , Point
   , WithOrigin (..)
   )
 import Ouroboros.Consensus.BlockchainTime
   ( BlockchainTime (..)
   , CurrentSlot (..)
   )
+import Ouroboros.Consensus.Config (TopLevelConfig, configLedger)
 import Ouroboros.Consensus.HeaderValidation
   ( HasAnnTip
   , HeaderState
@@ -55,19 +67,35 @@ import Ouroboros.Consensus.HeaderValidation
   , headerStateChainDep
   , headerStateTip
   )
+import Ouroboros.Consensus.Ledger.Abstract
+  ( ComputeLedgerEvents (OmitLedgerEvents)
+  , LedgerConfig
+  , applyChainTick
+  , ledgerTipPoint
+  )
 import Ouroboros.Consensus.Ledger.Extended (headerState, ledgerState)
+import Ouroboros.Consensus.Ledger.SupportsMempool
+  ( ApplyTxErr
+  , LedgerSupportsMempool (..)
+  , WhetherToIntervene (DoNotIntervene)
+  )
+import Ouroboros.Consensus.Ledger.Tables.Utils (applyDiffs)
 import Ouroboros.Consensus.Storage.ChainDB (ChainDB)
 import qualified Ouroboros.Consensus.Storage.ChainDB as ChainDB
 import Ouroboros.Consensus.Storage.LedgerDB.Forker
-  ( ResolveLeiosBlock
+  ( ReadOnlyForker (..)
+  , ResolveLeiosBlock (..)
+  , ledgerStateReadOnlyForker
   , protocolStateLeiosAnnouncement
   )
 import Ouroboros.Consensus.Util.IOLike
   ( IOLike
   , STM
   , atomically
+  , bracket
   , orElse
   )
+import Ouroboros.Network.Protocol.LocalStateQuery.Type (Target (SpecificPoint))
 
 -- * Voting timing constants
 
@@ -101,20 +129,25 @@ runLeiosVoting ::
   , ResolveLeiosBlock blk
   , ConvertRawHash blk
   , HasAnnTip blk
+  , LedgerSupportsMempool blk
   ) =>
   Tracer m TraceLeiosKernel ->
+  TopLevelConfig blk ->
   ChainDB m blk ->
   BlockchainTime m ->
   LeiosDbHandle m ->
+  LeiosTxCache m () () SerializedEbBody ->
   LeiosVoteState m ->
   Maybe LeiosSigningKey ->
   m ()
-runLeiosVoting tracer chainDB btime leiosDB voteState = \case
+runLeiosVoting tracer cfg chainDB btime leiosDB txCache voteState = \case
   Nothing ->
     traceWith tracer $
       MkTraceLeiosKernel
         "runLeiosVoting: disabled because no topLevelConfigVotingKey"
-  Just sk -> do
+  -- A 'LeiosDbConnection' is not thread-safe, so this thread owns one for its
+  -- lifetime, the way each forge-credentials thread does.
+  Just sk -> withLeiosDb leiosDB $ \leiosConn -> do
     let vk = deriveVerKeyDSIGN sk
         signVote = signLeiosVote sk
         LeiosVoteState{addVote} = voteState
@@ -175,21 +208,127 @@ runLeiosVoting tracer chainDB btime leiosDB voteState = \case
             (True, _, _) -> notVoted TooLate
             (_, Nothing, _) -> notVoted ChainTipDoesNotAnnounce
             (_, _, Nothing) -> notVoted NotOnCommittee
+            -- Only now, with every cheap check passed, is it worth paying for
+            -- ledger work: we never validate an EB we would not vote for.
             (_, Just rbHash, Just voterId) -> do
-              let vote = signVote voterId rbHash
-              addVote vote >>= \case
-                Added weight mCert -> do
-                  traceWith tracer TraceLeiosVoted{vote, weight}
-                  traceWith tracer TraceLeiosVoteAcquired{vote}
-                  -- Trace certification whenever the tally crosses
-                  -- 'minCertificationThreshold'. May fire more than once
-                  -- per point if subsequent votes also come in; consumers
-                  -- (e.g. ThreadNet's 'propCertifying') dedupe.
-                  case mCert of
-                    Just _ -> traceWith tracer TraceLeiosCertified{rbHash}
-                    Nothing -> pure ()
-                err ->
-                  error $ "runLeiosVoting: unexpected error on addVote: " <> show err
+              let announcerPoint = ledgerTipPoint (ledgerState extLedger)
+              validateEbClosure
+                (configLedger cfg)
+                chainDB
+                leiosConn
+                txCache
+                point
+                announcerPoint
+                >>= \case
+                  EbClosureNoLedger -> notVoted ChainTipDoesNotAnnounce
+                  EbClosureInvalid err -> notVoted $ EbTxsInvalid (Text.pack (show err))
+                  EbClosureValid reapplied applied -> do
+                    traceWith tracer TraceLeiosEbValidated{ebPoint = point, reapplied, applied}
+                    let vote = signVote voterId rbHash
+                    addVote vote >>= \case
+                      Added weight mCert -> do
+                        traceWith tracer TraceLeiosVoted{vote, weight}
+                        traceWith tracer TraceLeiosVoteAcquired{vote}
+                        -- Trace certification whenever the tally crosses
+                        -- 'minCertificationThreshold'. May fire more than once
+                        -- per point if subsequent votes also come in; consumers
+                        -- (e.g. ThreadNet's 'propCertifying') dedupe.
+                        case mCert of
+                          Just _ -> traceWith tracer TraceLeiosCertified{rbHash}
+                          Nothing -> pure ()
+                      err ->
+                        error $ "runLeiosVoting: unexpected error on addVote: " <> show err
+
+-- * Validating the endorsed transactions
+
+-- | The outcome of checking an EB's endorsed transactions.
+data EbClosureVerdict blk
+  = -- | Every tx applied, and the txs validated here have been recorded in the
+    -- tx-cache. Carries how many were reapplied versus validated in full — the
+    -- cache's hit rate.
+    EbClosureValid !Int !Int
+  | -- | A tx did not apply, so this EB must not be certified.
+    EbClosureInvalid !(ApplyTxErr blk)
+  | -- | The announcing RB's ledger state was gone before we could read it:
+    -- chain-sel moved on. No vote, but nothing is wrong with the EB.
+    EbClosureNoLedger
+
+-- | Apply an EB's endorsed transactions to the announcing RB's ledger state,
+-- which is the state they will meet if the EB is ever certified.
+--
+-- Each tx is validated in full, except where the LeiosTxCache reports it
+-- already validated: then only the state-dependent checks re-run
+-- ('LedgerSupportsMempool.reapplyTx' rather than 'applyTx'). That is where the
+-- cache earns its keep — consecutive EBs overlap heavily, and a forger's own EB
+-- is entirely pre-validated by its mempool.
+validateEbClosure ::
+  forall m blk.
+  ( IOLike m
+  , ResolveLeiosBlock blk
+  , LedgerSupportsMempool blk
+  ) =>
+  LedgerConfig blk ->
+  ChainDB m blk ->
+  LeiosDbConnection m ->
+  LeiosTxCache m () () SerializedEbBody ->
+  LeiosPoint ->
+  -- | The announcing RB, whose unticked ledger state the closure applies to.
+  Point blk ->
+  m (EbClosureVerdict blk)
+validateEbClosure lcfg chainDB leiosConn txCache point announcerPoint =
+  -- REVIEW: How expensive is it to open a forker - should we re-use one for the
+  -- whole vote logic?
+  bracket
+    (ChainDB.openReadOnlyForkerAtPoint chainDB (SpecificPoint announcerPoint))
+    (either (\_ -> pure ()) roforkerClose)
+    $ \case
+      Left _ -> pure EbClosureNoLedger
+      Right extForker -> do
+        let forker = ledgerStateReadOnlyForker extForker
+        lsBase <- atomically $ roforkerGetLedgerState forker
+        -- Load txs from disk
+        closure <- resolveLeiosClosure leiosConn (pointEbHash point)
+        -- Resolve their input UTxOs
+        let keys = foldMap (getTransactionKeySets . snd) closure
+        values <- roforkerReadTables forker keys
+        -- Determine which txs we can just reapply (the cache hits)
+        decided <- withLookupTx txCache $ \look -> mapM (decide look) closure
+        let st0 = applyMempoolDiffs values keys (applyChainTick OmitLedgerEvents lcfg slot lsBase)
+        goValidate st0 decided 0 0
+ where
+  -- The EB's slot is also its announcer's, so ticking to it mirrors what the
+  -- apply path does when a later RB certifies this EB.
+  slot = pointSlotNo point
+
+  -- NOTE: 'assumeValidatedClosureTx' sits on the lookup that licenses it: the
+  -- tag is the evidence that this tx was validated before, so the token is
+  -- built here and nowhere else.
+  decide look (txh, tx) =
+    look txh >>= \case
+      Just Right{} -> pure (txh, Right (assumeValidatedClosureTx tx))
+      _ -> pure (txh, Left tx)
+
+  -- Apply or reapply txs and tag the former as validated in the cache
+  goValidate _ [] !reapplied !applied =
+    pure $ EbClosureValid reapplied applied
+  goValidate !st ((txh, decision) : rest) !reapplied !applied =
+    case decision of
+      Right vtx ->
+        -- Already validated once, so only the state-dependent checks re-run. A
+        -- failure here is state-dependent (a spent input, say) and says nothing
+        -- about the static checks, so the tx keeps the tag it already has.
+        case runExcept $ reapplyTx lcfg slot vtx st of
+          Left err -> pure $ EbClosureInvalid err
+          Right st' -> goValidate st' rest (reapplied + 1) applied
+      Left tx ->
+        case runExcept $ applyTx lcfg DoNotIntervene slot tx st of
+          Left err -> pure $ EbClosureInvalid err
+          Right (st', _vtx) -> do
+            recordValidated txh
+            goValidate (applyDiffs st st') rest reapplied (applied + 1)
+
+  recordValidated txh =
+    withLockedInsertAppliedTx txCache $ \w0 step -> step w0 txh ()
 
 -- | Read the current wall-clock slot, retrying until it is known.
 knownSlot :: IOLike m => BlockchainTime m -> STM m SlotNo

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosVoting.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosVoting.hs
@@ -28,7 +28,7 @@ import Control.Monad.Class.MonadTimer (MonadTimer, registerDelay)
 import Control.Monad.Class.MonadTimer.SI (diffTimeToMicrosecondsAsInt)
 import Control.Monad.Except (runExcept)
 import Control.Monad.Trans.Class (lift)
-import Control.Monad.Trans.Except (ExceptT, runExceptT, throwE)
+import Control.Monad.Trans.Except (ExceptT (..), runExceptT, throwE)
 import Control.Tracer (Tracer, traceWith)
 import qualified Data.Map.Strict as Map
 import Data.Proxy (Proxy (..))
@@ -157,8 +157,8 @@ lVoteWindow = 4
 data VoteTimers m = VoteTimers
   { scheduleVoteTime :: LeiosPoint -> m ()
   -- ^ Arm a timer for a newly acquired EB. One whose window is already open
-  -- clamps to a near-zero delay and fires immediately, so "already open" is not
-  -- a separate case for the caller.
+  -- gives a non-positive delay, which 'registerDelay' fires immediately, so
+  -- "already open" is not a separate case for the caller.
   , waitNextVoteTime :: STM m (LeiosPoint, RelativeTime)
   -- ^ Block until an armed EB's window opens, yielding it and the moment after
   -- which a vote for it would be too late. It is disarmed in the same
@@ -272,18 +272,22 @@ runLeiosVoting tracer lcfg chainDB systemTime leiosDB txCache voteState = \case
     -- lifetime, the way each forge-credentials thread does.
     withLeiosDb leiosDB $ \leiosConn -> do
       chan <- subscribeEbNotifications leiosDB
-      let waitAcquiredEbTxs =
+      -- One message per transaction, even the ones we do not act on. Looping
+      -- here instead would be a read that only sticks if the transaction
+      -- commits: a run that ended in 'retry' would put every 'AcquiredEb' it
+      -- had skipped back, to be skipped again on the next wake.
+      let takeEbNotification =
             readTChan chan >>= \case
-              AcquiredEb{} -> waitAcquiredEbTxs
-              AcquiredEbTxs point -> pure point
+              AcquiredEb{} -> pure Nothing
+              AcquiredEbTxs point -> pure (Just point)
 
       VoteTimers{scheduleVoteTime, waitNextVoteTime} <-
         newVoteTimers tracer lcfg chainDB systemTime
 
       forever $
-        atomically ((Left <$> waitAcquiredEbTxs) <|> (Right <$> waitNextVoteTime))
+        atomically ((Left <$> takeEbNotification) <|> (Right <$> waitNextVoteTime))
           >>= \case
-            Left point -> scheduleVoteTime point
+            Left mPoint -> mapM_ scheduleVoteTime mPoint
             Right (point, deadline) ->
               goVote leiosConn sk point deadline >>= \case
                 Left reason -> traceWith tracer TraceLeiosNotVoted{ebPoint = point, reason}
@@ -293,11 +297,14 @@ runLeiosVoting tracer lcfg chainDB systemTime leiosDB txCache voteState = \case
   -- vote. Every way of not voting leaves via 'throwE', and the reason is
   -- traced once, here.
   --
-  -- Validation runs /before/ the deadline is checked, deliberately: applying
-  -- a closure takes real time, so whether we are still inside the vote
-  -- window has to be judged by the clock as it reads when we are ready to
-  -- sign, not by a reading taken before the work. The cheap checks come
-  -- first, so an EB we would not vote for is never validated.
+  -- The deadline is checked twice, for two different reasons. Once up front,
+  -- because a timer can fire already expired: 'scheduleVoteTime' arms on
+  -- acquisition, and a closure that completes long after its EB's slot gives a
+  -- negative delay, so the window can be shut before the timer exists. And
+  -- again after validation, because applying a closure takes real time, so
+  -- whether we are still inside the window has to be judged by the clock as it
+  -- reads when we are ready to sign. The cheap checks come first either way, so
+  -- an EB we would not vote for is never validated.
   goVote ::
     LeiosDbConnection m ->
     -- \| Our voting key, to find our committee seat and sign votes.
@@ -309,53 +316,67 @@ runLeiosVoting tracer lcfg chainDB systemTime leiosDB txCache voteState = \case
     m (Either LeiosNotVotedReason ())
   goVote leiosConn sk point deadline = do
     let vk = deriveVerKeyDSIGN sk
-    withForkerAt VolatileTip $ \case
-      Nothing ->
-        -- Should not happen: VolatileTip target never fails to open. It's safe
-        -- to interpret this non-typed corner case the same way as if we were
-        -- not on the announcing chain.
-        pure $ Left ChainTipDoesNotAnnounce
-      Just forker -> runExceptT $ do
-        -- One consistent view of the selection: the header state that has
-        -- to announce this EB and the ledger state its closure has to apply
-        -- to come from the same forker.
-        extLs <- lift $ atomically $ roforkerGetLedgerState forker
-        let ls = ledgerState extLs
-            hs = headerState extLs
-            readTables = roforkerReadTables (ledgerStateReadOnlyForker forker)
-        rbHash <-
-          tipAnnouncerFor @blk hs point ?>= ChainTipDoesNotAnnounce
-        seatId <-
-          (getLeiosCommittee ls >>= getLeiosSeatId vk) ?>= NotOnCommittee
+    -- Before opening a forker, let alone validating: the window may already
+    -- have shut before this timer was ever armed.
+    expired <- (> deadline) <$> systemTimeCurrent systemTime
+    if expired
+      then pure $ Left TooLate
+      else withForkerAt VolatileTip $ \case
+        Nothing ->
+          -- Should not happen: VolatileTip target never fails to open. It's safe
+          -- to interpret this non-typed corner case the same way as if we were
+          -- not on the announcing chain.
+          pure $ Left ChainTipDoesNotAnnounce
+        Just forker -> runExceptT $ do
+          -- One consistent view of the selection: the header state that has
+          -- to announce this EB and the ledger state its closure has to apply
+          -- to come from the same forker.
+          extLs <- lift $ atomically $ roforkerGetLedgerState forker
+          let ls = ledgerState extLs
+              hs = headerState extLs
+              readTables = roforkerReadTables (ledgerStateReadOnlyForker forker)
+          rbHash <-
+            tipAnnouncerFor @blk hs point ?>= ChainTipDoesNotAnnounce
+          seatId <-
+            (getLeiosCommittee ls >>= getLeiosSeatId vk) ?>= NotOnCommittee
 
-        lift (validateEbClosure lcfg leiosConn txCache readTables point ls) >>= \case
-          EbClosureInvalid err ->
-            -- TODO: Text in error
-            throwE . EbTxsInvalid . Text.pack $ show err
-          EbClosureValid reapplied applied ->
-            lift $ traceWith tracer TraceLeiosEbValidated{ebPoint = point, reapplied, applied}
+          lift (validateEbClosure lcfg leiosConn txCache readTables point ls) >>= \case
+            EbClosureInvalid err ->
+              -- TODO: Text in error
+              throwE . EbTxsInvalid . Text.pack $ show err
+            EbClosureValid reapplied applied ->
+              lift $ traceWith tracer TraceLeiosEbValidated{ebPoint = point, reapplied, applied}
 
-        now <- lift $ systemTimeCurrent systemTime
-        when (now > deadline) $
-          throwE TooLate
+          now <- lift $ systemTimeCurrent systemTime
+          when (now > deadline) $
+            throwE TooLate
 
-        let vote = signLeiosVote sk seatId rbHash
-        lift $
-          addVote vote
-            >>= \case
-              Added weight mCert -> do
-                traceWith tracer TraceLeiosVoted{vote, weight}
-                traceWith tracer TraceLeiosVoteAcquired{vote}
-                -- Trace certification whenever the tally crosses
-                -- 'minCertificationThreshold'. May fire more than once per
-                -- point if subsequent votes also come in; consumers (e.g.
-                -- ThreadNet's 'propCertifying') dedupe.
-                case mCert of
-                  Just _ -> traceWith tracer TraceLeiosCertified{rbHash}
-                  Nothing -> pure ()
-              err ->
-                -- TODO: Make this a NotVoted error / trace
-                error $ "runLeiosVoting: unexpected error on addVote: " <> show err
+          let vote = signLeiosVote sk seatId rbHash
+          ExceptT $
+            addVote vote
+              >>= \case
+                Added weight mCert -> fmap Right $ do
+                  traceWith tracer TraceLeiosVoted{vote, weight}
+                  traceWith tracer TraceLeiosVoteAcquired{vote}
+                  -- Trace certification whenever the tally crosses
+                  -- 'minCertificationThreshold'. May fire more than once per
+                  -- point if subsequent votes also come in; consumers (e.g.
+                  -- ThreadNet's 'propCertifying') dedupe.
+                  case mCert of
+                    Just _ -> traceWith tracer TraceLeiosCertified{rbHash}
+                    Nothing -> pure ()
+                -- A trace rather than an 'error', which under
+                -- 'forkLinkedThread' would take the node down.
+                --
+                -- TODO: do not vote across an epoch boundary at all. 'seatId'
+                -- comes from the forker above and 'addVote' re-reads the
+                -- committee from the current selection, with closure validation
+                -- in between, so a boundary crossed in that gap silently makes
+                -- the positional 'LeiosSeatId' someone else's seat. Signing
+                -- first and finding out afterwards is not the answer: we should
+                -- establish that we are still on the same committee, and still
+                -- hold that seat, before the vote is cast.
+                err -> pure . Left . VoteRejected . Text.pack $ show err
 
   LeiosVoteState{addVote} = voteState
 

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosVoting.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosVoting.hs
@@ -116,6 +116,14 @@ import Ouroboros.Network.Protocol.LocalStateQuery.Type (Target (VolatileTip))
 -- described in the Leios protocol specification. Real values should come
 -- from the protocol parameters once wired in.
 
+-- TODO: Fetching and validating an EB's closure should start when the closure
+-- arrives, streamed, rather than after this wait. Validation is linear in the
+-- closure -- a full ~13.5k-tx closure takes ~1.5s even when every tx is a
+-- tx-cache hit -- so doing it inside the vote window spends the window on work
+-- that could have been done while waiting for it to open. A devnet run showed
+-- exactly that: as closures filled up, the time from votable to validated grew
+-- past the window and voting stopped entirely.
+
 -- | How long after its announcing slot /begins/ before an EB's voters may cast
 -- a vote. Serves as the equivocation-detection window: if a peer equivocates by
 -- announcing two different EBs on the same slot, we want to observe the second
@@ -174,13 +182,24 @@ newVoteTimers tracer lcfg chainDB systemTime = do
                   <> prettyLeiosPoint point
                   <> ": "
                   <> show horizon
-            Right onset -> do
+            Right announced -> do
               now <- systemTimeCurrent systemTime
+              let voteAt = addRelTime lHdrWait announced
+                  voteDeadline = addRelTime lVoteWindow voteAt
+                  voteIn = voteAt `diffRelTime` now
+              traceWith tracer $
+                TraceLeiosVoteScheduled
+                  { ebPoint = point
+                  , voteIn
+                  , deadlineIn = voteDeadline `diffRelTime` now
+                  }
               timer <-
-                registerDelay . max 1 . diffTimeToMicrosecondsAsInt . nominalDelay $
-                  diffRelTime (votableAt onset) now
+                registerDelay
+                  . max 1
+                  . diffTimeToMicrosecondsAsInt
+                  $ nominalDelay voteIn
               atomically . modifyTVar pendingVotes . Map.insert point $
-                (timer, addRelTime lVoteWindow (votableAt onset))
+                (timer, voteDeadline)
       , -- Reading every armed timer puts them all in this transaction's read
         -- set, so it wakes on any of them, and 'Map.toList' is in point order,
         -- so simultaneous firings break towards the earlier slot.
@@ -192,8 +211,6 @@ newVoteTimers tracer lcfg chainDB systemTime = do
               modifyTVar pendingVotes (Map.delete point)
               pure (point, deadline)
       }
- where
-  votableAt = addRelTime lHdrWait
 
 -- | When a slot begins, in wall-clock terms.
 --
@@ -249,7 +266,8 @@ runLeiosVoting tracer lcfg chainDB systemTime leiosDB txCache voteState = \case
               AcquiredEb{} -> waitAcquiredEbTxs
               AcquiredEbTxs point -> pure point
 
-      VoteTimers{scheduleVoteTime, waitNextVoteTime} <- newVoteTimers tracer lcfg chainDB systemTime
+      VoteTimers{scheduleVoteTime, waitNextVoteTime} <-
+        newVoteTimers tracer lcfg chainDB systemTime
 
       forever $
         atomically ((Left <$> waitAcquiredEbTxs) <|> (Right <$> waitNextVoteTime))

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosVoting.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosVoting.hs
@@ -15,22 +15,23 @@ module LeiosVoting
 
 import Cardano.Crypto.DSIGN (DSIGNAlgorithm (deriveVerKeyDSIGN))
 import Cardano.Slotting.Slot (SlotNo (..))
+import Control.Applicative ((<|>))
 import Control.Concurrent.Class.MonadSTM.Strict
   ( modifyTVar
   , newTVar
   , readTChan
   , readTVar
-  , tryReadTChan
   )
-import Control.Monad (forM_, forever)
+import Control.Monad (filterM, forever, when)
 import qualified Control.Monad.Class.MonadSTM.Internal as TVar
 import Control.Monad.Class.MonadTimer (MonadTimer, registerDelay)
 import Control.Monad.Class.MonadTimer.SI (diffTimeToMicrosecondsAsInt)
 import Control.Monad.Except (runExcept)
+import Control.Monad.Trans.Class (lift)
+import Control.Monad.Trans.Except (ExceptT, runExceptT, throwE)
 import Control.Tracer (Tracer, traceWith)
+import qualified Data.Map.Strict as Map
 import Data.Proxy (Proxy (..))
-import Data.Set (Set)
-import qualified Data.Set as Set
 import qualified Data.Text as Text
 import Data.Time.Clock (NominalDiffTime)
 import LeiosDemoDb
@@ -43,7 +44,6 @@ import LeiosDemoTypes
   ( HasLeiosVoting (..)
   , LeiosNotVotedReason (..)
   , LeiosPoint (..)
-  , LeiosSeatId
   , LeiosSigningKey
   , RbHash (..)
   , SerializedEbBody
@@ -56,6 +56,7 @@ import LeiosTxCache (LeiosTxCache (..))
 import LeiosVoteState (AddVoteResult (..), LeiosVoteState (..))
 import Ouroboros.Consensus.Block
   ( ConvertRawHash (..)
+  , Point
   , WithOrigin (..)
   )
 import Ouroboros.Consensus.BlockchainTime
@@ -64,7 +65,6 @@ import Ouroboros.Consensus.BlockchainTime
   , addRelTime
   , diffRelTime
   )
-import Ouroboros.Consensus.Config (TopLevelConfig, configLedger)
 import Ouroboros.Consensus.HardFork.Abstract (HasHardForkHistory (..))
 import qualified Ouroboros.Consensus.HardFork.History.Qry as Qry
 import Ouroboros.Consensus.HeaderValidation
@@ -83,7 +83,6 @@ import Ouroboros.Consensus.Ledger.Abstract
   , LedgerTables
   , ValuesMK
   , applyChainTick
-  , ledgerTipPoint
   )
 import Ouroboros.Consensus.Ledger.Extended (headerState, ledgerState)
 import Ouroboros.Consensus.Ledger.SupportsMempool
@@ -96,6 +95,7 @@ import Ouroboros.Consensus.Storage.ChainDB (ChainDB)
 import qualified Ouroboros.Consensus.Storage.ChainDB as ChainDB
 import Ouroboros.Consensus.Storage.LedgerDB.Forker
   ( ReadOnlyForker (..)
+  , ReadOnlyForker'
   , ResolveLeiosBlock (..)
   , ledgerStateReadOnlyForker
   , protocolStateLeiosAnnouncement
@@ -107,7 +107,7 @@ import Ouroboros.Consensus.Util.IOLike
   , bracket
   )
 import Ouroboros.Consensus.Util.Time (nominalDelay)
-import Ouroboros.Network.Protocol.LocalStateQuery.Type (Target (SpecificPoint))
+import Ouroboros.Network.Protocol.LocalStateQuery.Type (Target (VolatileTip))
 
 -- * Voting timing constants
 
@@ -126,6 +126,74 @@ lHdrWait = 3
 -- | How long after 'lHdrWait' votes are still accepted. Stub for 'L_vote'.
 lVoteWindow :: NominalDiffTime
 lVoteWindow = 4
+
+-- * Vote timers
+
+-- | A vote timer per acquired EB, armed at the wall-clock moment that EB's
+-- voting window opens.
+--
+-- There is no priority queue: the wall clock does the prioritising, since
+-- whichever timer fires first is by construction the EB whose window opens
+-- first.
+data VoteTimers m = VoteTimers
+  { scheduleVoteTime :: LeiosPoint -> m ()
+  -- ^ Arm a timer for a newly acquired EB. One whose window is already open
+  -- clamps to a near-zero delay and fires immediately, so "already open" is not
+  -- a separate case for the caller.
+  , waitNextVoteTime :: STM m (LeiosPoint, RelativeTime)
+  -- ^ Block until an armed EB's window opens, yielding it and the moment after
+  -- which a vote for it would be too late. It is disarmed in the same
+  -- transaction, so each EB's window opens exactly once.
+  }
+
+newVoteTimers ::
+  forall m blk.
+  ( IOLike m
+  , MonadTimer m
+  , HasHardForkHistory blk
+  ) =>
+  Tracer m TraceLeiosKernel ->
+  LedgerConfig blk ->
+  ChainDB m blk ->
+  SystemTime m ->
+  m (VoteTimers m)
+newVoteTimers tracer lcfg chainDB systemTime = do
+  -- An armed timer, and the deadline it was armed against, per acquired EB.
+  pendingVotes <- atomically $ newTVar Map.empty
+  pure
+    VoteTimers
+      { scheduleVoteTime = \point -> do
+          extLedger <- atomically $ ChainDB.getCurrentLedger chainDB
+          case slotOnset lcfg (ledgerState extLedger) (pointSlotNo point) of
+            -- Cannot happen for an EB announced on our own chain: its slot is
+            -- at or behind the tip whose summary we just read. Drop it rather
+            -- than arm a timer we cannot place, and say so.
+            Left horizon ->
+              traceWith tracer . MkTraceLeiosKernel $
+                "newVoteTimers: no wall-clock onset for "
+                  <> prettyLeiosPoint point
+                  <> ": "
+                  <> show horizon
+            Right onset -> do
+              now <- systemTimeCurrent systemTime
+              timer <-
+                registerDelay . max 1 . diffTimeToMicrosecondsAsInt . nominalDelay $
+                  diffRelTime (votableAt onset) now
+              atomically . modifyTVar pendingVotes . Map.insert point $
+                (timer, addRelTime lVoteWindow (votableAt onset))
+      , -- Reading every armed timer puts them all in this transaction's read
+        -- set, so it wakes on any of them, and 'Map.toList' is in point order,
+        -- so simultaneous firings break towards the earlier slot.
+        waitNextVoteTime = do
+          armed <- readTVar pendingVotes
+          filterM (\(_, (timer, _)) -> TVar.readTVar timer) (Map.toList armed) >>= \case
+            [] -> TVar.retry
+            (point, (_, deadline)) : _ -> do
+              modifyTVar pendingVotes (Map.delete point)
+              pure (point, deadline)
+      }
+ where
+  votableAt = addRelTime lHdrWait
 
 -- | When a slot begins, in wall-clock terms.
 --
@@ -158,7 +226,7 @@ runLeiosVoting ::
   , MonadTimer m
   ) =>
   Tracer m TraceLeiosKernel ->
-  TopLevelConfig blk ->
+  LedgerConfig blk ->
   ChainDB m blk ->
   SystemTime m ->
   LeiosDbHandle m ->
@@ -166,182 +234,106 @@ runLeiosVoting ::
   LeiosVoteState m ->
   Maybe LeiosSigningKey ->
   m ()
-runLeiosVoting tracer cfg chainDB systemTime leiosDB txCache voteState = \case
+runLeiosVoting tracer lcfg chainDB systemTime leiosDB txCache voteState = \case
   Nothing ->
     traceWith tracer $
       MkTraceLeiosKernel
         "runLeiosVoting: disabled because no topLevelConfigVotingKey"
-  -- A 'LeiosDbConnection' is not thread-safe, so this thread owns one for its
-  -- lifetime, the way each forge-credentials thread does.
-  Just sk -> withLeiosDb leiosDB $ \leiosConn -> do
-    let vk = deriveVerKeyDSIGN sk
-        signVote = signLeiosVote sk
-        LeiosVoteState{addVote} = voteState
-    chan <- subscribeEbNotifications leiosDB
+  Just sk ->
+    -- A 'LeiosDbConnection' is not thread-safe, so this thread owns one for its
+    -- lifetime, the way each forge-credentials thread does.
+    withLeiosDb leiosDB $ \leiosConn -> do
+      chan <- subscribeEbNotifications leiosDB
+      let waitAcquiredEbTxs =
+            readTChan chan >>= \case
+              AcquiredEb{} -> waitAcquiredEbTxs
+              AcquiredEbTxs point -> pure point
 
-    -- 'pendingVar' holds EB closures whose voting windows we still owe
-    -- a decision on. The 'Ord LeiosPoint' instance orders by slot then
-    -- hash, so 'Set.minView' yields the earliest upcoming deadline.
-    -- A burst of closures arriving in the same slot no longer
-    -- serialises voting through the L_hdr wait for the first one:
-    -- each is enqueued as it arrives and drained the moment its
-    -- window opens.
-    pendingVar <- atomically $ newTVar (Set.empty :: Set LeiosPoint)
+      VoteTimers{scheduleVoteTime, waitNextVoteTime} <- newVoteTimers tracer lcfg chainDB systemTime
 
-    let
-      -- Enqueue a fresh acquisition. Retries until the channel has
-      -- one available; ignores 'AcquiredEb' (no txs closure yet).
-      takeAcquisition :: STM m ()
-      takeAcquisition =
-        readTChan chan >>= \case
-          AcquiredEb{} -> pure ()
-          AcquiredEbTxs point -> modifyTVar pendingVar (Set.insert point)
-
-      -- Move whatever has already arrived into the pending set, blocking only
-      -- when there is nothing pending to act on at all.
-      ingest :: STM m ()
-      ingest = do
-        pending <- readTVar pendingVar
-        if Set.null pending then takeAcquisition else drain
-       where
-        drain =
-          tryReadTChan chan >>= \case
-            Nothing -> pure ()
-            Just AcquiredEb{} -> drain
-            Just (AcquiredEbTxs point) -> do
-              modifyTVar pendingVar (Set.insert point)
-              drain
-
-      -- Everything the node has to be asked about before we can decide, read
-      -- as one consistent view of the selected chain.
-      readTip = atomically $ ChainDB.getCurrentLedger chainDB
-
-      -- Validate an EB's closure against the announcing RB's ledger state.
-      -- Losing that state to chain-sel is not the EB's fault, so it reads as
-      -- 'ChainTipDoesNotAnnounce' rather than a rejection.
-      validateClosure extLedger point =
-        -- REVIEW: How expensive is it to open a forker - should we re-use
-        -- one for the whole vote logic?
-        -- TODO: refactor: withForker announcerPoint $ \(ls, forker) ->
-        bracket
-          (ChainDB.openReadOnlyForkerAtPoint chainDB (SpecificPoint (ledgerTipPoint (ledgerState extLedger))))
-          (either (\_ -> pure ()) roforkerClose)
-          $ \case
-            Left _ -> pure $ Left ChainTipDoesNotAnnounce
-            Right extForker -> do
-              let forker = ledgerStateReadOnlyForker extForker
-              lsBase <- atomically $ roforkerGetLedgerState forker
-              validateEbClosure
-                (configLedger cfg)
-                leiosConn
-                txCache
-                (roforkerReadTables forker)
-                point
-                lsBase
-                >>= \case
-                  -- XXX: Text in error
-                  EbClosureInvalid err -> pure $ Left $ EbTxsInvalid $ Text.pack $ show err
-                  EbClosureValid reapplied applied -> pure $ Right (reapplied, applied)
-
-      -- Decide and, if we may, cast the vote.
-      voteOn point extLedger deadline = do
-        let notVoted r = traceWith tracer TraceLeiosNotVoted{ebPoint = point, reason = r}
-        decideVote
-          (getLeiosCommittee (ledgerState extLedger) >>= getLeiosSeatId vk)
-          (tipAnnouncerFor @blk (headerState extLedger) point)
-          (validateClosure extLedger point)
-          (systemTimeCurrent systemTime)
-          deadline
+      forever $
+        atomically ((Left <$> waitAcquiredEbTxs) <|> (Right <$> waitNextVoteTime))
           >>= \case
-            Left reason -> notVoted reason
-            Right (rbHash, voterId, (reapplied, applied)) -> do
-              traceWith tracer TraceLeiosEbValidated{ebPoint = point, reapplied, applied}
-              let vote = signVote voterId rbHash
-              addVote vote >>= \case
-                Added weight mCert -> do
-                  traceWith tracer TraceLeiosVoted{vote, weight}
-                  traceWith tracer TraceLeiosVoteAcquired{vote}
-                  -- Trace certification whenever the tally crosses
-                  -- 'minCertificationThreshold'. May fire more than once
-                  -- per point if subsequent votes also come in; consumers
-                  -- (e.g. ThreadNet's 'propCertifying') dedupe.
-                  case mCert of
-                    Just _ -> traceWith tracer TraceLeiosCertified{rbHash}
-                    Nothing -> pure ()
-                err ->
-                  error $ "runLeiosVoting: unexpected error on addVote: " <> show err
+            Left point -> scheduleVoteTime point
+            Right (point, deadline) ->
+              goVote leiosConn sk point deadline >>= \case
+                Left reason -> traceWith tracer TraceLeiosNotVoted{ebPoint = point, reason}
+                Right () -> pure ()
+ where
+  -- Decide whether to vote for an acquired EB and, if we may, cast the
+  -- vote. Every way of not voting leaves via 'throwE', and the reason is
+  -- traced once, here.
+  --
+  -- Validation runs /before/ the deadline is checked, deliberately: applying
+  -- a closure takes real time, so whether we are still inside the vote
+  -- window has to be judged by the clock as it reads when we are ready to
+  -- sign, not by a reading taken before the work. The cheap checks come
+  -- first, so an EB we would not vote for is never validated.
+  goVote ::
+    LeiosDbConnection m ->
+    -- \| Our voting key, to find our committee seat and sign votes.
+    LeiosSigningKey ->
+    -- \| The leios point of the EB to vote on.
+    LeiosPoint ->
+    -- \| The moment after which a vote is too late.
+    RelativeTime ->
+    m (Either LeiosNotVotedReason ())
+  goVote leiosConn sk point deadline = do
+    let vk = deriveVerKeyDSIGN sk
+    withForkerAt VolatileTip $ \case
+      Nothing -> pure $ Left ChainTipDoesNotAnnounce
+      Just forker -> runExceptT $ do
+        -- One consistent view of the selection: the header state that has
+        -- to announce this EB and the ledger state its closure has to apply
+        -- to come from the same forker.
+        extLs <- lift $ atomically $ roforkerGetLedgerState forker
+        let ls = ledgerState extLs
+            hs = headerState extLs
+            readTables = roforkerReadTables (ledgerStateReadOnlyForker forker)
+        rbHash <-
+          tipAnnouncerFor @blk hs point ?>= ChainTipDoesNotAnnounce
+        seatId <-
+          (getLeiosCommittee ls >>= getLeiosSeatId vk) ?>= NotOnCommittee
 
-    forever $ do
-      atomically ingest
-      mNext <- atomically $ fmap fst . Set.minView <$> readTVar pendingVar
-      forM_ mNext $ \point -> do
-        extLedger <- readTip
-        now <- systemTimeCurrent systemTime
-        case slotOnset (configLedger cfg) (ledgerState extLedger) (pointSlotNo point) of
-          Left horizon -> do
-            -- Cannot happen for an EB announced on our own chain: its slot is
-            -- at or behind the tip whose summary we just read. Drop it rather
-            -- than spin on it, and say so.
-            atomically $ modifyTVar pendingVar (Set.delete point)
-            traceWith tracer . MkTraceLeiosKernel $
-              "runLeiosVoting: no wall-clock onset for "
-                <> prettyLeiosPoint point
-                <> ": "
-                <> show horizon
-          Right onset -> do
-            let votableAt = addRelTime lHdrWait onset
-            if now < votableAt
-              then do
-                -- Wait until it is votable, but wake early if something
-                -- arrives: an EB turning up late with an older slot must not
-                -- have to sit out this one's wait. Never register a zero
-                -- delay.
-                varTimeout <-
-                  registerDelay . max 1 . diffTimeToMicrosecondsAsInt . nominalDelay $
-                    diffRelTime votableAt now
-                atomically $
-                  (TVar.check =<< TVar.readTVar varTimeout) `TVar.orElse` takeAcquisition
-              else do
-                atomically $ modifyTVar pendingVar (Set.delete point)
-                voteOn point extLedger (addRelTime lVoteWindow votableAt)
+        lift (validateEbClosure lcfg leiosConn txCache readTables point ls) >>= \case
+          EbClosureInvalid err ->
+            -- XXX: Text in error
+            throwE . EbTxsInvalid . Text.pack $ show err
+          EbClosureValid reapplied applied ->
+            lift $ traceWith tracer TraceLeiosEbValidated{ebPoint = point, reapplied, applied}
 
--- * The vote decision
+        now <- lift $ systemTimeCurrent systemTime
+        when (now > deadline) $
+          throwE TooLate
 
--- | Whether to vote for an acquired EB, and why not when we don't.
---
--- Validation runs /before/ the deadline is checked, deliberately: applying a
--- closure takes real time, so whether we are still inside the vote window has
--- to be judged by the clock as it reads when we are ready to sign, not by a
--- reading taken before the work. The cheap checks still come first, so an EB we
--- would not vote for is never validated.
-decideVote ::
-  Monad m =>
-  -- | Our seat on the voting committee, if we hold one.
-  Maybe LeiosSeatId ->
-  -- | The announcing RB's hash, if our tip announces this EB.
-  Maybe RbHash ->
-  -- | Validate the EB's closure.
-  m (Either LeiosNotVotedReason a) ->
-  -- | Read the wall clock. Called after validation.
-  m RelativeTime ->
-  -- | The moment after which a vote is too late.
-  RelativeTime ->
-  m (Either LeiosNotVotedReason (RbHash, LeiosSeatId, a))
-decideVote mSeat mAnnouncer validate readNow deadline =
-  case (mAnnouncer, mSeat) of
-    (Nothing, _) -> pure $ Left ChainTipDoesNotAnnounce
-    (_, Nothing) -> pure $ Left NotOnCommittee
-    (Just rbHash, Just seatId) ->
-      validate >>= \case
-        Left reason -> pure $ Left reason
-        Right a -> do
-          now <- readNow
-          pure $
-            if now > deadline
-              then Left TooLate
-              else Right (rbHash, seatId, a)
+        let vote = signLeiosVote sk seatId rbHash
+        lift $
+          addVote vote
+            >>= \case
+              Added weight mCert -> do
+                traceWith tracer TraceLeiosVoted{vote, weight}
+                traceWith tracer TraceLeiosVoteAcquired{vote}
+                -- Trace certification whenever the tally crosses
+                -- 'minCertificationThreshold'. May fire more than once per
+                -- point if subsequent votes also come in; consumers (e.g.
+                -- ThreadNet's 'propCertifying') dedupe.
+                case mCert of
+                  Just _ -> traceWith tracer TraceLeiosCertified{rbHash}
+                  Nothing -> pure ()
+              err ->
+                -- XXX: Make this a NotVoted error / trace
+                error $ "runLeiosVoting: unexpected error on addVote: " <> show err
 
--- * Validating the endorsed transactions
+  LeiosVoteState{addVote} = voteState
+
+  -- The forker at a target, for as long as the continuation needs it, or
+  -- 'Nothing' when chain-sel has already moved off it.
+  withForkerAt :: Target (Point blk) -> (Maybe (ReadOnlyForker' m blk) -> m a) -> m a
+  withForkerAt tgt k =
+    bracket
+      (ChainDB.openReadOnlyForkerAtPoint chainDB tgt)
+      (either (\_ -> pure ()) roforkerClose)
+      (either (\_ -> k Nothing) (k . Just))
 
 -- | The outcome of checking an EB's endorsed transactions.
 data EbClosureVerdict blk
@@ -444,3 +436,7 @@ tipAnnouncerFor hs point = do
   if announcedPoint == point
     then Just (MkRbHash (toRawHash (Proxy @blk) (annTipHash tip)))
     else Nothing
+
+(?>=) :: Monad m => Maybe a -> e -> ExceptT e m a
+(?>=) Nothing e = throwE e
+(?>=) (Just x) _ = pure x

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosVoting.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosVoting.hs
@@ -15,6 +15,7 @@ module LeiosVoting
 
 import Cardano.Crypto.DSIGN (DSIGNAlgorithm (deriveVerKeyDSIGN))
 import Cardano.Slotting.Slot (SlotNo (..))
+import Control.Applicative ((<|>))
 import Control.Concurrent.Class.MonadSTM.Strict
   ( modifyTVar
   , newTVar
@@ -52,7 +53,6 @@ import LeiosTxCache (LeiosTxCache (..))
 import LeiosVoteState (AddVoteResult (..), LeiosVoteState (..))
 import Ouroboros.Consensus.Block
   ( ConvertRawHash (..)
-  , Point
   , WithOrigin (..)
   )
 import Ouroboros.Consensus.BlockchainTime
@@ -69,7 +69,12 @@ import Ouroboros.Consensus.HeaderValidation
   )
 import Ouroboros.Consensus.Ledger.Abstract
   ( ComputeLedgerEvents (OmitLedgerEvents)
+  , EmptyMK
+  , KeysMK
   , LedgerConfig
+  , LedgerState
+  , LedgerTables
+  , ValuesMK
   , applyChainTick
   , ledgerTipPoint
   )
@@ -93,7 +98,6 @@ import Ouroboros.Consensus.Util.IOLike
   , STM
   , atomically
   , bracket
-  , orElse
   )
 import Ouroboros.Network.Protocol.LocalStateQuery.Type (Target (SpecificPoint))
 
@@ -193,9 +197,7 @@ runLeiosVoting tracer cfg chainDB btime leiosDB txCache voteState = \case
     -- acquisition. 'orElse' gives priority to voting over ingesting,
     -- so we can't stall a due vote behind a chan drain.
     forever $ do
-      mWork <-
-        atomically $
-          (Just <$> takeReady) `orElse` (Nothing <$ takeAcquisition)
+      mWork <- atomically $ (Just <$> takeReady) <|> (Nothing <$ takeAcquisition)
       case mWork of
         Nothing -> pure ()
         Just (point, currentSlot, extLedger) -> do
@@ -204,6 +206,9 @@ runLeiosVoting tracer cfg chainDB btime leiosDB txCache voteState = \case
               notVoted r = traceWith tracer TraceLeiosNotVoted{ebPoint = point, reason = r}
               mVoterId = getLeiosCommittee (ledgerState extLedger) >>= getLeiosSeatId vk
               mAnnouncer = tipAnnouncerFor @blk (headerState extLedger) point
+          -- FIXME: Check the deadline against wall clock not the ledger
+          -- state. The latter is only advancing whenever a block is
+          -- adopted.
           case (currentSlot > deadlineSlot, mAnnouncer, mVoterId) of
             (True, _, _) -> notVoted TooLate
             (_, Nothing, _) -> notVoted ChainTipDoesNotAnnounce
@@ -212,32 +217,45 @@ runLeiosVoting tracer cfg chainDB btime leiosDB txCache voteState = \case
             -- ledger work: we never validate an EB we would not vote for.
             (_, Just rbHash, Just voterId) -> do
               let announcerPoint = ledgerTipPoint (ledgerState extLedger)
-              validateEbClosure
-                (configLedger cfg)
-                chainDB
-                leiosConn
-                txCache
-                point
-                announcerPoint
-                >>= \case
-                  EbClosureNoLedger -> notVoted ChainTipDoesNotAnnounce
-                  EbClosureInvalid err -> notVoted $ EbTxsInvalid (Text.pack (show err))
-                  EbClosureValid reapplied applied -> do
-                    traceWith tracer TraceLeiosEbValidated{ebPoint = point, reapplied, applied}
-                    let vote = signVote voterId rbHash
-                    addVote vote >>= \case
-                      Added weight mCert -> do
-                        traceWith tracer TraceLeiosVoted{vote, weight}
-                        traceWith tracer TraceLeiosVoteAcquired{vote}
-                        -- Trace certification whenever the tally crosses
-                        -- 'minCertificationThreshold'. May fire more than once
-                        -- per point if subsequent votes also come in; consumers
-                        -- (e.g. ThreadNet's 'propCertifying') dedupe.
-                        case mCert of
-                          Just _ -> traceWith tracer TraceLeiosCertified{rbHash}
-                          Nothing -> pure ()
-                      err ->
-                        error $ "runLeiosVoting: unexpected error on addVote: " <> show err
+              -- REVIEW: How expensive is it to open a forker - should we re-use
+              -- one for the whole vote logic?
+              -- TODO: refactor: withForker announcerPoint $ \(ls, forker) ->
+              bracket
+                (ChainDB.openReadOnlyForkerAtPoint chainDB (SpecificPoint announcerPoint))
+                (either (\_ -> pure ()) roforkerClose)
+                $ \case
+                  -- Chain-sel moved off the announcer before we could read
+                  -- its ledger state. No vote, but nothing is wrong with the EB.
+                  Left _ -> notVoted ChainTipDoesNotAnnounce
+                  Right extForker -> do
+                    let forker = ledgerStateReadOnlyForker extForker
+                    lsBase <- atomically $ roforkerGetLedgerState forker
+                    validateEbClosure
+                      (configLedger cfg)
+                      leiosConn
+                      txCache
+                      (roforkerReadTables forker)
+                      point
+                      lsBase
+                      >>= \case
+                        -- XXX: Text in error
+                        EbClosureInvalid err -> notVoted $ EbTxsInvalid (Text.pack $ show err)
+                        EbClosureValid reapplied applied -> do
+                          traceWith tracer TraceLeiosEbValidated{ebPoint = point, reapplied, applied}
+                          let vote = signVote voterId rbHash
+                          addVote vote >>= \case
+                            Added weight mCert -> do
+                              traceWith tracer TraceLeiosVoted{vote, weight}
+                              traceWith tracer TraceLeiosVoteAcquired{vote}
+                              -- Trace certification whenever the tally crosses
+                              -- 'minCertificationThreshold'. May fire more than once
+                              -- per point if subsequent votes also come in; consumers
+                              -- (e.g. ThreadNet's 'propCertifying') dedupe.
+                              case mCert of
+                                Just _ -> traceWith tracer TraceLeiosCertified{rbHash}
+                                Nothing -> pure ()
+                            err ->
+                              error $ "runLeiosVoting: unexpected error on addVote: " <> show err
 
 -- * Validating the endorsed transactions
 
@@ -249,9 +267,6 @@ data EbClosureVerdict blk
     EbClosureValid !Int !Int
   | -- | A tx did not apply, so this EB must not be certified.
     EbClosureInvalid !(ApplyTxErr blk)
-  | -- | The announcing RB's ledger state was gone before we could read it:
-    -- chain-sel moved on. No vote, but nothing is wrong with the EB.
-    EbClosureNoLedger
 
 -- | Apply an EB's endorsed transactions to the announcing RB's ledger state,
 -- which is the state they will meet if the EB is ever certified.
@@ -268,33 +283,25 @@ validateEbClosure ::
   , LedgerSupportsMempool blk
   ) =>
   LedgerConfig blk ->
-  ChainDB m blk ->
   LeiosDbConnection m ->
   LeiosTxCache m () () SerializedEbBody ->
+  -- | Read the ledger tables the closure's txs need, as
+  -- 'resolveAndApplyLeiosClosure' does on the apply path.
+  (LedgerTables (LedgerState blk) KeysMK -> m (LedgerTables (LedgerState blk) ValuesMK)) ->
   LeiosPoint ->
-  -- | The announcing RB, whose unticked ledger state the closure applies to.
-  Point blk ->
+  -- | The announcing RB's unticked ledger state, which the closure applies to.
+  LedgerState blk EmptyMK ->
   m (EbClosureVerdict blk)
-validateEbClosure lcfg chainDB leiosConn txCache point announcerPoint =
-  -- REVIEW: How expensive is it to open a forker - should we re-use one for the
-  -- whole vote logic?
-  bracket
-    (ChainDB.openReadOnlyForkerAtPoint chainDB (SpecificPoint announcerPoint))
-    (either (\_ -> pure ()) roforkerClose)
-    $ \case
-      Left _ -> pure EbClosureNoLedger
-      Right extForker -> do
-        let forker = ledgerStateReadOnlyForker extForker
-        lsBase <- atomically $ roforkerGetLedgerState forker
-        -- Load txs from disk
-        closure <- resolveLeiosClosure leiosConn (pointEbHash point)
-        -- Resolve their input UTxOs
-        let keys = foldMap (getTransactionKeySets . snd) closure
-        values <- roforkerReadTables forker keys
-        -- Determine which txs we can just reapply (the cache hits)
-        decided <- withLookupTx txCache $ \look -> mapM (decide look) closure
-        let st0 = applyMempoolDiffs values keys (applyChainTick OmitLedgerEvents lcfg slot lsBase)
-        goValidate st0 decided 0 0
+validateEbClosure lcfg leiosConn txCache resolveValues point lsBase = do
+  -- Load txs from disk
+  closure <- resolveLeiosClosure leiosConn (pointEbHash point)
+  -- Resolve their input UTxOs
+  let keys = foldMap (getTransactionKeySets . snd) closure
+  values <- resolveValues keys
+  -- Determine which txs we can just reapply (the cache hits)
+  decided <- withLookupTx txCache $ \look -> mapM (decide look) closure
+  let st0 = applyMempoolDiffs values keys (applyChainTick OmitLedgerEvents lcfg slot lsBase)
+  goValidate st0 decided 0 0
  where
   -- The EB's slot is also its announcer's, so ticking to it mirrors what the
   -- apply path does when a later RB certifies this EB.

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ChainSync/Server.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ChainSync/Server.hs
@@ -169,7 +169,7 @@ chainSyncBlocksServer tracer chainDB ccfg leiosDb flr = ChainSyncServer $ do
           Left _ -> pure sblk
           Right blk -> do
             resolveLeiosClosure leiosDb (pointEbHash prevAnn)
-              <&> inlineLeiosClosure blk
+              <&> inlineLeiosClosure blk . map snd
               <&> encode
         _ -> pure sblk
       pure (WithPoint sblk' pt)

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/Forker.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/Forker.hs
@@ -822,6 +822,27 @@ class ResolveLeiosBlock blk where
     m [(TxHash, GenTx blk)]
   resolveLeiosClosure _ _ = pure []
 
+  -- | Rebuild the 'Validated' token for a closure tx that the LeiosTxCache
+  -- reports as already validated, so the voting thread can pick
+  -- 'LedgerSupportsMempool.reapplyTx' — which skips only the static checks
+  -- (witnesses, scripts) — over a full 'LedgerSupportsMempool.applyTx'.
+  --
+  -- The token carries no evidence of its own; the cache's tag is the evidence,
+  -- and the ledger recomputes every state-dependent check from the state at
+  -- hand. Calling this on a tx the cache has /not/ tagged validated would skip
+  -- checks that were never run.
+  --
+  -- NOTE: the cache's tag does not record which protocol version the tx was
+  -- validated under, so an EB straddling a protocol-version change could skip
+  -- a static check whose rules changed. The mempool has the same exposure, and
+  -- the cache only retains a short window of EBs.
+  --
+  -- The default panics, like 'leiosClosureTxKeySets': a non-Leios block never
+  -- reaches the voting path.
+  assumeValidatedClosureTx :: GenTx blk -> Validated (GenTx blk)
+  assumeValidatedClosureTx _ =
+    error "assumeValidatedClosureTx: not Leios-enabled for this block type"
+
   -- | The ledger keys read by a closure tx — what 'forkerReadTables' needs
   -- to load before 'applyLeiosClosure' can run. Leios-enabled instances
   -- should override with their 'LedgerSupportsMempool.getTransactionKeySets'.

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/Forker.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/Forker.hs
@@ -800,8 +800,9 @@ data OCINStaleness = FreshOCIN | StaleOCIN
 -- blk' is correct.
 class ResolveLeiosBlock blk where
   -- | For a CertRB, look up the EB closure that the cert in this block's
-  -- body attests to and return it as a list of transactions (in the order
-  -- they appear in the EB). 'Nothing' for non-CertRB blocks.
+  -- body attests to and return its transactions, each paired with the
+  -- 'TxHash' it is stored under, in the order they appear in the EB. Empty
+  -- for non-CertRB blocks.
   --
   -- This is the apply-path variant: the caller applies the closure txs
   -- onto the parent ledger state via 'applyLeiosClosure', then applies
@@ -810,11 +811,15 @@ class ResolveLeiosBlock blk where
   -- folded into the unticked ledger state, mirroring how a non-CertRB
   -- Praos block's body txs would be applied — but sourced from the
   -- LeiosDB rather than the block body.
+  --
+  -- The 'TxHash' comes free with the read and is what keys the
+  -- 'LeiosTxCache', which the voting thread consults to decide whether a
+  -- closure tx still needs full validation.
   resolveLeiosClosure ::
     Monad m =>
     LeiosDbConnection m ->
     EbHash ->
-    m [GenTx blk]
+    m [(TxHash, GenTx blk)]
   resolveLeiosClosure _ _ = pure []
 
   -- | The ledger keys read by a closure tx — what 'forkerReadTables' needs
@@ -943,7 +948,7 @@ resolveLeiosBlock leiosDb cds b =
     Just (announcedPoint, _) ->
       -- NOTE: This produces a block that would fail full validation.
       resolveLeiosClosure leiosDb (pointEbHash announcedPoint)
-        <&> inlineLeiosClosure b
+        <&> inlineLeiosClosure b . map snd
 
 -- | The result of resolving an announced EB's closure and applying it a ledger state.
 data LeiosClosureApplied blk = LeiosClosureApplied
@@ -975,7 +980,7 @@ resolveAndApplyLeiosClosure ::
   m (Either (LedgerErr (LedgerState blk)) (LeiosClosureApplied blk))
 resolveAndApplyLeiosClosure leiosDb lcfg ebHash readValues extraKeys lsBase = do
   -- Load EB txs from disk
-  closureTxs <- resolveLeiosClosure leiosDb ebHash
+  closureTxs <- map snd <$> resolveLeiosClosure leiosDb ebHash
   -- UTXO-HD of the whole closure
   let closureKeys = foldMap leiosClosureTxKeySets closureTxs <> extraKeys
   closureVals <- readValues closureKeys

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/Forker.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/Forker.hs
@@ -857,11 +857,15 @@ class ResolveLeiosBlock blk where
     error "leiosClosureTxKeySets: not Leios-enabled for this block type"
 
   -- | Apply an EB closure's transactions onto an /unticked/ ledger state,
-  -- without validation. The closure has already been individually
-  -- validated when each tx was inserted into the LeiosDb, so we trust it
-  -- here (era-level @ApplyTxValidation ValidateNone@). Returns the
-  -- unticked post-closure ledger state, ready to feed into
+  -- without validation (era-level @ApplyTxValidation ValidateNone@). Returns
+  -- the unticked post-closure ledger state, ready to feed into
   -- 'tickThenApply' for the CertRB itself.
+  --
+  -- What licenses the trust is the /certificate/: a quorum of the voting
+  -- committee applied this closure before signing (see
+  -- 'LeiosVoting.validateEbClosure'), and only a certified EB reaches this
+  -- path. Insertion into the LeiosDb validates nothing, so a node that never
+  -- voted is trusting the committee, not its own check.
   --
   -- The slot is obtained from the provided ledger state.
   --

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/Forker.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/Forker.hs
@@ -827,15 +827,10 @@ class ResolveLeiosBlock blk where
   -- 'LedgerSupportsMempool.reapplyTx' — which skips only the static checks
   -- (witnesses, scripts) — over a full 'LedgerSupportsMempool.applyTx'.
   --
-  -- The token carries no evidence of its own; the cache's tag is the evidence,
-  -- and the ledger recomputes every state-dependent check from the state at
-  -- hand. Calling this on a tx the cache has /not/ tagged validated would skip
-  -- checks that were never run.
-  --
-  -- NOTE: the cache's tag does not record which protocol version the tx was
-  -- validated under, so an EB straddling a protocol-version change could skip
-  -- a static check whose rules changed. The mempool has the same exposure, and
-  -- the cache only retains a short window of EBs.
+  -- NOTE: The token carries no evidence of its own; the cache's tag is the
+  -- evidence, and the ledger recomputes every state-dependent check from the
+  -- state at hand. Calling this on a tx the cache has /not/ tagged validated
+  -- would skip checks that were never run!
   --
   -- The default panics, like 'leiosClosureTxKeySets': a non-Leios block never
   -- reaches the voting path.

--- a/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Ledger/Block.hs
+++ b/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Ledger/Block.hs
@@ -80,7 +80,7 @@ import Cardano.Crypto.Hash (Hash, HashAlgorithm, SHA256, ShortHash)
 import qualified Cardano.Crypto.Hash as Hash
 import qualified Codec.CBOR.Decoding as CBOR
 import qualified Codec.CBOR.Encoding as CBOR
-import Codec.Serialise (Serialise (..), serialise)
+import Codec.Serialise (Serialise (..), deserialise, serialise)
 import Control.Monad.Except
 import qualified Data.ByteString.Lazy as Lazy
 import Data.Kind (Type)
@@ -88,6 +88,7 @@ import Data.Proxy
 import Data.Typeable
 import Data.Word
 import GHC.Generics (Generic)
+import LeiosDemoDb (leiosDbLookupEbClosure)
 import LeiosVoting (HasLeiosVoting)
 import NoThunks.Class (NoThunks (..))
 import Ouroboros.Consensus.Block
@@ -136,10 +137,21 @@ data SimpleBlock' c ext ext' = SimpleBlock
   }
   deriving (Generic, Show, Eq)
 
--- | Default 'ResolveLeiosBlock' — mock blocks never carry Leios certs.
+-- | Mock blocks never carry Leios certs, so the certificate-shaped methods keep
+-- their defaults. The two the Leios voting thread needs are real, though, so
+-- that 'LeiosVoting.validateEbClosure' can be tested against mock blocks --
+-- 'assumeValidatedClosureTx' in particular defaults to a panic.
+--
+-- Narrowed to @ext' ~ ext@ because that is where 'GenTx' is defined.
 instance
-  (Typeable c, Typeable ext, Typeable ext') =>
-  ResolveLeiosBlock (SimpleBlock' c ext ext')
+  (Typeable c, Typeable ext, Serialise (GenTx (SimpleBlock' c ext ext))) =>
+  ResolveLeiosBlock (SimpleBlock' c ext ext)
+  where
+  resolveLeiosClosure leiosDb ebHash =
+    maybe [] (fmap (fmap (deserialise . Lazy.fromStrict)))
+      <$> leiosDbLookupEbClosure leiosDb ebHash
+
+  assumeValidatedClosureTx = ValidatedSimpleGenTx
 
 instance HasLeiosVoting (SimpleBlock' c ext ext')
 

--- a/ouroboros-consensus/test/consensus-test/Main.hs
+++ b/ouroboros-consensus/test/consensus-test/Main.hs
@@ -33,6 +33,7 @@ import qualified Test.LeiosTxCache.Optimized.MutableHashTable (tests)
 import qualified Test.LeiosTxCache.Reference (tests)
 import qualified Test.LeiosUtils.CallTrace (tests)
 import qualified Test.LeiosVoteState (tests)
+import qualified Test.LeiosVoting (tests)
 import Test.Tasty
 import Test.Util.TestEnv
   ( defaultMainWithTestEnv
@@ -93,6 +94,7 @@ tests =
         , Test.LeiosTxCache.Optimized.MutableHashTable.tests
         , Test.LeiosTxCache.Reference.tests
         , Test.LeiosVoteState.tests
+        , Test.LeiosVoting.tests
         , Test.LeiosUtils.CallTrace.tests
         ]
     ]

--- a/ouroboros-consensus/test/consensus-test/Test/LeiosVoting.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/LeiosVoting.hs
@@ -80,21 +80,26 @@ tests =
 -- | Nothing in the cache yet, so every tx goes through the full 'applyTx'.
 prop_freshClosureFullyApplied :: Property
 prop_freshClosureFullyApplied =
-  forAllValidClosure 4 $ \txs -> ioProperty $ do
-    (verdict, tagged) <- runValidate txs
+  forAllValidClosure 4 $ \acquired txs -> ioProperty $ do
+    (verdict, tagged) <- runValidate acquired txs
     pure $
       conjoin
         [ verdict === Valid 0 (length txs)
         , tagged === map (const True) txs
             & counterexample "every validated tx should be tagged"
         ]
+        -- A tx the cache never saw acquired must behave exactly like one it
+        -- holds unapplied, so the verdict above is asserted across the mix.
+        & tabulate
+          "txs the cache had seen acquired"
+          [show (length (filter id acquired)) <> "/" <> show (length acquired)]
 
 -- | The tags the first pass left behind send the second pass down 'reapplyTx',
 -- which is the whole point of consulting the cache.
 prop_secondLookReapplies :: Property
 prop_secondLookReapplies =
-  forAllValidClosure 4 $ \txs -> ioProperty $ do
-    (_, _, second) <- runValidateTwice txs
+  forAllValidClosure 4 $ \acquired txs -> ioProperty $ do
+    (_, _, second) <- runValidateTwice acquired txs
     pure $ second === Valid (length txs) 0
 
 -- | A closure that fails part-way must still leave everything it validated
@@ -102,8 +107,8 @@ prop_secondLookReapplies =
 -- and holds regardless of the tx that sank the EB.
 prop_recordsValidatedBeforeFailure :: Property
 prop_recordsValidatedBeforeFailure =
-  forAllValidThenInvalid 3 $ \good bad -> ioProperty $ do
-    (verdict, tagged) <- runValidate (good <> [bad])
+  forAllValidThenInvalid 3 $ \acquired good bad -> ioProperty $ do
+    (verdict, tagged) <- runValidate acquired (good <> [bad])
     pure $
       conjoin
         [ isInvalid verdict
@@ -115,8 +120,8 @@ prop_recordsValidatedBeforeFailure =
 -- | The failing tx itself is not recorded -- it never validated.
 prop_stopsAtFirstFailure :: Property
 prop_stopsAtFirstFailure =
-  forAllValidThenInvalid 2 $ \good bad -> ioProperty $ do
-    (_, tagged) <- runValidate (good <> [bad])
+  forAllValidThenInvalid 2 $ \acquired good bad -> ioProperty $ do
+    (_, tagged) <- runValidate acquired (good <> [bad])
     pure $
       last tagged === False
         & counterexample "the failing tx must not be tagged validated"
@@ -125,17 +130,19 @@ prop_stopsAtFirstFailure =
   Generators
 -------------------------------------------------------------------------------}
 
-forAllValidClosure :: Int -> ([TestTx] -> Property) -> Property
+forAllValidClosure :: Int -> ([Bool] -> [TestTx] -> Property) -> Property
 forAllValidClosure n k =
   forAll (fst <$> genValidTxs n testInitLedger) $ \txs ->
-    length txs === n .&&. k txs
+    forAll (vectorOf n arbitrary) $ \acquired ->
+      length txs === n .&&. k acquired txs
 
 -- | @n@ txs that apply, then one that does not.
-forAllValidThenInvalid :: Int -> ([TestTx] -> TestTx -> Property) -> Property
+forAllValidThenInvalid :: Int -> ([Bool] -> [TestTx] -> TestTx -> Property) -> Property
 forAllValidThenInvalid n k =
   forAll (genValidTxs n testInitLedger) $ \(good, ledger') ->
     forAll (genInvalidTx ledger') $ \bad ->
-      length good === n .&&. k good bad
+      forAll (vectorOf (n + 1) arbitrary) $ \acquired ->
+        length good === n .&&. k acquired good bad
 
 {-------------------------------------------------------------------------------
   Harness
@@ -161,14 +168,14 @@ isInvalid = \case
 
 -- | Run 'validateEbClosure' over a closure, returning its verdict and, per tx
 -- in closure order, whether the cache now reports it validated.
-runValidate :: [TestTx] -> IO (Verdict, [Bool])
-runValidate txs = do
-  withHarness txs $ \h -> validateOnce h txs
+runValidate :: [Bool] -> [TestTx] -> IO (Verdict, [Bool])
+runValidate acquired txs = do
+  withHarness acquired txs $ \h -> validateOnce h txs
 
 -- | As 'runValidate', but validates the same closure twice against the same
 -- cache, so the second pass sees the first pass's tags.
-runValidateTwice :: [TestTx] -> IO (Verdict, [Bool], Verdict)
-runValidateTwice txs = withHarness txs $ \h -> do
+runValidateTwice :: [Bool] -> [TestTx] -> IO (Verdict, [Bool], Verdict)
+runValidateTwice acquired txs = withHarness acquired txs $ \h -> do
   (first', tagged) <- validateOnce h txs
   (second', _) <- validateOnce h txs
   pure (first', tagged, second')
@@ -200,8 +207,11 @@ validateOnce Harness{hConn, hCache, hPoint} txs = do
 -- | An in-memory LeiosDb holding the closure, and a cache that has seen the
 -- announcement and body -- the state LeiosFetch would have left behind, since
 -- 'withLockedInsertAppliedTx' only upgrades entries a body already created.
-withHarness :: [TestTx] -> (Harness -> IO a) -> IO a
-withHarness txs k = do
+--
+-- @acquired@ says, per tx, whether the cache has seen it acquired; 'False'
+-- leaves the voting logic to find nothing for it.
+withHarness :: [Bool] -> [TestTx] -> (Harness -> IO a) -> IO a
+withHarness acquired txs k = do
   db :: LeiosDbHandle IO <- newLeiosDBInMemory
   withLeiosDb db $ \conn -> do
     leiosDbInsertEbPoint conn point (leiosEbBytesSize eb)
@@ -213,11 +223,16 @@ withHarness txs k = do
     -- The fold over the not-yet-acquired txs is what a fetch would use to build
     -- its request; here only the refcount bump matters, so it folds into ().
     void $ insertBody cache (pointEbHash point) (serializeEbBody eb) () (\() _ _ _ -> ())
-    -- Mark them acquired, as a fetch would. Not the only way an entry appears --
-    -- a tx taken straight from the mempool goes to Applied without passing
-    -- through here -- but it is the path this harness exercises.
+    -- Mark them acquired, as a fetch would -- but only the ones the caller asked
+    -- for. A lookup that finds nothing must be tolerated exactly like one that
+    -- finds an unapplied entry: a tx can reach the cache straight from the
+    -- mempool without passing through here, and a just-restarted node may hold
+    -- neither.
     void $ withLockedInsertUnappliedTx cache $ \w0 step ->
-      foldM (\w tx -> step w (txHashOf tx) (txBytesSize tx) ()) w0 txs
+      foldM
+        (\w (tx, seen) -> if seen then step w (txHashOf tx) (txBytesSize tx) () else pure w)
+        w0
+        (zip txs acquired)
 
     k Harness{hConn = conn, hCache = cache, hPoint = point}
  where

--- a/ouroboros-consensus/test/consensus-test/Test/LeiosVoting.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/LeiosVoting.hs
@@ -44,9 +44,8 @@ import LeiosTxCache
 import LeiosVoting (EbClosureVerdict (..), validateEbClosure)
 import Ouroboros.Consensus.Block (SlotNo (..))
 import Ouroboros.Consensus.Ledger.Basics (LedgerState)
-import Ouroboros.Consensus.Ledger.Tables (projectLedgerTables)
 import Ouroboros.Consensus.Ledger.Tables.MapKind (EmptyMK, ValuesMK)
-import Ouroboros.Consensus.Ledger.Tables.Utils (forgetLedgerTables)
+import Ouroboros.Consensus.Ledger.Tables.Utils (forgetLedgerTables, restrictValues')
 import Test.Consensus.Mempool.Util
   ( TestBlock
   , TestTx
@@ -107,8 +106,8 @@ prop_secondLookReapplies =
 -- and holds regardless of the tx that sank the EB.
 prop_recordsValidatedBeforeFailure :: Property
 prop_recordsValidatedBeforeFailure =
-  forAllValidThenInvalid 3 $ \acquired good bad -> ioProperty $ do
-    (verdict, tagged) <- runValidate acquired (good <> [bad])
+  forAllValidThenInvalid 3 2 $ \acquired good bad after -> ioProperty $ do
+    (verdict, tagged) <- runValidate acquired (good <> [bad] <> after)
     pure $
       conjoin
         [ isInvalid verdict
@@ -117,14 +116,16 @@ prop_recordsValidatedBeforeFailure =
             & counterexample "txs validated before the failure should be tagged"
         ]
 
--- | The failing tx itself is not recorded -- it never validated.
+-- | Validation abandons the closure at the first failure: neither the failing
+-- tx nor anything behind it is recorded, even though the tail would have
+-- applied.
 prop_stopsAtFirstFailure :: Property
 prop_stopsAtFirstFailure =
-  forAllValidThenInvalid 2 $ \acquired good bad -> ioProperty $ do
-    (_, tagged) <- runValidate acquired (good <> [bad])
+  forAllValidThenInvalid 2 2 $ \acquired good bad after -> ioProperty $ do
+    (_, tagged) <- runValidate acquired (good <> [bad] <> after)
     pure $
-      last tagged === False
-        & counterexample "the failing tx must not be tagged validated"
+      drop (length good) tagged === map (const False) (bad : after)
+        & counterexample "the failing tx and everything after it must be untagged"
 
 {-------------------------------------------------------------------------------
   Generators
@@ -136,13 +137,18 @@ forAllValidClosure n k =
     forAll (vectorOf n arbitrary) $ \acquired ->
       length txs === n .&&. k acquired txs
 
--- | @n@ txs that apply, then one that does not.
-forAllValidThenInvalid :: Int -> ([Bool] -> [TestTx] -> TestTx -> Property) -> Property
-forAllValidThenInvalid n k =
+-- | @n@ txs that apply, then one that does not, then @m@ that /would/ apply if
+-- they were reached. The tail is generated against the same ledger state as the
+-- failing tx, which never commits, so reaching it is the only reason it could
+-- fail to be tagged.
+forAllValidThenInvalid ::
+  Int -> Int -> ([Bool] -> [TestTx] -> TestTx -> [TestTx] -> Property) -> Property
+forAllValidThenInvalid n m k =
   forAll (genValidTxs n testInitLedger) $ \(good, ledger') ->
     forAll (genInvalidTx ledger') $ \bad ->
-      forAll (vectorOf (n + 1) arbitrary) $ \acquired ->
-        length good === n .&&. k acquired good bad
+      forAll (fst <$> genValidTxs m ledger') $ \after ->
+        forAll (vectorOf (n + 1 + m) arbitrary) $ \acquired ->
+          length good === n .&&. length after === m .&&. k acquired good bad after
 
 {-------------------------------------------------------------------------------
   Harness
@@ -193,7 +199,11 @@ validateOnce Harness{hConn, hCache, hPoint} txs = do
       testLedgerConfigNoSizeLimits
       hConn
       hCache
-      (\_keys -> pure (projectLedgerTables testInitLedger))
+      -- Restricted to what was asked for, not the whole UTxO: a closure whose
+      -- key sets came back empty would otherwise still validate, and the
+      -- transitive-closure TODO in 'validateEbClosure' has nothing to fail
+      -- against.
+      (\keys -> pure (restrictValues' testInitLedger keys))
       hPoint
       baseLedger
   tagged <- withLookupTx hCache $ \look ->

--- a/ouroboros-consensus/test/consensus-test/Test/LeiosVoting.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/LeiosVoting.hs
@@ -17,7 +17,6 @@ import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as Lazy
 import Data.Function ((&))
-import Data.IORef (modifyIORef', newIORef, readIORef)
 import qualified Data.Vector.Strict as V
 import LeiosDemoDb
   ( LeiosDbConnection (..)
@@ -28,9 +27,7 @@ import LeiosDemoDb
 import LeiosDemoTypes
   ( BytesSize
   , LeiosEb (..)
-  , LeiosNotVotedReason (..)
   , LeiosPoint (..)
-  , LeiosSeatId (..)
   , LeiosTx (..)
   , RbHash (..)
   , SerializedEbBody
@@ -44,9 +41,8 @@ import LeiosTxCache
   ( LeiosTxCache (..)
   , newPureLeiosTxCache
   )
-import LeiosVoting (EbClosureVerdict (..), decideVote, validateEbClosure)
+import LeiosVoting (EbClosureVerdict (..), validateEbClosure)
 import Ouroboros.Consensus.Block (SlotNo (..))
-import Ouroboros.Consensus.BlockchainTime (RelativeTime (..))
 import Ouroboros.Consensus.Ledger.Basics (LedgerState)
 import Ouroboros.Consensus.Ledger.Tables (projectLedgerTables)
 import Ouroboros.Consensus.Ledger.Tables.MapKind (EmptyMK, ValuesMK)
@@ -69,15 +65,6 @@ tests =
   testGroup
     "LeiosVoting"
     [ testGroup
-        "decideVote"
-        [ testProperty "abstains when the tip does not announce" prop_abstainsWhenTipDoesNotAnnounce
-        , testProperty "abstains when off the committee" prop_abstainsWhenOffCommittee
-        , testProperty "does not validate what it would not vote for" prop_noValidationWhenAbstaining
-        , testProperty "abstains when the closure is rejected" prop_abstainsOnInvalidClosure
-        , testProperty "reads the clock after validating" prop_deadlineJudgedAfterValidation
-        , testProperty "votes when everything passes" prop_votesWhenEverythingPasses
-        ]
-    , testGroup
         "validateEbClosure"
         [ testProperty "a fresh closure is validated in full" prop_freshClosureFullyApplied
         , testProperty "a second look reapplies instead" prop_secondLookReapplies
@@ -85,99 +72,6 @@ tests =
         , testProperty "a tx after the failure is not recorded" prop_stopsAtFirstFailure
         ]
     ]
-
-{-------------------------------------------------------------------------------
-  decideVote
--------------------------------------------------------------------------------}
-
--- | A 'decideVote' run that records whether validation happened and lets the
--- clock be read as late as the decision wants it.
-runDecide ::
-  Maybe LeiosSeatId ->
-  Maybe RbHash ->
-  Either LeiosNotVotedReason () ->
-  -- | What the clock reads, versus a deadline of 100.
-  RelativeTime ->
-  IO (Either LeiosNotVotedReason (RbHash, LeiosSeatId, ()), Bool)
-runDecide mSeat mAnnouncer closure now = do
-  validatedRef <- newIORef False
-  outcome <-
-    decideVote
-      mSeat
-      mAnnouncer
-      (modifyIORef' validatedRef (const True) >> pure closure)
-      (pure now)
-      deadlineAt
-  (,) outcome <$> readIORef validatedRef
-
-deadlineAt :: RelativeTime
-deadlineAt = RelativeTime 100
-
-inTime, tooLate :: RelativeTime
-inTime = RelativeTime 50
-tooLate = RelativeTime 150
-
-someSeat :: LeiosSeatId
-someSeat = LeiosSeatId 0
-
-someRb :: RbHash
-someRb = MkRbHash (BS.replicate 32 7)
-
-prop_abstainsWhenTipDoesNotAnnounce :: Property
-prop_abstainsWhenTipDoesNotAnnounce = ioProperty $ do
-  (outcome, _) <- runDecide (Just someSeat) Nothing (Right ()) inTime
-  pure $ abstainedBecause outcome === Just "ChainTipDoesNotAnnounce"
-
-prop_abstainsWhenOffCommittee :: Property
-prop_abstainsWhenOffCommittee = ioProperty $ do
-  (outcome, _) <- runDecide Nothing (Just someRb) (Right ()) inTime
-  pure $ abstainedBecause outcome === Just "NotOnCommittee"
-
--- | The cheap checks gate the expensive one: an EB we would not vote for must
--- never be validated.
-prop_noValidationWhenAbstaining :: Property
-prop_noValidationWhenAbstaining = ioProperty $ do
-  (_, v1) <- runDecide (Just someSeat) Nothing (Right ()) inTime
-  (_, v2) <- runDecide Nothing (Just someRb) (Right ()) inTime
-  pure $
-    (v1, v2) === (False, False)
-      & counterexample "validated an EB that failed a cheap check"
-
-prop_abstainsOnInvalidClosure :: Property
-prop_abstainsOnInvalidClosure = ioProperty $ do
-  (outcome, validated) <- runDecide (Just someSeat) (Just someRb) (Left TooLate) inTime
-  pure $
-    conjoin
-      [ abstainedBecause outcome === Just "TooLate"
-      , validated === True & counterexample "should have validated"
-      ]
-
--- | The deadline is judged by the clock as it reads /after/ validation, not
--- before: validating a closure takes real time, and a vote signed past the
--- window is no use.
-prop_deadlineJudgedAfterValidation :: Property
-prop_deadlineJudgedAfterValidation = ioProperty $ do
-  (outcome, validated) <- runDecide (Just someSeat) (Just someRb) (Right ()) tooLate
-  pure $
-    conjoin
-      [ abstainedBecause outcome === Just "TooLate"
-          & counterexample "a clock past the deadline should abstain"
-      , validated === True
-          & counterexample "validation must run before the deadline is judged"
-      ]
-
-prop_votesWhenEverythingPasses :: Property
-prop_votesWhenEverythingPasses = ioProperty $ do
-  (outcome, _) <- runDecide (Just someSeat) (Just someRb) (Right ()) inTime
-  pure $ case outcome of
-    Right (rb, seat, ()) -> (rb, seat) === (someRb, someSeat)
-    Left r -> counterexample ("expected a vote, abstained: " <> show r) False
-
--- | 'LeiosNotVotedReason' has no 'Eq', so compare its constructor by name.
-abstainedBecause :: Either LeiosNotVotedReason a -> Maybe String
-abstainedBecause = \case
-  Right _ -> Nothing
-  Left r -> Just (takeWhile (/= ' ') (show r))
 
 {-------------------------------------------------------------------------------
   validateEbClosure

--- a/ouroboros-consensus/test/consensus-test/Test/LeiosVoting.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/LeiosVoting.hs
@@ -17,6 +17,7 @@ import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as Lazy
 import Data.Function ((&))
+import Data.IORef (modifyIORef', newIORef, readIORef)
 import qualified Data.Vector.Strict as V
 import LeiosDemoDb
   ( LeiosDbConnection (..)
@@ -27,7 +28,9 @@ import LeiosDemoDb
 import LeiosDemoTypes
   ( BytesSize
   , LeiosEb (..)
+  , LeiosNotVotedReason (..)
   , LeiosPoint (..)
+  , LeiosSeatId (..)
   , LeiosTx (..)
   , RbHash (..)
   , SerializedEbBody
@@ -41,8 +44,9 @@ import LeiosTxCache
   ( LeiosTxCache (..)
   , newPureLeiosTxCache
   )
-import LeiosVoting (EbClosureVerdict (..), validateEbClosure)
+import LeiosVoting (EbClosureVerdict (..), decideVote, validateEbClosure)
 import Ouroboros.Consensus.Block (SlotNo (..))
+import Ouroboros.Consensus.BlockchainTime (RelativeTime (..))
 import Ouroboros.Consensus.Ledger.Basics (LedgerState)
 import Ouroboros.Consensus.Ledger.Tables (projectLedgerTables)
 import Ouroboros.Consensus.Ledger.Tables.MapKind (EmptyMK, ValuesMK)
@@ -65,6 +69,15 @@ tests =
   testGroup
     "LeiosVoting"
     [ testGroup
+        "decideVote"
+        [ testProperty "abstains when the tip does not announce" prop_abstainsWhenTipDoesNotAnnounce
+        , testProperty "abstains when off the committee" prop_abstainsWhenOffCommittee
+        , testProperty "does not validate what it would not vote for" prop_noValidationWhenAbstaining
+        , testProperty "abstains when the closure is rejected" prop_abstainsOnInvalidClosure
+        , testProperty "reads the clock after validating" prop_deadlineJudgedAfterValidation
+        , testProperty "votes when everything passes" prop_votesWhenEverythingPasses
+        ]
+    , testGroup
         "validateEbClosure"
         [ testProperty "a fresh closure is validated in full" prop_freshClosureFullyApplied
         , testProperty "a second look reapplies instead" prop_secondLookReapplies
@@ -74,7 +87,100 @@ tests =
     ]
 
 {-------------------------------------------------------------------------------
-  Properties
+  decideVote
+-------------------------------------------------------------------------------}
+
+-- | A 'decideVote' run that records whether validation happened and lets the
+-- clock be read as late as the decision wants it.
+runDecide ::
+  Maybe LeiosSeatId ->
+  Maybe RbHash ->
+  Either LeiosNotVotedReason () ->
+  -- | What the clock reads, versus a deadline of 100.
+  RelativeTime ->
+  IO (Either LeiosNotVotedReason (RbHash, LeiosSeatId, ()), Bool)
+runDecide mSeat mAnnouncer closure now = do
+  validatedRef <- newIORef False
+  outcome <-
+    decideVote
+      mSeat
+      mAnnouncer
+      (modifyIORef' validatedRef (const True) >> pure closure)
+      (pure now)
+      deadlineAt
+  (,) outcome <$> readIORef validatedRef
+
+deadlineAt :: RelativeTime
+deadlineAt = RelativeTime 100
+
+inTime, tooLate :: RelativeTime
+inTime = RelativeTime 50
+tooLate = RelativeTime 150
+
+someSeat :: LeiosSeatId
+someSeat = LeiosSeatId 0
+
+someRb :: RbHash
+someRb = MkRbHash (BS.replicate 32 7)
+
+prop_abstainsWhenTipDoesNotAnnounce :: Property
+prop_abstainsWhenTipDoesNotAnnounce = ioProperty $ do
+  (outcome, _) <- runDecide (Just someSeat) Nothing (Right ()) inTime
+  pure $ abstainedBecause outcome === Just "ChainTipDoesNotAnnounce"
+
+prop_abstainsWhenOffCommittee :: Property
+prop_abstainsWhenOffCommittee = ioProperty $ do
+  (outcome, _) <- runDecide Nothing (Just someRb) (Right ()) inTime
+  pure $ abstainedBecause outcome === Just "NotOnCommittee"
+
+-- | The cheap checks gate the expensive one: an EB we would not vote for must
+-- never be validated.
+prop_noValidationWhenAbstaining :: Property
+prop_noValidationWhenAbstaining = ioProperty $ do
+  (_, v1) <- runDecide (Just someSeat) Nothing (Right ()) inTime
+  (_, v2) <- runDecide Nothing (Just someRb) (Right ()) inTime
+  pure $
+    (v1, v2) === (False, False)
+      & counterexample "validated an EB that failed a cheap check"
+
+prop_abstainsOnInvalidClosure :: Property
+prop_abstainsOnInvalidClosure = ioProperty $ do
+  (outcome, validated) <- runDecide (Just someSeat) (Just someRb) (Left TooLate) inTime
+  pure $
+    conjoin
+      [ abstainedBecause outcome === Just "TooLate"
+      , validated === True & counterexample "should have validated"
+      ]
+
+-- | The deadline is judged by the clock as it reads /after/ validation, not
+-- before: validating a closure takes real time, and a vote signed past the
+-- window is no use.
+prop_deadlineJudgedAfterValidation :: Property
+prop_deadlineJudgedAfterValidation = ioProperty $ do
+  (outcome, validated) <- runDecide (Just someSeat) (Just someRb) (Right ()) tooLate
+  pure $
+    conjoin
+      [ abstainedBecause outcome === Just "TooLate"
+          & counterexample "a clock past the deadline should abstain"
+      , validated === True
+          & counterexample "validation must run before the deadline is judged"
+      ]
+
+prop_votesWhenEverythingPasses :: Property
+prop_votesWhenEverythingPasses = ioProperty $ do
+  (outcome, _) <- runDecide (Just someSeat) (Just someRb) (Right ()) inTime
+  pure $ case outcome of
+    Right (rb, seat, ()) -> (rb, seat) === (someRb, someSeat)
+    Left r -> counterexample ("expected a vote, abstained: " <> show r) False
+
+-- | 'LeiosNotVotedReason' has no 'Eq', so compare its constructor by name.
+abstainedBecause :: Either LeiosNotVotedReason a -> Maybe String
+abstainedBecause = \case
+  Right _ -> Nothing
+  Left r -> Just (takeWhile (/= ' ') (show r))
+
+{-------------------------------------------------------------------------------
+  validateEbClosure
 -------------------------------------------------------------------------------}
 
 -- | Nothing in the cache yet, so every tx goes through the full 'applyTx'.

--- a/ouroboros-consensus/test/consensus-test/Test/LeiosVoting.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/LeiosVoting.hs
@@ -1,0 +1,243 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+-- | Unit tests for 'validateEbClosure', the part of the Leios voting thread
+-- that decides whether an EB's endorsed transactions actually apply.
+--
+-- Mock blocks stand in for a real era: the interesting behaviour here is the
+-- orchestration -- which ledger rule each tx goes through, and what ends up
+-- recorded in the LeiosTxCache -- not the ledger rules themselves.
+module Test.LeiosVoting (tests) where
+
+import qualified Codec.Serialise as Serialise
+import Control.Monad (foldM, void)
+import Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as Lazy
+import Data.Function ((&))
+import qualified Data.Vector.Strict as V
+import LeiosDemoDb
+  ( LeiosDbConnection (..)
+  , LeiosDbHandle
+  , newLeiosDBInMemory
+  , withLeiosDb
+  )
+import LeiosDemoTypes
+  ( BytesSize
+  , LeiosEb (..)
+  , LeiosPoint (..)
+  , LeiosTx (..)
+  , RbHash (..)
+  , SerializedEbBody
+  , TxHash
+  , hashLeiosEb
+  , hashLeiosTx
+  , leiosEbBytesSize
+  , serializeEbBody
+  )
+import LeiosTxCache
+  ( LeiosTxCache (..)
+  , newPureLeiosTxCache
+  )
+import LeiosVoting (EbClosureVerdict (..), validateEbClosure)
+import Ouroboros.Consensus.Block (SlotNo (..))
+import Ouroboros.Consensus.Ledger.Basics (LedgerState)
+import Ouroboros.Consensus.Ledger.Tables (projectLedgerTables)
+import Ouroboros.Consensus.Ledger.Tables.MapKind (EmptyMK, ValuesMK)
+import Ouroboros.Consensus.Ledger.Tables.Utils (forgetLedgerTables)
+import Test.Consensus.Mempool.Util
+  ( TestBlock
+  , TestTx
+  , genInvalidTx
+  , genValidTxs
+  , testInitLedger
+  , testLedgerConfigNoSizeLimits
+  )
+import Test.QuickCheck
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.QuickCheck (testProperty)
+import Test.Util.Orphans.IOLike ()
+
+tests :: TestTree
+tests =
+  testGroup
+    "LeiosVoting"
+    [ testGroup
+        "validateEbClosure"
+        [ testProperty "a fresh closure is validated in full" prop_freshClosureFullyApplied
+        , testProperty "a second look reapplies instead" prop_secondLookReapplies
+        , testProperty "records the txs validated before a failure" prop_recordsValidatedBeforeFailure
+        , testProperty "a tx after the failure is not recorded" prop_stopsAtFirstFailure
+        ]
+    ]
+
+{-------------------------------------------------------------------------------
+  Properties
+-------------------------------------------------------------------------------}
+
+-- | Nothing in the cache yet, so every tx goes through the full 'applyTx'.
+prop_freshClosureFullyApplied :: Property
+prop_freshClosureFullyApplied =
+  forAllValidClosure 4 $ \txs -> ioProperty $ do
+    (verdict, tagged) <- runValidate txs
+    pure $
+      conjoin
+        [ verdict === Valid 0 (length txs)
+        , tagged === map (const True) txs
+            & counterexample "every validated tx should be tagged"
+        ]
+
+-- | The tags the first pass left behind send the second pass down 'reapplyTx',
+-- which is the whole point of consulting the cache.
+prop_secondLookReapplies :: Property
+prop_secondLookReapplies =
+  forAllValidClosure 4 $ \txs -> ioProperty $ do
+    (_, _, second) <- runValidateTwice txs
+    pure $ second === Valid (length txs) 0
+
+-- | A closure that fails part-way must still leave everything it validated
+-- before the failure recorded: that work was done against a real ledger state
+-- and holds regardless of the tx that sank the EB.
+prop_recordsValidatedBeforeFailure :: Property
+prop_recordsValidatedBeforeFailure =
+  forAllValidThenInvalid 3 $ \good bad -> ioProperty $ do
+    (verdict, tagged) <- runValidate (good <> [bad])
+    pure $
+      conjoin
+        [ isInvalid verdict
+            & counterexample ("expected an invalid verdict, got " <> show verdict)
+        , take (length good) tagged === map (const True) good
+            & counterexample "txs validated before the failure should be tagged"
+        ]
+
+-- | The failing tx itself is not recorded -- it never validated.
+prop_stopsAtFirstFailure :: Property
+prop_stopsAtFirstFailure =
+  forAllValidThenInvalid 2 $ \good bad -> ioProperty $ do
+    (_, tagged) <- runValidate (good <> [bad])
+    pure $
+      last tagged === False
+        & counterexample "the failing tx must not be tagged validated"
+
+{-------------------------------------------------------------------------------
+  Generators
+-------------------------------------------------------------------------------}
+
+forAllValidClosure :: Int -> ([TestTx] -> Property) -> Property
+forAllValidClosure n k =
+  forAll (fst <$> genValidTxs n testInitLedger) $ \txs ->
+    length txs === n .&&. k txs
+
+-- | @n@ txs that apply, then one that does not.
+forAllValidThenInvalid :: Int -> ([TestTx] -> TestTx -> Property) -> Property
+forAllValidThenInvalid n k =
+  forAll (genValidTxs n testInitLedger) $ \(good, ledger') ->
+    forAll (genInvalidTx ledger') $ \bad ->
+      length good === n .&&. k good bad
+
+{-------------------------------------------------------------------------------
+  Harness
+-------------------------------------------------------------------------------}
+
+-- | 'EbClosureVerdict' is not 'Eq'/'Show' (its error type need not be), so
+-- compare a projection of it.
+data Verdict
+  = -- | Reapplied and applied counts, in that order.
+    Valid Int Int
+  | Invalid
+  deriving (Eq, Show)
+
+summarise :: EbClosureVerdict blk -> Verdict
+summarise = \case
+  EbClosureValid r a -> Valid r a
+  EbClosureInvalid _ -> Invalid
+
+isInvalid :: Verdict -> Bool
+isInvalid = \case
+  Invalid -> True
+  Valid{} -> False
+
+-- | Run 'validateEbClosure' over a closure, returning its verdict and, per tx
+-- in closure order, whether the cache now reports it validated.
+runValidate :: [TestTx] -> IO (Verdict, [Bool])
+runValidate txs = do
+  withHarness txs $ \h -> validateOnce h txs
+
+-- | As 'runValidate', but validates the same closure twice against the same
+-- cache, so the second pass sees the first pass's tags.
+runValidateTwice :: [TestTx] -> IO (Verdict, [Bool], Verdict)
+runValidateTwice txs = withHarness txs $ \h -> do
+  (first', tagged) <- validateOnce h txs
+  (second', _) <- validateOnce h txs
+  pure (first', tagged, second')
+
+data Harness = Harness
+  { hConn :: LeiosDbConnection IO
+  , hCache :: LeiosTxCache IO () () SerializedEbBody
+  , hPoint :: LeiosPoint
+  }
+
+validateOnce :: Harness -> [TestTx] -> IO (Verdict, [Bool])
+validateOnce Harness{hConn, hCache, hPoint} txs = do
+  verdict <-
+    validateEbClosure
+      testLedgerConfigNoSizeLimits
+      hConn
+      hCache
+      (\_keys -> pure (projectLedgerTables testInitLedger))
+      hPoint
+      baseLedger
+  tagged <- withLookupTx hCache $ \look ->
+    mapM (\tx -> isValidated <$> look (txHashOf tx)) txs
+  pure (summarise verdict, tagged)
+ where
+  isValidated = \case
+    Just (Right ()) -> True
+    _ -> False
+
+-- | An in-memory LeiosDb holding the closure, and a cache that has seen the
+-- announcement and body -- the state LeiosFetch would have left behind, since
+-- 'withLockedInsertAppliedTx' only upgrades entries a body already created.
+withHarness :: [TestTx] -> (Harness -> IO a) -> IO a
+withHarness txs k = do
+  db :: LeiosDbHandle IO <- newLeiosDBInMemory
+  withLeiosDb db $ \conn -> do
+    leiosDbInsertEbPoint conn point (leiosEbBytesSize eb)
+    void $ leiosDbInsertEbBody conn point eb
+    void $ leiosDbInsertTxs conn [(txHashOf tx, txBytes tx) | tx <- txs]
+
+    cache <- newPureLeiosTxCache
+    void $ insertAnnouncement cache (pointSlotNo point) rbHash (pointEbHash point)
+    -- The fold over the not-yet-acquired txs is what a fetch would use to build
+    -- its request; here only the refcount bump matters, so it folds into ().
+    void $ insertBody cache (pointEbHash point) (serializeEbBody eb) () (\() _ _ _ -> ())
+    -- Mark them acquired, as a fetch would: only then can they be upgraded.
+    void $ withLockedInsertUnappliedTx cache $ \w0 step ->
+      foldM (\w tx -> step w (txHashOf tx) (txBytesSize tx) ()) w0 txs
+
+    k Harness{hConn = conn, hCache = cache, hPoint = point}
+ where
+  eb = ebOf txs
+  point = MkLeiosPoint (SlotNo 1) (hashLeiosEb eb)
+  rbHash = MkRbHash (BS.replicate 32 0)
+
+baseLedger :: LedgerState TestBlock EmptyMK
+baseLedger = forgetLedgerTables (testInitLedger :: LedgerState TestBlock ValuesMK)
+
+-- | The LeiosDb keys txs by the hash of their stored bytes, so hash the same
+-- bytes we store.
+txBytes :: TestTx -> ByteString
+txBytes = Lazy.toStrict . Serialise.serialise
+
+txHashOf :: TestTx -> TxHash
+txHashOf = hashLeiosTx . MkLeiosTx . txBytes
+
+txBytesSize :: TestTx -> BytesSize
+txBytesSize = fromIntegral . BS.length . txBytes
+
+ebOf :: [TestTx] -> LeiosEb
+ebOf txs =
+  MkLeiosEb $
+    V.fromList [(txHashOf tx, txBytesSize tx) | tx <- txs]

--- a/ouroboros-consensus/test/consensus-test/Test/LeiosVoting.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/LeiosVoting.hs
@@ -213,7 +213,9 @@ withHarness txs k = do
     -- The fold over the not-yet-acquired txs is what a fetch would use to build
     -- its request; here only the refcount bump matters, so it folds into ().
     void $ insertBody cache (pointEbHash point) (serializeEbBody eb) () (\() _ _ _ -> ())
-    -- Mark them acquired, as a fetch would: only then can they be upgraded.
+    -- Mark them acquired, as a fetch would. Not the only way an entry appears --
+    -- a tx taken straight from the mempool goes to Applied without passing
+    -- through here -- but it is the path this harness exercises.
     void $ withLockedInsertUnappliedTx cache $ \w0 step ->
       foldM (\w tx -> step w (txHashOf tx) (txBytesSize tx) ()) w0 txs
 


### PR DESCRIPTION
Resolves and validates EB closures in `runLeiosVoting`.

This is using the `TxCache` from https://github.com/IntersectMBO/ouroboros-consensus/pull/2188 to determine whether we need to `applyTx` or `reapplyTx` via the existing `LedgerSupportsMempool` API.

As this change is heavily restructuring the Leios voting loop, I realized that we incorrectly used the `currentSlot` to determine whether voting timed out -> this is wrong! The current slot (derived via `ChainDB.getCurrentLedger`) is only ever advancing when the tip advances. Thus, the "time" was lagging quite a lot. Changed the semantics determine onset and deadline of voting period using the wall clock (via `slotToWallclock`).