### PR TITLE
Leios prototype: trace the per-point vote tally

### DIFF
--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToNode.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToNode.hs
@@ -575,15 +575,31 @@ mkHandlers
                     traceWith tracer $ MkTraceLeiosPeer $ "MsgLeiosVotes " <> show vs
                     forM_ vs $ \vote -> do
                       result <- addVote vote
-                      -- TODO: Keep track of the running tally (even after certification)
                       traceWith kernelTracer TraceLeiosVoteAcquired{vote}
                       -- A remote vote can be the one that tips this
                       -- node's tally past 'minCertificationThreshold';
                       -- trace certification whenever 'addVote' surfaces
                       -- a cert for the point.
+                      --
+                      -- The tally is traced only on 'Added', so one line per
+                      -- distinct vote rather than per arrival: the same vote
+                      -- reaches us from every peer that has it, and those
+                      -- duplicates return 'AlreadyKnown' with no tally to
+                      -- report.
                       case result of
-                        Added _ (Just _) ->
-                          traceWith kernelTracer TraceLeiosCertified{rbHash = Leios.announcingRbHash vote}
+                        Added weight tally mCert -> do
+                          traceWith kernelTracer $
+                            TraceLeiosTally
+                              { rbHash = Leios.announcingRbHash vote
+                              , seatId = Leios.voterId vote
+                              , weight
+                              , tally
+                              , threshold = Leios.minCertificationThreshold
+                              }
+                          case mCert of
+                            Just _ ->
+                              traceWith kernelTracer TraceLeiosCertified{rbHash = Leios.announcingRbHash vote}
+                            Nothing -> pure ()
                         _ -> pure ()
               )
       , hLeiosNotifyServer = \_version peer -> do

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoTypes.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoTypes.hs
@@ -1373,15 +1373,16 @@ data TraceLeiosKernel
     TraceLeiosBlockCertified {atSlot :: SlotNo, certifiedPoint :: LeiosPoint}
   | TraceLeiosVoted {vote :: LeiosVote, weight :: Weight}
   | TraceLeiosVoteAcquired {vote :: LeiosVote}
-  | -- | The running per-point tally moved, i.e. a vote was newly added rather
-    -- than being a duplicate arrival. Emitted once per distinct vote, so the
-    -- max per 'RbHash' is that point's final accumulated weight, whether or not
-    -- it ever reached 'minCertificationThreshold'. That margin is otherwise
-    -- unobservable: only certified points reach the chain, so a point that
-    -- stalls below the threshold leaves no other trace of how close it came.
-    -- The adding voter and its own weight ride along so the line stands alone.
-    -- A consumer can then attribute the tally, and say what a seat that never
-    -- voted would have been worth, without a second source for seat weights.
+  | -- | A vote was accepted for this point rather than rejected as a duplicate
+    -- arrival, carrying the running tally after the update. Emitted once per
+    -- accepted vote, so the max per 'RbHash' is that point's final accumulated
+    -- weight, whether or not it ever reached 'minCertificationThreshold'. That
+    -- margin is otherwise unobservable: only certified points reach the chain,
+    -- so a point that stalls below the threshold leaves no other trace of how
+    -- close it came. Note the tally does not necessarily move: a seat that
+    -- votes twice with distinct signatures replaces its own entry at the same
+    -- weight, so 'weight' identifies the accepted vote and is not summable
+    -- across lines. Read 'tally' for the total.
     -- 'seatId' rather than 'voterId': 'LeiosVote' already has a 'voterId'
     -- field, and a second one in this module makes the qualified selector
     -- ambiguous for importers.

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoTypes.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoTypes.hs
@@ -1373,6 +1373,25 @@ data TraceLeiosKernel
     TraceLeiosBlockCertified {atSlot :: SlotNo, certifiedPoint :: LeiosPoint}
   | TraceLeiosVoted {vote :: LeiosVote, weight :: Weight}
   | TraceLeiosVoteAcquired {vote :: LeiosVote}
+  | -- | The running per-point tally moved, i.e. a vote was newly added rather
+    -- than being a duplicate arrival. Emitted once per distinct vote, so the
+    -- max per 'RbHash' is that point's final accumulated weight, whether or not
+    -- it ever reached 'minCertificationThreshold'. That margin is otherwise
+    -- unobservable: only certified points reach the chain, so a point that
+    -- stalls below the threshold leaves no other trace of how close it came.
+    -- The adding voter and its own weight ride along so the line stands alone.
+    -- A consumer can then attribute the tally, and say what a seat that never
+    -- voted would have been worth, without a second source for seat weights.
+    -- 'seatId' rather than 'voterId': 'LeiosVote' already has a 'voterId'
+    -- field, and a second one in this module makes the qualified selector
+    -- ambiguous for importers.
+    TraceLeiosTally
+      { rbHash :: RbHash
+      , seatId :: LeiosSeatId
+      , weight :: Weight
+      , tally :: Weight
+      , threshold :: Weight
+      }
   | TraceLeiosCertified {rbHash :: RbHash}
   | -- | A vote is scheduled to happen.
     TraceLeiosVoteScheduled
@@ -1643,6 +1662,19 @@ traceLeiosKernelToObject = \case
     mconcat
       [ "kind" .= Aeson.String "LeiosVoteAcquired"
       , "vote" .= voteToObject vote
+      ]
+  TraceLeiosTally{rbHash = announcingRbHash, seatId, weight, tally, threshold} ->
+    mconcat
+      [ "kind" .= Aeson.String "LeiosTally"
+      , "rbHash" .= prettyRbHash announcingRbHash
+      , -- Rendered as voterId to match 'voteToObject', so consumers index one
+        -- name across the vote traces.
+        "voterId" .= seatId.leiosSeatIndex
+      , -- Same precision rationale as 'LeiosVoted' above.
+        "weight" .= fromRational @Pico weight
+      , "tally" .= fromRational @Pico tally
+      , -- Carried so the ratio is self-contained and survives a threshold change.
+        "threshold" .= fromRational @Pico threshold
       ]
   TraceLeiosCertified{rbHash = announcingRbHash} ->
     mconcat

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosVoteState.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosVoteState.hs
@@ -55,10 +55,15 @@ data AddVoteResult
     -- The LeiosCert is 'Just' whenever that tally is at or above
     -- 'minCertificationThreshold'.
     --
+    -- Both fields are 'Weight', so transposing them at a construction or
+    -- destructuring site type checks and yields plausible but wrong telemetry.
+    -- Keep the order above when touching either this constructor or its three
+    -- use sites.
+    --
     -- The tally is surfaced rather than traced where it is computed because
-    -- 'addVote' runs inside 'atomically' and STM cannot trace. Callers emit it,
-    -- as they already do for certification.
-    Added Weight Weight (Maybe LeiosCert)
+    -- the update runs in STM, which cannot trace. Callers emit it, as they
+    -- already do for certification.
+    Added !Weight !Weight (Maybe LeiosCert)
   deriving (Eq, Show)
 
 data LeiosVoteSubscription m = LeiosVoteSubscription {getNextVote :: STM m LeiosVote}
@@ -68,6 +73,11 @@ data LeiosVoteSubscription m = LeiosVoteSubscription {getNextVote :: STM m Leios
 -- threshold is crossed.
 data PointState = PointState
   { psVoters :: !(Map LeiosSeatId (Weight, LeiosSignature))
+  , psTotal :: !Weight
+  -- ^ Running sum of 'psVoters' weights, maintained incrementally. Kept in the
+  -- state rather than recomputed per vote: summing the map is linear in the
+  -- committee, so recomputing made the per-point cost quadratic, and every
+  -- post-threshold vote paid it too once the tally started being reported.
   , psCert :: !(Maybe LeiosCert)
   -- ^ Assembled once when this point's total weight first reaches
   -- 'minCertificationThreshold'; reused for subsequent post-threshold
@@ -75,7 +85,7 @@ data PointState = PointState
   }
 
 emptyPointState :: PointState
-emptyPointState = PointState Map.empty Nothing
+emptyPointState = PointState Map.empty 0 Nothing
 
 -- | Create a new empty 'LeiosVoteState'.
 newLeiosVoteState ::
@@ -123,12 +133,17 @@ newLeiosVoteState getCommittee = do
                           -- threshold is crossed.
                           states <- readTVar pointStates
                           let pst = Map.findWithDefault emptyPointState vote.announcingRbHash states
-                              pst' =
-                                pst
-                                  { psVoters =
-                                      Map.insert vote.voterId (weight, vote.voteSignature) pst.psVoters
-                                  }
-                              totalW = sum [w | (w, _) <- Map.elems pst'.psVoters]
+                              -- 'Map.insert' replaces any entry this seat already
+                              -- had, so the running total must drop the old weight
+                              -- rather than simply adding the new one.
+                              (mOld, voters') =
+                                Map.insertLookupWithKey
+                                  (\_ new _old -> new)
+                                  vote.voterId
+                                  (weight, vote.voteSignature)
+                                  pst.psVoters
+                              totalW = pst.psTotal + weight - maybe 0 fst mOld
+                              pst' = pst{psVoters = voters', psTotal = totalW}
                               pst'' = case pst.psCert of
                                 Just _ -> pst'
                                 Nothing

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosVoteState.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosVoteState.hs
@@ -50,10 +50,15 @@ data AddVoteResult
   = NoCommittee
   | VoteInvalid VoteInvalid
   | AlreadyKnown
-  | -- | The vote was added to the state, with the running per-point weight
-    -- after this addition. The LeiosCert is 'Just' whenever the tally for the
-    -- vote's point is at or above 'minCertificationThreshold'.
-    Added Weight (Maybe LeiosCert)
+  | -- | The vote was added to the state. The first 'Weight' is this voter's own
+    -- weight; the second is the running per-point tally after this addition.
+    -- The LeiosCert is 'Just' whenever that tally is at or above
+    -- 'minCertificationThreshold'.
+    --
+    -- The tally is surfaced rather than traced where it is computed because
+    -- 'addVote' runs inside 'atomically' and STM cannot trace. Callers emit it,
+    -- as they already do for certification.
+    Added Weight Weight (Maybe LeiosCert)
   deriving (Eq, Show)
 
 data LeiosVoteSubscription m = LeiosVoteSubscription {getNextVote :: STM m LeiosVote}
@@ -141,7 +146,7 @@ newLeiosVoteState getCommittee = do
                                         Right cert -> pst'{psCert = Just cert}
                                   | otherwise -> pst'
                           writeTVar pointStates $! Map.insert vote.announcingRbHash pst'' states
-                          pure $ Added weight pst''.psCert
+                          pure $ Added weight totalW pst''.psCert
       , subscribeVotes = do
           chan <- atomically $ dupTChan votesChan
           pure $

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosVoting.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosVoting.hs
@@ -49,6 +49,7 @@ import LeiosDemoTypes
   , SerializedEbBody
   , TraceLeiosKernel (..)
   , getLeiosSeatId
+  , minCertificationThreshold
   , prettyLeiosPoint
   , signLeiosVote
   )
@@ -355,9 +356,17 @@ runLeiosVoting tracer lcfg chainDB systemTime leiosDB txCache voteState = \case
           ExceptT $
             addVote vote
               >>= \case
-                Added weight mCert -> fmap Right $ do
+                Added weight tally mCert -> fmap Right $ do
                   traceWith tracer TraceLeiosVoted{vote, weight}
                   traceWith tracer TraceLeiosVoteAcquired{vote}
+                  traceWith tracer $
+                    TraceLeiosTally
+                      { rbHash
+                      , seatId
+                      , weight
+                      , tally
+                      , threshold = minCertificationThreshold
+                      }
                   -- Trace certification whenever the tally crosses
                   -- 'minCertificationThreshold'. May fire more than once per
                   -- point if subsequent votes also come in; consumers (e.g.

--- a/ouroboros-consensus/test/consensus-test/Test/LeiosVoteState.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/LeiosVoteState.hs
@@ -14,12 +14,16 @@ import Control.Concurrent.Class.MonadSTM.Strict
 import Control.Monad (forM_)
 import Control.Monad.Class.MonadTimer.SI (timeout)
 import Control.Monad.IOSim (runSimOrThrow)
+import Data.Function (on)
+import Data.List (nubBy)
 import Data.Maybe (fromJust, isNothing)
 import LeiosDemoTypes
   ( LeiosSeatId (..)
   , LeiosSigningKey
   , LeiosVote (..)
+  , RbHash
   , VoteInvalid (..)
+  , Weight
   , getLeiosSeatId
   , leiosCommitteeSize
   , signLeiosVote
@@ -41,6 +45,7 @@ import Test.QuickCheck
   , forAll
   , listOf1
   , property
+  , sublistOf
   , suchThat
   , (.&&.)
   , (===)
@@ -60,6 +65,7 @@ tests =
     , testProperty "invalid vote is rejected and not published" prop_invalidVoteRejected
     , testProperty "no committee rejects vote" prop_noCommitteeRejected
     , testProperty "vote signed with key not on committee is rejected" prop_signerNotInCommittee
+    , testProperty "reported tally accumulates the reported weights" prop_tallyAccumulates
     ]
 
 -- | A 'VotingKey' that is *not* a member of the given committee.
@@ -198,3 +204,45 @@ prop_signerNotInCommittee =
 isAdded :: AddVoteResult -> Property
 isAdded Added{} = property True
 isAdded r = counterexample ("expected Added, got " ++ show r) False
+
+-- | Votes for one point, one per distinct committee seat.
+--
+-- Deduplicated on seat rather than on key: two keys mapping to the same seat
+-- would have the second replace the first in the tally rather than add to it,
+-- which is a different property from the one below.
+genOneVotePerSeat :: TestCommittee -> RbHash -> Gen [LeiosVote]
+genOneVotePerSeat c rbHash = do
+  keys <- sublistOf c.allKeys `suchThat` (not . null)
+  pure [signLeiosVote key (seatOf key) rbHash | key <- nubBy ((==) `on` seatOf) keys]
+ where
+  seatOf key = fromJust $ getLeiosSeatId (deriveVerKeyDSIGN key) c.committee
+
+-- | The tally reported with each accepted vote must be the running sum of the
+-- individual weights reported so far.
+--
+-- This pins the incrementally maintained 'psTotal' against the sum over the
+-- voter map that it replaced. Nothing else in this suite asserts anything about
+-- the tally value, so without this a wrong total is invisible to the tests and
+-- shows up only as wrong telemetry.
+prop_tallyAccumulates :: Property
+prop_tallyAccumulates =
+  forAll genCommittee $ \testCommittee ->
+    forAll genRbHash $ \rbHash ->
+      forAll (genOneVotePerSeat testCommittee rbHash) $ \votes ->
+        property $ runSimOrThrow $ do
+          st <- newLeiosVoteState (pure (Just testCommittee.committee))
+          results <- mapM (addVote st) votes
+          pure $ case traverse addedWeights results of
+            Nothing ->
+              counterexample ("expected every add to be Added, got " ++ show results) False
+            Just weighted ->
+              let (ownWeights, tallies) = unzip weighted
+               in counterexample
+                    ("own weights " ++ show ownWeights ++ ", tallies " ++ show tallies)
+                    (tallies === scanl1 (+) ownWeights)
+
+-- | The own weight and running tally carried by 'Added', or 'Nothing' for any
+-- other result.
+addedWeights :: AddVoteResult -> Maybe (Weight, Weight)
+addedWeights (Added ownWeight tally _) = Just (ownWeight, tally)
+addedWeights _ = Nothing


### PR DESCRIPTION
# Description

The Leios certification margin is currently unobservable. `totalW` is computed in
`LeiosVoteState` and compared against `minCertificationThreshold` but never traced,
and only certified points reach the chain, so a point that stalls below the threshold
leaves no record of how close it came. A diffusion near miss is indistinguishable from
a structural shortfall.

This adds `TraceLeiosTally {rbHash, seatId, weight, tally, threshold}`. The tally is
surfaced through `AddVoteResult`'s `Added` and emitted by the callers in `LeiosVoting`
and `NodeToNode`, as they already do for certification, because the update itself runs
in STM. In `NodeToNode` it replaces the `TODO` about keeping track of the running
tally.

It fires only on `Added`, so once per distinct vote rather than once per arrival:
duplicates short-circuit as `AlreadyKnown` before the map update, with no tally to
report. On one relay that is roughly a 25x reduction in lines, the ratio being the
peer count delivering the same vote. Each line carries the adding seat and its own
weight next to the tally, so a consumer can attribute the tally without a second
source for seat weights.

`PointState` gains `psTotal :: !Weight`, maintained incrementally. Reporting the tally
would otherwise force `totalW` on every accepted vote, including post-certification
votes where it had been dead code, and summing the voter map is linear in the
committee. This also removes the pre-existing quadratic.

## Testing

`prop_tallyAccumulates` in `Test/LeiosVoteState.hs` pins the reported tally against
the running sum of the reported weights. It is the equivalence test between the
incremental `psTotal` and the sum over the voter map it replaces.