### PR TITLE
Leios prototype: various fixes

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1786144110,
-        "narHash": "sha256-7hIsWllt2gyPIZ8Wvb1BImf9xfQwDkz0B3sXIZpctxg=",
+        "lastModified": 1788515479,
+        "narHash": "sha256-UoIoRsh+rWKJCJ03z8R/a2RJE9eA0rq8acYHwZWN3aQ=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "89f08ac683754f1746d5cd1ff4ea60ba13faec29",
+        "rev": "244c29aac8aa9ae3611105ece01497bc91c40ff7",
         "type": "github"
       },
       "original": {
@@ -253,11 +253,11 @@
     "hackageNix": {
       "flake": false,
       "locked": {
-        "lastModified": 1784626207,
-        "narHash": "sha256-1WjrU24q6MMXMABYMXoYNQaJfodxzni8XF1XGFJEHiM=",
+        "lastModified": 1788733461,
+        "narHash": "sha256-O4GC+w90Uv2ySOi45gF7junZNLJevZZNNJJ3q+L8olc=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "770f679832f66818d1ebe410b30a7283ec10fbd6",
+        "rev": "28ff55bf37cdae6069e0b1bf1aab484c7e71efad",
         "type": "github"
       },
       "original": {

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToNode.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToNode.hs
@@ -575,15 +575,31 @@ mkHandlers
                     traceWith tracer $ MkTraceLeiosPeer $ "MsgLeiosVotes " <> show vs
                     forM_ vs $ \vote -> do
                       result <- addVote vote
-                      -- TODO: Keep track of the running tally (even after certification)
                       traceWith kernelTracer TraceLeiosVoteAcquired{vote}
                       -- A remote vote can be the one that tips this
                       -- node's tally past 'minCertificationThreshold';
                       -- trace certification whenever 'addVote' surfaces
                       -- a cert for the point.
+                      --
+                      -- The tally is traced only on 'Added', so one line per
+                      -- distinct vote rather than per arrival: the same vote
+                      -- reaches us from every peer that has it, and those
+                      -- duplicates return 'AlreadyKnown' with no tally to
+                      -- report.
                       case result of
-                        Added _ (Just _) ->
-                          traceWith kernelTracer TraceLeiosCertified{rbHash = Leios.announcingRbHash vote}
+                        Added weight tally mCert -> do
+                          traceWith kernelTracer $
+                            TraceLeiosTally
+                              { rbHash = Leios.announcingRbHash vote
+                              , seatId = Leios.voterId vote
+                              , weight
+                              , tally
+                              , threshold = Leios.minCertificationThreshold
+                              }
+                          case mCert of
+                            Just _ ->
+                              traceWith kernelTracer TraceLeiosCertified{rbHash = Leios.announcingRbHash vote}
+                            Nothing -> pure ()
                         _ -> pure ()
               )
       , hLeiosNotifyServer = \_version peer -> do

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToNode.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToNode.hs
@@ -573,7 +573,10 @@ mkHandlers
                       pure . Map.insertWith Leios.mergeOffer p Leios.TxsClosureAlsoOffered
                     void $ MVar.tryPutMVar getLeiosReady ()
                   MsgLeiosVotes vs -> do
-                    traceWith tracer $ MkTraceLeiosPeer $ "MsgLeiosVotes " <> show vs
+                    -- No peer-level trace here: 'TraceLeiosVoteAcquired' below
+                    -- reports every vote with structured fields, and votes are
+                    -- the one Leios message whose count scales with committee
+                    -- size, so rendering each one cost more than the vote.
                     forM_ vs $ \vote -> do
                       result <- addVote vote
                       -- Traced on 'Added' only, so one line per distinct vote

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToNode.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/Network/NodeToNode.hs
@@ -131,6 +131,7 @@ import LeiosVoteState
   ( AddVoteResult (..)
   , LeiosVoteState (..)
   , LeiosVoteSubscription (..)
+  , VoteTally (..)
   , subscribeVotes
   )
 import qualified Network.Mux as Mux
@@ -575,26 +576,22 @@ mkHandlers
                     traceWith tracer $ MkTraceLeiosPeer $ "MsgLeiosVotes " <> show vs
                     forM_ vs $ \vote -> do
                       result <- addVote vote
-                      traceWith kernelTracer TraceLeiosVoteAcquired{vote}
-                      -- A remote vote can be the one that tips this
-                      -- node's tally past 'minCertificationThreshold';
-                      -- trace certification whenever 'addVote' surfaces
-                      -- a cert for the point.
+                      -- Traced on 'Added' only, so one line per distinct vote
+                      -- rather than per arrival: the same vote reaches us from
+                      -- every peer that has it, and those duplicates return
+                      -- 'AlreadyKnown' with no tally to report.
                       --
-                      -- The tally is traced only on 'Added', so one line per
-                      -- distinct vote rather than per arrival: the same vote
-                      -- reaches us from every peer that has it, and those
-                      -- duplicates return 'AlreadyKnown' with no tally to
-                      -- report.
+                      -- A remote vote can be the one that tips this node's
+                      -- tally past the threshold, so certification is traced
+                      -- whenever 'addVote' surfaces a cert for the point.
                       case result of
-                        Added weight tally mCert -> do
+                        Added VoteTally{vtWeight, vtTally, vtThreshold} mCert -> do
                           traceWith kernelTracer $
-                            TraceLeiosTally
-                              { rbHash = Leios.announcingRbHash vote
-                              , seatId = Leios.voterId vote
-                              , weight
-                              , tally
-                              , threshold = Leios.minCertificationThreshold
+                            TraceLeiosVoteAcquired
+                              { vote
+                              , weight = vtWeight
+                              , tally = vtTally
+                              , threshold = vtThreshold
                               }
                           case mCert of
                             Just _ ->

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoTypes.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoTypes.hs
@@ -1394,6 +1394,25 @@ data TraceLeiosKernel
     TraceLeiosBlockCertified {atSlot :: SlotNo, certifiedPoint :: LeiosPoint}
   | TraceLeiosVoted {vote :: LeiosVote, weight :: Weight}
   | TraceLeiosVoteAcquired {vote :: LeiosVote}
+  | -- | The running per-point tally moved, i.e. a vote was newly added rather
+    -- than being a duplicate arrival. Emitted once per distinct vote, so the
+    -- max per 'RbHash' is that point's final accumulated weight, whether or not
+    -- it ever reached 'minCertificationThreshold'. That margin is otherwise
+    -- unobservable: only certified points reach the chain, so a point that
+    -- stalls below the threshold leaves no other trace of how close it came.
+    -- The adding voter and its own weight ride along so the line stands alone.
+    -- A consumer can then attribute the tally, and say what a seat that never
+    -- voted would have been worth, without a second source for seat weights.
+    -- 'seatId' rather than 'voterId': 'LeiosVote' already has a 'voterId'
+    -- field, and a second one in this module makes the qualified selector
+    -- ambiguous for importers.
+    TraceLeiosTally
+      { rbHash :: RbHash
+      , seatId :: LeiosSeatId
+      , weight :: Weight
+      , tally :: Weight
+      , threshold :: Weight
+      }
   | TraceLeiosCertified {rbHash :: RbHash}
   | -- | A vote is scheduled to happen.
     TraceLeiosVoteScheduled
@@ -1664,6 +1683,19 @@ traceLeiosKernelToObject = \case
     mconcat
       [ "kind" .= Aeson.String "LeiosVoteAcquired"
       , "vote" .= voteToObject vote
+      ]
+  TraceLeiosTally{rbHash = announcingRbHash, seatId, weight, tally, threshold} ->
+    mconcat
+      [ "kind" .= Aeson.String "LeiosTally"
+      , "rbHash" .= prettyRbHash announcingRbHash
+      , -- Rendered as voterId to match 'voteToObject', so consumers index one
+        -- name across the vote traces.
+        "voterId" .= seatId.leiosSeatIndex
+      , -- Same precision rationale as 'LeiosVoted' above.
+        "weight" .= fromRational @Pico weight
+      , "tally" .= fromRational @Pico tally
+      , -- Carried so the ratio is self-contained and survives a threshold change.
+        "threshold" .= fromRational @Pico threshold
       ]
   TraceLeiosCertified{rbHash = announcingRbHash} ->
     mconcat

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoTypes.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoTypes.hs
@@ -1393,23 +1393,22 @@ data TraceLeiosKernel
     -- forging/announcing anyways.
     TraceLeiosBlockCertified {atSlot :: SlotNo, certifiedPoint :: LeiosPoint}
   | TraceLeiosVoted {vote :: LeiosVote, weight :: Weight}
-  | TraceLeiosVoteAcquired {vote :: LeiosVote}
-  | -- | A vote was accepted for this point rather than rejected as a duplicate
+  | -- | A vote was accepted for its point rather than rejected as a duplicate
     -- arrival, carrying the running tally after the update. Emitted once per
-    -- accepted vote, so the max per 'RbHash' is that point's final accumulated
-    -- weight, whether or not it ever reached 'minCertificationThreshold'. That
-    -- margin is otherwise unobservable: only certified points reach the chain,
-    -- so a point that stalls below the threshold leaves no other trace of how
-    -- close it came. Note the tally does not necessarily move: a seat that
-    -- votes twice with distinct signatures replaces its own entry at the same
-    -- weight, so 'weight' identifies the accepted vote and is not summable
-    -- across lines. Read 'tally' for the total.
-    -- 'seatId' rather than 'voterId': 'LeiosVote' already has a 'voterId'
-    -- field, and a second one in this module makes the qualified selector
-    -- ambiguous for importers.
-    TraceLeiosTally
-      { rbHash :: RbHash
-      , seatId :: LeiosSeatId
+    -- accepted vote -- not once per arrival, since the same vote reaches us
+    -- from every peer holding it and those return 'AlreadyKnown'.
+    --
+    -- The max 'tally' per 'RbHash' is that point's final accumulated weight,
+    -- whether or not it ever reached the threshold. That margin is otherwise
+    -- unobservable: only certified points reach the chain, so a point that
+    -- stalls below the threshold leaves no other trace of how close it came.
+    --
+    -- The tally does not necessarily move: a seat that votes twice with
+    -- distinct signatures replaces its own entry at the same weight, so
+    -- 'weight' identifies the accepted vote and is not summable across lines.
+    -- Read 'tally' for the total.
+    TraceLeiosVoteAcquired
+      { vote :: LeiosVote
       , weight :: Weight
       , tally :: Weight
       , threshold :: Weight
@@ -1680,18 +1679,12 @@ traceLeiosKernelToObject = \case
         -- is reasonable precision here.
         "weight" .= fromRational @Pico weight
       ]
-  TraceLeiosVoteAcquired{vote} ->
+  TraceLeiosVoteAcquired{vote, weight, tally, threshold} ->
     mconcat
       [ "kind" .= Aeson.String "LeiosVoteAcquired"
-      , "vote" .= voteToObject vote
-      ]
-  TraceLeiosTally{rbHash = announcingRbHash, seatId, weight, tally, threshold} ->
-    mconcat
-      [ "kind" .= Aeson.String "LeiosTally"
-      , "rbHash" .= prettyRbHash announcingRbHash
-      , -- Rendered as voterId to match 'voteToObject', so consumers index one
-        -- name across the vote traces.
-        "voterId" .= seatId.leiosSeatIndex
+      , -- Carries rbHash and voterId, so the tally is indexable by point
+        -- without a second trace to join against.
+        "vote" .= voteToObject vote
       , -- Same precision rationale as 'LeiosVoted' above.
         "weight" .= fromRational @Pico weight
       , "tally" .= fromRational @Pico tally

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoTypes.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoTypes.hs
@@ -1394,15 +1394,16 @@ data TraceLeiosKernel
     TraceLeiosBlockCertified {atSlot :: SlotNo, certifiedPoint :: LeiosPoint}
   | TraceLeiosVoted {vote :: LeiosVote, weight :: Weight}
   | TraceLeiosVoteAcquired {vote :: LeiosVote}
-  | -- | The running per-point tally moved, i.e. a vote was newly added rather
-    -- than being a duplicate arrival. Emitted once per distinct vote, so the
-    -- max per 'RbHash' is that point's final accumulated weight, whether or not
-    -- it ever reached 'minCertificationThreshold'. That margin is otherwise
-    -- unobservable: only certified points reach the chain, so a point that
-    -- stalls below the threshold leaves no other trace of how close it came.
-    -- The adding voter and its own weight ride along so the line stands alone.
-    -- A consumer can then attribute the tally, and say what a seat that never
-    -- voted would have been worth, without a second source for seat weights.
+  | -- | A vote was accepted for this point rather than rejected as a duplicate
+    -- arrival, carrying the running tally after the update. Emitted once per
+    -- accepted vote, so the max per 'RbHash' is that point's final accumulated
+    -- weight, whether or not it ever reached 'minCertificationThreshold'. That
+    -- margin is otherwise unobservable: only certified points reach the chain,
+    -- so a point that stalls below the threshold leaves no other trace of how
+    -- close it came. Note the tally does not necessarily move: a seat that
+    -- votes twice with distinct signatures replaces its own entry at the same
+    -- weight, so 'weight' identifies the accepted vote and is not summable
+    -- across lines. Read 'tally' for the total.
     -- 'seatId' rather than 'voterId': 'LeiosVote' already has a 'voterId'
     -- field, and a second one in this module makes the qualified selector
     -- ambiguous for importers.

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosVoteState.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosVoteState.hs
@@ -53,10 +53,15 @@ data AddVoteResult
     -- The LeiosCert is 'Just' whenever that tally is at or above
     -- 'minCertificationThreshold'.
     --
+    -- Both fields are 'Weight', so transposing them at a construction or
+    -- destructuring site type checks and yields plausible but wrong telemetry.
+    -- Keep the order above when touching either this constructor or its three
+    -- use sites.
+    --
     -- The tally is surfaced rather than traced where it is computed because
-    -- 'addVote' runs inside 'atomically' and STM cannot trace. Callers emit it,
-    -- as they already do for certification.
-    Added Weight Weight (Maybe LeiosCert)
+    -- the update runs in STM, which cannot trace. Callers emit it, as they
+    -- already do for certification.
+    Added !Weight !Weight (Maybe LeiosCert)
   deriving (Eq, Show)
 
 data LeiosVoteSubscription m = LeiosVoteSubscription {getNextVote :: STM m LeiosVote}
@@ -66,6 +71,11 @@ data LeiosVoteSubscription m = LeiosVoteSubscription {getNextVote :: STM m Leios
 -- threshold is crossed.
 data PointState = PointState
   { psVoters :: !(Map LeiosSeatId (Weight, LeiosSignature))
+  , psTotal :: !Weight
+  -- ^ Running sum of 'psVoters' weights, maintained incrementally. Kept in the
+  -- state rather than recomputed per vote: summing the map is linear in the
+  -- committee, so recomputing made the per-point cost quadratic, and every
+  -- post-threshold vote paid it too once the tally started being reported.
   , psCert :: !(Maybe LeiosCert)
   -- ^ Assembled once when this point's total weight first reaches
   -- 'minCertificationThreshold'; reused for subsequent post-threshold
@@ -73,7 +83,7 @@ data PointState = PointState
   }
 
 emptyPointState :: PointState
-emptyPointState = PointState Map.empty Nothing
+emptyPointState = PointState Map.empty 0 Nothing
 
 -- | Create a new empty 'LeiosVoteState'.
 newLeiosVoteState ::
@@ -121,12 +131,17 @@ newLeiosVoteState getCommittee = do
                           -- threshold is crossed.
                           states <- readTVar pointStates
                           let pst = Map.findWithDefault emptyPointState vote.announcingRbHash states
-                              pst' =
-                                pst
-                                  { psVoters =
-                                      Map.insert vote.voterId (weight, vote.voteSignature) pst.psVoters
-                                  }
-                              totalW = sum [w | (w, _) <- Map.elems pst'.psVoters]
+                              -- 'Map.insert' replaces any entry this seat already
+                              -- had, so the running total must drop the old weight
+                              -- rather than simply adding the new one.
+                              (mOld, voters') =
+                                Map.insertLookupWithKey
+                                  (\_ new _old -> new)
+                                  vote.voterId
+                                  (weight, vote.voteSignature)
+                                  pst.psVoters
+                              totalW = pst.psTotal + weight - maybe 0 fst mOld
+                              pst' = pst{psVoters = voters', psTotal = totalW}
                               pst'' = case pst.psCert of
                                 Just _ -> pst'
                                 Nothing

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosVoteState.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosVoteState.hs
@@ -48,10 +48,15 @@ data AddVoteResult
   = NoCommittee
   | VoteInvalid VoteInvalid
   | AlreadyKnown
-  | -- | The vote was added to the state, with the running per-point weight
-    -- after this addition. The LeiosCert is 'Just' whenever the tally for the
-    -- vote's point is at or above 'minCertificationThreshold'.
-    Added Weight (Maybe LeiosCert)
+  | -- | The vote was added to the state. The first 'Weight' is this voter's own
+    -- weight; the second is the running per-point tally after this addition.
+    -- The LeiosCert is 'Just' whenever that tally is at or above
+    -- 'minCertificationThreshold'.
+    --
+    -- The tally is surfaced rather than traced where it is computed because
+    -- 'addVote' runs inside 'atomically' and STM cannot trace. Callers emit it,
+    -- as they already do for certification.
+    Added Weight Weight (Maybe LeiosCert)
   deriving (Eq, Show)
 
 data LeiosVoteSubscription m = LeiosVoteSubscription {getNextVote :: STM m LeiosVote}
@@ -139,7 +144,7 @@ newLeiosVoteState getCommittee = do
                                         Right cert -> pst'{psCert = Just cert}
                                   | otherwise -> pst'
                           writeTVar pointStates $! Map.insert vote.announcingRbHash pst'' states
-                          pure $ Added weight pst''.psCert
+                          pure $ Added weight totalW pst''.psCert
       , subscribeVotes = do
           chan <- atomically $ dupTChan votesChan
           pure $

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosVoteState.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosVoteState.hs
@@ -48,20 +48,30 @@ data AddVoteResult
   = NoCommittee
   | VoteInvalid VoteInvalid
   | AlreadyKnown
-  | -- | The vote was added to the state. The first 'Weight' is this voter's own
-    -- weight; the second is the running per-point tally after this addition.
-    -- The LeiosCert is 'Just' whenever that tally is at or above
-    -- 'minCertificationThreshold'.
-    --
-    -- Both fields are 'Weight', so transposing them at a construction or
-    -- destructuring site type checks and yields plausible but wrong telemetry.
-    -- Keep the order above when touching either this constructor or its three
-    -- use sites.
+  | -- | The vote was added to the state. The 'LeiosCert' is 'Just' whenever the
+    -- tally is at or above the quorum threshold in force.
     --
     -- The tally is surfaced rather than traced where it is computed because
     -- the update runs in STM, which cannot trace. Callers emit it, as they
     -- already do for certification.
-    Added !Weight !Weight (Maybe LeiosCert)
+    Added !VoteTally (Maybe LeiosCert)
+  deriving (Eq, Show)
+
+-- | What one accepted vote did to its point's tally.
+--
+-- A record rather than three positional 'Weight's: transposing any two of them
+-- at a construction or destructuring site would type check and yield plausible
+-- but wrong telemetry.
+data VoteTally = VoteTally
+  { vtWeight :: !Weight
+  -- ^ The accepted vote's own weight.
+  , vtTally :: !Weight
+  -- ^ Running per-point tally after this vote was counted.
+  , vtThreshold :: !Weight
+  -- ^ The quorum in force when the tally was taken. Carried alongside rather
+  -- than looked up by consumers because it comes from the committee that
+  -- validated this vote, and that committee turns over at epoch boundaries.
+  }
   deriving (Eq, Show)
 
 data LeiosVoteSubscription m = LeiosVoteSubscription {getNextVote :: STM m LeiosVote}
@@ -159,7 +169,14 @@ newLeiosVoteState getCommittee = do
                                         Right cert -> pst'{psCert = Just cert}
                                   | otherwise -> pst'
                           writeTVar pointStates $! Map.insert vote.announcingRbHash pst'' states
-                          pure $ Added weight totalW pst''.psCert
+                          pure $
+                            Added
+                              VoteTally
+                                { vtWeight = weight
+                                , vtTally = totalW
+                                , vtThreshold = threshold
+                                }
+                              pst''.psCert
       , subscribeVotes = do
           chan <- atomically $ dupTChan votesChan
           pure $

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosVoting.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosVoting.hs
@@ -49,6 +49,7 @@ import LeiosDemoTypes
   , SerializedEbBody
   , TraceLeiosKernel (..)
   , getLeiosSeatId
+  , minCertificationThreshold
   , prettyLeiosPoint
   , signLeiosVote
   )
@@ -355,9 +356,17 @@ runLeiosVoting tracer lcfg chainDB systemTime leiosDB txCache voteState = \case
           ExceptT $
             addVote vote
               >>= \case
-                Added weight mCert -> fmap Right $ do
+                Added weight tally mCert -> fmap Right $ do
                   traceWith tracer TraceLeiosVoted{vote, weight}
                   traceWith tracer TraceLeiosVoteAcquired{vote}
+                  traceWith tracer $
+                    TraceLeiosTally
+                      { rbHash
+                      , seatId
+                      , weight
+                      , tally
+                      , threshold = minCertificationThreshold
+                      }
                   -- Trace certification whenever the tally crosses
                   -- 'minCertificationThreshold'. May fire more than once per
                   -- point if subsequent votes also come in; consumers (e.g.

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosVoting.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosVoting.hs
@@ -49,12 +49,11 @@ import LeiosDemoTypes
   , SerializedEbBody
   , TraceLeiosKernel (..)
   , getLeiosSeatId
-  , minCertificationThreshold
   , prettyLeiosPoint
   , signLeiosVote
   )
 import LeiosTxCache (LeiosTxCache (..))
-import LeiosVoteState (AddVoteResult (..), LeiosVoteState (..))
+import LeiosVoteState (AddVoteResult (..), LeiosVoteState (..), VoteTally (..))
 import Ouroboros.Consensus.Block
   ( ConvertRawHash (..)
   , Point
@@ -356,16 +355,14 @@ runLeiosVoting tracer lcfg chainDB systemTime leiosDB txCache voteState = \case
           ExceptT $
             addVote vote
               >>= \case
-                Added weight tally mCert -> fmap Right $ do
-                  traceWith tracer TraceLeiosVoted{vote, weight}
-                  traceWith tracer TraceLeiosVoteAcquired{vote}
+                Added VoteTally{vtWeight, vtTally, vtThreshold} mCert -> fmap Right $ do
+                  traceWith tracer TraceLeiosVoted{vote, weight = vtWeight}
                   traceWith tracer $
-                    TraceLeiosTally
-                      { rbHash
-                      , seatId
-                      , weight
-                      , tally
-                      , threshold = minCertificationThreshold
+                    TraceLeiosVoteAcquired
+                      { vote
+                      , weight = vtWeight
+                      , tally = vtTally
+                      , threshold = vtThreshold
                       }
                   -- Trace certification whenever the tally crosses
                   -- 'minCertificationThreshold'. May fire more than once per

--- a/ouroboros-consensus/test/consensus-test/Test/LeiosVoteState.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/LeiosVoteState.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedRecordDot #-}
 
 module Test.LeiosVoteState (tests) where
@@ -32,6 +33,7 @@ import LeiosDemoTypes
   )
 import LeiosVoteState
   ( AddVoteResult (..)
+  , VoteTally (..)
   , addVote
   , getNextVote
   , newLeiosVoteState
@@ -295,5 +297,5 @@ prop_tallyAccumulates =
 -- | The own weight and running tally carried by 'Added', or 'Nothing' for any
 -- other result.
 addedWeights :: AddVoteResult -> Maybe (Weight, Weight)
-addedWeights (Added ownWeight tally _) = Just (ownWeight, tally)
+addedWeights (Added VoteTally{vtWeight, vtTally} _) = Just (vtWeight, vtTally)
 addedWeights _ = Nothing

--- a/ouroboros-consensus/test/consensus-test/Test/LeiosVoteState.hs
+++ b/ouroboros-consensus/test/consensus-test/Test/LeiosVoteState.hs
@@ -14,6 +14,8 @@ import Control.Concurrent.Class.MonadSTM.Strict
 import Control.Monad (forM_)
 import Control.Monad.Class.MonadTimer.SI (timeout)
 import Control.Monad.IOSim (runSimOrThrow)
+import Data.Function (on)
+import Data.List (nubBy)
 import Data.Maybe (fromJust, isJust, isNothing)
 import Data.Ratio ((%))
 import LeiosDemoTypes
@@ -46,6 +48,7 @@ import Test.QuickCheck
   , forAll
   , listOf1
   , property
+  , sublistOf
   , suchThat
   , (.&&.)
   , (===)
@@ -66,6 +69,7 @@ tests =
     , testProperty "no committee rejects vote" prop_noCommitteeRejected
     , testProperty "vote signed with key not on committee is rejected" prop_signerNotInCommittee
     , testProperty "certification follows the threshold parameter" prop_certificationFollowsThreshold
+    , testProperty "reported tally accumulates the reported weights" prop_tallyAccumulates
     ]
 
 -- | A 'VotingKey' that is *not* a member of the given committee.
@@ -251,3 +255,45 @@ votesForEverySeat c rbHash =
 -- | The weight a vote carries, as the committee accounts for it.
 voteWeight :: TestCommittee -> LeiosVote -> Weight
 voteWeight c vote = either (const 0) id $ validateLeiosVote c.committee vote
+
+-- | Votes for one point, one per distinct committee seat.
+--
+-- Deduplicated on seat rather than on key: two keys mapping to the same seat
+-- would have the second replace the first in the tally rather than add to it,
+-- which is a different property from the one below.
+genOneVotePerSeat :: TestCommittee -> RbHash -> Gen [LeiosVote]
+genOneVotePerSeat c rbHash = do
+  keys <- sublistOf c.allKeys `suchThat` (not . null)
+  pure [signLeiosVote key (seatOf key) rbHash | key <- nubBy ((==) `on` seatOf) keys]
+ where
+  seatOf key = fromJust $ getLeiosSeatId (deriveVerKeyDSIGN key) c.committee
+
+-- | The tally reported with each accepted vote must be the running sum of the
+-- individual weights reported so far.
+--
+-- This pins the incrementally maintained 'psTotal' against the sum over the
+-- voter map that it replaced. Nothing else in this suite asserts anything about
+-- the tally value, so without this a wrong total is invisible to the tests and
+-- shows up only as wrong telemetry.
+prop_tallyAccumulates :: Property
+prop_tallyAccumulates =
+  forAll genCommittee $ \testCommittee ->
+    forAll genRbHash $ \rbHash ->
+      forAll (genOneVotePerSeat testCommittee rbHash) $ \votes ->
+        property $ runSimOrThrow $ do
+          st <- newLeiosVoteState (pure (Just (testCommittee.committee, testQuorumThreshold)))
+          results <- mapM (addVote st) votes
+          pure $ case traverse addedWeights results of
+            Nothing ->
+              counterexample ("expected every add to be Added, got " ++ show results) False
+            Just weighted ->
+              let (ownWeights, tallies) = unzip weighted
+               in counterexample
+                    ("own weights " ++ show ownWeights ++ ", tallies " ++ show tallies)
+                    (tallies === scanl1 (+) ownWeights)
+
+-- | The own weight and running tally carried by 'Added', or 'Nothing' for any
+-- other result.
+addedWeights :: AddVoteResult -> Maybe (Weight, Weight)
+addedWeights (Added ownWeight tally _) = Just (ownWeight, tally)
+addedWeights _ = Nothing


### PR DESCRIPTION
Fixes various things on the prototype:
- https://github.com/IntersectMBO/ouroboros-consensus/pull/2256, but folded into `VoteAcquired` (instead of another trace)
- Drop the `Peer.Msg` trace that shows all the votes received (again)