### PR TITLE
db-truncater: support Leios chains

### DIFF
--- a/ouroboros-consensus-cardano/README.md
+++ b/ouroboros-consensus-cardano/README.md
@@ -439,6 +439,8 @@ It then does three things to the Leios database:
 3. Vacuum the file, which returns the freed pages to the filesystem.
 
 Step 3 rewrites the file, so it needs free space of about the size of the file.
+SQLite puts that copy in the system temp directory, not beside the database.
+Set `SQLITE_TMPDIR` if that filesystem is small.
 
 Pass `--stubbed-leios-db` for a chain that holds no certifying block, such as a chain that predates Leios.
 Without the flag the tool needs `DB_PATH/leios.db` and refuses to start when that file is absent.

--- a/ouroboros-consensus-cardano/README.md
+++ b/ouroboros-consensus-cardano/README.md
@@ -78,10 +78,10 @@ The user can use snapshots created by the node or they can create their own snap
 
 The user can limit the maximum number of blocks that db-analyser will process.
 
-#### --stubbed-leios-db
+#### --no-leios-db
 
 ```
-[--stubbed-leios-db]
+[--no-leios-db]
 ```
 
 Run with an empty in-memory Leios database, rather than the `leios.db` file under the `--db` path.
@@ -206,7 +206,7 @@ Lastly the user can provide the analysis that should be run on the chain:
   Therefore, it is recommended to start with NUM=1, and only use NUM=2 when you
   want to test the performance impact of a more filled mempool.
 
-  On a Leios chain, this pass reads the Leios database, so do not pass `--stubbed-leios-db`.
+  On a Leios chain, this pass reads the Leios database, so do not pass `--no-leios-db`.
   A block that certifies an EB has an empty body.
   The txs that it causes the ledger to apply are in the EB that it certifies, and the Leios database holds them.
   This pass adds them to the mempool, and it reports their count and their total size in the `ebNumTxs` and `ebTxsByteSize` columns.
@@ -442,7 +442,7 @@ Step 3 rewrites the file, so it needs free space of about the size of the file.
 SQLite puts that copy in the system temp directory, not beside the database.
 Set `SQLITE_TMPDIR` if that filesystem is small.
 
-Pass `--stubbed-leios-db` for a chain that holds no certifying block, such as a chain that predates Leios.
+Pass `--no-leios-db` for a chain that holds no certifying block, such as a chain that predates Leios.
 Without the flag the tool needs `DB_PATH/leios.db` and refuses to start when that file is absent.
 See the db-analyser section on that flag for why the tool cannot make the call itself.
 

--- a/ouroboros-consensus-cardano/README.md
+++ b/ouroboros-consensus-cardano/README.md
@@ -404,6 +404,46 @@ The tool expects the given ChainDB path (`--db` option) to *not* be present. Sho
 
 A limit must be specified up to which the tool synthesizes a ChainDB. Possible limits are either the number of slots processed (`-s`), the number of epochs processed (`-e`) or the absolute number of blocks in the resulting ChainDB (`-b`).
 
+## db-truncater
+
+Cut a chain back to a given slot or block number.
+The tool edits the ImmutableDB in place, so the truncation is destructive and irreversible.
+
+Basic usage:
+```sh
+cabal run db-truncater -- \
+  --db /path/to/chaindb \
+  --truncate-after-slot 42 \
+  --config /path/to/config.json
+```
+
+Pass either `--truncate-after-slot SLOT_NUMBER` or `--truncate-after-block BLOCK_NUMBER`.
+The tool finds the last block at or below that point and makes it the new tip.
+If the ImmutableDB tip already sits at or below that point, the tool changes nothing.
+
+The tool does not touch the VolatileDB or the ledger snapshots.
+Both still describe the longer chain after a truncation.
+
+Additional flags:
+
+ - `--verbose`: Trace the ImmutableDB events to stderr.
+
+### The Leios database
+
+On a Leios chain the tool also cuts `DB_PATH/leios.db` back to the new tip.
+It truncates the ImmutableDB first, because the other order can leave a certifying block whose endorser block (EB) is gone.
+It then does three things to the Leios database:
+
+1. Delete the EBs announced after the new tip slot, with their bodies.
+2. Delete the transactions that no EB references any more.
+3. Vacuum the file, which returns the freed pages to the filesystem.
+
+Step 3 rewrites the file, so it needs free space of about the size of the file.
+
+Pass `--stubbed-leios-db` for a chain that holds no certifying block, such as a chain that predates Leios.
+Without the flag the tool needs `DB_PATH/leios.db` and refuses to start when that file is absent.
+See the db-analyser section on that flag for why the tool cannot make the call itself.
+
 ## ImmDB Server
 
 A standalone tool that serves a Cardano ImmutableDB via ChainSync and BlockFetch.

--- a/ouroboros-consensus-cardano/README.md
+++ b/ouroboros-consensus-cardano/README.md
@@ -78,20 +78,24 @@ The user can use snapshots created by the node or they can create their own snap
 
 The user can limit the maximum number of blocks that db-analyser will process.
 
-#### --no-leios-db
+#### --leios-db and --no-leios-db
 
 ```
-[--no-leios-db]
+[--leios-db PATH | --no-leios-db]
 ```
-
-Run with an empty in-memory Leios database, rather than the `leios.db` file under the `--db` path.
 
 A Praos block (a Leios ranking block) that carries a certificate has an empty body on the wire.
 Its transactions are in the endorser block (EB) that it certifies, and those live in the Leios database, not in the ImmutableDB.
-So the tool reads `DB_PATH/leios.db`, which is where the node writes that database, and it refuses to start when that file is absent.
-If your node writes the file elsewhere, symlink it into `DB_PATH`.
+So the tool reads that database, and it refuses to start when it finds no such file.
 
-Pass this flag for a chain that holds no certifying block, such as a chain that predates Leios.
+Without `--leios-db` the tool reads `DB_PATH/leios.db`.
+That is where a node with the default `LeiosDbConfig` writes it, as long as the node keeps all its databases under one path.
+A node that splits the immutable path from the volatile one writes the file under the volatile path.
+A node can also name another file in its configuration.
+Pass `--leios-db` in both cases.
+
+`--no-leios-db` runs with an empty in-memory Leios database and reads no file.
+Pass it for a chain that holds no certifying block, such as a chain that predates Leios.
 The tool cannot tell such a chain from a Leios one before it reads the chain, so it cannot make that call itself.
 If you pass the flag on a chain that does hold a certifying block, the analysis stops at that block.
 
@@ -242,6 +246,7 @@ export NODE_DIR="/path/to/cardano-node-data/db-leios"
 That directory holds `config.json`, the genesis files, and `db/`.
 `db/` is the chain database. It holds `immutable/`, `volatile/`, `ledger/`, and,
 on a Leios chain, `leios.db`.
+The node configuration decides the name and the directory of that last file, so pass `--leios-db` when it is not there.
 
 #### Checking the Leios analyses
 
@@ -430,7 +435,7 @@ Additional flags:
 
 ### The Leios database
 
-On a Leios chain the tool also cuts `DB_PATH/leios.db` back to the new tip.
+On a Leios chain the tool also cuts the Leios database back to the new tip.
 It truncates the ImmutableDB first, because the other order can leave a certifying block whose endorser block (EB) is gone.
 It then does three things to the Leios database:
 
@@ -442,9 +447,9 @@ Step 3 rewrites the file, so it needs free space of about the size of the file.
 SQLite puts that copy in the system temp directory, not beside the database.
 Set `SQLITE_TMPDIR` if that filesystem is small.
 
+Without `--leios-db` the tool reads `DB_PATH/leios.db`, and it refuses to start when that file is absent.
 Pass `--no-leios-db` for a chain that holds no certifying block, such as a chain that predates Leios.
-Without the flag the tool needs `DB_PATH/leios.db` and refuses to start when that file is absent.
-See the db-analyser section on that flag for why the tool cannot make the call itself.
+See the db-analyser section on those two flags for the paths a node writes and for why the tool cannot make the call itself.
 
 ## ImmDB Server
 

--- a/ouroboros-consensus-cardano/app/DBAnalyser/Parsers.hs
+++ b/ouroboros-consensus-cardano/app/DBAnalyser/Parsers.hs
@@ -11,6 +11,7 @@ module DBAnalyser.Parsers
 import Cardano.Tools.DBAnalyser.Analysis
 import Cardano.Tools.DBAnalyser.Block.Cardano
 import Cardano.Tools.DBAnalyser.Types
+import Cardano.Tools.LeiosDb (LeiosDbSource (..))
 import qualified Data.Foldable as Foldable
 import Options.Applicative
 import Ouroboros.Consensus.Block (SlotNo (..), WithOrigin (..))
@@ -63,9 +64,9 @@ parseDBAnalyserConfig =
     <*> parseNoLeiosDb
 
 -- | Run with an empty in-memory LeiosDb, rather than the node's @leios.db@.
-parseNoLeiosDb :: Parser Bool
+parseNoLeiosDb :: Parser LeiosDbSource
 parseNoLeiosDb =
-  switch $
+  flag NodeLeiosDb NoLeiosDb $
     mconcat
       [ long "no-leios-db"
       , help $

--- a/ouroboros-consensus-cardano/app/DBAnalyser/Parsers.hs
+++ b/ouroboros-consensus-cardano/app/DBAnalyser/Parsers.hs
@@ -4,7 +4,7 @@
 module DBAnalyser.Parsers
   ( parseCmdLine
   , parseCardanoArgs
-  , parseStubbedLeiosDb
+  , parseNoLeiosDb
   , CardanoBlockArgs
   ) where
 
@@ -60,14 +60,14 @@ parseDBAnalyserConfig =
             , help "use v2 LSM backend"
             ]
       ]
-    <*> parseStubbedLeiosDb
+    <*> parseNoLeiosDb
 
 -- | Run with an empty in-memory LeiosDb, rather than the node's @leios.db@.
-parseStubbedLeiosDb :: Parser Bool
-parseStubbedLeiosDb =
+parseNoLeiosDb :: Parser Bool
+parseNoLeiosDb =
   switch $
     mconcat
-      [ long "stubbed-leios-db"
+      [ long "no-leios-db"
       , help $
           "Do not use the leios.db file under the --db path. Pass this for a "
             <> "chain that holds no block with a Leios certificate. Without "

--- a/ouroboros-consensus-cardano/app/DBAnalyser/Parsers.hs
+++ b/ouroboros-consensus-cardano/app/DBAnalyser/Parsers.hs
@@ -4,6 +4,7 @@
 module DBAnalyser.Parsers
   ( parseCmdLine
   , parseCardanoArgs
+  , parseStubbedLeiosDb
   , CardanoBlockArgs
   ) where
 
@@ -70,9 +71,8 @@ parseStubbedLeiosDb =
       , help $
           "Use an empty in-memory LeiosDb, rather than the leios.db file under "
             <> "the --db path. Pass this for a chain that holds no block with a "
-            <> "Leios certificate, and hence no endorser block to resolve. "
-            <> "Without this flag, the tool refuses to start when it finds no "
-            <> "such file."
+            <> "Leios certificate. Without this flag, the tool refuses to start "
+            <> "when it finds no such file."
       ]
 
 parseSelectDB :: Parser SelectDB

--- a/ouroboros-consensus-cardano/app/DBAnalyser/Parsers.hs
+++ b/ouroboros-consensus-cardano/app/DBAnalyser/Parsers.hs
@@ -69,10 +69,9 @@ parseStubbedLeiosDb =
     mconcat
       [ long "stubbed-leios-db"
       , help $
-          "Use an empty in-memory LeiosDb, rather than the leios.db file under "
-            <> "the --db path. Pass this for a chain that holds no block with a "
-            <> "Leios certificate. Without this flag, the tool refuses to start "
-            <> "when it finds no such file."
+          "Do not use the leios.db file under the --db path. Pass this for a "
+            <> "chain that holds no block with a Leios certificate. Without "
+            <> "this flag, the tool refuses to start when it finds no such file."
       ]
 
 parseSelectDB :: Parser SelectDB

--- a/ouroboros-consensus-cardano/app/DBAnalyser/Parsers.hs
+++ b/ouroboros-consensus-cardano/app/DBAnalyser/Parsers.hs
@@ -4,7 +4,7 @@
 module DBAnalyser.Parsers
   ( parseCmdLine
   , parseCardanoArgs
-  , parseNoLeiosDb
+  , parseLeiosDbSource
   , CardanoBlockArgs
   ) where
 
@@ -61,19 +61,35 @@ parseDBAnalyserConfig =
             , help "use v2 LSM backend"
             ]
       ]
-    <*> parseNoLeiosDb
+    <*> parseLeiosDbSource
 
--- | Run with an empty in-memory LeiosDb, rather than the node's @leios.db@.
-parseNoLeiosDb :: Parser LeiosDbSource
-parseNoLeiosDb =
-  flag NodeLeiosDb NoLeiosDb $
-    mconcat
-      [ long "no-leios-db"
-      , help $
-          "Do not use the leios.db file under the --db path. Pass this for a "
-            <> "chain that holds no block with a Leios certificate. Without "
-            <> "this flag, the tool refuses to start when it finds no such file."
-      ]
+-- | Where the tool finds the LeiosDb, or that it uses none.
+--
+-- The two flags exclude each other: @--no-leios-db@ leaves no path to read.
+parseLeiosDbSource :: Parser LeiosDbSource
+parseLeiosDbSource =
+  parseNoLeiosDb <|> fmap LeiosDbFile parseLeiosDbPath
+ where
+  parseNoLeiosDb =
+    flag' NoLeiosDb $
+      mconcat
+        [ long "no-leios-db"
+        , help $
+            "Do not use a LeiosDb file. Pass this for a chain that holds no "
+              <> "block with a Leios certificate. Without this flag, the tool "
+              <> "refuses to start when it finds no such file."
+        ]
+  parseLeiosDbPath =
+    optional $
+      strOption $
+        mconcat
+          [ long "leios-db"
+          , metavar "PATH"
+          , help $
+              "Path of the Leios SQLite database. Defaults to leios.db under "
+                <> "the --db path, which is where a node with the default "
+                <> "LeiosDbConfig writes it."
+          ]
 
 parseSelectDB :: Parser SelectDB
 parseSelectDB =

--- a/ouroboros-consensus-cardano/app/DBTruncater/Parsers.hs
+++ b/ouroboros-consensus-cardano/app/DBTruncater/Parsers.hs
@@ -14,7 +14,7 @@ parseDBTruncaterConfig =
     <$> parseChainDBPath
     <*> parseTruncateAfter
     <*> parseVerbose
-    <*> parseStubbedLeiosDb
+    <*> parseNoLeiosDb
  where
   parseChainDBPath =
     strOption $

--- a/ouroboros-consensus-cardano/app/DBTruncater/Parsers.hs
+++ b/ouroboros-consensus-cardano/app/DBTruncater/Parsers.hs
@@ -14,6 +14,7 @@ parseDBTruncaterConfig =
     <$> parseChainDBPath
     <*> parseTruncateAfter
     <*> parseVerbose
+    <*> parseStubbedLeiosDb
  where
   parseChainDBPath =
     strOption $

--- a/ouroboros-consensus-cardano/app/DBTruncater/Parsers.hs
+++ b/ouroboros-consensus-cardano/app/DBTruncater/Parsers.hs
@@ -14,7 +14,7 @@ parseDBTruncaterConfig =
     <$> parseChainDBPath
     <*> parseTruncateAfter
     <*> parseVerbose
-    <*> parseNoLeiosDb
+    <*> parseLeiosDbSource
  where
   parseChainDBPath =
     strOption $

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Leios.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Leios.hs
@@ -227,7 +227,7 @@ missingEbBodyError ebHash =
   "Could not resolve the EB "
     <> show ebHash
     <> ", because the LeiosDb holds no body for it. Either the analysis ran "
-    <> "with --stubbed-leios-db, which uses an empty in-memory LeiosDb, or the "
+    <> "with --no-leios-db, which uses an empty in-memory LeiosDb, or the "
     <> "chain and the node's leios.db do not match: the node that applied the "
     <> "certifying block held that EB."
 

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Run.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Run.hs
@@ -152,7 +152,7 @@ analyse dbaConfig args =
     lsmSalt <- fst . genWord64 <$> newStdGen
     ProtocolInfo{pInfoInitLedger = genesisLedger, pInfoConfig = cfg} <-
       mkProtocolInfo args
-    leiosDbHandle <- openLeiosDb stubbedLeiosDb dbDir
+    leiosDbHandle <- openLeiosDb noLeiosDb dbDir
     let shfs = Node.stdMkChainDbHasFS dbDir
         chunkInfo = Node.nodeImmutableDbChunkInfo (configStorage cfg)
         flavargs = case ldbBackend of
@@ -252,7 +252,7 @@ analyse dbaConfig args =
     , validation
     , verbose
     , ldbBackend
-    , stubbedLeiosDb
+    , noLeiosDb
     } = dbaConfig
 
   SelectImmutableDB startSlot = selectDB

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Run.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Run.hs
@@ -14,7 +14,7 @@ import Cardano.Ledger.BaseTypes
 import Cardano.Tools.DBAnalyser.Analysis
 import Cardano.Tools.DBAnalyser.HasAnalysis
 import Cardano.Tools.DBAnalyser.Types
-import Cardano.Tools.LeiosDb (openLeiosDb)
+import Cardano.Tools.LeiosDb (leiosDbPath)
 import Control.Monad.Trans.Class
 import Control.ResourceRegistry
 import Control.Tracer (Tracer (..), emit, nullTracer)
@@ -22,7 +22,7 @@ import Data.Functor.Contravariant ((>$<))
 import qualified Data.SOP.Dict as Dict
 import Data.Singletons (Sing, SingI (..))
 import qualified Debug.Trace as Debug
-import LeiosDemoDb (withLeiosDb)
+import LeiosDemoDb (newLeiosDBInMemory, newLeiosDBSQLite, withLeiosDb)
 import LeiosDemoTypes (HasLeiosVoting)
 import Ouroboros.Consensus.Block
 import Ouroboros.Consensus.Config
@@ -152,7 +152,10 @@ analyse dbaConfig args =
     lsmSalt <- fst . genWord64 <$> newStdGen
     ProtocolInfo{pInfoInitLedger = genesisLedger, pInfoConfig = cfg} <-
       mkProtocolInfo args
-    leiosDbHandle <- openLeiosDb noLeiosDb dbDir
+    leiosDbHandle <-
+      leiosDbPath leiosDbSource dbDir >>= \case
+        Nothing -> newLeiosDBInMemory
+        Just path -> newLeiosDBSQLite nullTracer path
     let shfs = Node.stdMkChainDbHasFS dbDir
         chunkInfo = Node.nodeImmutableDbChunkInfo (configStorage cfg)
         flavargs = case ldbBackend of
@@ -252,7 +255,7 @@ analyse dbaConfig args =
     , validation
     , verbose
     , ldbBackend
-    , noLeiosDb
+    , leiosDbSource
     } = dbaConfig
 
   SelectImmutableDB startSlot = selectDB

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Run.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Run.hs
@@ -14,7 +14,7 @@ import Cardano.Ledger.BaseTypes
 import Cardano.Tools.DBAnalyser.Analysis
 import Cardano.Tools.DBAnalyser.HasAnalysis
 import Cardano.Tools.DBAnalyser.Types
-import Control.Monad (unless)
+import Cardano.Tools.LeiosDb (openLeiosDb)
 import Control.Monad.Trans.Class
 import Control.ResourceRegistry
 import Control.Tracer (Tracer (..), emit, nullTracer)
@@ -22,7 +22,7 @@ import Data.Functor.Contravariant ((>$<))
 import qualified Data.SOP.Dict as Dict
 import Data.Singletons (Sing, SingI (..))
 import qualified Debug.Trace as Debug
-import LeiosDemoDb (newLeiosDBInMemory, newLeiosDBSQLite, withLeiosDb)
+import LeiosDemoDb (withLeiosDb)
 import LeiosDemoTypes (HasLeiosVoting)
 import Ouroboros.Consensus.Block
 import Ouroboros.Consensus.Config
@@ -57,10 +57,7 @@ import Ouroboros.Consensus.Util.Args
 import Ouroboros.Consensus.Util.IOLike
 import Ouroboros.Consensus.Util.Orphans ()
 import Ouroboros.Network.Block (genesisPoint)
-import qualified System.Directory as Directory
-import System.Exit (die)
 import System.FS.API
-import qualified System.FilePath as FilePath
 import System.IO
 import System.Random
 import Text.Printf (printf)
@@ -155,7 +152,7 @@ analyse dbaConfig args =
     lsmSalt <- fst . genWord64 <$> newStdGen
     ProtocolInfo{pInfoInitLedger = genesisLedger, pInfoConfig = cfg} <-
       mkProtocolInfo args
-    leiosDbHandle <- openLeiosDb
+    leiosDbHandle <- openLeiosDb stubbedLeiosDb dbDir
     let shfs = Node.stdMkChainDbHasFS dbDir
         chunkInfo = Node.nodeImmutableDbChunkInfo (configStorage cfg)
         flavargs = case ldbBackend of
@@ -259,32 +256,6 @@ analyse dbaConfig args =
     } = dbaConfig
 
   SelectImmutableDB startSlot = selectDB
-
-  -- The node writes its LeiosDb next to the other ChainDB files, so the tool
-  -- derives that path from --db rather than take one of its own. An operator
-  -- who puts the file elsewhere can symlink it into place.
-  --
-  -- A missing file is fatal, because the tool cannot tell whether the chain
-  -- holds a cert-RB before it reads the chain.
-  --
-  -- Hence this check, rather than a check inside the SQLite backend: that
-  -- backend opens with 'SQLOpenCreate' and it creates the schema when it finds
-  -- no file. So without this check the tool would write an empty leios.db into
-  -- the node's directory and fail only at the first cert-RB.
-  openLeiosDb
-    | stubbedLeiosDb = newLeiosDBInMemory
-    | otherwise = do
-        let leiosDbPath = dbDir FilePath.</> "leios.db"
-        exists <- Directory.doesFileExist leiosDbPath
-        unless exists $
-          die $
-            "No LeiosDb at "
-              <> leiosDbPath
-              <> ". A block that carries a Leios certificate has an empty body, "
-              <> "and the transactions that it puts on the chain are in the "
-              <> "endorser block that it certifies, which the LeiosDb holds. "
-              <> "Pass --stubbed-leios-db if this chain holds no such block."
-        newLeiosDBSQLite nullTracer leiosDbPath
 
   withImmutableDB immutableDbArgs =
     bracket

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Run.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Run.hs
@@ -14,7 +14,7 @@ import Cardano.Ledger.BaseTypes
 import Cardano.Tools.DBAnalyser.Analysis
 import Cardano.Tools.DBAnalyser.HasAnalysis
 import Cardano.Tools.DBAnalyser.Types
-import Cardano.Tools.LeiosDb (leiosDbPath)
+import Cardano.Tools.LeiosDb (LeiosDbSource (..), requireNodeLeiosDb)
 import Control.Monad.Trans.Class
 import Control.ResourceRegistry
 import Control.Tracer (Tracer (..), emit, nullTracer)
@@ -152,10 +152,9 @@ analyse dbaConfig args =
     lsmSalt <- fst . genWord64 <$> newStdGen
     ProtocolInfo{pInfoInitLedger = genesisLedger, pInfoConfig = cfg} <-
       mkProtocolInfo args
-    leiosDbHandle <-
-      leiosDbPath leiosDbSource dbDir >>= \case
-        Nothing -> newLeiosDBInMemory
-        Just path -> newLeiosDBSQLite nullTracer path
+    leiosDbHandle <- case leiosDbSource of
+      NoLeiosDb -> newLeiosDBInMemory
+      NodeLeiosDb -> newLeiosDBSQLite nullTracer =<< requireNodeLeiosDb dbDir
     let shfs = Node.stdMkChainDbHasFS dbDir
         chunkInfo = Node.nodeImmutableDbChunkInfo (configStorage cfg)
         flavargs = case ldbBackend of

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Run.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Run.hs
@@ -14,7 +14,7 @@ import Cardano.Ledger.BaseTypes
 import Cardano.Tools.DBAnalyser.Analysis
 import Cardano.Tools.DBAnalyser.HasAnalysis
 import Cardano.Tools.DBAnalyser.Types
-import Cardano.Tools.LeiosDb (LeiosDbSource (..), requireNodeLeiosDb)
+import Cardano.Tools.LeiosDb (LeiosDbSource (..), requireLeiosDbFile)
 import Control.Monad.Trans.Class
 import Control.ResourceRegistry
 import Control.Tracer (Tracer (..), emit, nullTracer)
@@ -154,7 +154,8 @@ analyse dbaConfig args =
       mkProtocolInfo args
     leiosDbHandle <- case leiosDbSource of
       NoLeiosDb -> newLeiosDBInMemory
-      NodeLeiosDb -> newLeiosDBSQLite nullTracer =<< requireNodeLeiosDb dbDir
+      LeiosDbFile mPath ->
+        newLeiosDBSQLite nullTracer =<< requireLeiosDbFile dbDir mPath
     let shfs = Node.stdMkChainDbHasFS dbDir
         chunkInfo = Node.nodeImmutableDbChunkInfo (configStorage cfg)
         flavargs = case ldbBackend of

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Types.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Types.hs
@@ -3,6 +3,7 @@
 
 module Cardano.Tools.DBAnalyser.Types (module Cardano.Tools.DBAnalyser.Types) where
 
+import Cardano.Tools.LeiosDb (LeiosDbSource)
 import Data.Word
 import Ouroboros.Consensus.Block
 
@@ -17,8 +18,9 @@ data DBAnalyserConfig = DBAnalyserConfig
   , analysis :: AnalysisName
   , confLimit :: Limit
   , ldbBackend :: LedgerDBBackend
-  , noLeiosDb :: Bool
-  -- ^ Use an empty in-memory LeiosDb instead of @leios.db@ under 'dbDir'.
+  , leiosDbSource :: LeiosDbSource
+  -- ^ 'NoLeiosDb' uses an empty in-memory LeiosDb instead of @leios.db@ under
+  -- 'dbDir'.
   --
   -- The tool cannot tell a pre-Leios chain from a Leios one before it reads
   -- the chain, so it cannot decide on its own whether an absent @leios.db@ is

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Types.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Types.hs
@@ -17,7 +17,7 @@ data DBAnalyserConfig = DBAnalyserConfig
   , analysis :: AnalysisName
   , confLimit :: Limit
   , ldbBackend :: LedgerDBBackend
-  , stubbedLeiosDb :: Bool
+  , noLeiosDb :: Bool
   -- ^ Use an empty in-memory LeiosDb instead of @leios.db@ under 'dbDir'.
   --
   -- The tool cannot tell a pre-Leios chain from a Leios one before it reads

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Types.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBAnalyser/Types.hs
@@ -19,13 +19,13 @@ data DBAnalyserConfig = DBAnalyserConfig
   , confLimit :: Limit
   , ldbBackend :: LedgerDBBackend
   , leiosDbSource :: LeiosDbSource
-  -- ^ 'NoLeiosDb' uses an empty in-memory LeiosDb instead of @leios.db@ under
-  -- 'dbDir'.
+  -- ^ 'NoLeiosDb' uses an empty in-memory LeiosDb instead of a LeiosDb file.
   --
   -- The tool cannot tell a pre-Leios chain from a Leios one before it reads
-  -- the chain, so it cannot decide on its own whether an absent @leios.db@ is
-  -- a problem. It therefore needs the file, and this flag is how the caller
-  -- says that the chain holds no cert-RB and that the empty stub is enough.
+  -- the chain, so it cannot decide on its own whether an absent LeiosDb file
+  -- is a problem. It therefore needs the file, and 'NoLeiosDb' is how the
+  -- caller says that the chain holds no cert-RB and that the empty stub is
+  -- enough.
   }
 
 data AnalysisName

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBTruncater/Run.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBTruncater/Run.hs
@@ -48,8 +48,8 @@ truncate ::
   DBTruncaterConfig ->
   Args block ->
   IO ()
-truncate DBTruncaterConfig{dbDir, truncateAfter, verbose, stubbedLeiosDb} args = do
-  mLeiosDbPath <- leiosDbPath stubbedLeiosDb dbDir
+truncate DBTruncaterConfig{dbDir, truncateAfter, verbose, noLeiosDb} args = do
+  mLeiosDbPath <- leiosDbPath noLeiosDb dbDir
   withRegistry $ \registry -> do
     lock <- mkLock
     immutableDBTracer <- mkTracer lock verbose

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBTruncater/Run.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBTruncater/Run.hs
@@ -10,6 +10,7 @@ module Cardano.Tools.DBTruncater.Run (truncate) where
 import Cardano.Slotting.Slot (WithOrigin (..))
 import Cardano.Tools.DBAnalyser.HasAnalysis
 import Cardano.Tools.DBTruncater.Types
+import Cardano.Tools.LeiosDb (openLeiosDb)
 import Control.Monad
 import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.Maybe (MaybeT (..))
@@ -18,6 +19,7 @@ import Control.Tracer (Tracer (..), emit)
 import Data.Foldable (asum)
 import Data.Functor ((<&>))
 import Data.Functor.Identity
+import LeiosDemoDb (withLeiosDb)
 import Ouroboros.Consensus.Block
 import Ouroboros.Consensus.Config
 import Ouroboros.Consensus.Node as Node
@@ -42,8 +44,9 @@ truncate ::
   DBTruncaterConfig ->
   Args block ->
   IO ()
-truncate DBTruncaterConfig{dbDir, truncateAfter, verbose} args = do
-  withRegistry $ \registry -> do
+truncate DBTruncaterConfig{dbDir, truncateAfter, verbose, stubbedLeiosDb} args = do
+  leiosDbHandle <- openLeiosDb stubbedLeiosDb dbDir
+  withRegistry $ \registry -> withLeiosDb leiosDbHandle $ \_leiosDb -> do
     lock <- mkLock
     immutableDBTracer <- mkTracer lock verbose
     ProtocolInfo

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBTruncater/Run.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBTruncater/Run.hs
@@ -48,8 +48,8 @@ truncate ::
   DBTruncaterConfig ->
   Args block ->
   IO ()
-truncate DBTruncaterConfig{dbDir, truncateAfter, verbose, noLeiosDb} args = do
-  mLeiosDbPath <- leiosDbPath noLeiosDb dbDir
+truncate DBTruncaterConfig{dbDir, truncateAfter, verbose, leiosDbSource} args = do
+  mLeiosDbPath <- leiosDbPath leiosDbSource dbDir
   withRegistry $ \registry -> do
     lock <- mkLock
     immutableDBTracer <- mkTracer lock verbose

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBTruncater/Run.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBTruncater/Run.hs
@@ -10,7 +10,7 @@ module Cardano.Tools.DBTruncater.Run (truncate) where
 import Cardano.Slotting.Slot (WithOrigin (..))
 import Cardano.Tools.DBAnalyser.HasAnalysis
 import Cardano.Tools.DBTruncater.Types
-import Cardano.Tools.LeiosDb (openLeiosDb)
+import Cardano.Tools.LeiosDb (leiosDbPath)
 import Control.Monad
 import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.Maybe (MaybeT (..))
@@ -19,7 +19,11 @@ import Control.Tracer (Tracer (..), emit)
 import Data.Foldable (asum)
 import Data.Functor ((<&>))
 import Data.Functor.Identity
-import LeiosDemoDb (withLeiosDb)
+import LeiosDemoDb
+  ( deleteDanglingTxs
+  , truncateLeiosDbAfterSlot
+  , vacuumLeiosDb
+  )
 import Ouroboros.Consensus.Block
 import Ouroboros.Consensus.Config
 import Ouroboros.Consensus.Node as Node
@@ -45,8 +49,8 @@ truncate ::
   Args block ->
   IO ()
 truncate DBTruncaterConfig{dbDir, truncateAfter, verbose, stubbedLeiosDb} args = do
-  leiosDbHandle <- openLeiosDb stubbedLeiosDb dbDir
-  withRegistry $ \registry -> withLeiosDb leiosDbHandle $ \_leiosDb -> do
+  mLeiosDbPath <- leiosDbPath stubbedLeiosDb dbDir
+  withRegistry $ \registry -> do
     lock <- mkLock
     immutableDBTracer <- mkTracer lock verbose
     ProtocolInfo
@@ -100,6 +104,12 @@ truncate DBTruncaterConfig{dbDir, truncateAfter, verbose, stubbedLeiosDb} args =
                   , show newTip
                   ]
               deleteAfter internal (At newTip)
+              -- Truncate the LeiosDb after the ImmutableDB. The other order
+              -- can leave a cert-RB whose EB is gone.
+              forM_ mLeiosDbPath $ \path -> do
+                truncateLeiosDbAfterSlot path (tipSlotNo newTip)
+                deleteDanglingTxs path
+                vacuumLeiosDb path
 
 -- | Given a predicate, and an iterator, find the last item for which
 -- the predicate passes.

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBTruncater/Run.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBTruncater/Run.hs
@@ -106,10 +106,28 @@ truncate DBTruncaterConfig{dbDir, truncateAfter, verbose, stubbedLeiosDb} args =
               deleteAfter internal (At newTip)
               -- Truncate the LeiosDb after the ImmutableDB. The other order
               -- can leave a cert-RB whose EB is gone.
-              forM_ mLeiosDbPath $ \path -> do
-                truncateLeiosDbAfterSlot path (tipSlotNo newTip)
-                deleteDanglingTxs path
-                vacuumLeiosDb path
+              forM_ mLeiosDbPath $ \path ->
+                (`onException` hPutStrLn stderr (leiosDbCutFailed newTip)) $ do
+                  truncateLeiosDbAfterSlot path (tipSlotNo newTip)
+                  deleteDanglingTxs path
+                  vacuumLeiosDb path
+
+leiosDbCutFailed :: Tip blk -> String
+leiosDbCutFailed newTip =
+  mconcat
+    [ "The ImmutableDB is truncated to slot "
+    , slot
+    , ". The LeiosDb cut did not complete, so leios.db still holds the EBs "
+    , "announced after that slot. Nothing on the truncated chain reads them, "
+    , "so you can leave them. To remove them, re-run with a "
+    , "--truncate-after-slot below "
+    , slot
+    , ": a re-run at "
+    , slot
+    , " reports \"Nothing to truncate\" and changes nothing."
+    ]
+ where
+  slot = show (tipSlotNo newTip)
 
 -- | Given a predicate, and an iterator, find the last item for which
 -- the predicate passes.

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBTruncater/Run.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBTruncater/Run.hs
@@ -10,7 +10,7 @@ module Cardano.Tools.DBTruncater.Run (truncate) where
 import Cardano.Slotting.Slot (WithOrigin (..))
 import Cardano.Tools.DBAnalyser.HasAnalysis
 import Cardano.Tools.DBTruncater.Types
-import Cardano.Tools.LeiosDb (LeiosDbSource (..), requireNodeLeiosDb)
+import Cardano.Tools.LeiosDb (LeiosDbSource (..), requireLeiosDbFile)
 import Control.Monad
 import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.Maybe (MaybeT (..))
@@ -53,7 +53,7 @@ truncate DBTruncaterConfig{dbDir, truncateAfter, verbose, leiosDbSource} args = 
   -- fails before the tool deletes any block.
   mLeiosDbPath <- case leiosDbSource of
     NoLeiosDb -> pure Nothing
-    NodeLeiosDb -> Just <$> requireNodeLeiosDb dbDir
+    LeiosDbFile mPath -> Just <$> requireLeiosDbFile dbDir mPath
   withRegistry $ \registry -> do
     lock <- mkLock
     immutableDBTracer <- mkTracer lock verbose
@@ -121,7 +121,7 @@ leiosDbCutFailed newTip =
   mconcat
     [ "The ImmutableDB is truncated to slot "
     , slot
-    , ". The LeiosDb cut did not complete, so leios.db still holds the EBs "
+    , ". The LeiosDb cut did not complete, so the LeiosDb still holds the EBs "
     , "announced after that slot. Nothing on the truncated chain reads them, "
     , "so you can leave them. To remove them, re-run with a "
     , "--truncate-after-slot below "

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBTruncater/Run.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBTruncater/Run.hs
@@ -10,7 +10,7 @@ module Cardano.Tools.DBTruncater.Run (truncate) where
 import Cardano.Slotting.Slot (WithOrigin (..))
 import Cardano.Tools.DBAnalyser.HasAnalysis
 import Cardano.Tools.DBTruncater.Types
-import Cardano.Tools.LeiosDb (leiosDbPath)
+import Cardano.Tools.LeiosDb (LeiosDbSource (..), requireNodeLeiosDb)
 import Control.Monad
 import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.Maybe (MaybeT (..))
@@ -49,7 +49,11 @@ truncate ::
   Args block ->
   IO ()
 truncate DBTruncaterConfig{dbDir, truncateAfter, verbose, leiosDbSource} args = do
-  mLeiosDbPath <- leiosDbPath leiosDbSource dbDir
+  -- Check the file before the ImmutableDB truncation, so a missing LeiosDb
+  -- fails before the tool deletes any block.
+  mLeiosDbPath <- case leiosDbSource of
+    NoLeiosDb -> pure Nothing
+    NodeLeiosDb -> Just <$> requireNodeLeiosDb dbDir
   withRegistry $ \registry -> do
     lock <- mkLock
     immutableDBTracer <- mkTracer lock verbose

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBTruncater/Types.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBTruncater/Types.hs
@@ -3,17 +3,19 @@ module Cardano.Tools.DBTruncater.Types
   , TruncateAfter (..)
   ) where
 
+import Cardano.Tools.LeiosDb (LeiosDbSource)
 import Ouroboros.Consensus.Block.Abstract
 
 data DBTruncaterConfig = DBTruncaterConfig
   { dbDir :: FilePath
   , truncateAfter :: TruncateAfter
   , verbose :: Bool
-  , noLeiosDb :: Bool
-  -- ^ Skip every LeiosDb operation. The tool then neither opens nor modifies
-  -- the @leios.db@ under 'dbDir', whether or not that file exists.
+  , leiosDbSource :: LeiosDbSource
+  -- ^ 'NoLeiosDb' skips every LeiosDb operation. The tool then neither opens
+  -- nor modifies the @leios.db@ under 'dbDir', whether or not that file
+  -- exists.
   --
-  -- Without this flag the tool requires that file, because it cannot tell a
+  -- With 'NodeLeiosDb' the tool requires that file, because it cannot tell a
   -- pre-Leios chain from a Leios one before it reads the chain.
   }
 

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBTruncater/Types.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBTruncater/Types.hs
@@ -9,7 +9,7 @@ data DBTruncaterConfig = DBTruncaterConfig
   { dbDir :: FilePath
   , truncateAfter :: TruncateAfter
   , verbose :: Bool
-  , stubbedLeiosDb :: Bool
+  , noLeiosDb :: Bool
   -- ^ Skip every LeiosDb operation. The tool then neither opens nor modifies
   -- the @leios.db@ under 'dbDir', whether or not that file exists.
   --

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBTruncater/Types.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBTruncater/Types.hs
@@ -9,6 +9,11 @@ data DBTruncaterConfig = DBTruncaterConfig
   { dbDir :: FilePath
   , truncateAfter :: TruncateAfter
   , verbose :: Bool
+  , stubbedLeiosDb :: Bool
+  -- ^ Use an empty in-memory LeiosDb instead of @leios.db@ under 'dbDir'.
+  --
+  -- The tool cannot tell a pre-Leios chain from a Leios one, so it needs the
+  -- file. This flag is how the caller says that the chain has none.
   }
 
 -- | Where to truncate the ImmutableDB.

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBTruncater/Types.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBTruncater/Types.hs
@@ -10,10 +10,11 @@ data DBTruncaterConfig = DBTruncaterConfig
   , truncateAfter :: TruncateAfter
   , verbose :: Bool
   , stubbedLeiosDb :: Bool
-  -- ^ Use an empty in-memory LeiosDb instead of @leios.db@ under 'dbDir'.
+  -- ^ Skip every LeiosDb operation. The tool then neither opens nor modifies
+  -- the @leios.db@ under 'dbDir', whether or not that file exists.
   --
-  -- The tool cannot tell a pre-Leios chain from a Leios one, so it needs the
-  -- file. This flag is how the caller says that the chain has none.
+  -- Without this flag the tool requires that file, because it cannot tell a
+  -- pre-Leios chain from a Leios one before it reads the chain.
   }
 
 -- | Where to truncate the ImmutableDB.

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBTruncater/Types.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBTruncater/Types.hs
@@ -12,10 +12,9 @@ data DBTruncaterConfig = DBTruncaterConfig
   , verbose :: Bool
   , leiosDbSource :: LeiosDbSource
   -- ^ 'NoLeiosDb' skips every LeiosDb operation. The tool then neither opens
-  -- nor modifies the @leios.db@ under 'dbDir', whether or not that file
-  -- exists.
+  -- nor modifies any LeiosDb file, whether or not one exists.
   --
-  -- With 'NodeLeiosDb' the tool requires that file, because it cannot tell a
+  -- With 'LeiosDbFile' the tool requires that file, because it cannot tell a
   -- pre-Leios chain from a Leios one before it reads the chain.
   }
 

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/LeiosDb.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/LeiosDb.hs
@@ -1,4 +1,4 @@
-module Cardano.Tools.LeiosDb (openLeiosDb) where
+module Cardano.Tools.LeiosDb (leiosDbPath, openLeiosDb) where
 
 import Control.Monad (unless)
 import Control.Tracer (nullTracer)
@@ -7,36 +7,45 @@ import qualified System.Directory as Directory
 import System.Exit (die)
 import qualified System.FilePath as FilePath
 
--- | Open the @leios.db@ that the node writes under its ChainDB directory.
+-- | The path of the @leios.db@ that the node writes under its ChainDB
+-- directory, or 'Nothing' when the caller asks for the stub.
 --
 -- The tool derives that path from @--db@ rather than take one of its own. An
 -- operator who puts the file elsewhere can symlink it into place.
 --
 -- A missing file is fatal, because a tool cannot tell whether the chain holds a
 -- cert-RB before it reads the chain. The caller passes 'True' to say that the
--- chain holds no cert-RB, and that an empty in-memory LeiosDb is enough.
+-- chain holds no cert-RB.
 --
 -- Hence this check, rather than a check inside the SQLite backend: that backend
 -- opens with 'SQLOpenCreate' and it creates the schema when it finds no file.
 -- So without this check the tool would write an empty leios.db into the node's
 -- directory and fail only at the first cert-RB.
-openLeiosDb ::
-  -- | Use an empty in-memory LeiosDb.
+leiosDbPath ::
+  -- | Use no LeiosDb file.
   Bool ->
   -- | The ChainDB directory.
   FilePath ->
-  IO (LeiosDbHandle IO)
-openLeiosDb stubbedLeiosDb dbDir
-  | stubbedLeiosDb = newLeiosDBInMemory
+  IO (Maybe FilePath)
+leiosDbPath stubbedLeiosDb dbDir
+  | stubbedLeiosDb = pure Nothing
   | otherwise = do
-      let leiosDbPath = dbDir FilePath.</> "leios.db"
-      exists <- Directory.doesFileExist leiosDbPath
+      let path = dbDir FilePath.</> "leios.db"
+      exists <- Directory.doesFileExist path
       unless exists $
         die $
           "No LeiosDb at "
-            <> leiosDbPath
+            <> path
             <> ". A block that carries a Leios certificate has an empty body, "
             <> "and the transactions that it puts on the chain are in the "
             <> "endorser block that it certifies, which the LeiosDb holds. "
             <> "Pass --stubbed-leios-db if this chain holds no such block."
-      newLeiosDBSQLite nullTracer leiosDbPath
+      pure (Just path)
+
+-- | Open the node's LeiosDb, or an empty in-memory one for the stub.
+openLeiosDb :: Bool -> FilePath -> IO (LeiosDbHandle IO)
+openLeiosDb stubbedLeiosDb dbDir = do
+  mPath <- leiosDbPath stubbedLeiosDb dbDir
+  case mPath of
+    Nothing -> newLeiosDBInMemory
+    Just path -> newLeiosDBSQLite nullTracer path

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/LeiosDb.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/LeiosDb.hs
@@ -1,52 +1,47 @@
-module Cardano.Tools.LeiosDb (leiosDbPath, openLeiosDb) where
+module Cardano.Tools.LeiosDb (LeiosDbSource (..), leiosDbPath) where
 
 import Control.Monad (unless)
-import Control.Tracer (nullTracer)
-import LeiosDemoDb (LeiosDbHandle, newLeiosDBInMemory, newLeiosDBSQLite)
 import qualified System.Directory as Directory
 import System.Exit (die)
 import qualified System.FilePath as FilePath
 
+-- | Which LeiosDb the tool works on, per @--no-leios-db@.
+data LeiosDbSource
+  = -- | The @leios.db@ under the @--db@ directory.
+    NodeLeiosDb
+  | -- | No file. db-analyser uses an empty in-memory LeiosDb, and db-truncater
+    -- skips every LeiosDb step.
+    NoLeiosDb
+
 -- | The path of the @leios.db@ that the node writes under its ChainDB
--- directory, or 'Nothing' when the caller passes --no-leios-db.
+-- directory, or 'Nothing' for 'NoLeiosDb'.
 --
 -- The tool derives that path from @--db@ rather than take one of its own. An
 -- operator who puts the file elsewhere can symlink it into place.
 --
 -- A missing file is fatal, because a tool cannot tell whether the chain holds a
--- cert-RB before it reads the chain. The caller passes 'True' to say that the
--- chain holds no cert-RB.
+-- cert-RB before it reads the chain. The caller passes 'NoLeiosDb' to say that
+-- the chain holds no cert-RB.
 --
 -- Hence this check, rather than a check inside the SQLite backend: that backend
 -- opens with 'SQLOpenCreate' and it creates the schema when it finds no file.
 -- So without this check the tool would write an empty leios.db into the node's
 -- directory and fail only at the first cert-RB.
 leiosDbPath ::
-  -- | Use no LeiosDb file.
-  Bool ->
+  LeiosDbSource ->
   -- | The ChainDB directory.
   FilePath ->
   IO (Maybe FilePath)
-leiosDbPath noLeiosDb dbDir
-  | noLeiosDb = pure Nothing
-  | otherwise = do
-      let path = dbDir FilePath.</> "leios.db"
-      exists <- Directory.doesFileExist path
-      unless exists $
-        die $
-          "No LeiosDb at "
-            <> path
-            <> ". A block that carries a Leios certificate has an empty body, "
-            <> "and the transactions that it puts on the chain are in the "
-            <> "endorser block that it certifies, which the LeiosDb holds. "
-            <> "Pass --no-leios-db if this chain holds no such block."
-      pure (Just path)
-
--- | Open the node's LeiosDb, or an empty in-memory one when the caller passes
--- --no-leios-db.
-openLeiosDb :: Bool -> FilePath -> IO (LeiosDbHandle IO)
-openLeiosDb noLeiosDb dbDir = do
-  mPath <- leiosDbPath noLeiosDb dbDir
-  case mPath of
-    Nothing -> newLeiosDBInMemory
-    Just path -> newLeiosDBSQLite nullTracer path
+leiosDbPath NoLeiosDb _dbDir = pure Nothing
+leiosDbPath NodeLeiosDb dbDir = do
+  let path = dbDir FilePath.</> "leios.db"
+  exists <- Directory.doesFileExist path
+  unless exists $
+    die $
+      "No LeiosDb at "
+        <> path
+        <> ". A block that carries a Leios certificate has an empty body, "
+        <> "and the transactions that it puts on the chain are in the "
+        <> "endorser block that it certifies, which the LeiosDb holds. "
+        <> "Pass --no-leios-db if this chain holds no such block."
+  pure (Just path)

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/LeiosDb.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/LeiosDb.hs
@@ -1,0 +1,42 @@
+module Cardano.Tools.LeiosDb (openLeiosDb) where
+
+import Control.Monad (unless)
+import Control.Tracer (nullTracer)
+import LeiosDemoDb (LeiosDbHandle, newLeiosDBInMemory, newLeiosDBSQLite)
+import qualified System.Directory as Directory
+import System.Exit (die)
+import qualified System.FilePath as FilePath
+
+-- | Open the @leios.db@ that the node writes under its ChainDB directory.
+--
+-- The tool derives that path from @--db@ rather than take one of its own. An
+-- operator who puts the file elsewhere can symlink it into place.
+--
+-- A missing file is fatal, because a tool cannot tell whether the chain holds a
+-- cert-RB before it reads the chain. The caller passes 'True' to say that the
+-- chain holds no cert-RB, and that an empty in-memory LeiosDb is enough.
+--
+-- Hence this check, rather than a check inside the SQLite backend: that backend
+-- opens with 'SQLOpenCreate' and it creates the schema when it finds no file.
+-- So without this check the tool would write an empty leios.db into the node's
+-- directory and fail only at the first cert-RB.
+openLeiosDb ::
+  -- | Use an empty in-memory LeiosDb.
+  Bool ->
+  -- | The ChainDB directory.
+  FilePath ->
+  IO (LeiosDbHandle IO)
+openLeiosDb stubbedLeiosDb dbDir
+  | stubbedLeiosDb = newLeiosDBInMemory
+  | otherwise = do
+      let leiosDbPath = dbDir FilePath.</> "leios.db"
+      exists <- Directory.doesFileExist leiosDbPath
+      unless exists $
+        die $
+          "No LeiosDb at "
+            <> leiosDbPath
+            <> ". A block that carries a Leios certificate has an empty body, "
+            <> "and the transactions that it puts on the chain are in the "
+            <> "endorser block that it certifies, which the LeiosDb holds. "
+            <> "Pass --stubbed-leios-db if this chain holds no such block."
+      newLeiosDBSQLite nullTracer leiosDbPath

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/LeiosDb.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/LeiosDb.hs
@@ -8,7 +8,7 @@ import System.Exit (die)
 import qualified System.FilePath as FilePath
 
 -- | The path of the @leios.db@ that the node writes under its ChainDB
--- directory, or 'Nothing' when the caller asks for the stub.
+-- directory, or 'Nothing' when the caller passes --no-leios-db.
 --
 -- The tool derives that path from @--db@ rather than take one of its own. An
 -- operator who puts the file elsewhere can symlink it into place.
@@ -27,8 +27,8 @@ leiosDbPath ::
   -- | The ChainDB directory.
   FilePath ->
   IO (Maybe FilePath)
-leiosDbPath stubbedLeiosDb dbDir
-  | stubbedLeiosDb = pure Nothing
+leiosDbPath noLeiosDb dbDir
+  | noLeiosDb = pure Nothing
   | otherwise = do
       let path = dbDir FilePath.</> "leios.db"
       exists <- Directory.doesFileExist path
@@ -39,13 +39,14 @@ leiosDbPath stubbedLeiosDb dbDir
             <> ". A block that carries a Leios certificate has an empty body, "
             <> "and the transactions that it puts on the chain are in the "
             <> "endorser block that it certifies, which the LeiosDb holds. "
-            <> "Pass --stubbed-leios-db if this chain holds no such block."
+            <> "Pass --no-leios-db if this chain holds no such block."
       pure (Just path)
 
--- | Open the node's LeiosDb, or an empty in-memory one for the stub.
+-- | Open the node's LeiosDb, or an empty in-memory one when the caller passes
+-- --no-leios-db.
 openLeiosDb :: Bool -> FilePath -> IO (LeiosDbHandle IO)
-openLeiosDb stubbedLeiosDb dbDir = do
-  mPath <- leiosDbPath stubbedLeiosDb dbDir
+openLeiosDb noLeiosDb dbDir = do
+  mPath <- leiosDbPath noLeiosDb dbDir
   case mPath of
     Nothing -> newLeiosDBInMemory
     Just path -> newLeiosDBSQLite nullTracer path

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/LeiosDb.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/LeiosDb.hs
@@ -1,23 +1,28 @@
-module Cardano.Tools.LeiosDb (LeiosDbSource (..), requireNodeLeiosDb) where
+module Cardano.Tools.LeiosDb (LeiosDbSource (..), requireLeiosDbFile) where
 
 import Control.Monad (unless)
+import Data.Maybe (fromMaybe)
 import qualified System.Directory as Directory
 import System.Exit (die)
 import qualified System.FilePath as FilePath
 
--- | Which LeiosDb the tool works on, per @--no-leios-db@.
+-- | Which LeiosDb the tool works on, per @--leios-db@ and @--no-leios-db@.
 data LeiosDbSource
-  = -- | The @leios.db@ under the @--db@ directory.
-    NodeLeiosDb
+  = -- | The LeiosDb file. 'Nothing' is the @--db@ directory default, see
+    -- 'requireLeiosDbFile'.
+    LeiosDbFile (Maybe FilePath)
   | -- | No file. db-analyser uses an empty in-memory LeiosDb, and db-truncater
     -- skips every LeiosDb step.
     NoLeiosDb
 
--- | The path of the @leios.db@ that the node writes under its ChainDB
--- directory. Dies if that file does not exist.
+-- | The path of the LeiosDb file. Dies if that file does not exist.
 --
--- The tool derives that path from @--db@ rather than take one of its own. An
--- operator who puts the file elsewhere can symlink it into place.
+-- Without @--leios-db@ the tool reads @leios.db@ under the @--db@ directory,
+-- which is where a node with the default @LeiosDbConfig@ writes it. That
+-- default holds only when the node keeps all its databases under one path. A
+-- node that splits the immutable path from the volatile one writes the file
+-- under the volatile path, and a node can also name another file altogether.
+-- @--leios-db@ is for both cases.
 --
 -- A missing file is fatal, because a tool cannot tell whether the chain holds a
 -- cert-RB before it reads the chain. The operator passes @--no-leios-db@ to say
@@ -27,12 +32,14 @@ data LeiosDbSource
 -- opens with 'SQLOpenCreate' and it creates the schema when it finds no file.
 -- So without this check the tool would write an empty leios.db into the node's
 -- directory and fail only at the first cert-RB.
-requireNodeLeiosDb ::
-  -- | The ChainDB directory.
+requireLeiosDbFile ::
+  -- | The ChainDB directory, that is @--db@.
   FilePath ->
+  -- | The @--leios-db@ path, if the operator gave one.
+  Maybe FilePath ->
   IO FilePath
-requireNodeLeiosDb dbDir = do
-  let path = dbDir FilePath.</> "leios.db"
+requireLeiosDbFile dbDir mPath = do
+  let path = fromMaybe (dbDir FilePath.</> "leios.db") mPath
   exists <- Directory.doesFileExist path
   unless exists $
     die $
@@ -41,5 +48,6 @@ requireNodeLeiosDb dbDir = do
         <> ". A block that carries a Leios certificate has an empty body, "
         <> "and the transactions that it puts on the chain are in the "
         <> "endorser block that it certifies, which the LeiosDb holds. "
-        <> "Pass --no-leios-db if this chain holds no such block."
+        <> "Pass --leios-db if the node writes that file elsewhere, or "
+        <> "--no-leios-db if this chain holds no such block."
   pure path

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/LeiosDb.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/LeiosDb.hs
@@ -1,4 +1,4 @@
-module Cardano.Tools.LeiosDb (LeiosDbSource (..), leiosDbPath) where
+module Cardano.Tools.LeiosDb (LeiosDbSource (..), requireNodeLeiosDb) where
 
 import Control.Monad (unless)
 import qualified System.Directory as Directory
@@ -14,26 +14,24 @@ data LeiosDbSource
     NoLeiosDb
 
 -- | The path of the @leios.db@ that the node writes under its ChainDB
--- directory, or 'Nothing' for 'NoLeiosDb'.
+-- directory. Dies if that file does not exist.
 --
 -- The tool derives that path from @--db@ rather than take one of its own. An
 -- operator who puts the file elsewhere can symlink it into place.
 --
 -- A missing file is fatal, because a tool cannot tell whether the chain holds a
--- cert-RB before it reads the chain. The caller passes 'NoLeiosDb' to say that
--- the chain holds no cert-RB.
+-- cert-RB before it reads the chain. The operator passes @--no-leios-db@ to say
+-- that the chain holds no cert-RB.
 --
 -- Hence this check, rather than a check inside the SQLite backend: that backend
 -- opens with 'SQLOpenCreate' and it creates the schema when it finds no file.
 -- So without this check the tool would write an empty leios.db into the node's
 -- directory and fail only at the first cert-RB.
-leiosDbPath ::
-  LeiosDbSource ->
+requireNodeLeiosDb ::
   -- | The ChainDB directory.
   FilePath ->
-  IO (Maybe FilePath)
-leiosDbPath NoLeiosDb _dbDir = pure Nothing
-leiosDbPath NodeLeiosDb dbDir = do
+  IO FilePath
+requireNodeLeiosDb dbDir = do
   let path = dbDir FilePath.</> "leios.db"
   exists <- Directory.doesFileExist path
   unless exists $
@@ -44,4 +42,4 @@ leiosDbPath NodeLeiosDb dbDir = do
         <> "and the transactions that it puts on the chain are in the "
         <> "endorser block that it certifies, which the LeiosDb holds. "
         <> "Pass --no-leios-db if this chain holds no such block."
-  pure (Just path)
+  pure path

--- a/ouroboros-consensus-cardano/test/tools-test/Main.hs
+++ b/ouroboros-consensus-cardano/test/tools-test/Main.hs
@@ -84,7 +84,7 @@ testAnalyserConfig =
     , -- The synthesized chain holds no certifying block, and DBSynthesizer
       -- writes no leios.db, so the empty in-memory LeiosDb stub is both enough
       -- and the only option.
-      stubbedLeiosDb = True
+      noLeiosDb = True
     }
 
 -- | The truncater cuts the chain back to this slot. Far enough into the
@@ -99,7 +99,7 @@ testTruncaterConfig =
     { DBTruncater.dbDir = chainDB
     , DBTruncater.truncateAfter = DBTruncater.TruncateAfterSlot truncateAfter
     , DBTruncater.verbose = False
-    , DBTruncater.stubbedLeiosDb = False
+    , DBTruncater.noLeiosDb = False
     }
 
 testBlockArgs :: Cardano.Args (CardanoBlock StandardCrypto)

--- a/ouroboros-consensus-cardano/test/tools-test/Main.hs
+++ b/ouroboros-consensus-cardano/test/tools-test/Main.hs
@@ -6,6 +6,16 @@ import Cardano.Tools.DBAnalyser.Types
 import qualified Cardano.Tools.DBImmutaliser.Run as DBImmutaliser
 import qualified Cardano.Tools.DBSynthesizer.Run as DBSynthesizer
 import Cardano.Tools.DBSynthesizer.Types
+import qualified Cardano.Tools.DBTruncater.Run as DBTruncater
+import qualified Cardano.Tools.DBTruncater.Types as DBTruncater
+import Data.String (fromString)
+import LeiosDemoDb
+  ( leiosDbInsertEbPoint
+  , leiosDbScanEbPoints
+  , newLeiosDBSQLite
+  , withLeiosDb
+  )
+import LeiosDemoTypes (EbHash (..), LeiosPoint (..))
 import Ouroboros.Consensus.Block
 import Ouroboros.Consensus.Cardano.Block
 import qualified Test.Cardano.Tools.Headers
@@ -77,6 +87,21 @@ testAnalyserConfig =
       stubbedLeiosDb = True
     }
 
+-- | The truncater cuts the chain back to this slot. Far enough into the
+-- synthesized chain that a block precedes it, and far enough from its end that
+-- blocks follow it.
+truncateAfter :: SlotNo
+truncateAfter = 4096
+
+testTruncaterConfig :: DBTruncater.DBTruncaterConfig
+testTruncaterConfig =
+  DBTruncater.DBTruncaterConfig
+    { DBTruncater.dbDir = chainDB
+    , DBTruncater.truncateAfter = DBTruncater.TruncateAfterSlot truncateAfter
+    , DBTruncater.verbose = False
+    , DBTruncater.stubbedLeiosDb = False
+    }
+
 testBlockArgs :: Cardano.Args (CardanoBlock StandardCrypto)
 testBlockArgs = Cardano.CardanoBlockArgs nodeConfig Nothing
 
@@ -121,14 +146,47 @@ blockCountTest logStep = do
       ++ "; expected: "
       ++ show blockCount
       ++ ")"
+
+  logStep "writing a LeiosDb next to the chain"
+  -- DBSynthesizer writes no leios.db, so the test writes one. The kept EB is
+  -- announced below the truncation slot, and the dropped one above every block
+  -- the synthesis forged.
+  leiosDb <- newLeiosDBSQLite mempty (chainDB <> "/leios.db")
+  let keptEb = MkLeiosPoint 0 (mkEbHash '1')
+      droppedEb = MkLeiosPoint 500000 (mkEbHash '2')
+  withLeiosDb leiosDb $ \con ->
+    mapM_ (\point -> leiosDbInsertEbPoint con point 500) [keptEb, droppedEb]
+
+  logStep "running truncation"
+  DBTruncater.truncate testTruncaterConfig testBlockArgs
+
+  ebPoints <- withLeiosDb leiosDb leiosDbScanEbPoints
+  ebPoints == [(0, pointEbHash keptEb)]
+    @? "the LeiosDb does not hold the kept EB alone: " ++ show ebPoints
+
+  logStep "running analysis after truncation"
+  resultTruncated <- DBAnalyser.analyse testAnalyserConfig testBlockArgs
+  -- The leader schedule picks the slots, so the surviving count is not known
+  -- here. Check only that the chain shrank and is not empty.
+  case resultTruncated of
+    Just (ResultCountBlock countAfter) ->
+      (countAfter > 0 && countAfter < blockCount)
+        @? "truncation left "
+          ++ show countAfter
+          ++ " of "
+          ++ show blockCount
+          ++ " blocks"
+    _ -> assertFailure $ "analysis after truncation returned " ++ show resultTruncated
  where
   genTxs _ _ _ _ = pure []
+
+  mkEbHash c = MkEbHash (fromString (replicate 32 c))
 
 tests :: TestTree
 tests =
   testGroup
     "cardano-tools"
-    [ testCaseSteps "synthesize and analyse: blockCount\n" blockCountTest
+    [ testCaseSteps "synthesize, analyse and truncate\n" blockCountTest
     , Test.Cardano.Tools.Headers.tests
     ]
 

--- a/ouroboros-consensus-cardano/test/tools-test/Main.hs
+++ b/ouroboros-consensus-cardano/test/tools-test/Main.hs
@@ -8,6 +8,7 @@ import qualified Cardano.Tools.DBSynthesizer.Run as DBSynthesizer
 import Cardano.Tools.DBSynthesizer.Types
 import qualified Cardano.Tools.DBTruncater.Run as DBTruncater
 import qualified Cardano.Tools.DBTruncater.Types as DBTruncater
+import Cardano.Tools.LeiosDb (LeiosDbSource (..))
 import Data.String (fromString)
 import LeiosDemoDb
   ( leiosDbInsertEbPoint
@@ -84,7 +85,7 @@ testAnalyserConfig =
     , -- The synthesized chain holds no certifying block, and DBSynthesizer
       -- writes no leios.db, so the empty in-memory LeiosDb stub is both enough
       -- and the only option.
-      noLeiosDb = True
+      leiosDbSource = NoLeiosDb
     }
 
 -- | The truncater cuts the chain back to this slot. Far enough into the
@@ -99,7 +100,7 @@ testTruncaterConfig =
     { DBTruncater.dbDir = chainDB
     , DBTruncater.truncateAfter = DBTruncater.TruncateAfterSlot truncateAfter
     , DBTruncater.verbose = False
-    , DBTruncater.noLeiosDb = False
+    , DBTruncater.leiosDbSource = NodeLeiosDb
     }
 
 testBlockArgs :: Cardano.Args (CardanoBlock StandardCrypto)

--- a/ouroboros-consensus-cardano/test/tools-test/Main.hs
+++ b/ouroboros-consensus-cardano/test/tools-test/Main.hs
@@ -100,7 +100,7 @@ testTruncaterConfig =
     { DBTruncater.dbDir = chainDB
     , DBTruncater.truncateAfter = DBTruncater.TruncateAfterSlot truncateAfter
     , DBTruncater.verbose = False
-    , DBTruncater.leiosDbSource = NodeLeiosDb
+    , DBTruncater.leiosDbSource = LeiosDbFile Nothing
     }
 
 testBlockArgs :: Cardano.Args (CardanoBlock StandardCrypto)

--- a/ouroboros-consensus.cabal
+++ b/ouroboros-consensus.cabal
@@ -1955,6 +1955,7 @@ library unstable-cardano-tools
     Cardano.Tools.ImmDBServer.Json.Say
     Cardano.Tools.ImmDBServer.Json.SendRecv
     Cardano.Tools.ImmDBServer.MiniProtocols
+    Cardano.Tools.LeiosDb
     Cardano.Tools.ThreadNet.Run
 
   other-modules:

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoDb.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoDb.hs
@@ -19,6 +19,7 @@ module LeiosDemoDb
 
     -- * Re-exported for internal tooling
   , truncateLeiosDbAfterSlot
+  , deleteDanglingTxs
 
     -- * SQL (re-exported for leiosdemo app)
   , sql_schema
@@ -41,7 +42,8 @@ import LeiosDemoDb.InMemory
   , newLeiosDBInMemoryWith
   )
 import LeiosDemoDb.SQLite
-  ( newLeiosDBSQLite
+  ( deleteDanglingTxs
+  , newLeiosDBSQLite
   , newLeiosDBSQLiteFromEnv
   , sql_insert_eb
   , sql_insert_ebBody

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoDb.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoDb.hs
@@ -20,6 +20,7 @@ module LeiosDemoDb
     -- * Re-exported for internal tooling
   , truncateLeiosDbAfterSlot
   , deleteDanglingTxs
+  , vacuumLeiosDb
 
     -- * SQL (re-exported for leiosdemo app)
   , sql_schema
@@ -50,5 +51,6 @@ import LeiosDemoDb.SQLite
   , sql_insert_tx
   , sql_schema
   , truncateLeiosDbAfterSlot
+  , vacuumLeiosDb
   )
 import LeiosDemoDb.Trace (TraceLeiosDb (..))

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoDb.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoDb.hs
@@ -17,6 +17,9 @@ module LeiosDemoDb
   , newLeiosDBSQLiteFromEnv
   , newLeiosDBSQLite
 
+    -- * Re-exported for internal tooling
+  , truncateLeiosDbAfterSlot
+
     -- * SQL (re-exported for leiosdemo app)
   , sql_schema
   , sql_insert_eb
@@ -44,5 +47,6 @@ import LeiosDemoDb.SQLite
   , sql_insert_ebBody
   , sql_insert_tx
   , sql_schema
+  , truncateLeiosDbAfterSlot
   )
 import LeiosDemoDb.Trace (TraceLeiosDb (..))

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoDb/SQLite.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoDb/SQLite.hs
@@ -537,7 +537,7 @@ vacuumLeiosDb dbPath =
 -- rather than gain an empty database. No 'busy_timeout' either, so a write that
 -- meets the node's own write lock gives up after the retries in 'withDie'
 -- rather than block.
-withExistingDb :: HasCallStack => FilePath -> (DB.Database -> IO a) -> IO a
+withExistingDb :: FilePath -> (DB.Database -> IO a) -> IO a
 withExistingDb dbPath =
   MonadThrow.bracket
     (open2 (fromString dbPath) [SQLOpenReadWrite] SQLVFSDefault)

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoDb/SQLite.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoDb/SQLite.hs
@@ -500,17 +500,26 @@ truncateLeiosDbAfterSlot dbPath (SlotNo slot) =
     dbWithTransactionAs "BEGIN IMMEDIATE" db $
       dbExec db (fromString deletes)
  where
-  -- 'ebTxs' and 'ebsMissingTxs' are keyed by EB hash and carry no slot, and the
-  -- same EB can be announced in several slots. So a body is deleted only when
-  -- the truncation drops every announcement of that EB.
   deletes =
     unlines
-      [ "DELETE FROM ebTxs WHERE ebHashBytes NOT IN (" <> remainingHashes <> ");"
-      , "DELETE FROM ebsMissingTxs WHERE ebHashBytes NOT IN (" <> remainingHashes <> ");"
+      [ "DELETE FROM ebTxs WHERE ebHashBytes IN (" <> droppedHashes <> ");"
+      , "DELETE FROM ebsMissingTxs WHERE ebHashBytes IN (" <> droppedHashes <> ");"
       , "DELETE FROM ebs WHERE ebSlot > " <> show slot <> ";"
       ]
 
-  remainingHashes = "SELECT ebHashBytes FROM ebs WHERE ebSlot <= " <> show slot
+  -- The EBs whose bodies the truncation drops.
+  --
+  -- 'ebs' holds one row per announcement, so the same EB hash can appear at
+  -- several slots. 'ebTxs' and 'ebsMissingTxs' hold one copy per hash and carry
+  -- no slot. So an EB announced at slot 5 and again at slot 15 keeps its body
+  -- when the cut is at slot 10. That is what the EXCEPT does: take the hashes
+  -- announced after the cut, then remove the ones also announced at or before
+  -- it.
+  droppedHashes =
+    "SELECT ebHashBytes FROM ebs WHERE ebSlot > "
+      <> show slot
+      <> " EXCEPT SELECT ebHashBytes FROM ebs WHERE ebSlot <= "
+      <> show slot
 
 -- | Delete the transactions that no EB references.
 --

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoDb/SQLite.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoDb/SQLite.hs
@@ -10,6 +10,9 @@ module LeiosDemoDb.SQLite
   ( newLeiosDBSQLiteFromEnv
   , newLeiosDBSQLite
 
+    -- * Re-exported for internal tooling
+  , truncateLeiosDbAfterSlot
+
     -- * SQL strings (re-exported for leiosdemo app)
   , sql_schema
   , sql_insert_eb
@@ -483,6 +486,34 @@ sqlFilterMissingTxs conn txHashes =
       DB.Row -> do
         txHash <- MkTxHash <$> DB.columnBlob stmt 0
         loop (txHash : acc)
+
+-- | Delete the EBs announced after the given slot.
+--
+-- For internal tooling.
+truncateLeiosDbAfterSlot :: HasCallStack => FilePath -> SlotNo -> IO ()
+truncateLeiosDbAfterSlot dbPath (SlotNo slot) =
+  MonadThrow.bracket openReadWrite (void . DB.close) $ \db ->
+    -- One transaction, so a crash cannot leave an EB that is still announced
+    -- but has no body.
+    dbWithTransactionAs "BEGIN IMMEDIATE" db $
+      dbExec db (fromString deletes)
+ where
+  -- No 'SQLOpenCreate', unlike 'openSQLiteConnection': a path with no database
+  -- must fail here rather than gain an empty one. No 'busy_timeout' either, so
+  -- a database another process holds open refuses the write at once.
+  openReadWrite = open2 (fromString dbPath) [SQLOpenReadWrite] SQLVFSDefault
+
+  -- 'ebTxs' and 'ebsMissingTxs' are keyed by EB hash and carry no slot, and the
+  -- same EB can be announced in several slots. So a body is deleted only when
+  -- the truncation drops every announcement of that EB.
+  deletes =
+    unlines
+      [ "DELETE FROM ebTxs WHERE ebHashBytes NOT IN (" <> remainingHashes <> ");"
+      , "DELETE FROM ebsMissingTxs WHERE ebHashBytes NOT IN (" <> remainingHashes <> ");"
+      , "DELETE FROM ebs WHERE ebSlot > " <> show slot <> ";"
+      ]
+
+  remainingHashes = "SELECT ebHashBytes FROM ebs WHERE ebSlot <= " <> show slot
 
 -- | Build a JSON array of hex-encoded blobs: @["aabb...","1234...",...]@.
 -- Consumed on the SQL side via @json_each(?)@ + @unhex(je.value)@.

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoDb/SQLite.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoDb/SQLite.hs
@@ -494,7 +494,7 @@ sqlFilterMissingTxs conn txHashes =
 -- For internal tooling.
 truncateLeiosDbAfterSlot :: HasCallStack => FilePath -> SlotNo -> IO ()
 truncateLeiosDbAfterSlot dbPath (SlotNo slot) =
-  withExistingDb dbPath $ \db ->
+  withExistingLeiosDbFile dbPath $ \db ->
     -- One transaction, so a crash cannot leave an EB that is still announced
     -- but has no body.
     dbWithTransactionAs "BEGIN IMMEDIATE" db $
@@ -517,7 +517,7 @@ truncateLeiosDbAfterSlot dbPath (SlotNo slot) =
 -- For internal tooling.
 deleteDanglingTxs :: HasCallStack => FilePath -> IO ()
 deleteDanglingTxs dbPath =
-  withExistingDb dbPath $ \db ->
+  withExistingLeiosDbFile dbPath $ \db ->
     dbExec db . fromString $
       "DELETE FROM txs WHERE txHashBytes NOT IN (SELECT txHashBytes FROM ebTxs)"
 
@@ -528,17 +528,20 @@ deleteDanglingTxs dbPath =
 -- of the file. For internal tooling.
 vacuumLeiosDb :: HasCallStack => FilePath -> IO ()
 vacuumLeiosDb dbPath =
-  withExistingDb dbPath $ \db ->
+  withExistingLeiosDbFile dbPath $ \db ->
     dbExec db (fromString "VACUUM")
 
--- | Open a LeiosDb that must already exist.
+-- | Open the LeiosDb file at the given path, which must already exist.
+--
+-- Unrelated to 'withLeiosDb', which brackets a 'LeiosDbConnection' that a
+-- 'LeiosDbHandle' opens.
 --
 -- No 'SQLOpenCreate', unlike 'openSQLiteConnection': a wrong path must fail
 -- rather than gain an empty database. No 'busy_timeout' either, so a write that
 -- meets the node's own write lock gives up after the retries in 'withDie'
 -- rather than block.
-withExistingDb :: FilePath -> (DB.Database -> IO a) -> IO a
-withExistingDb dbPath =
+withExistingLeiosDbFile :: FilePath -> (DB.Database -> IO a) -> IO a
+withExistingLeiosDbFile dbPath =
   MonadThrow.bracket
     (open2 (fromString dbPath) [SQLOpenReadWrite] SQLVFSDefault)
     (void . DB.close)

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoDb/SQLite.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoDb/SQLite.hs
@@ -534,8 +534,9 @@ vacuumLeiosDb dbPath =
 -- | Open a LeiosDb that must already exist.
 --
 -- No 'SQLOpenCreate', unlike 'openSQLiteConnection': a wrong path must fail
--- rather than gain an empty database. No 'busy_timeout' either, so a database
--- another process holds open refuses a write at once.
+-- rather than gain an empty database. No 'busy_timeout' either, so a write that
+-- meets the node's own write lock gives up after the retries in 'withDie'
+-- rather than block.
 withExistingDb :: HasCallStack => FilePath -> (DB.Database -> IO a) -> IO a
 withExistingDb dbPath =
   MonadThrow.bracket

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoDb/SQLite.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoDb/SQLite.hs
@@ -13,6 +13,7 @@ module LeiosDemoDb.SQLite
     -- * Re-exported for internal tooling
   , truncateLeiosDbAfterSlot
   , deleteDanglingTxs
+  , vacuumLeiosDb
 
     -- * SQL strings (re-exported for leiosdemo app)
   , sql_schema
@@ -519,6 +520,16 @@ deleteDanglingTxs dbPath =
   withExistingDb dbPath $ \db ->
     dbExec db . fromString $
       "DELETE FROM txs WHERE txHashBytes NOT IN (SELECT txHashBytes FROM ebTxs)"
+
+-- | Shrink a LeiosDb file to the space its rows need.
+--
+-- A delete frees pages inside the file without returning them to the
+-- filesystem. This rewrites the file, so it needs free space of about the size
+-- of the file. For internal tooling.
+vacuumLeiosDb :: HasCallStack => FilePath -> IO ()
+vacuumLeiosDb dbPath =
+  withExistingDb dbPath $ \db ->
+    dbExec db (fromString "VACUUM")
 
 -- | Open a LeiosDb that must already exist.
 --

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoDb/SQLite.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoDb/SQLite.hs
@@ -12,6 +12,7 @@ module LeiosDemoDb.SQLite
 
     -- * Re-exported for internal tooling
   , truncateLeiosDbAfterSlot
+  , deleteDanglingTxs
 
     -- * SQL strings (re-exported for leiosdemo app)
   , sql_schema
@@ -492,17 +493,12 @@ sqlFilterMissingTxs conn txHashes =
 -- For internal tooling.
 truncateLeiosDbAfterSlot :: HasCallStack => FilePath -> SlotNo -> IO ()
 truncateLeiosDbAfterSlot dbPath (SlotNo slot) =
-  MonadThrow.bracket openReadWrite (void . DB.close) $ \db ->
+  withExistingDb dbPath $ \db ->
     -- One transaction, so a crash cannot leave an EB that is still announced
     -- but has no body.
     dbWithTransactionAs "BEGIN IMMEDIATE" db $
       dbExec db (fromString deletes)
  where
-  -- No 'SQLOpenCreate', unlike 'openSQLiteConnection': a path with no database
-  -- must fail here rather than gain an empty one. No 'busy_timeout' either, so
-  -- a database another process holds open refuses the write at once.
-  openReadWrite = open2 (fromString dbPath) [SQLOpenReadWrite] SQLVFSDefault
-
   -- 'ebTxs' and 'ebsMissingTxs' are keyed by EB hash and carry no slot, and the
   -- same EB can be announced in several slots. So a body is deleted only when
   -- the truncation drops every announcement of that EB.
@@ -514,6 +510,26 @@ truncateLeiosDbAfterSlot dbPath (SlotNo slot) =
       ]
 
   remainingHashes = "SELECT ebHashBytes FROM ebs WHERE ebSlot <= " <> show slot
+
+-- | Delete the transactions that no EB references.
+--
+-- For internal tooling.
+deleteDanglingTxs :: HasCallStack => FilePath -> IO ()
+deleteDanglingTxs dbPath =
+  withExistingDb dbPath $ \db ->
+    dbExec db . fromString $
+      "DELETE FROM txs WHERE txHashBytes NOT IN (SELECT txHashBytes FROM ebTxs)"
+
+-- | Open a LeiosDb that must already exist.
+--
+-- No 'SQLOpenCreate', unlike 'openSQLiteConnection': a wrong path must fail
+-- rather than gain an empty database. No 'busy_timeout' either, so a database
+-- another process holds open refuses a write at once.
+withExistingDb :: HasCallStack => FilePath -> (DB.Database -> IO a) -> IO a
+withExistingDb dbPath =
+  MonadThrow.bracket
+    (open2 (fromString dbPath) [SQLOpenReadWrite] SQLVFSDefault)
+    (void . DB.close)
 
 -- | Build a JSON array of hex-encoded blobs: @["aabb...","1234...",...]@.
 -- Consumed on the SQL side via @json_each(?)@ + @unhex(je.value)@.

--- a/ouroboros-consensus/test/consensus-test/Test/LeiosDemoDb.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/LeiosDemoDb.hs
@@ -39,6 +39,7 @@ import LeiosDemoDb
   , leiosDbScanEbPoints
   , newLeiosDBInMemory
   , newLeiosDBSQLite
+  , truncateLeiosDbAfterSlot
   , withLeiosDb
   )
 import LeiosDemoTypes
@@ -77,6 +78,12 @@ tests :: TestTree
 tests =
   testGroup "LeiosDemoDb" $
     forEachImplementation mkTestGroups
+      <> [ testGroup
+             "truncateLeiosDbAfterSlot"
+             [ testCase "drops the EBs announced after the slot, with their bodies" $
+                 withFreshSQLiteFile test_truncateDropsEbsAfterSlot
+             ]
+         ]
 
 -- | Database creation strategy for different implementations.
 data DbImpl
@@ -98,6 +105,20 @@ withFreshDb SQLite action = do
     )
     snd
     (action . fst)
+
+-- | Create a fresh SQLite database and hand its path to the action, which
+-- 'truncateLeiosDbAfterSlot' needs.
+withFreshSQLiteFile :: (FilePath -> LeiosDbHandle IO -> IO a) -> IO a
+withFreshSQLiteFile action = do
+  sysTmp <- getCanonicalTemporaryDirectory
+  bracket
+    (createTempDirectory sysTmp "leios-test")
+    removeDirectoryRecursive
+    ( \tmpDir -> do
+        let dbPath = tmpDir <> "/test.db"
+        db <- newLeiosDBSQLite nullTracer dbPath
+        action dbPath db
+    )
 
 -- | Run tests for each database implementation (InMemory and SQLite).
 forEachImplementation :: (DbImpl -> [TestTree]) -> [TestTree]
@@ -813,3 +834,28 @@ prop_completedEbNoBody impl =
         result === Nothing
           & counterexample "Expected Nothing for EB with no body inserted"
           & tabulate "lookupEbClosure (no body)" [timeBucket queryTime]
+
+-- * truncateLeiosDbAfterSlot
+
+test_truncateDropsEbsAfterSlot :: FilePath -> LeiosDbHandle IO -> IO ()
+test_truncateDropsEbsAfterSlot dbPath db = do
+  let eb = mkTestEb 2
+      keptHash = mkTestEbHash 1
+      droppedHash = mkTestEbHash 2
+  withLeiosDb db $ \con -> do
+    leiosDbInsertEbPoint con (MkLeiosPoint 5 keptHash) (leiosEbBytesSize eb)
+    void $ leiosDbInsertEbBody con (MkLeiosPoint 5 keptHash) eb
+    -- The kept EB is announced again at a slot the truncation drops.
+    leiosDbInsertEbPoint con (MkLeiosPoint 15 keptHash) (leiosEbBytesSize eb)
+    leiosDbInsertEbPoint con (MkLeiosPoint 15 droppedHash) (leiosEbBytesSize eb)
+    void $ leiosDbInsertEbBody con (MkLeiosPoint 15 droppedHash) eb
+
+  truncateLeiosDbAfterSlot dbPath 10
+
+  withLeiosDb db $ \con -> do
+    points <- leiosDbScanEbPoints con
+    points @?= [(5, keptHash)]
+    keptBody <- leiosDbLookupEbBody con keptHash
+    keptBody @?= V.toList (leiosEbTxs eb)
+    droppedBody <- leiosDbLookupEbBody con droppedHash
+    droppedBody @?= []

--- a/ouroboros-consensus/test/consensus-test/Test/LeiosDemoDb.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/LeiosDemoDb.hs
@@ -30,6 +30,7 @@ import qualified Data.Vector.Strict as V
 import LeiosDemoDb
   ( LeiosDbHandle (..)
   , LeiosEbNotification (..)
+  , deleteDanglingTxs
   , leiosDbBatchRetrieveTxs
   , leiosDbInsertEbBody
   , leiosDbInsertEbPoint
@@ -82,6 +83,11 @@ tests =
              "truncateLeiosDbAfterSlot"
              [ testCase "drops the EBs announced after the slot, with their bodies" $
                  withFreshSQLiteFile test_truncateDropsEbsAfterSlot
+             ]
+         , testGroup
+             "deleteDanglingTxs"
+             [ testCase "keeps the txs an EB references" $
+                 withFreshSQLiteFile test_deleteDanglingTxs
              ]
          ]
 
@@ -859,3 +865,32 @@ test_truncateDropsEbsAfterSlot dbPath db = do
     keptBody @?= V.toList (leiosEbTxs eb)
     droppedBody <- leiosDbLookupEbBody con droppedHash
     droppedBody @?= []
+
+-- * deleteDanglingTxs
+
+test_deleteDanglingTxs :: FilePath -> LeiosDbHandle IO -> IO ()
+test_deleteDanglingTxs dbPath db = do
+  let eb = mkTestEb 2
+      ebHash = mkTestEbHash 1
+      danglingTx = mkTestTxHash 9
+      txBytes = BS.replicate 10 0
+  withLeiosDb db $ \con -> do
+    leiosDbInsertEbPoint con (MkLeiosPoint 5 ebHash) (leiosEbBytesSize eb)
+    void $ leiosDbInsertEbBody con (MkLeiosPoint 5 ebHash) eb
+    void $
+      leiosDbInsertTxs con $
+        (danglingTx, txBytes) : [(txHash, txBytes) | (txHash, _) <- V.toList (leiosEbTxs eb)]
+
+  deleteDanglingTxs dbPath
+
+  withLeiosDb db $ \con -> do
+    closure <- leiosDbLookupEbClosure con ebHash
+    fmap (map fst) closure @?= Just (map fst (V.toList (leiosEbTxs eb)))
+    -- A closure resolves only when the db holds every tx the body names. So
+    -- this probe resolves only if the delete missed the dangling tx.
+    let probeEb = MkLeiosEb (V.fromList [(danglingTx, 10)])
+        probePoint = MkLeiosPoint 6 (mkTestEbHash 2)
+    leiosDbInsertEbPoint con probePoint (leiosEbBytesSize probeEb)
+    void $ leiosDbInsertEbBody con probePoint probeEb
+    probeClosure <- leiosDbLookupEbClosure con probePoint.pointEbHash
+    probeClosure @?= Nothing


### PR DESCRIPTION
This PR adapts db-truncater to Leios. Part of https://github.com/input-output-hk/ouroboros-leios/issues/1023

After it truncates the ImmutableDB, the tool cuts `leios.db` back to the new tip slot, deletes the transactions that no endorser block references, and vacuums the file.
`--stubbed-leios-db` skips all of that, for a chain that carries no Leios certificate.

The LeiosDb work is three standalone functions in `LeiosDemoDb.SQLite`, each with a unit test. `tools-test` now covers db-truncater end to end, which it did not before.