### PR TITLE
Nice CBOR diffs for the golden files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,5 @@
 # GitHub Linguist annotations.
 # https://github.com/github-linguist/linguist/blob/master/docs/overrides.md
 
-ouroboros-consensus-cardano/golden/**/* linguist-generated=true
+ouroboros-consensus-cardano/golden/**/* linguist-generated=true diff=cbor
 docs/website/yarn.lock linguist-generated=true


### PR DESCRIPTION
`.gitattributes` marks the golden serialisation files as CBOR:

```gitattributes
ouroboros-consensus-cardano/golden/**/* linguist-generated=true diff=cbor
```

`diff=cbor` means "use the diff driver named `cbor`". Git does not ship one; each of us defines it locally. If you do nothing, the attribute is inert and you keep getting `Binary files ... differ`. If you set it up, you get a structural diff of the CBOR instead.

## Setup

### 1. `cbor-diag`

```bash
gem install --user-install cbor-diag
export PATH="$(ruby -e 'puts Gem.user_dir')/bin:$PATH"   # provides cbor2pretty.rb
```

### 2. The `cbor2pretty` wrapper

`cbor2pretty.rb` stops at the first level, which is a problem here: our golden files are full of CBOR-in-CBOR (a `tag(24)` wrapping a byte string that is itself a CBOR encoding, i.e. `Serialised`/annotated blobs), shown as an opaque hex string. This wrapper recursively expands those, indented to match the parent and prefixed with an arrow so you can tell the levels apart. Save as `~/.local/bin/cbor2pretty`, `chmod +x`:

```bash
#!/bin/bash

cbor2pretty.rb $1 | \
    awk -v q="'" -v dq="\"" '
BEGIN { a = 0 }

/tag\(24\)/ {a = 1}

/"/ {
  if (a == 1)
  { print $0;
    spaces = match($0,/[^ ]|$/)-1;
    cmd = "perl -E " q "say " dq " " dq " x " spaces q;
    cmd | getline spacess;
    close(cmd);
    system("perl -e " q "print pack " dq "H*" dq ", " dq $1 dq q " \
           | cbor2pretty.rb \
           | sed " q "s/^/@" spacess "/g" q);
    a = 0
  }
  else
  {
    print
  };
  next
}

{print}
'
```

(replace the `@` in the `sed` with whatever marker you like — a `U+2B5E ⭞` is what I use, it stands out without looking like CBOR output.)

### 3. The diff driver

In `~/.gitconfig`:

```gitconfig
[diff "cbor"]
    textconv = cbor2pretty
    cachetextconv = true
```

`cachetextconv` matters: the wrapper shells out to Ruby and Perl several times per file, so without caching `git log -p` gets slow.

## Result

```diff
@@ -1,5 +1,5 @@
 82                                  # array(2)
-   07                               # unsigned(7)
+   08                               # unsigned(8)
    d8 18                            # tag(24)
       4d                            # bytes(13)
          83a300d901028001800200a0f6 # "..."
```

with the nested payload expanded below it, so changes *inside* a `tag(24)` blob also show up structurally. Works for `git diff`, `show`, `log -p`, `add -p`, and composes with pagers like delta.

[cbor-diag]: https://github.com/cabo/cbor-diag
