### PR TITLE
Do not send LeiosNotify requests while syncing

### DIFF
--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToNode.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToNode.hs
@@ -137,6 +137,7 @@ import qualified Network.Mux as Mux
 import Network.TypedProtocol.Codec
 import Network.TypedProtocol.Peer (Peer (Effect))
 import Ouroboros.Consensus.Block
+import Ouroboros.Consensus.BlockchainTime (getCurrentSlot)
 import Ouroboros.Consensus.BlockchainTime.WallClock.Types
   ( diffRelTime
   , systemTimeCurrent
@@ -387,6 +388,7 @@ mkHandlers
     , getTracers = tracers
     , getPeerSharingAPI
     , getGsmState
+    , getBlockchainTime
     }
   txSubmissionLogicVersion =
     Handlers
@@ -496,9 +498,17 @@ mkHandlers
           peerStateVar <- Prim.newMutVar (SlotNo 0, Announcements.emptyPeerState)
           pure $
             leiosNotifyClientPeerPipelined
-              ( atomically controlMessageSTM <&> \case
-                  Terminate -> Left ()
-                  _ -> Right leiosNotifyPipelineDepth
+              ( atomically $
+                  controlMessageSTM >>= \case
+                    Terminate -> pure (Left ())
+                    _ -> do
+                      -- Gate on the immutable tip being able to forecast to the
+                      -- current wall clock.
+                      Leios.awaitImmTipCanForecastNow
+                        getTopLevelConfig
+                        (ChainDB.getImmutableLedger getChainDB)
+                        (getCurrentSlot getBlockchainTime)
+                      pure $ Right leiosNotifyPipelineDepth
               )
               ( pure $ \case
                   MsgLeiosBlockAnnouncement hdr -> do

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToNode.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToNode.hs
@@ -507,15 +507,7 @@ mkHandlers
                     anc <- case Leios.mkAnnouncingHeader hdr of
                       Nothing -> throwIO Leios.ExnLeiosBlockAnnouncementMissing
                       Just x -> pure x
-                    -- The volatile tip dates the announcement (longest forecast
-                    -- horizon), the immutable tip judges OCIN revocation (only
-                    -- a state that cannot roll back may revoke). Read together
-                    -- so the two cannot disagree about the same chain.
-                    (volLedger, immLedger) <-
-                      atomically $
-                        (,)
-                          <$> ChainDB.getCurrentLedger getChainDB
-                          <*> ChainDB.getImmutableLedger getChainDB
+                    immLedger <- atomically $ ChainDB.getImmutableLedger getChainDB
                     (latestPruneSlot, peerSt0) <- Prim.readMutVar peerStateVar
                     res <-
                       runExceptT $
@@ -524,11 +516,9 @@ mkHandlers
                           Leios.ancElId
                           ( \ancH ->
                               Leios.announcementValidity
-                                kernelTracer
                                 systemTime
                                 chainSyncFutureCheck
                                 getTopLevelConfig
-                                volLedger
                                 immLedger
                                 (Leios.ancHeader ancH)
                           )

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic.hs
@@ -127,9 +127,6 @@ import Ouroboros.Consensus.BlockchainTime.WallClock.Types
   , systemTimeCurrent
   )
 import Ouroboros.Consensus.Config (TopLevelConfig, configLedger)
-import Ouroboros.Consensus.HardFork.History
-  ( PastHorizonException (PastHorizon)
-  )
 import Ouroboros.Consensus.Ledger.Abstract (getTipSlot)
 import Ouroboros.Consensus.Ledger.Basics (EmptyMK)
 import Ouroboros.Consensus.Ledger.Extended (ExtLedgerState, ledgerState)
@@ -1632,14 +1629,6 @@ instance Exception ExnLeiosBlockAnnouncementMissing
 -- Chronos) — blocking the per-peer handler is acceptable, as a (near-)future
 -- announcement is the peer's fault.
 --
--- A slot past the forecast horizon is /not/ the peer's fault, so it must not
--- disconnect them: it means our own ledger is too far behind to date the
--- announcement, which is the ordinary state of affairs while syncing. The
--- verdict is 'VerdictIgnore' and 'TraceLeiosAnnouncementPastHorizon' records it.
--- The horizon comes from the volatile tip rather than the immutable one for the
--- same reason — it is the longest forecast we have, and every slot it buys is a
--- peer we do not drop.
---
 -- If the announcement is valid and 'FreshOCIN', the verdict carries its data and
 -- whether to relay it downstream (see 'ShouldRelay' and
 -- 'maxAnnouncementAgeSend'). If it is valid but 'StaleOCIN' (its opcert counter
@@ -1649,15 +1638,9 @@ instance Exception ExnLeiosBlockAnnouncementMissing
 -- relaying it.
 announcementValidity ::
   (IOLike m, LedgerSupportsProtocol blk, ResolveLeiosBlock blk) =>
-  Tracer m TraceLeiosKernel ->
   SystemTime m ->
   InFutureCheck.SomeHeaderInFutureCheck m blk ->
   TopLevelConfig blk ->
-  -- | The volatile tip's ledger state, for the in-future check: it forecasts
-  -- furthest, and a shorter horizon costs us peers.
-  ExtLedgerState blk EmptyMK ->
-  -- | The immutable tip's ledger state, for the OCIN revocation check: a
-  -- revocation only counts once it cannot be rolled back.
   ExtLedgerState blk EmptyMK ->
   Header blk ->
   m
@@ -1665,43 +1648,38 @@ announcementValidity ::
         (AnnouncementInvalidity blk)
         (ShouldRelay, RelativeTime, NominalDiffTime, (LeiosPoint, BytesSize))
     )
-announcementValidity tracer systemTime futureCheck cfg volLedger immLedger hdr = do
-  mbOnset <- case futureCheck of
+announcementValidity systemTime futureCheck cfg immLedger hdr = do
+  onset <- case futureCheck of
     InFutureCheck.SomeHeaderInFutureCheck hifc -> do
       arrival <- InFutureCheck.recordHeaderArrival hifc hdr
-      case runExcept $
-        InFutureCheck.judgeHeaderArrival
-          hifc
-          (configLedger cfg)
-          (ledgerState volLedger)
-          arrival of
-        Left PastHorizon{} -> do
-          traceWith tracer $ TraceLeiosAnnouncementPastHorizon (blockSlot hdr)
-          pure Nothing
-        Right judgment -> do
-          arrivalResult <- InFutureCheck.handleHeaderArrival hifc judgment
-          Just <$> either throwIO pure (runExcept arrivalResult)
-  case mbOnset of
-    Nothing -> pure VerdictIgnore
-    Just onset -> do
-      -- The in-future check has delayed this thread until 'onset' if the
-      -- slot was near-future, so 'now' is at or after 'onset' and the age
-      -- is non-negative.
-      now <- systemTimeCurrent systemTime
-      let age = diffRelTime now onset
-      pure $
-        -- Only this function holds the wall clock, so it owns the too-old check.
-        if age > maxAnnouncementAgeRecv
-          then VerdictTooOld
-          else
-            let shouldRelay =
-                  if age <= maxAnnouncementAgeSend
-                    then DoRelay
-                    else DoNotRelay
-             in case validateAnnouncementHeader cfg immLedger hdr of
-                  Left inv -> VerdictInvalid inv
-                  Right (StaleOCIN, _v) -> VerdictIgnore
-                  Right (FreshOCIN, v) -> VerdictProcess (shouldRelay, onset, age, v)
+      judgment <-
+        either throwIO pure $
+          runExcept $
+            InFutureCheck.judgeHeaderArrival
+              hifc
+              (configLedger cfg)
+              (ledgerState immLedger)
+              arrival
+      arrivalResult <- InFutureCheck.handleHeaderArrival hifc judgment
+      either throwIO pure (runExcept arrivalResult)
+  -- The in-future check has delayed this thread until 'onset' if the
+  -- slot was near-future, so 'now' is at or after 'onset' and the age
+  -- is non-negative.
+  now <- systemTimeCurrent systemTime
+  let age = diffRelTime now onset
+  pure $
+    -- Only this function holds the wall clock, so it owns the too-old check.
+    if age > maxAnnouncementAgeRecv
+      then VerdictTooOld
+      else
+        let shouldRelay =
+              if age <= maxAnnouncementAgeSend
+                then DoRelay
+                else DoNotRelay
+         in case validateAnnouncementHeader cfg immLedger hdr of
+              Left inv -> VerdictInvalid inv
+              Right (StaleOCIN, _v) -> VerdictIgnore
+              Right (FreshOCIN, v) -> VerdictProcess (shouldRelay, onset, age, v)
 
 -- | Record a validated, newly-announced EB body as missing, unless its already
 -- pruned\/tracked\/acquired

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic.hs
@@ -120,6 +120,9 @@ import Ouroboros.Consensus.Block
   , headerHash
   , toRawHash
   )
+import Ouroboros.Consensus.BlockchainTime
+  ( CurrentSlot (CurrentSlot, CurrentSlotUnknown)
+  )
 import Ouroboros.Consensus.BlockchainTime.WallClock.Types
   ( RelativeTime
   , SystemTime
@@ -127,10 +130,14 @@ import Ouroboros.Consensus.BlockchainTime.WallClock.Types
   , systemTimeCurrent
   )
 import Ouroboros.Consensus.Config (TopLevelConfig, configLedger)
+import Ouroboros.Consensus.Forecast (forecastFor)
 import Ouroboros.Consensus.Ledger.Abstract (getTipSlot)
 import Ouroboros.Consensus.Ledger.Basics (EmptyMK)
 import Ouroboros.Consensus.Ledger.Extended (ExtLedgerState, ledgerState)
-import Ouroboros.Consensus.Ledger.SupportsProtocol (LedgerSupportsProtocol)
+import Ouroboros.Consensus.Ledger.SupportsProtocol
+  ( LedgerSupportsProtocol
+  , ledgerViewForecastAt
+  )
 import qualified Ouroboros.Consensus.MiniProtocol.ChainSync.Client.InFutureCheck as InFutureCheck
 import Ouroboros.Consensus.Protocol.Abstract (ChainDepState)
 import Ouroboros.Consensus.Storage.LedgerDB.Forker
@@ -1620,6 +1627,38 @@ data ExnLeiosBlockAnnouncementMissing = ExnLeiosBlockAnnouncementMissing
 
 instance Exception ExnLeiosBlockAnnouncementMissing
 
+-- | Block until the immutable tip can forecast the ledger view to the current
+-- slot
+--
+-- LeiosNotify replies are fresh, ie in slots near the wall clock, and
+-- 'announcementValidity' judges them by forecasting from the immutable tip.
+-- Until that tip reaches approximately /now/, a fresh reply would be
+-- @PastHorizon@, and a reply we cannot judge is no grounds to punish the
+-- peer. So we don't even send a request.
+--
+-- The current slot is read via the caller's 'CurrentSlot' action, which uses
+-- the volatile tip; its horizon reaches further, so gating on it alone would
+-- send requests too soon.
+awaitImmTipCanForecastNow ::
+  (IOLike m, LedgerSupportsProtocol blk) =>
+  TopLevelConfig blk ->
+  -- | the /immutable/ tip's ledger state
+  StrictSTM.STM m (ExtLedgerState blk mk) ->
+  StrictSTM.STM m CurrentSlot ->
+  StrictSTM.STM m ()
+awaitImmTipCanForecastNow cfg readImmutableLedger readCurrentSlot =
+  readCurrentSlot >>= \case
+    CurrentSlotUnknown -> StrictSTM.retry
+    CurrentSlot slot -> do
+      immLedger <- readImmutableLedger
+      case runExcept
+        ( forecastFor
+            (ledgerViewForecastAt (configLedger cfg) (ledgerState immLedger))
+            slot
+        ) of
+        Left _ -> StrictSTM.retry
+        Right _ -> pure ()
+
 -- | The @validate@ callback for 'onAnnouncement'.
 --
 -- First apply ChainSync's in-future check to the announced slot's wall-clock
@@ -1641,6 +1680,8 @@ announcementValidity ::
   SystemTime m ->
   InFutureCheck.SomeHeaderInFutureCheck m blk ->
   TopLevelConfig blk ->
+  -- | The immutable tip's ledger state, for the OCIN revocation check: a
+  -- revocation only counts once it cannot be rolled back.
   ExtLedgerState blk EmptyMK ->
   Header blk ->
   m

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic/Announcements/Validate.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoLogic/Announcements/Validate.hs
@@ -227,6 +227,12 @@ validateAnnouncementHeader cfg extLedger hdr =
     -- that our lagging tip would spuriously trip (see
     -- 'validateAnnouncementChainDepState'). Any error it returns is a genuine
     -- rejection.
+    --
+    -- Ticks the immutable tip's header state to the announcing slot without
+    -- applying the intervening headers: sound within the forecast horizon, since
+    -- the nonce and stake the VRF/KES checks use are already fixed and stale
+    -- opcert counters only yield 'StaleOCIN', never a false rejection. No TICKF
+    -- analog is warranted: unlike the ledger tick, nothing costly is discarded.
     let tickedHeaderState =
           tickHeaderState (configConsensus cfg) ledgerView slot (headerState extLedger)
     staleness <-

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoTypes.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoTypes.hs
@@ -1386,10 +1386,6 @@ data TraceLeiosKernel
   | TraceLeiosDb TraceLeiosDb
   | -- | A forged RB both certifies an EB and announce a new one
     TraceLeiosCertifiedAndAnnounced {atSlot :: SlotNo, rbHash :: RbHash}
-  | -- | An EB announcement whose slot our ledger cannot place on the wall clock,
-    -- because it is beyond the forecast horizon. Ordinary while syncing: the
-    -- announcement describes the network's tip and we are far behind it.
-    TraceLeiosAnnouncementPastHorizon {atSlot :: SlotNo}
   | -- | The node accepted a new EB announcement, deduplicated across all peers
     -- and its own block forging (see 'AnnouncementSource').
     TraceLeiosAnnouncementAccepted
@@ -1684,11 +1680,6 @@ traceLeiosKernelToObject = \case
       [ "kind" .= Aeson.String "LeiosCertifiedAndAnnounced"
       , "slotNo" .= slotNo
       , "rbHash" .= prettyRbHash rbHash
-      ]
-  TraceLeiosAnnouncementPastHorizon{atSlot} ->
-    mconcat
-      [ "kind" .= Aeson.String "LeiosAnnouncementPastHorizon"
-      , "slotNo" .= atSlot
       ]
   TraceLeiosAnnouncementAccepted announcementSource equivocation acc mbAge ->
     mconcat $


### PR DESCRIPTION
This PR is a replacement for PR https://github.com/IntersectMBO/ouroboros-consensus/pull/2252

PR 2252 fixes the original undesirable disconnects by ignoring incoming messages that our ledger state is too old to validate. But that means it allows the peer to send invalid messages, which means _unbounded_, etc. Fine for unblocking the testnet, but unacceptable for a mainnet node.

This PR reverts PR 2252 and then adds a simpler fix: don't send LeiosNotify requests while our immutable tip is too old for us to validate the replies. Key fact: (honest) LeiosNotify replies are _young_. So if our imm tip is too old to know what the _current_ slot is _and_ to forecast to that slot, then it'll be too old to just the LeiosNotify replies.

So: don't send LeiosNotify requests while we're unable to know the current slot and forecast to it from our imm tip.