### PR TITLE
[Peras 65] Split degenerate BlockSupportsPeras instance

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -16,7 +16,7 @@ index-state:
   -- Bump this if you need newer packages from Hackage
   , hackage.haskell.org 2026-07-31T11:39:47Z
   -- Bump this if you need newer packages from CHaP
-  , cardano-haskell-packages 2026-07-30T09:29:13Z
+  , cardano-haskell-packages 2026-08-17T11:09:16Z
 
 packages: .
 

--- a/changelog.d/20260826_213708_agustin.mista_split_degenerate_block_supports_peras.md
+++ b/changelog.d/20260826_213708_agustin.mista_split_degenerate_block_supports_peras.md
@@ -1,0 +1,10 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+### Breaking
+
+- Replaced the degenerate `BlockSupportsPeras` instance with explicit block- and era-specific instances.

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1785405248,
-        "narHash": "sha256-qMmv6sncwdCXZWOgTY00TjQvTIStNm+xf3d3TyT9m70=",
+        "lastModified": 1786970582,
+        "narHash": "sha256-V1jy4O3CNrd8dPvK2/c79ok4jLO5GXetugI4nvgcq/A=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "2f34a2539b504182c147262d5e2ee454ee76cf44",
+        "rev": "c0770200fcaa899ecdef548183dfee78e17bfb57",
         "type": "github"
       },
       "original": {

--- a/ouroboros-consensus-cardano/src/byron/Ouroboros/Consensus/Byron/Ledger/PBFT.hs
+++ b/ouroboros-consensus-cardano/src/byron/Ouroboros/Consensus/Byron/Ledger/PBFT.hs
@@ -23,6 +23,7 @@ import Ouroboros.Consensus.Byron.Crypto.DSIGN
 import Ouroboros.Consensus.Byron.Ledger.Block
 import Ouroboros.Consensus.Byron.Ledger.Config
 import Ouroboros.Consensus.Byron.Ledger.Serialisation ()
+import Ouroboros.Consensus.Byron.Node.Peras ()
 import Ouroboros.Consensus.Byron.Protocol
 import Ouroboros.Consensus.Protocol.Abstract
 import Ouroboros.Consensus.Protocol.PBFT

--- a/ouroboros-consensus-cardano/src/byron/Ouroboros/Consensus/Byron/Node/Peras.hs
+++ b/ouroboros-consensus-cardano/src/byron/Ouroboros/Consensus/Byron/Node/Peras.hs
@@ -1,0 +1,39 @@
+{-# LANGUAGE TypeFamilies #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+-- | Empty Peras support for Byron.
+--
+-- NOTE: this module exists solely because the orphan module
+-- 'Ouroboros.Consensus.Byron.Node.Serialisation' needs some of these instances,
+-- but defining them there would be too confusing.
+module Ouroboros.Consensus.Byron.Node.Peras () where
+
+import Ouroboros.Consensus.Block.SupportsPeras
+  ( BlockSupportsPeras (..)
+  , VoidPerasCert
+  , VoidPerasCrypto
+  , VoidPerasError
+  , VoidPerasVote
+  , VoidPerasVotingCommitteeScheme
+  , defaultForgePerasCert
+  , defaultForgePerasVoteIfEligible
+  , defaultVerifyPerasCert
+  , defaultVerifyPerasVote
+  )
+import Ouroboros.Consensus.Byron.Ledger.Block (ByronBlock)
+
+{-------------------------------------------------------------------------------
+  BlockSupportsPeras
+-------------------------------------------------------------------------------}
+
+instance BlockSupportsPeras ByronBlock where
+  type PerasVote ByronBlock = VoidPerasVote ByronBlock
+  type PerasCert ByronBlock = VoidPerasCert ByronBlock
+  type PerasError ByronBlock = VoidPerasError ByronBlock
+  type PerasCrypto ByronBlock = VoidPerasCrypto ByronBlock
+  type PerasVotingCommitteeScheme ByronBlock = VoidPerasVotingCommitteeScheme
+  forgePerasVoteIfEligible = defaultForgePerasVoteIfEligible
+  verifyPerasVote = defaultVerifyPerasVote
+  forgePerasCert = defaultForgePerasCert
+  verifyPerasCert = defaultVerifyPerasCert
+  getPerasCertInBlock _ = Right Nothing

--- a/ouroboros-consensus-cardano/src/byron/Ouroboros/Consensus/Byron/Node/Serialisation.hs
+++ b/ouroboros-consensus-cardano/src/byron/Ouroboros/Consensus/Byron/Node/Serialisation.hs
@@ -24,6 +24,7 @@ import Data.Word
 import Ouroboros.Consensus.Block
 import Ouroboros.Consensus.Byron.Ledger
 import Ouroboros.Consensus.Byron.Ledger.Conversions
+import Ouroboros.Consensus.Byron.Node.Peras ()
 import Ouroboros.Consensus.Byron.Protocol
 import Ouroboros.Consensus.HeaderValidation
 import Ouroboros.Consensus.Ledger.Query

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Block.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Block.hs
@@ -9,6 +9,7 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilyDependencies #-}
 {-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE UndecidableSuperClasses #-}
 
 module Ouroboros.Consensus.Shelley.Ledger.Block
@@ -66,12 +67,13 @@ import NoThunks.Class (NoThunks (..))
 import Ouroboros.Consensus.Block
 import Ouroboros.Consensus.HardFork.Combinator
   ( HasPartialConsensusConfig
-  , LedgerState
   )
 import Ouroboros.Consensus.HardFork.History (EpochToPerasRoundInfo)
 import Ouroboros.Consensus.HeaderValidation
-import Ouroboros.Consensus.Ledger.SupportsPeras (LedgerStateSupportsPeras)
-import Ouroboros.Consensus.Peras.Context (StateSupportsPerasEpochContext (..))
+import Ouroboros.Consensus.Peras.Context
+  ( MaybeEraIndexedEpochToPerasRoundInfo
+  , StateSupportsPerasEpochContext
+  )
 import Ouroboros.Consensus.Protocol.Abstract
 import Ouroboros.Consensus.Protocol.Praos.Common
   ( PraosTiebreakerView
@@ -135,16 +137,15 @@ class
   , Crypto (ProtoCrypto proto)
   , -- Peras constraints
     StateSupportsPerasEpochContext (ShelleyBlock proto era)
+  , BlockSupportsPeras (ShelleyBlock proto era)
   , MaybeEraIndexedEpochToPerasRoundInfo (ShelleyBlock proto era) ~ EpochToPerasRoundInfo
   , -- Backwards compatibility
     Plain.FromCBOR (LegacyPParams era)
   , Plain.ToCBOR (LegacyPParams era)
-  , LedgerStateSupportsPeras (LedgerState (ShelleyBlock proto era))
-  , LedgerStateSupportsPeras (Ticked LedgerState (ShelleyBlock proto era))
   ) =>
   ShelleyCompatible proto era
 
-instance ShelleyCompatible proto era => ConvertRawHash (ShelleyBlock proto era) where
+instance StandardHash (ShelleyBlock proto era) => ConvertRawHash (ShelleyBlock proto era) where
   -- 'HASH' is currently 'Blake2b_256', whose digest is 256 bits, i.e. 32 bytes,
   -- so this resolves to 32.
   type HashSize (ShelleyBlock proto era) = Crypto.HashSize HASH
@@ -255,7 +256,7 @@ instance ShelleyCompatible proto era => GetPrevHash (ShelleyBlock proto era) whe
       . pHeaderPrevHash
       . shelleyHeaderRaw
 
-instance ShelleyCompatible proto era => StandardHash (ShelleyBlock proto era)
+instance StandardHash (ShelleyBlock proto era)
 
 instance ShelleyCompatible proto era => HasAnnTip (ShelleyBlock proto era)
 

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Node.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Node.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
@@ -42,6 +43,7 @@ import Ouroboros.Consensus.Shelley.Protocol.Abstract
   ( ProtoCrypto
   , pHeaderIssuer
   )
+import Ouroboros.Consensus.Util (ShowProxy)
 
 {-------------------------------------------------------------------------------
   ProtocolInfo
@@ -113,5 +115,8 @@ instance
   , TxLimits (ShelleyBlock proto era)
   , NoHardForks (ShelleyBlock proto era)
   , Crypto (ProtoCrypto proto)
+  , SerialiseNodeToNodeConstraints (ShelleyBlock proto era)
+  , ShowProxy (PerasCert (ShelleyBlock proto era))
+  , ShowProxy (PerasVote (ShelleyBlock proto era))
   ) =>
   RunNode (ShelleyBlock proto era)

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Node/Peras.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Node/Peras.hs
@@ -15,6 +15,18 @@ module Ouroboros.Consensus.Shelley.Node.Peras () where
 
 import Cardano.Ledger.Api
 import Data.Typeable (Typeable)
+import Ouroboros.Consensus.Block.SupportsPeras
+  ( BlockSupportsPeras (..)
+  , VoidPerasCert
+  , VoidPerasCrypto
+  , VoidPerasError
+  , VoidPerasVote
+  , VoidPerasVotingCommitteeScheme
+  , defaultForgePerasCert
+  , defaultForgePerasVoteIfEligible
+  , defaultVerifyPerasCert
+  , defaultVerifyPerasVote
+  )
 import Ouroboros.Consensus.HardFork.History (EpochToPerasRoundInfo, forgetEraIndex)
 import Ouroboros.Consensus.Peras.Context (StateSupportsPerasEpochContext (..))
 import Ouroboros.Consensus.Protocol.Abstract
@@ -113,9 +125,6 @@ instance
   fromMaybeEraIndexedEpochToPerasRoundInfo _ = id
   mkBoundedPerasEpochContext = error "mkBoundedPerasEpochContext: ConwayEra does not support Peras"
 
--- TODO: this instance will have a real implementation as soon as we remove the
--- degenerate 'BlockSupportsPeras' instance. That's why we don't have a global
--- instance for all eras :)
 instance
   ( Typeable proto
   , ChainDepStateSupportsPeras (ChainDepState proto)
@@ -129,3 +138,94 @@ instance
   toMaybeEraIndexedEpochToPerasRoundInfo _ = forgetEraIndex
   fromMaybeEraIndexedEpochToPerasRoundInfo _ = id
   mkBoundedPerasEpochContext = error "mkBoundedPerasEpochContext: DijkstraEra does not support Peras (yet)"
+
+{-------------------------------------------------------------------------------
+  BlockSupportsPeras
+-------------------------------------------------------------------------------}
+
+instance Typeable proto => BlockSupportsPeras (ShelleyBlock proto ShelleyEra) where
+  type PerasVote (ShelleyBlock proto ShelleyEra) = VoidPerasVote (ShelleyBlock proto ShelleyEra)
+  type PerasCert (ShelleyBlock proto ShelleyEra) = VoidPerasCert (ShelleyBlock proto ShelleyEra)
+  type PerasError (ShelleyBlock proto ShelleyEra) = VoidPerasError (ShelleyBlock proto ShelleyEra)
+  type PerasCrypto (ShelleyBlock proto ShelleyEra) = VoidPerasCrypto (ShelleyBlock proto ShelleyEra)
+  type PerasVotingCommitteeScheme (ShelleyBlock proto ShelleyEra) = VoidPerasVotingCommitteeScheme
+  forgePerasVoteIfEligible = defaultForgePerasVoteIfEligible
+  verifyPerasVote = defaultVerifyPerasVote
+  forgePerasCert = defaultForgePerasCert
+  verifyPerasCert = defaultVerifyPerasCert
+  getPerasCertInBlock _ = Right Nothing
+
+instance Typeable proto => BlockSupportsPeras (ShelleyBlock proto AllegraEra) where
+  type PerasVote (ShelleyBlock proto AllegraEra) = VoidPerasVote (ShelleyBlock proto AllegraEra)
+  type PerasCert (ShelleyBlock proto AllegraEra) = VoidPerasCert (ShelleyBlock proto AllegraEra)
+  type PerasError (ShelleyBlock proto AllegraEra) = VoidPerasError (ShelleyBlock proto AllegraEra)
+  type PerasCrypto (ShelleyBlock proto AllegraEra) = VoidPerasCrypto (ShelleyBlock proto AllegraEra)
+  type PerasVotingCommitteeScheme (ShelleyBlock proto AllegraEra) = VoidPerasVotingCommitteeScheme
+  forgePerasVoteIfEligible = defaultForgePerasVoteIfEligible
+  verifyPerasVote = defaultVerifyPerasVote
+  forgePerasCert = defaultForgePerasCert
+  verifyPerasCert = defaultVerifyPerasCert
+  getPerasCertInBlock _ = Right Nothing
+
+instance Typeable proto => BlockSupportsPeras (ShelleyBlock proto MaryEra) where
+  type PerasVote (ShelleyBlock proto MaryEra) = VoidPerasVote (ShelleyBlock proto MaryEra)
+  type PerasCert (ShelleyBlock proto MaryEra) = VoidPerasCert (ShelleyBlock proto MaryEra)
+  type PerasError (ShelleyBlock proto MaryEra) = VoidPerasError (ShelleyBlock proto MaryEra)
+  type PerasCrypto (ShelleyBlock proto MaryEra) = VoidPerasCrypto (ShelleyBlock proto MaryEra)
+  type PerasVotingCommitteeScheme (ShelleyBlock proto MaryEra) = VoidPerasVotingCommitteeScheme
+  forgePerasVoteIfEligible = defaultForgePerasVoteIfEligible
+  verifyPerasVote = defaultVerifyPerasVote
+  forgePerasCert = defaultForgePerasCert
+  verifyPerasCert = defaultVerifyPerasCert
+  getPerasCertInBlock _ = Right Nothing
+
+instance Typeable proto => BlockSupportsPeras (ShelleyBlock proto AlonzoEra) where
+  type PerasVote (ShelleyBlock proto AlonzoEra) = VoidPerasVote (ShelleyBlock proto AlonzoEra)
+  type PerasCert (ShelleyBlock proto AlonzoEra) = VoidPerasCert (ShelleyBlock proto AlonzoEra)
+  type PerasError (ShelleyBlock proto AlonzoEra) = VoidPerasError (ShelleyBlock proto AlonzoEra)
+  type PerasCrypto (ShelleyBlock proto AlonzoEra) = VoidPerasCrypto (ShelleyBlock proto AlonzoEra)
+  type PerasVotingCommitteeScheme (ShelleyBlock proto AlonzoEra) = VoidPerasVotingCommitteeScheme
+  forgePerasVoteIfEligible = defaultForgePerasVoteIfEligible
+  verifyPerasVote = defaultVerifyPerasVote
+  forgePerasCert = defaultForgePerasCert
+  verifyPerasCert = defaultVerifyPerasCert
+  getPerasCertInBlock _ = Right Nothing
+
+instance Typeable proto => BlockSupportsPeras (ShelleyBlock proto BabbageEra) where
+  type PerasVote (ShelleyBlock proto BabbageEra) = VoidPerasVote (ShelleyBlock proto BabbageEra)
+  type PerasCert (ShelleyBlock proto BabbageEra) = VoidPerasCert (ShelleyBlock proto BabbageEra)
+  type PerasError (ShelleyBlock proto BabbageEra) = VoidPerasError (ShelleyBlock proto BabbageEra)
+  type PerasCrypto (ShelleyBlock proto BabbageEra) = VoidPerasCrypto (ShelleyBlock proto BabbageEra)
+  type PerasVotingCommitteeScheme (ShelleyBlock proto BabbageEra) = VoidPerasVotingCommitteeScheme
+  forgePerasVoteIfEligible = defaultForgePerasVoteIfEligible
+  verifyPerasVote = defaultVerifyPerasVote
+  forgePerasCert = defaultForgePerasCert
+  verifyPerasCert = defaultVerifyPerasCert
+  getPerasCertInBlock _ = Right Nothing
+
+instance Typeable proto => BlockSupportsPeras (ShelleyBlock proto ConwayEra) where
+  type PerasVote (ShelleyBlock proto ConwayEra) = VoidPerasVote (ShelleyBlock proto ConwayEra)
+  type PerasCert (ShelleyBlock proto ConwayEra) = VoidPerasCert (ShelleyBlock proto ConwayEra)
+  type PerasError (ShelleyBlock proto ConwayEra) = VoidPerasError (ShelleyBlock proto ConwayEra)
+  type PerasCrypto (ShelleyBlock proto ConwayEra) = VoidPerasCrypto (ShelleyBlock proto ConwayEra)
+  type PerasVotingCommitteeScheme (ShelleyBlock proto ConwayEra) = VoidPerasVotingCommitteeScheme
+  forgePerasVoteIfEligible = defaultForgePerasVoteIfEligible
+  verifyPerasVote = defaultVerifyPerasVote
+  forgePerasCert = defaultForgePerasCert
+  verifyPerasCert = defaultVerifyPerasCert
+  getPerasCertInBlock _ = Right Nothing
+
+-- NOTE: temporarily wired to the void implementation until we land some of the
+-- machinery needed to use production types (and which conflicted with the
+-- degenerate 'BlockSupportsPeras' instance).
+instance Typeable proto => BlockSupportsPeras (ShelleyBlock proto DijkstraEra) where
+  type PerasVote (ShelleyBlock proto DijkstraEra) = VoidPerasVote (ShelleyBlock proto DijkstraEra)
+  type PerasCert (ShelleyBlock proto DijkstraEra) = VoidPerasCert (ShelleyBlock proto DijkstraEra)
+  type PerasError (ShelleyBlock proto DijkstraEra) = VoidPerasError (ShelleyBlock proto DijkstraEra)
+  type PerasCrypto (ShelleyBlock proto DijkstraEra) = VoidPerasCrypto (ShelleyBlock proto DijkstraEra)
+  type PerasVotingCommitteeScheme (ShelleyBlock proto DijkstraEra) = VoidPerasVotingCommitteeScheme
+  forgePerasVoteIfEligible = defaultForgePerasVoteIfEligible
+  verifyPerasVote = defaultVerifyPerasVote
+  forgePerasCert = defaultForgePerasCert
+  verifyPerasCert = defaultVerifyPerasCert
+  getPerasCertInBlock _ = Right Nothing

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Node/Serialisation.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Node/Serialisation.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
@@ -64,9 +65,7 @@ import Ouroboros.Network.Block
 instance ShelleyCompatible proto era => HasBinaryBlockInfo (ShelleyBlock proto era) where
   getBinaryBlockInfo = shelleyBinaryBlockInfo
 
-instance
-  ShelleyCompatible proto era =>
-  SerialiseDiskConstraints (ShelleyBlock proto era)
+instance ShelleyCompatible proto era => SerialiseDiskConstraints (ShelleyBlock proto era)
 
 instance ShelleyCompatible proto era => EncodeDisk (ShelleyBlock proto era) (ShelleyBlock proto era) where
   encodeDisk _ = encodeShelleyBlock
@@ -127,22 +126,67 @@ instance
   SerialiseNodeToNode
 -------------------------------------------------------------------------------}
 
-instance
+-- | Shared implementation of 'estimateBlockSize' for all Shelley-based eras.
+estimateBlockSizeShelley ::
   ShelleyCompatible proto era =>
-  SerialiseNodeToNodeConstraints (ShelleyBlock proto era)
+  Header (ShelleyBlock proto era) ->
+  SizeInBytes
+estimateBlockSizeShelley hdr = overhead + hdrSize + bodySize
+ where
+  -- The maximum block size is 65536, the CBOR-in-CBOR tag for this block
+  -- is:
+  --
+  -- > D8 18          # tag(24)
+  -- >    1A 00010000 # bytes(65536)
+  --
+  -- Which is 7 bytes, enough for up to 4294967295 bytes.
+  overhead = 7 {- CBOR-in-CBOR -} + 1 {- encodeListLen -}
+  bodySize = fromIntegral . pHeaderBlockSize . shelleyHeaderRaw $ hdr
+  hdrSize = fromIntegral . pHeaderSize . shelleyHeaderRaw $ hdr
+
+instance
+  ShelleyCompatible proto ShelleyEra =>
+  SerialiseNodeToNodeConstraints (ShelleyBlock proto ShelleyEra)
   where
-  estimateBlockSize hdr = overhead + hdrSize + bodySize
-   where
-    -- The maximum block size is 65536, the CBOR-in-CBOR tag for this block
-    -- is:
-    --
-    -- > D8 18          # tag(24)
-    -- >    1A 00010000 # bytes(65536)
-    --
-    -- Which is 7 bytes, enough for up to 4294967295 bytes.
-    overhead = 7 {- CBOR-in-CBOR -} + 1 {- encodeListLen -}
-    bodySize = fromIntegral . pHeaderBlockSize . shelleyHeaderRaw $ hdr
-    hdrSize = fromIntegral . pHeaderSize . shelleyHeaderRaw $ hdr
+  estimateBlockSize = estimateBlockSizeShelley
+
+instance
+  ShelleyCompatible proto AllegraEra =>
+  SerialiseNodeToNodeConstraints (ShelleyBlock proto AllegraEra)
+  where
+  estimateBlockSize = estimateBlockSizeShelley
+
+instance
+  ShelleyCompatible proto MaryEra =>
+  SerialiseNodeToNodeConstraints (ShelleyBlock proto MaryEra)
+  where
+  estimateBlockSize = estimateBlockSizeShelley
+
+instance
+  ShelleyCompatible proto AlonzoEra =>
+  SerialiseNodeToNodeConstraints (ShelleyBlock proto AlonzoEra)
+  where
+  estimateBlockSize = estimateBlockSizeShelley
+
+instance
+  ShelleyCompatible proto BabbageEra =>
+  SerialiseNodeToNodeConstraints (ShelleyBlock proto BabbageEra)
+  where
+  estimateBlockSize = estimateBlockSizeShelley
+
+instance
+  ShelleyCompatible proto ConwayEra =>
+  SerialiseNodeToNodeConstraints (ShelleyBlock proto ConwayEra)
+  where
+  estimateBlockSize = estimateBlockSizeShelley
+
+-- NOTE: Dijkstra needs a separate instance because it affects the block size.
+-- This will implemented on a separate change.
+instance
+  ShelleyCompatible proto DijkstraEra =>
+  SerialiseNodeToNodeConstraints (ShelleyBlock proto DijkstraEra)
+  where
+  estimateBlockSize = estimateBlockSizeShelley
 
 -- | CBOR-in-CBOR for the annotation. This also makes it compatible with the
 -- wrapped ('Serialised') variant.

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/ShelleyHFC.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/ShelleyHFC.hs
@@ -84,6 +84,7 @@ import Ouroboros.Consensus.Ledger.SupportsProtocol
   , ledgerViewForecastAt
   )
 import Ouroboros.Consensus.Node.NetworkProtocolVersion
+import Ouroboros.Consensus.Node.Run (SerialiseNodeToNodeConstraints)
 import Ouroboros.Consensus.Protocol.Abstract
 import Ouroboros.Consensus.Protocol.Praos
 import Ouroboros.Consensus.Protocol.TPraos
@@ -167,6 +168,7 @@ instance
   ( ShelleyCompatible proto era
   , LedgerSupportsProtocol (ShelleyBlock proto era)
   , TxLimits (ShelleyBlock proto era)
+  , SerialiseNodeToNodeConstraints (ShelleyBlock proto era)
   , Crypto (ProtoCrypto proto)
   ) =>
   SerialiseHFC '[ShelleyBlock proto era]
@@ -175,6 +177,7 @@ instance
   ( ShelleyCompatible proto era
   , LedgerSupportsProtocol (ShelleyBlock proto era)
   , TxLimits (ShelleyBlock proto era)
+  , SerialiseNodeToNodeConstraints (ShelleyBlock proto era)
   , Crypto (ProtoCrypto proto)
   ) =>
   SerialiseConstraintsHFC (ShelleyBlock proto era)

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Run.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Run.hs
@@ -68,6 +68,7 @@ openLedgerDB ::
   forall blk.
   ( All Top (HardForkIndices blk)
   , LedgerSupportsProtocol blk
+  , BlockSupportsPeras blk
   , StateSupportsPerasEpochContext blk
   , InspectLedger blk
   ) =>

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToNode.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToNode.hs
@@ -275,8 +275,9 @@ mkHandlers ::
   ( IOLike m
   , MonadTime m
   , MonadTimer m
-  , LedgerSupportsMempool blk
   , HasTxId (GenTx blk)
+  , BlockSupportsPeras blk
+  , LedgerSupportsMempool blk
   , LedgerSupportsProtocol blk
   , Ord addrNTN
   , Hashable addrNTN
@@ -610,6 +611,8 @@ showTracers ::
   , Show (Header blk)
   , Show (GenTx blk)
   , Show (GenTxId blk)
+  , Show (PerasVote blk)
+  , Show (PerasCert blk)
   , HasHeader blk
   , HasNestedContent Header blk
   ) =>
@@ -762,10 +765,13 @@ mkApps ::
   , Exception e
   , NFData e
   , LedgerSupportsProtocol blk
+  , BlockSupportsPeras blk
   , ShowProxy blk
   , ShowProxy (Header blk)
   , ShowProxy (TxId (GenTx blk))
   , ShowProxy (GenTx blk)
+  , ShowProxy (PerasVote blk)
+  , ShowProxy (PerasCert blk)
   , Show addrNTN
   , LedgerSupportsMempool blk
   , HasTxId (GenTx blk)

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Node/Tracers.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Node/Tracers.hs
@@ -208,6 +208,7 @@ showTracers ::
   , Show (TxMeasurePhase2 blk)
   , Show (PerasVote blk)
   , Show (PerasCert blk)
+  , Show (PerasError blk)
   , Show remotePeer
   , HasRawTxId (GenTxId blk)
   , LedgerSupportsProtocol blk
@@ -427,6 +428,7 @@ deriving instance
   , Eq (CannotForge blk)
   , Eq (TxMeasurePhase1 blk)
   , Eq (TxMeasurePhase2 blk)
+  , Eq (PerasError blk)
   ) =>
   Eq (TraceForgeEvent blk)
 deriving instance
@@ -437,6 +439,7 @@ deriving instance
   , Show (CannotForge blk)
   , Show (TxMeasurePhase1 blk)
   , Show (TxMeasurePhase2 blk)
+  , Show (PerasError blk)
   ) =>
   Show (TraceForgeEvent blk)
 

--- a/ouroboros-consensus-diffusion/src/unstable-diffusion-testlib/Test/ThreadNet/General.hs
+++ b/ouroboros-consensus-diffusion/src/unstable-diffusion-testlib/Test/ThreadNet/General.hs
@@ -48,6 +48,7 @@ import qualified Ouroboros.Consensus.Block.Abstract as BA
 import qualified Ouroboros.Consensus.BlockchainTime as BTime
 import Ouroboros.Consensus.Config.SecurityParam
 import Ouroboros.Consensus.Ledger.Extended (ExtValidationError)
+import Ouroboros.Consensus.Ledger.SupportsProtocol (LedgerSupportsProtocol)
 import Ouroboros.Consensus.Node.NetworkProtocolVersion
 import Ouroboros.Consensus.Node.ProtocolInfo
 import Ouroboros.Consensus.Node.Run
@@ -283,7 +284,12 @@ data BlockRejection blk = BlockRejection
   , brReason :: !(ExtValidationError blk)
   , brRejector :: !NodeId
   }
-  deriving Show
+
+deriving instance
+  ( LedgerSupportsProtocol blk
+  , BlockSupportsPeras blk
+  ) =>
+  Show (BlockRejection blk)
 
 data PropGeneralArgs blk = PropGeneralArgs
   { pgaBlockProperty :: blk -> Property

--- a/ouroboros-consensus-diffusion/src/unstable-diffusion-testlib/Test/ThreadNet/Network.hs
+++ b/ouroboros-consensus-diffusion/src/unstable-diffusion-testlib/Test/ThreadNet/Network.hs
@@ -1746,6 +1746,7 @@ nullDebugTracers ::
   ( Monad m
   , Show peer
   , LedgerSupportsProtocol blk
+  , BlockSupportsPeras blk
   , TracingConstraints blk
   ) =>
   Tracers m peer Void blk
@@ -1777,6 +1778,8 @@ type TracingConstraints blk =
   , Show (TxMeasurePhase1 blk)
   , Show (TxMeasurePhase2 blk)
   , Show (ReasonForSwitch (TiebreakerView (BlockProtocol blk)))
+  , Show (PerasVote blk)
+  , Show (PerasCert blk)
   , HasNestedContent Header blk
   , HasRawTxId (GenTxId blk)
   )

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup.hs
@@ -32,6 +32,7 @@ import Ouroboros.Consensus.Block.Abstract
 import Ouroboros.Consensus.Block.SupportsDiffusionPipelining
   ( BlockSupportsDiffusionPipelining
   )
+import Ouroboros.Consensus.Block.SupportsPeras (BlockSupportsPeras)
 import Ouroboros.Consensus.Config.SupportsNode (ConfigSupportsNode)
 import Ouroboros.Consensus.HardFork.Abstract (HasHardForkHistory (..))
 import Ouroboros.Consensus.Ledger.Basics (LedgerState)
@@ -164,6 +165,7 @@ runGenesisTest ::
   , StateSupportsPerasEpochContext blk
   , ChainDB.SerialiseDiskConstraints blk
   , BlockSupportsDiffusionPipelining blk
+  , BlockSupportsPeras blk
   , InspectLedger blk
   , ConvertRawHash blk
   , CanUpgradeLedgerTables LedgerState blk
@@ -226,6 +228,7 @@ runConformanceTest ::
   , StateSupportsPerasEpochContext blk
   , ChainDB.SerialiseDiskConstraints blk
   , BlockSupportsDiffusionPipelining blk
+  , BlockSupportsPeras blk
   , InspectLedger blk
   , ConvertRawHash blk
   , CanUpgradeLedgerTables LedgerState blk

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/TestSuite.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/TestSuite.hs
@@ -36,6 +36,7 @@ import Data.SOP (All, Top)
 import GHC.Generics (Generic, Generically (..))
 import Ouroboros.Consensus.Block
   ( BlockSupportsDiffusionPipelining
+  , BlockSupportsPeras
   , ConvertRawHash
   , Header
   )
@@ -188,6 +189,7 @@ toTestTree ::
   , StateSupportsPerasEpochContext blk
   , SerialiseDiskConstraints blk
   , BlockSupportsDiffusionPipelining blk
+  , BlockSupportsPeras blk
   , InspectLedger blk
   , ConvertRawHash blk
   , CanUpgradeLedgerTables LedgerState blk

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator/A.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator/A.hs
@@ -90,10 +90,17 @@ import Ouroboros.Consensus.Node.InitStorage
 import Ouroboros.Consensus.Node.NetworkProtocolVersion
 import Ouroboros.Consensus.Node.Run
 import Ouroboros.Consensus.Node.Serialisation
+import Ouroboros.Consensus.Peras.Cert.Mock (MockPerasCert)
 import Ouroboros.Consensus.Peras.Context
   ( StateSupportsPerasEpochContext (..)
   , mkBoundedPerasEpochContextWith
   )
+import Ouroboros.Consensus.Peras.Crypto.Mock
+  ( MockPerasCrypto
+  , MockPerasVotingCommitteeScheme
+  )
+import Ouroboros.Consensus.Peras.Error.Mock (MockPerasError)
+import Ouroboros.Consensus.Peras.Vote.Mock (MockPerasVote)
 import Ouroboros.Consensus.Peras.Voting.Mock (mkMockPerasVotingCommitteeInput)
 import Ouroboros.Consensus.Protocol.Abstract
 import Ouroboros.Consensus.Storage.ImmutableDB (simpleChunkInfo)
@@ -319,9 +326,9 @@ instance LedgerStateSupportsPeras (LedgerState BlockA)
 
 instance LedgerStateSupportsPeras (Ticked LedgerState BlockA)
 
--- NOTE: BlockA is only ever used wrapped in the
--- hard fork combinator (which implements 'hardForkSummary' directly and never
--- delegates to the underlying era), so this method is never actually called.
+-- NOTE: BlockA is only ever used wrapped in the hard fork combinator (which
+-- implements 'hardForkSummary' directly and never delegates to the underlying
+-- era), so this method is never actually called.
 instance HasHardForkHistory BlockA where
   type HardForkIndices BlockA = '[BlockA]
   hardForkSummary = error "BlockA being used as a SingleEraBlock"
@@ -331,6 +338,18 @@ instance StateSupportsPerasEpochContext BlockA where
   toMaybeEraIndexedEpochToPerasRoundInfo _ = forgetEraIndex
   fromMaybeEraIndexedEpochToPerasRoundInfo _ = id
   mkBoundedPerasEpochContext = mkBoundedPerasEpochContextWith mkMockPerasVotingCommitteeInput
+
+instance BlockSupportsPeras BlockA where
+  type PerasCrypto BlockA = MockPerasCrypto BlockA
+  type PerasVotingCommitteeScheme BlockA = MockPerasVotingCommitteeScheme BlockA
+  type PerasVote BlockA = MockPerasVote BlockA
+  type PerasCert BlockA = MockPerasCert BlockA
+  type PerasError BlockA = MockPerasError BlockA
+  forgePerasVoteIfEligible = defaultForgePerasVoteIfEligible
+  verifyPerasVote = defaultVerifyPerasVote
+  forgePerasCert = defaultForgePerasCert
+  verifyPerasCert = defaultVerifyPerasCert
+  getPerasCertInBlock _ = Right Nothing
 
 instance HasPartialConsensusConfig ProtocolA
 

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator/B.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator/B.hs
@@ -73,10 +73,17 @@ import Ouroboros.Consensus.Node.InitStorage
 import Ouroboros.Consensus.Node.NetworkProtocolVersion
 import Ouroboros.Consensus.Node.Run
 import Ouroboros.Consensus.Node.Serialisation
+import Ouroboros.Consensus.Peras.Cert.Mock (MockPerasCert)
 import Ouroboros.Consensus.Peras.Context
   ( StateSupportsPerasEpochContext (..)
   , mkBoundedPerasEpochContextWith
   )
+import Ouroboros.Consensus.Peras.Crypto.Mock
+  ( MockPerasCrypto
+  , MockPerasVotingCommitteeScheme
+  )
+import Ouroboros.Consensus.Peras.Error.Mock (MockPerasError)
+import Ouroboros.Consensus.Peras.Vote.Mock (MockPerasVote)
 import Ouroboros.Consensus.Peras.Voting.Mock (mkMockPerasVotingCommitteeInput)
 import Ouroboros.Consensus.Protocol.Abstract
 import Ouroboros.Consensus.Storage.ImmutableDB (simpleChunkInfo)
@@ -274,9 +281,9 @@ instance LedgerStateSupportsPeras (LedgerState BlockB)
 
 instance LedgerStateSupportsPeras (Ticked LedgerState BlockB)
 
--- NOTE: BlockA is only ever used wrapped in the
--- hard fork combinator (which implements 'hardForkSummary' directly and never
--- delegates to the underlying era), so this method is never actually called.
+-- NOTE: BlockB is only ever used wrapped in the hard fork combinator (which
+-- implements 'hardForkSummary' directly and never delegates to the underlying
+-- era), so this method is never actually called.
 instance HasHardForkHistory BlockB where
   type HardForkIndices BlockB = '[BlockB]
   hardForkSummary = error "BlockB being used as a SingleEraBlock"
@@ -286,6 +293,18 @@ instance StateSupportsPerasEpochContext BlockB where
   toMaybeEraIndexedEpochToPerasRoundInfo _ = forgetEraIndex
   fromMaybeEraIndexedEpochToPerasRoundInfo _ = id
   mkBoundedPerasEpochContext = mkBoundedPerasEpochContextWith mkMockPerasVotingCommitteeInput
+
+instance BlockSupportsPeras BlockB where
+  type PerasCrypto BlockB = MockPerasCrypto BlockB
+  type PerasVotingCommitteeScheme BlockB = MockPerasVotingCommitteeScheme BlockB
+  type PerasVote BlockB = MockPerasVote BlockB
+  type PerasCert BlockB = MockPerasCert BlockB
+  type PerasError BlockB = MockPerasError BlockB
+  forgePerasVoteIfEligible = defaultForgePerasVoteIfEligible
+  verifyPerasVote = defaultVerifyPerasVote
+  forgePerasCert = defaultForgePerasCert
+  verifyPerasCert = defaultVerifyPerasCert
+  getPerasCertInBlock _ = Right Nothing
 
 instance HasPartialConsensusConfig ProtocolB
 

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/ChainSync.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/ChainSync.hs
@@ -23,6 +23,7 @@ import Control.Tracer
 import Data.Proxy (Proxy (..))
 import Network.TypedProtocol.Codec (AnyMessage)
 import Ouroboros.Consensus.Block (Header, Point)
+import Ouroboros.Consensus.Block.SupportsPeras (BlockSupportsPeras)
 import Ouroboros.Consensus.BlockchainTime (RelativeTime (..))
 import Ouroboros.Consensus.Config
   ( DiffusionPipeliningSupport (..)
@@ -94,7 +95,10 @@ import Test.Util.Orphans.IOLike ()
 -- messages and the “in future” checks are disabled.
 basicChainSyncClient ::
   forall m blk.
-  (IOLike m, LedgerSupportsProtocol blk) =>
+  ( IOLike m
+  , LedgerSupportsProtocol blk
+  , BlockSupportsPeras blk
+  ) =>
   PeerId ->
   Tracer m (TraceEvent blk) ->
   TopLevelConfig blk ->
@@ -148,7 +152,13 @@ basicChainSyncClient
 -- 'basicChainSyncClient', synchronously. Exceptions are caught, sent to the
 -- 'StateViewTracers' and logged.
 runChainSyncClient ::
-  (IOLike m, MonadTimer m, LedgerSupportsProtocol blk, ShowProxy blk, ShowProxy (Header blk)) =>
+  ( IOLike m
+  , MonadTimer m
+  , LedgerSupportsProtocol blk
+  , BlockSupportsPeras blk
+  , ShowProxy blk
+  , ShowProxy (Header blk)
+  ) =>
   Tracer m (TraceEvent blk) ->
   TopLevelConfig blk ->
   ChainDbView m blk ->

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/NodeLifecycle.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/NodeLifecycle.hs
@@ -139,6 +139,7 @@ mkChainDb ::
   , StateSupportsPerasEpochContext blk
   , ChainDB.SerialiseDiskConstraints blk
   , BlockSupportsDiffusionPipelining blk
+  , BlockSupportsPeras blk
   , InspectLedger blk
   , ConvertRawHash blk
   , CanUpgradeLedgerTables LedgerState blk
@@ -192,6 +193,7 @@ restoreNode ::
   , StateSupportsPerasEpochContext blk
   , ChainDB.SerialiseDiskConstraints blk
   , BlockSupportsDiffusionPipelining blk
+  , BlockSupportsPeras blk
   , InspectLedger blk
   , ConvertRawHash blk
   , CanUpgradeLedgerTables LedgerState blk
@@ -222,6 +224,7 @@ lifecycleStart ::
   , StateSupportsPerasEpochContext blk
   , ChainDB.SerialiseDiskConstraints blk
   , BlockSupportsDiffusionPipelining blk
+  , BlockSupportsPeras blk
   , InspectLedger blk
   , ConvertRawHash blk
   , CanUpgradeLedgerTables LedgerState blk

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Run.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Run.hs
@@ -173,6 +173,7 @@ startChainSyncConnectionThread ::
   ( IOLike m
   , MonadTimer m
   , LedgerSupportsProtocol blk
+  , BlockSupportsPeras blk
   , ShowProxy blk
   , ShowProxy (Header blk)
   ) =>

--- a/ouroboros-consensus.cabal
+++ b/ouroboros-consensus.cabal
@@ -245,6 +245,7 @@ library
     Ouroboros.Consensus.Peras.Crypto.BLS
     Ouroboros.Consensus.Peras.Crypto.Mock
     Ouroboros.Consensus.Peras.Error.Mock
+    Ouroboros.Consensus.Peras.Error.V1
     Ouroboros.Consensus.Peras.Params
     Ouroboros.Consensus.Peras.SelectView
     Ouroboros.Consensus.Peras.Types
@@ -404,7 +405,7 @@ library
     singletons ^>=3,
     small-steps ^>=1.1,
     sop-core ^>=0.5,
-    sop-extras ^>=0.4.1,
+    sop-extras ^>=0.4.2,
     streaming,
     strict >=0.1 && <0.6,
     strict-checked-vars ^>=0.2,
@@ -1386,6 +1387,7 @@ library cardano
     Ouroboros.Consensus.Byron.Ledger.PBFT
     Ouroboros.Consensus.Byron.Ledger.Serialisation
     Ouroboros.Consensus.Byron.Node
+    Ouroboros.Consensus.Byron.Node.Peras
     Ouroboros.Consensus.Byron.Node.Serialisation
     Ouroboros.Consensus.Byron.Protocol
     Ouroboros.Consensus.Cardano

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Block/SupportsPeras.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Block/SupportsPeras.hs
@@ -12,8 +12,6 @@
 {-# LANGUAGE TypeFamilyDependencies #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
--- Disabled until we get rid of the degenerate 'BlockSupportsPeras' instance.
-{-# OPTIONS_GHC -Wno-redundant-constraints #-}
 
 module Ouroboros.Consensus.Block.SupportsPeras
   ( -- * Voting committee types for Peras
@@ -91,14 +89,10 @@ import qualified Ouroboros.Consensus.Committee.Class as Committee
 import Ouroboros.Consensus.Committee.Crypto (ElectionId, PrivateKey, VoteCandidate)
 import Ouroboros.Consensus.Committee.Types (PoolId (..))
 import Ouroboros.Consensus.Peras.Cert.Class
-import Ouroboros.Consensus.Peras.Cert.Mock (MockPerasCert (..))
-import Ouroboros.Consensus.Peras.Crypto.Mock (MockPerasCrypto, MockPerasVotingCommitteeScheme)
-import Ouroboros.Consensus.Peras.Error.Mock (MockPerasError (..))
 import Ouroboros.Consensus.Peras.Params
 import Ouroboros.Consensus.Peras.Types
 import Ouroboros.Consensus.Peras.Void
 import Ouroboros.Consensus.Peras.Vote.Class
-import Ouroboros.Consensus.Peras.Vote.Mock (MockPerasVote)
 import Ouroboros.Consensus.Peras.Voting.Adapter
 
 -- * Voting committee types for Peras
@@ -420,20 +414,6 @@ defaultVerifyPerasCert context cert = do
     else
       throwError (injectQuorumNotReachedError totalVoteWeight)
 
--- TODO: degenerate instance for all blks to get things to compile
--- see https://github.com/tweag/cardano-peras/issues/73
-instance (StandardHash blk, Typeable blk) => BlockSupportsPeras blk where
-  type PerasCrypto blk = MockPerasCrypto blk
-  type PerasVotingCommitteeScheme blk = MockPerasVotingCommitteeScheme blk
-  type PerasError blk = MockPerasError blk
-  type PerasCert blk = MockPerasCert blk
-  type PerasVote blk = MockPerasVote blk
-  forgePerasVoteIfEligible = defaultForgePerasVoteIfEligible
-  verifyPerasVote = defaultVerifyPerasVote
-  forgePerasCert = defaultForgePerasCert
-  verifyPerasCert = defaultVerifyPerasCert
-  getPerasCertInBlock _ = Right Nothing
-
 -- * Validated types
 
 data ValidatedPerasVote blk
@@ -498,11 +478,6 @@ instance IsPerasError (VoidPerasError blk) blk where
     error "injectConversionError: VoidPerasError cannot be inhabited"
   injectQuorumNotReachedError _ =
     error "injectQuorumNotReachedError: VoidPerasError cannot be inhabited"
-
-instance IsPerasError (MockPerasError blk) blk where
-  injectVotingCommitteeError = PerasVotingCommitteeError
-  injectConversionError = PerasVotingConversionError
-  injectQuorumNotReachedError = PerasQuorumNotReachedError
 
 -- * Types and functions related to Peras vote collection and quorum checking
 
@@ -681,6 +656,8 @@ toUniqueVotesWithSameTarget ::
   ( vote ~ PerasVote blk
   , crypto ~ PerasCrypto blk
   , committee ~ PerasVotingCommitteeScheme blk
+  , ElectionId crypto ~ PerasRoundNo
+  , CryptoSupportsVotingCommittee crypto committee
   , PerasVoteCompatibleWithVotingCommittee vote crypto committee
   , Eq (VoteCandidate crypto)
   ) =>

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Abstract/SingleEraBlock.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Abstract/SingleEraBlock.hs
@@ -48,7 +48,10 @@ import Ouroboros.Consensus.Ledger.SupportsPeerSelection
 import Ouroboros.Consensus.Ledger.SupportsProtocol
 import Ouroboros.Consensus.Node.InitStorage
 import Ouroboros.Consensus.Node.Serialisation
-import Ouroboros.Consensus.Peras.Context (StateSupportsPerasEpochContext (..))
+import Ouroboros.Consensus.Peras.Context
+  ( MaybeEraIndexedEpochToPerasRoundInfo
+  , StateSupportsPerasEpochContext (..)
+  )
 import Ouroboros.Consensus.Protocol.Abstract
 import Ouroboros.Consensus.Storage.Serialisation
 import Ouroboros.Consensus.Ticked
@@ -77,6 +80,7 @@ class
   , ConfigSupportsNode blk
   , NodeInitStorage blk
   , BlockSupportsDiffusionPipelining blk
+  , BlockSupportsPeras blk
   , StateSupportsPerasEpochContext blk
   , MaybeEraIndexedEpochToPerasRoundInfo blk ~ EpochToPerasRoundInfo
   , BlockSupportsMetrics blk

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Basics.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Basics.hs
@@ -1,17 +1,23 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
+-- TODO: figure out how to move the 'IsPerasVote'/'IsPerasCert' next to the
+-- definition of 'OneEraPerasVote' and 'OneEraPerasCert'.
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Ouroboros.Consensus.HardFork.Combinator.Basics
   ( -- * Hard fork protocol, block, and ledger state
@@ -34,6 +40,11 @@ module Ouroboros.Consensus.HardFork.Combinator.Basics
   , distribLedgerConfig
   , distribTopLevelConfig
 
+    -- ** Functions on Peras context
+  , injectHFCBoundedPerasEpochContext
+  , projectHFCBoundedPerasEpochContext
+  , injectHFCPerasEpochContextResolver
+
     -- * HFC injection/projection helpers for Peras
   , distribHardForkPoint
   , injectHardForkPoint
@@ -44,17 +55,53 @@ module Ouroboros.Consensus.HardFork.Combinator.Basics
   ) where
 
 import Cardano.Slotting.EpochInfo
+import Data.Bifunctor (bimap)
+import Data.Functor.Product (Product (..))
 import Data.Kind (Type)
-import Data.SOP (K (..))
+import Data.SOP (I (..), K (..), type (:.:) (..))
 import Data.SOP.Constraint
+import Data.SOP.Dict (Dict (..))
+import qualified Data.SOP.Dict as Dict
+import Data.SOP.Either (hdistribute, mkEitherF)
 import Data.SOP.Functors
+import Data.SOP.Index (himap, injectNS)
+import qualified Data.SOP.Match as Match
 import Data.SOP.Strict
 import Data.Typeable
 import GHC.Generics (Generic)
 import NoThunks.Class (NoThunks)
 import Ouroboros.Consensus.Block.Abstract
+import Ouroboros.Consensus.Block.SupportsPeras
+  ( BlockSupportsPeras (..)
+  , BoostedBlock
+  , IsPerasCert (..)
+  , IsPerasError (..)
+  , IsPerasVote (..)
+  , PerasEpochContext (..)
+  , PerasRoundNo
+  , PerasVoteCollection (..)
+  , PerasVoteCollectionWithQuorum (..)
+  , ValidatedPerasCert (..)
+  , ValidatedPerasVote (..)
+  , castPerasParams
+  , unsafeAssumeQuorum
+  , unsafePerasVoteCollection
+  )
+import Ouroboros.Consensus.BlockchainTime (WithArrivalTime (..))
+import Ouroboros.Consensus.Committee.Crypto
+  ( ElectionId
+  , VoteCandidate
+  )
 import Ouroboros.Consensus.Config
-import Ouroboros.Consensus.HardFork.Combinator.Abstract
+import Ouroboros.Consensus.HardFork.Combinator.Abstract.CanHardFork
+  ( CanHardFork
+  , EqualHashSizeOfHead
+  , HashSizeOfHead
+  )
+import Ouroboros.Consensus.HardFork.Combinator.Abstract.SingleEraBlock
+  ( SingleEraBlock
+  , proxySingle
+  )
 import Ouroboros.Consensus.HardFork.Combinator.AcrossEras
 import Ouroboros.Consensus.HardFork.Combinator.PartialConfig
 import qualified Ouroboros.Consensus.HardFork.Combinator.State.Infra as State
@@ -63,6 +110,10 @@ import Ouroboros.Consensus.HardFork.Combinator.State.Types
 import qualified Ouroboros.Consensus.HardFork.History as History
 import Ouroboros.Consensus.Ledger.Abstract
 import Ouroboros.Consensus.Ledger.SupportsPeras (LedgerStateSupportsPeras (..))
+import Ouroboros.Consensus.Peras.Context
+  ( BoundedPerasEpochContext (..)
+  , PerasEpochContextResolver (..)
+  )
 import Ouroboros.Consensus.Protocol.Abstract
 import Ouroboros.Consensus.TypeFamilyWrappers
 import Ouroboros.Consensus.Util (ShowProxy)
@@ -292,6 +343,407 @@ injectHardForkPoint = \case
     GenesisPoint
   BlockPoint s h ->
     BlockPoint s (OneEraHash (toShortRawHash (Proxy @blk) h))
+
+-- | Project a 'PerasVoteCollectionWithQuorum' of the hard fork block into a
+-- 'NS' of 'PerasVoteCollectionWithQuorum' of the single era blocks.
+projectHFCPerasVoteCollectionWithQuorum ::
+  All SingleEraBlock xs =>
+  PerasVoteCollectionWithQuorum (HardForkBlock xs) ->
+  Maybe (NS PerasVoteCollectionWithQuorum xs)
+projectHFCPerasVoteCollectionWithQuorum hfcCollection =
+  let votes = pvcVotes $ forgetQuorum hfcCollection
+      neMapNs = projectHFCWithArrivalTimeValidatedPerasVote <$> votes
+   in case Match.matchNEMap neMapNs of
+        Left _mismatch ->
+          Nothing
+        Right nsNeMap ->
+          Just $
+            hcmap
+              proxySingle
+              ( \(Comp compedValMap) ->
+                  unsafeAssumeQuorum $
+                    unsafePerasVoteCollection
+                      ((\(Comp v) -> v) <$> compedValMap)
+              )
+              nsNeMap
+
+-- NOTE: this assumes PerasParams are the same for all eras.
+--
+-- In the future, @pecParams@ will be an @NP@ of @PerasParams@.
+projectHFCPerasEpochContext ::
+  All Top xs =>
+  PerasEpochContext (HardForkBlock xs) ->
+  NS PerasEpochContext xs
+projectHFCPerasEpochContext PerasEpochContext{pecCommittee, pecParams} =
+  hmap
+    ( \(WrapPerasVotingCommittee committee) ->
+        PerasEpochContext
+          { pecCommittee = committee
+          , pecParams = castPerasParams pecParams
+          }
+    )
+    . getOneEraPerasVotingCommittee
+    $ pecCommittee
+
+injectHFCPerasEpochContext ::
+  All Top xs =>
+  NS PerasEpochContext xs ->
+  PerasEpochContext (HardForkBlock xs)
+injectHFCPerasEpochContext =
+  hcollapse
+    . himap
+      ( \idx context ->
+          K $
+            PerasEpochContext
+              { pecCommittee =
+                  OneEraPerasVotingCommittee
+                    . injectNS idx
+                    . WrapPerasVotingCommittee
+                    . pecCommittee
+                    $ context
+              , pecParams =
+                  castPerasParams
+                    . pecParams
+                    $ context
+              }
+      )
+
+-- | Inject a 'NS' of 'BoundedPerasEpochContext' of the single era blocks into a
+-- 'BoundedPerasEpochContext' of the hard fork block.
+injectHFCBoundedPerasEpochContext ::
+  All Top xs =>
+  NS BoundedPerasEpochContext xs ->
+  BoundedPerasEpochContext (HardForkBlock xs)
+injectHFCBoundedPerasEpochContext =
+  hcollapse
+    . himap
+      ( \idx context ->
+          K $
+            BoundedPerasEpochContext
+              { startPerasRoundNo =
+                  startPerasRoundNo context
+              , endPerasRoundNo =
+                  endPerasRoundNo context
+              , epochContext =
+                  injectHFCPerasEpochContext
+                    . injectNS idx
+                    . epochContext
+                    $ context
+              }
+      )
+
+-- | Project a 'BoundedPerasEpochContext' of the hard fork block into a 'NS' of
+-- 'BoundedPerasEpochContext' of the single era blocks.
+projectHFCBoundedPerasEpochContext ::
+  All Top xs =>
+  BoundedPerasEpochContext (HardForkBlock xs) ->
+  NS BoundedPerasEpochContext xs
+projectHFCBoundedPerasEpochContext
+  BoundedPerasEpochContext
+    { startPerasRoundNo
+    , endPerasRoundNo
+    , epochContext
+    } =
+    hmap
+      ( \(WrapPerasVotingCommittee committee) ->
+          BoundedPerasEpochContext
+            { startPerasRoundNo =
+                startPerasRoundNo
+            , endPerasRoundNo =
+                endPerasRoundNo
+            , epochContext =
+                PerasEpochContext
+                  { pecCommittee = committee
+                  , pecParams = castPerasParams (pecParams epochContext)
+                  }
+            }
+      )
+      . getOneEraPerasVotingCommittee
+      $ pecCommittee epochContext
+
+-- | Inject a 'NS' of 'PerasEpochContextResolver' of the single era blocks into
+-- a 'PerasEpochContextResolver' of the hard fork block.
+injectHFCPerasEpochContextResolver ::
+  All Top xs =>
+  NS PerasEpochContextResolver xs ->
+  PerasEpochContextResolver (HardForkBlock xs)
+injectHFCPerasEpochContextResolver =
+  hcollapse
+    . himap
+      ( \idx resolver ->
+          case resolver of
+            PerasEpochContextResolverError err ->
+              K $ PerasEpochContextResolverError err
+            PerasEpochContextResolver currBoundedContext prevBoundedContext ->
+              K $
+                PerasEpochContextResolver
+                  (injectHFCBoundedPerasEpochContext . injectNS idx <$> currBoundedContext)
+                  (injectHFCBoundedPerasEpochContext . injectNS idx <$> prevBoundedContext)
+      )
+
+injectHFCValidatedPerasVote ::
+  All Top xs =>
+  NS ValidatedPerasVote xs ->
+  ValidatedPerasVote (HardForkBlock xs)
+injectHFCValidatedPerasVote =
+  hcollapse
+    . himap
+      ( \idx vote ->
+          K $
+            ValidatedPerasVote
+              { vpvVote =
+                  OneEraPerasVote
+                    . injectNS idx
+                    . WrapPerasVote
+                    . vpvVote
+                    $ vote
+              , vpvVoteWeight =
+                  vpvVoteWeight vote
+              }
+      )
+
+injectHFCValidatedPerasCert ::
+  All Top xs =>
+  NS ValidatedPerasCert xs ->
+  ValidatedPerasCert (HardForkBlock xs)
+injectHFCValidatedPerasCert =
+  hcollapse
+    . himap
+      ( \idx cert ->
+          K $
+            ValidatedPerasCert
+              { vpcCert =
+                  OneEraPerasCert
+                    . injectNS idx
+                    . WrapPerasCert
+                    . vpcCert
+                    $ cert
+              , vpcCertBoost =
+                  vpcCertBoost cert
+              }
+      )
+
+projectHFCValidatedPerasVote ::
+  All Top xs =>
+  ValidatedPerasVote (HardForkBlock xs) ->
+  NS ValidatedPerasVote xs
+projectHFCValidatedPerasVote
+  ValidatedPerasVote
+    { vpvVote
+    , vpvVoteWeight
+    } =
+    hmap
+      ( \(WrapPerasVote v) ->
+          ValidatedPerasVote
+            { vpvVote = v
+            , vpvVoteWeight
+            }
+      )
+      . getOneEraPerasVote
+      $ vpvVote
+
+projectHFCWithArrivalTimeValidatedPerasVote ::
+  All Top xs =>
+  WithArrivalTime (ValidatedPerasVote (HardForkBlock xs)) ->
+  NS (WithArrivalTime :.: ValidatedPerasVote) xs
+projectHFCWithArrivalTimeValidatedPerasVote (WithArrivalTime arrivalTime validatedVote) =
+  hmap (Comp . WithArrivalTime arrivalTime)
+    . projectHFCValidatedPerasVote
+    $ validatedVote
+
+{-------------------------------------------------------------------------------
+  BlockSupportsPeras
+-------------------------------------------------------------------------------}
+
+-- ** Type and class instances that are required for the 'BlockSupportsPeras'
+
+-- instance of 'HardForkBlock'
+
+type instance ElectionId (OneEraPerasCrypto xs) = PerasRoundNo
+type instance BoostedBlock (OneEraPerasVote xs) = Point (HardForkBlock xs)
+type instance BoostedBlock (OneEraPerasCert xs) = Point (HardForkBlock xs)
+type instance VoteCandidate (OneEraPerasCrypto xs) = Point (HardForkBlock xs)
+
+instance
+  ( CanHardFork xs
+  , All SingleEraBlock xs
+  ) =>
+  IsPerasVote (OneEraPerasVote xs) (HardForkBlock xs)
+  where
+  getPerasVoteRound =
+    hcollapse
+      . hcmap proxySingle (K . getPerasVoteRound . unwrapPerasVote)
+      . getOneEraPerasVote
+  getPerasVoteSeatIndex =
+    hcollapse
+      . hcmap proxySingle (K . getPerasVoteSeatIndex . unwrapPerasVote)
+      . getOneEraPerasVote
+  getPerasVoteBlock =
+    hcollapse
+      . hcmap proxySingle (K . injectHardForkPoint . getPerasVotePoint . unwrapPerasVote)
+      . getOneEraPerasVote
+
+instance
+  CanHardFork xs =>
+  IsPerasCert (OneEraPerasCert xs) (HardForkBlock xs)
+  where
+  getPerasCertRound =
+    hcollapse
+      . hcmap proxySingle (K . getPerasCertRound . unwrapPerasCert)
+      . getOneEraPerasCert
+  getPerasCertBlock =
+    hcollapse
+      . hcmap proxySingle (K . injectHardForkPoint . getPerasCertPoint . unwrapPerasCert)
+      . getOneEraPerasCert
+
+instance
+  CanHardFork xs =>
+  IsPerasError (HardForkPerasError xs) (HardForkBlock xs)
+  where
+  -- NOTE: in practice this is never produced at the HFC level
+  injectVotingCommitteeError _ = HardForkPerasErrorCommitteeError
+
+  -- NOTE: in practice this is never produced at the HFC level
+  injectConversionError _ = HardForkPerasErrorConversionError
+
+  -- NOTE: in practice this is never produced at the HFC level
+  injectQuorumNotReachedError _ = HardForkPerasErrorQuorumNotReachedError
+
+-- ** 'BlockSupportsPeras' instance for 'HardForkBlock'
+
+class
+  ( SingleEraBlock blk
+  , EqualHashSizeOfHead xs blk
+  ) =>
+  SingleEraBlockWithHashSizeOfHead xs blk
+
+instance
+  ( SingleEraBlock blk
+  , EqualHashSizeOfHead xs blk
+  ) =>
+  SingleEraBlockWithHashSizeOfHead xs blk
+
+proofSingleEraBlockWithHashSizeOfHead ::
+  forall xs.
+  ( All SingleEraBlock xs
+  , All (EqualHashSizeOfHead xs) xs
+  ) =>
+  Dict (All (SingleEraBlockWithHashSizeOfHead xs)) xs
+proofSingleEraBlockWithHashSizeOfHead =
+  Dict.mapAll
+    (\Dict -> Dict)
+    ( Dict.zipAll
+        (Dict :: Dict (All SingleEraBlock) xs)
+        (Dict :: Dict (All (EqualHashSizeOfHead xs)) xs)
+    )
+
+instance
+  ( StandardHash (HardForkBlock xs)
+  , HashSize (HardForkBlock xs) ~ HashSizeOfHead xs
+  , CanHardFork xs
+  ) =>
+  BlockSupportsPeras (HardForkBlock xs)
+  where
+  type PerasVote (HardForkBlock xs) = OneEraPerasVote xs
+  type PerasCert (HardForkBlock xs) = OneEraPerasCert xs
+  type PerasError (HardForkBlock xs) = HardForkPerasError xs
+  type PerasCrypto (HardForkBlock xs) = OneEraPerasCrypto xs
+  type PerasVotingCommitteeScheme (HardForkBlock xs) = OneEraPerasVotingCommitteeScheme xs
+
+  forgePerasVoteIfEligible context poolId privKey roundNo point =
+    let
+      nsPrivKeyContext =
+        hzipWith
+          Pair
+          (getPerEraPerasPrivateKey privKey)
+          (projectHFCPerasEpochContext context)
+     in
+      case proofSingleEraBlockWithHashSizeOfHead @xs of
+        Dict ->
+          bimap
+            (HardForkPerasErrorOneEraPerasError . OneEraPerasError)
+            (fmap injectHFCValidatedPerasVote . hsequence')
+            . hdistribute
+            . hcmap
+              (Proxy @(SingleEraBlockWithHashSizeOfHead xs))
+              ( \(Pair (WrapPerasPrivateKey privKey') context') ->
+                  mkEitherF WrapPerasError Comp $
+                    forgePerasVoteIfEligible
+                      context'
+                      poolId
+                      privKey'
+                      roundNo
+                      (distribHardForkPoint point)
+              )
+            $ nsPrivKeyContext
+
+  verifyPerasVote context vote =
+    case Match.matchNS (projectHFCPerasEpochContext context) (getOneEraPerasVote vote) of
+      Left _mismatch ->
+        Left HardForkPerasErrorEraMismatch
+      Right nsContextVote ->
+        bimap
+          (HardForkPerasErrorOneEraPerasError . OneEraPerasError)
+          injectHFCValidatedPerasVote
+          . hdistribute
+          . hcmap
+            proxySingle
+            ( \(Pair context' (WrapPerasVote vote')) ->
+                mkEitherF WrapPerasError id $
+                  verifyPerasVote context' vote'
+            )
+          $ nsContextVote
+
+  forgePerasCert context collection =
+    case projectHFCPerasVoteCollectionWithQuorum collection of
+      Nothing ->
+        Left HardForkPerasErrorEraMismatch
+      Just nsCollection ->
+        case Match.matchNS (projectHFCPerasEpochContext context) nsCollection of
+          Left _mismatch ->
+            Left HardForkPerasErrorEraMismatch
+          Right nsContextCollection ->
+            bimap
+              (HardForkPerasErrorOneEraPerasError . OneEraPerasError)
+              injectHFCValidatedPerasCert
+              . hdistribute
+              . hcmap
+                proxySingle
+                ( \(Pair context' collection') ->
+                    mkEitherF WrapPerasError id $
+                      forgePerasCert context' collection'
+                )
+              $ nsContextCollection
+
+  verifyPerasCert context cert =
+    case Match.matchNS (projectHFCPerasEpochContext context) (getOneEraPerasCert cert) of
+      Left _mismatch ->
+        Left HardForkPerasErrorEraMismatch
+      Right nsContextCert ->
+        bimap
+          (HardForkPerasErrorOneEraPerasError . OneEraPerasError)
+          injectHFCValidatedPerasCert
+          . hdistribute
+          . hcmap
+            proxySingle
+            ( \(Pair context' (WrapPerasCert cert')) ->
+                mkEitherF WrapPerasError id $
+                  verifyPerasCert context' cert'
+            )
+          $ nsContextCert
+
+  getPerasCertInBlock (HardForkBlock (OneEraBlock nsBlock)) =
+    bimap
+      (HardForkPerasErrorOneEraPerasError . OneEraPerasError)
+      (fmap OneEraPerasCert . hsequence')
+      . hdistribute
+      . hcmap
+        proxySingle
+        ( \(I block) ->
+            mkEitherF WrapPerasError (Comp . fmap WrapPerasCert) $
+              getPerasCertInBlock block
+        )
+      $ nsBlock
 
 {-------------------------------------------------------------------------------
   LedgerSupportsPeras

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Block.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Block.hs
@@ -20,6 +20,7 @@ module Ouroboros.Consensus.HardFork.Combinator.Block
   ( -- * Type family instances
     Header (..)
   , NestedCtxt_ (..)
+  , ConvertRawHash (..)
 
     -- * AnnTip
   , distribAnnTip

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Embed/Nary.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Embed/Nary.hs
@@ -240,13 +240,9 @@ instance Inject WrapChainDepState where
   inject = coerce .: injectHardForkState
 
 instance Inject PerasEpochContextResolver where
-  inject _iidx _ =
-    -- NOTE: we initially used:
-    -- @
-    --   PerasEpochContextResolverError "Not yet implemented for the HFC"
-    -- @
-    -- But the default below save us from having to update golden files twice.
-    PerasEpochContextResolver NoPerasEnabled NoPerasEnabled
+  inject iidx =
+    injectHFCPerasEpochContextResolver
+      . injectNS (forgetInjectionIndex iidx)
 
 instance Inject PerasState where
   inject iidx PerasState{..} =

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Embed/Unary.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Embed/Unary.hs
@@ -364,37 +364,27 @@ instance Isomorphic PerasState where
           case perasEpochContextResolver of
             PerasEpochContextResolverError err ->
               PerasEpochContextResolverError err
-            PerasEpochContextResolver _hfcCurrBoundedContext _hfcPrevBoundedContext ->
-              -- NOTE: we initially used:
-              -- @
-              --   PerasEpochContextResolverError "Not yet implemented for the HFC"
-              -- @
-              -- But the default below save us from having to update golden files twice.
-              --
-              -- This will be fixed after getting rid of the degenerate
-              -- 'BlockSupportsPeras' instance in Peras 65:
-              -- https://github.com/IntersectMBO/ouroboros-consensus/pull/2240
-              PerasEpochContextResolver NoPerasEnabled NoPerasEnabled
+            PerasEpochContextResolver hfcCurrBoundedContext hfcPrevBoundedContext ->
+              PerasEpochContextResolver
+                (fromZ . projectHFCBoundedPerasEpochContext <$> hfcCurrBoundedContext)
+                (fromZ . projectHFCBoundedPerasEpochContext <$> hfcPrevBoundedContext)
       , latestPerasCertOnChainRound =
           latestPerasCertOnChainRound
       }
+   where
+    fromZ :: NS f '[a] -> f a
+    fromZ (Z x) = x
 
   inject PerasState{..} =
     PerasState
       { perasEpochContextResolver =
-          -- NOTE: we initially used:
-          -- @
-          --   PerasEpochContextResolverError "Not yet implemented for the HFC"
-          -- @
-          -- But the default below save us from having to update golden files twice.
-          --
-          -- This will be fixed after getting rid of the degenerate
-          -- 'BlockSupportsPeras' instance in Peras 65:
-          -- https://github.com/IntersectMBO/ouroboros-consensus/pull/2240
-          PerasEpochContextResolver NoPerasEnabled NoPerasEnabled
+          injectHFCPerasEpochContextResolver (toZ perasEpochContextResolver)
       , latestPerasCertOnChainRound =
           latestPerasCertOnChainRound
       }
+   where
+    toZ :: f a -> NS f '[a]
+    toZ x = Z x
 
 instance Isomorphic (Flip ExtLedgerState mk) where
   project (Flip ExtLedgerState{..}) =

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Ledger.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Ledger.hs
@@ -50,6 +50,7 @@ module Ouroboros.Consensus.HardFork.Combinator.Ledger
 import Control.Monad (guard)
 import Control.Monad.Except (throwError, withExcept)
 import qualified Control.State.Transition.Extended as STS
+import Data.Bifunctor (bimap)
 import Data.Functor ((<&>))
 import Data.Functor.Product
 import Data.Kind (Type)
@@ -60,6 +61,7 @@ import Data.Proxy
 import Data.SOP.BasicFunctors
 import Data.SOP.Constraint
 import Data.SOP.Counting (getExactly)
+import Data.SOP.Either (hdistribute, mkEitherF)
 import Data.SOP.Functors (Flip (..))
 import Data.SOP.InPairs (InPairs (..))
 import qualified Data.SOP.InPairs as InPairs
@@ -91,8 +93,10 @@ import Ouroboros.Consensus.HardFork.Combinator.Translation
 import Ouroboros.Consensus.HardFork.History
   ( Bound (..)
   , EpochToPerasRoundInfo
+  , EraIndexed
   , EraParams
   , SafeZone (..)
+  , eraIndexedToNS
   , forgetEraIndex
   )
 import qualified Ouroboros.Consensus.HardFork.History as History
@@ -102,11 +106,7 @@ import Ouroboros.Consensus.Ledger.Inspect
 import Ouroboros.Consensus.Ledger.SupportsPeras (LedgerStateSupportsPeras (..))
 import Ouroboros.Consensus.Ledger.SupportsProtocol
 import Ouroboros.Consensus.Ledger.Tables.Utils
-import Ouroboros.Consensus.Peras.Context
-  ( StateSupportsPerasEpochContext (..)
-  , mkBoundedPerasEpochContextWith
-  )
-import Ouroboros.Consensus.Peras.Voting.Mock (mkMockPerasVotingCommitteeInput)
+import Ouroboros.Consensus.Peras.Context (StateSupportsPerasEpochContext (..))
 import Ouroboros.Consensus.TypeFamilyWrappers
 import Ouroboros.Consensus.Util.Condense
 import Ouroboros.Consensus.Util.IndexedMemPack (IndexedMemPack)
@@ -347,16 +347,36 @@ instance
       . State.tip
       . tickedHardForkLedgerStatePerEra
 
--- TODO: this instance will have a full implementation as soon as we remove the
--- degenerate 'BlockSupportsPeras' instance.
 instance
   CanHardFork xs =>
   StateSupportsPerasEpochContext (HardForkBlock xs)
   where
-  type MaybeEraIndexedEpochToPerasRoundInfo (HardForkBlock xs) = EpochToPerasRoundInfo
-  fromMaybeEraIndexedEpochToPerasRoundInfo _ = id
-  toMaybeEraIndexedEpochToPerasRoundInfo _ = forgetEraIndex
-  mkBoundedPerasEpochContext = mkBoundedPerasEpochContextWith mkMockPerasVotingCommitteeInput
+  type
+    MaybeEraIndexedEpochToPerasRoundInfo (HardForkBlock xs) =
+      EraIndexed xs EpochToPerasRoundInfo
+
+  fromMaybeEraIndexedEpochToPerasRoundInfo _ = forgetEraIndex
+  toMaybeEraIndexedEpochToPerasRoundInfo _ = id
+
+  mkBoundedPerasEpochContext epochToPerasRoundInfo ledgerState headerState =
+    bimap
+      (HardForkPerasErrorOneEraPerasError . OneEraPerasError)
+      injectHFCBoundedPerasEpochContext
+      ( hdistribute
+          . hcmap
+            proxySingle
+            ( \_ ->
+                mkEitherF WrapPerasError id $
+                  mkBoundedPerasEpochContext
+                    ( fromMaybeEraIndexedEpochToPerasRoundInfo
+                        (Proxy @(HardForkBlock xs))
+                        epochToPerasRoundInfo
+                    )
+                    ledgerState
+                    headerState
+            )
+          $ eraIndexedToNS epochToPerasRoundInfo
+      )
 
 {-------------------------------------------------------------------------------
   HeaderValidation

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Serialisation/Common.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Serialisation/Common.hs
@@ -104,6 +104,7 @@ import Ouroboros.Consensus.HardFork.Combinator.State.Instances
 import Ouroboros.Consensus.Ledger.Query
 import Ouroboros.Consensus.Node.NetworkProtocolVersion
 import Ouroboros.Consensus.Node.Run
+import Ouroboros.Consensus.Node.Serialisation (SerialiseNodeToNode)
 import Ouroboros.Consensus.Storage.Serialisation
 import Ouroboros.Consensus.TypeFamilyWrappers
 import Ouroboros.Network.Block (Serialised)
@@ -205,6 +206,9 @@ class
   , LedgerDbSerialiseConstraints (HardForkBlock xs)
   , VolatileDbSerialiseConstraints (HardForkBlock xs)
   , EncodeDiskDep (NestedCtxt Header) (HardForkBlock xs)
+  , -- Required for Peras
+    SerialiseNodeToNode (HardForkBlock xs) (PerasVote (HardForkBlock xs))
+  , SerialiseNodeToNode (HardForkBlock xs) (PerasCert (HardForkBlock xs))
   ) =>
   SerialiseHFC xs
   where

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Serialisation/SerialiseNodeToNode.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Serialisation/SerialiseNodeToNode.hs
@@ -164,3 +164,21 @@ instance
   where
   encodeNodeToNode = dispatchEncoder `after` (getOneEraGenTxId . getHardForkGenTxId)
   decodeNodeToNode = fmap (HardForkGenTxId . OneEraGenTxId) .: dispatchDecoder
+
+{-------------------------------------------------------------------------------
+  Peras
+-------------------------------------------------------------------------------}
+
+instance
+  SerialiseHFC xs =>
+  SerialiseNodeToNode (HardForkBlock xs) (OneEraPerasVote xs)
+  where
+  encodeNodeToNode = dispatchEncoder `after` getOneEraPerasVote
+  decodeNodeToNode = fmap OneEraPerasVote .: dispatchDecoder
+
+instance
+  SerialiseHFC xs =>
+  SerialiseNodeToNode (HardForkBlock xs) (OneEraPerasCert xs)
+  where
+  encodeNodeToNode = dispatchEncoder `after` getOneEraPerasCert
+  decodeNodeToNode = fmap OneEraPerasCert .: dispatchDecoder

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Dual.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Dual.hs
@@ -62,7 +62,7 @@ module Ouroboros.Consensus.Ledger.Dual
   , encodeDualLedgerState
   ) where
 
-import Cardano.Binary (enforceSize)
+import Cardano.Binary (FromCBOR, ToCBOR, enforceSize)
 import Codec.CBOR.Decoding (Decoder)
 import Codec.CBOR.Encoding (Encoding, encodeListLen)
 import Codec.Serialise
@@ -270,6 +270,12 @@ class
   , Serialise (BridgeLedger m a)
   , Serialise (BridgeBlock m a)
   , Serialise (BridgeTx m a)
+  , -- Requirements for Peras epoch context
+    Show (PerasEpochContext (DualBlock m a))
+  , Eq (PerasEpochContext (DualBlock m a))
+  , NoThunks (PerasEpochContext (DualBlock m a))
+  , FromCBOR (PerasEpochContext (DualBlock m a))
+  , ToCBOR (PerasEpochContext (DualBlock m a))
   , Show (BridgeTx m a)
   ) =>
   Bridge m a
@@ -537,13 +543,6 @@ dualExtValidationErrorMain = \case
   ExtValidationErrorLedger e -> ExtValidationErrorLedger (dualLedgerErrorMain e)
   ExtValidationErrorHeader e -> ExtValidationErrorHeader (castHeaderError e)
   ExtValidationErrorPerasEpochContextResolver e -> ExtValidationErrorPerasEpochContextResolver e
-  -- NOTE: this will become an impossible case for the dual block after removing
-  -- the degenerate 'BlockSupportsPeras' instance, since:
-  -- @
-  --   PerasError (DualBlock m a) ~ VoidPerasError (DualBlock m a) ~ Void
-  -- @
-  ExtValidationErrorPerasCertInBlock _ ->
-    error "dualExtValidationErrorMain: impossible error for dual block"
 
 {-------------------------------------------------------------------------------
   LedgerSupportsProtocol
@@ -1231,3 +1230,21 @@ instance
   toMaybeEraIndexedEpochToPerasRoundInfo _ = forgetEraIndex
   fromMaybeEraIndexedEpochToPerasRoundInfo _ = id
   mkBoundedPerasEpochContext = error "mkBoundedPerasEpochContext: DualBlock does not support Peras"
+
+instance
+  ( StandardHash m
+  , Typeable m
+  , Typeable a
+  ) =>
+  BlockSupportsPeras (DualBlock m a)
+  where
+  type PerasVote (DualBlock m a) = VoidPerasVote (DualBlock m a)
+  type PerasCert (DualBlock m a) = VoidPerasCert (DualBlock m a)
+  type PerasError (DualBlock m a) = VoidPerasError (DualBlock m a)
+  type PerasCrypto (DualBlock m a) = VoidPerasCrypto (DualBlock m a)
+  type PerasVotingCommitteeScheme (DualBlock m a) = VoidPerasVotingCommitteeScheme
+  forgePerasVoteIfEligible = defaultForgePerasVoteIfEligible
+  verifyPerasVote = defaultVerifyPerasVote
+  forgePerasCert = defaultForgePerasCert
+  verifyPerasCert = defaultVerifyPerasCert
+  getPerasCertInBlock _ = Right Nothing

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Extended.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Extended.hs
@@ -42,6 +42,7 @@ import Codec.CBOR.Decoding (Decoder, decodeListLen)
 import Codec.CBOR.Encoding (Encoding, encodeListLen)
 import Control.DeepSeq (NFData)
 import Control.Monad.Except
+import Control.Monad.Trans.Except (except)
 import Data.Functor ((<&>))
 import Data.Maybe.Strict (StrictMaybe (..))
 import Data.Proxy
@@ -64,7 +65,6 @@ import Ouroboros.Consensus.Block.Abstract
 import Ouroboros.Consensus.Block.SupportsPeras
   ( BlockSupportsPeras (..)
   , IsPerasCert (..)
-  , PerasWeight (..)
   , ValidatedPerasCert (..)
   , pattern NoPerasEnabled
   )
@@ -81,6 +81,7 @@ import Ouroboros.Consensus.Peras.Context
   , PerasEpochContextResolverHandle (..)
   , StateSupportsPerasEpochContext (..)
   , initPerasEpochContextResolver
+  , resolveRoundNo
   , tickPerasEpochContextResolver
   )
 import Ouroboros.Consensus.Protocol.Abstract
@@ -333,27 +334,39 @@ applyHelper f opts cfg blk TickedExtLedgerState{..} = do
 
 -- | Extract and validate a Peras certificate from a block, if it exists.
 --
--- NOTE: this is a placeholder until we get rid of the degenerate
--- 'BlockSupportsPeras' instance.
+-- This can fail in several ways:
+-- 1. The block contains a Peras certificate that cannot be deserialized (temporary).
+-- 2. The certificate claims to be from a round we cannot resolve.
+-- 3. The certificate is invalid in the epoch resolved for its round.
 extractAndValidatePerasCertFromBlock ::
   forall blk.
   BlockSupportsPeras blk =>
   PerasEpochContextResolver blk ->
   blk ->
   Except (LedgerErr ExtLedgerState blk) (Maybe (ValidatedPerasCert blk))
-extractAndValidatePerasCertFromBlock _ blk = do
-  case getPerasCertInBlock blk of
-    Left err ->
-      throwError (ExtValidationErrorPerasCertInBlock err)
-    Right Nothing ->
+extractAndValidatePerasCertFromBlock perasResolver blk = do
+  getPerasCertInBlockOrFail blk >>= \case
+    Nothing ->
       pure Nothing
-    Right (Just cert) -> do
-      pure $
-        Just
-          ValidatedPerasCert
-            { vpcCert = cert
-            , vpcCertBoost = PerasWeight 0
-            }
+    Just cert -> do
+      let roundNo = getPerasCertRound cert
+      context <- resolveRoundNoOrFail roundNo
+      Just <$> verifyPerasCertOrFail context cert
+ where
+  getPerasCertInBlockOrFail =
+    withExcept ExtValidationErrorPerasCertInBlock
+      . except
+      . getPerasCertInBlock
+
+  resolveRoundNoOrFail =
+    withExcept ExtValidationErrorPerasEpochContextResolver
+      . except
+      . resolveRoundNo perasResolver
+
+  verifyPerasCertOrFail context =
+    withExcept ExtValidationErrorPerasCertInBlock
+      . except
+      . verifyPerasCert context
 
 instance
   ( GetBlockKeySets blk

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ChainSync/Client.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ChainSync/Client.hs
@@ -344,6 +344,7 @@ bracketChainSyncClient ::
   ( IOLike m
   , Ord peer
   , LedgerSupportsProtocol blk
+  , BlockSupportsPeras blk
   , MonadTimer m
   ) =>
   Tracer m (TraceChainSyncClientEvent blk) ->
@@ -856,6 +857,7 @@ chainSyncClient ::
   forall m blk.
   ( IOLike m
   , LedgerSupportsProtocol blk
+  , BlockSupportsPeras blk
   ) =>
   ConfigEnv m blk ->
   DynamicEnv m blk ->
@@ -999,6 +1001,7 @@ findIntersectionTop ::
   forall m blk arrival judgment.
   ( IOLike m
   , LedgerSupportsProtocol blk
+  , BlockSupportsPeras blk
   ) =>
   ConfigEnv m blk ->
   DynamicEnv m blk ->
@@ -1195,6 +1198,7 @@ knownIntersectionStateTop ::
   forall m blk arrival judgment.
   ( IOLike m
   , LedgerSupportsProtocol blk
+  , BlockSupportsPeras blk
   ) =>
   ConfigEnv m blk ->
   DynamicEnv m blk ->
@@ -1649,6 +1653,7 @@ checkKnownInvalid ::
   forall m blk arrival judgment.
   ( IOLike m
   , LedgerSupportsProtocol blk
+  , BlockSupportsPeras blk
   ) =>
   ConfigEnv m blk ->
   DynamicEnv m blk ->
@@ -1708,6 +1713,7 @@ checkTime ::
   forall m blk arrival judgment.
   ( IOLike m
   , LedgerSupportsProtocol blk
+  , BlockSupportsPeras blk
   ) =>
   ConfigEnv m blk ->
   DynamicEnv m blk ->
@@ -2098,6 +2104,7 @@ invalidBlockRejector ::
   forall m blk.
   ( IOLike m
   , LedgerSupportsProtocol blk
+  , BlockSupportsPeras blk
   ) =>
   Tracer m (TraceChainSyncClientEvent blk) ->
   NodeToNodeVersion ->
@@ -2287,7 +2294,9 @@ data ChainSyncClientException
       -- We store the intersection point the upstream node sent us.
       (Their (Tip blk))
   | forall blk.
-    LedgerSupportsProtocol blk =>
+    ( LedgerSupportsProtocol blk
+    , BlockSupportsPeras blk
+    ) =>
     InvalidBlock
       -- | Block that triggered the validity check.
       (Point blk)

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ObjectDiffusion/ObjectPool/PerasCert.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ObjectDiffusion/ObjectPool/PerasCert.hs
@@ -16,8 +16,12 @@ import Data.Foldable (traverse_)
 import Data.Map (Map)
 import qualified Data.Map as Map
 import qualified Data.Set as Set
-import Data.Typeable (Typeable)
-import Ouroboros.Consensus.Block
+import Ouroboros.Consensus.Block.SupportsPeras
+  ( BlockSupportsPeras (..)
+  , IsPerasCert (..)
+  , PerasRoundNo
+  , ValidatedPerasCert (..)
+  )
 import Ouroboros.Consensus.BlockchainTime.WallClock.Types
   ( SystemTime (..)
   , WithArrivalTime (..)
@@ -49,7 +53,9 @@ takeAscMap n = Map.fromDistinctAscList . take n . Map.toAscList
 
 -- | Internal helper: create a pool reader from a @getCertsAfter@ function.
 makePerasCertPoolReader ::
-  IOLike m =>
+  ( IOLike m
+  , IsPerasCert (PerasCert blk) blk
+  ) =>
   ( PerasCertTicketNo ->
     STM m (Map PerasCertTicketNo (m (WithArrivalTime (ValidatedPerasCert blk))))
   ) ->
@@ -70,7 +76,9 @@ makePerasCertPoolReader getCertsAfterSTM =
     }
 
 makeTestPerasCertPoolReaderFromCertDB ::
-  IOLike m =>
+  ( IOLike m
+  , IsPerasCert (PerasCert blk) blk
+  ) =>
   PerasCertDB m blk ->
   ObjectPoolReader PerasRoundNo (PerasCert blk) PerasCertTicketNo m
 makeTestPerasCertPoolReaderFromCertDB perasCertDB =
@@ -78,7 +86,9 @@ makeTestPerasCertPoolReaderFromCertDB perasCertDB =
     (PerasCertDB.getCertsAfter perasCertDB)
 
 makePerasCertPoolReaderFromChainDB ::
-  IOLike m =>
+  ( IOLike m
+  , IsPerasCert (PerasCert blk) blk
+  ) =>
   ChainDB m blk ->
   ObjectPoolReader PerasRoundNo (PerasCert blk) PerasCertTicketNo m
 makePerasCertPoolReaderFromChainDB chainDB =
@@ -94,7 +104,9 @@ makePerasCertPoolReaderFromChainDB chainDB =
 -- see 'makePerasCertPoolWriterFromChainDB' which creates a pool writer from the
 -- 'ChainDB' with proper handling of chain selection side-effects.
 makeTestPerasCertPoolWriterFromCertDB ::
-  (StandardHash blk, Typeable blk, IOLike m) =>
+  ( IOLike m
+  , BlockSupportsPeras blk
+  ) =>
   SystemTime m ->
   PerasCertDB m blk ->
   PerasEpochContextResolverHandle m blk ->
@@ -122,7 +134,9 @@ makeTestPerasCertPoolWriterFromCertDB systemTime perasCertDB resolverHandle =
 -- | Create a pool writer from the 'ChainDB'. This properly handles any needed
 -- chain selection side-effects.
 makePerasCertPoolWriterFromChainDB ::
-  (StandardHash blk, Typeable blk, IOLike m) =>
+  ( IOLike m
+  , BlockSupportsPeras blk
+  ) =>
   SystemTime m ->
   ChainDB m blk ->
   ObjectPoolWriter PerasRoundNo (PerasCert blk) m

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ObjectDiffusion/ObjectPool/PerasVote.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/MiniProtocol/ObjectDiffusion/ObjectPool/PerasVote.hs
@@ -16,8 +16,13 @@ import Data.Foldable (traverse_)
 import Data.Map (Map)
 import qualified Data.Map as Map
 import qualified Data.Set as Set
-import Data.Typeable (Typeable)
-import Ouroboros.Consensus.Block
+import Ouroboros.Consensus.Block.SupportsPeras
+  ( BlockSupportsPeras (..)
+  , IsPerasVote
+  , PerasVoteId
+  , ValidatedPerasVote (..)
+  , getPerasVoteId
+  )
 import Ouroboros.Consensus.BlockchainTime.WallClock.Types
   ( SystemTime (..)
   , WithArrivalTime (..)
@@ -49,7 +54,9 @@ takeAscMap n = Map.fromDistinctAscList . take n . Map.toAscList
 
 -- | Internal helper: create a pool reader from a @getVotesAfter@ function.
 makePerasVotePoolReader ::
-  IOLike m =>
+  ( IOLike m
+  , IsPerasVote (PerasVote blk) blk
+  ) =>
   ( PerasVoteTicketNo ->
     STM m (Map PerasVoteTicketNo (WithArrivalTime (ValidatedPerasVote blk)))
   ) ->
@@ -68,7 +75,9 @@ makePerasVotePoolReader getVotesAfterSTM =
     }
 
 makeTestPerasVotePoolReaderFromVoteDB ::
-  IOLike m =>
+  ( IOLike m
+  , IsPerasVote (PerasVote blk) blk
+  ) =>
   PerasVoteDB m blk ->
   ObjectPoolReader PerasVoteId (PerasVote blk) PerasVoteTicketNo m
 makeTestPerasVotePoolReaderFromVoteDB perasVoteDB =
@@ -76,7 +85,9 @@ makeTestPerasVotePoolReaderFromVoteDB perasVoteDB =
     (PerasVoteDB.getVotesAfter perasVoteDB)
 
 makePerasVotePoolReaderFromChainDB ::
-  IOLike m =>
+  ( IOLike m
+  , IsPerasVote (PerasVote blk) blk
+  ) =>
   ChainDB m blk ->
   ObjectPoolReader PerasVoteId (PerasVote blk) PerasVoteTicketNo m
 makePerasVotePoolReaderFromChainDB chainDB =
@@ -94,7 +105,9 @@ makePerasVotePoolReaderFromChainDB chainDB =
 -- see 'makePerasVotePoolWriterFromChainDB' which creates a pool writer from the
 -- 'ChainDB' and thus properly handles the produced certs.
 makeTestPerasVotePoolWriterFromVoteDB ::
-  (StandardHash blk, Typeable blk, IOLike m) =>
+  ( IOLike m
+  , BlockSupportsPeras blk
+  ) =>
   SystemTime m ->
   PerasVoteDB m blk ->
   PerasEpochContextResolverHandle m blk ->
@@ -123,7 +136,9 @@ makeTestPerasVotePoolWriterFromVoteDB systemTime perasVoteDB resolverHandle =
 -- This properly handles the produced certs by letting the ChainDB take care
 -- of them (see 'ChainDB.addPerasVoteWithAsyncCertHandling').
 makePerasVotePoolWriterFromChainDB ::
-  (StandardHash blk, Typeable blk, IOLike m) =>
+  ( IOLike m
+  , BlockSupportsPeras blk
+  ) =>
   SystemTime m ->
   ChainDB m blk ->
   ObjectPoolWriter PerasVoteId (PerasVote blk) m

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Node/Run.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Node/Run.hs
@@ -115,6 +115,7 @@ class
   , NodeInitStorage blk
   , BlockSupportsMetrics blk
   , BlockSupportsDiffusionPipelining blk
+  , BlockSupportsPeras blk
   , StateSupportsPerasEpochContext blk
   , BlockSupportsSanityCheck blk
   , Show (CannotForge blk)

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Node/Serialisation.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Node/Serialisation.hs
@@ -4,7 +4,6 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RecordWildCards #-}
@@ -42,9 +41,9 @@ import Codec.CBOR.Decoding (Decoder, decodeListLenOf)
 import Codec.CBOR.Encoding (Encoding, encodeListLen)
 import Codec.Serialise (Serialise (decode, encode))
 import Data.Kind
-import qualified Data.List.NonEmpty as NonEmpty
 import Data.SOP.BasicFunctors
-import qualified Data.Set.NonEmpty as NESet
+import Data.Typeable (Typeable)
+import Data.Void (absurd)
 import Ouroboros.Consensus.Block
 import Ouroboros.Consensus.Ledger.Abstract
 import Ouroboros.Consensus.Ledger.SupportsMempool
@@ -52,8 +51,8 @@ import Ouroboros.Consensus.Ledger.SupportsMempool
   , GenTxId
   )
 import Ouroboros.Consensus.Node.NetworkProtocolVersion
-import Ouroboros.Consensus.Peras.Cert.Mock (MockPerasCert (..))
-import Ouroboros.Consensus.Peras.Vote.Mock (MockPerasVote (..))
+import qualified Ouroboros.Consensus.Peras.Cert.V1 as V1
+import qualified Ouroboros.Consensus.Peras.Vote.V1 as V1
 import Ouroboros.Consensus.TypeFamilyWrappers
 import Ouroboros.Consensus.Util (Some (..))
 import Ouroboros.Network.Block
@@ -190,6 +189,14 @@ deriving newtype instance
   SerialiseNodeToNode blk (GenTxId blk) =>
   SerialiseNodeToNode blk (WrapGenTxId blk)
 
+deriving newtype instance
+  SerialiseNodeToNode blk (PerasVote blk) =>
+  SerialiseNodeToNode blk (WrapPerasVote blk)
+
+deriving newtype instance
+  SerialiseNodeToNode blk (PerasCert blk) =>
+  SerialiseNodeToNode blk (WrapPerasCert blk)
+
 instance ConvertRawHash blk => SerialiseNodeToNode blk (Point blk) where
   encodeNodeToNode _ccfg _version = encodePoint $ encodeRawHash (Proxy @blk)
   decodeNodeToNode _ccfg _version = decodePoint $ decodeRawHash (Proxy @blk)
@@ -206,72 +213,6 @@ instance SerialiseNodeToNode blk PerasSeatIndex where
   encodeNodeToNode _ccfg _version = toCBOR . unPerasSeatIndex
   decodeNodeToNode _ccfg _version = PerasSeatIndex <$> fromCBOR
 
--- NOTE: currently defined here to avoid a cyclic module dependency.
--- To be moved next to its corresponding type definition.
-instance
-  ConvertRawHash blk =>
-  SerialiseNodeToNode blk (MockPerasVote blk)
-  where
-  encodeNodeToNode
-    ccfg
-    version
-    MockPerasVote
-      { mockVoteRound
-      , mockVoteBlock
-      , mockVoteSeatIndex
-      } =
-      encodeListLen 3
-        <> encodeNodeToNode ccfg version mockVoteRound
-        <> encodeNodeToNode ccfg version mockVoteBlock
-        <> encodeNodeToNode ccfg version mockVoteSeatIndex
-  decodeNodeToNode ccfg version = do
-    decodeListLenOf 3
-    mockVoteRound <- decodeNodeToNode ccfg version
-    mockVoteBlock <- decodeNodeToNode ccfg version
-    mockVoteSeatIndex <- decodeNodeToNode ccfg version
-    pure
-      MockPerasVote
-        { mockVoteRound
-        , mockVoteBlock
-        , mockVoteSeatIndex
-        }
-
--- NOTE: currently defined here to avoid a cyclic module dependency.
--- To be moved next to its corresponding type definition.
-instance
-  ConvertRawHash blk =>
-  SerialiseNodeToNode blk (MockPerasCert blk)
-  where
-  encodeNodeToNode
-    ccfg
-    version
-    MockPerasCert
-      { mockCertRound
-      , mockCertBlock
-      , mockCertVoters
-      } =
-      encodeListLen 3
-        <> encodeNodeToNode ccfg version mockCertRound
-        <> encodeNodeToNode ccfg version mockCertBlock
-        <> toCBOR (NonEmpty.toList (NESet.toList mockCertVoters))
-  decodeNodeToNode ccfg version = do
-    decodeListLenOf 3
-    mockCertRound <- decodeNodeToNode ccfg version
-    mockCertBlock <- decodeNodeToNode ccfg version
-    mockCertVoters <- decodeNodeToNodeNonEmptySet ccfg version
-    pure
-      MockPerasCert
-        { mockCertRound
-        , mockCertBlock
-        , mockCertVoters
-        }
-   where
-    decodeNodeToNodeNonEmptySet _ccfg _version = do
-      xs <- fromCBOR
-      case NonEmpty.nonEmpty xs of
-        Nothing -> fail "Expected a non-empty set of PerasSeatIndex"
-        Just neSet -> pure (NESet.fromList neSet)
-
 instance SerialiseNodeToNode blk PerasVoteId where
   -- Consistent with the 'Serialise' instance for 'PerasVoteId' defined in Ouroboros.Consensus.Block.SupportsPeras
   encodeNodeToNode ccfg version PerasVoteId{..} =
@@ -283,6 +224,22 @@ instance SerialiseNodeToNode blk PerasVoteId where
     pviRoundNo <- decodeNodeToNode ccfg version
     pviSeatIndex <- decodeNodeToNode ccfg version
     pure $ PerasVoteId pviRoundNo pviSeatIndex
+
+instance SerialiseNodeToNode blk (VoidPerasVote blk) where
+  encodeNodeToNode _ _ = absurd . unVoidPerasVote
+  decodeNodeToNode _ _ = fail "VoidPerasVote cannot be decoded"
+
+instance SerialiseNodeToNode blk (VoidPerasCert blk) where
+  encodeNodeToNode _ _ = absurd . unVoidPerasCert
+  decodeNodeToNode _ _ = fail "VoidPerasCert cannot be decoded"
+
+instance Typeable tag => SerialiseNodeToNode blk (V1.PerasVote tag) where
+  encodeNodeToNode _ccfg _version = toCBOR
+  decodeNodeToNode _ccfg _version = fromCBOR
+
+instance Typeable tag => SerialiseNodeToNode blk (V1.PerasCert tag) where
+  encodeNodeToNode _ccfg _version = toCBOR
+  decodeNodeToNode _ccfg _version = fromCBOR
 
 deriving newtype instance
   SerialiseNodeToClient blk (GenTxId blk) =>

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Peras/Cert/Mock.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Peras/Cert/Mock.hs
@@ -34,9 +34,11 @@ import Data.Typeable (Typeable)
 import GHC.Generics (Generic)
 import NoThunks.Class (NoThunks)
 import Ouroboros.Consensus.Block.Abstract
-  ( Point
+  ( ConvertRawHash
+  , Point
   , StandardHash
   )
+import Ouroboros.Consensus.Node.Serialisation (SerialiseNodeToNode (..))
 import Ouroboros.Consensus.Peras.Cert.Class (IsPerasCert (..))
 import Ouroboros.Consensus.Peras.Types
   ( BoostedBlock
@@ -112,6 +114,40 @@ instance
         <> toCBOR mockCertRound
         <> toCBOR mockCertBlock
         <> toCBOR (NonEmpty.toList (NESet.toList mockCertVoters))
+
+instance
+  ConvertRawHash blk =>
+  SerialiseNodeToNode blk (MockPerasCert blk)
+  where
+  encodeNodeToNode
+    ccfg
+    version
+    MockPerasCert
+      { mockCertRound
+      , mockCertBlock
+      , mockCertVoters
+      } =
+      encodeListLen 3
+        <> encodeNodeToNode ccfg version mockCertRound
+        <> encodeNodeToNode ccfg version mockCertBlock
+        <> toCBOR (NonEmpty.toList (NESet.toList mockCertVoters))
+  decodeNodeToNode ccfg version = do
+    decodeListLenOf 3
+    mockCertRound <- decodeNodeToNode ccfg version
+    mockCertBlock <- decodeNodeToNode ccfg version
+    mockCertVoters <- decodeNodeToNodeNonEmptySet ccfg version
+    pure
+      MockPerasCert
+        { mockCertRound
+        , mockCertBlock
+        , mockCertVoters
+        }
+   where
+    decodeNodeToNodeNonEmptySet _ccfg _version = do
+      xs <- fromCBOR
+      case NonEmpty.nonEmpty xs of
+        Nothing -> fail "Expected a non-empty set of PerasSeatIndex"
+        Just neSet -> pure (NESet.fromList neSet)
 
 -- * Orphan instances
 

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Peras/Context.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Peras/Context.hs
@@ -16,9 +16,6 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
--- TODO: remove this after getting rid of the degenerate 'BlockSupportsPeras'
--- instance that renders some of the constraints here redundant.
-{-# OPTIONS_GHC -Wno-redundant-constraints #-}
 
 module Ouroboros.Consensus.Peras.Context
   ( -- * Bounded Peras epoch context
@@ -89,8 +86,10 @@ import Ouroboros.Consensus.Block.SupportsPeras
   , IsPerasCert (..)
   , IsPerasError (..)
   , IsPerasVote (..)
+  , PerasCert
   , PerasEpochContext (..)
   , PerasRoundNo
+  , PerasVote
   , PerasVotingCommittee
   , PerasVotingCommitteeInput
   , ValidatedPerasCert

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Peras/Error/Mock.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Peras/Error/Mock.hs
@@ -17,26 +17,41 @@ import Control.Exception (Exception)
 import Data.Typeable (Typeable)
 import GHC.Generics (Generic)
 import NoThunks.Class (NoThunks)
-import Ouroboros.Consensus.Committee.Types (VoteWeight)
-import Ouroboros.Consensus.Peras.Crypto.Mock
-  ( MockPerasCrypto
-  , MockPerasVotingCommitteeScheme
-  , VotingCommitteeError
+import Ouroboros.Consensus.Block.SupportsPeras
+  ( IsPerasError (..)
+  , PerasVotingCommitteeError
+  , VoteWeight
   )
 import Ouroboros.Consensus.Peras.Voting.Adapter (PerasConversionError)
 
 -- | Collection of voting-related errors for Peras
 data MockPerasError blk
   = PerasVotingCommitteeError
-      (VotingCommitteeError (MockPerasCrypto blk) (MockPerasVotingCommitteeScheme blk))
+      (PerasVotingCommitteeError blk)
   | PerasVotingConversionError
       PerasConversionError
   | PerasQuorumNotReachedError
       VoteWeight
   | InputStakeDistrIsEmpty
 
-deriving instance Show (MockPerasError blk)
-deriving instance Eq (MockPerasError blk)
-deriving instance NoThunks (MockPerasError blk)
-deriving instance Generic (MockPerasError blk)
-deriving instance Typeable blk => Exception (MockPerasError blk)
+deriving instance
+  Show (PerasVotingCommitteeError blk) =>
+  Show (MockPerasError blk)
+deriving instance
+  Eq (PerasVotingCommitteeError blk) =>
+  Eq (MockPerasError blk)
+deriving instance
+  NoThunks (PerasVotingCommitteeError blk) =>
+  NoThunks (MockPerasError blk)
+deriving instance
+  Generic (MockPerasError blk)
+deriving instance
+  ( Typeable blk
+  , Show (PerasVotingCommitteeError blk)
+  ) =>
+  Exception (MockPerasError blk)
+
+instance IsPerasError (MockPerasError blk) blk where
+  injectVotingCommitteeError = PerasVotingCommitteeError
+  injectConversionError = PerasVotingConversionError
+  injectQuorumNotReachedError = PerasQuorumNotReachedError

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Peras/Vote/Mock.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Peras/Vote/Mock.hs
@@ -23,9 +23,11 @@ import Data.Typeable (Typeable)
 import GHC.Generics (Generic)
 import NoThunks.Class (NoThunks)
 import Ouroboros.Consensus.Block.Abstract
-  ( Point
+  ( ConvertRawHash
+  , Point
   , StandardHash
   )
+import Ouroboros.Consensus.Node.Serialisation (SerialiseNodeToNode (..))
 import Ouroboros.Consensus.Peras.Types
   ( BoostedBlock
   , PerasRoundNo
@@ -96,3 +98,31 @@ instance
         <> toCBOR mockVoteRound
         <> toCBOR mockVoteBlock
         <> toCBOR mockVoteSeatIndex
+
+instance
+  ConvertRawHash blk =>
+  SerialiseNodeToNode blk (MockPerasVote blk)
+  where
+  encodeNodeToNode
+    ccfg
+    version
+    MockPerasVote
+      { mockVoteRound
+      , mockVoteBlock
+      , mockVoteSeatIndex
+      } =
+      encodeListLen 3
+        <> encodeNodeToNode ccfg version mockVoteRound
+        <> encodeNodeToNode ccfg version mockVoteBlock
+        <> encodeNodeToNode ccfg version mockVoteSeatIndex
+  decodeNodeToNode ccfg version = do
+    decodeListLenOf 3
+    mockVoteRound <- decodeNodeToNode ccfg version
+    mockVoteBlock <- decodeNodeToNode ccfg version
+    mockVoteSeatIndex <- decodeNodeToNode ccfg version
+    pure
+      MockPerasVote
+        { mockVoteRound
+        , mockVoteBlock
+        , mockVoteSeatIndex
+        }

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Peras/Voting/Mock.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Peras/Voting/Mock.hs
@@ -1,8 +1,5 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TypeOperators #-}
--- TODO: remove this once we we get rid of the degenerate 'BlockSupportsPeras'
--- instance making the equality constraint below redundant.
-{-# OPTIONS_GHC -Wno-redundant-constraints #-}
 
 module Ouroboros.Consensus.Peras.Voting.Mock
   ( mkMockPerasVotingCommitteeInput

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl.hs
@@ -107,6 +107,7 @@ withDB ::
   , LedgerSupportsProtocol blk
   , StateSupportsPerasEpochContext blk
   , BlockSupportsDiffusionPipelining blk
+  , BlockSupportsPeras blk
   , InspectLedger blk
   , ConvertRawHash blk
   , SerialiseDiskConstraints blk
@@ -123,6 +124,7 @@ openDB ::
   , LedgerSupportsProtocol blk
   , StateSupportsPerasEpochContext blk
   , BlockSupportsDiffusionPipelining blk
+  , BlockSupportsPeras blk
   , InspectLedger blk
   , ConvertRawHash blk
   , SerialiseDiskConstraints blk
@@ -138,6 +140,7 @@ openDBInternal ::
   , LedgerSupportsProtocol blk
   , StateSupportsPerasEpochContext blk
   , BlockSupportsDiffusionPipelining blk
+  , BlockSupportsPeras blk
   , InspectLedger blk
   , ConvertRawHash blk
   , SerialiseDiskConstraints blk

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Background.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Background.hs
@@ -96,6 +96,7 @@ import System.Random
 launchBgTasks ::
   forall m blk.
   ( IOLike m
+  , IsPerasCert (PerasCert blk) blk
   , LedgerSupportsProtocol blk
   , BlockSupportsDiffusionPipelining blk
   , InspectLedger blk
@@ -659,6 +660,7 @@ dumpGcSchedule (GcSchedule varQueue) = toList <$> readTVar varQueue
 -- ChainDB.
 addBlockRunner ::
   ( IOLike m
+  , IsPerasCert (PerasCert blk) blk
   , LedgerSupportsProtocol blk
   , BlockSupportsDiffusionPipelining blk
   , InspectLedger blk

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/ChainSel.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/ChainSel.hs
@@ -301,7 +301,9 @@ addBlockAsync CDB{cdbTracer, cdbChainSelQueue} =
 
 addPerasCertAsync ::
   forall m blk.
-  IOLike m =>
+  ( IOLike m
+  , IsPerasCert (PerasCert blk) blk
+  ) =>
   ChainDbEnv m blk ->
   WithArrivalTime (ValidatedPerasCert blk) ->
   m (AddPerasCertPromise m)
@@ -313,7 +315,9 @@ addPerasCertAsync CDB{cdbTracer, cdbChainSelQueue} =
 -- the ChainDB as well.
 addPerasVoteWithAsyncCertHandling ::
   forall m blk.
-  IOLike m =>
+  ( IOLike m
+  , IsPerasCert (PerasCert blk) blk
+  ) =>
   ChainDbEnv m blk ->
   WithArrivalTime (ValidatedPerasVote blk) ->
   m (AddPerasVoteResult blk, Maybe (AddPerasCertPromise m))
@@ -346,6 +350,7 @@ triggerChainSelectionAsync CDB{cdbTracer, cdbChainSelQueue} =
 chainSelSync ::
   forall m blk.
   ( IOLike m
+  , IsPerasCert (PerasCert blk) blk
   , LedgerSupportsProtocol blk
   , BlockSupportsDiffusionPipelining blk
   , InspectLedger blk

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Types.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl/Types.hs
@@ -393,7 +393,11 @@ data ChainDbEnv m blk = CDB
 -- (but avoid including @m@ because we cannot impose @Typeable m@ as a
 -- constraint and still have it work with the simulator)
 instance
-  (IOLike m, LedgerSupportsProtocol blk, BlockSupportsDiffusionPipelining blk) =>
+  ( IOLike m
+  , LedgerSupportsProtocol blk
+  , BlockSupportsPeras blk
+  , BlockSupportsDiffusionPipelining blk
+  ) =>
   NoThunks (ChainDbEnv m blk)
   where
   showTypeOf _ = "ChainDbEnv m " ++ show (typeRep (Proxy @blk))
@@ -545,7 +549,24 @@ data InvalidBlockInfo blk = InvalidBlockInfo
   { invalidBlockReason :: !(ExtValidationError blk)
   , invalidBlockSlotNo :: !SlotNo
   }
-  deriving (Eq, Show, Generic, NoThunks)
+
+deriving instance
+  ( LedgerSupportsProtocol blk
+  , BlockSupportsPeras blk
+  ) =>
+  Show (InvalidBlockInfo blk)
+deriving instance
+  ( LedgerSupportsProtocol blk
+  , BlockSupportsPeras blk
+  ) =>
+  Eq (InvalidBlockInfo blk)
+deriving instance
+  ( LedgerSupportsProtocol blk
+  , BlockSupportsPeras blk
+  ) =>
+  NoThunks (InvalidBlockInfo blk)
+deriving instance
+  Generic (InvalidBlockInfo blk)
 
 {-------------------------------------------------------------------------------
   Blocks to add
@@ -641,7 +662,9 @@ addBlockToAdd tracer (ChainSelQueue{varChainSelQueue, varChainSelPoints}) punish
 
 -- | Add a Peras certificate to the background queue.
 addPerasCertToQueue ::
-  IOLike m =>
+  ( IOLike m
+  , IsPerasCert (PerasCert blk) blk
+  ) =>
   Tracer m (TraceAddPerasCertEvent blk) ->
   ChainSelQueue m blk ->
   WithArrivalTime (ValidatedPerasCert blk) ->
@@ -794,6 +817,7 @@ data TraceEvent blk
 deriving instance
   ( Show (Header blk)
   , LedgerSupportsProtocol blk
+  , BlockSupportsPeras blk
   , InspectLedger blk
   , Show (TraceAddBlockEvent blk)
   ) =>
@@ -946,6 +970,7 @@ data TraceAddBlockEvent blk
 deriving instance
   ( Eq (Header blk)
   , LedgerSupportsProtocol blk
+  , BlockSupportsPeras blk
   , InspectLedger blk
   , Eq (ReasonForSwitch (WithEmptyFragment (WeightedSelectView (BlockProtocol blk))))
   , Eq (ReasonForSwitch (SelectView (BlockProtocol blk)))
@@ -954,6 +979,7 @@ deriving instance
 deriving instance
   ( Show (Header blk)
   , LedgerSupportsProtocol blk
+  , BlockSupportsPeras blk
   , InspectLedger blk
   , Show (ReasonForSwitch (WithEmptyFragment (WeightedSelectView (BlockProtocol blk))))
   , Show (ReasonForSwitch (SelectView (BlockProtocol blk)))
@@ -973,11 +999,13 @@ data TraceValidationEvent blk
 deriving instance
   ( Eq (Header blk)
   , LedgerSupportsProtocol blk
+  , BlockSupportsPeras blk
   ) =>
   Eq (TraceValidationEvent blk)
 deriving instance
   ( Show (Header blk)
   , LedgerSupportsProtocol blk
+  , BlockSupportsPeras blk
   ) =>
   Show (TraceValidationEvent blk)
 
@@ -1007,11 +1035,13 @@ data TraceInitChainSelEvent blk
 deriving instance
   ( Eq (Header blk)
   , LedgerSupportsProtocol blk
+  , BlockSupportsPeras blk
   ) =>
   Eq (TraceInitChainSelEvent blk)
 deriving instance
   ( Show (Header blk)
   , LedgerSupportsProtocol blk
+  , BlockSupportsPeras blk
   ) =>
   Show (TraceInitChainSelEvent blk)
 

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB.hs
@@ -52,6 +52,7 @@ openDB ::
   ( IOLike m
   , All Top (HardForkIndices blk)
   , LedgerSupportsProtocol blk
+  , BlockSupportsPeras blk
   , StateSupportsPerasEpochContext blk
   , InspectLedger blk
   , HasCallStack

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/V2.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/LedgerDB/V2.hs
@@ -74,6 +74,7 @@ mkInitDb ::
   forall m blk backend.
   ( All Top (HardForkIndices blk)
   , LedgerSupportsProtocol blk
+  , BlockSupportsPeras blk
   , StateSupportsPerasEpochContext blk
   , Backend m backend blk
   , IOLike m

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/PerasCertDB/API.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/PerasCertDB/API.hs
@@ -142,7 +142,9 @@ data AddPerasCertResult
 
 -- | After adding a cert, its round number should be present in 'getCertIds'.
 prop_addCertThenGetCertIds ::
-  MonadSTM m =>
+  ( MonadSTM m
+  , IsPerasCert (PerasCert blk) blk
+  ) =>
   PerasCertDB m blk ->
   WithArrivalTime (ValidatedPerasCert blk) ->
   m Bool
@@ -157,7 +159,9 @@ prop_addCertThenGetCertIds db cert =
 -- | 'getCertsAfter' with ticket 0 should return all certs in the database.
 -- NOTE: this property is not purely STM.
 prop_getCertsAfterZero ::
-  MonadSTM m =>
+  ( MonadSTM m
+  , IsPerasCert (PerasCert blk) blk
+  ) =>
   PerasCertDB m blk ->
   m Bool
 prop_getCertsAfterZero db = do
@@ -192,7 +196,9 @@ prop_getCertsAfterMonotonic db ticketNo =
 -- | After garbage collection for slot S, no certs with target slot < S should remain.
 -- NOTE: this property is not purely STM.
 prop_garbageCollectRemovesOldCerts ::
-  MonadSTM m =>
+  ( MonadSTM m
+  , IsPerasCert (PerasCert blk) blk
+  ) =>
   PerasCertDB m blk ->
   SlotNo ->
   m Bool
@@ -208,7 +214,9 @@ prop_garbageCollectRemovesOldCerts db slotNo = do
 -- | After adding a cert, the round number reported by 'getLatestCertSeen'
 -- should be greater than or equal to its previous value.
 prop_addCertLatestCertSeenMonotonic ::
-  MonadSTM m =>
+  ( MonadSTM m
+  , IsPerasCert (PerasCert blk) blk
+  ) =>
   PerasCertDB m blk ->
   WithArrivalTime (ValidatedPerasCert blk) ->
   m Bool
@@ -225,7 +233,9 @@ prop_addCertLatestCertSeenMonotonic db cert =
 
 -- | 'getLatestCertSeen' is not affected by garbage collection.
 prop_garbageCollectPreservesLatestCertSeen ::
-  MonadSTM m =>
+  ( MonadSTM m
+  , IsPerasCert (PerasCert blk) blk
+  ) =>
   PerasCertDB m blk ->
   SlotNo ->
   m Bool

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/PerasCertDB/Impl.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/PerasCertDB/Impl.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE StandaloneKindSignatures #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -63,8 +64,15 @@ data PerasCertDbState blk = PerasCertDbState
   -- ^ The certificate with the highest round number that has been added to the
   -- db since it has been opened.
   }
-  deriving stock (Show, Generic)
-  deriving anyclass NoThunks
+
+deriving instance
+  Show (PerasCert blk) =>
+  Show (PerasCertDbState blk)
+deriving instance
+  NoThunks (PerasCert blk) =>
+  NoThunks (PerasCertDbState blk)
+deriving instance
+  Generic (PerasCertDbState blk)
 
 initialPerasCertDbState :: WithFingerprint (PerasCertDbState blk)
 initialPerasCertDbState =
@@ -79,6 +87,7 @@ initialPerasCertDbState =
 
 -- | Check that the fields of 'PerasCertDbState' are in sync.
 invariantForPerasCertDbState ::
+  IsPerasCert (PerasCert blk) blk =>
   WithFingerprint (PerasCertDbState blk) ->
   Either String ()
 invariantForPerasCertDbState pcds = do
@@ -115,7 +124,15 @@ data TraceEvent blk
       AddPerasCertResult
   | GarbageCollected
       SlotNo
-  deriving stock (Show, Eq, Generic)
+
+deriving instance
+  Show (PerasCert blk) =>
+  Show (TraceEvent blk)
+deriving instance
+  Eq (PerasCert blk) =>
+  Eq (TraceEvent blk)
+deriving instance
+  Generic (TraceEvent blk)
 
 {------------------------------------------------------------------------------
   Creating the database
@@ -135,7 +152,7 @@ defaultArgs =
 createDB ::
   forall m blk.
   ( IOLike m
-  , StandardHash blk
+  , BlockSupportsPeras blk
   ) =>
   Complete PerasCertDbArgs m blk ->
   m (PerasCertDB m blk)
@@ -170,7 +187,9 @@ createDB args = do
 -- TODO: we will need to update this method with non-trivial validation logic
 -- see https://github.com/tweag/cardano-peras/issues/120
 implAddCert ::
-  IOLike m =>
+  ( IOLike m
+  , IsPerasCert (PerasCert blk) blk
+  ) =>
   PerasCertDbEnv m blk ->
   WithArrivalTime (ValidatedPerasCert blk) ->
   STM m (m AddPerasCertResult)
@@ -211,6 +230,7 @@ implAddCert PerasCertDbEnv{pcdbTracer, pcdbState} cert = do
 implGetWeightSnapshot ::
   ( IOLike m
   , StandardHash blk
+  , IsPerasCert (PerasCert blk) blk
   ) =>
   PerasCertDbEnv m blk ->
   STM m (WithFingerprint (PerasWeightSnapshot blk))
@@ -254,7 +274,9 @@ implGetLatestCertSeen PerasCertDbEnv{pcdbState} = do
 
 implGarbageCollect ::
   forall m blk.
-  IOLike m =>
+  ( IOLike m
+  , IsPerasCert (PerasCert blk) blk
+  ) =>
   PerasCertDbEnv m blk ->
   SlotNo ->
   STM m (m ())

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/PerasVoteDB/Impl.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/PerasVoteDB/Impl.hs
@@ -32,7 +32,6 @@ import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
 import Data.Set (Set)
 import Data.Set qualified as Set
-import Data.Typeable (Typeable)
 import GHC.Generics (Generic)
 import NoThunks.Class
 import Ouroboros.Consensus.Block
@@ -183,8 +182,7 @@ defaultArgs =
 createDB ::
   forall m blk.
   ( IOLike m
-  , StandardHash blk
-  , Typeable blk
+  , BlockSupportsPeras blk
   ) =>
   Complete PerasVoteDbArgs m blk ->
   PerasEpochContextResolverHandle m blk ->
@@ -221,8 +219,7 @@ createDB args perasEpochContextResolverHandle = do
 implAddVote ::
   forall m blk.
   ( IOLike m
-  , StandardHash blk
-  , Typeable blk
+  , BlockSupportsPeras blk
   ) =>
   PerasEpochContextResolverHandle m blk ->
   PerasVoteDbEnv m blk ->
@@ -329,7 +326,9 @@ implGetForgedCertForRound PerasVoteDbEnv{pvdeState} roundNo = do
 
 implGarbageCollect ::
   forall m blk.
-  IOLike m =>
+  ( IOLike m
+  , IsPerasVote (PerasVote blk) blk
+  ) =>
   PerasVoteDbEnv m blk ->
   SlotNo ->
   STM m (m ())

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Storage/TestBlock.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Ouroboros/Storage/TestBlock.hs
@@ -123,7 +123,14 @@ import Ouroboros.Consensus.Peras.Context
   ( StateSupportsPerasEpochContext (..)
   , mkBoundedPerasEpochContextWith
   )
-import Ouroboros.Consensus.Peras.Crypto.Mock (MockPerasCrypto, MockPerasVotingCommitteeScheme)
+import Ouroboros.Consensus.Peras.Crypto.Mock
+  ( MockPerasCrypto
+  , MockPerasVotingCommitteeScheme
+  )
+import Ouroboros.Consensus.Peras.Error.Mock (MockPerasError)
+import Ouroboros.Consensus.Peras.Vote.Mock
+  ( MockPerasVote (..)
+  )
 import Ouroboros.Consensus.Peras.Voting.Mock (mkMockPerasVotingCommitteeInput)
 import Ouroboros.Consensus.Protocol.Abstract
 import Ouroboros.Consensus.Protocol.BFT
@@ -635,22 +642,18 @@ instance ApplyBlock LedgerState TestBlock where
             TestLedger
               (Chain.blockPoint tb)
               (BlockHash (blockHash tb))
-              ( let
-                  -- NOTE: this bypasses the degenerate global implementation of
-                  -- 'BlockSupportsPeras.getPerasCertInBlock' for 'TestBlock',
-                  -- which currently always returns 'Nothing'.
-                  --
-                  -- TODO: refactor this to use 'getPerasCertInBlock' after the
-                  -- HFC plumbing for 'BlockSupportsPeras' is in place.
-                  certRoundInBlock = getPerasCertRound <$> tbPerasCert testBody
-                 in
-                  -- the highest Peras certificate round number  we've seen so far
-                  case (certRoundInBlock, latestPerasCertRound) of
-                    (Nothing, Nothing) -> Nothing
-                    (Just rb, Nothing) -> Just rb
-                    (Nothing, Just rl) -> Just rl
-                    (Just rb, Just rl) -> Just (rb `max` rl)
-              )
+              latestPerasCertRound'
+   where
+    -- The round number of the Peras certificate stored in this block, if any
+    perasCertRoundInBlock =
+      either (const Nothing) (fmap getPerasCertRound) (getPerasCertInBlock tb)
+    -- The highest Peras certificate round number we've seen so far
+    latestPerasCertRound' =
+      case (perasCertRoundInBlock, latestPerasCertRound) of
+        (Nothing, Nothing) -> Nothing
+        (Just rb, Nothing) -> Just rb
+        (Nothing, Just rl) -> Just rl
+        (Just rb, Just rl) -> Just (rb `max` rl)
 
   applyBlockLedgerResult = defaultApplyBlockLedgerResult
   reapplyBlockLedgerResult =
@@ -748,6 +751,19 @@ instance StateSupportsPerasEpochContext TestBlock where
   toMaybeEraIndexedEpochToPerasRoundInfo _ = forgetEraIndex
   fromMaybeEraIndexedEpochToPerasRoundInfo _ = id
   mkBoundedPerasEpochContext = mkBoundedPerasEpochContextWith mkMockPerasVotingCommitteeInput
+
+-- NOTE: this is a mocked up implementation without crypto!
+instance BlockSupportsPeras TestBlock where
+  type PerasCrypto TestBlock = MockPerasCrypto TestBlock
+  type PerasVotingCommitteeScheme TestBlock = MockPerasVotingCommitteeScheme TestBlock
+  type PerasVote TestBlock = MockPerasVote TestBlock
+  type PerasCert TestBlock = MockPerasCert TestBlock
+  type PerasError TestBlock = MockPerasError TestBlock
+  forgePerasVoteIfEligible = defaultForgePerasVoteIfEligible
+  verifyPerasVote = defaultVerifyPerasVote
+  forgePerasCert = defaultForgePerasCert
+  verifyPerasCert = defaultVerifyPerasCert
+  getPerasCertInBlock = Right . tbPerasCert . testBody
 
 instance InspectLedger TestBlock
 

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/Serialisation/Roundtrip.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/Serialisation/Roundtrip.hs
@@ -905,7 +905,13 @@ $( do
  )
 examplesRoundtrip ::
   forall blk.
-  (SerialiseDiskConstraints blk, Eq blk, Show blk, LedgerSupportsProtocol blk) =>
+  ( SerialiseDiskConstraints blk
+  , LedgerSupportsProtocol blk
+  , Eq blk
+  , Show blk
+  , Eq (PerasVotingCommittee blk)
+  , Show (PerasVotingCommittee blk)
+  ) =>
   CodecConfig blk ->
   Examples blk ->
   [TestTree]

--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/TestBlock.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/TestBlock.hs
@@ -144,11 +144,18 @@ import Ouroboros.Consensus.Ledger.Tables.Utils
 import Ouroboros.Consensus.Node.NetworkProtocolVersion
 import Ouroboros.Consensus.Node.ProtocolInfo
 import Ouroboros.Consensus.NodeId
+import Ouroboros.Consensus.Peras.Cert.Mock (MockPerasCert (..))
 import Ouroboros.Consensus.Peras.Context
   ( StateSupportsPerasEpochContext (..)
   , mkBoundedPerasEpochContextWith
   )
+import Ouroboros.Consensus.Peras.Crypto.Mock
+  ( MockPerasCrypto
+  , MockPerasVotingCommitteeScheme
+  )
+import Ouroboros.Consensus.Peras.Error.Mock (MockPerasError)
 import Ouroboros.Consensus.Peras.SelectView (weightedSelectView)
+import Ouroboros.Consensus.Peras.Vote.Mock (MockPerasVote (..))
 import Ouroboros.Consensus.Peras.Voting.Mock (mkMockPerasVotingCommitteeInput)
 import Ouroboros.Consensus.Peras.Weight (PerasWeightSnapshot)
 import Ouroboros.Consensus.Protocol.Abstract
@@ -705,6 +712,32 @@ instance PayloadSemantics ptype => LedgerSupportsProtocol (TestBlockWith ptype) 
   protocolLedgerView _ _ = ()
   ledgerViewForecastAt cfg state =
     constantForecastInRange (strictMaybeToMaybe (tblcForecastRange cfg)) () (getTipSlot state)
+
+{-------------------------------------------------------------------------------
+  BlockSupportsPeras
+-------------------------------------------------------------------------------}
+
+-- NOTE: this is a mocked up implementation without crypto!
+instance
+  Typeable ptype =>
+  BlockSupportsPeras (TestBlockWith ptype)
+  where
+  type PerasCrypto (TestBlockWith ptype) = MockPerasCrypto (TestBlockWith ptype)
+  type
+    PerasVotingCommitteeScheme (TestBlockWith ptype) =
+      MockPerasVotingCommitteeScheme (TestBlockWith ptype)
+  type PerasVote (TestBlockWith ptype) = MockPerasVote (TestBlockWith ptype)
+  type PerasCert (TestBlockWith ptype) = MockPerasCert (TestBlockWith ptype)
+  type PerasError (TestBlockWith ptype) = MockPerasError (TestBlockWith ptype)
+  forgePerasVoteIfEligible = defaultForgePerasVoteIfEligible
+  verifyPerasVote = defaultVerifyPerasVote
+  forgePerasCert = defaultForgePerasCert
+  verifyPerasCert = defaultVerifyPerasCert
+  getPerasCertInBlock _ = Right Nothing
+
+{-------------------------------------------------------------------------------
+  Test infrastructure: config
+-------------------------------------------------------------------------------}
 
 singleNodeTestConfigWith ::
   CodecConfig (TestBlockWith ptype) ->

--- a/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Ledger/Block/Praos.hs
+++ b/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Ledger/Block/Praos.hs
@@ -37,6 +37,7 @@ import Ouroboros.Consensus.Mock.Ledger.Address
 import Ouroboros.Consensus.Mock.Ledger.Block
 import Ouroboros.Consensus.Mock.Ledger.Forge
 import Ouroboros.Consensus.Mock.Node.Abstract
+import Ouroboros.Consensus.Mock.Node.Peras ()
 import Ouroboros.Consensus.Mock.Protocol.Praos
 import Ouroboros.Consensus.Protocol.Signed
 import Ouroboros.Consensus.Storage.Serialisation

--- a/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Ledger/Block/PraosRule.hs
+++ b/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Ledger/Block/PraosRule.hs
@@ -31,6 +31,7 @@ import Ouroboros.Consensus.Ledger.SupportsProtocol
 import Ouroboros.Consensus.Mock.Ledger.Block
 import Ouroboros.Consensus.Mock.Ledger.Forge
 import Ouroboros.Consensus.Mock.Node.Abstract
+import Ouroboros.Consensus.Mock.Node.Peras ()
 import Ouroboros.Consensus.Mock.Protocol.LeaderSchedule
 import Ouroboros.Consensus.Mock.Protocol.Praos
 import Ouroboros.Consensus.NodeId (CoreNodeId)

--- a/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Node/Peras.hs
+++ b/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Node/Peras.hs
@@ -13,6 +13,18 @@ module Ouroboros.Consensus.Mock.Node.Peras () where
 
 import Data.Typeable (Typeable)
 import Ouroboros.Consensus.Block (BlockProtocol)
+import Ouroboros.Consensus.Block.SupportsPeras
+  ( BlockSupportsPeras (..)
+  , VoidPerasCert
+  , VoidPerasCrypto
+  , VoidPerasError
+  , VoidPerasVote
+  , VoidPerasVotingCommitteeScheme
+  , defaultForgePerasCert
+  , defaultForgePerasVoteIfEligible
+  , defaultVerifyPerasCert
+  , defaultVerifyPerasVote
+  )
 import Ouroboros.Consensus.HardFork.History (EpochToPerasRoundInfo, forgetEraIndex)
 import Ouroboros.Consensus.Mock.Ledger.Block (SimpleBlock, SimpleCrypto)
 import Ouroboros.Consensus.Peras.Context (StateSupportsPerasEpochContext (..))
@@ -34,3 +46,20 @@ instance
   toMaybeEraIndexedEpochToPerasRoundInfo _ = forgetEraIndex
   fromMaybeEraIndexedEpochToPerasRoundInfo _ = id
   mkBoundedPerasEpochContext = error "mkBoundedPerasEpochContext: SimpleBlock does not support Peras"
+
+instance
+  ( SimpleCrypto c
+  , Typeable ext
+  ) =>
+  BlockSupportsPeras (SimpleBlock c ext)
+  where
+  type PerasVote (SimpleBlock c ext) = VoidPerasVote (SimpleBlock c ext)
+  type PerasCert (SimpleBlock c ext) = VoidPerasCert (SimpleBlock c ext)
+  type PerasError (SimpleBlock c ext) = VoidPerasError (SimpleBlock c ext)
+  type PerasCrypto (SimpleBlock c ext) = VoidPerasCrypto (SimpleBlock c ext)
+  type PerasVotingCommitteeScheme (SimpleBlock c ext) = VoidPerasVotingCommitteeScheme
+  forgePerasVoteIfEligible = defaultForgePerasVoteIfEligible
+  verifyPerasVote = defaultVerifyPerasVote
+  forgePerasCert = defaultForgePerasCert
+  verifyPerasCert = defaultVerifyPerasCert
+  getPerasCertInBlock _ = Right Nothing

--- a/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Node/Serialisation.hs
+++ b/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Node/Serialisation.hs
@@ -27,6 +27,7 @@ import Ouroboros.Consensus.Ledger.Query
 import Ouroboros.Consensus.Ledger.SupportsMempool
 import Ouroboros.Consensus.Mock.Ledger
 import Ouroboros.Consensus.Mock.Node.Abstract
+import Ouroboros.Consensus.Mock.Node.Peras ()
 import Ouroboros.Consensus.Node.NetworkProtocolVersion
 import Ouroboros.Consensus.Node.Run
 import Ouroboros.Consensus.Node.Serialisation

--- a/ouroboros-consensus/src/unstable-tutorials/Ouroboros/Consensus/Tutorial/Simple.lhs
+++ b/ouroboros-consensus/src/unstable-tutorials/Ouroboros/Consensus/Tutorial/Simple.lhs
@@ -51,10 +51,21 @@ First, some imports we'll need:
 >    Header, StorageConfig, ChainHash, HasHeader(..), HeaderFields(..),
 >    HeaderHash, Point, StandardHash)
 > import Ouroboros.Consensus.Protocol.Abstract
->   (SecurityParam(..), ConsensusConfig, ConsensusProtocol(..), NoTiebreaker(..))
+>    (SecurityParam(..), ConsensusConfig, ConsensusProtocol(..), NoTiebreaker(..))
 > import Ouroboros.Consensus.Ticked ( Ticked, Ticked(TickedTrivial) )
 > import Ouroboros.Consensus.Block
->   (BlockSupportsProtocol (tiebreakerView, validateView))
+>    ( BlockSupportsProtocol (tiebreakerView, validateView)
+>    , BlockSupportsPeras (..)
+>    , VoidPerasCert
+>    , VoidPerasCrypto
+>    , VoidPerasError
+>    , VoidPerasVote
+>    , VoidPerasVotingCommitteeScheme
+>    , defaultForgePerasCert
+>    , defaultForgePerasVoteIfEligible
+>    , defaultVerifyPerasCert
+>    , defaultVerifyPerasVote
+>    )
 > import Ouroboros.Consensus.Ledger.Abstract
 >   (AuxLedgerEvent, GetTip(..), IsLedger(..), LedgerCfg,
 >    LedgerResult(LedgerResult, lrEvents, lrResult),
@@ -396,7 +407,20 @@ will know nothing about the structure of the data - instead there are other
 typeclasses needed to build an interface to derive things that are needed from
 this value.  We'll implement those typeclasses next.
 
+We also need to instantiate `BlockSupportsPeras` for `BlockC`. Since `BlockC`
+does not support Peras, we use the void Peras types and default implementations.
 
+> instance BlockSupportsPeras BlockC where
+>   type PerasVote BlockC = VoidPerasVote BlockC
+>   type PerasCert BlockC = VoidPerasCert BlockC
+>   type PerasError BlockC = VoidPerasError BlockC
+>   type PerasCrypto BlockC = VoidPerasCrypto BlockC
+>   type PerasVotingCommitteeScheme BlockC = VoidPerasVotingCommitteeScheme
+>   forgePerasVoteIfEligible = defaultForgePerasVoteIfEligible
+>   verifyPerasVote = defaultVerifyPerasVote
+>   forgePerasCert = defaultForgePerasCert
+>   verifyPerasCert = defaultVerifyPerasCert
+>   getPerasCertInBlock _ = Right Nothing
 
 Interface to the Block Header
 -----------------------------

--- a/ouroboros-consensus/src/unstable-tutorials/Ouroboros/Consensus/Tutorial/WithEpoch.lhs
+++ b/ouroboros-consensus/src/unstable-tutorials/Ouroboros/Consensus/Tutorial/WithEpoch.lhs
@@ -71,6 +71,18 @@ And imports, of course:
 >   BlockProtocol, castHeaderFields, BlockConfig, CodecConfig,
 >   StorageConfig, Point, castPoint, WithOrigin (..), EpochNo (EpochNo),
 >   pointSlot, blockPoint, BlockNo (..))
+> import Ouroboros.Consensus.Block.SupportsPeras
+>   ( BlockSupportsPeras (..)
+>   , VoidPerasCert
+>   , VoidPerasCrypto
+>   , VoidPerasError
+>   , VoidPerasVote
+>   , VoidPerasVotingCommitteeScheme
+>   , defaultForgePerasCert
+>   , defaultForgePerasVoteIfEligible
+>   , defaultVerifyPerasCert
+>   , defaultVerifyPerasVote
+>   )
 > import Ouroboros.Consensus.Block.SupportsProtocol
 >   (BlockSupportsProtocol (..))
 > import Ouroboros.Consensus.Protocol.Abstract
@@ -207,6 +219,21 @@ defined earlier:
 > type instance HeaderHash BlockD = Hash
 
 > instance StandardHash BlockD
+
+We also need to instantiate `BlockSupportsPeras` for `BlockD`. Since `BlockD`
+does not support Peras, we use the void Peras types and default implementations.
+
+> instance BlockSupportsPeras BlockD where
+>   type PerasVote BlockD = VoidPerasVote BlockD
+>   type PerasCert BlockD = VoidPerasCert BlockD
+>   type PerasError BlockD = VoidPerasError BlockD
+>   type PerasCrypto BlockD = VoidPerasCrypto BlockD
+>   type PerasVotingCommitteeScheme BlockD = VoidPerasVotingCommitteeScheme
+>   forgePerasVoteIfEligible = defaultForgePerasVoteIfEligible
+>   verifyPerasVote = defaultVerifyPerasVote
+>   forgePerasCert = defaultForgePerasCert
+>   verifyPerasCert = defaultVerifyPerasCert
+>   getPerasCertInBlock _ = Right Nothing
 
 Then we define a function `computeBlockHash` which computes a `Hash` for a
 `BlockD` - basically aggregating all the data in the block besides the hash

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/MiniProtocol/ObjectDiffusion/PerasCert/Smoke.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/MiniProtocol/ObjectDiffusion/PerasCert/Smoke.hs
@@ -26,7 +26,6 @@ import Ouroboros.Consensus.Storage.PerasCertDB.API
 import qualified Ouroboros.Consensus.Storage.PerasCertDB.API as PerasCertDB
 import qualified Ouroboros.Consensus.Storage.PerasCertDB.Impl as PerasCertDB
 import Ouroboros.Consensus.Util.IOLike
-import Ouroboros.Network.Block (StandardHash)
 import Ouroboros.Network.Protocol.ObjectDiffusion.Codec
 import Ouroboros.Network.Protocol.ObjectDiffusion.Inbound
   ( objectDiffusionInboundPeerPipelined
@@ -51,7 +50,7 @@ tests =
 
 newCertDB ::
   ( IOLike m
-  , StandardHash blk
+  , BlockSupportsPeras blk
   ) =>
   [WithArrivalTime (ValidatedPerasCert blk)] ->
   m (PerasCertDB m blk)

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/MiniProtocol/ObjectDiffusion/PerasVote/Smoke.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/MiniProtocol/ObjectDiffusion/PerasVote/Smoke.hs
@@ -5,7 +5,6 @@ module Test.Consensus.MiniProtocol.ObjectDiffusion.PerasVote.Smoke
 import Control.Monad (join)
 import Control.Tracer (contramap, nullTracer)
 import qualified Data.Map as Map
-import Data.Typeable (Typeable)
 import Network.TypedProtocol.Driver.Simple (runPeer, runPipelinedPeer)
 import Ouroboros.Consensus.Block.SupportsPeras
 import Ouroboros.Consensus.BlockchainTime.WallClock.Types
@@ -26,7 +25,6 @@ import Ouroboros.Consensus.Storage.PerasVoteDB
   )
 import qualified Ouroboros.Consensus.Storage.PerasVoteDB as PerasVoteDB
 import Ouroboros.Consensus.Util.IOLike
-import Ouroboros.Network.Block (StandardHash)
 import Ouroboros.Network.Protocol.ObjectDiffusion.Codec
 import Ouroboros.Network.Protocol.ObjectDiffusion.Inbound
   ( objectDiffusionInboundPeerPipelined
@@ -51,8 +49,7 @@ tests =
 
 newVoteDB ::
   ( IOLike m
-  , Typeable blk
-  , StandardHash blk
+  , BlockSupportsPeras blk
   ) =>
   PerasEpochContextResolverHandle m blk ->
   [WithArrivalTime (ValidatedPerasVote blk)] ->

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/Model.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/Model.hs
@@ -9,6 +9,7 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 -- | Model implementation of the chain DB
@@ -116,6 +117,7 @@ import Ouroboros.Consensus.Ledger.Abstract
 import Ouroboros.Consensus.Ledger.Extended
 import Ouroboros.Consensus.Ledger.Peras (PerasState (..))
 import Ouroboros.Consensus.Ledger.SupportsProtocol
+import Ouroboros.Consensus.Peras.Cert.Mock (MockPerasCert)
 import Ouroboros.Consensus.Peras.Context
   ( PerasEpochContextResolver
   , StateSupportsPerasEpochContext
@@ -279,7 +281,11 @@ getMaxSlotNo = foldMap (MaxSlotNo . blockSlot) . blocks
 -- * After VolatileDB corruption, the whole chain might have more than weight
 --   @k@, but the tip of the ImmutableDB might be buried under significantly
 --   less than weight @k@ worth of blocks.
-maxActualRollback :: HasHeader blk => SecurityParam -> Model blk -> PerasWeight
+maxActualRollback ::
+  ( HasHeader blk
+  , IsPerasCert (PerasCert blk) blk
+  ) =>
+  SecurityParam -> Model blk -> PerasWeight
 maxActualRollback k m =
   foldMap' (weightBoostOfPoint weights)
     . takeWhile (/= immutableTipPoint)
@@ -307,7 +313,9 @@ maxActualRollback k m =
 -- ImmutableDB to know the most recent \"immutable\" block.
 immutableChain ::
   forall blk.
-  HasHeader blk =>
+  ( HasHeader blk
+  , IsPerasCert (PerasCert blk) blk
+  ) =>
   SecurityParam ->
   Model blk ->
   Chain blk
@@ -347,7 +355,10 @@ immutableChain k m =
 -- 2. The suffix of the current chain not part of the 'immutableDbChain', i.e.,
 --    the \"ImmutableDB\".
 volatileChain ::
-  (HasHeader a, HasHeader blk) =>
+  ( HasHeader a
+  , HasHeader blk
+  , IsPerasCert (PerasCert blk) blk
+  ) =>
   SecurityParam ->
   -- | Provided since 'AnchoredFragment' is not a functor
   (blk -> a) ->
@@ -372,7 +383,9 @@ volatileChain k f m =
 -- because the background thread copying blocks to the ImmutableDB might not
 -- have caught up.
 immutableBlockNo ::
-  HasHeader blk =>
+  ( HasHeader blk
+  , IsPerasCert (PerasCert blk) blk
+  ) =>
   SecurityParam -> Model blk -> WithOrigin BlockNo
 immutableBlockNo k = Chain.headBlockNo . immutableChain k
 
@@ -382,7 +395,9 @@ immutableBlockNo k = Chain.headBlockNo . immutableChain k
 -- This is used for garbage collection of the VolatileDB, which is done in
 -- terms of slot numbers, not in terms of block numbers.
 immutableSlotNo ::
-  HasHeader blk =>
+  ( HasHeader blk
+  , IsPerasCert (PerasCert blk) blk
+  ) =>
   SecurityParam ->
   Model blk ->
   WithOrigin SlotNo
@@ -416,7 +431,9 @@ getLoEFragment :: Model blk -> LoE (AnchoredFragment blk)
 getLoEFragment = loeFragment
 
 perasWeights ::
-  StandardHash blk =>
+  ( StandardHash blk
+  , IsPerasCert (PerasCert blk) blk
+  ) =>
   Model blk -> PerasWeightSnapshot blk
 perasWeights =
   PerasCertDBModel.getWeightSnapshot . perasCertModel
@@ -494,6 +511,7 @@ addPerasCert ::
   , LedgerTablesAreTrivial ExtLedgerState blk
   , BlockSupportsPeras blk
   , StateSupportsPerasEpochContext blk
+  , Ord (PerasCert blk)
   ) =>
   TopLevelConfig blk ->
   WithArrivalTime (ValidatedPerasCert blk) ->
@@ -515,6 +533,9 @@ addPerasVote ::
   , LedgerTablesAreTrivial ExtLedgerState blk
   , BlockSupportsPeras blk
   , StateSupportsPerasEpochContext blk
+  , Ord (PerasVote blk)
+  , Ord (PerasCert blk)
+  , PerasCert blk ~ MockPerasCert blk
   ) =>
   TopLevelConfig blk ->
   WithArrivalTime (ValidatedPerasVote blk) ->
@@ -725,7 +746,9 @@ updateLoE cfg f m = (tipPoint m', m')
 -------------------------------------------------------------------------------}
 
 stream ::
-  GetPrevHash blk =>
+  ( GetPrevHash blk
+  , IsPerasCert (PerasCert blk) blk
+  ) =>
   SecurityParam ->
   StreamFrom blk ->
   StreamTo blk ->
@@ -1037,7 +1060,9 @@ successors = Map.unionsWith Map.union . map single
 
 between ::
   forall blk.
-  GetPrevHash blk =>
+  ( GetPrevHash blk
+  , IsPerasCert (PerasCert blk) blk
+  ) =>
   SecurityParam ->
   StreamFrom blk ->
   StreamTo blk ->
@@ -1139,7 +1164,9 @@ between k from to m = do
 -- tip).
 garbageCollectable ::
   forall blk.
-  HasHeader blk =>
+  ( HasHeader blk
+  , IsPerasCert (PerasCert blk) blk
+  ) =>
   SecurityParam -> Model blk -> blk -> Bool
 garbageCollectable secParam m b =
   -- Note: we don't use the block number but the slot number, as the
@@ -1155,7 +1182,9 @@ garbageCollectable secParam m b =
 -- case from a block that was never added to the model in the first place.
 garbageCollectablePoint ::
   forall blk.
-  HasHeader blk =>
+  ( HasHeader blk
+  , IsPerasCert (PerasCert blk) blk
+  ) =>
   SecurityParam -> Model blk -> RealPoint blk -> Bool
 garbageCollectablePoint secParam m pt
   | Just blk <- getBlock (realPointHash pt) m =
@@ -1168,7 +1197,9 @@ garbageCollectablePoint secParam m pt
 -- garbage collected it.
 garbageCollectableIteratorNext ::
   forall blk.
-  ModelSupportsBlock blk =>
+  ( ModelSupportsBlock blk
+  , IsPerasCert (PerasCert blk) blk
+  ) =>
   SecurityParam -> Model blk -> IteratorId -> Bool
 garbageCollectableIteratorNext secParam m itId =
   case fst (iteratorNext itId GetBlock m) of
@@ -1186,7 +1217,9 @@ garbageCollectableIteratorNext secParam m itId =
 -- used in isolation and is not exported.
 garbageCollect ::
   forall blk.
-  HasHeader blk =>
+  ( HasHeader blk
+  , IsPerasCert (PerasCert blk) blk
+  ) =>
   SecurityParam -> Model blk -> Model blk
 garbageCollect secParam m@Model{..} =
   m
@@ -1218,7 +1251,9 @@ data ShouldGarbageCollect = GarbageCollect | DoNotGarbageCollect
 -- Idempotent.
 copyToImmutableDB ::
   forall blk.
-  HasHeader blk =>
+  ( HasHeader blk
+  , IsPerasCert (PerasCert blk) blk
+  ) =>
   SecurityParam -> ShouldGarbageCollect -> Model blk -> Model blk
 copyToImmutableDB secParam shouldCollectGarbage m =
   garbageCollectIf shouldCollectGarbage $

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
@@ -398,6 +398,9 @@ type TestConstraints blk =
   , CanUpgradeLedgerTables LedgerState blk
   , ImmutableEraParams blk
   , StateSupportsPerasEpochContext blk
+  , BlockSupportsPeras blk
+  , PerasVote blk ~ MockPerasVote blk
+  , PerasCert blk ~ MockPerasCert blk
   )
 
 deriving instance

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/PerasCertDB/Model.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/PerasCertDB/Model.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 module Test.Ouroboros.Storage.PerasCertDB.Model
   ( Model (..)
@@ -36,9 +38,9 @@ data Model blk = Model
   }
   deriving Generic
 
-deriving instance StandardHash blk => Show (Model blk)
+deriving instance Show (PerasCert blk) => Show (Model blk)
 
-instance StandardHash blk => ToExpr (Model blk) where
+instance Show (PerasCert blk) => ToExpr (Model blk) where
   toExpr = defaultExprViaShow
 
 initModel :: Model blk
@@ -48,7 +50,9 @@ openDB :: Model blk -> Model blk
 openDB model = model{open = True}
 
 addCert ::
-  StandardHash blk =>
+  ( Ord (PerasCert blk)
+  , IsPerasCert (PerasCert blk) blk
+  ) =>
   Model blk -> WithArrivalTime (ValidatedPerasCert blk) -> (AddPerasCertResult, Model blk)
 addCert model@Model{certs, latestCertSeen} cert
   | certs `hasRoundNo` cert = (PerasCertAlreadyInDB, model)
@@ -67,6 +71,7 @@ addCert model@Model{certs, latestCertSeen} cert
             Just prev
 
 hasRoundNo ::
+  IsPerasCert (PerasCert blk) blk =>
   Set (WithArrivalTime (ValidatedPerasCert blk)) ->
   WithArrivalTime (ValidatedPerasCert blk) ->
   Bool
@@ -74,7 +79,9 @@ hasRoundNo certs cert =
   (getPerasCertRound cert) `Set.member` (Set.map getPerasCertRound certs)
 
 getWeightSnapshot ::
-  StandardHash blk =>
+  ( IsPerasCert (PerasCert blk) blk
+  , StandardHash blk
+  ) =>
   Model blk -> PerasWeightSnapshot blk
 getWeightSnapshot Model{certs} =
   mkPerasWeightSnapshot
@@ -88,7 +95,9 @@ getLatestCertSeen ::
 getLatestCertSeen Model{latestCertSeen} =
   latestCertSeen
 
-garbageCollect :: SlotNo -> Model blk -> Model blk
+garbageCollect ::
+  IsPerasCert (PerasCert blk) blk =>
+  SlotNo -> Model blk -> Model blk
 garbageCollect slotNo model@Model{certs, latestCertSeen} =
   model
     { certs = Set.filter keepCert certs

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/PerasVoteDB/Model.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/PerasVoteDB/Model.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Test.Ouroboros.Storage.PerasVoteDB.Model
@@ -157,6 +158,8 @@ closeDB model =
 
 addVote ::
   ( StandardHash blk
+  , Ord (PerasVote blk)
+  , PerasCert blk ~ MockPerasCert blk
   , IsPerasVote (PerasVote blk) blk
   , IsPerasCert (PerasCert blk) blk
   ) =>


### PR DESCRIPTION
This PR replaces the degenerate `BlockSupportsPeras` instance with explicit block- and era-specific instances, and adapting the hard-fork combinator support, node-to-node serialization, ChainDB, LedgerDB, Peras vote/certificate storage, and test infrastructure to the new non-degenerate interface.

| Block type / era | Peras implementation |
| --- | --- |
| `ByronBlock` | Void |
| `ShelleyEra` through `ConwayEra` | Void |
| `DijkstraEra` | Void temporarily, pending follow-up production Peras plumbing |
| `HardForkBlock` | Real, dispatched to the selected era |
| `TestBlock`, `TestBlockWith`, `BlockA`, and `BlockB` | Mock |
| `SimpleBlock` | Void |

NOTE:  `DijkstraEra` is temporarily wired to the Void implementation. Its real implementation will follow once the dependent Peras changes are in place.