### PR TITLE
[Peras 64] Refactor BlockSupportsPeras type class

### DIFF
--- a/changelog.d/20260826_135320_agustin.mista_refactor_block_supports_peras.md
+++ b/changelog.d/20260826_135320_agustin.mista_refactor_block_supports_peras.md
@@ -1,0 +1,14 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+### Breaking
+
+- Refactored `BlockSupportsPeras` to use `PerasEpochContext` when forging and verifying Peras votes and certificates.
+
+### Non-Breaking
+
+- Extended `ChainDB` with `getPerasEpochContextResolverHandle` for Peras vote validation and certificate forging.

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToNode.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToNode.hs
@@ -396,17 +396,7 @@ mkHandlers
             , 50 -- TODO: see https://github.com/tweag/cardano-peras/issues/97
             , 50 -- TODO: see https://github.com/tweag/cardano-peras/issues/97
             )
-            ( makePerasVotePoolWriterFromChainDB
-                systemTime
-                -- TODO: when actual plumbing for Peras is ready, we will have to
-                -- extract the committee selection data from the chainDB to pass
-                -- it here, instead of relying on an empty the stake distribution.
-                --
-                -- Note that the empty stake distribution will cause all votes to
-                -- be considered invalid.
-                (pure (PerasVoteStakeDistr mempty))
-                getChainDB
-            )
+            (makePerasVotePoolWriterFromChainDB systemTime getChainDB)
             version
             controlMessageSTM
       , hPerasVoteDiffusionServer = \version peer ->

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Node/RethrowPolicy.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Node/RethrowPolicy.hs
@@ -107,7 +107,7 @@ consensusRethrowPolicy pb =
     <> mkRethrowPolicy
       ( \_ctx (e :: PerasVoteDbError blk) ->
           case e of
-            MultipleWinnersInRound{} -> ourBug -- TODO: should we instead shutdown the node?
+            MultipleWinnersInRound{} -> ourBug
             ForgingCertError{} -> ourBug
             EpochContextNotFoundForRound{} -> ourBug
       )

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Node/RethrowPolicy.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Node/RethrowPolicy.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Ouroboros.Consensus.Node.RethrowPolicy (consensusRethrowPolicy) where
@@ -10,7 +11,7 @@ import Control.ResourceRegistry
   )
 import Data.Proxy (Proxy)
 import Data.Typeable (Typeable)
-import Ouroboros.Consensus.Block (StandardHash)
+import Ouroboros.Consensus.Block (BlockSupportsPeras (..), StandardHash)
 import Ouroboros.Consensus.BlockchainTime
 import Ouroboros.Consensus.MiniProtocol.BlockFetch.Server
   ( BlockFetchServerException
@@ -48,7 +49,10 @@ import System.FS.API.Types (FsError)
 -- terminate with a storage layer exception (restart with full recovery).
 consensusRethrowPolicy ::
   forall blk.
-  (Typeable blk, StandardHash blk) =>
+  ( Typeable blk
+  , StandardHash blk
+  , Show (PerasError blk)
+  ) =>
   Proxy blk ->
   RethrowPolicy
 consensusRethrowPolicy pb =
@@ -105,6 +109,7 @@ consensusRethrowPolicy pb =
           case e of
             MultipleWinnersInRound{} -> ourBug -- TODO: should we instead shutdown the node?
             ForgingCertError{} -> ourBug
+            EpochContextNotFoundForRound{} -> ourBug
       )
     -- Some chain sync client exceptions indicate malicious behaviour,
     -- others merely mean that we should disconnect from this client

--- a/ouroboros-consensus/bench/PerasCertDB-bench/Main.hs
+++ b/ouroboros-consensus/bench/PerasCertDB-bench/Main.hs
@@ -115,7 +115,7 @@ fragments = iterate' addSuccessorBlock genesisFragment
        in (xs AF.:> x) AF.:> TestBlock.mkNextBlock x nextBlockSlot dummyBody
 
   dummyBody :: TestBody
-  dummyBody = TestBody{tbForkNo = 0, tbIsValid = True, tbPerasCertRound = Nothing}
+  dummyBody = TestBody{tbForkNo = 0, tbIsValid = True, tbPerasCert = Nothing}
 
 -- | Given a chain fragment, construct a weight snapshot where there's a boosted block every 90 slots
 uniformWeightSnapshot :: AF.AnchoredFragment TestBlock -> PerasWeightSnapshot TestBlock

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Block/SupportsPeras.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Block/SupportsPeras.hs
@@ -31,12 +31,9 @@ module Ouroboros.Consensus.Block.SupportsPeras
   , defaultForgePerasCert
   , defaultVerifyPerasCert
 
-    -- * To be removed in favor of using a 'PerasEpochContext' directly
-  , PerasVoteStakeDistr (..)
-
     -- * Validated types
-  , ValidatedPerasCert (..)
   , ValidatedPerasVote (..)
+  , ValidatedPerasCert (..)
 
     -- * Peras error types
   , IsPerasError (..)
@@ -68,10 +65,9 @@ module Ouroboros.Consensus.Block.SupportsPeras
   , module Ouroboros.Consensus.Peras.Vote.Class
   ) where
 
-import Cardano.Binary (FromCBOR (..), ToCBOR (..))
-import Codec.Serialise.Decoding (decodeListLenOf)
-import Codec.Serialise.Encoding (encodeListLen)
+import Cardano.Binary (FromCBOR (..), ToCBOR (..), decodeListLenOf, encodeListLen)
 import Control.Exception (assert)
+import Control.Exception.Base (Exception)
 import Control.Monad.Error.Class (MonadError (..))
 import Data.Bifunctor (Bifunctor (..))
 import Data.Containers.NonEmpty (HasNonEmpty (..))
@@ -79,12 +75,11 @@ import Data.Kind (Type)
 import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.Map.NonEmpty as NEMap
 import Data.Map.Strict (Map)
-import qualified Data.Set.NonEmpty as NESet
 import Data.Traversable (for)
 import Data.Typeable (Typeable)
 import GHC.Generics (Generic)
-import NoThunks.Class
-import Ouroboros.Consensus.Block.Abstract
+import NoThunks.Class (NoThunks)
+import Ouroboros.Consensus.Block.Abstract (Point, StandardHash)
 import Ouroboros.Consensus.BlockchainTime.WallClock.Types (WithArrivalTime (..))
 import Ouroboros.Consensus.Committee.Class
   ( CryptoSupportsVotingCommittee (..)
@@ -93,8 +88,8 @@ import Ouroboros.Consensus.Committee.Class
   , unsafeUniqueVotesWithSameTarget
   )
 import qualified Ouroboros.Consensus.Committee.Class as Committee
-import Ouroboros.Consensus.Committee.Crypto (PrivateKey, VoteCandidate)
-import Ouroboros.Consensus.Committee.Types (PoolId)
+import Ouroboros.Consensus.Committee.Crypto (ElectionId, PrivateKey, VoteCandidate)
+import Ouroboros.Consensus.Committee.Types (PoolId (..))
 import Ouroboros.Consensus.Peras.Cert.Class
 import Ouroboros.Consensus.Peras.Cert.Mock (MockPerasCert (..))
 import Ouroboros.Consensus.Peras.Crypto.Mock (MockPerasCrypto, MockPerasVotingCommitteeScheme)
@@ -178,67 +173,108 @@ deriving instance
 deriving instance
   Generic (PerasEpochContext blk)
 
--- * Peras types
-
--- TODO: to be removed in favor of using a 'PerasEpochContext' directly.
-newtype PerasVoteStakeDistr = PerasVoteStakeDistr
-  { unPerasVoteStakeDistr :: Map PerasSeatIndex VoteWeight
-  }
-  deriving newtype NoThunks
-  deriving stock (Show, Eq, Generic)
-
 -- * BlockSupportsPeras class
 
 class
-  ( StandardHash blk
-  , Show (PerasParams blk)
+  ( -- Basic block constraints
+    StandardHash blk
+  , Typeable blk
+  , -- PerasVote constraints
+    Typeable (PerasVote blk)
+  , Show (PerasVote blk)
+  , Eq (PerasVote blk)
+  , NoThunks (PerasVote blk)
+  , IsPerasVote (PerasVote blk) blk
+  , Typeable (BoostedBlock (PerasVote blk))
+  , Show (BoostedBlock (PerasVote blk))
+  , Eq (BoostedBlock (PerasVote blk))
+  , NoThunks (BoostedBlock (PerasVote blk))
+  , -- PerasCert constraints
+    Typeable (PerasCert blk)
+  , Show (PerasCert blk)
+  , Eq (PerasCert blk)
   , NoThunks (PerasCert blk)
+  , IsPerasCert (PerasCert blk) blk
+  , Typeable (BoostedBlock (PerasCert blk))
+  , Show (BoostedBlock (PerasCert blk))
+  , Eq (BoostedBlock (PerasCert blk))
+  , NoThunks (BoostedBlock (PerasCert blk))
+  , -- PerasError constraints
+    Typeable (PerasError blk)
+  , Show (PerasError blk)
+  , Eq (PerasError blk)
+  , NoThunks (PerasError blk)
+  , IsPerasError (PerasError blk) blk
+  , Exception (PerasError blk)
+  , -- PerasVotingCommittee constraints
+    Typeable (PerasVotingCommittee blk)
+  , Show (PerasVotingCommittee blk)
+  , Eq (PerasVotingCommittee blk)
+  , NoThunks (PerasVotingCommittee blk)
+  , -- PerasEpochContext constraints
+    Typeable (PerasEpochContext blk)
+  , Show (PerasEpochContext blk)
+  , Eq (PerasEpochContext blk)
+  , NoThunks (PerasEpochContext blk)
+  , -- Compatiblity with committee/crypto
+    Show (PerasCrypto blk)
+  , Eq (PerasCrypto blk)
+  , Typeable (PerasCrypto blk)
+  , NoThunks (PerasCrypto blk)
+  , Show (PerasVotingCommitteeScheme blk)
+  , Eq (PerasVotingCommitteeScheme blk)
+  , Typeable (PerasVotingCommitteeScheme blk)
+  , NoThunks (PerasVotingCommitteeScheme blk)
+  , ElectionId (PerasCrypto blk) ~ PerasRoundNo
+  , VoteCandidate (PerasCrypto blk) ~ BoostedBlock (PerasVote blk)
+  , VoteCandidate (PerasCrypto blk) ~ BoostedBlock (PerasCert blk)
   ) =>
   BlockSupportsPeras blk
   where
   -- | The concrete Peras vote type for this block type.
   type PerasVote blk = (vote :: Type) | vote -> blk
 
-  type PerasVote blk = VoidPerasVote blk
-
   -- | The concrete Peras certificate type for this block type.
   type PerasCert blk = (cert :: Type) | cert -> blk
 
-  type PerasCert blk = VoidPerasCert blk
-
   -- | The concrete Peras error type for this block type.
   type PerasError blk = (err :: Type) | err -> blk
-
-  type PerasError blk = VoidPerasError blk
 
   -- | The crypto scheme used for Peras votes and certificates.
   --
   -- Used to dispatch a block type to a its corresponding voting crypto scheme.
   type PerasCrypto blk :: Type
 
-  type PerasCrypto blk = VoidPerasCrypto blk
-
   -- | The voting committee scheme used for Peras.
   --
   -- Used to dispatch a block type to a its corresponding voting committee scheme.
   type PerasVotingCommitteeScheme blk :: Type
 
-  type PerasVotingCommitteeScheme blk = VoidPerasVotingCommitteeScheme
+  -- | Forge a Peras vote if the given pool is eligible to vote in the given round.
+  forgePerasVoteIfEligible ::
+    PerasEpochContext blk ->
+    PoolId ->
+    PrivateKey (PerasCrypto blk) ->
+    PerasRoundNo ->
+    Point blk ->
+    Either (PerasError blk) (Maybe (ValidatedPerasVote blk))
 
-  validatePerasCert ::
-    PerasParams blk ->
-    PerasCert blk ->
-    Either (PerasError blk) (ValidatedPerasCert blk)
-
-  validatePerasVote ::
-    PerasParams blk ->
-    PerasVoteStakeDistr ->
+  -- | Verify a Peras vote and return its weight if valid.
+  verifyPerasVote ::
+    PerasEpochContext blk ->
     PerasVote blk ->
     Either (PerasError blk) (ValidatedPerasVote blk)
 
+  -- | Forge a Peras certificate from a collection of votes reaching quorum.
   forgePerasCert ::
-    PerasParams blk ->
+    PerasEpochContext blk ->
     PerasVoteCollectionWithQuorum blk ->
+    Either (PerasError blk) (ValidatedPerasCert blk)
+
+  -- | Verify a Peras certificate and return its boost if valid.
+  verifyPerasCert ::
+    PerasEpochContext blk ->
+    PerasCert blk ->
     Either (PerasError blk) (ValidatedPerasCert blk)
 
   -- | Extract a Peras certificate optionally stored in a block.
@@ -247,7 +283,7 @@ class
   -- if the block is from an era that does not support Peras certificates.
   getPerasCertInBlock ::
     blk ->
-    Maybe (PerasCert blk)
+    Either (PerasError blk) (Maybe (PerasCert blk))
 
 -- | Forge a Peras vote if the given pool is eligible to vote in the given round.
 defaultForgePerasVoteIfEligible ::
@@ -386,40 +422,17 @@ defaultVerifyPerasCert context cert = do
 
 -- TODO: degenerate instance for all blks to get things to compile
 -- see https://github.com/tweag/cardano-peras/issues/73
-instance StandardHash blk => BlockSupportsPeras blk where
+instance (StandardHash blk, Typeable blk) => BlockSupportsPeras blk where
   type PerasCrypto blk = MockPerasCrypto blk
   type PerasVotingCommitteeScheme blk = MockPerasVotingCommitteeScheme blk
   type PerasError blk = MockPerasError blk
   type PerasCert blk = MockPerasCert blk
   type PerasVote blk = MockPerasVote blk
-
-  validatePerasCert params cert =
-    Right
-      ValidatedPerasCert
-        { vpcCert = cert
-        , vpcCertBoost = perasWeight params
-        }
-
-  validatePerasVote _params _stakeDistr vote =
-    Right
-      ValidatedPerasVote
-        { vpvVote = vote
-        , vpvVoteWeight = VoteWeight 0
-        }
-
-  forgePerasCert params votes =
-    Right $
-      ValidatedPerasCert
-        { vpcCert =
-            MockPerasCert
-              { mockCertRound = pvtRoundNo (pvcTarget (forgetQuorum votes))
-              , mockCertBlock = pvtBlock (pvcTarget (forgetQuorum votes))
-              , mockCertVoters = NESet.fromList (pviSeatIndex <$> NEMap.keys (pvcVotes (forgetQuorum votes)))
-              }
-        , vpcCertBoost = perasWeight params
-        }
-
-  getPerasCertInBlock _ = Nothing
+  forgePerasVoteIfEligible = defaultForgePerasVoteIfEligible
+  verifyPerasVote = defaultVerifyPerasVote
+  forgePerasCert = defaultForgePerasCert
+  verifyPerasCert = defaultVerifyPerasCert
+  getPerasCertInBlock _ = Right Nothing
 
 -- * Validated types
 
@@ -470,7 +483,7 @@ instance
   getPerasCertRound = getPerasCertRound . vpcCert
   getPerasCertBlock = getPerasCertBlock . vpcCert
 
---- * Peras error types
+-- * Peras error types
 
 -- | Error types that support injecting certain types of Peras errors
 class IsPerasError err blk | err -> blk where

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Dual.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Dual.hs
@@ -537,6 +537,13 @@ dualExtValidationErrorMain = \case
   ExtValidationErrorLedger e -> ExtValidationErrorLedger (dualLedgerErrorMain e)
   ExtValidationErrorHeader e -> ExtValidationErrorHeader (castHeaderError e)
   ExtValidationErrorPerasEpochContextResolver e -> ExtValidationErrorPerasEpochContextResolver e
+  -- NOTE: this will become an impossible case for the dual block after removing
+  -- the degenerate 'BlockSupportsPeras' instance, since:
+  -- @
+  --   PerasError (DualBlock m a) ~ VoidPerasError (DualBlock m a) ~ Void
+  -- @
+  ExtValidationErrorPerasCertInBlock _ ->
+    error "dualExtValidationErrorMain: impossible error for dual block"
 
 {-------------------------------------------------------------------------------
   LedgerSupportsProtocol

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Extended.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Extended.hs
@@ -96,6 +96,7 @@ data ExtValidationError blk
   = ExtValidationErrorLedger !(LedgerErr LedgerState blk)
   | ExtValidationErrorHeader !(HeaderError blk)
   | ExtValidationErrorPerasEpochContextResolver !PerasEpochContextNotFoundForRound
+  | ExtValidationErrorPerasCertInBlock !(PerasError blk)
   deriving Generic
 
 deriving instance
@@ -342,9 +343,11 @@ extractAndValidatePerasCertFromBlock ::
   Except (LedgerErr ExtLedgerState blk) (Maybe (ValidatedPerasCert blk))
 extractAndValidatePerasCertFromBlock _ blk = do
   case getPerasCertInBlock blk of
-    Nothing ->
+    Left err ->
+      throwError (ExtValidationErrorPerasCertInBlock err)
+    Right Nothing ->
       pure Nothing
-    Just cert -> do
+    Right (Just cert) -> do
       pure $
         Just
           ValidatedPerasCert

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ObjectDiffusion/ObjectPool/PerasCert.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ObjectDiffusion/ObjectPool/PerasCert.hs
@@ -1,5 +1,4 @@
-{-# LANGUAGE GADTs #-}
-{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE FlexibleContexts #-}
 
 -- | Instantiate 'ObjectPoolReader' and 'ObjectPoolWriter' using Peras
 -- certificates from the 'PerasCertDB' (or the 'ChainDB' which is wrapping the
@@ -11,20 +10,24 @@ module Ouroboros.Consensus.MiniProtocol.ObjectDiffusion.ObjectPool.PerasCert
   , makePerasCertPoolWriterFromChainDB
   ) where
 
-import Control.Monad (join)
-import Data.Either (partitionEithers)
-import Data.Functor (void)
+import Data.Foldable (traverse_)
 import Data.Map (Map)
 import qualified Data.Map as Map
-import Data.Set (Set)
 import qualified Data.Set as Set
-import GHC.Exception (throw)
+import Data.Typeable (Typeable)
 import Ouroboros.Consensus.Block
 import Ouroboros.Consensus.BlockchainTime.WallClock.Types
   ( SystemTime (..)
   , WithArrivalTime (..)
   )
 import Ouroboros.Consensus.MiniProtocol.ObjectDiffusion.ObjectPool.API
+  ( ObjectPoolReader (..)
+  , ObjectPoolWriter (..)
+  )
+import Ouroboros.Consensus.Peras.Context
+  ( PerasEpochContextResolverHandle
+  , verifyPerasCertWithHandle
+  )
 import Ouroboros.Consensus.Storage.ChainDB.API (ChainDB)
 import qualified Ouroboros.Consensus.Storage.ChainDB.API as ChainDB
 import Ouroboros.Consensus.Storage.PerasCertDB.API
@@ -32,7 +35,7 @@ import Ouroboros.Consensus.Storage.PerasCertDB.API
   , PerasCertTicketNo
   )
 import qualified Ouroboros.Consensus.Storage.PerasCertDB.API as PerasCertDB
-import Ouroboros.Consensus.Util.IOLike
+import Ouroboros.Consensus.Util.IOLike (IOLike, MonadSTM (..))
 
 -- | TODO: replace by `Data.Map.take` as soon as we move to GHC 9.8
 takeAscMap :: Int -> Map k v -> Map k v
@@ -89,20 +92,26 @@ makePerasCertPoolReaderFromChainDB chainDB =
 -- see 'makePerasCertPoolWriterFromChainDB' which creates a pool writer from the
 -- 'ChainDB' with proper handling of chain selection side-effects.
 makePerasCertPoolWriterFromCertDB ::
-  (StandardHash blk, IOLike m) =>
+  (StandardHash blk, Typeable blk, IOLike m) =>
   SystemTime m ->
   PerasCertDB m blk ->
+  PerasEpochContextResolverHandle m blk ->
   ObjectPoolWriter PerasRoundNo (PerasCert blk) m
-makePerasCertPoolWriterFromCertDB systemTime perasCertDB =
+makePerasCertPoolWriterFromCertDB systemTime perasCertDB resolverHandle =
   ObjectPoolWriter
     { opwObjectId = getPerasCertRound
-    , opwAddObjects = \certs ->
-        processCerts
-          systemTime
-          (PerasCertDB.getCertIds perasCertDB)
-          (validatePerasCert defaultPerasParams) -- TODO replace when actual plumbing is in place
-          (void . join . atomically . PerasCertDB.addCert perasCertDB)
-          certs
+    , opwAddObjects = \certs -> do
+        now <- systemTimeCurrent systemTime
+        atomically $ do
+          alreadyInDb <- PerasCertDB.getCertIds perasCertDB
+          let certsNotAlreadyInDb = filter ((`Set.notMember` alreadyInDb) . getPerasCertRound) certs
+          validatedCerts <- traverse (verifyPerasCertWithHandle resolverHandle) certsNotAlreadyInDb
+          -- Some certs are invalid => reject the whole batch
+          --
+          -- NOTE: we could combine the two 'traverse' operations into one in
+          -- which case any validated cert would be immediately added no matter
+          -- what is the validity of the other certs in the batch.
+          traverse_ (PerasCertDB.addCert perasCertDB . WithArrivalTime now) validatedCerts
     , opwHasObject = do
         certIds <- PerasCertDB.getCertIds perasCertDB
         pure $ \roundNo -> Set.member roundNo certIds
@@ -111,75 +120,27 @@ makePerasCertPoolWriterFromCertDB systemTime perasCertDB =
 -- | Create a pool writer from the 'ChainDB'. This properly handles any needed
 -- chain selection side-effects.
 makePerasCertPoolWriterFromChainDB ::
-  (StandardHash blk, IOLike m) =>
+  (StandardHash blk, Typeable blk, IOLike m) =>
   SystemTime m ->
   ChainDB m blk ->
   ObjectPoolWriter PerasRoundNo (PerasCert blk) m
 makePerasCertPoolWriterFromChainDB systemTime chainDB =
-  ObjectPoolWriter
-    { opwObjectId = getPerasCertRound
-    , opwAddObjects = \certs ->
-        processCerts
-          systemTime
-          (ChainDB.getPerasCertIds chainDB)
-          -- TODO replace when actual plumbing is in place
-          (validatePerasCert defaultPerasParams)
-          -- We do not want to block the writer thread on waiting for ChainSel
-          -- side-effects to complete, so we use the async version of adding
-          -- certs to the ChainDB and ignore the returned promise.
-          -- The async action is still launched and executed behind the scenes
-          -- even though we drop the promise.
-          (void . ChainDB.addPerasCertAsync chainDB)
-          certs
-    , opwHasObject = do
-        certIds <- ChainDB.getPerasCertIds chainDB
-        pure $ \roundNo -> Set.member roundNo certIds
-    }
-
-data PerasCertInboundException
-  = forall blk. PerasCertValidationError [PerasError blk]
-
-deriving instance Show PerasCertInboundException
-
-instance Exception PerasCertInboundException
-
--- | Process a batch of inbound Peras certificates received from a peer.
---
--- Certificates whose round number is already present in the database (as
--- determined by @alreadyInDbSTM@) are silently skipped. The remaining
--- certificates are validated; if /any/ certificate in the batch fails
--- validation, the entire batch is rejected by throwing a
--- 'PerasCertInboundException' (which should make us disconnect from the distant
--- peer, see 'withPeer' bracket function from `ouroboros-network`). Otherwise,
--- each valid certificate is timestamped with the current wall-clock time and
--- added to the database via @addCert@.
-processCerts ::
-  MonadSTM m =>
-  SystemTime m ->
-  STM m (Set PerasRoundNo) ->
-  (PerasCert blk -> Either (PerasError blk) (ValidatedPerasCert blk)) ->
-  (WithArrivalTime (ValidatedPerasCert blk) -> m ()) ->
-  [PerasCert blk] ->
-  m ()
-processCerts systemTime alreadyInDbSTM validateCert addCert certs = do
-  alreadyInDb <- atomically alreadyInDbSTM
-  let certsNotAlreadyInDb = filter (not . (`Set.member` alreadyInDb) . getPerasCertRound) certs
-  now <- systemTimeCurrent systemTime
-  case partitionEithers (validateCert <$> certsNotAlreadyInDb) of
-    -- All certs are valid => add them to the pool
-    ([], validatedCerts) ->
-      mapM_
-        (addCert . WithArrivalTime now)
-        validatedCerts
-    -- Some certs are invalid => reject the whole batch
-    --
-    -- N.B. it has been requested in PR review
-    -- https://github.com/IntersectMBO/ouroboros-consensus/pull/1768#discussion_r2747873186
-    -- to gather all validation errors and report them together in the exception
-    -- rather than just report the first error encountered.
-    -- This assumes that cert validation is cheap, which may not be true in
-    -- practice depending on the actual crypto/committee selection scheme.
-    -- Hence we may revisit this to lazily abort validation upon the first error
-    -- encountered.
-    (errs, _) ->
-      throw (PerasCertValidationError errs)
+  let resolverHandle = ChainDB.getPerasEpochContextResolverHandle chainDB
+   in ObjectPoolWriter
+        { opwObjectId = getPerasCertRound
+        , opwAddObjects = \certs -> do
+            now <- systemTimeCurrent systemTime
+            validatedCerts <- atomically $ do
+              alreadyInDb <- ChainDB.getPerasCertIds chainDB
+              let certsNotAlreadyInDb = filter ((`Set.notMember` alreadyInDb) . getPerasCertRound) certs
+              traverse (verifyPerasCertWithHandle resolverHandle) certsNotAlreadyInDb
+            -- Some certs are invalid => reject the whole batch
+            --
+            -- NOTE: we could combine the two 'traverse' operations into one in
+            -- which case any validated cert would be immediately added no
+            -- matter what is the validity of the other certs in the batch.
+            traverse_ (ChainDB.addPerasCertAsync chainDB . WithArrivalTime now) validatedCerts
+        , opwHasObject = do
+            certIds <- ChainDB.getPerasCertIds chainDB
+            pure $ \roundNo -> Set.member roundNo certIds
+        }

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ObjectDiffusion/ObjectPool/PerasCert.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ObjectDiffusion/ObjectPool/PerasCert.hs
@@ -4,10 +4,12 @@
 -- certificates from the 'PerasCertDB' (or the 'ChainDB' which is wrapping the
 -- 'PerasCertDB').
 module Ouroboros.Consensus.MiniProtocol.ObjectDiffusion.ObjectPool.PerasCert
-  ( makePerasCertPoolReaderFromCertDB
-  , makePerasCertPoolWriterFromCertDB
-  , makePerasCertPoolReaderFromChainDB
+  ( makePerasCertPoolReaderFromChainDB
   , makePerasCertPoolWriterFromChainDB
+
+    -- * For testing purposes
+  , makeTestPerasCertPoolReaderFromCertDB
+  , makeTestPerasCertPoolWriterFromCertDB
   ) where
 
 import Data.Foldable (traverse_)
@@ -67,11 +69,11 @@ makePerasCertPoolReader getCertsAfterSTM =
               certsAfterLastKnown
     }
 
-makePerasCertPoolReaderFromCertDB ::
+makeTestPerasCertPoolReaderFromCertDB ::
   IOLike m =>
   PerasCertDB m blk ->
   ObjectPoolReader PerasRoundNo (PerasCert blk) PerasCertTicketNo m
-makePerasCertPoolReaderFromCertDB perasCertDB =
+makeTestPerasCertPoolReaderFromCertDB perasCertDB =
   makePerasCertPoolReader
     (PerasCertDB.getCertsAfter perasCertDB)
 
@@ -91,13 +93,13 @@ makePerasCertPoolReaderFromChainDB chainDB =
 -- for tests against the 'PerasCertDB' in isolation; for actual production use,
 -- see 'makePerasCertPoolWriterFromChainDB' which creates a pool writer from the
 -- 'ChainDB' with proper handling of chain selection side-effects.
-makePerasCertPoolWriterFromCertDB ::
+makeTestPerasCertPoolWriterFromCertDB ::
   (StandardHash blk, Typeable blk, IOLike m) =>
   SystemTime m ->
   PerasCertDB m blk ->
   PerasEpochContextResolverHandle m blk ->
   ObjectPoolWriter PerasRoundNo (PerasCert blk) m
-makePerasCertPoolWriterFromCertDB systemTime perasCertDB resolverHandle =
+makeTestPerasCertPoolWriterFromCertDB systemTime perasCertDB resolverHandle =
   ObjectPoolWriter
     { opwObjectId = getPerasCertRound
     , opwAddObjects = \certs -> do

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ObjectDiffusion/ObjectPool/PerasVote.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ObjectDiffusion/ObjectPool/PerasVote.hs
@@ -1,5 +1,4 @@
-{-# LANGUAGE GADTs #-}
-{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE FlexibleContexts #-}
 
 -- | Instantiate 'ObjectPoolReader' and 'ObjectPoolWriter' using Peras
 -- votes from the 'PerasVoteDB' (or the 'ChainDB' which is wrapping the
@@ -11,29 +10,32 @@ module Ouroboros.Consensus.MiniProtocol.ObjectDiffusion.ObjectPool.PerasVote
   , makePerasVotePoolWriterFromChainDB
   ) where
 
-import Control.Monad (join)
-import Data.Either (partitionEithers)
-import Data.Functor (void)
+import Data.Foldable (traverse_)
 import Data.Map (Map)
 import qualified Data.Map as Map
-import Data.Set (Set)
 import qualified Data.Set as Set
-import GHC.Exception (throw)
+import Data.Typeable (Typeable)
 import Ouroboros.Consensus.Block
 import Ouroboros.Consensus.BlockchainTime.WallClock.Types
   ( SystemTime (..)
   , WithArrivalTime (..)
   )
 import Ouroboros.Consensus.MiniProtocol.ObjectDiffusion.ObjectPool.API
+  ( ObjectPoolReader (..)
+  , ObjectPoolWriter (..)
+  )
+import Ouroboros.Consensus.Peras.Context
+  ( PerasEpochContextResolverHandle
+  , verifyPerasVoteWithHandle
+  )
 import Ouroboros.Consensus.Storage.ChainDB.API (ChainDB)
 import qualified Ouroboros.Consensus.Storage.ChainDB.API as ChainDB
 import Ouroboros.Consensus.Storage.PerasVoteDB.API
   ( PerasVoteDB
   , PerasVoteTicketNo
-  , zeroPerasVoteTicketNo
   )
 import qualified Ouroboros.Consensus.Storage.PerasVoteDB.API as PerasVoteDB
-import Ouroboros.Consensus.Util.IOLike
+import Ouroboros.Consensus.Util.IOLike (IOLike, MonadSTM (..))
 
 -- | TODO: replace by `Data.Map.take` as soon as we move to GHC 9.8
 takeAscMap :: Int -> Map k v -> Map k v
@@ -53,7 +55,7 @@ makePerasVotePoolReader ::
 makePerasVotePoolReader getVotesAfterSTM =
   ObjectPoolReader
     { oprObjectId = getPerasVoteId
-    , oprZeroTicketNo = zeroPerasVoteTicketNo
+    , oprZeroTicketNo = PerasVoteDB.zeroPerasVoteTicketNo
     , oprObjectsAfter = \lastKnown limit -> do
         votesAfterLastKnownNoLimit <- getVotesAfterSTM lastKnown
         if Map.null votesAfterLastKnownNoLimit
@@ -90,27 +92,26 @@ makePerasVotePoolReaderFromChainDB chainDB =
 -- see 'makePerasVotePoolWriterFromChainDB' which creates a pool writer from the
 -- 'ChainDB' and thus properly handles the produced certs.
 makePerasVotePoolWriterFromVoteDB ::
-  (StandardHash blk, IOLike m) =>
+  (StandardHash blk, Typeable blk, IOLike m) =>
   SystemTime m ->
-  -- | This is needed for validating votes (since it is during the validation of
-  -- votes that we give them a verified weight. In the future, we won't read it
-  -- from the stake distr directly, but rather use the committee selection data)
-  STM m PerasVoteStakeDistr ->
   PerasVoteDB m blk ->
+  PerasEpochContextResolverHandle m blk ->
   ObjectPoolWriter PerasVoteId (PerasVote blk) m
-makePerasVotePoolWriterFromVoteDB systemTime getStakeDistrSTM perasVoteDB =
+makePerasVotePoolWriterFromVoteDB systemTime perasVoteDB resolverHandle =
   ObjectPoolWriter
     { opwObjectId = getPerasVoteId
-    , opwAddObjects = \votes ->
-        processVotes
-          systemTime
-          (PerasVoteDB.getVoteIds perasVoteDB)
-          -- TODO: in the future we won't need just the stake distribution for
-          -- validating votes, but also the whole committee selection context
-          -- (containing vote weights of committee members = voters)
-          (\vote -> getStakeDistrSTM >>= \sd -> pure $ validatePerasVote defaultPerasParams sd vote)
-          (void . join . atomically . PerasVoteDB.addVote perasVoteDB)
-          votes
+    , opwAddObjects = \votes -> do
+        now <- systemTimeCurrent systemTime
+        atomically $ do
+          alreadyInDb <- PerasVoteDB.getVoteIds perasVoteDB
+          let votesNotAlreadyInDb = filter ((`Set.notMember` alreadyInDb) . getPerasVoteId) votes
+          validatedVotes <- traverse (verifyPerasVoteWithHandle resolverHandle) votesNotAlreadyInDb
+          -- Some votes are invalid => reject the whole batch
+          --
+          -- NOTE: we could combine the two 'traverse' operations into one in
+          -- which case any validated vote would be immediately added no matter
+          -- what is the validity of the other votes in the batch.
+          traverse_ (PerasVoteDB.addVote perasVoteDB . WithArrivalTime now) validatedVotes
     , opwHasObject = do
         voteIds <- PerasVoteDB.getVoteIds perasVoteDB
         pure $ \voteId -> Set.member voteId voteIds
@@ -120,82 +121,27 @@ makePerasVotePoolWriterFromVoteDB systemTime getStakeDistrSTM perasVoteDB =
 -- This properly handles the produced certs by letting the ChainDB take care
 -- of them (see 'ChainDB.addPerasVoteWithAsyncCertHandling').
 makePerasVotePoolWriterFromChainDB ::
-  (StandardHash blk, IOLike m) =>
+  (StandardHash blk, Typeable blk, IOLike m) =>
   SystemTime m ->
-  -- | This is needed for validating votes (since its during the validation of
-  -- votes that we give them a verified weight. In the future, we won't read it
-  -- from the stake distr directly, but rather use the committee selection data)
-  STM m PerasVoteStakeDistr ->
   ChainDB m blk ->
   ObjectPoolWriter PerasVoteId (PerasVote blk) m
-makePerasVotePoolWriterFromChainDB systemTime getStakeDistrSTM chainDB =
-  ObjectPoolWriter
-    { opwObjectId = getPerasVoteId
-    , opwAddObjects = \votes ->
-        processVotes
-          systemTime
-          (ChainDB.getPerasVoteIds chainDB)
-          -- TODO: in the future we won't need just the stake distribution for
-          -- validating votes, but also the whole committee selection context
-          -- (containing vote weights of committee members = voters)
-          (\vote -> getStakeDistrSTM >>= \sd -> pure $ validatePerasVote defaultPerasParams sd vote)
-          -- We do not want to block the writer thread on waiting for ChainSel
-          -- side-effects to complete, so we use the async version of adding
-          -- votes to the ChainDB and ignore the returned promise.
-          -- The async action (if any) is still launched and executed behind the
-          -- scenes even though we drop the promise.
-          (void . ChainDB.addPerasVoteWithAsyncCertHandling chainDB)
-          votes
-    , opwHasObject = do
-        voteIds <- ChainDB.getPerasVoteIds chainDB
-        pure $ \voteId -> Set.member voteId voteIds
-    }
-
-data PerasVoteInboundException
-  = forall blk. PerasVoteValidationError [PerasError blk]
-
-deriving instance Show PerasVoteInboundException
-
-instance Exception PerasVoteInboundException
-
--- | Process a batch of inbound Peras votes received from a peer.
---
--- Votes whose ID is already present in the database (as determined by
--- @alreadyInDbSTM@) are silently skipped. The remaining votes are validated;
--- if /any/ vote in the batch fails validation, the entire batch is rejected
--- by throwing a 'PerasVoteInboundException' (which should make us disconnect
--- from the distant peer, see 'withPeer' bracket function from
--- `ouroboros-network`). Otherwise, each valid vote is timestamped with the
--- current wall-clock time and added to the database via @addVote@.
-processVotes ::
-  MonadSTM m =>
-  SystemTime m ->
-  STM m (Set PerasVoteId) ->
-  (PerasVote blk -> STM m (Either (PerasError blk) (ValidatedPerasVote blk))) ->
-  (WithArrivalTime (ValidatedPerasVote blk) -> m ()) ->
-  [PerasVote blk] ->
-  m ()
-processVotes systemTime alreadyInDbSTM validateVote addVote votes = do
-  validationResults <- atomically $ do
-    alreadyInDb <- alreadyInDbSTM
-    let votesNotAlreadyInDb = filter (not . (`Set.member` alreadyInDb) . getPerasVoteId) votes
-    mapM validateVote votesNotAlreadyInDb
-  now <- systemTimeCurrent systemTime
-  case partitionEithers validationResults of
-    -- All votes are valid => add them to the pool
-    ([], validatedVotes) ->
-      mapM_
-        (addVote . WithArrivalTime now)
-        validatedVotes
-    -- Some votes are invalid => reject the whole batch
-    --
-    -- N.B. it has been requested in PR review
-    -- https://github.com/IntersectMBO/ouroboros-consensus/pull/1768#discussion_r2747873186
-    -- to gather all validation errors and report them together in the exception
-    -- rather than just report the first error encountered.
-    -- This assumes that vote validation is cheap, which may not be true in
-    -- practice depending on the actual crypto/committee selection scheme.
-    -- Hence we may revisit this to lazily abort validation upon the first error
-    -- encountered.
-    (errs, _) ->
-      throw (PerasVoteValidationError errs)
+makePerasVotePoolWriterFromChainDB systemTime chainDB =
+  let resolverHandle = ChainDB.getPerasEpochContextResolverHandle chainDB
+   in ObjectPoolWriter
+        { opwObjectId = getPerasVoteId
+        , opwAddObjects = \votes -> do
+            now <- systemTimeCurrent systemTime
+            validatedVotes <- atomically $ do
+              alreadyInDb <- ChainDB.getPerasVoteIds chainDB
+              let votesNotAlreadyInDb = filter ((`Set.notMember` alreadyInDb) . getPerasVoteId) votes
+              traverse (verifyPerasVoteWithHandle resolverHandle) votesNotAlreadyInDb
+            -- Some votes are invalid => reject the whole batch
+            --
+            -- NOTE: we could combine the two 'traverse' operations into one in
+            -- which case any validated vote would be immediately added no
+            -- matter what is the validity of the other votes in the batch.
+            traverse_ (ChainDB.addPerasVoteWithAsyncCertHandling chainDB . WithArrivalTime now) validatedVotes
+        , opwHasObject = do
+            voteIds <- ChainDB.getPerasVoteIds chainDB
+            pure $ \voteId -> Set.member voteId voteIds
+        }

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ObjectDiffusion/ObjectPool/PerasVote.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ObjectDiffusion/ObjectPool/PerasVote.hs
@@ -4,10 +4,12 @@
 -- votes from the 'PerasVoteDB' (or the 'ChainDB' which is wrapping the
 -- 'PerasVoteDB').
 module Ouroboros.Consensus.MiniProtocol.ObjectDiffusion.ObjectPool.PerasVote
-  ( makePerasVotePoolReaderFromVoteDB
-  , makePerasVotePoolWriterFromVoteDB
-  , makePerasVotePoolReaderFromChainDB
+  ( makePerasVotePoolReaderFromChainDB
   , makePerasVotePoolWriterFromChainDB
+
+    -- * For testing purposes
+  , makeTestPerasVotePoolReaderFromVoteDB
+  , makeTestPerasVotePoolWriterFromVoteDB
   ) where
 
 import Data.Foldable (traverse_)
@@ -65,11 +67,11 @@ makePerasVotePoolReader getVotesAfterSTM =
             pure $ Map.map (vpvVote . forgetArrivalTime) votesAfterLastKnown
     }
 
-makePerasVotePoolReaderFromVoteDB ::
+makeTestPerasVotePoolReaderFromVoteDB ::
   IOLike m =>
   PerasVoteDB m blk ->
   ObjectPoolReader PerasVoteId (PerasVote blk) PerasVoteTicketNo m
-makePerasVotePoolReaderFromVoteDB perasVoteDB =
+makeTestPerasVotePoolReaderFromVoteDB perasVoteDB =
   makePerasVotePoolReader
     (PerasVoteDB.getVotesAfter perasVoteDB)
 
@@ -91,13 +93,13 @@ makePerasVotePoolReaderFromChainDB chainDB =
 -- for tests against the 'PerasVoteDB' in isolation; for actual production use,
 -- see 'makePerasVotePoolWriterFromChainDB' which creates a pool writer from the
 -- 'ChainDB' and thus properly handles the produced certs.
-makePerasVotePoolWriterFromVoteDB ::
+makeTestPerasVotePoolWriterFromVoteDB ::
   (StandardHash blk, Typeable blk, IOLike m) =>
   SystemTime m ->
   PerasVoteDB m blk ->
   PerasEpochContextResolverHandle m blk ->
   ObjectPoolWriter PerasVoteId (PerasVote blk) m
-makePerasVotePoolWriterFromVoteDB systemTime perasVoteDB resolverHandle =
+makeTestPerasVotePoolWriterFromVoteDB systemTime perasVoteDB resolverHandle =
   ObjectPoolWriter
     { opwObjectId = getPerasVoteId
     , opwAddObjects = \votes -> do

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Peras/Context.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Peras/Context.hs
@@ -33,6 +33,9 @@ module Ouroboros.Consensus.Peras.Context
   , PerasEpochContextResolverHandle (..)
   , mockPerasEpochContextResolverHandle
   , withResolvedRoundNo
+  , verifyPerasVoteWithHandle
+  , verifyPerasCertWithHandle
+  , forgePerasVoteIfEligibleWithHandle
 
     -- * Extracting and resolving Peras epoch contexts from the node state
   , StateSupportsPerasEpochContext (..)
@@ -77,19 +80,26 @@ import GHC.Generics (Generic)
 import Ouroboros.Consensus.Block.Abstract
   ( BlockProtocol
   , EpochNo (..)
+  , Point
   , SlotNo
   , WithOrigin (..)
   )
 import Ouroboros.Consensus.Block.SupportsPeras
   ( BlockSupportsPeras (..)
+  , IsPerasCert (..)
   , IsPerasError (..)
+  , IsPerasVote (..)
   , PerasEpochContext (..)
   , PerasRoundNo
   , PerasVotingCommittee
   , PerasVotingCommitteeInput
+  , ValidatedPerasCert
+  , ValidatedPerasVote
   )
 import Ouroboros.Consensus.Committee.Class (CryptoSupportsVotingCommittee)
 import qualified Ouroboros.Consensus.Committee.Class as Committee
+import Ouroboros.Consensus.Committee.Crypto (PrivateKey)
+import Ouroboros.Consensus.Committee.Types (PoolId)
 import Ouroboros.Consensus.HardFork.Abstract (HasHardForkHistory (..))
 import Ouroboros.Consensus.HardFork.History.Qry
   ( EpochToPerasRoundInfo (..)
@@ -486,6 +496,52 @@ withResolvedRoundNo handle roundNo k = do
       case k context of
         Left err -> throwSTM err
         Right a -> pure a
+
+-- | Like 'verifyPerasVote', but using a 'PerasEpochContextResolverHandle' to
+-- resolve the epoch context for the round number of the given vote.
+verifyPerasVoteWithHandle ::
+  ( MonadSTM m
+  , MonadThrow (STM m)
+  , BlockSupportsPeras blk
+  ) =>
+  PerasEpochContextResolverHandle m blk ->
+  PerasVote blk ->
+  STM m (ValidatedPerasVote blk)
+verifyPerasVoteWithHandle handle vote =
+  withResolvedRoundNo handle (getPerasVoteRound vote) $ \context ->
+    verifyPerasVote context vote
+
+-- | Like 'verifyPerasCert', but using a 'PerasEpochContextResolverHandle' to
+-- resolve the epoch context for the round number of the given certificate.
+verifyPerasCertWithHandle ::
+  ( MonadSTM m
+  , MonadThrow (STM m)
+  , BlockSupportsPeras blk
+  ) =>
+  PerasEpochContextResolverHandle m blk ->
+  PerasCert blk ->
+  STM m (ValidatedPerasCert blk)
+verifyPerasCertWithHandle handle cert =
+  withResolvedRoundNo handle (getPerasCertRound cert) $ \context ->
+    verifyPerasCert context cert
+
+-- | Like 'forgePerasVoteIfEligible', but using a
+-- 'PerasEpochContextResolverHandle' to resolve the epoch context for the given
+-- round number.
+forgePerasVoteIfEligibleWithHandle ::
+  ( MonadSTM m
+  , MonadThrow (STM m)
+  , BlockSupportsPeras blk
+  ) =>
+  PerasEpochContextResolverHandle m blk ->
+  PoolId ->
+  PrivateKey (PerasCrypto blk) ->
+  PerasRoundNo ->
+  Point blk ->
+  STM m (Maybe (ValidatedPerasVote blk))
+forgePerasVoteIfEligibleWithHandle handle poolId privateKey roundNo point =
+  withResolvedRoundNo handle roundNo $ \context ->
+    forgePerasVoteIfEligible context poolId privateKey roundNo point
 
 -- * Extracting and resolving Peras epoch contexts from the node state
 

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Peras/Vote/Aggregation.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Peras/Vote/Aggregation.hs
@@ -47,9 +47,10 @@
 --
 -- = Quorum Threshold and Multiple Winners
 --
--- The quorum threshold is parameterized via 'PerasParams'. Depending on this
--- configuration and the weight distribution, it may be theoretically possible
--- for multiple targets to exceed the threshold within the same round.
+-- The quorum threshold is parameterized via 'PerasParams' inside
+-- 'PerasEpochContext'. Depending on this configuration and the weight
+-- distribution, it may be theoretically possible for multiple targets to exceed
+-- the threshold within the same round.
 --
 -- This module treats multiple winners as an error condition and rejects votes
 -- that would cause this, raising instead a 'RoundVoteStateLoserAboveQuorum'
@@ -90,18 +91,25 @@ module Ouroboros.Consensus.Peras.Vote.Aggregation
   , PerasTargetVoteState
   , getPerasTargetVoteStateTotalWeight
   , getPerasTargetVoteStateBlock
+  , PerasVoteCollectionWithQuorum (..)
   ) where
 
 import Control.Exception (assert)
+import Control.Monad.Class.MonadSTM (MonadSTM (..))
+import Data.Bifunctor (Bifunctor (..))
 import Data.Functor.Compose (Compose (..))
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import Data.Maybe (fromMaybe)
 import Data.Word (Word64)
 import GHC.Generics (Generic)
 import NoThunks.Class (NoThunks (..))
 import Ouroboros.Consensus.Block
 import Ouroboros.Consensus.BlockchainTime (WithArrivalTime)
+import Ouroboros.Consensus.Peras.Context
+  ( PerasEpochContextNotFoundForRound
+  , PerasEpochContextResolverHandle (..)
+  , resolveRoundNo
+  )
 
 {-------------------------------------------------------------------------------
   Voting state for a given Peras round
@@ -110,6 +118,7 @@ import Ouroboros.Consensus.BlockchainTime (WithArrivalTime)
 -- | Current vote state for a given round
 data PerasRoundVoteState blk = PerasRoundVoteState
   { prvsRoundNo :: !PerasRoundNo
+  , prvsEpochContext :: !(PerasEpochContext blk)
   , prvsState :: !(Either (NoQuorum blk) (Quorum blk))
   }
 
@@ -234,18 +243,27 @@ getPerasRoundVoteStateMaxTargetedSlot PerasRoundVoteState{prvsState} =
 
 -- | Create a fresh round vote state for the given round number
 freshRoundVoteState ::
+  MonadSTM m =>
   PerasRoundNo ->
-  PerasRoundVoteState blk
-freshRoundVoteState roundNo =
-  PerasRoundVoteState
-    { prvsRoundNo = roundNo
-    , prvsState =
-        Left
-          NoQuorum
-            { candidateStates =
-                Map.empty
-            }
-    }
+  PerasEpochContextResolverHandle m blk ->
+  STM m (Either (UpdateRoundVoteStateError blk) (PerasRoundVoteState blk))
+freshRoundVoteState roundNo resolverHandle = do
+  resolver <- getPerasEpochContextResolver resolverHandle
+  pure $
+    bimap RoundVoteStateEpochContextNotFound mkFreshRoundVoteState $
+      resolveRoundNo resolver roundNo
+ where
+  mkFreshRoundVoteState context =
+    PerasRoundVoteState
+      { prvsRoundNo = roundNo
+      , prvsEpochContext = context
+      , prvsState =
+          Left
+            NoQuorum
+              { candidateStates =
+                  Map.empty
+              }
+      }
 
 -- | Errors that may occur when updating the round vote state with a new vote
 data UpdateRoundVoteStateError blk
@@ -254,6 +272,8 @@ data UpdateRoundVoteStateError blk
       (PerasTargetVoteState blk 'Loser)
   | RoundVoteStateForgingCertError
       (PerasError blk)
+  | RoundVoteStateEpochContextNotFound
+      PerasEpochContextNotFoundForRound
 
 -- | Add a vote to an existing round vote aggregate.
 --
@@ -263,13 +283,12 @@ data UpdateRoundVoteStateError blk
 -- quorum) or if forging the certificate fails.
 updatePerasRoundVoteState ::
   forall blk.
-  StandardHash blk =>
+  BlockSupportsPeras blk =>
   WithArrivalTime (ValidatedPerasVote blk) ->
-  PerasParams blk ->
   PerasRoundVoteState blk ->
   Either (UpdateRoundVoteStateError blk) (PerasRoundVoteState blk)
-updatePerasRoundVoteState vote params roundState =
-  assert (getPerasVoteRound vote == prvsRoundNo roundState) $ do
+updatePerasRoundVoteState vote roundState =
+  assert (getPerasVoteRound vote == getPerasRoundVoteStateRound roundState) $ do
     case roundState of
       -- Quorum not yet reached
       state@PerasRoundVoteState
@@ -281,9 +300,9 @@ updatePerasRoundVoteState vote params roundState =
         } -> do
           let updateMaybeCandidateState = \case
                 Nothing ->
-                  candidateOrWinnerVoteStateSingleton params vote
+                  candidateOrWinnerVoteStateSingleton (prvsEpochContext roundState) vote
                 Just oldCandidateState ->
-                  updateCandidateVoteState params vote oldCandidateState
+                  updateCandidateVoteState (prvsEpochContext roundState) vote oldCandidateState
           candidateOrWinnerState <-
             updateMaybeCandidateState (Map.lookup (getPerasVotePoint vote) candidateStates)
           case candidateOrWinnerState of
@@ -312,6 +331,7 @@ updatePerasRoundVoteState vote params roundState =
                 PerasRoundVoteState
                   { prvsRoundNo =
                       prvsRoundNo roundState
+                  , prvsEpochContext = prvsEpochContext roundState
                   , prvsState =
                       Right
                         Quorum
@@ -355,9 +375,9 @@ updatePerasRoundVoteState vote params roundState =
             else do
               let updateMaybeLoserVoteState = \case
                     Nothing ->
-                      loserVoteStateSingleton params winnerState vote
+                      loserVoteStateSingleton (prvsEpochContext roundState) winnerState vote
                     Just oldLoserState ->
-                      updateLoserVoteState params winnerState vote oldLoserState
+                      updateLoserVoteState (prvsEpochContext roundState) winnerState vote oldLoserState
 
               loserStates' <-
                 Map.alterF (\mState -> Just <$> updateMaybeLoserVoteState mState) votePoint loserStates
@@ -380,49 +400,59 @@ updatePerasRoundVoteState vote params roundState =
 -- May fail if the state transition is invalid (e.g., a loser going above
 -- quorum) or if forging the certificate fails.
 updatePerasRoundVoteStates ::
-  forall blk.
-  StandardHash blk =>
+  forall m blk.
+  (BlockSupportsPeras blk, MonadSTM m) =>
   WithArrivalTime (ValidatedPerasVote blk) ->
-  PerasParams blk ->
+  PerasEpochContextResolverHandle m blk ->
   Map PerasRoundNo (PerasRoundVoteState blk) ->
-  Either
-    (UpdateRoundVoteStateError blk)
-    (PerasRoundVoteState blk, Map PerasRoundNo (PerasRoundVoteState blk))
-updatePerasRoundVoteStates vote params =
+  STM
+    m
+    ( Either
+        (UpdateRoundVoteStateError blk)
+        (PerasRoundVoteState blk, Map PerasRoundNo (PerasRoundVoteState blk))
+    )
+updatePerasRoundVoteStates vote epochContextResolverHandle =
   alterMapAndReturnUpdatedValue
     updateMaybePerasRoundVoteState
     (getPerasVoteRound vote)
  where
-  -- We use the Functor instance of `Compose (Either e) ((,) s)` ≅
-  -- `λt. Either e (s, t)` in `Map.alterF`. That way, we can return both the
+  -- We use the Functor instance of `Compose (STM m) (Compose (Either e) ((,) s))` ≅
+  -- `λt. STM m (Either e (s, t))` in `Map.alterF`. That way, we can return both the
   -- updated map and the updated leaf in one pass, and still handle errors.
   alterMapAndReturnUpdatedValue ::
     Ord k =>
-    (Maybe a -> Either e (a, a)) ->
+    (Maybe a -> STM m (Either e (a, a))) ->
     k ->
     Map k a ->
-    Either e (a, Map k a)
+    STM m (Either e (a, Map k a))
   alterMapAndReturnUpdatedValue f k =
-    getCompose . Map.alterF (fmap Just . (Compose . f)) k
+    getCompose . getCompose . Map.alterF (fmap Just . (Compose . Compose . f)) k
 
   -- If there is no existing state for the vote's round, create a fresh one.
   existingOrFreshRoundVoteState ::
     Maybe (PerasRoundVoteState blk) ->
-    PerasRoundVoteState blk
-  existingOrFreshRoundVoteState =
-    fromMaybe (freshRoundVoteState (getPerasVoteRound vote))
+    STM m (Either (UpdateRoundVoteStateError blk) (PerasRoundVoteState blk))
+  existingOrFreshRoundVoteState = \case
+    Nothing -> freshRoundVoteState (getPerasVoteRound vote) epochContextResolverHandle
+    Just roundState -> pure (Right roundState)
 
   -- Update the round state, creating a fresh one if necessary, and returning
   -- the updated state.
   updateMaybePerasRoundVoteState ::
     Maybe (PerasRoundVoteState blk) ->
-    Either
-      (UpdateRoundVoteStateError blk)
-      (PerasRoundVoteState blk, PerasRoundVoteState blk)
+    STM
+      m
+      ( Either
+          (UpdateRoundVoteStateError blk)
+          (PerasRoundVoteState blk, PerasRoundVoteState blk)
+      )
   updateMaybePerasRoundVoteState mRoundState = do
-    let roundState = existingOrFreshRoundVoteState mRoundState
-    newRoundState <- updatePerasRoundVoteState vote params roundState
-    pure (newRoundState, newRoundState)
+    existingOrFreshRoundVoteState mRoundState >>= \case
+      Left err -> pure (Left err)
+      Right roundState -> do
+        case updatePerasRoundVoteState vote roundState of
+          Left err -> pure (Left err)
+          Right newRoundState -> pure (Right (newRoundState, newRoundState))
 
 {-------------------------------------------------------------------------------
   Peras round vote state pattern synonyms
@@ -543,28 +573,29 @@ ptvsVoteCollection = \case
 
 candidateOrWinnerVoteStateSingleton ::
   BlockSupportsPeras blk =>
-  PerasParams blk ->
+  PerasEpochContext blk ->
   WithArrivalTime (ValidatedPerasVote blk) ->
   Either
     (UpdateRoundVoteStateError blk)
     (PerasVoteStateCandidateOrWinner blk)
-candidateOrWinnerVoteStateSingleton params vote =
+candidateOrWinnerVoteStateSingleton epochContext vote =
   let voteCollection = perasVoteCollectionSingleton vote
-   in case perasVoteCollectionCheckQuorum params voteCollection of
+   in case perasVoteCollectionCheckQuorum (pecParams epochContext) voteCollection of
         Just votesWithQuorum -> do
-          cert <- forgePerasCert params votesWithQuorum `onErr` RoundVoteStateForgingCertError
+          cert <- forgePerasCert epochContext votesWithQuorum `onErr` RoundVoteStateForgingCertError
           pure $ BecameWinner $ PerasTargetVoteWinner voteCollection cert
         Nothing ->
           pure $ RemainedCandidate $ PerasTargetVoteCandidate voteCollection
 
 loserVoteStateSingleton ::
-  PerasParams blk ->
+  BlockSupportsPeras blk =>
+  PerasEpochContext blk ->
   PerasTargetVoteState blk 'Winner ->
   WithArrivalTime (ValidatedPerasVote blk) ->
   Either (UpdateRoundVoteStateError blk) (PerasTargetVoteState blk 'Loser)
-loserVoteStateSingleton params winnerState vote =
+loserVoteStateSingleton epochContext winnerState vote =
   let voteCollection = perasVoteCollectionSingleton vote
-   in case perasVoteCollectionCheckQuorum params voteCollection of
+   in case perasVoteCollectionCheckQuorum (pecParams epochContext) voteCollection of
         Just _ ->
           Left $ RoundVoteStateLoserAboveQuorum winnerState (PerasTargetVoteLoser voteCollection)
         Nothing ->
@@ -590,20 +621,20 @@ data PerasVoteStateCandidateOrWinner blk
 --
 -- May fail if the candidate is elected winner but forging the certificate fails.
 updateCandidateVoteState ::
-  StandardHash blk =>
-  PerasParams blk ->
+  BlockSupportsPeras blk =>
+  PerasEpochContext blk ->
   WithArrivalTime (ValidatedPerasVote blk) ->
   PerasTargetVoteState blk 'Candidate ->
   Either
     (UpdateRoundVoteStateError blk)
     (PerasVoteStateCandidateOrWinner blk)
-updateCandidateVoteState params vote oldState =
+updateCandidateVoteState epochContext vote oldState =
   let
     newVoteCollection = perasVoteCollectionAddVote vote (ptvsVoteCollection oldState)
    in
-    case perasVoteCollectionCheckQuorum params newVoteCollection of
+    case perasVoteCollectionCheckQuorum (pecParams epochContext) newVoteCollection of
       Just votesWithQuorum -> do
-        cert <- forgePerasCert params votesWithQuorum `onErr` RoundVoteStateForgingCertError
+        cert <- forgePerasCert epochContext votesWithQuorum `onErr` RoundVoteStateForgingCertError
         pure $ BecameWinner (PerasTargetVoteWinner newVoteCollection cert)
       Nothing -> do
         pure $ RemainedCandidate (PerasTargetVoteCandidate newVoteCollection)
@@ -614,16 +645,16 @@ updateCandidateVoteState params vote oldState =
 --
 -- May fail if the loser goes above quorum by adding the vote.
 updateLoserVoteState ::
-  StandardHash blk =>
-  PerasParams blk ->
+  BlockSupportsPeras blk =>
+  PerasEpochContext blk ->
   PerasTargetVoteState blk 'Winner ->
   WithArrivalTime (ValidatedPerasVote blk) ->
   PerasTargetVoteState blk 'Loser ->
   Either (UpdateRoundVoteStateError blk) (PerasTargetVoteState blk 'Loser)
-updateLoserVoteState params winnerState vote oldState =
+updateLoserVoteState epochContext winnerState vote oldState =
   assert (getPerasVoteTarget vote == pvcTarget (ptvsVoteCollection oldState)) $ do
     let newVoteCollection = perasVoteCollectionAddVote vote (ptvsVoteCollection oldState)
-     in case perasVoteCollectionCheckQuorum params newVoteCollection of
+     in case perasVoteCollectionCheckQuorum (pecParams epochContext) newVoteCollection of
           Just _ ->
             Left $ RoundVoteStateLoserAboveQuorum winnerState (PerasTargetVoteLoser newVoteCollection)
           Nothing ->

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/API.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/API.hs
@@ -94,6 +94,7 @@ import Ouroboros.Consensus.HeaderStateHistory
 import Ouroboros.Consensus.HeaderValidation (HeaderWithTime (..))
 import Ouroboros.Consensus.Ledger.Abstract
 import Ouroboros.Consensus.Ledger.Extended
+import Ouroboros.Consensus.Peras.Context (PerasEpochContextResolverHandle)
 import Ouroboros.Consensus.Peras.Weight (PerasWeightSnapshot)
 import Ouroboros.Consensus.Storage.ChainDB.API.Types.InvalidBlockPunishment
 import Ouroboros.Consensus.Storage.Common
@@ -466,6 +467,8 @@ data ChainDB m blk = ChainDB
   -- given one, in ascending order.
   , getPerasVoteIds :: STM m (Set PerasVoteId)
   -- ^ Get the set of all Peras vote IDs currently in the database.
+  , getPerasEpochContextResolverHandle :: PerasEpochContextResolverHandle m blk
+  -- ^ Returns a handle to obtain the 'PerasEpochContext' for a given 'PerasRoundNo'
   , waitForImmutableBlock :: RealPoint blk -> m (Either SeekBlockError (RealPoint blk))
   -- ^ Wait until the immutable tip's slot is equal or greater than the given slot:
   --   - returns the block when it becomes the immutable tip,

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl.hs
@@ -55,12 +55,15 @@ import GHC.Stack (HasCallStack)
 import NoThunks.Class
 import Ouroboros.Consensus.Block
 import Ouroboros.Consensus.Config
-import Ouroboros.Consensus.HardFork.Abstract
+import Ouroboros.Consensus.HardFork.Abstract (HasHardForkHistory (..))
 import Ouroboros.Consensus.HeaderValidation (mkHeaderWithTime)
-import Ouroboros.Consensus.Ledger.Extended (ledgerState)
+import Ouroboros.Consensus.Ledger.Extended (ledgerState, mkPerasEpochContextResolverHandle)
 import Ouroboros.Consensus.Ledger.Inspect
 import Ouroboros.Consensus.Ledger.SupportsProtocol
-import Ouroboros.Consensus.Peras.Context (StateSupportsPerasEpochContext)
+import Ouroboros.Consensus.Peras.Context
+  ( PerasEpochContextResolverHandle (..)
+  , StateSupportsPerasEpochContext
+  )
 import Ouroboros.Consensus.Storage.ChainDB.API (ChainDB)
 import qualified Ouroboros.Consensus.Storage.ChainDB.API as API
 import Ouroboros.Consensus.Storage.ChainDB.Impl.Args
@@ -196,8 +199,9 @@ openDBInternal args launchBgTasks = runWithTempRegistry $ do
   lift $ do
     traceWith tracer $ TraceOpenEvent OpenedLgrDB
 
+    let resolverHandle = mkPerasEpochContextResolverHandle (LedgerDB.getVolatileTip lgrDB)
     perasCertDB <- PerasCertDB.createDB argsPerasCertDB
-    perasVoteDB <- PerasVoteDB.createDB argsPerasVoteDB
+    perasVoteDB <- PerasVoteDB.createDB argsPerasVoteDB resolverHandle
 
     varInvalid <- newTVarIO (WithFingerprint Map.empty (Fingerprint 0))
 
@@ -312,6 +316,10 @@ openDBInternal args launchBgTasks = runWithTempRegistry $ do
             , addPerasVoteWithAsyncCertHandling = getEnv1 h ChainSel.addPerasVoteWithAsyncCertHandling
             , getPerasVotesAfter = getEnvSTM1 h Query.getPerasVotesAfter
             , getPerasVoteIds = getEnvSTM h Query.getPerasVoteIds
+            , getPerasEpochContextResolverHandle =
+                PerasEpochContextResolverHandle $
+                  getEnvSTM h $
+                    Query.getPerasEpochContextResolver
             , waitForImmutableBlock = getEnv1 h Query.waitForImmutableBlock
             , getLatestPerasCertOnChainRound = getEnvSTM h Query.getLatestPerasCertOnChainRound
             }

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Args.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Args.hs
@@ -228,7 +228,6 @@ completeChainDbArgs
       , cdbPerasVoteDbArgs =
           PerasVoteDB.PerasVoteDbArgs
             { PerasVoteDB.pvdbaTracer = PerasVoteDB.pvdbaTracer (cdbPerasVoteDbArgs defArgs)
-            , PerasVoteDB.pvdbaPerasParams = defaultPerasParams
             }
       , cdbsArgs =
           (cdbsArgs defArgs)

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Query.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Query.hs
@@ -28,6 +28,7 @@ module Ouroboros.Consensus.Storage.ChainDB.Impl.Query
   , getPerasVotesAfter
   , getPerasVoteIds
   , getLatestPerasCertOnChainRound
+  , getPerasEpochContextResolver
   , getStatistics
   , getTipBlock
   , getTipHeader
@@ -49,6 +50,7 @@ import Control.Monad.Trans.Class
 import Control.ResourceRegistry
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
+import Data.Maybe.Strict (strictMaybeToMaybe)
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.Typeable
@@ -61,6 +63,8 @@ import Ouroboros.Consensus.HeaderStateHistory
 import Ouroboros.Consensus.HeaderValidation (HeaderWithTime)
 import Ouroboros.Consensus.Ledger.Abstract (EmptyMK)
 import Ouroboros.Consensus.Ledger.Extended
+import Ouroboros.Consensus.Ledger.Peras (PerasState (..))
+import Ouroboros.Consensus.Peras.Context (PerasEpochContextResolver)
 import Ouroboros.Consensus.Peras.Weight
   ( PerasWeightSnapshot
   , takeVolatileSuffix
@@ -370,6 +374,23 @@ getPerasVoteIds ::
   ChainDbEnv m blk -> STM m (Set PerasVoteId)
 getPerasVoteIds CDB{..} = PerasVoteDB.getVoteIds cdbPerasVoteDB
 
+getLatestPerasCertOnChainRound ::
+  IOLike m =>
+  ChainDbEnv m blk ->
+  STM m (Maybe PerasRoundNo)
+getLatestPerasCertOnChainRound CDB{..} = do
+  strictMaybeToMaybe
+    . latestPerasCertOnChainRound
+    . perasState
+    <$> LedgerDB.getVolatileTip cdbLedgerDB
+
+getPerasEpochContextResolver ::
+  MonadSTM m =>
+  ChainDbEnv m blk ->
+  STM m (PerasEpochContextResolver blk)
+getPerasEpochContextResolver =
+  fmap (perasEpochContextResolver . perasState) . getCurrentLedger
+
 -- | Wait until the slot of the given point is smaller or equal than the immutable tip slot,
 --   and then return:
 --   - the block at the target slot if there is a block in the immutable DB at that slot;
@@ -403,14 +424,6 @@ waitForImmutableBlock CDB{cdbImmutableDB} targetRealPoint = do
           <> show e
           <> ". The ImmutableDB could have been concurrently truncated."
     result@Right{} -> pure result
-
-getLatestPerasCertOnChainRound ::
-  IOLike m =>
-  ChainDbEnv m blk ->
-  STM m (Maybe PerasRoundNo)
-getLatestPerasCertOnChainRound _ = do
-  -- Placeholder until we finish rewiring this into the extended ledger state
-  pure Nothing
 
 {-------------------------------------------------------------------------------
   Unifying interface over the immutable DB and volatile DB, but independent

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/PerasVoteDB/API.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/PerasVoteDB/API.hs
@@ -3,8 +3,11 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 module Ouroboros.Consensus.Storage.PerasVoteDB.API
   ( PerasVoteDB (..)
@@ -32,11 +35,13 @@ import Data.Map (Map)
 import qualified Data.Map.Strict as Map
 import Data.Set (Set)
 import qualified Data.Set as Set
+import Data.Typeable (Typeable)
 import Data.Word (Word64)
 import GHC.Generics (Generic)
 import NoThunks.Class
 import Ouroboros.Consensus.Block
 import Ouroboros.Consensus.BlockchainTime.WallClock.Types (WithArrivalTime (..))
+import Ouroboros.Consensus.Peras.Context (PerasEpochContextNotFoundForRound)
 import Ouroboros.Consensus.Util.MonadSTM.NormalForm (MonadSTM (..))
 
 data PerasVoteDB m blk = PerasVoteDB
@@ -83,8 +88,21 @@ data AddPerasVoteResult blk
   = PerasVoteAlreadyInDB
   | AddedPerasVoteButDidntGenerateNewCert
   | AddedPerasVoteAndGeneratedNewCert (ValidatedPerasCert blk)
-  deriving stock (Generic, Eq, Ord, Show)
-  deriving anyclass NoThunks
+
+deriving instance
+  Show (PerasCert blk) =>
+  Show (AddPerasVoteResult blk)
+deriving instance
+  Eq (PerasCert blk) =>
+  Eq (AddPerasVoteResult blk)
+deriving instance
+  Ord (PerasCert blk) =>
+  Ord (AddPerasVoteResult blk)
+deriving instance
+  NoThunks (PerasCert blk) =>
+  NoThunks (AddPerasVoteResult blk)
+deriving instance
+  Generic (AddPerasVoteResult blk)
 
 {-------------------------------------------------------------------------------
   Exceptions
@@ -98,17 +116,33 @@ newtype BlockedPerasRoundWinner blk
   = BlockedPerasRoundWinner (Point blk, VoteWeight)
   deriving stock (Show, Eq)
 
-data PerasVoteDbError blk
-  = -- | Attempted to add a vote that would lead to multiple winners for the
-    -- same round
-    MultipleWinnersInRound
-      PerasRoundNo
-      (ExistingPerasRoundWinner blk)
-      (BlockedPerasRoundWinner blk)
-  | -- | An error occurred while forging a certificate
-    ForgingCertError (PerasError blk)
-  deriving stock Show
-  deriving anyclass Exception
+data PerasVoteDbError blk where
+  -- | Attempted to add a vote that would lead to multiple winners for the same round
+  MultipleWinnersInRound ::
+    PerasRoundNo ->
+    (ExistingPerasRoundWinner blk) ->
+    (BlockedPerasRoundWinner blk) ->
+    PerasVoteDbError blk
+  -- | An error occurred while forging a certificate
+  ForgingCertError ::
+    PerasError blk ->
+    PerasVoteDbError blk
+  -- | The epoch context for the round of the vote could not be found
+  EpochContextNotFoundForRound ::
+    PerasEpochContextNotFoundForRound ->
+    PerasVoteDbError blk
+
+deriving instance
+  ( StandardHash blk
+  , Show (PerasError blk)
+  ) =>
+  Show (PerasVoteDbError blk)
+deriving instance
+  ( StandardHash blk
+  , Show (PerasError blk)
+  , Typeable blk
+  ) =>
+  Exception (PerasVoteDbError blk)
 
 -- * Invariants
 
@@ -116,7 +150,9 @@ data PerasVoteDbError blk
 
 -- | After adding a vote, its ID should be present in 'getVoteIds'.
 prop_addVoteThenGetVoteIds ::
-  MonadSTM m =>
+  ( MonadSTM m
+  , IsPerasVote (PerasVote blk) blk
+  ) =>
   PerasVoteDB m blk ->
   WithArrivalTime (ValidatedPerasVote blk) ->
   m Bool
@@ -130,7 +166,9 @@ prop_addVoteThenGetVoteIds db vote =
 
 -- | 'getVotesAfter' with ticket 0 should return all votes in the database.
 prop_getVotesAfterZero ::
-  MonadSTM m =>
+  ( MonadSTM m
+  , IsPerasVote (PerasVote blk) blk
+  ) =>
   PerasVoteDB m blk ->
   m Bool
 prop_getVotesAfterZero db =
@@ -161,7 +199,9 @@ prop_getVotesAfterMonotonic db ticketNo =
 
 -- | After garbage collection for slot S, no votes with target slot < S should remain.
 prop_garbageCollectRemovesOldVotes ::
-  MonadSTM m =>
+  ( MonadSTM m
+  , IsPerasVote (PerasVote blk) blk
+  ) =>
   PerasVoteDB m blk ->
   SlotNo ->
   m Bool
@@ -180,7 +220,10 @@ prop_garbageCollectRemovesOldVotes db slotNo =
 -- | When adding a vote results in a certificate just being forged for a round,
 -- this certificate should also be retrievable via 'getForgedCertForRound'.
 prop_addVoteThenGetForgedCertForRound ::
-  (MonadSTM m, StandardHash blk) =>
+  ( MonadSTM m
+  , Eq (PerasCert blk)
+  , IsPerasVote (PerasVote blk) blk
+  ) =>
   PerasVoteDB m blk ->
   WithArrivalTime (ValidatedPerasVote blk) ->
   m Bool

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/PerasVoteDB/Impl.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/PerasVoteDB/Impl.hs
@@ -4,9 +4,13 @@
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE ImportQualifiedPost #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE StandaloneKindSignatures #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 module Ouroboros.Consensus.Storage.PerasVoteDB.Impl
   ( -- * Opening
@@ -21,7 +25,6 @@ module Ouroboros.Consensus.Storage.PerasVoteDB.Impl
 import Control.Monad (when)
 import Control.Monad.Except (throwError)
 import Control.Tracer (Tracer, nullTracer, traceWith)
-import Data.Data (Typeable)
 import Data.Foldable (for_)
 import Data.Foldable qualified as Foldable
 import Data.Kind (Type)
@@ -29,10 +32,12 @@ import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
 import Data.Set (Set)
 import Data.Set qualified as Set
+import Data.Typeable (Typeable)
 import GHC.Generics (Generic)
 import NoThunks.Class
 import Ouroboros.Consensus.Block
 import Ouroboros.Consensus.BlockchainTime (WithArrivalTime (..))
+import Ouroboros.Consensus.Peras.Context
 import Ouroboros.Consensus.Peras.Vote.Aggregation
 import Ouroboros.Consensus.Storage.PerasVoteDB.API
 import Ouroboros.Consensus.Util.Args
@@ -61,8 +66,30 @@ data PerasVoteDbState blk = PerasVoteDbState
   , pvdsLastTicketNo :: !PerasVoteTicketNo
   -- ^ The most recent 'PerasVoteTicketNo' (or 'zeroPerasVoteTicketNo' otherwise).
   }
-  deriving stock (Show, Generic)
-  deriving anyclass NoThunks
+
+deriving instance
+  ( StandardHash blk
+  , Show (PerasVote blk)
+  , Show (PerasCert blk)
+  , Show (PerasVotingCommittee blk)
+  ) =>
+  Show (PerasVoteDbState blk)
+deriving instance
+  ( StandardHash blk
+  , Eq (PerasVote blk)
+  , Eq (PerasCert blk)
+  , Eq (PerasVotingCommittee blk)
+  ) =>
+  Eq (PerasVoteDbState blk)
+deriving instance
+  ( StandardHash blk
+  , NoThunks (PerasVote blk)
+  , NoThunks (PerasCert blk)
+  , NoThunks (PerasVotingCommittee blk)
+  ) =>
+  NoThunks (PerasVoteDbState blk)
+deriving instance
+  Generic (PerasVoteDbState blk)
 
 initialPerasVoteDbState :: WithFingerprint (PerasVoteDbState blk)
 initialPerasVoteDbState =
@@ -77,6 +104,7 @@ initialPerasVoteDbState =
 
 -- | Check that the fields of 'PerasVoteState' are in sync.
 invariantForPerasVoteDbState ::
+  IsPerasVote (PerasVote blk) blk =>
   WithFingerprint (PerasVoteDbState blk) -> Either String ()
 invariantForPerasVoteDbState pvs = do
   for_ (Map.toList pvdsRoundVoteStates) $ \(roundNo, prvs) ->
@@ -118,7 +146,24 @@ data TraceEvent blk
       (AddPerasVoteResult blk)
   | GarbageCollected
       SlotNo
-  deriving stock (Show, Eq, Generic)
+
+deriving instance
+  ( Show (PerasVote blk)
+  , Show (PerasCert blk)
+  ) =>
+  Show (TraceEvent blk)
+deriving instance
+  ( Eq (PerasVote blk)
+  , Eq (PerasCert blk)
+  ) =>
+  Eq (TraceEvent blk)
+deriving instance
+  ( NoThunks (PerasVote blk)
+  , NoThunks (PerasCert blk)
+  ) =>
+  NoThunks (TraceEvent blk)
+deriving instance
+  Generic (TraceEvent blk)
 
 {------------------------------------------------------------------------------
   Creating the database
@@ -127,14 +172,12 @@ data TraceEvent blk
 type PerasVoteDbArgs :: (Type -> Type) -> (Type -> Type) -> Type -> Type
 data PerasVoteDbArgs f m blk = PerasVoteDbArgs
   { pvdbaTracer :: Tracer m (TraceEvent blk)
-  , pvdbaPerasParams :: HKD f (PerasParams blk)
   }
 
 defaultArgs :: Monad m => Incomplete PerasVoteDbArgs m blk
 defaultArgs =
   PerasVoteDbArgs
     { pvdbaTracer = nullTracer
-    , pvdbaPerasParams = noDefault
     }
 
 createDB ::
@@ -144,8 +187,9 @@ createDB ::
   , Typeable blk
   ) =>
   Complete PerasVoteDbArgs m blk ->
+  PerasEpochContextResolverHandle m blk ->
   m (PerasVoteDB m blk)
-createDB args@PerasVoteDbArgs{pvdbaPerasParams} = do
+createDB args perasEpochContextResolverHandle = do
   pvdeState <-
     newTVarWithInvariantIO
       (either Just (const Nothing) . invariantForPerasVoteDbState)
@@ -157,7 +201,7 @@ createDB args@PerasVoteDbArgs{pvdbaPerasParams} = do
           }
   pure
     PerasVoteDB
-      { addVote = implAddVote pvdbaPerasParams env
+      { addVote = implAddVote perasEpochContextResolverHandle env
       , getVoteIds = implGetVoteIds env
       , getVotesAfter = implGetVotesAfter env
       , getForgedCertForRound = implGetForgedCertForRound env
@@ -175,15 +219,16 @@ createDB args@PerasVoteDbArgs{pvdbaPerasParams} = do
 -- TODO: we will need to update this method with non-trivial validation logic
 -- see https://github.com/tweag/cardano-peras/issues/120
 implAddVote ::
+  forall m blk.
   ( IOLike m
   , StandardHash blk
   , Typeable blk
   ) =>
-  PerasParams blk ->
+  PerasEpochContextResolverHandle m blk ->
   PerasVoteDbEnv m blk ->
   WithArrivalTime (ValidatedPerasVote blk) ->
   STM m (m (AddPerasVoteResult blk))
-implAddVote perasParams PerasVoteDbEnv{pvdeTracer, pvdeState} vote = do
+implAddVote resolverHandle PerasVoteDbEnv{pvdeTracer, pvdeState} vote = do
   let voteId = getPerasVoteId vote
   addPerasVoteRes <- do
     WithFingerprint pvds fp <- readTVar pvdeState
@@ -208,7 +253,7 @@ implAddVote perasParams PerasVoteDbEnv{pvdeTracer, pvdeState} vote = do
         pvsVotesByTicket' = Map.insert pvsLastTicketNo' vote (pvdsVotesByTicket pvds)
 
     (addPerasVoteRes, pvsRoundVoteStates') <-
-      case updatePerasRoundVoteStates vote perasParams (pvdsRoundVoteStates pvds) of
+      updatePerasRoundVoteStates vote resolverHandle (pvdsRoundVoteStates pvds) >>= \case
         -- Added vote and reached a quorum, forging a new certificate
         Right (VoteGeneratedNewCert cert, pvsRoundVoteStates') ->
           pure (AddedPerasVoteAndGeneratedNewCert cert, pvsRoundVoteStates')
@@ -237,6 +282,9 @@ implAddVote perasParams PerasVoteDbEnv{pvdeTracer, pvdeState} vote = do
         Left (RoundVoteStateForgingCertError forgeErr) ->
           throwSTM $
             ForgingCertError forgeErr
+        Left (RoundVoteStateEpochContextNotFound resolverErr) ->
+          throwSTM $
+            EpochContextNotFoundForRound @blk resolverErr
 
     pure
       ( addPerasVoteRes

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Storage/TestBlock.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Storage/TestBlock.hs
@@ -145,6 +145,7 @@ import Test.QuickCheck
 import Test.Util.Orphans.Arbitrary ()
 import Test.Util.Orphans.SignableRepresentation ()
 import Test.Util.Orphans.ToExpr ()
+import Test.Util.Peras (divisorClosestToQuotient)
 
 {-------------------------------------------------------------------------------
   TestBlock
@@ -210,13 +211,13 @@ data TestBody = TestBody
   -- Note that this is a /local/ number, it is specific to this block,
   -- other blocks need not be aware of it.
   , tbIsValid :: !Bool
-  , tbPerasCertRound :: !(Maybe PerasRoundNo)
+  , tbPerasCert :: !(Maybe (PerasCert TestBlock))
   -- ^ Some real blocks will ocasionally carry a Peras certificate inside their
-  -- body to coordinate the end of a cooldown period. For the purposes of the
-  -- ChainDB, we don't really care about the details of the certificate other
-  -- than its round number, which needs to be stored (and carefully updated
-  -- whenever a newer one pops up) so it can be used to evaluate the Peras
-  -- voting rules and decide if a node should resume voting.
+  -- body to coordinate the end of a cooldown period.
+  -- NOTE: for the purposes of the ChainDB, we don't care about the details of
+  -- the certificate other than its round number, which needs to be stored (and
+  -- carefully updated whenever a newer one pops up) so it can be used to
+  -- evaluate the Peras voting rules and decide if a node should resume voting.
   }
   deriving stock (Eq, Show, Generic)
   deriving anyclass (NFData, NoThunks, Serialise, Hashable)
@@ -641,7 +642,7 @@ instance ApplyBlock LedgerState TestBlock where
                   --
                   -- TODO: refactor this to use 'getPerasCertInBlock' after the
                   -- HFC plumbing for 'BlockSupportsPeras' is in place.
-                  certRoundInBlock = tbPerasCertRound testBody
+                  certRoundInBlock = getPerasCertRound <$> tbPerasCert testBody
                  in
                   -- the highest Peras certificate round number  we've seen so far
                   case (certRoundInBlock, latestPerasCertRound) of
@@ -805,7 +806,19 @@ mkTestConfig k ChunkSize{chunkCanContainEBB, numRegularBlocks} =
       , eraSlotLength = slotLength
       , eraSafeZone = HardFork.StandardSafeZone (unNonZero (maxRollbacks k) * 2)
       , eraGenesisWin = GenesisWindow (unNonZero (maxRollbacks k) * 2)
-      , eraPerasRoundLength = dijkstraPerasRoundLength
+      , -- Epoch size is 'numRegularBlocks' (between 5 and 15), and
+        -- perasRoundLength should divive it.
+        -- picking the closest divisor to get us about 3 Peras rounds per epoch
+        -- gives us a suitable distribution of perasRoundLengths:
+        -- >>> flip divisorClosestToQuotient 3 <$> [5..15]
+        -- [1,2,1,2,3,2,1,4,1,7,5]
+        -- TODO: it would be better to generate PerasRoundLength randomly in
+        -- accordance with the 'ChunkInfo' directly, but that would require an
+        -- overhaul of how test config is propagated all over this file.
+        -- See https://github.com/tweag/cardano-peras/issues/257
+        eraPerasRoundLength =
+          PerasEnabled . PerasRoundLength $
+            divisorClosestToQuotient numRegularBlocks 3
       }
 
 instance ImmutableEraParams TestBlock where
@@ -999,6 +1012,11 @@ deriving anyclass instance
 deriving anyclass instance ToExpr FsPath
 deriving anyclass instance ToExpr BlocksPerFile
 deriving instance ToExpr BinaryBlockInfo
+
+-- ** Serialise for MockPerasCert via FromCBOR/ToCBOR
+instance Serialise (MockPerasCert TestBlock) where
+  encode = toCBOR
+  decode = fromCBOR
 
 -- ** FromCBOR/ToCBOR for Point TestBlock via Serialise
 instance FromCBOR (Point TestBlock) where

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/ChainDB.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/ChainDB.hs
@@ -21,7 +21,6 @@ import Ouroboros.Consensus.HardFork.History.EraParams (eraEpochSize)
 import Ouroboros.Consensus.Ledger.Abstract
 import Ouroboros.Consensus.Ledger.Extended (ExtLedgerState)
 import Ouroboros.Consensus.Ledger.SupportsProtocol
-import Ouroboros.Consensus.Peras.Params (defaultPerasParams)
 import Ouroboros.Consensus.Storage.ChainDB hiding
   ( TraceFollowerEvent (..)
   )
@@ -140,7 +139,6 @@ fromMinimalChainDbArgs MinimalChainDbArgs{..} =
     , cdbPerasVoteDbArgs =
         PerasVoteDbArgs
           { pvdbaTracer = nullTracer
-          , pvdbaPerasParams = defaultPerasParams
           }
     , cdbsArgs =
         ChainDbSpecificArgs

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/MiniProtocol/ObjectDiffusion/PerasCert/Smoke.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/MiniProtocol/ObjectDiffusion/PerasCert/Smoke.hs
@@ -1,8 +1,5 @@
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TypeApplications #-}
-{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Test.Consensus.MiniProtocol.ObjectDiffusion.PerasCert.Smoke
   ( tests
@@ -20,6 +17,7 @@ import Ouroboros.Consensus.BlockchainTime.WallClock.Types
   )
 import Ouroboros.Consensus.MiniProtocol.ObjectDiffusion.ObjectPool.API
 import Ouroboros.Consensus.MiniProtocol.ObjectDiffusion.ObjectPool.PerasCert
+import Ouroboros.Consensus.Peras.Context (mockPerasEpochContextResolverHandle)
 import Ouroboros.Consensus.Storage.PerasCertDB.API
   ( AddPerasCertResult (..)
   , PerasCertDB
@@ -52,7 +50,11 @@ tests =
     ]
 
 newCertDB ::
-  (IOLike m, StandardHash blk) => [WithArrivalTime (ValidatedPerasCert blk)] -> m (PerasCertDB m blk)
+  ( IOLike m
+  , StandardHash blk
+  ) =>
+  [WithArrivalTime (ValidatedPerasCert blk)] ->
+  m (PerasCertDB m blk)
 newCertDB certs = do
   db <- PerasCertDB.createDB (PerasCertDB.PerasCertDbArgs @Identity nullTracer)
   mapM_
@@ -82,11 +84,13 @@ prop_smoke =
                 , m [PerasCert TestBlock]
                 )
             mkPoolInterfaces = do
+              epochContextResolverHandle <- mockPerasEpochContextResolverHandle epochContext
+
               outboundPool <- newCertDB watValidatedCerts
               inboundPool <- newCertDB []
 
               let outboundPoolReader = makePerasCertPoolReaderFromCertDB outboundPool
-                  inboundPoolWriter = makePerasCertPoolWriterFromCertDB mockSystemTime inboundPool
+                  inboundPoolWriter = makePerasCertPoolWriterFromCertDB mockSystemTime inboundPool epochContextResolverHandle
                   getAllInboundPoolContent = do
                     certsMap <-
                       atomically $

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/MiniProtocol/ObjectDiffusion/PerasCert/Smoke.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/MiniProtocol/ObjectDiffusion/PerasCert/Smoke.hs
@@ -89,8 +89,8 @@ prop_smoke =
               outboundPool <- newCertDB watValidatedCerts
               inboundPool <- newCertDB []
 
-              let outboundPoolReader = makePerasCertPoolReaderFromCertDB outboundPool
-                  inboundPoolWriter = makePerasCertPoolWriterFromCertDB mockSystemTime inboundPool epochContextResolverHandle
+              let outboundPoolReader = makeTestPerasCertPoolReaderFromCertDB outboundPool
+                  inboundPoolWriter = makeTestPerasCertPoolWriterFromCertDB mockSystemTime inboundPool epochContextResolverHandle
                   getAllInboundPoolContent = do
                     certsMap <-
                       atomically $

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/MiniProtocol/ObjectDiffusion/PerasVote/Smoke.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/MiniProtocol/ObjectDiffusion/PerasVote/Smoke.hs
@@ -1,15 +1,11 @@
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# OPTIONS_GHC -Wno-orphans #-}
-
 module Test.Consensus.MiniProtocol.ObjectDiffusion.PerasVote.Smoke
   ( tests
   ) where
 
 import Control.Monad (join)
 import Control.Tracer (contramap, nullTracer)
-import Data.Data (Typeable)
 import qualified Data.Map as Map
+import Data.Typeable (Typeable)
 import Network.TypedProtocol.Driver.Simple (runPeer, runPipelinedPeer)
 import Ouroboros.Consensus.Block.SupportsPeras
 import Ouroboros.Consensus.BlockchainTime.WallClock.Types
@@ -18,7 +14,10 @@ import Ouroboros.Consensus.BlockchainTime.WallClock.Types
   )
 import Ouroboros.Consensus.MiniProtocol.ObjectDiffusion.ObjectPool.API
 import Ouroboros.Consensus.MiniProtocol.ObjectDiffusion.ObjectPool.PerasVote
-import Ouroboros.Consensus.Peras.Vote.Mock (MockPerasVote (..))
+import Ouroboros.Consensus.Peras.Context
+  ( PerasEpochContextResolverHandle
+  , mockPerasEpochContextResolverHandle
+  )
 import Ouroboros.Consensus.Storage.PerasVoteDB
   ( AddPerasVoteResult (..)
   , PerasVoteDB
@@ -51,10 +50,16 @@ tests =
     ]
 
 newVoteDB ::
-  (IOLike m, StandardHash blk, Typeable blk) =>
-  [WithArrivalTime (ValidatedPerasVote blk)] -> m (PerasVoteDB m blk)
-newVoteDB votes = do
-  db <- PerasVoteDB.createDB (PerasVoteDB.PerasVoteDbArgs nullTracer defaultPerasParams)
+  ( IOLike m
+  , Typeable blk
+  , StandardHash blk
+  ) =>
+  PerasEpochContextResolverHandle m blk ->
+  [WithArrivalTime (ValidatedPerasVote blk)] ->
+  m (PerasVoteDB m blk)
+newVoteDB resolverHandle votes = do
+  let args = PerasVoteDB.PerasVoteDbArgs nullTracer
+  db <- PerasVoteDB.createDB args resolverHandle
   mapM_
     ( \vote -> do
         result <- join $ atomically $ PerasVoteDB.addVote db vote
@@ -82,21 +87,13 @@ prop_smoke =
                 , m [PerasVote TestBlock]
                 )
             mkPoolInterfaces = do
-              outboundPool <- newVoteDB watValidatedVotes
-              inboundPool <- newVoteDB []
+              epochContextResolverHandle <- mockPerasEpochContextResolverHandle epochContext
+
+              outboundPool <- newVoteDB epochContextResolverHandle watValidatedVotes
+              inboundPool <- newVoteDB epochContextResolverHandle []
 
               let outboundPoolReader = makePerasVotePoolReaderFromVoteDB outboundPool
-                  stakeDistr =
-                    PerasVoteStakeDistr $
-                      Map.fromList
-                        [ (mockVoteSeatIndex (vpvVote v), vpvVoteWeight v)
-                        | WithArrivalTime _ v <- watValidatedVotes
-                        ]
-                  inboundPoolWriter =
-                    makePerasVotePoolWriterFromVoteDB
-                      mockSystemTime
-                      (pure stakeDistr)
-                      inboundPool
+                  inboundPoolWriter = makePerasVotePoolWriterFromVoteDB mockSystemTime inboundPool epochContextResolverHandle
                   getAllInboundPoolContent = do
                     votesMap <-
                       atomically $

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/MiniProtocol/ObjectDiffusion/PerasVote/Smoke.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/MiniProtocol/ObjectDiffusion/PerasVote/Smoke.hs
@@ -92,8 +92,8 @@ prop_smoke =
               outboundPool <- newVoteDB epochContextResolverHandle watValidatedVotes
               inboundPool <- newVoteDB epochContextResolverHandle []
 
-              let outboundPoolReader = makePerasVotePoolReaderFromVoteDB outboundPool
-                  inboundPoolWriter = makePerasVotePoolWriterFromVoteDB mockSystemTime inboundPool epochContextResolverHandle
+              let outboundPoolReader = makeTestPerasVotePoolReaderFromVoteDB outboundPool
+                  inboundPoolWriter = makeTestPerasVotePoolWriterFromVoteDB mockSystemTime inboundPool epochContextResolverHandle
                   getAllInboundPoolContent = do
                     votesMap <-
                       atomically $

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/Iterator.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/Iterator.hs
@@ -115,11 +115,11 @@ tests =
 
 -- All blocks on the same chain
 a, b, c, d, e :: TestBlock
-a = firstBlock 0 TestBody{tbForkNo = 0, tbIsValid = True, tbPerasCertRound = Nothing}
-b = mkNextBlock a 1 TestBody{tbForkNo = 0, tbIsValid = True, tbPerasCertRound = Nothing}
-c = mkNextBlock b 2 TestBody{tbForkNo = 0, tbIsValid = True, tbPerasCertRound = Nothing}
-d = mkNextBlock c 3 TestBody{tbForkNo = 0, tbIsValid = True, tbPerasCertRound = Nothing}
-e = mkNextBlock d 4 TestBody{tbForkNo = 0, tbIsValid = True, tbPerasCertRound = Nothing}
+a = firstBlock 0 TestBody{tbForkNo = 0, tbIsValid = True, tbPerasCert = Nothing}
+b = mkNextBlock a 1 TestBody{tbForkNo = 0, tbIsValid = True, tbPerasCert = Nothing}
+c = mkNextBlock b 2 TestBody{tbForkNo = 0, tbIsValid = True, tbPerasCert = Nothing}
+d = mkNextBlock c 3 TestBody{tbForkNo = 0, tbIsValid = True, tbPerasCert = Nothing}
+e = mkNextBlock d 4 TestBody{tbForkNo = 0, tbIsValid = True, tbPerasCert = Nothing}
 
 -- | Requested stream = A -> C
 --
@@ -176,9 +176,9 @@ prop_1435_case1 =
     (Left (ForkTooOld (StreamFromInclusive (blockRealPoint b'))))
  where
   canContainEBB = const True
-  ebb = firstEBB canContainEBB TestBody{tbForkNo = 0, tbIsValid = True, tbPerasCertRound = Nothing}
-  b = mkNextBlock ebb 0 TestBody{tbForkNo = 0, tbIsValid = True, tbPerasCertRound = Nothing}
-  b' = mkNextBlock ebb 0 TestBody{tbForkNo = 1, tbIsValid = True, tbPerasCertRound = Nothing}
+  ebb = firstEBB canContainEBB TestBody{tbForkNo = 0, tbIsValid = True, tbPerasCert = Nothing}
+  b = mkNextBlock ebb 0 TestBody{tbForkNo = 0, tbIsValid = True, tbPerasCert = Nothing}
+  b' = mkNextBlock ebb 0 TestBody{tbForkNo = 1, tbIsValid = True, tbPerasCert = Nothing}
 
 -- | Requested stream = EBB' -> EBB' where EBB, B, and EBB' are all blocks in
 -- the same slot, and EBB' is not part of the current chain nor ChainDB.
@@ -197,9 +197,9 @@ prop_1435_case2 =
     (Left (ForkTooOld (StreamFromInclusive (blockRealPoint ebb'))))
  where
   canContainEBB = const True
-  ebb = firstEBB canContainEBB TestBody{tbForkNo = 0, tbIsValid = True, tbPerasCertRound = Nothing}
-  b = mkNextBlock ebb 0 TestBody{tbForkNo = 0, tbIsValid = True, tbPerasCertRound = Nothing}
-  ebb' = firstEBB canContainEBB TestBody{tbForkNo = 1, tbIsValid = True, tbPerasCertRound = Nothing}
+  ebb = firstEBB canContainEBB TestBody{tbForkNo = 0, tbIsValid = True, tbPerasCert = Nothing}
+  b = mkNextBlock ebb 0 TestBody{tbForkNo = 0, tbIsValid = True, tbPerasCert = Nothing}
+  ebb' = firstEBB canContainEBB TestBody{tbForkNo = 1, tbIsValid = True, tbPerasCert = Nothing}
 
 -- | Requested stream = EBB -> EBB where EBB and B are all blocks in the same
 -- slot.
@@ -218,8 +218,8 @@ prop_1435_case3 =
     (Right (map Right [ebb]))
  where
   canContainEBB = const True
-  ebb = firstEBB canContainEBB TestBody{tbForkNo = 0, tbIsValid = True, tbPerasCertRound = Nothing}
-  b = mkNextBlock ebb 0 TestBody{tbForkNo = 0, tbIsValid = True, tbPerasCertRound = Nothing}
+  ebb = firstEBB canContainEBB TestBody{tbForkNo = 0, tbIsValid = True, tbPerasCert = Nothing}
+  b = mkNextBlock ebb 0 TestBody{tbForkNo = 0, tbIsValid = True, tbPerasCert = Nothing}
 
 -- | Requested stream = EBB -> EBB where EBB and B are all blocks in the same
 -- slot.
@@ -238,8 +238,8 @@ prop_1435_case4 =
     (Right (map Right [ebb]))
  where
   canContainEBB = const True
-  ebb = firstEBB canContainEBB TestBody{tbForkNo = 0, tbIsValid = True, tbPerasCertRound = Nothing}
-  b = mkNextBlock ebb 0 TestBody{tbForkNo = 0, tbIsValid = True, tbPerasCertRound = Nothing}
+  ebb = firstEBB canContainEBB TestBody{tbForkNo = 0, tbIsValid = True, tbPerasCert = Nothing}
+  b = mkNextBlock ebb 0 TestBody{tbForkNo = 0, tbIsValid = True, tbPerasCert = Nothing}
 
 -- | Requested stream = EBB -> EBB where EBB and B' are all blocks in the same
 -- slot, and B' is not part of the current chain nor ChainDB.
@@ -258,8 +258,8 @@ prop_1435_case5 =
     (Left (ForkTooOld (StreamFromInclusive (blockRealPoint b'))))
  where
   canContainEBB = const True
-  ebb = firstEBB canContainEBB TestBody{tbForkNo = 0, tbIsValid = True, tbPerasCertRound = Nothing}
-  b' = mkNextBlock ebb 0 TestBody{tbForkNo = 1, tbIsValid = True, tbPerasCertRound = Nothing}
+  ebb = firstEBB canContainEBB TestBody{tbForkNo = 0, tbIsValid = True, tbPerasCert = Nothing}
+  b' = mkNextBlock ebb 0 TestBody{tbForkNo = 1, tbIsValid = True, tbPerasCert = Nothing}
 
 -- | Requested stream = EBB' -> EBB' where EBB and EBB' are all blocks in the
 -- same slot, and EBB' is not part of the current chain nor ChainDB.
@@ -278,8 +278,8 @@ prop_1435_case6 =
     (Left (ForkTooOld (StreamFromInclusive (blockRealPoint ebb'))))
  where
   canContainEBB = const True
-  ebb = firstEBB canContainEBB TestBody{tbForkNo = 0, tbIsValid = True, tbPerasCertRound = Nothing}
-  ebb' = firstEBB canContainEBB TestBody{tbForkNo = 1, tbIsValid = True, tbPerasCertRound = Nothing}
+  ebb = firstEBB canContainEBB TestBody{tbForkNo = 0, tbIsValid = True, tbPerasCert = Nothing}
+  ebb' = firstEBB canContainEBB TestBody{tbForkNo = 1, tbIsValid = True, tbPerasCert = Nothing}
 
 -- | The general property test
 prop_general_test ::

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
@@ -15,6 +15,7 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
@@ -124,10 +125,14 @@ import Ouroboros.Consensus.HeaderValidation
 import Ouroboros.Consensus.Ledger.Abstract
 import Ouroboros.Consensus.Ledger.Extended
 import Ouroboros.Consensus.Ledger.Inspect
+import Ouroboros.Consensus.Ledger.Peras (PerasState (..))
 import Ouroboros.Consensus.Ledger.SupportsProtocol
 import Ouroboros.Consensus.Ledger.Tables.Utils
 import Ouroboros.Consensus.Peras.Cert.Mock (MockPerasCert (..))
-import Ouroboros.Consensus.Peras.Context (StateSupportsPerasEpochContext)
+import Ouroboros.Consensus.Peras.Context
+  ( StateSupportsPerasEpochContext
+  , perasEpochContextResolverBounds
+  )
 import Ouroboros.Consensus.Peras.Vote.Mock (MockPerasVote (..))
 import Ouroboros.Consensus.Protocol.Abstract
 import Ouroboros.Consensus.Storage.ChainDB hiding
@@ -161,6 +166,7 @@ import Test.Ouroboros.Storage.ChainDB.Model
   , IteratorId
   , ModelSupportsBlock
   , ShouldGarbageCollect (DoNotGarbageCollect, GarbageCollect)
+  , currentLedger
   )
 import qualified Test.Ouroboros.Storage.ChainDB.Model as Model
 import Test.Ouroboros.Storage.Orphans ()
@@ -259,7 +265,17 @@ data Cmd blk it flr
     UpdateLedgerSnapshots
   | -- Corruption
     WipeVolatileDB
-  deriving (Generic, Show, Functor, Foldable, Traversable)
+  deriving (Generic, Functor, Foldable, Traversable)
+
+deriving instance
+  ( StandardHash blk
+  , Show blk
+  , Show it
+  , Show flr
+  , Show (PerasCert blk)
+  , Show (PerasVote blk)
+  ) =>
+  Show (Cmd blk it flr)
 
 -- = Invalid blocks
 --
@@ -1079,6 +1095,13 @@ lockstep model@Model{..} cmd (At resp) =
   Generator
 -------------------------------------------------------------------------------}
 
+-- | Whether the selected chain of the model is still at Origin. While it is,
+-- the header state cannot resolve a valid Peras context, so Peras actions would
+-- fail in the SUT. Note this is stronger than the DB being empty: the DB can
+-- contain dangling fork blocks while the selected chain is still at Origin.
+atOrigin :: HasHeader blk => DBModel blk -> Bool
+atOrigin dbModel = Model.tipPoint dbModel == GenesisPoint
+
 -- | Generate a 'Cmd'
 --
 -- NOTE: the frequencies for generating blocks and Peras certificates are
@@ -1110,17 +1133,21 @@ generator loe genBlock genPerasBlock m@Model{..} =
         -- The following frequencies achieve this in practice:
         let freq = case loe of
               LoEDisabled ->
-                -- We must reduce the probability of Peras events to trigger on
-                -- an empty DB since there are no interesting blocks to vote for
-                if empty then 1 else 25
+                -- While the selected chain is still at Origin, we cannot
+                -- resolve a valid Peras context, so the SUT would reject Peras
+                -- actions. Only generate them once the header state has
+                -- advanced past Origin.
+                if atOrigin dbModel then 0 else 25
               -- The LoE does not yet support Peras.
               LoEEnabled () -> 0
          in (freq, genAddPerasCert)
       , let freq = case loe of
               LoEDisabled ->
-                -- We must reduce the probability of Peras events to trigger on
-                -- an empty DB since there are no interesting blocks to vote for
-                if empty then 20 else 500
+                -- While the selected chain is still at Origin, we cannot
+                -- resolve a valid Peras context, so the SUT would reject Peras
+                -- actions. Only generate them once the header state has
+                -- advanced past Origin.
+                if atOrigin dbModel then 0 else 500
               -- The LoE does not yet support Peras.
               LoEEnabled () -> 0
          in (freq, genAddPerasVote)
@@ -1307,6 +1334,7 @@ generator loe genBlock genPerasBlock m@Model{..} =
     -- threshold for multiple different blocks in the same round, avoiding the
     -- MultipleWinnersInRound error.
     let voteModel = Model.perasVoteModel dbModel
+        weightFromVoteEntry = unVoteWeight . vpvVoteWeight . forgetArrivalTime . PerasVoteDBModel.veVote
         -- Compute total weight per round from the vote model
         weightPerRound :: Map.Map PerasRoundNo Rational
         weightPerRound =
@@ -1314,7 +1342,7 @@ generator loe genBlock genPerasBlock m@Model{..} =
             (+)
             [ ( pvtRoundNo target
               , sum
-                  [ unVoteWeight (vpvVoteWeight (forgetArrivalTime (PerasVoteDBModel.veVote ve)))
+                  [ weightFromVoteEntry ve
                   | ve <- Set.toList entries
                   ]
               )
@@ -1464,6 +1492,13 @@ generator loe genBlock genPerasBlock m@Model{..} =
 chooseSlot :: SlotNo -> SlotNo -> Gen SlotNo
 chooseSlot (SlotNo start) (SlotNo end) = SlotNo <$> choose (start, end)
 
+chooseSlotWithLimit :: SlotNo -> SlotNo -> SlotNo -> Gen (Maybe SlotNo)
+chooseSlotWithLimit (SlotNo limit) (SlotNo start) (SlotNo end) =
+  let end' = min end limit
+   in if start > end'
+        then return Nothing
+        else Just . SlotNo <$> choose (start, end')
+
 {-------------------------------------------------------------------------------
   Shrinking
 -------------------------------------------------------------------------------}
@@ -1502,8 +1537,21 @@ precondition Model{..} (At cmd) =
   forAll (iters cmd) (`member` RE.keys knownIters)
     .&& forAll (flrs cmd) (`member` RE.keys knownFollowers)
     .&& case cmd of
-      -- Even though we ensure this in the generator, shrinking might change
-      -- it.
+      -- Even though we ensure that the chain is not at origin in the generator,
+      -- shrinking might change it.
+      -- While the selected chain is still at Origin, we cannot resolve a valid
+      -- Peras context, so the SUT would reject Peras actions. Shrinking can
+      -- remove the 'AddBlock's preceding a Peras command, so we must forbid
+      -- them here as well.
+      AddPerasCert{} -> Not (Boolean (atOrigin dbModel))
+      -- Same thing here, we need to ensure that the chain is not at origin.
+      --
+      -- In addition, we also make sure that the Peras round number is within
+      -- the supported bounds of the current context resolver because forging
+      -- a cert from validated votes requires access to a Peras epoch context.
+      AddPerasVote watValVote _ ->
+        (Not (Boolean (atOrigin dbModel)))
+          :&& (Boolean (withinContextBounds (getPerasVoteRound watValVote)))
       GetBlockComponent pt -> Not $ garbageCollectable pt
       GetGCedBlockComponent pt -> garbageCollectable pt
       IteratorNext it -> Not $ garbageCollectableIteratorNext it
@@ -1547,6 +1595,17 @@ precondition Model{..} (At cmd) =
         Boolean $
           Map.notMember (blockHash blk) $
             Model.invalid dbModel
+
+  withinContextBounds :: PerasRoundNo -> Bool
+  withinContextBounds roundNo =
+    lo <= roundNo && roundNo < hi
+   where
+    (lo, hi) =
+      perasEpochContextResolverBounds
+        . perasEpochContextResolver
+        . perasState
+        . currentLedger
+        $ dbModel
 
 transition ::
   (TestConstraints blk, Show1 r, Eq1 r) =>
@@ -1668,8 +1727,12 @@ deriving instance
   , ToExpr (TipInfo blk)
   , ToExpr (LedgerState blk EmptyMK)
   , ToExpr (ExtValidationError blk)
+  , ToExpr (PerasVotingCommittee blk)
   , StandardHash blk
   , Show blk
+  , Show (PerasVote blk)
+  , Show (PerasCert blk)
+  , Show (PerasVotingCommittee blk)
   ) =>
   ToExpr (Model blk IO Concrete)
 
@@ -1906,53 +1969,55 @@ genBlkPair ::
   )
 genBlkPair chunkInfo loe Model{..} =
   ( -- For block generation
-    frequency
-      [ -- We want to prioritise growing the tree connected to genesis, as it is
-        -- the most likely growth pattern.
-        --
-        -- However, we want to produce more chainSel events than in real life,
-        -- so we prioritise growing /any/ branch, not just the current chain tip
-        genSuccOfCurrentChainTip_WithFreq 5
-      , genSuccOfAlreadyInChainDBConnected_IfAnyWithFreq 20
-      , -- We also highly prioritise the "gap blocks", i.e. blocks that are
-        -- needed to fill the gap between blocks that are already part of the
-        -- ChainDB. Gap blocks might or might not be connected to genesis at the
-        -- moment, but ultimately if all saved gap blocks get added, they will
-        -- all be connected to genesis.
-        genFromSavedGapBlocks_IfAnyWithFreq 20
-      , -- Now we also want a small probability to generate blocks that are not
-        -- connected to genesis at all. We can either generate completely new
-        -- gaps (to model out-of-order block reception), or expand on an
-        -- existing one by adding the successor of a dangling block already part
-        -- of the ChainDB.
-        --
-        -- Be careful, if the ChainDB ends up containing too many dangling
-        -- blocks, Peras targets will mostly be disconnected blocks and
-        -- consequently Peras action won't result in direct chain selection
-        -- events (instead the chain selection events will be delayed until the
-        -- gap gets filled). So we need to keep the following frequencies low.
-        genNewGap_WithFreq 2
-      , genSuccOfAlreadyInChainDBDangling_IfAnyWithFreq 2
-      , -- Finally we want a small probability to re-add an existing block of the
-        -- ChainDB
-        genAlreadyInChainDB_IfAnyWithFreq 1
-      ]
+    loopUntilJust $
+      frequency
+        [ -- We want to prioritise growing the tree connected to genesis, as it is
+          -- the most likely growth pattern.
+          --
+          -- However, we want to produce more chainSel events than in real life,
+          -- so we prioritise growing /any/ branch, not just the current chain tip
+          (5, genSuccOfCurrentChainTip_withGapBlocks)
+        , (20, genSuccOfAlreadyInChainDBConnected_withGapBlocks)
+        , -- We also highly prioritise the "gap blocks", i.e. blocks that are
+          -- needed to fill the gap between blocks that are already part of the
+          -- ChainDB. Gap blocks might or might not be connected to genesis at the
+          -- moment, but ultimately if all saved gap blocks get added, they will
+          -- all be connected to genesis.
+          (20, genFromSavedGapBlocks_withGapBlocks)
+        , -- Now we also want a small probability to generate blocks that are not
+          -- connected to genesis at all. We can either generate completely new
+          -- gaps (to model out-of-order block reception), or expand on an
+          -- existing one by adding the successor of a dangling block already part
+          -- of the ChainDB.
+          --
+          -- Be careful, if the ChainDB ends up containing too many dangling
+          -- blocks, Peras targets will mostly be disconnected blocks and
+          -- consequently Peras action won't result in direct chain selection
+          -- events (instead the chain selection events will be delayed until the
+          -- gap gets filled). So we need to keep the following frequencies low.
+          (2, genNewGap_withGapBlocks)
+        , (2, genSuccOfAlreadyInChainDBDangling_withGapBlocks)
+        , -- Finally we want a small probability to re-add an existing block of the
+          -- ChainDB
+          (1, genAlreadyInChainDB_withGapBlocks)
+        ]
   , -- For Peras vote and certs
-    frequency
-      [ -- Peras actions can theoretically only target rather old (and
-        -- connected) blocks, so there is a high chance that these blocks are
-        -- already part of the ChainDB. Consequently, we prioritise generating
-        -- Peras targets that are already part of the ChainDB and connected to
-        -- genesis
-        genAlreadyInChainDBConnected_IfAnyWithFreq 20
-      , -- We also want a small probability of generating Peras targets that are
-        -- not yet part of the ChainDB or not connected, to model the case where
-        -- we receive a cert/vote for a block before we receive the block itself
-        genSuccOfAlreadyInChainDB_IfAnyWithFreq 2
-      , genNewGap_WithFreq 1
-      , genAlreadyInChainDBDangling_IfAnyWithFreq 1
-      , genFromSavedGapBlocks_IfAnyWithFreq 1
-      ]
+    loopUntilJust $
+      frequency
+        [ -- Peras actions can theoretically only target rather old (and
+          -- connected) blocks, so there is a high chance that these blocks are
+          -- already part of the ChainDB. Consequently, we prioritise generating
+          -- Peras targets that are already part of the ChainDB and connected to
+          -- genesis
+          (20, genAlreadyInChainDBConnected_withGapBlocks)
+        , -- We also want a small probability of generating Peras targets that are
+          -- not yet part of the ChainDB or not connected, to model the case where
+          -- we receive a cert/vote for a block before we receive the block itself
+          (2, genSuccOfAlreadyInChainDB_withGapBlocks)
+        , (1, genNewGap_withGapBlocks)
+        , (1, genAlreadyInChainDBDangling_withGapBlocks)
+        , (1, genFromSavedGapBlocks_withGapBlocks)
+        ]
   )
  where
   k = unNonZero (maxRollbacks (configSecurityParam (unOpaque modelConfig)))
@@ -1982,19 +2047,27 @@ genBlkPair chunkInfo loe Model{..} =
   danglingBlocksMap :: Map.Map TestHeaderHash TestBlock
   danglingBlocksMap = Map.difference chainDBBlocksMap connectedBlocksMap
 
-  noBlocksAlreadyInChainDB = Map.null chainDBBlocksMap
-  noConnectedBlocksAlreadyInChainDB = Map.null connectedBlocksMap
-  noDanglingBlocksAlreadyInChainDB = Map.null danglingBlocksMap
-
   savedGapBlocks = seenBlocks genState
-  noSavedGapBlocks = Map.null savedGapBlocks
+
+  andThen :: Gen (Maybe a) -> (a -> Gen (Maybe b)) -> Gen (Maybe b)
+  andThen genA f =
+    genA >>= \case
+      Nothing -> pure Nothing
+      Just a -> f a
+
+  loopUntilJust :: Gen (Maybe a) -> Gen a
+  loopUntilJust gen = do
+    mbA <- gen
+    case mbA of
+      Nothing -> loopUntilJust gen
+      Just a -> pure a
 
   -- This helper function is used to wrap generators when we know that the
   -- returned block is not going to create a new gap (i.e. there exist a path
   -- from an existing block of the ChainDB to this returned block that is either
   -- empty or made of blocks that are already in the saved gap blocks).
-  noNewSavedGapBlocks :: Gen TestBlock -> Gen (TestBlock, Persistent [TestBlock])
-  noNewSavedGapBlocks = fmap (,Persistent [])
+  noNewSavedGapBlocks :: Gen (Maybe TestBlock) -> Gen (Maybe (TestBlock, Persistent [TestBlock]))
+  noNewSavedGapBlocks = fmap (fmap (,Persistent []))
 
   -- Generate a block or EBB fitting on genesis
   genFirstBlock :: Gen TestBlock
@@ -2010,19 +2083,43 @@ genBlkPair chunkInfo loe Model{..} =
         )
       ]
 
-  -- Helper that generates a block that fits onto the given block.
-  genSuccOf :: TestBlock -> Gen TestBlock
-  genSuccOf b =
+  -- We don't want to generate blocks that are more than one epoch in the
+  -- future, relative to the slot of the current selected chain tip (i.e. the
+  -- current header/ledger state).
+  --
+  -- The size of an epoch in slots is simply the 'numRegularBlocks' of the chunk config,
+  -- cf. eraParams definition in 'mkTestConfig' in Test.Ouroboros.Storage.TestBlock
+  maxSlotOfNextEpoch :: SlotNo
+  maxSlotOfNextEpoch = SlotNo ((nextEpoch + 1) * epochSize - 1)
+   where
+    -- When the tip is at Origin, we cap the max slot to the last slot of epoch
+    -- 0. Otherwise, we allow generating blocks up to the last slot of the epoch
+    -- following the one containing the current tip.
+    nextEpoch = case Model.tipBlock dbModel of
+      Nothing -> 0
+      Just b -> (unSlotNo (blockSlot b) `div` epochSize) + 1
+    -- The chunk size is uniform (see 'mkTestCfg'), so the epoch size is the
+    -- same for every slot; we can use slot 0 to compute it.
+    epochSize =
+      ImmutableDB.numRegularBlocks $
+        ImmutableDB.getChunkSize chunkInfo $
+          ImmutableDB.chunkIndexOfSlot chunkInfo 0
+
+  -- Helper that generates a block that fits onto the given block. The generated
+  -- block never occupies a slot larger than @maxSlot@ (see 'maxSlotOfNextEpoch')
+  -- except if it is an EBB block.
+  genSuccOf :: SlotNo -> TestBlock -> Gen (Maybe TestBlock)
+  genSuccOf maxSlot b =
     frequency
       [
         ( 4
         , do
-            slotNo <-
+            mbSlotNo <-
               if fromIsEBB (testBlockIsEBB b)
-                then chooseSlot (blockSlot b) (blockSlot b + 2)
-                else chooseSlot (blockSlot b + 1) (blockSlot b + 3)
+                then chooseSlotWithLimit maxSlot (blockSlot b) (blockSlot b + 2)
+                else chooseSlotWithLimit maxSlot (blockSlot b + 1) (blockSlot b + 3)
             body <- genBody
-            return $ mkNextBlock b slotNo body
+            return $ fmap (\slotNo -> mkNextBlock b slotNo body) mbSlotNo
         )
       , -- An EBB is never followed directly by another EBB, otherwise they
         -- would have the same 'BlockNo', as the EBB has the same 'BlockNo' of
@@ -2040,18 +2137,12 @@ genBlkPair chunkInfo loe Model{..} =
                   ImmutableDB.chunkSlotForBoundaryBlock
                     chunkInfo
                     (prevEpoch + 1)
-                nextNextEBB =
-                  ImmutableDB.chunkSlotForBoundaryBlock
-                    chunkInfo
-                    (prevEpoch + 2)
-            (slotNo, epoch) <-
-              first (ImmutableDB.chunkSlotToSlot chunkInfo)
-                <$> frequency
-                  [ (7, return (nextEBB, prevEpoch + 1))
-                  , (1, return (nextNextEBB, prevEpoch + 2))
-                  ]
+                slotNo =
+                  ImmutableDB.chunkSlotToSlot chunkInfo nextEBB
+                epoch =
+                  prevEpoch + 1
             body <- genBody
-            return $ mkNextEBB canContainEBB b slotNo epoch body
+            return $ Just $ mkNextEBB canContainEBB b slotNo epoch body
         )
       ]
 
@@ -2061,97 +2152,100 @@ genBlkPair chunkInfo loe Model{..} =
   -- don't add just yet. These are in turn returned and stored as seen blocks
   -- in the generator state of the model. We can sample from these later on to
   -- (hopefully) fill the gaps.
-  genNewGap :: Gen (TestBlock, Persistent [TestBlock])
-  genNewGap = do
+  genNewGap_withGapBlocks :: Gen (Maybe (TestBlock, Persistent [TestBlock]))
+  genNewGap_withGapBlocks = do
     gapSize <- choose (1, 3)
     start <-
-      if noBlocksAlreadyInChainDB
-        then genFirstBlock
+      if Map.null chainDBBlocksMap
+        then Just <$> genFirstBlock
         else genSuccOfAlreadyInChainDB
-    go gapSize start []
+    case start of
+      Nothing -> return Nothing
+      Just tip -> Just <$> go maxSlotOfNextEpoch gapSize tip []
    where
-    go :: Int -> TestBlock -> [TestBlock] -> Gen (TestBlock, Persistent [TestBlock])
-    go 0 tip gapBlks = return (tip, Persistent gapBlks)
-    go n tip gapBlks = do
-      tip' <- genSuccOf tip
-      go (n - 1) tip' (tip : gapBlks)
-  genNewGap_WithFreq freq =
-    (freq, genNewGap)
+    go :: SlotNo -> Int -> TestBlock -> [TestBlock] -> Gen (TestBlock, Persistent [TestBlock])
+    go _maxSlotNo 0 tip gapBlks = return (tip, Persistent gapBlks)
+    go maxSlotNo n tip gapBlks = do
+      mbTip' <- genSuccOf maxSlotNo tip
+      case mbTip' of
+        Nothing ->
+          -- We couldn't generate a successor block, so we return the current tip and the gap blocks we have so far.
+          return (tip, Persistent gapBlks)
+        Just tip' ->
+          go maxSlotNo (n - 1) tip' (tip : gapBlks)
 
   -- An intermediate gap block that was generated by 'genNewGap' but
   -- saved for later in the model's generator state. See 'GenState' for details.
-  genFromSavedGapBlocks :: Gen TestBlock
-  genFromSavedGapBlocks = elements (Map.elems savedGapBlocks)
-  genFromSavedGapBlocks_IfAnyWithFreq freq =
+  genFromSavedGapBlocks =
+    if Map.null savedGapBlocks
+      then pure Nothing
+      else Just <$> elements (Map.elems savedGapBlocks)
+  genFromSavedGapBlocks_withGapBlocks =
     -- we can use 'noNewSavedGapBlocks' since any gap block leading to the
     -- returned block should already be part of the saved gap blocks
-    (if noSavedGapBlocks then 0 else freq, noNewSavedGapBlocks genFromSavedGapBlocks)
+    noNewSavedGapBlocks genFromSavedGapBlocks
 
-  genAlreadyInChainDB :: Gen TestBlock
-  genAlreadyInChainDB = elements $ Map.elems chainDBBlocksMap
-  genAlreadyInChainDB_IfAnyWithFreq freq =
+  genAlreadyInChainDB =
+    if Map.null chainDBBlocksMap
+      then pure Nothing
+      else Just <$> elements (Map.elems chainDBBlocksMap)
+  genAlreadyInChainDB_withGapBlocks =
     -- we can use 'noNewSavedGapBlocks' since gap blocks should have been saved
     -- when the block was first added to the ChainDB
-    (if noBlocksAlreadyInChainDB then 0 else freq, noNewSavedGapBlocks genAlreadyInChainDB)
+    noNewSavedGapBlocks genAlreadyInChainDB
 
   -- A block that already exists in the ChainDB and is connected to genesis.
-  genAlreadyInChainDBConnected :: Gen TestBlock
-  genAlreadyInChainDBConnected = elements $ Map.elems connectedBlocksMap
-  genAlreadyInChainDBConnected_IfAnyWithFreq freq =
+  genAlreadyInChainDBConnected =
+    if Map.null connectedBlocksMap
+      then pure Nothing
+      else Just <$> elements (Map.elems connectedBlocksMap)
+  genAlreadyInChainDBConnected_withGapBlocks =
     -- we can use 'noNewSavedGapBlocks' since gap blocks should have been saved
     -- when the block was first added to the ChainDB
-    ( if noConnectedBlocksAlreadyInChainDB then 0 else freq
-    , noNewSavedGapBlocks genAlreadyInChainDBConnected
-    )
+    noNewSavedGapBlocks genAlreadyInChainDBConnected
 
   -- A block that already exists in the ChainDB but is NOT connected to genesis
   -- (i.e. it is dangling/disconnected).
-  genAlreadyInChainDBDangling :: Gen TestBlock
-  genAlreadyInChainDBDangling = elements $ Map.elems danglingBlocksMap
-  genAlreadyInChainDBDangling_IfAnyWithFreq freq =
+  genAlreadyInChainDBDangling =
+    if Map.null danglingBlocksMap
+      then pure Nothing
+      else Just <$> elements (Map.elems danglingBlocksMap)
+  genAlreadyInChainDBDangling_withGapBlocks =
     -- we can use 'noNewSavedGapBlocks' since gap blocks should have been saved
     -- when the block was first added to the ChainDB
-    ( if noDanglingBlocksAlreadyInChainDB then 0 else freq
-    , noNewSavedGapBlocks genAlreadyInChainDBDangling
-    )
+    noNewSavedGapBlocks genAlreadyInChainDBDangling
 
   -- A block that fits onto the current chain
-  genSuccOfCurrentChainTip :: Gen TestBlock
   genSuccOfCurrentChainTip = case Model.tipBlock dbModel of
     Nothing -> genFirstBlock
-    Just b -> genSuccOf b
-  genSuccOfCurrentChainTip_WithFreq freq =
+    Just b ->
+      fromMaybe (error "Generating successor of current chain tip should never fail")
+        <$> genSuccOf maxSlotOfNextEpoch b
+  genSuccOfCurrentChainTip_withGapBlocks =
     -- we can use 'noNewSavedGapBlocks' since there is no gap block leading to
     -- the immediate successor of a block on the current chain
-    (freq, noNewSavedGapBlocks genSuccOfCurrentChainTip)
+    noNewSavedGapBlocks (Just <$> genSuccOfCurrentChainTip)
 
   -- A block that fits onto any block in the ChainDB (connected or dangling)
-  genSuccOfAlreadyInChainDB :: Gen TestBlock
-  genSuccOfAlreadyInChainDB = genAlreadyInChainDB >>= genSuccOf
-  genSuccOfAlreadyInChainDB_IfAnyWithFreq freq =
+  genSuccOfAlreadyInChainDB = genAlreadyInChainDB `andThen` \b -> genSuccOf maxSlotOfNextEpoch b
+  genSuccOfAlreadyInChainDB_withGapBlocks =
     -- we can use 'noNewSavedGapBlocks' since there is no gap block leading to
     -- the immediate successor of a block in the ChainDB
-    (if noBlocksAlreadyInChainDB then 0 else freq, noNewSavedGapBlocks genSuccOfAlreadyInChainDB)
+    noNewSavedGapBlocks genSuccOfAlreadyInChainDB
 
   -- A block that fits onto some connected block @b@ in the ChainDB.
-  genSuccOfAlreadyInChainDBConnected :: Gen TestBlock
-  genSuccOfAlreadyInChainDBConnected = genAlreadyInChainDBConnected >>= genSuccOf
-  genSuccOfAlreadyInChainDBConnected_IfAnyWithFreq freq =
+  genSuccOfAlreadyInChainDBConnected = genAlreadyInChainDBConnected `andThen` \b -> genSuccOf maxSlotOfNextEpoch b
+  genSuccOfAlreadyInChainDBConnected_withGapBlocks =
     -- we can use 'noNewSavedGapBlocks' since there is no gap block leading to
     -- the immediate successor of a block in the ChainDB
-    ( if noConnectedBlocksAlreadyInChainDB then 0 else freq
-    , noNewSavedGapBlocks genSuccOfAlreadyInChainDBConnected
-    )
+    noNewSavedGapBlocks genSuccOfAlreadyInChainDBConnected
 
   -- A block that fits onto some dangling (disconnected) block @b@ in the ChainDB.
-  genSuccOfAlreadyInChainDBDangling :: Gen TestBlock
-  genSuccOfAlreadyInChainDBDangling = genAlreadyInChainDBDangling >>= genSuccOf
-  genSuccOfAlreadyInChainDBDangling_IfAnyWithFreq freq =
+  genSuccOfAlreadyInChainDBDangling = genAlreadyInChainDBDangling `andThen` \b -> genSuccOf maxSlotOfNextEpoch b
+  genSuccOfAlreadyInChainDBDangling_withGapBlocks =
     -- we can use 'noNewSavedGapBlocks' since there is no gap block leading to
     -- the immediate successor of a block in the ChainDB
-    ( if noDanglingBlocksAlreadyInChainDB then 0 else freq
-    , noNewSavedGapBlocks genSuccOfAlreadyInChainDBDangling
-    )
+    noNewSavedGapBlocks genSuccOfAlreadyInChainDBDangling
 
   canContainEBB = const modelSupportsEBBs -- TODO: we could be more precise
   genBody :: Gen TestBody
@@ -2163,24 +2257,41 @@ genBlkPair chunkInfo loe Model{..} =
         [ (4, return True)
         , (1, return False)
         ]
-    perasCertRound <- do
-      let maxRoundNo =
-            case Model.roundNoOfLatestCertSeen dbModel of
-              Nothing -> 0
-              Just (PerasRoundNo r) -> r + 1
+    perasCert <- do
       frequency
-        [ (9, return Nothing)
+        [ (4, return Nothing)
         , let freq = case loe of
                 LoEDisabled -> 1
                 -- The LoE does not yet support Peras.
                 LoEEnabled () -> 0
-           in (freq, Just . PerasRoundNo <$> choose (0, maxRoundNo))
+           in (freq, Just <$> genPerasCert)
         ]
     return
       TestBody
         { tbForkNo = forkNo
         , tbIsValid = isValid
-        , tbPerasCertRound = perasCertRound
+        , tbPerasCert = perasCert
+        }
+
+  genPerasCert :: Gen (PerasCert TestBlock)
+  genPerasCert = do
+    let maxRoundNo =
+          case Model.roundNoOfLatestCertSeen dbModel of
+            Nothing -> 0
+            Just (PerasRoundNo r) -> r + 1
+    roundNo <-
+      PerasRoundNo <$> choose (0, maxRoundNo)
+    boostedBlock <-
+      -- NOTE: we don't care about this boosted block, it could be @Genesis@
+      blockPoint <$> genSuccOfCurrentChainTip
+    voters <-
+      genMockPerasVoterIndices
+
+    pure
+      MockPerasCert
+        { mockCertRound = roundNo
+        , mockCertBlock = boostedBlock
+        , mockCertVoters = voters
         }
 
 -- | Generate a random security parameter (k)

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/PerasVoteDB/StateMachine.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/PerasVoteDB/StateMachine.hs
@@ -37,6 +37,7 @@ import GHC.Generics (Generic)
 import Ouroboros.Consensus.Block.Abstract (Point (..), SlotNo (..))
 import Ouroboros.Consensus.Block.SupportsPeras
   ( IsPerasVote (..)
+  , PerasEpochContext (..)
   , PerasParams
   , PerasRoundNo (..)
   , PerasSeatIndex (..)
@@ -51,6 +52,7 @@ import Ouroboros.Consensus.BlockchainTime.WallClock.Types
   ( RelativeTime (..)
   , WithArrivalTime (..)
   )
+import Ouroboros.Consensus.Peras.Context (mockPerasEpochContextResolverHandle)
 import Ouroboros.Consensus.Peras.Vote.Mock (MockPerasVote (..))
 import Ouroboros.Consensus.Storage.PerasVoteDB
   ( AddPerasVoteResult (..)
@@ -84,7 +86,11 @@ import Test.QuickCheck.StateModel
   )
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.QuickCheck (testProperty)
-import Test.Util.TestBlock (TestBlock, TestHash (..))
+import Test.Util.Peras (genMockPerasVotingCommittee)
+import Test.Util.TestBlock
+  ( TestBlock
+  , TestHash (..)
+  )
 import Test.Util.TestEnv (adjustQuickCheckMaxSize, adjustQuickCheckTests)
 
 tests :: TestTree
@@ -128,6 +134,7 @@ newtype Model = Model (Model.Model TestBlock)
 instance StateModel Model where
   data Action Model a where
     CreateDB ::
+      PerasEpochContext TestBlock ->
       Action Model ()
     AddVote ::
       WithArrivalTime (ValidatedPerasVote TestBlock) ->
@@ -167,7 +174,14 @@ instance StateModel Model where
           ]
    where
     genCreateDB = do
-      pure CreateDB
+      committee <- genMockPerasVotingCommittee
+      let params = perasTestParams
+      pure $
+        CreateDB $
+          PerasEpochContext
+            { pecCommittee = committee
+            , pecParams = params
+            }
 
     genAddVote = do
       roundNo <- genRoundNo
@@ -231,7 +245,7 @@ instance StateModel Model where
 
   nextState (Model m) action _ =
     case action of
-      CreateDB -> Model $ Model.openDB m
+      CreateDB _context -> Model $ Model.openDB m
       AddVote vote -> Model $ snd $ Model.addVote vote m
       GetVoteIds -> Model $ m
       GetVotesAfter _ -> Model $ m
@@ -240,7 +254,7 @@ instance StateModel Model where
 
   precondition (Model m) action =
     case action of
-      CreateDB -> not (Model.open m)
+      CreateDB _context -> not (Model.open m)
       AddVote _ -> Model.open m
       GetVoteIds -> Model.open m
       GetVotesAfter _ -> Model.open m
@@ -256,9 +270,10 @@ instance HasVariables (Action Model a) where
 instance RunModel Model (StateT (PerasVoteDB IO TestBlock) IO) where
   perform _ action _ =
     case action of
-      CreateDB -> do
-        let args = PerasVoteDB.PerasVoteDbArgs nullTracer perasTestParams
-        voteDB <- lift $ PerasVoteDB.createDB args
+      CreateDB context -> do
+        let args = PerasVoteDB.PerasVoteDbArgs nullTracer
+        resolverHandle <- lift $ mockPerasEpochContextResolverHandle context
+        voteDB <- lift $ PerasVoteDB.createDB args resolverHandle
         put voteDB
       AddVote vote -> do
         voteDB <- get
@@ -371,6 +386,8 @@ perasVoteDBErrorTag err =
       "MultipleWinnersInRound"
     ForgingCertError{} ->
       "ForgingCertError"
+    EpochContextNotFoundForRound{} ->
+      "EpochContextNotFoundForRound"
 
 addVoteResultTag :: AddPerasVoteResult TestBlock -> String
 addVoteResultTag res =

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/VolatileDB/StateMachine.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/VolatileDB/StateMachine.hs
@@ -49,6 +49,7 @@ import GHC.Generics
 import GHC.Stack
 import qualified Generics.SOP as SOP
 import Ouroboros.Consensus.Block
+import Ouroboros.Consensus.Peras.Cert.Mock (MockPerasCert (..))
 import Ouroboros.Consensus.Storage.Common
 import Ouroboros.Consensus.Storage.VolatileDB
 import Ouroboros.Consensus.Storage.VolatileDB.Impl.Types (FileId)
@@ -77,6 +78,7 @@ import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.QuickCheck (testProperty)
 import Test.Util.Orphans.Arbitrary ()
 import Test.Util.Orphans.ToExpr ()
+import Test.Util.Peras.Mock (genMockPerasVoterIndices)
 import Test.Util.QuickCheck
 import Test.Util.SOP
 import Test.Util.ToExpr ()
@@ -392,7 +394,7 @@ generatorCmdImpl Model{..} =
       TestBody
         <$> arbitrary
         <*> arbitrary
-        <*> liftArbitrary (PerasRoundNo <$> arbitrary)
+        <*> liftArbitrary genPerasCert
     prevHash <-
       frequency
         [ (1, return GenesisHash)
@@ -406,6 +408,18 @@ generatorCmdImpl Model{..} =
     -- We don't care about chain length in the VolatileDB
     let clen = ChainLength (fromIntegral (unBlockNo no))
     return $ mkBlock canContainEBB body prevHash slot no clen ebb
+
+  genPerasCert :: Gen (PerasCert Block)
+  genPerasCert = do
+    mockCertRound <- PerasRoundNo <$> arbitrary
+    mockCertBlock <- blockPoint <$> genRandomBlock
+    mockCertVoters <- genMockPerasVoterIndices
+    pure $
+      MockPerasCert
+        { mockCertRound
+        , mockCertBlock
+        , mockCertVoters
+        }
 
   genHash :: Gen (HeaderHash Block)
   genHash =


### PR DESCRIPTION
This PR refactors `BlockSupportsPeras` to use epoch-dependent contexts to forge and verify votes and certificates. This includes:

- Refactoring `BlockSupportsPeras` to replace static `PerasParams` with `PerasEpochContext`s when forging and verifying objects.
- Adding resolver-handle helpers and propagating Peras epoch-context resolution through the `ChainDB`, `PerasVoteDB`, vote aggregation, and object-diffusion.
- Updating errors, constraints, and storage interfaces to account for the expanded requirements.
- Adapt `ChainDB` and `VolatileDB` state-machine tests to:
  - generate valid mock certificates, 
  - avoid Peras actions at origin, and 
  - constrain generated blocks and actions to resolvable context ranges.