### PR TITLE
[Peras 66] Extend BlockForging to accept an optional PerasCert

### DIFF
--- a/changelog.d/20260828_115055_agustin.mista_extend_block_forging.md
+++ b/changelog.d/20260828_115055_agustin.mista_extend_block_forging.md
@@ -1,0 +1,10 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+### Breaking
+
+- Extended `BlockForging.forgeBlock` with an optional `PerasCert` argument.

--- a/ouroboros-consensus-cardano/src/byron/Ouroboros/Consensus/Byron/Node.hs
+++ b/ouroboros-consensus-cardano/src/byron/Ouroboros/Consensus/Byron/Node.hs
@@ -59,7 +59,6 @@ import Ouroboros.Consensus.Protocol.PBFT
 import qualified Ouroboros.Consensus.Protocol.PBFT.State as S
 import Ouroboros.Consensus.Storage.ChainDB.Init (InitChainDB (..))
 import Ouroboros.Consensus.Storage.ImmutableDB (simpleChunkInfo)
-import Ouroboros.Consensus.Util ((....:))
 import Ouroboros.Network.Magic (NetworkMagic (..))
 
 {-------------------------------------------------------------------------------
@@ -142,7 +141,8 @@ byronBlockForging creds =
           canBeLeader
           slot
           tickedPBftState
-    , forgeBlock = \cfg -> return ....: forgeByronBlock cfg
+    , forgeBlock = \cfg bno slot _mbPerasCert st txs proof ->
+        return $ forgeByronBlock cfg bno slot st txs proof
     , finalize = pure ()
     }
  where

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Forge.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Forge.hs
@@ -49,6 +49,8 @@ forgeShelleyBlock ::
   BlockNo ->
   -- | Current slot number
   SlotNo ->
+  -- | Optional Peras certificate to include in the block
+  Maybe (PerasCert (ShelleyBlock proto era)) ->
   -- | Current ledger
   TickedLedgerState (ShelleyBlock proto era) mk ->
   -- | Txs to include
@@ -61,6 +63,7 @@ forgeShelleyBlock
   cfg
   curNo
   curSlot
+  _mbPerasCert -- Ignored for now
   tickedLedger
   txs
   isLeader = do

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Node/Praos.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Node/Praos.hs
@@ -87,10 +87,9 @@ praosSharedBlockForging
           praosCheckCanForge
             (configConsensus cfg)
             curSlot
-      , forgeBlock = \cfg ->
+      , forgeBlock =
           forgeShelleyBlock
             hotKey
             canBeLeader
-            cfg
       , finalize = HotKey.finalize hotKey
       }

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Node/TPraos.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Node/TPraos.hs
@@ -120,11 +120,10 @@ shelleySharedBlockForging hotKey slotToPeriod credentials =
           (configConsensus cfg)
           forgingVRFHash
           curSlot
-    , forgeBlock = \cfg ->
+    , forgeBlock =
         forgeShelleyBlock
           hotKey
           canBeLeader
-          cfg
     , finalize = HotKey.finalize hotKey
     }
  where
@@ -282,7 +281,6 @@ protocolInfoTPraosShelleyBased
         protVer
         genesis
         (shelleyBlockIssuerVKey <$> credentialss)
-
     storageConfig :: StorageConfig (ShelleyBlock (TPraos c) era)
     storageConfig =
       ShelleyStorageConfig

--- a/ouroboros-consensus-cardano/src/unstable-byron-testlib/Ouroboros/Consensus/ByronDual/Node.hs
+++ b/ouroboros-consensus-cardano/src/unstable-byron-testlib/Ouroboros/Consensus/ByronDual/Node.hs
@@ -43,7 +43,6 @@ import Ouroboros.Consensus.NodeId
 import Ouroboros.Consensus.Protocol.PBFT
 import qualified Ouroboros.Consensus.Protocol.PBFT.State as S
 import Ouroboros.Consensus.Storage.ChainDB.Init (InitChainDB (..))
-import Ouroboros.Consensus.Util ((.....:))
 import qualified Test.Cardano.Chain.Elaboration.Block as Spec.Test
 import qualified Test.Cardano.Chain.Elaboration.Delegation as Spec.Test
 import qualified Test.Cardano.Chain.Elaboration.Keys as Spec.Test
@@ -65,7 +64,8 @@ dualByronBlockForging creds =
     , updateForgeState = \cfg ->
         fmap castForgeStateUpdateInfo .: updateForgeState (dualTopLevelConfigMain cfg)
     , checkCanForge = checkCanForge . dualTopLevelConfigMain
-    , forgeBlock = return .....: forgeDualByronBlock
+    , forgeBlock = \cfg slot bno _mbPerasCert lst txs proof ->
+        return $ forgeDualByronBlock cfg slot bno lst txs proof
     , finalize = return ()
     }
  where

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBSynthesizer/Forging.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBSynthesizer/Forging.hs
@@ -231,6 +231,7 @@ runForge epochSize_ nextSlot opts chainDB blockForging cfg genTxs = do
           cfg
           bcBlockNo
           currentSlot
+          Nothing -- DBSynthesizer does not include Peras certs in blocks for now
           (forgetLedgerTables tickedLedgerState)
           txs
           proof

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
@@ -731,6 +731,7 @@ forkBlockForging IS{..} (MkBlockForging blockForgingM) =
           cfg
           bcBlockNo
           currentSlot
+          Nothing -- No PerasCert for now
           tickedLedgerState
           txs
           proof

--- a/ouroboros-consensus-diffusion/src/unstable-diffusion-testlib/Test/ThreadNet/Network.hs
+++ b/ouroboros-consensus-diffusion/src/unstable-diffusion-testlib/Test/ThreadNet/Network.hs
@@ -883,11 +883,12 @@ runThreadNetwork
             TopLevelConfig blk ->
             BlockNo ->
             SlotNo ->
+            Maybe (PerasCert blk) ->
             TickedLedgerState blk mk ->
             [Validated (GenTx blk)] ->
             IsLeader (BlockProtocol blk) ->
             m blk
-          customForgeBlock origBlockForging cfg' currentBno currentSlot tickedLdgSt txs prf = do
+          customForgeBlock origBlockForging cfg' currentBno currentSlot mbPerasCert tickedLdgSt txs prf = do
             let currentEpoch = HFF.futureSlotToEpoch future currentSlot
 
             -- EBBs are only ever possible in the first era
@@ -911,6 +912,7 @@ runThreadNetwork
                   cfg'
                   currentBno
                   currentSlot
+                  mbPerasCert
                   (forgetLedgerTables tickedLdgSt)
                   txs
                   prf
@@ -957,6 +959,7 @@ runThreadNetwork
                     cfg'
                     currentBno
                     currentSlot
+                    mbPerasCert
                     (forgetLedgerTables tickedLdgSt')
                     txs
                     prf

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator/A.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator/A.hs
@@ -398,7 +398,7 @@ blockForgingA =
     , canBeLeader = ()
     , updateForgeState = \_ _ _ -> return $ ForgeStateUpdated ()
     , checkCanForge = \_ _ _ _ _ -> return ()
-    , forgeBlock = \cfg bno slot st txs proof ->
+    , forgeBlock = \cfg bno slot _mbPerasCert st txs proof ->
         return $
           forgeBlockA cfg bno slot st (fmap txForgetValidated txs) proof
     , finalize = return ()

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator/B.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator/B.hs
@@ -343,7 +343,7 @@ blockForgingB =
     , canBeLeader = ()
     , updateForgeState = \_ _ _ -> return $ ForgeStateUpdated ()
     , checkCanForge = \_ _ _ _ _ -> return ()
-    , forgeBlock = \cfg bno slot st txs proof ->
+    , forgeBlock = \cfg bno slot _mbPerasCert st txs proof ->
         return $
           forgeBlockB cfg bno slot st (fmap txForgetValidated txs) proof
     , finalize = return ()

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Block/Forging.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Block/Forging.hs
@@ -28,6 +28,7 @@ import Data.Kind (Type)
 import Data.Text (Text)
 import GHC.Stack
 import Ouroboros.Consensus.Block.Abstract
+import Ouroboros.Consensus.Block.SupportsPeras (PerasCert)
 import Ouroboros.Consensus.Config
 import Ouroboros.Consensus.Ledger.Abstract
 import Ouroboros.Consensus.Ledger.SupportsMempool
@@ -122,6 +123,7 @@ data BlockForging m blk = BlockForging
       TopLevelConfig blk ->
       BlockNo -> -- Current block number
       SlotNo -> -- Current slot number
+      Maybe (PerasCert blk) -> -- Optional Peras certificate to include
       TickedLedgerState blk EmptyMK -> -- Current ledger state
       [Validated (GenTx blk)] -> -- Transactions to include
       IsLeader (BlockProtocol blk) -> -- Proof we are leader

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Embed/Unary.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Embed/Unary.hs
@@ -492,17 +492,21 @@ instance Functor m => Isomorphic (BlockForging m) where
               )
               (inject' (Proxy @(WrapIsLeader blk)) isLeader)
               (inject' (Proxy @(WrapForgeStateInfo blk)) forgeStateInfo)
-      , forgeBlock = \cfg bno sno tickedLgrSt txs isLeader ->
+      , forgeBlock = \cfg bno sno mbPerasCert tickedLgrSt txs isLeader ->
           project' (Proxy @(I blk))
             <$> forgeBlock
               (inject cfg)
               bno
               sno
+              (injectPerasCert mbPerasCert)
               (getFlipTickedLedgerState (inject (FlipTickedLedgerState tickedLgrSt)))
               (inject' (Proxy @(WrapValidatedGenTx blk)) <$> txs)
               (inject' (Proxy @(WrapIsLeader blk)) isLeader)
       }
    where
+    injectPerasCert :: Maybe (PerasCert blk) -> Maybe (PerasCert (HardForkBlock '[blk]))
+    injectPerasCert = fmap (OneEraPerasCert . Z . WrapPerasCert)
+
     injTickedChainDepSt ::
       EpochInfo (Except PastHorizonException) ->
       Ticked (ChainDepState (BlockProtocol blk)) ->
@@ -538,17 +542,21 @@ instance Functor m => Isomorphic (BlockForging m) where
               (projTickedChainDepSt tickedChainDepSt)
               (project' (Proxy @(WrapIsLeader blk)) isLeader)
               (project' (Proxy @(WrapForgeStateInfo blk)) forgeStateInfo)
-      , forgeBlock = \cfg bno sno tickedLgrSt txs isLeader ->
+      , forgeBlock = \cfg bno sno mbPerasCert tickedLgrSt txs isLeader ->
           inject' (Proxy @(I blk))
             <$> forgeBlock
               (project cfg)
               bno
               sno
+              (projectPerasCert mbPerasCert)
               (getFlipTickedLedgerState (project (FlipTickedLedgerState tickedLgrSt)))
               (project' (Proxy @(WrapValidatedGenTx blk)) <$> txs)
               (project' (Proxy @(WrapIsLeader blk)) isLeader)
       }
    where
+    projectPerasCert :: Maybe (PerasCert (HardForkBlock '[blk])) -> Maybe (PerasCert blk)
+    projectPerasCert = fmap (unwrapPerasCert . unZ . getOneEraPerasCert)
+
     projTickedChainDepSt ::
       Ticked (ChainDepState (HardForkProtocol '[blk])) ->
       Ticked (ChainDepState (BlockProtocol blk))

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Forging.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Forging.hs
@@ -310,6 +310,7 @@ hardForkForgeBlock ::
   TopLevelConfig (HardForkBlock xs) ->
   BlockNo ->
   SlotNo ->
+  Maybe (PerasCert (HardForkBlock xs)) ->
   TickedLedgerState (HardForkBlock xs) EmptyMK ->
   [Validated (GenTx (HardForkBlock xs))] ->
   HardForkIsLeader xs ->
@@ -319,6 +320,7 @@ hardForkForgeBlock
   cfg
   bno
   sno
+  mbPerasCert
   (TickedHardForkLedgerState transition ledgerState)
   txs
   isLeader =
@@ -375,6 +377,35 @@ hardForkForgeBlock
           error
             "Impossible! some transactions were rejected as untranslatable by rematchValidatedTxs but all of them have been translated and applied just now."
 
+    -- If we crossed an era boundary in this forge, and we are supposed to
+    -- include a Peras certificate in this block, we must ensure that the
+    -- certificate being passed to us (i.e., the latest certificate seen) is
+    -- from the same era as the block being forged. Otherwise, we drop it
+    -- (treating it as absent), since inter-era certificate inclusion is not
+    -- supported for now. In the unlikely event of recovering from a cooldown
+    -- period that crosses an era boundary, one should jumpstart the voting
+    -- process again via the same type of governance action that started this
+    -- process in the first place, but in the new era.
+    injectPerasCertIfSameEra ::
+      Index xs blk ->
+      PerasCert (HardForkBlock xs) ->
+      Maybe (PerasCert blk)
+    injectPerasCertIfSameEra index hardForkPerasCert =
+      case ( Match.matchNS
+               (getIndex index)
+               (getOneEraPerasCert hardForkPerasCert)
+           ) of
+        -- The Peras certificate is from a different era than the block being
+        -- forged, so we drop it (treating it as absent).
+        Left _mismatch ->
+          Nothing
+        -- The Peras certificate is from the same era as the block being forged,
+        -- so we keep it and pass it down to the current era's 'forgeBlock'.
+        Right nsPair ->
+          hcollapse $
+            hmap (\(Pair Refl (WrapPerasCert cert)) -> K (Just cert)) $
+              nsPair
+
     -- \| Unwraps all the layers needed for SOP and call 'forgeBlock'.
     forgeBlockOne ::
       Index xs blk ->
@@ -404,6 +435,7 @@ hardForkForgeBlock
           cfg'
           bno
           sno
+          (mbPerasCert >>= injectPerasCertIfSameEra index)
           ledgerState'
           (map unwrapValidatedGenTx txs')
           isLeader'

--- a/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Node.hs
+++ b/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Node.hs
@@ -103,7 +103,7 @@ simpleBlockForging aCanBeLeader aForgeExt =
     , canBeLeader = aCanBeLeader
     , updateForgeState = \_ _ _ -> return $ ForgeStateUpdated ()
     , checkCanForge = \_ _ _ _ _ -> return ()
-    , forgeBlock = \cfg bno slot lst txs proof ->
+    , forgeBlock = \cfg bno slot _mbPerasCert lst txs proof ->
         return $
           forgeSimple
             aForgeExt

--- a/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Node/PBFT.hs
+++ b/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Node/PBFT.hs
@@ -113,7 +113,7 @@ pbftBlockForging canBeLeader =
             canBeLeader
             slot
             tickedPBftState
-    , forgeBlock = \cfg slot bno lst txs proof ->
+    , forgeBlock = \cfg slot bno _mbPerasCert lst txs proof ->
         return $
           forgeSimple
             forgePBftExt

--- a/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Node/Praos.hs
+++ b/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Node/Praos.hs
@@ -140,7 +140,7 @@ praosBlockForging cid initHotKey = do
               . second forgeStateUpdateInfoFromUpdateInfo
               . evolveKey sno
       , checkCanForge = \_ _ _ _ _ -> return ()
-      , forgeBlock = \cfg bno sno tickedLedgerSt txs isLeader -> do
+      , forgeBlock = \cfg bno sno _mbPerasCert tickedLedgerSt txs isLeader -> do
           hotKey <- readMVar varHotKey
           return $
             forgeSimple


### PR DESCRIPTION
This PR extends `BlockForging.forgeBlock` with the option to pass a Peras certificate to be included in the block body. This involves:

- Passing a `Maybe (PerasCert blk)` from the node kernel through every block-forging implementation.
- Forwarding certificates through hard-fork forging _only_ when they belong to the era being forged (dropping certificates when forging crosses an era boundary, as cross-era certificate inclusion is not supported.)
- Updating all call sites accordingly.

NOTE: this doesn't yet implement the extended block body size calculation, but that should be fine since we don't yet include any certificate (the optional Peras certificate is hardcoded to `Nothing` in the node kernel).