### PR TITLE
tests: build against QuickCheck 2.18

### DIFF
--- a/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/QuickCheck.hs
+++ b/ouroboros-consensus/src/unstable-consensus-testlib/Test/Util/QuickCheck.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE RankNTypes #-}
@@ -43,6 +44,9 @@ module Test.Util.QuickCheck
 
     -- * Typeclass laws
   , prop_lawfulEqAndTotalOrd
+
+    -- * Deprecated symbols
+  , withNumTests
   ) where
 
 import Control.Monad.Except (Except, runExcept)
@@ -54,7 +58,19 @@ import Data.SOP.Constraint
 import Data.SOP.Strict
 import Ouroboros.Consensus.Util (repeatedly)
 import Ouroboros.Consensus.Util.Condense (Condense, condense)
+#if !MIN_VERSION_QuickCheck(2,18,0)
 import Test.QuickCheck
+#else
+import Test.QuickCheck hiding (withNumTests)
+import qualified Test.QuickCheck as QC
+#endif
+
+withNumTests :: Testable prop => Int -> prop -> Property
+#if !MIN_VERSION_QuickCheck(2,18,0)
+withNumTests = withMaxSuccess
+#else
+withNumTests = QC.withNumTests
+#endif
 
 {-------------------------------------------------------------------------------
   Generic QuickCheck utilities

--- a/ouroboros-consensus/test/consensus-test/Test/Consensus/Mempool/StateMachine.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/Consensus/Mempool/StateMachine.hs
@@ -86,6 +86,7 @@ import Test.Tasty
 import Test.Tasty.HUnit (assertBool, testCase)
 import Test.Tasty.QuickCheck
 import Test.Util.Orphans.ToExpr ()
+import qualified Test.Util.QuickCheck as QC'
 import Test.Util.ToExpr ()
 
 {-------------------------------------------------------------------------------
@@ -983,7 +984,7 @@ tests =
     "QSM"
     [ testCase "removal is not undone by a concurrent sync" prop_removeDuringSyncSM
     , testProperty "sequential" $
-        withMaxSuccess 1000 $
+        QC'.withNumTests 1000 $
           prop_mempoolSequential testLedgerConfigNoSizeLimits txMaxBytes' testInitLedger $
             \i -> fmap (fmap fst . fst) . genTxs i
     , testGroup
@@ -995,7 +996,7 @@ tests =
               prop_mempoolParallel testLedgerConfigNoSizeLimits txMaxBytes' testInitLedger Atomic $
                 \i -> fmap (fmap fst . fst) . genTxs i
         , testProperty "non atomic" $
-            withMaxSuccess 10 $
+            QC'.withNumTests 10 $
               prop_mempoolParallel testLedgerConfigNoSizeLimits txMaxBytes' testInitLedger NonAtomic $
                 \i -> fmap (fmap fst . fst) . genTxs i
         ]

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ImmutableDB/StateMachine.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/ImmutableDB/StateMachine.hs
@@ -749,14 +749,14 @@ generateCmd Model{..} =
         )
       ]
 
-  chooseWord64 :: Coercible a Word64 => (a, a) -> Gen a
-  chooseWord64 (start, end) = coerce $ choose @Word64 (coerce start, coerce end)
+  chooseWord64' :: Coercible a Word64 => (a, a) -> Gen a
+  chooseWord64' (start, end) = coerce $ choose @Word64 (coerce start, coerce end)
 
   chooseSlot :: (SlotNo, SlotNo) -> Gen SlotNo
-  chooseSlot = chooseWord64
+  chooseSlot = chooseWord64'
 
   chooseEpoch :: (EpochNo, EpochNo) -> Gen EpochNo
-  chooseEpoch = chooseWord64
+  chooseEpoch = chooseWord64'
 
   genCorruption :: Gen Corruption
   genCorruption = MkCorruption <$> generateCorruptions (NE.fromList dbFiles)

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/LedgerDB/StateMachine.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/LedgerDB/StateMachine.hs
@@ -93,6 +93,7 @@ import qualified Test.QuickCheck.Monadic as QC
 import Test.QuickCheck.StateModel
 import Test.Tasty
 import Test.Tasty.QuickCheck (frequency, tabulate, testProperty)
+import qualified Test.Util.QuickCheck as QC'
 import Test.Util.TestBlock hiding
   ( TestBlock
   , TestBlockCodecConfig
@@ -121,7 +122,7 @@ prop_sequential ::
   Actions Model ->
   QC.Property
 prop_sequential maxSuccess mkTestArguments getDiskDir fsOps actions =
-  QC.withMaxSuccess maxSuccess $
+  QC'.withNumTests maxSuccess $
     QC.monadic runner $
       Monad.void $
         runActions $

--- a/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/LedgerDB/V1/DbChangelog.hs
+++ b/ouroboros-consensus/test/storage-test/Test/Ouroboros/Storage/LedgerDB/V1/DbChangelog.hs
@@ -69,6 +69,7 @@ import Test.Tasty
 import Test.Tasty.QuickCheck hiding (elements)
 import Test.Util.Orphans.Arbitrary ()
 import Test.Util.QuickCheck
+import qualified Test.Util.QuickCheck as QC
 import qualified Test.Util.TestBlock as TestBlock
 import Text.Show.Pretty (ppShow)
 
@@ -94,14 +95,14 @@ tests =
         , testProperty "switchExpectedLedger" prop_switchExpectedLedger
         ]
     , testProperty "flushing" $
-        withMaxSuccess samples $
+        QC.withNumTests samples $
           conjoin
             [ counterexample
                 "flushing keeps immutable tip"
                 prop_flushingSplitsTheChangelog
             ]
     , testProperty "rolling back" $
-        withMaxSuccess samples $
+        QC.withNumTests samples $
           conjoin
             [ counterexample
                 "rollback after extension is noop"
@@ -114,9 +115,9 @@ tests =
                 prop_rollBackToVolatileTipIsNoop
             ]
     , testProperty "extending adds head to volatile states" $
-        withMaxSuccess samples prop_extendingAdvancesTipOfVolatileStates
+        QC.withNumTests samples prop_extendingAdvancesTipOfVolatileStates
     , testProperty "pruning before a slot works as expected" $
-        withMaxSuccess samples prop_pruningBeforeSlotCorrectness
+        QC.withNumTests samples prop_pruningBeforeSlotCorrectness
     ]
 
 {-------------------------------------------------------------------------------


### PR DESCRIPTION
On GHC 9.14 the solver picks QuickCheck 2.18, which deprecates `withMaxSuccess` and exports `chooseWord64`.
Both break the 9.14.1 CI job, because it compiles with `-Werror=deprecations` and `-Werror=name-shadowing`.

`Test.Util.QuickCheck` now gives a `withNumTests` that maps to `withMaxSuccess` before 2.18 and to the real function from 2.18 on, and the local `chooseWord64` helper is renamed.
This ports the test-only part of 624639730 from `main`, where the same change already landed with the LSM-tree update.