### PR TITLE
db-synthesizer: forge a Leios chain

### DIFF
--- a/changelog.d/20260821_155651_damian.nadales_export_decide_leios_certify.md
+++ b/changelog.d/20260821_155651_damian.nadales_export_decide_leios_certify.md
@@ -1,0 +1,13 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+### Non-Breaking
+
+- `Ouroboros.Consensus.NodeKernel.Forge` now exports `decideLeiosCertify`. It
+  decides whether the block being forged certifies the endorser block that its
+  parent announced. A forge loop outside the node kernel can reuse it instead of
+  writing a second copy.

--- a/ouroboros-consensus-cardano/README.md
+++ b/ouroboros-consensus-cardano/README.md
@@ -385,8 +385,9 @@ Additional flags:
 ## db-synthesizer
 
 ### About
-This tool synthesizes a valid ChainDB, replicating cardano-node's UX. The blocks
-forged to synthesize the ChainDB won't contain any transactions.
+This tool synthesizes a valid ChainDB, replicating cardano-node's UX.
+By default the blocks it forges hold no transactions.
+Give `--payment-signing-key` to fill them, and `--shelley-bls-key` to certify the endorser blocks they announce.
 
 A minimal test case is provided which incorporates a staked genesis and credentials for 2 forgers (cf. `test/config`).
 
@@ -408,6 +409,14 @@ The tool expects the given ChainDB path (`--db` option) to *not* be present. Sho
 #### limiting synthesis
 
 A limit must be specified up to which the tool synthesizes a ChainDB. Possible limits are either the number of slots processed (`-s`), the number of epochs processed (`-e`) or the absolute number of blocks in the resulting ChainDB (`-b`).
+
+#### transactions and Leios data
+
+Two options control what the forged blocks hold. Each one is optional, and each one changes the chain the tool writes.
+
+`--payment-signing-key` names a payment signing key that the Shelley genesis funds. The tool then fills each block with a chain of transactions, and it announces an endorser block that holds the transactions the block itself could not take. Without the option the tool forges empty blocks, announces no endorser block, and writes an empty `leios.db`.
+
+`--shelley-bls-key` names the BLS signing key that the pool registered as its `leiosKey`. The tool votes with it for each endorser block it announces, and a later block carries the resulting certificate. Without the option the tool casts no vote. It still announces endorser blocks, but no block certifies one, so the transactions of those blocks never reach the ledger.
 
 ## db-truncater
 

--- a/ouroboros-consensus-cardano/app/DBSynthesizer/Parsers.hs
+++ b/ouroboros-consensus-cardano/app/DBSynthesizer/Parsers.hs
@@ -25,6 +25,7 @@ parseNodeFilePaths =
     <$> parseNodeConfigFilePath
     <*> parseChainDBFilePath
     <*> optional parsePaymentKeyFilePath
+    <*> optional parseBlsKeyFilePath
 
 parseNodeCredentials :: Parser NodeCredentials
 parseNodeCredentials =
@@ -74,6 +75,16 @@ parsePaymentKeyFilePath =
         <> metavar "FILE"
         <> help
           "Path to a payment signing key, as cardano-cli writes it. Each forged block spends the output of this key and makes a new one. If you do not give this option, the tool forges empty blocks."
+        <> completer (bashCompleter "file")
+    )
+
+parseBlsKeyFilePath :: Parser FilePath
+parseBlsKeyFilePath =
+  strOption
+    ( long "shelley-bls-key"
+        <> metavar "FILE"
+        <> help
+          "Path to the pool's BLS signing key, as cardano-cli writes it. The tool needs this key to vote for the endorser blocks it announces. Without it the tool casts no vote."
         <> completer (bashCompleter "file")
     )
 

--- a/ouroboros-consensus-cardano/app/DBSynthesizer/Parsers.hs
+++ b/ouroboros-consensus-cardano/app/DBSynthesizer/Parsers.hs
@@ -24,6 +24,7 @@ parseNodeFilePaths =
   NodeFilePaths
     <$> parseNodeConfigFilePath
     <*> parseChainDBFilePath
+    <*> optional parsePaymentKeyFilePath
 
 parseNodeCredentials :: Parser NodeCredentials
 parseNodeCredentials =
@@ -63,6 +64,16 @@ parseNodeConfigFilePath =
     ( long "config"
         <> metavar "FILE"
         <> help "Path to the node's config.json"
+        <> completer (bashCompleter "file")
+    )
+
+parsePaymentKeyFilePath :: Parser FilePath
+parsePaymentKeyFilePath =
+  strOption
+    ( long "payment-signing-key"
+        <> metavar "FILE"
+        <> help
+          "Path to a payment signing key, as cardano-cli writes it. Each forged block spends the output of this key and makes a new one. If you do not give this option, the tool forges empty blocks."
         <> completer (bashCompleter "file")
     )
 

--- a/ouroboros-consensus-cardano/app/DBSynthesizer/Parsers.hs
+++ b/ouroboros-consensus-cardano/app/DBSynthesizer/Parsers.hs
@@ -74,7 +74,7 @@ parsePaymentKeyFilePath =
     ( long "payment-signing-key"
         <> metavar "FILE"
         <> help
-          "Path to a payment signing key, as cardano-cli writes it. Each forged block spends the output of this key and makes a new one. If you do not give this option, the tool forges empty blocks."
+          "Path to a payment signing key, as cardano-cli writes it. Each forged block spends the output of this key and makes a new one. If you do not give this option, the tool forges empty blocks and announces no endorser block."
         <> completer (bashCompleter "file")
     )
 
@@ -84,7 +84,7 @@ parseBlsKeyFilePath =
     ( long "shelley-bls-key"
         <> metavar "FILE"
         <> help
-          "Path to the pool's BLS signing key, as cardano-cli writes it. The tool needs this key to vote for the endorser blocks it announces. Without it the tool casts no vote."
+          "Path to the pool's BLS signing key, as cardano-cli writes it. The tool needs this key to vote for the endorser blocks it announces. Without it the tool casts no vote, so no block certifies an endorser block and the transactions of those blocks never reach the ledger."
         <> completer (bashCompleter "file")
     )
 

--- a/ouroboros-consensus-cardano/app/DBSynthesizer/Parsers.hs
+++ b/ouroboros-consensus-cardano/app/DBSynthesizer/Parsers.hs
@@ -25,7 +25,6 @@ parseNodeFilePaths =
     <$> parseNodeConfigFilePath
     <*> parseChainDBFilePath
     <*> optional parsePaymentKeyFilePath
-    <*> optional parseBlsKeyFilePath
 
 parseNodeCredentials :: Parser NodeCredentials
 parseNodeCredentials =
@@ -34,6 +33,7 @@ parseNodeCredentials =
     <*> optional parseVrfKeyFilePath
     <*> optional parseKesKeyFilePath
     <*> optional parseBulkFilePath
+    <*> optional parseBlsKeyFilePath
 
 parseDBSynthesizerOptions :: Parser DBSynthesizerOptions
 parseDBSynthesizerOptions =

--- a/ouroboros-consensus-cardano/app/db-synthesizer.hs
+++ b/ouroboros-consensus-cardano/app/db-synthesizer.hs
@@ -4,6 +4,7 @@
 --                       [--shelley-operational-certificate FILE]
 --                       [--shelley-vrf-key FILE] [--shelley-kes-key FILE]
 --                       [--bulk-credentials-file FILE]
+--                       [--shelley-bls-key FILE]
 --                       ((-s|--slots NUMBER) | (-b|--blocks NUMBER) |
 --                         (-e|--epochs NUMBER)) [-f | -a]
 --
@@ -18,6 +19,7 @@
 --   --shelley-kes-key FILE   Path to the KES signing key
 --   --bulk-credentials-file FILE
 --                            Path to the bulk credentials file
+--   --shelley-bls-key FILE   Path to the pool's BLS signing key
 --   -s,--slots NUMBER        Amount of slots to process
 --   -b,--blocks NUMBER       Amount of blocks to forge
 --   -e,--epochs NUMBER       Amount of epochs to process

--- a/ouroboros-consensus-cardano/app/db-synthesizer.hs
+++ b/ouroboros-consensus-cardano/app/db-synthesizer.hs
@@ -1,6 +1,6 @@
 -- | This tool synthesizes a valid ChainDB, replicating cardano-node's UX
 --
--- Usage: db-synthesizer --config FILE --db PATH
+-- Usage: db-synthesizer --config FILE --db PATH [--payment-signing-key FILE]
 --                       [--shelley-operational-certificate FILE]
 --                       [--shelley-vrf-key FILE] [--shelley-kes-key FILE]
 --                       [--bulk-credentials-file FILE]
@@ -10,6 +10,8 @@
 -- Available options:
 --   --config FILE            Path to the node's config.json
 --   --db PATH                Path to the Chain DB
+--   --payment-signing-key FILE
+--                            Path to the payment signing key
 --   --shelley-operational-certificate FILE
 --                            Path to the delegation certificate
 --   --shelley-vrf-key FILE   Path to the VRF signing key
@@ -25,6 +27,8 @@ module Main (main) where
 
 import Cardano.Crypto.Init (cryptoInit)
 import Cardano.Tools.DBSynthesizer.Run
+import Cardano.Tools.DBSynthesizer.TxGen (mkRespendTxGen)
+import Cardano.Tools.DBSynthesizer.Types (NodeFilePaths (nfpPaymentKey))
 import DBSynthesizer.Parsers
 import Main.Utf8 (withStdTerminalHandles)
 import System.Exit
@@ -33,7 +37,6 @@ main :: IO ()
 main = withStdTerminalHandles $ do
   cryptoInit
   (paths, creds, forgeOpts) <- parseCommandLine
-  let
-    genTxs _ _ _ _ = pure []
+  genTxs <- either die pure =<< mkRespendTxGen (nfpPaymentKey paths)
   result <- initialize paths creds forgeOpts >>= either die (uncurry (synthesize genTxs))
   putStrLn $ "--> done; result: " ++ show result

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBSynthesizer/BlsKey.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBSynthesizer/BlsKey.hs
@@ -8,9 +8,7 @@
 
 -- | The BLS signing key that the forger votes with.
 module Cardano.Tools.DBSynthesizer.BlsKey
-  ( BlsSigningKey (..)
-  , AsType (AsBlsSigningKey)
-  , readBlsSigningKey
+  ( readBlsSigningKey
   ) where
 
 import Cardano.Api.Any

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBSynthesizer/BlsKey.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBSynthesizer/BlsKey.hs
@@ -1,0 +1,61 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+
+-- | The BLS signing key that the forger votes with.
+module Cardano.Tools.DBSynthesizer.BlsKey
+  ( BlsSigningKey (..)
+  , AsType (AsBlsSigningKey)
+  , readBlsSigningKey
+  ) where
+
+import Cardano.Api.Any
+  ( FromCBOR
+  , HasTypeProxy (..)
+  , SerialiseAsCBOR
+  , ToCBOR
+  , displayError
+  )
+import Cardano.Api.SerialiseTextEnvelope
+  ( HasTextEnvelope (..)
+  , readFileTextEnvelope
+  )
+import qualified Cardano.Crypto.DSIGN.Class as Crypto
+import Cardano.Crypto.Leios (LeiosDSIGN, LeiosSigningKey)
+import Data.Bifunctor (bimap)
+import Data.Proxy (Proxy (..))
+import Data.String (fromString)
+
+-- | A stake pool's BLS signing key, as @cardano-cli node key-gen-BLS@ writes
+-- it. The pool registers the matching verification key as its @leiosKey@, and
+-- the ledger builds the voting committee from those registrations.
+--
+-- @Cardano.Api.Key.Internal.Leios@ holds the same type, with the same envelope
+-- type. That module is not exposed, and @Cardano.Api.Key@ re-exports no
+-- constructor for its signing key, so this copy tracks it by hand.
+newtype BlsSigningKey = BlsSigningKey {unBlsSigningKey :: LeiosSigningKey}
+  deriving newtype (ToCBOR, FromCBOR)
+  deriving anyclass SerialiseAsCBOR
+
+instance HasTypeProxy BlsSigningKey where
+  data AsType BlsSigningKey = AsBlsSigningKey
+  proxyToAsType _ = AsBlsSigningKey
+
+instance HasTextEnvelope BlsSigningKey where
+  -- This is "BlsSigningKey_bls12-381-BLS-Signature-Mininimal-Signature-Size",
+  -- the type that cardano-cli writes into the key file. The typo in "Mininimal"
+  -- is upstream.
+  textEnvelopeType _ =
+    "BlsSigningKey_" <> fromString (Crypto.algorithmNameDSIGN (Proxy @LeiosDSIGN))
+
+-- | Read the key from its JSON envelope.
+--
+-- The envelope names its own type, and this reader checks it. If you pass a VRF
+-- or KES key by mistake, the error names both types.
+readBlsSigningKey :: FilePath -> IO (Either String LeiosSigningKey)
+readBlsSigningKey path =
+  bimap displayError unBlsSigningKey <$> readFileTextEnvelope AsBlsSigningKey path

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBSynthesizer/Forging.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBSynthesizer/Forging.hs
@@ -20,17 +20,16 @@ import Control.Monad.Except (runExcept)
 import Control.Monad.IO.Class (liftIO)
 import qualified Control.Monad.Trans.Class as Trans
 import Control.Monad.Trans.Except (ExceptT (..), runExceptT, throwE)
-import Control.Tracer (Tracer, nullTracer)
+import Control.Tracer (Tracer, nullTracer, traceWith)
 import Data.ByteString.Short (fromShort)
 import Data.Either (isRight)
-import Data.IORef (IORef, modifyIORef', newIORef, readIORef)
 import Data.Maybe (fromJust, isJust)
 import Data.Proxy
 import Data.Word (Word64)
 import LeiosDemoDb (LeiosDbConnection)
 import LeiosDemoTypes
   ( RbHash (MkRbHash)
-  , TraceLeiosKernel
+  , TraceLeiosKernel (..)
   , getLeiosSeatId
   , leiosCommitteeSize
   , signLeiosVote
@@ -38,6 +37,7 @@ import LeiosDemoTypes
 import LeiosVoteState
   ( AddVoteResult (Added)
   , LeiosVoteState (addVote)
+  , VoteTally (..)
   , newLeiosVoteState
   )
 import LeiosVoting (HasLeiosVoting (getCurrentThreshold, getLeiosCommittee))
@@ -107,15 +107,6 @@ data ForgeState
 initialForgeState :: ForgeState
 initialForgeState = ForgeState 0 0 0 0
 
--- | What the forger's own votes achieved over a run.
-data VoteTally = VoteTally
-  { cast :: !Word64
-  -- ^ Votes the forger cast, one for every endorser block it announced.
-  , certified :: !Word64
-  -- ^ Votes that took the tally for their announcing block to the
-  -- certification threshold. A certificate exists for each one.
-  }
-
 -- | An action to generate transactions for a given block.
 --
 -- The first list fills the ranking block. The second fills the endorser block
@@ -157,18 +148,12 @@ runForge epochSize_ nextSlot opts chainDB blockForging cfg genTxs leiosDb leiosT
   putStrLn $ "--> will process until: " ++ show opts
   leiosVoteState <- newLeiosVoteState committee
   reportCommittee
-  -- 'goSlot' reports only success or failure to 'go', so the tally lives beside
-  -- 'ForgeState' rather than in it.
-  tally <- newIORef VoteTally{cast = 0, certified = 0}
-  endState <- go leiosVoteState tally initialForgeState{currentSlot = nextSlot}
+  endState <- go leiosVoteState initialForgeState{currentSlot = nextSlot}
   putStrLn $
     "--> forged and adopted "
       ++ show (forged endState)
       ++ " blocks; reached "
       ++ show (currentSlot endState)
-  VoteTally{cast, certified} <- readIORef tally
-  putStrLn $
-    "--> votes: " ++ show cast ++ " cast, " ++ show certified ++ " certified"
   pure $ ForgeResult $ fromIntegral $ forged endState
  where
   epochSize = unEpochSize epochSize_
@@ -214,11 +199,10 @@ runForge epochSize_ nextSlot opts chainDB blockForging cfg genTxs leiosDb leiosT
   -- against a node log sees the vote that many slots early.
   voteFor ::
     LeiosVoteState IO ->
-    IORef VoteTally ->
     blk ->
     [Validated (GenTx blk)] ->
     IO ()
-  voteFor leiosVoteState tally newBlock ebTxs
+  voteFor leiosVoteState newBlock ebTxs
     -- 'mkAndStoreEb' announces an endorser block exactly when it is given
     -- transactions. So an empty list means this block announced none, and there
     -- is nothing to vote for.
@@ -231,19 +215,27 @@ runForge epochSize_ nextSlot opts chainDB blockForging cfg genTxs leiosDb leiosT
                 let rbHash =
                       MkRbHash . fromShort . toShortRawHash (Proxy @blk) $
                         blockHash newBlock
-                addVote leiosVoteState (signLeiosVote sk seat rbHash) >>= \case
-                  Added _weight mCert ->
-                    modifyIORef' tally $ \t ->
-                      VoteTally
-                        { cast = cast t + 1
-                        , certified = certified t + if isJust mCert then 1 else 0
+                    vote = signLeiosVote sk seat rbHash
+                addVote leiosVoteState vote >>= \case
+                  Added VoteTally{vtWeight, vtTally, vtThreshold} mCert -> do
+                    -- The same events 'runLeiosVoting' emits.
+                    traceWith leiosTracer TraceLeiosVoted{vote, weight = vtWeight}
+                    traceWith leiosTracer $
+                      TraceLeiosVoteAcquired
+                        { vote
+                        , weight = vtWeight
+                        , tally = vtTally
+                        , threshold = vtThreshold
                         }
+                    case mCert of
+                      Just _ -> traceWith leiosTracer TraceLeiosCertified{rbHash}
+                      Nothing -> pure ()
                   -- 'reportCommittee' already showed the committee and the seat,
                   -- so any other result means the state changed under us. Stop,
                   -- rather than forge blocks that nobody certifies.
                   other -> fail $ "db-synthesizer: addVote returned " ++ show other
           -- No key or no seat. 'reportCommittee' said so at start-up, and the
-          -- run ends with "0 cast".
+          -- run emits no 'TraceLeiosVoted'.
           _ -> pure ()
 
   forgingDone :: ForgeState -> Bool
@@ -252,12 +244,12 @@ runForge epochSize_ nextSlot opts chainDB blockForging cfg genTxs leiosDb leiosT
     ForgeLimitBlock b -> (b ==) . forged
     ForgeLimitEpoch e -> (e ==) . currentEpoch
 
-  go :: LeiosVoteState IO -> IORef VoteTally -> ForgeState -> IO ForgeState
-  go leiosVoteState tally forgeState
+  go :: LeiosVoteState IO -> ForgeState -> IO ForgeState
+  go leiosVoteState forgeState
     | forgingDone forgeState = pure forgeState
     | otherwise =
-        go leiosVoteState tally . nextForgeState forgeState . isRight
-          =<< runExceptT (goSlot leiosVoteState tally $ currentSlot forgeState)
+        go leiosVoteState . nextForgeState forgeState . isRight
+          =<< runExceptT (goSlot leiosVoteState $ currentSlot forgeState)
 
   nextForgeState :: ForgeState -> Bool -> ForgeState
   nextForgeState ForgeState{currentSlot, forged, currentEpoch, processed} didForge =
@@ -275,8 +267,8 @@ runForge epochSize_ nextSlot opts chainDB blockForging cfg genTxs leiosDb leiosT
   exitEarly' = throwE
   lift = liftIO
 
-  goSlot :: LeiosVoteState IO -> IORef VoteTally -> SlotNo -> ExceptT String IO ()
-  goSlot leiosVoteState tally currentSlot = do
+  goSlot :: LeiosVoteState IO -> SlotNo -> ExceptT String IO ()
+  goSlot leiosVoteState currentSlot = do
     -- Figure out which block to connect to
     BlockContext{bcBlockNo, bcPrevPoint} <- do
       eBlkCtx <-
@@ -393,7 +385,7 @@ runForge epochSize_ nextSlot opts chainDB blockForging cfg genTxs leiosDb leiosT
     when (mbCurTip /= SuccesfullyAddedBlock (blockPoint newBlock)) $
       exitEarly' "block not adopted"
 
-    lift $ voteFor leiosVoteState tally newBlock ebTxs
+    lift $ voteFor leiosVoteState newBlock ebTxs
 
 -- | Context required to forge a block
 data BlockContext blk = BlockContext

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBSynthesizer/Forging.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBSynthesizer/Forging.hs
@@ -116,12 +116,17 @@ initialForgeState = ForgeState 0 0 0 0
 -- The 'Bool' says whether this block certifies the endorser block that its
 -- parent announced. Such a block must get no transactions, because 'mkBody'
 -- drops them and applies the certified endorser block's instead.
+--
+-- The 'IO' action records what this block leaves unspent. The caller runs it
+-- once the ChainDB adopts the block, and skips it otherwise. A generator that
+-- recorded the outputs as it built them would carry the outputs of a block
+-- that no chain holds.
 type GenTxs blk =
   SlotNo ->
   Bool ->
   ReadOnlyForker IO (ExtLedgerState blk) ->
   TickedLedgerState blk DiffMK ->
-  IO ([Validated (GenTx blk)], [Validated (GenTx blk)])
+  IO ([Validated (GenTx blk)], [Validated (GenTx blk)], IO ())
 
 -- DUPLICATE: runForge mirrors forging loop from ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
 -- For an extensive commentary of the forging loop, see there.
@@ -346,7 +351,7 @@ runForge epochSize_ nextSlot opts chainDB blockForging cfg votingKey genTxs leio
           currentSlot
           unticked
 
-    (rbTxs, ebTxs) <- withReadOnlyForkerAtPoint'
+    (rbTxs, ebTxs, commitLeftovers) <- withReadOnlyForkerAtPoint'
       chainDB
       (SpecificPoint bcPrevPoint)
       $ \case
@@ -386,6 +391,8 @@ runForge epochSize_ nextSlot opts chainDB blockForging cfg votingKey genTxs leio
 
     when (mbCurTip /= SuccesfullyAddedBlock (blockPoint newBlock)) $
       exitEarly' "block not adopted"
+
+    lift commitLeftovers
 
     lift $ voteFor leiosVoteState newBlock ebTxs
 

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBSynthesizer/Forging.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBSynthesizer/Forging.hs
@@ -89,12 +89,16 @@ data ForgeState
 initialForgeState :: ForgeState
 initialForgeState = ForgeState 0 0 0 0
 
--- | An action to generate transactions for a given block
+-- | An action to generate transactions for a given block.
+--
+-- The first list fills the ranking block. The second fills the endorser block
+-- that the ranking block announces. An empty second list announces no endorser
+-- block, because 'mkAndStoreEb' forges none for an empty list.
 type GenTxs blk =
   SlotNo ->
   ReadOnlyForker IO (ExtLedgerState blk) ->
   TickedLedgerState blk DiffMK ->
-  IO [Validated (GenTx blk)]
+  IO ([Validated (GenTx blk)], [Validated (GenTx blk)])
 
 -- DUPLICATE: runForge mirrors forging loop from ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
 -- For an extensive commentary of the forging loop, see there.
@@ -221,7 +225,7 @@ runForge epochSize_ nextSlot opts chainDB blockForging cfg genTxs _leiosDb = do
           -- the node's forging loop
           ExceptT . fmap (Right . fromJust) . withEarlyExit $
             withReadOnlyForkerAtPoint cdb tgt (Trans.lift . k)
-    txs <- withReadOnlyForkerAtPoint'
+    (rbTxs, ebTxs) <- withReadOnlyForkerAtPoint'
       chainDB
       (SpecificPoint bcPrevPoint)
       $ \case
@@ -244,8 +248,8 @@ runForge epochSize_ nextSlot opts chainDB blockForging cfg genTxs _leiosDb = do
             , fbCurrentBlockNo = bcBlockNo
             , fbCurrentSlotNo = currentSlot
             , fbCurrentTickedLedgerState = forgetLedgerTables tickedLedgerState
-            , fbRbTxs = txs
-            , fbEbTxs = []
+            , fbRbTxs = rbTxs
+            , fbEbTxs = ebTxs
             , fbIsLeader = proof
             , fbChainDepState = Nothing
             , fbLeiosTracer = Trace.nullTracer

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBSynthesizer/Forging.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBSynthesizer/Forging.hs
@@ -28,7 +28,8 @@ import Data.Proxy
 import Data.Word (Word64)
 import LeiosDemoDb (LeiosDbConnection)
 import LeiosDemoTypes
-  ( RbHash (MkRbHash)
+  ( LeiosSigningKey
+  , RbHash (MkRbHash)
   , TraceLeiosKernel (..)
   , getLeiosSeatId
   , leiosCommitteeSize
@@ -52,7 +53,6 @@ import Ouroboros.Consensus.Config
   ( TopLevelConfig
   , configConsensus
   , configLedger
-  , topLevelConfigVotingKey
   )
 import Ouroboros.Consensus.Forecast (forecastFor)
 import Ouroboros.Consensus.HeaderValidation
@@ -139,11 +139,13 @@ runForge ::
   ChainDB IO blk ->
   [BlockForging IO blk] ->
   TopLevelConfig blk ->
+  -- | The BLS key that this forger votes with, if it has one.
+  Maybe LeiosSigningKey ->
   GenTxs blk ->
   LeiosDbConnection IO ->
   Tracer IO TraceLeiosKernel ->
   IO ForgeResult
-runForge epochSize_ nextSlot opts chainDB blockForging cfg genTxs leiosDb leiosTracer = do
+runForge epochSize_ nextSlot opts chainDB blockForging cfg votingKey genTxs leiosDb leiosTracer = do
   putStrLn $ "--> epoch size: " ++ show epochSize_
   putStrLn $ "--> will process until: " ++ show opts
   leiosVoteState <- newLeiosVoteState committee
@@ -178,7 +180,7 @@ runForge epochSize_ nextSlot opts chainDB blockForging cfg genTxs leiosDb leiosT
         "committee: "
           ++ show (leiosCommitteeSize c)
           ++ " seats; our seat: "
-          ++ case topLevelConfigVotingKey cfg of
+          ++ case votingKey of
             Nothing -> "none, no voting key"
             Just sk -> case getLeiosSeatId (deriveVerKeyDSIGN sk) c of
               Nothing -> "none, our key holds no seat"
@@ -209,7 +211,7 @@ runForge epochSize_ nextSlot opts chainDB blockForging cfg genTxs leiosDb leiosT
     | null ebTxs = pure ()
     | otherwise = do
         mCommittee <- atomically committee
-        case (mCommittee, topLevelConfigVotingKey cfg) of
+        case (mCommittee, votingKey) of
           (Just (c, _threshold), Just sk)
             | Just seat <- getLeiosSeatId (deriveVerKeyDSIGN sk) c -> do
                 let rbHash =

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBSynthesizer/Forging.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBSynthesizer/Forging.hs
@@ -20,7 +20,7 @@ import Control.Monad.Except (runExcept)
 import Control.Monad.IO.Class (liftIO)
 import qualified Control.Monad.Trans.Class as Trans
 import Control.Monad.Trans.Except (ExceptT (..), runExceptT, throwE)
-import Control.Tracer as Trace (nullTracer)
+import Control.Tracer (Tracer, nullTracer)
 import Data.ByteString.Short (fromShort)
 import Data.Either (isRight)
 import Data.IORef (IORef, modifyIORef', newIORef, readIORef)
@@ -30,6 +30,7 @@ import Data.Word (Word64)
 import LeiosDemoDb (LeiosDbConnection)
 import LeiosDemoTypes
   ( RbHash (MkRbHash)
+  , TraceLeiosKernel
   , getLeiosSeatId
   , leiosCommitteeSize
   , signLeiosVote
@@ -149,8 +150,9 @@ runForge ::
   TopLevelConfig blk ->
   GenTxs blk ->
   LeiosDbConnection IO ->
+  Tracer IO TraceLeiosKernel ->
   IO ForgeResult
-runForge epochSize_ nextSlot opts chainDB blockForging cfg genTxs leiosDb = do
+runForge epochSize_ nextSlot opts chainDB blockForging cfg genTxs leiosDb leiosTracer = do
   putStrLn $ "--> epoch size: " ++ show epochSize_
   putStrLn $ "--> will process until: " ++ show opts
   leiosVoteState <- newLeiosVoteState committee
@@ -185,11 +187,10 @@ runForge epochSize_ nextSlot opts chainDB blockForging cfg genTxs leiosDb = do
   -- case ends with no vote counted.
   reportCommittee = do
     mCommittee <- atomically committee
-    -- TODO: shouldn't we be using other mechanism to report other than putStrLn?
-    putStrLn $ case mCommittee of
-      Nothing -> "--> committee: none; the era does not vote"
+    traceWith leiosTracer . MkTraceLeiosKernel $ case mCommittee of
+      Nothing -> "committee: none; the era does not vote"
       Just (c, _threshold) ->
-        "--> committee: "
+        "committee: "
           ++ show (leiosCommitteeSize c)
           ++ " seats; our seat: "
           ++ case topLevelConfigVotingKey cfg of
@@ -346,7 +347,7 @@ runForge epochSize_ nextSlot opts chainDB blockForging cfg genTxs leiosDb = do
         decideLeiosCertify
           leiosDb
           leiosVoteState
-          Trace.nullTracer
+          leiosTracer
           (configLedger cfg)
           currentSlot
           unticked
@@ -379,7 +380,7 @@ runForge epochSize_ nextSlot opts chainDB blockForging cfg genTxs leiosDb = do
             , fbEbTxs = ebTxs
             , fbIsLeader = proof
             , fbChainDepState = Nothing
-            , fbLeiosTracer = Trace.nullTracer
+            , fbLeiosTracer = leiosTracer
             , fbLeiosVoteState = leiosVoteState
             , fbMayLeiosCert = fst <$> mCert
             }

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBSynthesizer/Forging.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBSynthesizer/Forging.hs
@@ -10,6 +10,7 @@ module Cardano.Tools.DBSynthesizer.Forging
   , runForge
   ) where
 
+import Cardano.Crypto.DSIGN.Class (deriveVerKeyDSIGN)
 import Cardano.Tools.DBSynthesizer.Types
   ( ForgeLimit (..)
   , ForgeResult (..)
@@ -25,7 +26,9 @@ import Data.Maybe (fromJust, isJust)
 import Data.Proxy
 import Data.Word (Word64)
 import LeiosDemoDb (LeiosDbConnection)
+import LeiosDemoTypes (getLeiosSeatId, leiosCommitteeSize)
 import LeiosVoteState (LeiosVoteState, newLeiosVoteState)
+import LeiosVoting (HasLeiosVoting (getCurrentThreshold, getLeiosCommittee))
 import Ouroboros.Consensus.Block.Abstract as Block
 import Ouroboros.Consensus.Block.Forging as Block
   ( BlockForging (..)
@@ -37,6 +40,7 @@ import Ouroboros.Consensus.Config
   ( TopLevelConfig
   , configConsensus
   , configLedger
+  , topLevelConfigVotingKey
   )
 import Ouroboros.Consensus.Forecast (forecastFor)
 import Ouroboros.Consensus.HeaderValidation
@@ -59,6 +63,7 @@ import Ouroboros.Consensus.Storage.ChainDB.API as ChainDB
   , addBlockAsync
   , blockProcessed
   , getCurrentChain
+  , getCurrentLedger
   , getPastLedger
   , withReadOnlyForkerAtPoint
   )
@@ -105,7 +110,9 @@ type GenTxs blk =
 
 runForge ::
   forall blk.
-  LedgerSupportsProtocol blk =>
+  ( LedgerSupportsProtocol blk
+  , HasLeiosVoting blk
+  ) =>
   EpochSize ->
   SlotNo ->
   ForgeLimit ->
@@ -118,9 +125,8 @@ runForge ::
 runForge epochSize_ nextSlot opts chainDB blockForging cfg genTxs _leiosDb = do
   putStrLn $ "--> epoch size: " ++ show epochSize_
   putStrLn $ "--> will process until: " ++ show opts
-  -- Synthetic forging doesn't gather votes; supply a vote state with
-  -- no committee so 'queryCert' always returns 'Nothing'.
-  leiosVoteState <- newLeiosVoteState (pure Nothing)
+  leiosVoteState <- newLeiosVoteState committee
+  reportCommittee
   endState <- go leiosVoteState initialForgeState{currentSlot = nextSlot}
   putStrLn $
     "--> forged and adopted "
@@ -130,6 +136,33 @@ runForge epochSize_ nextSlot opts chainDB blockForging cfg genTxs _leiosDb = do
   pure $ ForgeResult $ fromIntegral $ forged endState
  where
   epochSize = unEpochSize epochSize_
+
+  -- The committee is rebuilt from the ledger state on every read,
+  -- because it changes with the stake distribution snapshot at each
+  -- epoch boundary.
+  committee = do
+    ls <- ledgerState <$> getCurrentLedger chainDB
+    pure $ (,) <$> getLeiosCommittee ls <*> getCurrentThreshold ls
+
+  -- A seat can exist without a key. If the pool registers no
+  -- 'leiosKey', its seat is keyless. If its proof of possession does
+  -- not verify, 'mkLeiosCommittee' also makes the seat keyless. If our
+  -- key differs from the registered one, no seat matches ours. Each
+  -- case ends with no vote counted.
+  reportCommittee = do
+    mCommittee <- atomically committee
+    -- TODO: shouldn't we be using other mechanism to report other than putStrLn?
+    putStrLn $ case mCommittee of
+      Nothing -> "--> committee: none; the era does not vote"
+      Just (c, _threshold) ->
+        "--> committee: "
+          ++ show (leiosCommitteeSize c)
+          ++ " seats; our seat: "
+          ++ case topLevelConfigVotingKey cfg of
+            Nothing -> "none, no voting key"
+            Just sk -> case getLeiosSeatId (deriveVerKeyDSIGN sk) c of
+              Nothing -> "none, our key holds no seat"
+              Just seat -> show seat
 
   forgingDone :: ForgeState -> Bool
   forgingDone = case opts of

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBSynthesizer/Forging.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBSynthesizer/Forging.hs
@@ -64,6 +64,7 @@ import Ouroboros.Consensus.Ledger.Extended
 import Ouroboros.Consensus.Ledger.SupportsMempool (GenTx)
 import Ouroboros.Consensus.Ledger.SupportsProtocol
 import Ouroboros.Consensus.Ledger.Tables.Utils (forgetLedgerTables)
+import Ouroboros.Consensus.NodeKernel.Forge (decideLeiosCertify)
 import Ouroboros.Consensus.Protocol.Abstract
   ( ChainDepState
   , tickChainDepState
@@ -119,8 +120,13 @@ data VoteTally = VoteTally
 -- The first list fills the ranking block. The second fills the endorser block
 -- that the ranking block announces. An empty second list announces no endorser
 -- block, because 'mkAndStoreEb' forges none for an empty list.
+--
+-- The 'Bool' says whether this block certifies the endorser block that its
+-- parent announced. Such a block must get no transactions, because 'mkBody'
+-- drops them and applies the certified endorser block's instead.
 type GenTxs blk =
   SlotNo ->
+  Bool ->
   ReadOnlyForker IO (ExtLedgerState blk) ->
   TickedLedgerState blk DiffMK ->
   IO ([Validated (GenTx blk)], [Validated (GenTx blk)])
@@ -133,6 +139,7 @@ runForge ::
   ( LedgerSupportsProtocol blk
   , HasLeiosVoting blk
   , ConvertRawHash blk
+  , ResolveLeiosBlock blk
   ) =>
   EpochSize ->
   SlotNo ->
@@ -143,7 +150,7 @@ runForge ::
   GenTxs blk ->
   LeiosDbConnection IO ->
   IO ForgeResult
-runForge epochSize_ nextSlot opts chainDB blockForging cfg genTxs _leiosDb = do
+runForge epochSize_ nextSlot opts chainDB blockForging cfg genTxs leiosDb = do
   putStrLn $ "--> epoch size: " ++ show epochSize_
   putStrLn $ "--> will process until: " ++ show opts
   leiosVoteState <- newLeiosVoteState committee
@@ -332,6 +339,18 @@ runForge epochSize_ nextSlot opts chainDB blockForging cfg genTxs _leiosDb = do
           -- the node's forging loop
           ExceptT . fmap (Right . fromJust) . withEarlyExit $
             withReadOnlyForkerAtPoint cdb tgt (Trans.lift . k)
+    -- Decide before generating. A certifying block carries no transactions of
+    -- its own, so the generator has to know.
+    mCert <-
+      lift $
+        decideLeiosCertify
+          leiosDb
+          leiosVoteState
+          Trace.nullTracer
+          (configLedger cfg)
+          currentSlot
+          unticked
+
     (rbTxs, ebTxs) <- withReadOnlyForkerAtPoint'
       chainDB
       (SpecificPoint bcPrevPoint)
@@ -340,6 +359,7 @@ runForge epochSize_ nextSlot opts chainDB blockForging cfg genTxs _leiosDb = do
         Right frk ->
           genTxs
             currentSlot
+            (isJust mCert)
             frk
             tickedLedgerState
 
@@ -361,7 +381,7 @@ runForge epochSize_ nextSlot opts chainDB blockForging cfg genTxs _leiosDb = do
             , fbChainDepState = Nothing
             , fbLeiosTracer = Trace.nullTracer
             , fbLeiosVoteState = leiosVoteState
-            , fbMayLeiosCert = Nothing
+            , fbMayLeiosCert = fst <$> mCert
             }
 
     -- Add the block to the chain DB (synchronously) and verify adoption

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBSynthesizer/Forging.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBSynthesizer/Forging.hs
@@ -21,13 +21,24 @@ import Control.Monad.IO.Class (liftIO)
 import qualified Control.Monad.Trans.Class as Trans
 import Control.Monad.Trans.Except (ExceptT (..), runExceptT, throwE)
 import Control.Tracer as Trace (nullTracer)
+import Data.ByteString.Short (fromShort)
 import Data.Either (isRight)
+import Data.IORef (IORef, modifyIORef', newIORef, readIORef)
 import Data.Maybe (fromJust, isJust)
 import Data.Proxy
 import Data.Word (Word64)
 import LeiosDemoDb (LeiosDbConnection)
-import LeiosDemoTypes (getLeiosSeatId, leiosCommitteeSize)
-import LeiosVoteState (LeiosVoteState, newLeiosVoteState)
+import LeiosDemoTypes
+  ( RbHash (MkRbHash)
+  , getLeiosSeatId
+  , leiosCommitteeSize
+  , signLeiosVote
+  )
+import LeiosVoteState
+  ( AddVoteResult (Added)
+  , LeiosVoteState (addVote)
+  , newLeiosVoteState
+  )
 import LeiosVoting (HasLeiosVoting (getCurrentThreshold, getLeiosCommittee))
 import Ouroboros.Consensus.Block.Abstract as Block
 import Ouroboros.Consensus.Block.Forging as Block
@@ -94,6 +105,15 @@ data ForgeState
 initialForgeState :: ForgeState
 initialForgeState = ForgeState 0 0 0 0
 
+-- | What the forger's own votes achieved over a run.
+data VoteTally = VoteTally
+  { cast :: !Word64
+  -- ^ Votes the forger cast, one for every endorser block it announced.
+  , certified :: !Word64
+  -- ^ Votes that took the tally for their announcing block to the
+  -- certification threshold. A certificate exists for each one.
+  }
+
 -- | An action to generate transactions for a given block.
 --
 -- The first list fills the ranking block. The second fills the endorser block
@@ -112,6 +132,7 @@ runForge ::
   forall blk.
   ( LedgerSupportsProtocol blk
   , HasLeiosVoting blk
+  , ConvertRawHash blk
   ) =>
   EpochSize ->
   SlotNo ->
@@ -127,12 +148,18 @@ runForge epochSize_ nextSlot opts chainDB blockForging cfg genTxs _leiosDb = do
   putStrLn $ "--> will process until: " ++ show opts
   leiosVoteState <- newLeiosVoteState committee
   reportCommittee
-  endState <- go leiosVoteState initialForgeState{currentSlot = nextSlot}
+  -- 'goSlot' reports only success or failure to 'go', so the tally lives beside
+  -- 'ForgeState' rather than in it.
+  tally <- newIORef VoteTally{cast = 0, certified = 0}
+  endState <- go leiosVoteState tally initialForgeState{currentSlot = nextSlot}
   putStrLn $
     "--> forged and adopted "
       ++ show (forged endState)
       ++ " blocks; reached "
       ++ show (currentSlot endState)
+  VoteTally{cast, certified} <- readIORef tally
+  putStrLn $
+    "--> votes: " ++ show cast ++ " cast, " ++ show certified ++ " certified"
   pure $ ForgeResult $ fromIntegral $ forged endState
  where
   epochSize = unEpochSize epochSize_
@@ -164,18 +191,65 @@ runForge epochSize_ nextSlot opts chainDB blockForging cfg genTxs _leiosDb = do
               Nothing -> "none, our key holds no seat"
               Just seat -> show seat
 
+  -- Vote for the endorser block that this block announces. The vote signs the
+  -- announcing block's hash, not the endorser block's.
+  --
+  -- 'runLeiosVoting' applies four checks that this function does not. Three of
+  -- them hold here already. 'forgeBlock' stores the closure before it returns,
+  -- so the closure is on disk. The caller votes only after the ChainDB adopts
+  -- the block, so the announcing block is the tip. The vote goes out in the
+  -- announcing slot, so it is inside the vote window.
+  --
+  -- The fourth is the wait of 'lHdrWaitSlots' after the announcing slot, which
+  -- gives an equivocating announcement time to arrive. One forger makes this
+  -- chain, so no second announcement exists. A reader that compares this trace
+  -- against a node log sees the vote that many slots early.
+  voteFor ::
+    LeiosVoteState IO ->
+    IORef VoteTally ->
+    blk ->
+    [Validated (GenTx blk)] ->
+    IO ()
+  voteFor leiosVoteState tally newBlock ebTxs
+    -- 'mkAndStoreEb' announces an endorser block exactly when it is given
+    -- transactions. So an empty list means this block announced none, and there
+    -- is nothing to vote for.
+    | null ebTxs = pure ()
+    | otherwise = do
+        mCommittee <- atomically committee
+        case (mCommittee, topLevelConfigVotingKey cfg) of
+          (Just (c, _threshold), Just sk)
+            | Just seat <- getLeiosSeatId (deriveVerKeyDSIGN sk) c -> do
+                let rbHash =
+                      MkRbHash . fromShort . toShortRawHash (Proxy @blk) $
+                        blockHash newBlock
+                addVote leiosVoteState (signLeiosVote sk seat rbHash) >>= \case
+                  Added _weight mCert ->
+                    modifyIORef' tally $ \t ->
+                      VoteTally
+                        { cast = cast t + 1
+                        , certified = certified t + if isJust mCert then 1 else 0
+                        }
+                  -- 'reportCommittee' already showed the committee and the seat,
+                  -- so any other result means the state changed under us. Stop,
+                  -- rather than forge blocks that nobody certifies.
+                  other -> fail $ "db-synthesizer: addVote returned " ++ show other
+          -- No key or no seat. 'reportCommittee' said so at start-up, and the
+          -- run ends with "0 cast".
+          _ -> pure ()
+
   forgingDone :: ForgeState -> Bool
   forgingDone = case opts of
     ForgeLimitSlot s -> (s ==) . processed
     ForgeLimitBlock b -> (b ==) . forged
     ForgeLimitEpoch e -> (e ==) . currentEpoch
 
-  go :: LeiosVoteState IO -> ForgeState -> IO ForgeState
-  go leiosVoteState forgeState
+  go :: LeiosVoteState IO -> IORef VoteTally -> ForgeState -> IO ForgeState
+  go leiosVoteState tally forgeState
     | forgingDone forgeState = pure forgeState
     | otherwise =
-        go leiosVoteState . nextForgeState forgeState . isRight
-          =<< runExceptT (goSlot leiosVoteState $ currentSlot forgeState)
+        go leiosVoteState tally . nextForgeState forgeState . isRight
+          =<< runExceptT (goSlot leiosVoteState tally $ currentSlot forgeState)
 
   nextForgeState :: ForgeState -> Bool -> ForgeState
   nextForgeState ForgeState{currentSlot, forged, currentEpoch, processed} didForge =
@@ -193,8 +267,8 @@ runForge epochSize_ nextSlot opts chainDB blockForging cfg genTxs _leiosDb = do
   exitEarly' = throwE
   lift = liftIO
 
-  goSlot :: LeiosVoteState IO -> SlotNo -> ExceptT String IO ()
-  goSlot leiosVoteState currentSlot = do
+  goSlot :: LeiosVoteState IO -> IORef VoteTally -> SlotNo -> ExceptT String IO ()
+  goSlot leiosVoteState tally currentSlot = do
     -- Figure out which block to connect to
     BlockContext{bcBlockNo, bcPrevPoint} <- do
       eBlkCtx <-
@@ -297,6 +371,8 @@ runForge epochSize_ nextSlot opts chainDB blockForging cfg genTxs _leiosDb = do
 
     when (mbCurTip /= SuccesfullyAddedBlock (blockPoint newBlock)) $
       exitEarly' "block not adopted"
+
+    lift $ voteFor leiosVoteState tally newBlock ebTxs
 
 -- | Context required to forge a block
 data BlockContext blk = BlockContext

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBSynthesizer/Run.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBSynthesizer/Run.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Cardano.Tools.DBSynthesizer.Run
@@ -29,13 +30,20 @@ import Data.Aeson as Aeson
   , Value
   , eitherDecodeFileStrict'
   , eitherDecodeStrict'
+  , encode
   , fromJSON
+  , (.=)
   )
 import Data.Bool (bool)
 import Data.ByteString as BS (ByteString, readFile)
+import qualified Data.ByteString.Lazy.Char8 as BSL8 (unpack)
 import Data.Functor (($>))
 import qualified Data.Set as Set
 import LeiosDemoDb (newLeiosDBSQLite, withLeiosDb)
+import LeiosDemoTypes
+  ( TraceLeiosKernel (TraceLeiosDb)
+  , traceLeiosKernelToObject
+  )
 import qualified Ouroboros.Consensus.Block.Forging as BlockForging
 import Ouroboros.Consensus.Cardano.Block
 import Ouroboros.Consensus.Cardano.Node
@@ -65,13 +73,23 @@ import qualified Ouroboros.Consensus.Storage.ChainDB.Impl.Args as ChainDB
 import qualified Ouroboros.Consensus.Storage.LedgerDB as LedgerDB
 import Ouroboros.Consensus.Storage.LedgerDB.V2.Backend
 import Ouroboros.Consensus.Storage.LedgerDB.V2.InMemory
-import Ouroboros.Consensus.Util.IOLike (atomically)
+import Ouroboros.Consensus.Util.IOLike
+  ( atomically
+  , bracket_
+  , diffTime
+  , getMonotonicTime
+  , newMVar
+  , putMVar
+  , takeMVar
+  )
 import Ouroboros.Network.Block
 import Ouroboros.Network.Point (WithOrigin (..))
 import System.Directory
 import System.FS.API (MountPoint (..), SomeHasFS (..))
 import System.FS.IO (ioHasFS)
 import System.FilePath (takeDirectory, (</>))
+import System.IO (hFlush, hPutStrLn, stderr)
+import Text.Printf (printf)
 
 initialize ::
   NodeFilePaths ->
@@ -181,6 +199,30 @@ eitherParseJson v = case fromJSON v of
   Error err -> Left err
   Success a -> Right a
 
+-- | Write each Leios event to stderr as one JSON object.
+--
+-- The object is the one cardano-node writes to its log. This tracer
+-- adds one field, @at@. It holds the seconds from the start of the
+-- run to the event.
+mkLeiosTracer :: IO (Tracer IO TraceLeiosKernel)
+mkLeiosTracer = do
+  startTime <- getMonotonicTime
+  -- The ChainDB gives this tracer to every LeiosDb connection it opens, so a
+  -- thread other than the forge loop can reach it. One write per lock keeps
+  -- each event on a line of its own.
+  lock <- newMVar ()
+  let withLock = bracket_ (takeMVar lock) (putMVar lock ())
+  pure $ Tracer . emit $ \ev -> withLock $ do
+    now <- getMonotonicTime
+    let at = realToFrac (diffTime now startTime) :: Double
+    hPutStrLn stderr $
+      BSL8.unpack $
+        Aeson.encode $
+          -- The seconds are a string with six decimals, because
+          -- aeson writes a number below 0.1 in exponent form.
+          ("at" .= (printf "%.6f" at :: String)) <> traceLeiosKernelToObject ev
+    hFlush stderr
+
 synthesize ::
   ( TopLevelConfig (CardanoBlock StandardCrypto) ->
     GenTxs (CardanoBlock StandardCrypto)
@@ -193,7 +235,9 @@ synthesize genTxs DBSynthesizerConfig{confOptions, confShelleyGenesis, confDbDir
     -- The node writes its LeiosDb next to the other ChainDB files.
     -- The tool derives that path from --db. That is also where
     -- db-analyser looks for it.
-    leiosDbHandle <- newLeiosDBSQLite nullTracer (confDbDir </> "leios.db")
+    leiosTracer <- mkLeiosTracer
+    leiosDbHandle <-
+      newLeiosDBSQLite (TraceLeiosDb >$< leiosTracer) (confDbDir </> "leios.db")
     (ProtocolInfo{pInfoConfig, pInfoInitLedger}, mkForgers) <-
       protocolInfoCardano (SomeHasFS (ioHasFS (MountPoint confDbDir))) runP
     let
@@ -244,7 +288,16 @@ synthesize genTxs DBSynthesizerConfig{confOptions, confShelleyGenesis, confDbDir
                   At s -> succ s
 
               putStrLn $ "--> starting at: " ++ show slotNo
-              runForge epochSize slotNo synthLimit chainDB forgers pInfoConfig (genTxs pInfoConfig) leiosDb
+              runForge
+                epochSize
+                slotNo
+                synthLimit
+                chainDB
+                forgers
+                pInfoConfig
+                (genTxs pInfoConfig)
+                leiosDb
+                leiosTracer
         else do
           putStrLn "--> no forgers found; leaving possibly existing ChainDB untouched"
           pure $ ForgeResult 0

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBSynthesizer/Run.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBSynthesizer/Run.hs
@@ -34,7 +34,7 @@ import Data.Bool (bool)
 import Data.ByteString as BS (ByteString, readFile)
 import Data.Functor (($>))
 import qualified Data.Set as Set
-import LeiosDemoDb (LeiosDbHandle (open), newLeiosDBInMemory)
+import LeiosDemoDb (newLeiosDBSQLite, withLeiosDb)
 import qualified Ouroboros.Consensus.Block.Forging as BlockForging
 import Ouroboros.Consensus.Cardano.Block
 import Ouroboros.Consensus.Cardano.Node
@@ -151,8 +151,10 @@ synthesize ::
   IO ForgeResult
 synthesize genTxs DBSynthesizerConfig{confOptions, confShelleyGenesis, confDbDir} runP =
   withRegistry $ \registry -> do
-    leiosDbHandle <- newLeiosDBInMemory
-    leiosDb <- open leiosDbHandle
+    -- The node writes its LeiosDb next to the other ChainDB files.
+    -- The tool derives that path from --db. That is also where
+    -- db-analyser looks for it.
+    leiosDbHandle <- newLeiosDBSQLite nullTracer (confDbDir </> "leios.db")
     (ProtocolInfo{pInfoConfig, pInfoInitLedger}, mkForgers) <-
       protocolInfoCardano (SomeHasFS (ioHasFS (MountPoint confDbDir))) runP
     let
@@ -187,15 +189,19 @@ synthesize genTxs DBSynthesizerConfig{confOptions, confShelleyGenesis, confDbDir
           putStrLn $ "--> opening ChainDB on file system with mode: " ++ show synthOpenMode
           preOpenChainDB synthOpenMode confDbDir
           let dbTracer = nullTracer
-          ChainDB.withDB (ChainDB.updateTracer dbTracer dbArgs) $ \chainDB -> do
-            slotNo <- do
-              tip <- atomically (ChainDB.getTipPoint chainDB)
-              pure $ case pointSlot tip of
-                Origin -> 0
-                At s -> succ s
+          -- Open after 'preOpenChainDB'. That call creates the db directory, and
+          -- with -f it deletes and recreates it. An earlier open loses the file
+          -- with no error.
+          withLeiosDb leiosDbHandle $ \leiosDb ->
+            ChainDB.withDB (ChainDB.updateTracer dbTracer dbArgs) $ \chainDB -> do
+              slotNo <- do
+                tip <- atomically (ChainDB.getTipPoint chainDB)
+                pure $ case pointSlot tip of
+                  Origin -> 0
+                  At s -> succ s
 
-            putStrLn $ "--> starting at: " ++ show slotNo
-            runForge epochSize slotNo synthLimit chainDB forgers pInfoConfig (genTxs pInfoConfig) leiosDb
+              putStrLn $ "--> starting at: " ++ show slotNo
+              runForge epochSize slotNo synthLimit chainDB forgers pInfoConfig (genTxs pInfoConfig) leiosDb
         else do
           putStrLn "--> no forgers found; leaving possibly existing ChainDB untouched"
           pure $ ForgeResult 0

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBSynthesizer/Run.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBSynthesizer/Run.hs
@@ -47,24 +47,15 @@ import LeiosDemoTypes
 import qualified Ouroboros.Consensus.Block.Forging as BlockForging
 import Ouroboros.Consensus.Cardano.Block
 import Ouroboros.Consensus.Cardano.Node
-import Ouroboros.Consensus.Config
-  ( TopLevelConfig
-  , configStorage
-  , topLevelConfigVotingKey
-  )
+import Ouroboros.Consensus.Config (TopLevelConfig, configStorage)
 import qualified Ouroboros.Consensus.Node as Node (stdMkChainDbHasFS)
 import qualified Ouroboros.Consensus.Node.InitStorage as Node
   ( nodeImmutableDbChunkInfo
   )
 import Ouroboros.Consensus.Node.ProtocolInfo (ProtocolInfo (..))
-import Ouroboros.Consensus.Protocol.Praos.Common
-  ( PraosCanBeLeader (praosCanBeLeaderSignKeyBLS)
-  )
 import Ouroboros.Consensus.Shelley.Ledger.SupportsProtocol ()
 import Ouroboros.Consensus.Shelley.Node
-  ( ProtocolParamsShelleyBased (shelleyBasedLeaderCredentials)
-  , ShelleyGenesis (..)
-  , ShelleyLeaderCredentials (shelleyLeaderCredentialsCanBeLeader)
+  ( ShelleyGenesis (..)
   , validateGenesis
   )
 import qualified Ouroboros.Consensus.Storage.ChainDB as ChainDB (getTipPoint)
@@ -96,49 +87,21 @@ initialize ::
   NodeCredentials ->
   DBSynthesizerOptions ->
   IO (Either String (DBSynthesizerConfig, CardanoProtocolParams StandardCrypto))
-initialize NodeFilePaths{nfpConfig, nfpChainDB, nfpBlsKey} creds synthOptions = do
+initialize NodeFilePaths{nfpConfig, nfpChainDB} creds synthOptions = do
   relativeToConfig :: (FilePath -> FilePath) <-
     (</>) . takeDirectory <$> makeAbsolute nfpConfig
   runExceptT $ do
     conf <- initConf relativeToConfig
-    proto <- initProtocol relativeToConfig conf >>= withVotingKey
+    proto <- initProtocol relativeToConfig conf
     pure (conf, proto)
  where
-  -- 'mkPraosLeaderCredentials' builds every credential with
-  -- 'praosCanBeLeaderSignKeyBLS = Nothing', and the files it reads hold no BLS
-  -- key. 'CardanoProtocolParams' is a plain record, so the key goes in here
-  -- instead of in that vendored module. 'protocolInfoCardano' then puts it in
-  -- 'topLevelConfigVotingKey'.
-  withVotingKey ::
-    CardanoProtocolParams StandardCrypto ->
-    ExceptT String IO (CardanoProtocolParams StandardCrypto)
-  withVotingKey proto = case nfpBlsKey of
-    Nothing -> pure proto
-    Just path -> do
-      votingKey <- ExceptT (readBlsSigningKey path)
-      let shelleyBased = shelleyBasedProtocolParams proto
-          setKey credentials =
-            credentials
-              { shelleyLeaderCredentialsCanBeLeader =
-                  (shelleyLeaderCredentialsCanBeLeader credentials)
-                    { praosCanBeLeaderSignKeyBLS = Just votingKey
-                    }
-              }
-      pure
-        proto
-          { shelleyBasedProtocolParams =
-              shelleyBased
-                { shelleyBasedLeaderCredentials =
-                    map setKey (shelleyBasedLeaderCredentials shelleyBased)
-                }
-          }
-
   initConf :: (FilePath -> FilePath) -> ExceptT String IO DBSynthesizerConfig
   initConf relativeToConfig = do
     inp <- handleIOExceptT show (BS.readFile nfpConfig)
     configStub <- adjustFilePaths relativeToConfig <$> readJson inp
     shelleyGenesis <- readFileJson $ ncsShelleyGenesisFile configStub
     _ <- hoistEither $ validateGenesis shelleyGenesis
+    votingKey <- traverse (ExceptT . readBlsSigningKey) (credBlsFile creds)
     let
       protocolCredentials =
         ProtocolFilepaths
@@ -156,6 +119,7 @@ initialize NodeFilePaths{nfpConfig, nfpChainDB, nfpBlsKey} creds synthOptions = 
         , confProtocolCredentials = protocolCredentials
         , confShelleyGenesis = shelleyGenesis
         , confDbDir = nfpChainDB
+        , confVotingKey = votingKey
         }
 
   initProtocol ::
@@ -230,7 +194,7 @@ synthesize ::
   DBSynthesizerConfig ->
   (CardanoProtocolParams StandardCrypto) ->
   IO ForgeResult
-synthesize genTxs DBSynthesizerConfig{confOptions, confShelleyGenesis, confDbDir} runP =
+synthesize genTxs DBSynthesizerConfig{confOptions, confShelleyGenesis, confDbDir, confVotingKey} runP =
   withRegistry $ \registry -> do
     -- The node writes its LeiosDb next to the other ChainDB files.
     -- The tool derives that path from --db. That is also where
@@ -257,10 +221,6 @@ synthesize genTxs DBSynthesizerConfig{confOptions, confShelleyGenesis, confDbDir
           leiosDbHandle
           (\_ -> pure ()) -- no LeiosTxCache in this tool
           $ ChainDB.defaultArgs
-
-    putStrLn $
-      "--> voting key: "
-        ++ maybe "absent" (const "present") (topLevelConfigVotingKey pInfoConfig)
 
     mbfs <- mkForgers nullTracer
     allocatedForgers <-
@@ -295,6 +255,7 @@ synthesize genTxs DBSynthesizerConfig{confOptions, confShelleyGenesis, confDbDir
                 chainDB
                 forgers
                 pInfoConfig
+                confVotingKey
                 (genTxs pInfoConfig)
                 leiosDb
                 leiosTracer

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBSynthesizer/Run.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBSynthesizer/Run.hs
@@ -9,11 +9,12 @@ module Cardano.Tools.DBSynthesizer.Run
 import Cardano.Api.Any (displayError)
 import Cardano.Node.Protocol.Cardano (mkConsensusProtocolCardano)
 import Cardano.Node.Types
+import Cardano.Tools.DBSynthesizer.BlsKey (readBlsSigningKey)
 import Cardano.Tools.DBSynthesizer.Forging
 import Cardano.Tools.DBSynthesizer.Orphans ()
 import Cardano.Tools.DBSynthesizer.Types
 import Control.Monad (filterM)
-import Control.Monad.Trans.Except (ExceptT)
+import Control.Monad.Trans.Except (ExceptT (ExceptT))
 import Control.Monad.Trans.Except.Extra
   ( firstExceptT
   , handleIOExceptT
@@ -38,15 +39,24 @@ import LeiosDemoDb (newLeiosDBSQLite, withLeiosDb)
 import qualified Ouroboros.Consensus.Block.Forging as BlockForging
 import Ouroboros.Consensus.Cardano.Block
 import Ouroboros.Consensus.Cardano.Node
-import Ouroboros.Consensus.Config (TopLevelConfig, configStorage)
+import Ouroboros.Consensus.Config
+  ( TopLevelConfig
+  , configStorage
+  , topLevelConfigVotingKey
+  )
 import qualified Ouroboros.Consensus.Node as Node (stdMkChainDbHasFS)
 import qualified Ouroboros.Consensus.Node.InitStorage as Node
   ( nodeImmutableDbChunkInfo
   )
 import Ouroboros.Consensus.Node.ProtocolInfo (ProtocolInfo (..))
+import Ouroboros.Consensus.Protocol.Praos.Common
+  ( PraosCanBeLeader (praosCanBeLeaderSignKeyBLS)
+  )
 import Ouroboros.Consensus.Shelley.Ledger.SupportsProtocol ()
 import Ouroboros.Consensus.Shelley.Node
-  ( ShelleyGenesis (..)
+  ( ProtocolParamsShelleyBased (shelleyBasedLeaderCredentials)
+  , ShelleyGenesis (..)
+  , ShelleyLeaderCredentials (shelleyLeaderCredentialsCanBeLeader)
   , validateGenesis
   )
 import qualified Ouroboros.Consensus.Storage.ChainDB as ChainDB (getTipPoint)
@@ -68,14 +78,43 @@ initialize ::
   NodeCredentials ->
   DBSynthesizerOptions ->
   IO (Either String (DBSynthesizerConfig, CardanoProtocolParams StandardCrypto))
-initialize NodeFilePaths{nfpConfig, nfpChainDB} creds synthOptions = do
+initialize NodeFilePaths{nfpConfig, nfpChainDB, nfpBlsKey} creds synthOptions = do
   relativeToConfig :: (FilePath -> FilePath) <-
     (</>) . takeDirectory <$> makeAbsolute nfpConfig
   runExceptT $ do
     conf <- initConf relativeToConfig
-    proto <- initProtocol relativeToConfig conf
+    proto <- initProtocol relativeToConfig conf >>= withVotingKey
     pure (conf, proto)
  where
+  -- 'mkPraosLeaderCredentials' builds every credential with
+  -- 'praosCanBeLeaderSignKeyBLS = Nothing', and the files it reads hold no BLS
+  -- key. 'CardanoProtocolParams' is a plain record, so the key goes in here
+  -- instead of in that vendored module. 'protocolInfoCardano' then puts it in
+  -- 'topLevelConfigVotingKey'.
+  withVotingKey ::
+    CardanoProtocolParams StandardCrypto ->
+    ExceptT String IO (CardanoProtocolParams StandardCrypto)
+  withVotingKey proto = case nfpBlsKey of
+    Nothing -> pure proto
+    Just path -> do
+      votingKey <- ExceptT (readBlsSigningKey path)
+      let shelleyBased = shelleyBasedProtocolParams proto
+          setKey credentials =
+            credentials
+              { shelleyLeaderCredentialsCanBeLeader =
+                  (shelleyLeaderCredentialsCanBeLeader credentials)
+                    { praosCanBeLeaderSignKeyBLS = Just votingKey
+                    }
+              }
+      pure
+        proto
+          { shelleyBasedProtocolParams =
+              shelleyBased
+                { shelleyBasedLeaderCredentials =
+                    map setKey (shelleyBasedLeaderCredentials shelleyBased)
+                }
+          }
+
   initConf :: (FilePath -> FilePath) -> ExceptT String IO DBSynthesizerConfig
   initConf relativeToConfig = do
     inp <- handleIOExceptT show (BS.readFile nfpConfig)
@@ -174,6 +213,10 @@ synthesize genTxs DBSynthesizerConfig{confOptions, confShelleyGenesis, confDbDir
           leiosDbHandle
           (\_ -> pure ()) -- no LeiosTxCache in this tool
           $ ChainDB.defaultArgs
+
+    putStrLn $
+      "--> voting key: "
+        ++ maybe "absent" (const "present") (topLevelConfigVotingKey pInfoConfig)
 
     mbfs <- mkForgers nullTracer
     allocatedForgers <-

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBSynthesizer/TxGen.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBSynthesizer/TxGen.hs
@@ -49,8 +49,10 @@ import Control.Monad.Except (runExcept)
 import Data.Bifunctor (first)
 import Data.Function ((&))
 import Data.IORef (IORef, modifyIORef', newIORef, readIORef, writeIORef)
+import Data.List (maximumBy)
 import qualified Data.Map.Strict as Map
 import qualified Data.Measure as Measure
+import Data.Ord (comparing)
 import Data.Proxy (Proxy (Proxy))
 import Data.SOP.BasicFunctors (K (K))
 import Data.SOP.Dict (Dict (Dict))
@@ -115,8 +117,9 @@ type Cardano = CardanoBlock StandardCrypto
 -- | The fee that each generated transaction pays.
 --
 -- The tool pays a fixed fee and does not compute the minimum. If the fee is
--- too low, 'applyTx' rejects the transaction. The ledger error names the fee
--- that it needs.
+-- too low, 'applyTx' rejects the first transaction and the ledger error names
+-- the fee that it needs. If the run instead spends the output down, the ledger
+-- stops it once the change no longer covers the minimum a UTxO entry holds.
 txFee :: Coin
 txFee = Coin 1_000_000
 
@@ -265,7 +268,11 @@ respendTxGen lastOutput (PaymentSigningKey signKey) cfg slot certifies forker ti
           "db-synthesizer: the payment signing key owns no output at slot "
             ++ show slot
             ++ ". Add an initialFunds entry for its address to the Shelley genesis."
-      entry : _ -> fillBlock (wrapGenTx idx) stateAtSlot entry
+      -- The key can own more than one output, and each transaction pays a fee
+      -- out of the one the generator picks. The largest output runs longest.
+      entries -> fillBlock (wrapGenTx idx) stateAtSlot (richest entries)
+   where
+    richest = maximumBy (comparing (\(_, txOut) -> txOut ^. coinTxOutL))
 
   wrapGenTx ::
     Index (CardanoEras StandardCrypto) x ->

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBSynthesizer/TxGen.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBSynthesizer/TxGen.hs
@@ -126,7 +126,7 @@ mkRespendTxGen ::
   Maybe FilePath ->
   IO (Either String (TopLevelConfig Cardano -> GenTxs Cardano))
 mkRespendTxGen Nothing =
-  pure $ Right $ \_cfg _slot _certifies _forker _ticked -> pure ([], [])
+  pure $ Right $ \_cfg _slot _certifies _forker _ticked -> pure ([], [], pure ())
 mkRespendTxGen (Just keyFile) = do
   lastOutput <- newIORef Nothing
   fmap (respendTxGen lastOutput) <$> readPaymentSigningKey keyFile
@@ -180,7 +180,9 @@ data Batch era = Batch
 -- the entry is absent, the generator stops the run. No later slot adds it.
 --
 -- The 'IORef' holds what the block before this one left unspent. It is empty on
--- the first slot of a run.
+-- the first slot of a run. The generator does not write it. It returns an
+-- action that writes it, and the forge loop runs that action once the ChainDB
+-- adopts the block.
 respendTxGen ::
   IORef (Maybe Leftovers) ->
   SigningKey PaymentKey ->
@@ -194,10 +196,13 @@ respendTxGen lastOutput (PaymentSigningKey signKey) cfg slot certifies forker ti
   -- It announces no endorser block of its own. Such a block would spend outputs
   -- that the certified endorser block makes. Those outputs are absent from the
   -- ledger state that this generator reads.
-  | certifies = do
-      modifyIORef' lastOutput . fmap $ \previous ->
-        previous{unspentNow = unspentIfCertified previous}
-      pure ([], [])
+  | certifies =
+      pure
+        ( []
+        , []
+        , modifyIORef' lastOutput . fmap $ \previous ->
+            previous{unspentNow = unspentIfCertified previous}
+        )
   | otherwise = case ticked of
       TickedHardForkLedgerState _transition perEra ->
         hcollapse $ hcimap proxySingle (\idx _state -> K (genForEra idx)) perEra
@@ -214,7 +219,7 @@ respendTxGen lastOutput (PaymentSigningKey signKey) cfg slot certifies forker ti
   -- the same index on, so no pairing here can go wrong.
   genForEra ::
     Index (CardanoEras StandardCrypto) x ->
-    IO ([Validated (GenTx Cardano)], [Validated (GenTx Cardano)])
+    IO ([Validated (GenTx Cardano)], [Validated (GenTx Cardano)], IO ())
   genForEra = \case
     IZ ->
       throwIO . userError $
@@ -226,7 +231,7 @@ respendTxGen lastOutput (PaymentSigningKey signKey) cfg slot certifies forker ti
     forall proto era.
     ShelleyBasedEra era =>
     Index (CardanoEras StandardCrypto) (ShelleyBlock proto era) ->
-    IO ([Validated (GenTx Cardano)], [Validated (GenTx Cardano)])
+    IO ([Validated (GenTx Cardano)], [Validated (GenTx Cardano)], IO ())
   genFor idx = do
     (keys, valuesAtParent) <- readCandidates idx
     -- The forker is at the point of the parent block, so its values are those
@@ -276,7 +281,7 @@ respendTxGen lastOutput (PaymentSigningKey signKey) cfg slot certifies forker ti
     (GenTx (ShelleyBlock proto era) -> GenTx Cardano) ->
     TickedLedgerState Cardano ValuesMK ->
     (TxIn, TxOut era) ->
-    IO ([Validated (GenTx Cardano)], [Validated (GenTx Cardano)])
+    IO ([Validated (GenTx Cardano)], [Validated (GenTx Cardano)], IO ())
   fillBlock wrap stateAtSlot start = do
     rb <- fillRb Cursor{cursorState = stateAtSlot, cursorEntry = start}
     when (null (batchTxs rb)) $
@@ -285,15 +290,18 @@ respendTxGen lastOutput (PaymentSigningKey signKey) cfg slot certifies forker ti
           ++ show slot
           ++ "."
     (ebTxs, cursorAfterEb) <- fillEb (batchUsedTotal rb) (batchCursor rb)
-    writeIORef
-      lastOutput
-      ( Just
-          Leftovers
-            { unspentNow = fst (cursorEntry (batchCursor rb))
-            , unspentIfCertified = fst (cursorEntry cursorAfterEb)
-            }
+    pure
+      ( batchTxs rb
+      , ebTxs
+      , writeIORef
+          lastOutput
+          ( Just
+              Leftovers
+                { unspentNow = fst (cursorEntry (batchCursor rb))
+                , unspentIfCertified = fst (cursorEntry cursorAfterEb)
+                }
+          )
       )
-    pure (batchTxs rb, ebTxs)
    where
     rbCapacity :: TxMeasure Cardano
     rbCapacity = blockCapacityTxMeasure lcfg stateAtSlot
@@ -371,9 +379,9 @@ respendTxGen lastOutput (PaymentSigningKey signKey) cfg slot certifies forker ti
   -- If the 'IORef' holds nothing, the generator reads the whole table. The
   -- 'IORef' is empty on the first slot of a run.
   --
-  -- The ledger must hold 'unspentNow'. This tool forges one chain and has no
-  -- competitor. So the ChainDB adopts every block that the tool makes. If the
-  -- input is absent, the ChainDB rejected a block.
+  -- The ledger must hold 'unspentNow', because the forge loop records a block's
+  -- outputs only after the ChainDB adopts that block. If the input is absent,
+  -- the ledger rolled back under the tool.
   readCandidates ::
     forall proto era.
     Index (CardanoEras StandardCrypto) (ShelleyBlock proto era) ->

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBSynthesizer/TxGen.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBSynthesizer/TxGen.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE EmptyCase #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NumericUnderscores #-}
@@ -49,7 +48,7 @@ import Control.Monad (when)
 import Control.Monad.Except (runExcept)
 import Data.Bifunctor (first)
 import Data.Function ((&))
-import Data.IORef (IORef, newIORef, readIORef, writeIORef)
+import Data.IORef (IORef, modifyIORef', newIORef, readIORef, writeIORef)
 import qualified Data.Map.Strict as Map
 import qualified Data.Measure as Measure
 import Data.Proxy (Proxy (Proxy))
@@ -126,7 +125,8 @@ txFee = Coin 1_000_000
 mkRespendTxGen ::
   Maybe FilePath ->
   IO (Either String (TopLevelConfig Cardano -> GenTxs Cardano))
-mkRespendTxGen Nothing = pure $ Right $ \_cfg _slot _forker _ticked -> pure ([], [])
+mkRespendTxGen Nothing =
+  pure $ Right $ \_cfg _slot _certifies _forker _ticked -> pure ([], [])
 mkRespendTxGen (Just keyFile) = do
   lastOutput <- newIORef Nothing
   fmap (respendTxGen lastOutput) <$> readPaymentSigningKey keyFile
@@ -136,6 +136,19 @@ mkRespendTxGen (Just keyFile) = do
 readPaymentSigningKey :: FilePath -> IO (Either String (SigningKey PaymentKey))
 readPaymentSigningKey path =
   first displayError <$> readFileTextEnvelope (AsSigningKey AsPaymentKey) path
+
+-- | The two inputs that a forged block leaves unspent.
+data Leftovers = Leftovers
+  { unspentNow :: TxIn
+  -- ^ The last transaction of the ranking block made this output. The next
+  -- block spends it. The transactions of the endorser block did not apply. So
+  -- the ledger holds none of their outputs.
+  , unspentIfCertified :: TxIn
+  -- ^ The last transaction of the endorser block made this output. If a later
+  -- block certifies the endorser block, its transactions apply. The next block
+  -- then spends this output instead. If the block announced no endorser block,
+  -- this equals 'unspentNow'.
+  }
 
 -- | A position in the sequence of transactions that the generator makes.
 --
@@ -166,17 +179,28 @@ data Batch era = Batch
 -- The genesis must hold an initialFunds entry for the address of the key. If
 -- the entry is absent, the generator stops the run. No later slot adds it.
 --
--- The 'IORef' holds the input that the last transaction of the block before
--- this one made.
+-- The 'IORef' holds what the block before this one left unspent. It is empty on
+-- the first slot of a run.
 respendTxGen ::
-  IORef (Maybe TxIn) ->
+  IORef (Maybe Leftovers) ->
   SigningKey PaymentKey ->
   TopLevelConfig Cardano ->
   GenTxs Cardano
-respendTxGen lastOutput (PaymentSigningKey signKey) cfg slot forker ticked =
-  case ticked of
-    TickedHardForkLedgerState _transition perEra ->
-      hcollapse $ hcimap proxySingle (\idx _state -> K (genForEra idx)) perEra
+respendTxGen lastOutput (PaymentSigningKey signKey) cfg slot certifies forker ticked
+  -- The certified endorser block's transactions apply with this block. This
+  -- block drops its own. So the ledger state holds the output that the last
+  -- transaction of that endorser block made.
+  --
+  -- It announces no endorser block of its own. Such a block would spend outputs
+  -- that the certified endorser block makes. Those outputs are absent from the
+  -- ledger state that this generator reads.
+  | certifies = do
+      modifyIORef' lastOutput . fmap $ \previous ->
+        previous{unspentNow = unspentIfCertified previous}
+      pure ([], [])
+  | otherwise = case ticked of
+      TickedHardForkLedgerState _transition perEra ->
+        hcollapse $ hcimap proxySingle (\idx _state -> K (genForEra idx)) perEra
  where
   lcfg = configLedger cfg
 
@@ -260,14 +284,15 @@ respendTxGen lastOutput (PaymentSigningKey signKey) cfg slot forker ticked =
         "db-synthesizer: not one generated transaction fits in the ranking block at slot "
           ++ show slot
           ++ "."
-    -- The endorser block's transactions do not reach the ledger when this block
-    -- applies. They apply when a later block certifies the endorser block. So
-    -- the next slot spends the output that the *ranking* block left.
-    writeIORef lastOutput (Just (fst (cursorEntry (batchCursor rb))))
-    -- The endorser block's own end has no consumer yet. Once the tool forges a
-    -- block that certifies an endorser block, that block advances the ledger to
-    -- this entry, and the generator has to spend it instead of the one above.
-    (ebTxs, _cursorAfterEb) <- fillEb (batchUsedTotal rb) (batchCursor rb)
+    (ebTxs, cursorAfterEb) <- fillEb (batchUsedTotal rb) (batchCursor rb)
+    writeIORef
+      lastOutput
+      ( Just
+          Leftovers
+            { unspentNow = fst (cursorEntry (batchCursor rb))
+            , unspentIfCertified = fst (cursorEntry cursorAfterEb)
+            }
+      )
     pure (batchTxs rb, ebTxs)
    where
     rbCapacity :: TxMeasure Cardano
@@ -343,12 +368,12 @@ respendTxGen lastOutput (PaymentSigningKey signKey) cfg slot forker ticked =
                   , cursorEntry = (TxIn (txIdTx tx) (TxIx 0), madeOut)
                   }
 
-  -- If the 'IORef' holds no key, the generator reads the whole table. The
+  -- If the 'IORef' holds nothing, the generator reads the whole table. The
   -- 'IORef' is empty on the first slot of a run.
   --
-  -- If the 'IORef' holds a key, the ledger must hold that key. This tool forges
-  -- one chain and has no competitor, so the ChainDB adopts every block that the
-  -- tool makes. A key that is absent means that the ChainDB rejected a block.
+  -- The ledger must hold 'unspentNow'. This tool forges one chain and has no
+  -- competitor. So the ChainDB adopts every block that the tool makes. If the
+  -- input is absent, the ChainDB rejected a block.
   readCandidates ::
     forall proto era.
     Index (CardanoEras StandardCrypto) (ShelleyBlock proto era) ->
@@ -361,8 +386,8 @@ respendTxGen lastOutput (PaymentSigningKey signKey) cfg slot forker ticked =
       Nothing -> do
         values <- readWholeUtxo forker
         pure (keysOf values, values)
-      Just txIn -> do
-        let keys = oneKey idx txIn
+      Just leftovers -> do
+        let keys = oneKey idx (unspentNow leftovers)
         values <- roforkerReadTables forker keys
         if Map.null (getValuesMK (getLedgerTables values))
           then
@@ -422,10 +447,6 @@ ownedBy signKey txOut = case txOut ^. addrTxOutL of
   _ -> False
 
 -- | Read every entry of the UTxO, one page at a time.
---
--- If the table holds more than 'maxUtxoEntries' entries, the read stops with an
--- error. A partial read hides the entry that the key owns. The generator then
--- reports the wrong error.
 readWholeUtxo ::
   ReadOnlyForker IO (ExtLedgerState Cardano) ->
   IO (LedgerTables (ExtLedgerState Cardano) ValuesMK)
@@ -436,12 +457,4 @@ readWholeUtxo forker = go emptyLedgerTables NoPreviousQuery
     let acc' = ltliftA2 unionValues acc page
     case mLastKey of
       Nothing -> pure acc'
-      Just lastKey
-        | Map.size (getValuesMK (getLedgerTables acc')) > maxUtxoEntries ->
-            throwIO . userError $
-              "db-synthesizer: the UTxO holds more than "
-                ++ show maxUtxoEntries
-                ++ " entries. Raise the limit in Cardano.Tools.DBSynthesizer.TxGen."
-        | otherwise -> go acc' (PreviousQueryWasUpTo lastKey)
-
-  maxUtxoEntries = 100_000 :: Int
+      Just lastKey -> go acc' (PreviousQueryWasUpTo lastKey)

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBSynthesizer/TxGen.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBSynthesizer/TxGen.hs
@@ -45,6 +45,7 @@ import Cardano.Protocol.Crypto (StandardCrypto)
 import Cardano.Tools.DBSynthesizer.Forging (GenTxs)
 import Control.DeepSeq (force)
 import Control.Exception (throwIO)
+import Control.Monad (when)
 import Control.Monad.Except (runExcept)
 import Data.Bifunctor (first)
 import Data.Function ((&))
@@ -78,6 +79,7 @@ import Ouroboros.Consensus.Ledger.SupportsMempool
   , WhetherToIntervene (DoNotIntervene)
   , applyTx
   , blockCapacityTxMeasure
+  , ebCapacityTxMeasure
   , txMeasure
   )
 import Ouroboros.Consensus.Ledger.Tables
@@ -124,7 +126,7 @@ txFee = Coin 1_000_000
 mkRespendTxGen ::
   Maybe FilePath ->
   IO (Either String (TopLevelConfig Cardano -> GenTxs Cardano))
-mkRespendTxGen Nothing = pure $ Right $ \_cfg _slot _forker _ticked -> pure []
+mkRespendTxGen Nothing = pure $ Right $ \_cfg _slot _forker _ticked -> pure ([], [])
 mkRespendTxGen (Just keyFile) = do
   lastOutput <- newIORef Nothing
   fmap (respendTxGen lastOutput) <$> readPaymentSigningKey keyFile
@@ -134,6 +136,30 @@ mkRespendTxGen (Just keyFile) = do
 readPaymentSigningKey :: FilePath -> IO (Either String (SigningKey PaymentKey))
 readPaymentSigningKey path =
   first displayError <$> readFileTextEnvelope (AsSigningKey AsPaymentKey) path
+
+-- | A position in the sequence of transactions that the generator makes.
+--
+-- Each transaction spends the output that the one before it made. A position is
+-- that output plus the ledger state that holds it, because the next transaction
+-- needs both.
+data Cursor era = Cursor
+  { cursorState :: TickedLedgerState Cardano ValuesMK
+  -- ^ The ledger state after every transaction up to this position applied.
+  , cursorEntry :: (TxIn, TxOut era)
+  -- ^ The output that the next transaction spends.
+  }
+
+-- | The result of 'fillBatch'.
+data Batch era = Batch
+  { batchTxs :: [Validated (GenTx Cardano)]
+  -- ^ The transactions it accepted, in the order the ledger applies them.
+  , batchUsedTotal :: TxMeasure Cardano
+  -- ^ The total measure of the transactions made for this forging opportunity,
+  -- including this batch. It spans the ranking block and the endorser block,
+  -- because 'fillEb' bounds their sum.
+  , batchCursor :: Cursor era
+  -- ^ The position where it stopped. That position's output is unspent.
+  }
 
 -- | Fill the block of this slot with transactions.
 --
@@ -164,7 +190,7 @@ respendTxGen lastOutput (PaymentSigningKey signKey) cfg slot forker ticked =
   -- the same index on, so no pairing here can go wrong.
   genForEra ::
     Index (CardanoEras StandardCrypto) x ->
-    IO [Validated (GenTx Cardano)]
+    IO ([Validated (GenTx Cardano)], [Validated (GenTx Cardano)])
   genForEra = \case
     IZ ->
       throwIO . userError $
@@ -176,7 +202,7 @@ respendTxGen lastOutput (PaymentSigningKey signKey) cfg slot forker ticked =
     forall proto era.
     ShelleyBasedEra era =>
     Index (CardanoEras StandardCrypto) (ShelleyBlock proto era) ->
-    IO [Validated (GenTx Cardano)]
+    IO ([Validated (GenTx Cardano)], [Validated (GenTx Cardano)])
   genFor idx = do
     (keys, valuesAtParent) <- readCandidates idx
     -- The forker is at the point of the parent block, so its values are those
@@ -226,49 +252,96 @@ respendTxGen lastOutput (PaymentSigningKey signKey) cfg slot forker ticked =
     (GenTx (ShelleyBlock proto era) -> GenTx Cardano) ->
     TickedLedgerState Cardano ValuesMK ->
     (TxIn, TxOut era) ->
-    IO [Validated (GenTx Cardano)]
-  fillBlock wrap stateAtSlot = go [] Measure.zero stateAtSlot
+    IO ([Validated (GenTx Cardano)], [Validated (GenTx Cardano)])
+  fillBlock wrap stateAtSlot start = do
+    rb <- fillRb Cursor{cursorState = stateAtSlot, cursorEntry = start}
+    when (null (batchTxs rb)) $
+      throwIO . userError $
+        "db-synthesizer: not one generated transaction fits in the ranking block at slot "
+          ++ show slot
+          ++ "."
+    -- The endorser block's transactions do not reach the ledger when this block
+    -- applies. They apply when a later block certifies the endorser block. So
+    -- the next slot spends the output that the *ranking* block left.
+    writeIORef lastOutput (Just (fst (cursorEntry (batchCursor rb))))
+    -- The endorser block's own end has no consumer yet. Once the tool forges a
+    -- block that certifies an endorser block, that block advances the ledger to
+    -- this entry, and the generator has to spend it instead of the one above.
+    (ebTxs, _cursorAfterEb) <- fillEb (batchUsedTotal rb) (batchCursor rb)
+    pure (batchTxs rb, ebTxs)
    where
-    capacity :: TxMeasure Cardano
-    capacity = blockCapacityTxMeasure lcfg stateAtSlot
+    rbCapacity :: TxMeasure Cardano
+    rbCapacity = blockCapacityTxMeasure lcfg stateAtSlot
 
-    go accepted used state (txIn, txOut) = do
-      (tx, madeOut) <- respendTx signKey txIn txOut
-      let genTx = wrap (mkShelleyTx tx)
-      measured <- case runExcept (txMeasure lcfg state genTx) of
-        Left err ->
-          throwIO . userError $
-            "db-synthesizer: a generated transaction breaks a per-transaction limit at slot "
-              ++ show slot
-              ++ ": "
-              ++ show err
-        Right measured -> pure measured
-      let used' = used `Measure.plus` measured
-      if not (used' Measure.<= capacity)
-        -- 'txIn' is the input that this block leaves unspent.
-        then stop accepted txIn
-        else case runExcept (applyTx lcfg DoNotIntervene slot genTx state) of
+    -- Fill the ranking block, from the start of the block.
+    fillRb :: Cursor era -> IO (Batch era)
+    fillRb = fillBatch rbCapacity Measure.zero
+
+    -- Resume where the ranking block stopped, and fill the endorser block. The
+    -- endorser block takes what the ranking block could not, up to the two
+    -- capacities added and counted from the start of the block. This is what
+    -- 'partitionMempool' does in the production forge loop.
+    fillEb ::
+      TxMeasure Cardano ->
+      Cursor era ->
+      IO ([Validated (GenTx Cardano)], Cursor era)
+    fillEb usedByRb cursor = case ebCapacityTxMeasure lcfg stateAtSlot of
+      -- The era has no Leios, so this block announces no endorser block.
+      Nothing -> pure ([], cursor)
+      Just ebCap -> do
+        batch <- fillBatch (rbCapacity `Measure.plus` ebCap) usedByRb cursor
+        -- No batch follows the endorser block, so its measure has no consumer.
+        pure (batchTxs batch, batchCursor batch)
+
+    -- Build one transaction at a time, each spending the output that the one
+    -- before it made. Stop at the first transaction that takes the total over
+    -- the bound, and leave that transaction out.
+    fillBatch ::
+      -- The bound on the total measure.
+      TxMeasure Cardano ->
+      -- The total measure of the transactions made for this forging opportunity
+      -- before this batch.
+      TxMeasure Cardano ->
+      Cursor era ->
+      IO (Batch era)
+    fillBatch bound = go []
+     where
+      go accepted used cursor = do
+        let Cursor{cursorState = state, cursorEntry = (txIn, txOut)} = cursor
+        (tx, madeOut) <- respendTx signKey txIn txOut
+        let genTx = wrap (mkShelleyTx tx)
+        measured <- case runExcept (txMeasure lcfg state genTx) of
           Left err ->
             throwIO . userError $
-              "db-synthesizer: the ledger rejected a generated transaction at slot "
+              "db-synthesizer: a generated transaction breaks a per-transaction limit at slot "
                 ++ show slot
                 ++ ": "
                 ++ show err
-          Right (stateAfterTx, validatedTx) ->
-            go
-              (validatedTx : accepted)
-              used'
-              (applyDiffs state stateAfterTx)
-              (TxIn (txIdTx tx) (TxIx 0), madeOut)
-
-    stop [] _ =
-      throwIO . userError $
-        "db-synthesizer: not one generated transaction fits in the block at slot "
-          ++ show slot
-          ++ "."
-    stop accepted unspent = do
-      writeIORef lastOutput (Just unspent)
-      pure (reverse accepted)
+          Right measured -> pure measured
+        let used' = used `Measure.plus` measured
+        if not (used' Measure.<= bound)
+          then
+            pure
+              Batch
+                { batchTxs = reverse accepted
+                , batchUsedTotal = used
+                , batchCursor = cursor
+                }
+          else case runExcept (applyTx lcfg DoNotIntervene slot genTx state) of
+            Left err ->
+              throwIO . userError $
+                "db-synthesizer: the ledger rejected a generated transaction at slot "
+                  ++ show slot
+                  ++ ": "
+                  ++ show err
+            Right (stateAfterTx, validatedTx) ->
+              go
+                (validatedTx : accepted)
+                used'
+                Cursor
+                  { cursorState = applyDiffs state stateAfterTx
+                  , cursorEntry = (TxIn (txIdTx tx) (TxIx 0), madeOut)
+                  }
 
   -- If the 'IORef' holds no key, the generator reads the whole table. The
   -- 'IORef' is empty on the first slot of a run.

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBSynthesizer/TxGen.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBSynthesizer/TxGen.hs
@@ -1,0 +1,374 @@
+{-# LANGUAGE EmptyCase #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+-- | Transaction generation for 'Cardano.Tools.DBSynthesizer.Run.synthesize'.
+--
+-- The tool fills each block with a chain of transactions. Each transaction
+-- spends the output that the transaction before it made.
+module Cardano.Tools.DBSynthesizer.TxGen
+  ( mkRespendTxGen
+  ) where
+
+import Cardano.Api.Any (displayError)
+import Cardano.Api.Key (AsType (AsSigningKey), Key (SigningKey))
+import Cardano.Api.KeysShelley (AsType (AsPaymentKey), PaymentKey, SigningKey (PaymentSigningKey))
+import Cardano.Api.SerialiseTextEnvelope (readFileTextEnvelope)
+import Cardano.Crypto.DSIGN (SignKeyDSIGN)
+import Cardano.Ledger.Api
+  ( Addr (Addr)
+  , EraTx
+  , EraTxOut
+  , Tx
+  , TxOut
+  , addrTxOutL
+  , bodyTxL
+  , coinTxOutL
+  , feeTxBodyL
+  , inputsTxBodyL
+  , mkBasicTx
+  , mkBasicTxBody
+  , mkBasicTxOut
+  , outputsTxBodyL
+  )
+import Cardano.Ledger.Api.Tx.In (TxIn (TxIn))
+import Cardano.Ledger.BaseTypes (TxIx (TxIx))
+import Cardano.Ledger.Coin (Coin (Coin), unCoin)
+import Cardano.Ledger.Core (TopTx, txIdTx)
+import qualified Cardano.Ledger.Keys as LK
+import Cardano.Ledger.Val (inject)
+import Cardano.Protocol.Crypto (StandardCrypto)
+import Cardano.Tools.DBSynthesizer.Forging (GenTxs)
+import Control.DeepSeq (force)
+import Control.Exception (throwIO)
+import Control.Monad.Except (runExcept)
+import Data.Bifunctor (first)
+import Data.Function ((&))
+import Data.IORef (IORef, newIORef, readIORef, writeIORef)
+import qualified Data.Map.Strict as Map
+import qualified Data.Measure as Measure
+import Data.Proxy (Proxy (Proxy))
+import Data.SOP.BasicFunctors (K (K))
+import Data.SOP.Dict (Dict (Dict))
+import Data.SOP.Index (Index (IS, IZ), dictIndexAll, hcimap, injectNS)
+import Data.SOP.Strict (hcollapse)
+import Data.Sequence.Strict ((|>))
+import qualified Data.Set as Set
+import Lens.Micro ((%~), (.~), (^.))
+import Ouroboros.Consensus.Cardano.Block (CardanoBlock, CardanoEras, LedgerState)
+import Ouroboros.Consensus.Cardano.Ledger ()
+import Ouroboros.Consensus.Config (TopLevelConfig, configLedger)
+import Ouroboros.Consensus.HardFork.Combinator.Abstract.SingleEraBlock (proxySingle)
+import Ouroboros.Consensus.HardFork.Combinator.AcrossEras (OneEraGenTx (OneEraGenTx))
+import Ouroboros.Consensus.HardFork.Combinator.Ledger
+  ( HasCanonicalTxIn (injectCanonicalTxIn)
+  , Ticked (TickedHardForkLedgerState)
+  , ejectLedgerTables
+  )
+import Ouroboros.Consensus.HardFork.Combinator.Mempool (GenTx (HardForkGenTx))
+import Ouroboros.Consensus.Ledger.Basics (TickedLedgerState)
+import Ouroboros.Consensus.Ledger.Extended (ExtLedgerState)
+import Ouroboros.Consensus.Ledger.SupportsMempool
+  ( TxMeasure
+  , Validated
+  , WhetherToIntervene (DoNotIntervene)
+  , applyTx
+  , blockCapacityTxMeasure
+  , txMeasure
+  )
+import Ouroboros.Consensus.Ledger.Tables
+  ( KeysMK (KeysMK)
+  , LedgerTables (LedgerTables)
+  , ValuesMK
+  , castLedgerTables
+  , getLedgerTables
+  , getValuesMK
+  , ltliftA2
+  )
+import Ouroboros.Consensus.Ledger.Tables.Utils
+  ( applyDiffForKeysOnTables
+  , applyDiffs
+  , emptyLedgerTables
+  , ltprj
+  , unionValues
+  )
+import Ouroboros.Consensus.Shelley.Ledger (IsShelleyBlock, ShelleyBlock)
+import Ouroboros.Consensus.Shelley.Ledger.Ledger
+  ( BigEndianTxIn (BigEndianTxIn, getOriginalTxIn)
+  , ShelleyBasedEra
+  )
+import Ouroboros.Consensus.Shelley.Ledger.Mempool (mkShelleyTx)
+import Ouroboros.Consensus.Shelley.Ledger.SupportsProtocol ()
+import Ouroboros.Consensus.Storage.LedgerDB.Forker
+  ( RangeQueryPrevious (NoPreviousQuery, PreviousQueryWasUpTo)
+  , ReadOnlyForker (roforkerRangeReadTables, roforkerReadTables)
+  )
+import Test.ThreadNet.Infra.Shelley (mkCredential, signTx)
+
+type Cardano = CardanoBlock StandardCrypto
+
+-- | The fee that each generated transaction pays.
+--
+-- The tool pays a fixed fee and does not compute the minimum. If the fee is
+-- too low, 'applyTx' rejects the transaction. The ledger error names the fee
+-- that it needs.
+txFee :: Coin
+txFee = Coin 1_000_000
+
+-- | Build the generator that the forge loop runs on each slot that the tool
+-- leads.
+mkRespendTxGen ::
+  Maybe FilePath ->
+  IO (Either String (TopLevelConfig Cardano -> GenTxs Cardano))
+mkRespendTxGen Nothing = pure $ Right $ \_cfg _slot _forker _ticked -> pure []
+mkRespendTxGen (Just keyFile) = do
+  lastOutput <- newIORef Nothing
+  fmap (respendTxGen lastOutput) <$> readPaymentSigningKey keyFile
+
+-- | Read a payment signing key from the JSON key file that
+-- @cardano-cli address key-gen@ writes.
+readPaymentSigningKey :: FilePath -> IO (Either String (SigningKey PaymentKey))
+readPaymentSigningKey path =
+  first displayError <$> readFileTextEnvelope (AsSigningKey AsPaymentKey) path
+
+-- | Fill the block of this slot with transactions.
+--
+-- The genesis must hold an initialFunds entry for the address of the key. If
+-- the entry is absent, the generator stops the run. No later slot adds it.
+--
+-- The 'IORef' holds the input that the last transaction of the block before
+-- this one made.
+respendTxGen ::
+  IORef (Maybe TxIn) ->
+  SigningKey PaymentKey ->
+  TopLevelConfig Cardano ->
+  GenTxs Cardano
+respendTxGen lastOutput (PaymentSigningKey signKey) cfg slot forker ticked =
+  case ticked of
+    TickedHardForkLedgerState _transition perEra ->
+      hcollapse $ hcimap proxySingle (\idx _state -> K (genForEra idx)) perEra
+ where
+  lcfg = configLedger cfg
+
+  -- The era must come from the ticked state, because that is the era of the
+  -- block that this slot forges. The era of the parent block is one behind
+  -- across a hard fork. The hard-fork combinator translates a transaction of
+  -- the era before, but the translation gives it a different id, and the
+  -- 'IORef' below then holds an input that no block ever made.
+  --
+  -- The match on the index gives the ledger types of that era, and it passes
+  -- the same index on, so no pairing here can go wrong.
+  genForEra ::
+    Index (CardanoEras StandardCrypto) x ->
+    IO [Validated (GenTx Cardano)]
+  genForEra = \case
+    IZ ->
+      throwIO . userError $
+        "db-synthesizer: transaction generation not supported in the Byron era."
+    IS idx -> case dictIndexAll (Proxy @IsShelleyBlock) idx of
+      Dict -> genFor (IS idx)
+
+  genFor ::
+    forall proto era.
+    ShelleyBasedEra era =>
+    Index (CardanoEras StandardCrypto) (ShelleyBlock proto era) ->
+    IO [Validated (GenTx Cardano)]
+  genFor idx = do
+    (keys, valuesAtParent) <- readCandidates idx
+    -- The forker is at the point of the parent block, so its values are those
+    -- of the ledger state after the parent block. The tick to this slot adds
+    -- the diffs that 'ticked' holds. The UTxO of this slot needs both.
+    let keysForSlot :: LedgerTables (TickedLedgerState Cardano) KeysMK
+        keysForSlot = castLedgerTables keys
+
+        valuesForSlot :: LedgerTables (TickedLedgerState Cardano) ValuesMK
+        valuesForSlot = castLedgerTables valuesAtParent
+
+        stateAtSlot :: TickedLedgerState Cardano ValuesMK
+        stateAtSlot = applyDiffForKeysOnTables valuesForSlot keysForSlot ticked
+
+        tablesAtSlot :: LedgerTables (LedgerState Cardano) ValuesMK
+        tablesAtSlot = ltprj stateAtSlot
+
+        -- The table of a CardanoBlock keeps a hard-fork wrapper on each key and
+        -- on each value. 'ejectLedgerTables' removes both wrappers, and gives
+        -- the types of one era. It also translates an output that an earlier
+        -- era made. A chain that stays in one era holds no such output. A chain
+        -- that crosses a hard fork holds outputs of the eras before the fork.
+        utxo :: Map.Map TxIn (TxOut era)
+        utxo =
+          Map.mapKeys getOriginalTxIn . getValuesMK . getLedgerTables $
+            ejectLedgerTables idx tablesAtSlot
+
+    case Map.toList (Map.filter (ownedBy signKey) utxo) of
+      [] ->
+        throwIO . userError $
+          "db-synthesizer: the payment signing key owns no output at slot "
+            ++ show slot
+            ++ ". Add an initialFunds entry for its address to the Shelley genesis."
+      entry : _ -> fillBlock (wrapGenTx idx) stateAtSlot entry
+
+  wrapGenTx ::
+    Index (CardanoEras StandardCrypto) x ->
+    GenTx x ->
+    GenTx Cardano
+  wrapGenTx idx = HardForkGenTx . OneEraGenTx . injectNS idx
+
+  -- The ledger applies the transactions of a block in order. So a transaction
+  -- can spend an output that an earlier transaction of the same block made.
+  fillBlock ::
+    forall proto era.
+    ShelleyBasedEra era =>
+    (GenTx (ShelleyBlock proto era) -> GenTx Cardano) ->
+    TickedLedgerState Cardano ValuesMK ->
+    (TxIn, TxOut era) ->
+    IO [Validated (GenTx Cardano)]
+  fillBlock wrap stateAtSlot = go [] Measure.zero stateAtSlot
+   where
+    capacity :: TxMeasure Cardano
+    capacity = blockCapacityTxMeasure lcfg stateAtSlot
+
+    go accepted used state (txIn, txOut) = do
+      (tx, madeOut) <- respendTx signKey txIn txOut
+      let genTx = wrap (mkShelleyTx tx)
+      measured <- case runExcept (txMeasure lcfg state genTx) of
+        Left err ->
+          throwIO . userError $
+            "db-synthesizer: a generated transaction breaks a per-transaction limit at slot "
+              ++ show slot
+              ++ ": "
+              ++ show err
+        Right measured -> pure measured
+      let used' = used `Measure.plus` measured
+      if not (used' Measure.<= capacity)
+        -- 'txIn' is the input that this block leaves unspent.
+        then stop accepted txIn
+        else case runExcept (applyTx lcfg DoNotIntervene slot genTx state) of
+          Left err ->
+            throwIO . userError $
+              "db-synthesizer: the ledger rejected a generated transaction at slot "
+                ++ show slot
+                ++ ": "
+                ++ show err
+          Right (stateAfterTx, validatedTx) ->
+            go
+              (validatedTx : accepted)
+              used'
+              (applyDiffs state stateAfterTx)
+              (TxIn (txIdTx tx) (TxIx 0), madeOut)
+
+    stop [] _ =
+      throwIO . userError $
+        "db-synthesizer: not one generated transaction fits in the block at slot "
+          ++ show slot
+          ++ "."
+    stop accepted unspent = do
+      writeIORef lastOutput (Just unspent)
+      pure (reverse accepted)
+
+  -- If the 'IORef' holds no key, the generator reads the whole table. The
+  -- 'IORef' is empty on the first slot of a run.
+  --
+  -- If the 'IORef' holds a key, the ledger must hold that key. This tool forges
+  -- one chain and has no competitor, so the ChainDB adopts every block that the
+  -- tool makes. A key that is absent means that the ChainDB rejected a block.
+  readCandidates ::
+    forall proto era.
+    Index (CardanoEras StandardCrypto) (ShelleyBlock proto era) ->
+    IO
+      ( LedgerTables (ExtLedgerState Cardano) KeysMK
+      , LedgerTables (ExtLedgerState Cardano) ValuesMK
+      )
+  readCandidates idx =
+    readIORef lastOutput >>= \case
+      Nothing -> do
+        values <- readWholeUtxo forker
+        pure (keysOf values, values)
+      Just txIn -> do
+        let keys = oneKey idx txIn
+        values <- roforkerReadTables forker keys
+        if Map.null (getValuesMK (getLedgerTables values))
+          then
+            throwIO . userError $
+              "db-synthesizer: the ChainDB did not adopt the block before slot "
+                ++ show slot
+                ++ ", so the output that it made is absent from the ledger."
+          else pure (keys, values)
+   where
+    keysOf values =
+      LedgerTables . KeysMK . Map.keysSet . getValuesMK . getLedgerTables $ values
+
+  oneKey ::
+    forall proto era.
+    Index (CardanoEras StandardCrypto) (ShelleyBlock proto era) ->
+    TxIn ->
+    LedgerTables (ExtLedgerState Cardano) KeysMK
+  oneKey idx txIn =
+    LedgerTables . KeysMK . Set.singleton $ injectCanonicalTxIn idx (BigEndianTxIn txIn)
+
+-- | Spend one output and pay the rest of it back to the same address.
+--
+-- The caller spends the returned output in the next transaction of the same
+-- block.
+respendTx ::
+  EraTx era =>
+  SignKeyDSIGN LK.DSIGN ->
+  TxIn ->
+  TxOut era ->
+  IO (Tx TopTx era, TxOut era)
+respendTx signKey txIn txOut
+  | unCoin change <= 0 =
+      throwIO . userError $
+        "db-synthesizer: the output that the payment signing key owns holds "
+          ++ show (unCoin inputValue)
+          ++ " lovelace, which does not cover the fee of "
+          ++ show (unCoin txFee)
+          ++ " lovelace."
+  | otherwise =
+      -- The forge loop runs NoThunks over the state it buffers.
+      pure . force $
+        ( mkBasicTx mkBasicTxBody
+            & bodyTxL . inputsTxBodyL %~ Set.insert txIn
+            & bodyTxL . outputsTxBodyL %~ (|> madeOut)
+            & bodyTxL . feeTxBodyL .~ txFee
+            & signTx signKey
+        , madeOut
+        )
+ where
+  inputValue = txOut ^. coinTxOutL
+  change = Coin (unCoin inputValue - unCoin txFee)
+  madeOut = mkBasicTxOut (txOut ^. addrTxOutL) (inject change)
+
+ownedBy :: EraTxOut era => SignKeyDSIGN LK.DSIGN -> TxOut era -> Bool
+ownedBy signKey txOut = case txOut ^. addrTxOutL of
+  Addr _ credential _ -> credential == mkCredential signKey
+  _ -> False
+
+-- | Read every entry of the UTxO, one page at a time.
+--
+-- If the table holds more than 'maxUtxoEntries' entries, the read stops with an
+-- error. A partial read hides the entry that the key owns. The generator then
+-- reports the wrong error.
+readWholeUtxo ::
+  ReadOnlyForker IO (ExtLedgerState Cardano) ->
+  IO (LedgerTables (ExtLedgerState Cardano) ValuesMK)
+readWholeUtxo forker = go emptyLedgerTables NoPreviousQuery
+ where
+  go acc prev = do
+    (page, mLastKey) <- roforkerRangeReadTables forker prev
+    let acc' = ltliftA2 unionValues acc page
+    case mLastKey of
+      Nothing -> pure acc'
+      Just lastKey
+        | Map.size (getValuesMK (getLedgerTables acc')) > maxUtxoEntries ->
+            throwIO . userError $
+              "db-synthesizer: the UTxO holds more than "
+                ++ show maxUtxoEntries
+                ++ " entries. Raise the limit in Cardano.Tools.DBSynthesizer.TxGen."
+        | otherwise -> go acc' (PreviousQueryWasUpTo lastKey)
+
+  maxUtxoEntries = 100_000 :: Int

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBSynthesizer/Types.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBSynthesizer/Types.hs
@@ -19,6 +19,7 @@ data NodeConfigStub = NodeConfigStub
 data NodeFilePaths = NodeFilePaths
   { nfpConfig :: !FilePath
   , nfpChainDB :: !FilePath
+  , nfpPaymentKey :: !(Maybe FilePath)
   }
   deriving Show
 

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBSynthesizer/Types.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBSynthesizer/Types.hs
@@ -3,6 +3,7 @@ module Cardano.Tools.DBSynthesizer.Types (module Cardano.Tools.DBSynthesizer.Typ
 import Cardano.Node.Types (ProtocolFilepaths)
 import Data.Aeson as Aeson (Value)
 import Data.Word (Word64)
+import LeiosDemoTypes (LeiosSigningKey)
 import Ouroboros.Consensus.Block.Abstract (SlotNo)
 import Ouroboros.Consensus.Shelley.Node (ShelleyGenesis)
 
@@ -20,7 +21,6 @@ data NodeFilePaths = NodeFilePaths
   { nfpConfig :: !FilePath
   , nfpChainDB :: !FilePath
   , nfpPaymentKey :: !(Maybe FilePath)
-  , nfpBlsKey :: !(Maybe FilePath)
   }
   deriving Show
 
@@ -29,6 +29,7 @@ data NodeCredentials = NodeCredentials
   , credVRFFile :: !(Maybe FilePath)
   , credKESFile :: !(Maybe FilePath)
   , credBulkFile :: !(Maybe FilePath)
+  , credBlsFile :: !(Maybe FilePath)
   }
   deriving Show
 
@@ -59,5 +60,6 @@ data DBSynthesizerConfig = DBSynthesizerConfig
   , confProtocolCredentials :: ProtocolFilepaths
   , confShelleyGenesis :: ShelleyGenesis
   , confDbDir :: FilePath
+  , confVotingKey :: Maybe LeiosSigningKey
+  -- ^ The BLS key that the forger votes with, from @--shelley-bls-key@.
   }
-  deriving Show

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBSynthesizer/Types.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBSynthesizer/Types.hs
@@ -20,6 +20,7 @@ data NodeFilePaths = NodeFilePaths
   { nfpConfig :: !FilePath
   , nfpChainDB :: !FilePath
   , nfpPaymentKey :: !(Maybe FilePath)
+  , nfpBlsKey :: !(Maybe FilePath)
   }
   deriving Show
 

--- a/ouroboros-consensus-cardano/test/tools-test/Main.hs
+++ b/ouroboros-consensus-cardano/test/tools-test/Main.hs
@@ -182,7 +182,7 @@ blockCountTest logStep = do
           ++ " blocks"
     _ -> assertFailure $ "analysis after truncation returned " ++ show resultTruncated
  where
-  genTxs _ _ _ _ _ = pure ([], [])
+  genTxs _ _ _ _ _ = pure ([], [], pure ())
 
   mkEbHash c = MkEbHash (fromString (replicate 32 c))
 

--- a/ouroboros-consensus-cardano/test/tools-test/Main.hs
+++ b/ouroboros-consensus-cardano/test/tools-test/Main.hs
@@ -47,6 +47,7 @@ testNodeFilePaths =
   NodeFilePaths
     { nfpConfig = nodeConfig
     , nfpChainDB = chainDB
+    , nfpPaymentKey = Nothing
     }
 
 testNodeCredentials :: NodeCredentials

--- a/ouroboros-consensus-cardano/test/tools-test/Main.hs
+++ b/ouroboros-consensus-cardano/test/tools-test/Main.hs
@@ -48,7 +48,6 @@ testNodeFilePaths =
     { nfpConfig = nodeConfig
     , nfpChainDB = chainDB
     , nfpPaymentKey = Nothing
-    , nfpBlsKey = Nothing
     }
 
 testNodeCredentials :: NodeCredentials
@@ -58,6 +57,7 @@ testNodeCredentials =
     , credVRFFile = Nothing
     , credKESFile = Nothing
     , credBulkFile = Just "ouroboros-consensus-cardano/test/tools-test/disk/config/bulk-creds-k2.json"
+    , credBlsFile = Nothing
     }
 
 testImmutaliserConfig :: DBImmutaliser.Opts

--- a/ouroboros-consensus-cardano/test/tools-test/Main.hs
+++ b/ouroboros-consensus-cardano/test/tools-test/Main.hs
@@ -83,9 +83,10 @@ testAnalyserConfig =
     , validation = Just ValidateAllBlocks
     , analysis = CountBlocks
     , confLimit = Unlimited
-    , -- The synthesized chain holds no certifying block, and DBSynthesizer
-      -- writes no leios.db, so the empty in-memory LeiosDb stub is both enough
-      -- and the only option.
+    , -- The stub generator below makes no transactions, so DBSynthesizer
+      -- announces no endorser block and forges no certifying block. The chain
+      -- then needs nothing from the leios.db that DBSynthesizer writes, and the
+      -- empty in-memory LeiosDb stub is enough.
       leiosDbSource = NoLeiosDb
     }
 

--- a/ouroboros-consensus-cardano/test/tools-test/Main.hs
+++ b/ouroboros-consensus-cardano/test/tools-test/Main.hs
@@ -181,7 +181,7 @@ blockCountTest logStep = do
           ++ " blocks"
     _ -> assertFailure $ "analysis after truncation returned " ++ show resultTruncated
  where
-  genTxs _ _ _ _ = pure []
+  genTxs _ _ _ _ = pure ([], [])
 
   mkEbHash c = MkEbHash (fromString (replicate 32 c))
 

--- a/ouroboros-consensus-cardano/test/tools-test/Main.hs
+++ b/ouroboros-consensus-cardano/test/tools-test/Main.hs
@@ -48,6 +48,7 @@ testNodeFilePaths =
     { nfpConfig = nodeConfig
     , nfpChainDB = chainDB
     , nfpPaymentKey = Nothing
+    , nfpBlsKey = Nothing
     }
 
 testNodeCredentials :: NodeCredentials

--- a/ouroboros-consensus-cardano/test/tools-test/Main.hs
+++ b/ouroboros-consensus-cardano/test/tools-test/Main.hs
@@ -182,7 +182,7 @@ blockCountTest logStep = do
           ++ " blocks"
     _ -> assertFailure $ "analysis after truncation returned " ++ show resultTruncated
  where
-  genTxs _ _ _ _ = pure ([], [])
+  genTxs _ _ _ _ _ = pure ([], [])
 
   mkEbHash c = MkEbHash (fromString (replicate 32 c))
 

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel/Forge.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel/Forge.hs
@@ -12,7 +12,8 @@
 {-# LANGUAGE TypeFamilies #-}
 
 module Ouroboros.Consensus.NodeKernel.Forge
-  ( forge
+  ( decideLeiosCertify
+  , forge
   ) where
 
 import Control.Monad

--- a/ouroboros-consensus.cabal
+++ b/ouroboros-consensus.cabal
@@ -1945,6 +1945,7 @@ library unstable-cardano-tools
     Cardano.Tools.DBSynthesizer.Forging
     Cardano.Tools.DBSynthesizer.Orphans
     Cardano.Tools.DBSynthesizer.Run
+    Cardano.Tools.DBSynthesizer.TxGen
     Cardano.Tools.DBSynthesizer.Types
     Cardano.Tools.DBTruncater.Run
     Cardano.Tools.DBTruncater.Types
@@ -2004,6 +2005,7 @@ library unstable-cardano-tools
     compact,
     containers,
     contra-tracer,
+    deepseq,
     directory,
     dot,
     filepath,
@@ -2012,6 +2014,7 @@ library unstable-cardano-tools
     githash,
     io-classes,
     io-classes:si-timers,
+    measures,
     microlens,
     mtl,
     network,

--- a/ouroboros-consensus.cabal
+++ b/ouroboros-consensus.cabal
@@ -1942,6 +1942,7 @@ library unstable-cardano-tools
     Cardano.Tools.DBAnalyser.Run
     Cardano.Tools.DBAnalyser.Types
     Cardano.Tools.DBImmutaliser.Run
+    Cardano.Tools.DBSynthesizer.BlsKey
     Cardano.Tools.DBSynthesizer.Forging
     Cardano.Tools.DBSynthesizer.Orphans
     Cardano.Tools.DBSynthesizer.Run
@@ -1981,6 +1982,7 @@ library unstable-cardano-tools
     bytestring,
     cardano-crypto,
     cardano-crypto-class,
+    cardano-crypto-leios,
     cardano-crypto-wrapper,
     cardano-diffusion:cardano-diffusion,
     cardano-git-rev ^>=0.2.1,


### PR DESCRIPTION
`db-synthesizer` forged empty blocks and threw away an in-memory `LeiosDb`, so it could not build a fixture for the other DB tools.
This branch makes it forge a Leios chain.

`--payment-signing-key` fills each block with a chain of transactions that respend one output.
What does not fit goes into an endorser block that the block announces.

`--shelley-bls-key` reads the voting committee from the ledger and signs a vote for each announced endorser block.
A later block carries the certificate.

The `LeiosDb` now lives at `<db>/leios.db`, the path the node writes and `db-analyser` reads.
Each Leios event goes to stderr as one JSON object.

`decideLeiosCertify` gains an export so the tool reuses the node's certification decision.
That is the only change outside the tool.

## Limitations

A ranking block either announces an endorser block or certifies its parent's, never both.

There is no Leios schedule.

The tool votes inline in its forge loop instead of running `runLeiosVoting`, so it models no vote window or announcement deadline.

## Verification

`tools-test` passes.
A 200-block Dijkstra run passes every check in [`check-synth-fixture`](https://github.com/input-output-hk/ouroboros-consensus-tools/tree/leios-prototype/check-synth-fixture): 121 announcements, 121 votes, 79 certifying blocks.
