### PR TITLE
Acquire EB closure age

### DIFF
--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToNode.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToNode.hs
@@ -598,8 +598,17 @@ mkHandlers
                               , threshold = vtThreshold
                               }
                           case mCert of
-                            Just _ ->
-                              traceWith kernelTracer TraceLeiosCertified{rbHash = Leios.announcingRbHash vote}
+                            Just _ -> do
+                              (_, Announcements.MkPeerState { Announcements.liveByRbHash }) <- Prim.readMutVar peerStateVar
+                              now <- systemTimeCurrent systemTime
+                              let rbHash = Leios.announcingRbHash vote
+                              ebAge <- case Map.lookup rbHash liveByRbHash of
+                                    Nothing -> pure Nothing
+                                    Just anc -> do
+                                      state <-Leios.ebState <$> MVar.readMVar getLeiosOutstanding
+                                      let ebPoint = Leios.ancLeiosPoint (Announcements.lastAnnouncement anc)
+                                      return $ Leios.ebPointAge now state ebPoint
+                              traceWith kernelTracer TraceLeiosCertified{rbHash = Leios.announcingRbHash vote, ebAge}
                             Nothing -> pure ()
                         _ -> pure ()
               )

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToNode.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToNode.hs
@@ -525,6 +525,7 @@ mkHandlers
                         Announcements.onAnnouncement
                           (contramap Leios.tracePeerAnnouncement tracer)
                           Leios.ancElId
+                          Leios.ancRbHash
                           ( \ancH ->
                               Leios.announcementValidity
                                 systemTime
@@ -556,7 +557,7 @@ mkHandlers
                       Left err -> throwIO $ Leios.ReactToAnnouncementError err
                       Right x -> pure x
                     let (!latestPruneSlot', !peerSt2) =
-                          Leios.prunePeerStateToImmTip immLedger latestPruneSlot peerSt1
+                          Leios.prunePeerStateToImmTip Leios.ancElId immLedger latestPruneSlot peerSt1
                     Prim.writeMutVar peerStateVar (latestPruneSlot', peerSt2)
                   MsgLeiosBlockOffer point ebBytesSize -> do
                     traceWith tracer $ MkTraceLeiosPeer $ "MsgLeiosBlockOffer " <> Leios.prettyLeiosPoint point

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
@@ -582,6 +582,7 @@ initNodeKernel
         runLeiosVoting
           (leiosKernelTracer tracers)
           (configLedger cfg)
+          (\now point -> flip (Leios.ebPointAge now) point . Leios.ebState <$> MVar.readMVar getLeiosOutstanding)
           chainDB
           systemTime
           leiosDB

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
@@ -599,7 +599,7 @@ initNodeKernel
               Origin -> pure ()
               NotOrigin immTipSlot -> do
                 MVar.modifyMVar_ getLeiosCentralState $
-                  pure . Announcements.pruneCentralState immTipSlot
+                  pure . Announcements.pruneCentralState immTipSlot Leios.ancElId
                 MVar.modifyMVar_ getLeiosOutstanding $
                   pure . snd . Leios.pruneOutstandingToImmTip immTipSlot
                 -- Backstop offer-prune: offers are keyed by point (slot-ordered),

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic.hs
@@ -166,6 +166,13 @@ traceException tracer toTrace action =
   per tx, and the serialized body is the @b@.
 -------------------------------------------------------------------------------}
 
+headerRbHash ::
+  forall blk.
+  (ConvertRawHash blk, HasHeader (Header blk)) =>
+  Header blk ->
+  RbHash
+headerRbHash = MkRbHash . toRawHash (Proxy @blk) . headerHash
+
 -- | Insert an EB announcement into the tx-cache index, keyed by the announced
 -- slot, the announcing RB header's hash, and the announced EB hash. Evicted
 -- bodies\/txs are discarded; they can be useful for debugging/etc.
@@ -179,7 +186,7 @@ recordAnnouncementInTxCache ::
 recordAnnouncementInTxCache txCache ancHdr point =
   void $ txCache.insertAnnouncement point.pointSlotNo rbh point.pointEbHash
  where
-  rbh = MkRbHash (toRawHash (Proxy @blk) (headerHash (ancHeader ancHdr)))
+  rbh = headerRbHash (ancHeader ancHdr)
 
 -- | Register a locally-forged EB in the tx-cache: its announcement, its
 -- body, and each of its txs as already-applied (the forger drew them from its
@@ -1523,10 +1530,15 @@ instance HasHeader (Header blk) => Eq (AnnouncingHeader blk) where
 -- | Interpret a header as a relayed EB announcement, or 'Nothing' if it carries
 -- no announcement (so it should not have been relayed as one). Parsing the
 -- announcement once here keeps it total for all later consumers (e.g. tracing).
-mkAnnouncingHeader :: ResolveLeiosBlock blk => Header blk -> Maybe (AnnouncingHeader blk)
+mkAnnouncingHeader ::
+  (ConvertRawHash blk, HasHeader (Header blk), ResolveLeiosBlock blk) =>
+  Header blk ->
+  Maybe (AnnouncingHeader blk)
 mkAnnouncingHeader h =
   headerLeiosAnnouncement h <&> \(MkLeiosPoint _ebSlot ebHash, ebBodySize) ->
-    UnsafeMkAnnouncingHeader h (MkAnnouncementFields (headerElId h) ebHash ebBodySize)
+    UnsafeMkAnnouncingHeader h (MkAnnouncementFields (headerElId h) ebHash ebBodySize rbHash)
+  where
+    rbHash = headerRbHash h
 
 -- | The other safe constructor of an 'AnnouncingHeader': for a header we already
 -- know announces a specific EB because we forged it. Unlike 'mkAnnouncingHeader'
@@ -1534,14 +1546,25 @@ mkAnnouncingHeader h =
 -- announcement fields come straight from the 'ForgedLeiosEb' whose EB the header
 -- announces by construction.
 mkForgedAnnouncingHeader ::
-  ResolveLeiosBlock blk => Header blk -> Leios.ForgedLeiosEb -> AnnouncingHeader blk
+  (ConvertRawHash blk, HasHeader (Header blk), ResolveLeiosBlock blk) =>
+  Header blk ->
+  Leios.ForgedLeiosEb ->
+  AnnouncingHeader blk
 mkForgedAnnouncingHeader h forgedEb =
   UnsafeMkAnnouncingHeader h $
-    MkAnnouncementFields (headerElId h) forgedEb.point.pointEbHash (leiosEbBytesSize forgedEb.body)
+    MkAnnouncementFields (headerElId h) forgedEb.point.pointEbHash (leiosEbBytesSize forgedEb.body) rbHash
+  where
+    rbHash = headerRbHash h
 
 -- | The election of an 'AnnouncingHeader'.
 ancElId :: AnnouncingHeader blk -> ElId
 ancElId = announcementElection . ancAnnouncementFields
+
+ancEbHash :: AnnouncingHeader blk -> EbHash
+ancEbHash = announcementEbHash . ancAnnouncementFields
+
+ancRbHash :: AnnouncingHeader blk -> RbHash
+ancRbHash = Leios.announcementRbHash . ancAnnouncementFields
 
 -- | The central-state handling shared by an incoming LeiosNotify
 -- 'MsgLeiosBlockAnnouncement' and a ChainSync 'MsgRollForward' that announces an
@@ -1583,6 +1606,7 @@ processAnnouncementCentrally
       Announcements.onAnnouncementCentral
         (contramap (traceNewAnnouncement provenance) kernelTracer)
         ancElId
+        ancRbHash
         ( \_elSt -> do
             -- A received announcement lists the EB for fetching; one we forged is
             -- instead marked 'BodyImminent' in 'ebState' so the fetch logic never
@@ -1772,14 +1796,15 @@ recordAnnouncedEb (outstandingVar, readyVar) onset (point, ebBytesSize) = do
 
 prunePeerStateToImmTip ::
   LedgerSupportsProtocol blk =>
+  (anc -> ElId) ->
   ExtLedgerState blk EmptyMK ->
   SlotNo ->
   PeerState anc ->
   (SlotNo, PeerState anc)
-prunePeerStateToImmTip immLedger latestPruneSlot peerSt =
+prunePeerStateToImmTip getElId immLedger latestPruneSlot peerSt =
   case getTipSlot (ledgerState immLedger) of
     NotOrigin immTipSlot
-      | latestPruneSlot < immTipSlot -> (immTipSlot, prunePeerState immTipSlot peerSt)
+      | latestPruneSlot < immTipSlot -> (immTipSlot, prunePeerState immTipSlot getElId peerSt)
     _ -> (latestPruneSlot, peerSt)
 
 -- | The just-counted announcement's fields, and whether it equivocates a prior

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic.hs
@@ -26,7 +26,7 @@ import Control.Monad.Primitive (PrimMonad, PrimState)
 import Control.Tracer (Tracer, contramap, nullTracer, traceWith)
 import qualified Data.Bits as Bits
 import qualified Data.ByteString as BS
-import Data.Foldable (fold)
+import Data.Foldable (fold, traverse_)
 import Data.Functor (void, (<&>))
 import qualified Data.IntMap as IntMap
 import qualified Data.IntMap.NonEmpty as NEIntMap
@@ -682,7 +682,7 @@ offsetsToBitmap offsets =
 -- for processing on the main peer thread. The collector must not touch
 -- the 'LeiosDbConnection' — it belongs to the main peer thread.
 data PendingResponse
-  = PendingBlockResponse !LeiosBlockRequest !LeiosEb
+  = PendingBlockResponse !LeiosBlockRequest !LeiosEb !RelativeTime
   | PendingBlockTxsResponse !LeiosBlockTxsRequest !(V.Vector LeiosTx)
 
 nextLeiosFetchClientCommand ::
@@ -727,7 +727,7 @@ nextLeiosFetchClientCommand ktracer tracer stopSTM kernelVars txCache db systemT
   drainResponses = do
     pending <- StrictSTM.atomically $ LazySTM.flushTQueue responseQ
     forM_ pending $ \case
-      PendingBlockResponse req eb ->
+      PendingBlockResponse req eb receivedTime ->
         processLeiosBlock
           ktracer
           tracer
@@ -736,7 +736,7 @@ nextLeiosFetchClientCommand ktracer tracer stopSTM kernelVars txCache db systemT
           db
           systemTime
           pullFromMempool
-          (ReceivedBlockFrom peerId req)
+          (ReceivedBlockFrom peerId req receivedTime)
           eb
       PendingBlockTxsResponse req txs ->
         processLeiosBlockTxs
@@ -791,9 +791,10 @@ nextLeiosFetchClientCommand ktracer tracer stopSTM kernelVars txCache db systemT
     LeiosBlockRequest req@(MkLeiosBlockRequest p _ebBytesSize) ->
       LF.MkSomeLeiosFetchJob
         (LF.MsgLeiosBlockRequest p)
-        ( pure $ \(LF.MsgLeiosBlock eb) ->
+        ( pure $ \(LF.MsgLeiosBlock eb) -> do
+            now <- systemTimeCurrent systemTime
             StrictSTM.atomically $
-              LazySTM.writeTQueue responseQ (PendingBlockResponse req eb)
+              LazySTM.writeTQueue responseQ (PendingBlockResponse req eb now)
         )
     LeiosBlockTxsRequest req@(MkLeiosBlockTxsRequest p jobs) ->
       -- The wire request is just the point + bitmap; the bitmap is the union of
@@ -816,7 +817,7 @@ nextLeiosFetchClientCommand ktracer tracer stopSTM kernelVars txCache db systemT
 -- emitting fetch-arrival telemetry (which would otherwise pollute the metrics
 -- with self-produced data).
 data LeiosBlockSource pid
-  = ReceivedBlockFrom (PeerId pid) LeiosBlockRequest
+  = ReceivedBlockFrom (PeerId pid) LeiosBlockRequest RelativeTime
   | -- | A locally-forged EB, carrying the point the forge assigned it.
     ForgedBlock !LeiosPoint
 
@@ -865,13 +866,14 @@ processLeiosBlock ::
   ) ->
   LeiosBlockSource pid ->
   LeiosEb ->
+  -- ^ time when then `LeiosEb` was received
   m ()
 processLeiosBlock ktracer tracer (outstandingVar, readyVar) txCache db systemTime pullFromMempool source eb = do
   now <- systemTimeCurrent systemTime
   -- validate it
-  let (mbPeer, point, ebBytesSize) = case source of
-        ReceivedBlockFrom peerId (MkLeiosBlockRequest p sz) -> (Just peerId, p, sz)
-        ForgedBlock p -> (Nothing, p, leiosEbBytesSize eb)
+  let (mbPeer, point, ebBytesSize, mbReceivedTime) = case source of
+        ReceivedBlockFrom peerId (MkLeiosBlockRequest p sz) t -> (Just peerId, p, sz, Just t)
+        ForgedBlock p -> (Nothing, p, leiosEbBytesSize eb, Nothing)
   traceWith tracer $ MkTraceLeiosPeer $ "[start] MsgLeiosBlock " <> Leios.prettyLeiosPoint point
   let MkLeiosPoint _ebSlot ebHash = point
   let ebBytesSize' = leiosEbBytesSize eb
@@ -907,6 +909,9 @@ processLeiosBlock ktracer tracer (outstandingVar, readyVar) txCache db systemTim
         invalidReply $ "MsgLeiosBlock duplicate tx hashes: " <> show duplicateTxHashes
   -- ingest it
   (bodyClass, mempoolNotCache, mempoolAndCache) <- MVar.modifyMVar outstandingVar $ \outstanding -> do
+    traverse_
+      (\receivedTime -> traceWith tracer (TraceLeiosReceivedEb point (ebPointAge receivedTime outstanding.ebState point)))
+      mbReceivedTime
     let tooOld = point.pointSlotNo < Leios.acquiredEbBodiesPrunedSlot outstanding
         novel = not $ maybe False Leios.ebStateHasBody (Map.lookup ebHash (Leios.ebState outstanding))
         -- Always: this request is no longer in flight and we now have the body,

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic.hs
@@ -1566,6 +1566,9 @@ ancEbHash = announcementEbHash . ancAnnouncementFields
 ancRbHash :: AnnouncingHeader blk -> RbHash
 ancRbHash = Leios.announcementRbHash . ancAnnouncementFields
 
+ancLeiosPoint :: AnnouncingHeader blk -> LeiosPoint
+ancLeiosPoint = Leios.announcementLeiosPoint . ancAnnouncementFields
+
 -- | The central-state handling shared by an incoming LeiosNotify
 -- 'MsgLeiosBlockAnnouncement' and a ChainSync 'MsgRollForward' that announces an
 -- EB: run 'Announcements.onAnnouncementCentral' (relay + dedup) and, for a

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic/Announcements.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic/Announcements.hs
@@ -42,11 +42,14 @@ import Control.Monad.Except (ExceptT, throwError)
 import Control.Monad.Trans (lift)
 import Control.Tracer (Tracer, traceWith)
 import Data.Functor.Compose (Compose (..))
+import qualified Data.List as List
 import qualified Data.Map.Strict as Map
 import qualified Data.Map.Strict as Strict (Map)
+import Data.Maybe (fromMaybe)
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.Time.Clock (NominalDiffTime)
+import qualified LeiosDemoTypes as Leios
 import LeiosDemoLogic.Announcements.ElBimap
 
 -----
@@ -57,10 +60,11 @@ import LeiosDemoLogic.Announcements.ElBimap
 data PeerState anc
   = MkPeerState
   { live :: !(Strict.Map ElId (ElState anc))
+  , liveByRbHash :: !(Strict.Map Leios.RbHash (ElState anc))
   }
 
 emptyPeerState :: PeerState anc
-emptyPeerState = MkPeerState Map.empty
+emptyPeerState = MkPeerState Map.empty Map.empty
 
 -- | State maintained within 'PeerState' for each election
 data ElState anc
@@ -87,17 +91,30 @@ secondAnnouncement = \case
   OneAnnouncement _x -> Nothing
   TwoAnnouncements _x1 x2 -> Just x2
 
+lastAnnouncement :: ElState anc -> anc
+lastAnnouncement anc = firstAnnouncement anc `fromMaybe` secondAnnouncement anc
+
 -- | Called whenever the ChainDB's immutable tip advances to a new slot
 --
 -- NOTE this pruning should happen ~60 s after the immutable tip
 -- advances.  That accommodates clock skew, transmission time, etc
 -- with only an insignificant increase in the stochastic bound on
 -- election count
-prunePeerState :: SlotNo -> PeerState anc -> PeerState anc
-prunePeerState immTipSlot st =
-  MkPeerState{live = live'}
+prunePeerState :: SlotNo -> (anc -> ElId) -> PeerState anc -> PeerState anc
+prunePeerState immTipSlot getElId st =
+    MkPeerState{live = live', liveByRbHash = liveByRbHash'}
  where
-  (_pruned, live') = Map.spanAntitone tooOld (live st)
+  (pruned, live') = Map.spanAntitone tooOld (live st)
+  prunedSet = Map.keysSet pruned
+  liveByRbHash' = Map.filter
+    (\anc ->
+      -- TODO: can both announcement have a different `ElId`?
+      let firstElId  = getElId (firstAnnouncement anc)
+          secondElId = maybe firstElId getElId (secondAnnouncement anc)
+      in 
+      all (`Set.notMember` prunedSet) (List.nub [firstElId, secondElId])
+    )
+    (liveByRbHash st)
 
   -- NB strict comparison, so that the immtip's own announcement is
   -- not pruned
@@ -126,15 +143,23 @@ extendLive ::
   forall anc invalidity.
   Eq anc =>
   ElId ->
+  (anc -> Leios.RbHash) ->
   anc ->
   PeerState anc ->
   Either (ErrAnnouncement invalidity) (ElState anc, PeerState anc)
-extendLive elId anc st =
-  getCompose $
-    fmap
-      (\live' -> MkPeerState{live = live'})
-      (Map.alterF (inj . upd) elId (live st))
+extendLive elId getRbHash anc st =
+  case getCompose $ Map.alterF (inj . upd) elId (live st) of
+    Left e -> Left e
+    Right (elState, live') ->
+      let firstRbHash    = getRbHash $ firstAnnouncement elState
+          lastRbHash     = getRbHash $ lastAnnouncement elState
+          liveByRbHash'  = if firstRbHash /= lastRbHash
+                           then Map.delete firstRbHash (liveByRbHash st)
+                           else liveByRbHash st
+          liveByRbHash'' = Map.insert lastRbHash elState liveByRbHash' in
+      Right (elState, MkPeerState { live = live', liveByRbHash = liveByRbHash'' })
  where
+
   -- 0 -> 1 ok
   -- 1 -> 2 ok when unequal
   -- 2 -> 3 not ok
@@ -179,6 +204,7 @@ onAnnouncement ::
   (Eq anc, Monad m) =>
   Tracer m (TraceLeiosNotifyPeerEvent anc) ->
   (anc -> ElId) ->
+  (anc -> Leios.RbHash) ->
   -- | How to validate the announcement
   --
   -- The peer is disconnected only for a rejecting verdict; both accepting
@@ -193,8 +219,8 @@ onAnnouncement ::
   PeerState anc ->
   anc ->
   ExceptT (ErrAnnouncement invalidity) m (PeerState anc)
-onAnnouncement tracer getEl validate process st anc = do
-  (elSt, st') <- case extendLive (getEl anc) anc st of
+onAnnouncement tracer getEl getRbHash validate process st anc = do
+  (elSt, st') <- case extendLive (getEl anc) getRbHash  anc st of
     Left err -> throwError err
     Right x -> pure x
   lift $ traceWith tracer $ TracePeerAnnouncement elSt
@@ -254,10 +280,10 @@ data TraceLeiosNotifyEvent peer anc
 --
 -- Unlike 'prunePeerState', a delay is undesirable here.
 pruneCentralState ::
-  Ord peer => SlotNo -> CentralState m peer anc -> CentralState m peer anc
-pruneCentralState immTipSlot st =
+  Ord peer => SlotNo -> (anc -> ElId) -> CentralState m peer anc -> CentralState m peer anc
+pruneCentralState immTipSlot getElId st =
   MkCentralState
-    { selfPeer = prunePeerState immTipSlot (selfPeer st) -- NB no delay
+    { selfPeer = prunePeerState immTipSlot getElId (selfPeer st) -- NB no delay
     , queues = queues st
     , gate = pruneElBimap immTipSlot (gate st)
     }
@@ -310,6 +336,7 @@ onAnnouncementCentral ::
   (MonadSTM m, Ord peer, Eq anc) =>
   Tracer m (TraceLeiosNotifyEvent peer anc) ->
   (anc -> ElId) ->
+  (anc -> Leios.RbHash) ->
   -- | Notify other components about a /new/ announcement
   --
   -- For example, notify the voting thread; it cares about both new
@@ -327,8 +354,8 @@ onAnnouncementCentral ::
   Maybe NominalDiffTime ->
   anc ->
   m (CentralState m peer anc)
-onAnnouncementCentral tracer getEl publishLocally st peer shouldRelay age anc =
-  case extendLive el anc (selfPeer st) of
+onAnnouncementCentral tracer getEl getRbHash publishLocally st peer shouldRelay age anc =
+  case extendLive el getRbHash anc (selfPeer st) of
     Left{} -> pure st -- complete noop for duplicates
     Right (elSt, selfPeer') -> do
       traceWith tracer $ TraceNewAnnouncement peer el elSt age

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoTypes.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoTypes.hs
@@ -83,6 +83,7 @@ import qualified Data.ByteString as BS
 import qualified Data.ByteString.Base16 as BS16
 import qualified Data.ByteString.Char8 as BS8
 import qualified Data.ByteString.Short as SBS
+import qualified Data.ByteString.Base16 as Base16
 import Data.Fixed (Pico)
 import qualified Data.Foldable as F
 import Data.IntMap.NonEmpty (NEIntMap)
@@ -102,6 +103,7 @@ import qualified Data.Set.NonEmpty as NESet
 import Data.String (fromString)
 import Data.Text (Text)
 import qualified Data.Text as T
+import qualified Data.Text.Encoding as T
 import Data.Time.Clock (NominalDiffTime)
 import Data.Vector.Strict (Vector)
 import qualified Data.Vector.Strict as V
@@ -1780,6 +1782,9 @@ data TraceLeiosPeer
   | TraceLeiosPeerDbException LeiosDbException
   | -- | This upstream peer relayed a valid, newly-counted EB announcement.
     TraceLeiosPeerAnnouncement !AnnouncementEquivocation !AnnouncementFields
+  | -- | Trace time when an EB was received.  Note that this message is traced
+    -- when the EB is processed.
+    TraceLeiosReceivedEb LeiosPoint (Maybe NominalDiffTime)
   deriving Show
 
 -----
@@ -1801,6 +1806,13 @@ traceLeiosPeerToObject = \case
       [ fromString "kind" .= Aeson.String "LeiosPeerAnnouncement"
       , announcementFieldsToObject acc
       , announcementEquivocationToObject equivocation
+      ]
+  TraceLeiosReceivedEb (MkLeiosPoint slotNo (MkEbHash ebHash)) time ->
+    mconcat
+      [ fromString "kind" .= Aeson.String "LeiosReceivedEb"
+      , fromString "slotNo" .= slotNo
+      , fromString "ebHash" .= T.decodeUtf8Lenient (Base16.encode ebHash)
+      , fromString "time" .= time
       ]
 
 -- | Consensus-side severity; cardano-node maps it to its @SeverityS@.
@@ -2065,6 +2077,7 @@ leiosPeerNSOf = \case
   MkTraceLeiosPeer{} -> LPNSMsg
   TraceLeiosPeerDbException{} -> LPNSDbException
   TraceLeiosPeerAnnouncement{} -> LPNSAnnouncement
+  TraceLeiosReceivedEb{} -> LPNSMsg
 
 leiosPeerNSInfo :: LeiosPeerNS -> LeiosNSInfo
 leiosPeerNSInfo = \case
@@ -2085,6 +2098,10 @@ traceLeiosPeerForHuman = \case
   TraceLeiosPeerDbException e -> "Leios peer DB exception: " <> T.pack (show e)
   TraceLeiosPeerAnnouncement equiv fields ->
     "EB announcement from peer (" <> T.pack (show equiv) <> "): " <> T.pack (show fields)
+  TraceLeiosReceivedEb point (Just time) ->
+    "EB received " <> T.pack (show point) <> " at " <> T.pack (show time)
+  TraceLeiosReceivedEb point Nothing ->
+    "EB received " <> T.pack (show point)
 
 -- * Protocol parameters
 

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoTypes.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoTypes.hs
@@ -1415,7 +1415,7 @@ data TraceLeiosKernel
       , tally :: Weight
       , threshold :: Weight
       }
-  | TraceLeiosCertified {rbHash :: RbHash}
+  | TraceLeiosCertified {rbHash :: RbHash, ebAge :: Maybe NominalDiffTime}
   | -- | A vote is scheduled to happen.
     TraceLeiosVoteScheduled
       {ebPoint :: LeiosPoint, voteIn :: NominalDiffTime, deadlineIn :: NominalDiffTime}
@@ -1457,6 +1457,14 @@ data AnnouncementFields = MkAnnouncementFields
   , announcementRbHash :: !RbHash
   }
   deriving (Eq, Show)
+
+announcementLeiosPoint :: AnnouncementFields -> LeiosPoint
+announcementLeiosPoint MkAnnouncementFields {
+    announcementElection = MkElId slot _,
+    announcementEbHash = ebHash
+  }
+  =
+  MkLeiosPoint slot ebHash
 
 -- | The bytes of one LeiosFetch arrival ('MsgLeiosBlock' or 'MsgLeiosBlockTxs'),
 -- partitioned by the arriving item's /prior/ state in the LeiosTxCache. The four

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoTypes.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoTypes.hs
@@ -1454,6 +1454,7 @@ data AnnouncementFields = MkAnnouncementFields
   { announcementElection :: !ElId
   , announcementEbHash :: !EbHash
   , announcementEbBodySize :: !BytesSize
+  , announcementRbHash :: !RbHash
   }
   deriving (Eq, Show)
 
@@ -1750,12 +1751,13 @@ traceLeiosKernelToObject = \case
 
 announcementFieldsToObject :: AnnouncementFields -> Aeson.Object
 announcementFieldsToObject
-  (MkAnnouncementFields (MkElId (SlotNo electionSlot) poolId) ebHash ebBodySize) =
+  (MkAnnouncementFields (MkElId (SlotNo electionSlot) poolId) ebHash ebBodySize rbHash) =
     mconcat
       [ "electionSlot" .= electionSlot
       , "electionPool" .= BS8.unpack (BS16.encode (SBS.fromShort poolId))
       , "ebHash" .= prettyEbHash ebHash
       , "ebBodySize" .= ebBodySize
+      , "rbHash" .= prettyRbHash rbHash
       ]
 
 announcementEquivocationToObject :: AnnouncementEquivocation -> Aeson.Object

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosVoting.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosVoting.hs
@@ -255,6 +255,7 @@ runLeiosVoting ::
   ) =>
   Tracer m TraceLeiosKernel ->
   LedgerConfig blk ->
+  (RelativeTime -> LeiosPoint -> m (Maybe NominalDiffTime)) ->
   ChainDB m blk ->
   SystemTime m ->
   LeiosDbHandle m ->
@@ -262,7 +263,7 @@ runLeiosVoting ::
   LeiosVoteState m ->
   Maybe LeiosSigningKey ->
   m ()
-runLeiosVoting tracer lcfg chainDB systemTime leiosDB txCache voteState = \case
+runLeiosVoting tracer lcfg ebPointAge chainDB systemTime leiosDB txCache voteState = \case
   Nothing ->
     traceWith tracer $
       MkTraceLeiosKernel
@@ -369,7 +370,9 @@ runLeiosVoting tracer lcfg chainDB systemTime leiosDB txCache voteState = \case
                   -- point if subsequent votes also come in; consumers (e.g.
                   -- ThreadNet's 'propCertifying') dedupe.
                   case mCert of
-                    Just _ -> traceWith tracer TraceLeiosCertified{rbHash}
+                    Just _ -> do
+                      ebAge <- ebPointAge now point
+                      traceWith tracer TraceLeiosCertified{rbHash, ebAge}
                     Nothing -> pure ()
                 -- A trace rather than an 'error', which under
                 -- 'forkLinkedThread' would take the node down.

--- a/ouroboros-consensus/test/consensus-test/Test/LeiosDemoLogic/Invariants.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/LeiosDemoLogic/Invariants.hs
@@ -452,7 +452,7 @@ applyCmd conn txCache kv peerVars peerId = \case
       conn
       dummySystemTime
       noMempoolPull
-      (ReceivedBlockFrom peerId req)
+      (ReceivedBlockFrom peerId req (RelativeTime 0))
       eb
     pure []
   ArriveTx v -> absurd v
@@ -780,7 +780,7 @@ raceSameHashMultiSlot = do
               conn
               dummySystemTime
               noMempoolPull
-              (ReceivedBlockFrom peerId (MkLeiosBlockRequest arrivalPoint ebBytesSize))
+              (ReceivedBlockFrom peerId (MkLeiosBlockRequest arrivalPoint ebBytesSize) (RelativeTime 0))
               eb
           )
       )


### PR DESCRIPTION

# Description

Added `NominalDiffTime` to `TraceLeiosBlockTxsAcquired`.  This will
allow us to compute 90, 95 and 99 percentiles of how long it takes to acquire
all txs announced in an EB.

# WARNING

To update your feature branch if it's stale, please rebase it manually on top of `main`. Don't update your feature branch by merging `main` into it. Your pull request will not pass CI if you do.
