### PR TITLE
Decode ShelleyGenesis from 15 fields only

### DIFF
--- a/changelog.d/20260828_183500_damian.nadales_getgenesisconfig_no_extra_config.md
+++ b/changelog.d/20260828_183500_damian.nadales_getgenesisconfig_no_extra_config.md
@@ -7,14 +7,14 @@ For top level release notes, leave all the headers commented out.
 
 ### Non-Breaking
 
-- Added `encodeShelleyGenesisNoExtraConfig` and `decodeShelleyGenesisWithOptionalExtraConfig`
+- Added `encodeShelleyGenesisNoExtraConfig` and `decodeShelleyGenesisNoExtraConfig`
   to `Ouroboros.Consensus.Shelley.Ledger.Query.LegacyShelleyGenesis`. They encode
-  `ShelleyGenesis` with 15 fields, and decode it from 15 or 16 fields.
+  and decode `ShelleyGenesis` with 15 fields.
 
 ### Patch
 
 - Fixed the `GetGenesisConfig` node-to-client query. `cardano-ledger-shelley`
   1.19.0.0 added the `sgExtraConfig` field to `ShelleyGenesis` and grew the CBOR
   record from 15 fields to 16, under a fixed node-to-client version. The node now
-  encodes 15 fields again, and the decoder accepts 15 or 16. `compactGenesis`
+  encodes and decodes 15 fields again. `compactGenesis`
   erases `sgExtraConfig`, so the reply carries no less data than before.

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Query.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Query.hs
@@ -1115,9 +1115,11 @@ genesisConfigEnDecoding ::
   ShelleyNodeToClientVersion ->
   (CompactGenesis -> Encoding, Decoder s CompactGenesis)
 genesisConfigEnDecoding v
+  | v > ShelleyNodeToClientVersion15 =
+      (toCBOR, fromCBOR)
   | v >= ShelleyNodeToClientVersion13 =
       ( encodeShelleyGenesisNoExtraConfig . getCompactGenesis
-      , compactGenesis <$> decodeShelleyGenesisWithOptionalExtraConfig
+      , compactGenesis <$> decodeShelleyGenesisNoExtraConfig
       )
   | otherwise =
       (encodeLegacyShelleyGenesis . getCompactGenesis, compactGenesis <$> decodeLegacyShelleyGenesis)

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Query/LegacyShelleyGenesis.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Query/LegacyShelleyGenesis.hs
@@ -6,7 +6,7 @@ module Ouroboros.Consensus.Shelley.Ledger.Query.LegacyShelleyGenesis
   , encodeLegacyShelleyGenesis
   , decodeLegacyShelleyGenesis
   , encodeShelleyGenesisNoExtraConfig
-  , decodeShelleyGenesisWithOptionalExtraConfig
+  , decodeShelleyGenesisNoExtraConfig
   ) where
 
 import Cardano.Ledger.BaseTypes
@@ -126,54 +126,45 @@ encodeShelleyGenesisNoExtraConfig
         <> encCBOR sgInitialFunds
         <> encCBOR sgStaking
 
--- | Decode 'ShelleyGenesis' from 15 or 16 fields.
---
--- cardano-ledger-shelley 1.19.0.0 and later encode 16 fields.
--- cardano-ledger-shelley 1.18 encodes 15.
--- We accept both.
-decodeShelleyGenesisWithOptionalExtraConfig :: Plain.Decoder s ShelleyGenesis
-decodeShelleyGenesisWithOptionalExtraConfig = toPlainDecoder Nothing shelleyProtVer $ do
-  len <- decodeListLen
-  case len of
-    15 -> pure ()
-    16 -> pure ()
-    _ ->
-      cborError $
-        DecoderErrorCustom "ShelleyGenesis" (Text.pack $ "unexpected record length " <> show len)
-  sgSystemStart <- decCBOR
-  sgNetworkMagic <- decCBOR
-  sgNetworkId <- decCBOR
-  sgActiveSlotsCoeff <- activeSlotsCoeffDecCBOR
-  sgSecurityParam <- decCBOR
-  sgEpochLength <- decCBOR
-  sgSlotsPerKESPeriod <- decCBOR
-  sgMaxKESEvolutions <- decCBOR
-  sgSlotLength <- decCBOR
-  sgUpdateQuorum <- decCBOR
-  sgMaxLovelaceSupply <- decCBOR
-  sgProtocolParams <- decCBOR
-  sgGenDelegs <- decCBOR
-  sgInitialFunds <- decCBOR
-  sgStaking <- decCBOR
-  sgExtraConfig <- if len == 16 then decCBOR else pure SNothing
-  pure $
-    ShelleyGenesis
-      sgSystemStart
-      sgNetworkMagic
-      sgNetworkId
-      sgActiveSlotsCoeff
-      sgSecurityParam
-      (EpochSize sgEpochLength)
-      sgSlotsPerKESPeriod
-      sgMaxKESEvolutions
-      sgSlotLength
-      sgUpdateQuorum
-      sgMaxLovelaceSupply
-      sgProtocolParams
-      sgGenDelegs
-      sgInitialFunds
-      sgStaking
-      sgExtraConfig
+-- | Decode 'ShelleyGenesis' from the 15 fields written by
+-- 'encodeShelleyGenesisNoExtraConfig'.
+decodeShelleyGenesisNoExtraConfig :: Plain.Decoder s ShelleyGenesis
+decodeShelleyGenesisNoExtraConfig = toPlainDecoder Nothing shelleyProtVer $
+  decodeRecordNamed "ShelleyGenesis" (const 15) $ do
+    sgSystemStart <- decCBOR
+    sgNetworkMagic <- decCBOR
+    sgNetworkId <- decCBOR
+    sgActiveSlotsCoeff <- activeSlotsCoeffDecCBOR
+    sgSecurityParam <- decCBOR
+    sgEpochLength <- decCBOR
+    sgSlotsPerKESPeriod <- decCBOR
+    sgMaxKESEvolutions <- decCBOR
+    sgSlotLength <- decCBOR
+    sgUpdateQuorum <- decCBOR
+    sgMaxLovelaceSupply <- decCBOR
+    sgProtocolParams <- decCBOR
+    sgGenDelegs <- decCBOR
+    sgInitialFunds <- decCBOR
+    sgStaking <- decCBOR
+    let sgExtraConfig = SNothing
+    pure $
+      ShelleyGenesis
+        sgSystemStart
+        sgNetworkMagic
+        sgNetworkId
+        sgActiveSlotsCoeff
+        sgSecurityParam
+        (EpochSize sgEpochLength)
+        sgSlotsPerKESPeriod
+        sgMaxKESEvolutions
+        sgSlotLength
+        sgUpdateQuorum
+        sgMaxLovelaceSupply
+        sgProtocolParams
+        sgGenDelegs
+        sgInitialFunds
+        sgStaking
+        sgExtraConfig
 
 activeSlotsCoeffEncCBOR :: PositiveUnitInterval -> Encoding
 activeSlotsCoeffEncCBOR = enforceEncodingVersion shelleyProtVer . encCBOR . unboundRational


### PR DESCRIPTION
Follow-up to #2251, addressing @lehins' review.

- Use the ledger codec for node-to-client versions above `ShelleyNodeToClientVersion15`.
- Decode exactly 15 fields with `decodeRecordNamed`, restoring support for indefinite length encoding.
- Set `sgExtraConfig` to `SNothing` instead of reading an optional 16th field, which changed an existing query with no version bump.
- Rename `decodeShelleyGenesisWithOptionalExtraConfig` to `decodeShelleyGenesisNoExtraConfig` and update the pending changelog fragment.

This also needs backporting to `ouroboros-consensus-4.x-backports`, where 4.2.1.0 shipped the previous behaviour.
