### PR TITLE
Replace deprecated withMaxSuccess in Roundtrip

### DIFF
--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/Serialisation/Roundtrip.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/Serialisation/Roundtrip.hs
@@ -661,9 +661,10 @@ roundtrip_SerialiseNodeToClient shouldCheckCBORvalidity ccfg =
   , -- Note: Ideally we'd just use 'rt' to test Ledger config, but that would
     -- require an 'Eq' and 'Show' instance for all ledger config types which
     -- we'd like to avoid (as the EpochInfo is a record of functions).
-    testProperty "roundtrip (comparing encoding) LedgerConfig" $
-      withMaxSuccess 20 $ \(Blind (WithVersion version a)) ->
-        roundtripComparingEncoding @(LedgerConfig blk) (enc version) (dec version) a
+    adjustQuickCheckTests (const 20) $
+      testProperty "roundtrip (comparing encoding) LedgerConfig" $
+        \(Blind (WithVersion version a)) ->
+          roundtripComparingEncoding @(LedgerConfig blk) (enc version) (dec version) a
   , rtWith
       @(SomeSecond Query blk)
       @(QueryVersion, BlockNodeToClientVersion blk)


### PR DESCRIPTION
The GHC 9.14.1 CI job fails to build `unstable-consensus-testlib`:

```
ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/Serialisation/Roundtrip.hs:665:7: error: [GHC-68441] [-Wdeprecations, -Werror=deprecations]
    In the use of 'withMaxSuccess' ... Deprecated: "Use withNumTests instead"
```

That job resolves QuickCheck 2.16, which deprecates `withMaxSuccess`.
A rename to `withNumTests` does not work, because the Nix shell and the other GHC versions use QuickCheck 2.15, which does not export it.

This change uses `adjustQuickCheckTests`, which the same file already calls at ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/Serialisation/Roundtrip.hs:376.
It sets the test count for that subtree and builds with both QuickCheck versions.