### PR TITLE
Forge refactor

### DIFF
--- a/changelog.d/20260909_162112_drazen.popovic_forge_refactor.md
+++ b/changelog.d/20260909_162112_drazen.popovic_forge_refactor.md
@@ -1,0 +1,9 @@
+### Breaking
+
+- Replace the positional arguments of `Ouroboros.Consensus.Block.Forging.forgeBlock`
+  with a `ForgeBlockArgs blk` record.
+
+### Non-Breaking
+
+- Add module `Ouroboros.Consensus.NodeKernel.Forge` extracting the block-forging
+  logic from `Ouroboros.Consensus.NodeKernel`.

--- a/ouroboros-consensus-cardano/src/byron/Ouroboros/Consensus/Byron/Ledger/Forge.hs
+++ b/ouroboros-consensus-cardano/src/byron/Ouroboros/Consensus/Byron/Ledger/Forge.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE RecordWildCards #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Ouroboros.Consensus.Byron.Ledger.Forge
@@ -44,21 +45,8 @@ import Ouroboros.Consensus.Ledger.SupportsMempool
   )
 import Ouroboros.Consensus.Protocol.PBFT
 
-forgeByronBlock ::
-  HasCallStack =>
-  TopLevelConfig ByronBlock ->
-  -- | Current block number
-  BlockNo ->
-  -- | Current slot number
-  SlotNo ->
-  -- | Current ledger
-  TickedLedgerState ByronBlock mk ->
-  -- | Txs to include
-  [Validated (GenTx ByronBlock)] ->
-  -- | Leader proof ('IsLeader')
-  PBftIsLeader PBftByronCrypto ->
-  ByronBlock
-forgeByronBlock cfg = forgeRegularBlock (configBlock cfg)
+forgeByronBlock :: HasCallStack => ForgeBlockArgs ByronBlock -> ByronBlock
+forgeByronBlock = forgeRegularBlock
 
 forgeEBB ::
   BlockConfig ByronBlock ->
@@ -131,25 +119,17 @@ initBlockPayloads =
 
 forgeRegularBlock ::
   HasCallStack =>
-  BlockConfig ByronBlock ->
-  -- | Current block number
-  BlockNo ->
-  -- | Current slot number
-  SlotNo ->
-  -- | Current ledger
-  TickedLedgerState ByronBlock mk ->
-  -- | Txs to include
-  [Validated (GenTx ByronBlock)] ->
-  -- | Leader proof ('IsLeader')
-  PBftIsLeader PBftByronCrypto ->
+  ForgeBlockArgs ByronBlock ->
   ByronBlock
-forgeRegularBlock cfg bno sno st txs isLeader =
+forgeRegularBlock ForgeBlockArgs{..} =
   forge $
     forgePBftFields
       (mkByronContextDSIGN cfg)
-      isLeader
+      fbIsLeader
       (reAnnotate byronProtVer $ Annotated toSign ())
  where
+  cfg = configBlock fbConfig
+
   epochSlots :: CC.Slot.EpochSlots
   epochSlots = byronEpochSlots cfg
 
@@ -158,7 +138,7 @@ forgeRegularBlock cfg bno sno st txs isLeader =
     foldr
       extendBlockPayloads
       initBlockPayloads
-      txs
+      fbTxs
 
   txPayload :: CC.UTxO.TxPayload
   txPayload = CC.UTxO.mkTxPayload (bpTxs blockPayloads)
@@ -203,28 +183,28 @@ forgeRegularBlock cfg bno sno st txs isLeader =
   proof = CC.Block.mkProof body
 
   prevHeaderHash :: CC.Block.HeaderHash
-  prevHeaderHash = case getTipHash st of
+  prevHeaderHash = case getTipHash fbCurrentTickedLedgerState of
     GenesisHash ->
       error
         "the first block on the Byron chain must be an EBB"
     BlockHash (ByronHash h) -> h
 
   epochAndSlotCount :: CC.Slot.EpochAndSlotCount
-  epochAndSlotCount = CC.Slot.fromSlotNumber epochSlots (coerce sno)
+  epochAndSlotCount = CC.Slot.fromSlotNumber epochSlots (coerce fbCurrentSlotNo)
 
   toSign :: CC.Block.ToSign
   toSign =
     CC.Block.ToSign
       { CC.Block.tsHeaderHash = prevHeaderHash
       , CC.Block.tsSlot = epochAndSlotCount
-      , CC.Block.tsDifficulty = coerce bno
+      , CC.Block.tsDifficulty = coerce fbCurrentBlockNo
       , CC.Block.tsBodyProof = proof
       , CC.Block.tsProtocolVersion = byronProtocolVersion cfg
       , CC.Block.tsSoftwareVersion = byronSoftwareVersion cfg
       }
 
   dlgCertificate :: CC.Delegation.Certificate
-  dlgCertificate = pbftIsLeaderDlgCert isLeader
+  dlgCertificate = pbftIsLeaderDlgCert fbIsLeader
 
   headerGenesisKey :: Crypto.VerificationKey
   VerKeyByronDSIGN headerGenesisKey = dlgCertGenVerKey dlgCertificate
@@ -253,8 +233,8 @@ forgeRegularBlock cfg bno sno st txs isLeader =
       CC.Block.AHeader
         { CC.Block.aHeaderProtocolMagicId = ann (Crypto.getProtocolMagicId (byronProtocolMagic cfg))
         , CC.Block.aHeaderPrevHash = ann prevHeaderHash
-        , CC.Block.aHeaderSlot = ann (coerce sno)
-        , CC.Block.aHeaderDifficulty = ann (coerce bno)
+        , CC.Block.aHeaderSlot = ann (coerce fbCurrentSlotNo)
+        , CC.Block.aHeaderDifficulty = ann (coerce fbCurrentBlockNo)
         , CC.Block.headerProtocolVersion = byronProtocolVersion cfg
         , CC.Block.headerSoftwareVersion = byronSoftwareVersion cfg
         , CC.Block.aHeaderProof = ann proof

--- a/ouroboros-consensus-cardano/src/byron/Ouroboros/Consensus/Byron/Node.hs
+++ b/ouroboros-consensus-cardano/src/byron/Ouroboros/Consensus/Byron/Node.hs
@@ -141,8 +141,7 @@ byronBlockForging creds =
           canBeLeader
           slot
           tickedPBftState
-    , forgeBlock = \cfg bno slot _mbPerasCert st txs proof ->
-        return $ forgeByronBlock cfg bno slot st txs proof
+    , forgeBlock = return . forgeByronBlock
     , finalize = pure ()
     }
  where

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Forge.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Forge.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 -- TODO: Ledger has a few deprecations that we are ignoring for now
@@ -21,7 +22,7 @@ import Ouroboros.Consensus.Block
 import Ouroboros.Consensus.Config
 import Ouroboros.Consensus.Ledger.Abstract
 import Ouroboros.Consensus.Ledger.SupportsMempool
-import Ouroboros.Consensus.Protocol.Abstract (CanBeLeader, IsLeader)
+import Ouroboros.Consensus.Protocol.Abstract (CanBeLeader)
 import Ouroboros.Consensus.Protocol.Ledger.HotKey (HotKey)
 import Ouroboros.Consensus.Shelley.Ledger.Block
 import Ouroboros.Consensus.Shelley.Ledger.Config
@@ -40,54 +41,39 @@ import Ouroboros.Consensus.Shelley.Protocol.Abstract
 -------------------------------------------------------------------------------}
 
 forgeShelleyBlock ::
-  forall m era proto mk.
+  forall m era proto.
   (ShelleyCompatible proto era, Monad m) =>
   HotKey (ProtoCrypto proto) m ->
   CanBeLeader proto ->
-  TopLevelConfig (ShelleyBlock proto era) ->
-  -- | Current block number
-  BlockNo ->
-  -- | Current slot number
-  SlotNo ->
-  -- | Optional Peras certificate to include in the block
-  Maybe (PerasCert (ShelleyBlock proto era)) ->
-  -- | Current ledger
-  TickedLedgerState (ShelleyBlock proto era) mk ->
-  -- | Txs to include
-  [Validated (GenTx (ShelleyBlock proto era))] ->
-  IsLeader proto ->
+  ForgeBlockArgs (ShelleyBlock proto era) ->
   m (ShelleyBlock proto era)
 forgeShelleyBlock
   hotKey
   cbl
-  cfg
-  curNo
-  curSlot
-  _mbPerasCert -- Ignored for now
-  tickedLedger
-  txs
-  isLeader = do
-    hdr <-
-      mkHeader @_ @(ProtoCrypto proto)
-        hotKey
-        cbl
-        isLeader
-        curSlot
-        curNo
-        prevHash
-        (SL.hashBlockBody @era body)
-        actualBodySize
-        protocolVersion
-    let blk = mkShelleyBlock $ SL.Block hdr body
-    return $
-      assert (verifyBlockIntegrity (configSlotsPerKESPeriod $ configConsensus cfg) blk) $
-        blk
+  ForgeBlockArgs{..} =
+    do
+      hdr <-
+        mkHeader @_ @(ProtoCrypto proto)
+          hotKey
+          cbl
+          fbIsLeader
+          fbCurrentSlotNo
+          fbCurrentBlockNo
+          prevHash
+          (SL.hashBlockBody @era body)
+          actualBodySize
+          protocolVersion
+      let blk = mkShelleyBlock $ SL.Block hdr body
+      return $
+        assert (verifyBlockIntegrity (configSlotsPerKESPeriod $ configConsensus fbConfig) blk) $
+          blk
    where
-    protocolVersion = shelleyProtocolVersion $ configBlock cfg
+    protocolVersion = shelleyProtocolVersion $ configBlock fbConfig
 
     body =
       SL.mkBasicBlockBody
-        & SL.txSeqBlockBodyL .~ Seq.fromList (fmap extractTx txs)
+        & SL.txSeqBlockBodyL
+          .~ Seq.fromList (fmap extractTx fbTxs)
 
     actualBodySize = SL.blockBodySize protocolVersion body
 
@@ -99,4 +85,4 @@ forgeShelleyBlock
       toShelleyPrevHash @proto
         . castHash
         . getTipHash
-        $ tickedLedger
+        $ fbCurrentTickedLedgerState

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Node/Praos.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Node/Praos.hs
@@ -87,9 +87,6 @@ praosSharedBlockForging
           praosCheckCanForge
             (configConsensus cfg)
             curSlot
-      , forgeBlock =
-          forgeShelleyBlock
-            hotKey
-            canBeLeader
+      , forgeBlock = forgeShelleyBlock hotKey canBeLeader
       , finalize = HotKey.finalize hotKey
       }

--- a/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Node/TPraos.hs
+++ b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Node/TPraos.hs
@@ -120,10 +120,7 @@ shelleySharedBlockForging hotKey slotToPeriod credentials =
           (configConsensus cfg)
           forgingVRFHash
           curSlot
-    , forgeBlock =
-        forgeShelleyBlock
-          hotKey
-          canBeLeader
+    , forgeBlock = forgeShelleyBlock hotKey canBeLeader
     , finalize = HotKey.finalize hotKey
     }
  where

--- a/ouroboros-consensus-cardano/src/unstable-byron-testlib/Ouroboros/Consensus/ByronDual/Ledger.hs
+++ b/ouroboros-consensus-cardano/src/unstable-byron-testlib/Ouroboros/Consensus/ByronDual/Ledger.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
@@ -38,8 +39,6 @@ import Ouroboros.Consensus.Byron.Crypto.DSIGN
 import Ouroboros.Consensus.Byron.Ledger
 import Ouroboros.Consensus.Byron.Protocol
 import Ouroboros.Consensus.ByronSpec.Ledger
-import Ouroboros.Consensus.Config
-import Ouroboros.Consensus.Ledger.Abstract
 import Ouroboros.Consensus.Ledger.Dual
 import Ouroboros.Consensus.Protocol.PBFT
 import qualified Test.Cardano.Chain.Elaboration.Block as Spec.Test
@@ -212,19 +211,9 @@ bridgeTransactionIds =
 
 forgeDualByronBlock ::
   HasCallStack =>
-  TopLevelConfig DualByronBlock ->
-  -- | Current block number
-  BlockNo ->
-  -- | Current slot number
-  SlotNo ->
-  -- | Ledger
-  TickedLedgerState DualByronBlock mk ->
-  -- | Txs to add in the block
-  [Validated (GenTx DualByronBlock)] ->
-  -- | Leader proof ('IsLeader')
-  PBftIsLeader PBftByronCrypto ->
+  ForgeBlockArgs DualByronBlock ->
   DualByronBlock
-forgeDualByronBlock cfg curBlockNo curSlotNo tickedLedger vtxs isLeader =
+forgeDualByronBlock ForgeBlockArgs{..} =
   -- NOTE: We do not /elaborate/ the real Byron block from the spec one, but
   -- instead we /forge/ it. This is important, because we want to test that
   -- codepath. This does mean that we do not get any kind of "bridge" between
@@ -234,27 +223,30 @@ forgeDualByronBlock cfg curBlockNo curSlotNo tickedLedger vtxs isLeader =
   DualBlock
     { dualBlockMain = main
     , dualBlockAux = Just aux
-    , dualBlockBridge = mconcat $ map vDualGenTxBridge vtxs
+    , dualBlockBridge = mconcat $ map vDualGenTxBridge fbTxs
     }
  where
   main :: ByronBlock
   main =
-    forgeByronBlock
-      (dualTopLevelConfigMain cfg)
-      curBlockNo
-      curSlotNo
-      (tickedDualLedgerStateMain tickedLedger)
-      (map vDualGenTxMain vtxs)
-      isLeader
+    forgeByronBlock $
+      ForgeBlockArgs
+        { fbConfig = dualTopLevelConfigMain fbConfig
+        , fbCurrentBlockNo
+        , fbCurrentSlotNo
+        , fbPerasCert = Nothing -- Doesn't support Peras
+        , fbCurrentTickedLedgerState = tickedDualLedgerStateMain fbCurrentTickedLedgerState
+        , fbTxs = map vDualGenTxMain fbTxs
+        , fbIsLeader
+        }
 
   aux :: ByronSpecBlock
   aux =
     forgeByronSpecBlock
-      curBlockNo
-      curSlotNo
-      (tickedDualLedgerStateAux tickedLedger)
-      (map vDualGenTxAux vtxs)
+      fbCurrentBlockNo
+      fbCurrentSlotNo
+      (tickedDualLedgerStateAux fbCurrentTickedLedgerState)
+      (map vDualGenTxAux fbTxs)
       ( bridgeToSpecKey
-          (tickedDualLedgerStateBridge tickedLedger)
-          (hashVerKey . deriveVerKeyDSIGN . pbftIsLeaderSignKey $ isLeader)
+          (tickedDualLedgerStateBridge fbCurrentTickedLedgerState)
+          (hashVerKey . deriveVerKeyDSIGN . pbftIsLeaderSignKey $ fbIsLeader)
       )

--- a/ouroboros-consensus-cardano/src/unstable-byron-testlib/Ouroboros/Consensus/ByronDual/Node.hs
+++ b/ouroboros-consensus-cardano/src/unstable-byron-testlib/Ouroboros/Consensus/ByronDual/Node.hs
@@ -64,8 +64,7 @@ dualByronBlockForging creds =
     , updateForgeState = \cfg ->
         fmap castForgeStateUpdateInfo .: updateForgeState (dualTopLevelConfigMain cfg)
     , checkCanForge = checkCanForge . dualTopLevelConfigMain
-    , forgeBlock = \cfg slot bno _mbPerasCert lst txs proof ->
-        return $ forgeDualByronBlock cfg slot bno lst txs proof
+    , forgeBlock = return . forgeDualByronBlock
     , finalize = return ()
     }
  where

--- a/ouroboros-consensus-cardano/src/unstable-byron-testlib/Test/Consensus/Byron/Examples.hs
+++ b/ouroboros-consensus-cardano/src/unstable-byron-testlib/Test/Consensus/Byron/Examples.hs
@@ -7,7 +7,8 @@
 
 module Test.Consensus.Byron.Examples
   ( -- * Setup
-    cfg
+    topLevelConfig
+  , blockConfig
   , codecConfig
   , leaderCredentials
   , ledgerConfig
@@ -37,7 +38,9 @@ import qualified Data.Map.Strict as Map
 import Ouroboros.Consensus.Block
 import Ouroboros.Consensus.Byron.Crypto.DSIGN (SignKeyDSIGN (..))
 import Ouroboros.Consensus.Byron.Ledger
-import Ouroboros.Consensus.Byron.Node (ByronLeaderCredentials (..))
+import Ouroboros.Consensus.Byron.Node
+  ( ByronLeaderCredentials (..)
+  )
 import Ouroboros.Consensus.Config
 import Ouroboros.Consensus.HeaderValidation
 import Ouroboros.Consensus.Ledger.Abstract
@@ -45,6 +48,9 @@ import Ouroboros.Consensus.Ledger.Extended
 import Ouroboros.Consensus.Ledger.Peras (initPerasState)
 import Ouroboros.Consensus.Ledger.Query
 import Ouroboros.Consensus.Ledger.Tables.Utils
+import Ouroboros.Consensus.Node.ProtocolInfo
+  ( NumCoreNodes (NumCoreNodes)
+  )
 import Ouroboros.Consensus.NodeId
 import Ouroboros.Consensus.Protocol.Abstract
 import Ouroboros.Consensus.Protocol.PBFT
@@ -55,6 +61,7 @@ import qualified Test.Cardano.Chain.Common.Example as CC
 import qualified Test.Cardano.Chain.Genesis.Dummy as CC
 import qualified Test.Cardano.Chain.UTxO.Example as CC
 import qualified Test.Cardano.Chain.Update.Example as CC
+import Test.ThreadNet.Infra.Byron.Genesis (byronPBftParams)
 import Test.ThreadNet.Infra.Byron.ProtocolInfo (mkLeaderCredentials)
 import Test.Util.Serialisation.Examples
   ( Examples (Examples)
@@ -78,8 +85,22 @@ secParam = SecurityParam $ knownNonZeroBounded @2
 windowSize :: S.WindowSize
 windowSize = S.WindowSize 2
 
-cfg :: BlockConfig ByronBlock
-cfg =
+topLevelConfig :: TopLevelConfig ByronBlock
+topLevelConfig =
+  TopLevelConfig
+    { topLevelConfigProtocol = pbftConfig
+    , topLevelConfigLedger = CC.dummyConfig
+    , topLevelConfigBlock = blockConfig
+    , topLevelConfigCodec = codecConfig
+    , topLevelConfigStorage = ByronStorageConfig blockConfig
+    , topLevelConfigCheckpoints = emptyCheckpointsMap
+    }
+
+pbftConfig :: ConsensusConfig (PBft c)
+pbftConfig = PBftConfig{pbftParams = byronPBftParams secParam (NumCoreNodes 1)}
+
+blockConfig :: BlockConfig ByronBlock
+blockConfig =
   ByronConfig
     { byronGenesisConfig = CC.dummyConfig
     , byronProtocolVersion = CC.exampleProtocolVersion
@@ -132,13 +153,18 @@ examples =
 
 exampleBlock :: ByronBlock
 exampleBlock =
-  forgeRegularBlock
-    cfg
-    (BlockNo 1)
-    (SlotNo 1)
-    (applyChainTick OmitLedgerEvents ledgerConfig (SlotNo 1) (forgetLedgerTables ledgerStateAfterEBB))
-    [ValidatedByronTx exampleGenTx]
-    (fakeMkIsLeader leaderCredentials)
+  forgeRegularBlock $
+    ForgeBlockArgs
+      { fbConfig = topLevelConfig
+      , fbCurrentBlockNo = BlockNo 1
+      , fbCurrentSlotNo = SlotNo 1
+      , fbPerasCert = Nothing -- Doesn't support Peras
+      , fbCurrentTickedLedgerState =
+          forgetLedgerTables $
+            applyChainTick OmitLedgerEvents ledgerConfig (SlotNo 1) (forgetLedgerTables ledgerStateAfterEBB)
+      , fbTxs = [ValidatedByronTx exampleGenTx]
+      , fbIsLeader = fakeMkIsLeader leaderCredentials
+      }
  where
   -- \| Normally, we'd have to use 'checkIsLeader' to produce this proof.
   fakeMkIsLeader (ByronLeaderCredentials signKey dlgCert _ _) =
@@ -148,7 +174,7 @@ exampleBlock =
       }
 
 exampleEBB :: ByronBlock
-exampleEBB = forgeEBB cfg (SlotNo 0) (BlockNo 0) GenesisHash
+exampleEBB = forgeEBB blockConfig (SlotNo 0) (BlockNo 0) GenesisHash
 
 exampleSerialisedBlock :: Serialised ByronBlock
 exampleSerialisedBlock = Serialised "<BLOCK>"

--- a/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBSynthesizer/Forging.hs
+++ b/ouroboros-consensus-cardano/src/unstable-cardano-tools/Cardano/Tools/DBSynthesizer/Forging.hs
@@ -26,6 +26,7 @@ import Data.Word (Word64)
 import Ouroboros.Consensus.Block.Abstract as Block
 import Ouroboros.Consensus.Block.Forging as Block
   ( BlockForging (..)
+  , ForgeBlockArgs (..)
   , ShouldForge (..)
   , checkShouldForge
   )
@@ -228,13 +229,15 @@ runForge epochSize_ nextSlot opts chainDB blockForging cfg genTxs = do
       lift $
         Block.forgeBlock
           blockForging'
-          cfg
-          bcBlockNo
-          currentSlot
-          Nothing -- DBSynthesizer does not include Peras certs in blocks for now
-          (forgetLedgerTables tickedLedgerState)
-          txs
-          proof
+          Block.ForgeBlockArgs
+            { Block.fbConfig = cfg
+            , Block.fbCurrentBlockNo = bcBlockNo
+            , Block.fbCurrentSlotNo = currentSlot
+            , Block.fbPerasCert = Nothing -- DBSynthesizer does not include Peras certs in blocks for now
+            , Block.fbCurrentTickedLedgerState = forgetLedgerTables tickedLedgerState
+            , Block.fbTxs = txs
+            , Block.fbIsLeader = proof
+            }
 
     -- Add the block to the chain DB (synchronously) and verify adoption
     let noPunish = InvalidBlockPunishment.noPunishment

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
@@ -599,29 +599,7 @@ forkBlockForging IS{..} (MkBlockForging blockForgingM) =
 
           trace $ TraceLedgerState currentSlot bcPrevPoint
 
-          -- We require the ticked ledger view in order to construct the ticked
-          -- 'ChainDepState'.
-          ledgerView <-
-            case runExcept $
-              forecastFor
-                ( ledgerViewForecastAt
-                    (configLedger cfg)
-                    (ledgerState unticked)
-                )
-                currentSlot of
-              Left err -> do
-                -- There are so many empty slots between the tip of our chain and the
-                -- current slot that we cannot get an ledger view anymore In
-                -- principle, this is no problem; we can still produce a block (we use
-                -- the ticked ledger state). However, we probably don't /want/ to
-                -- produce a block in this case; we are most likely missing a blocks
-                -- on our chain.
-                trace $ TraceNoLedgerView currentSlot err
-                exitEarly
-              Right lv ->
-                return lv
-
-          trace $ TraceLedgerView currentSlot
+          ledgerView <- getLedgerView trace cfg currentSlot unticked
 
           -- Tick the 'ChainDepState' for the 'SlotNo' we're producing a block for. We
           -- only need the ticked 'ChainDepState' to check the whether we're a leader.
@@ -910,6 +888,39 @@ addBlockToChainDB trace chainDB mempool currentSlot txs newBlock = do
     -- block, i.e., the @HasTxs@ class, is not implementable by all blocks,
     -- e.g., @DualBlock@.
     trace $ TraceAdoptedBlock currentSlot newBlock txs
+
+-- | Obtain the ticked ledger view for 'currentSlot', required in order to
+-- construct the ticked 'ChainDepState'.
+getLedgerView ::
+  (IOLike m, RunNode blk) =>
+  (TraceForgeEvent blk -> WithEarlyExit m ()) ->
+  TopLevelConfig blk ->
+  SlotNo ->
+  ExtLedgerState blk EmptyMK ->
+  WithEarlyExit m (LedgerView (BlockProtocol blk))
+getLedgerView trace cfg currentSlot unticked = do
+  ledgerView <-
+    case runExcept $
+      forecastFor
+        ( ledgerViewForecastAt
+            (configLedger cfg)
+            (ledgerState unticked)
+        )
+        currentSlot of
+      Left err -> do
+        -- There are so many empty slots between the tip of our chain and the
+        -- current slot that we cannot get an ledger view anymore In
+        -- principle, this is no problem; we can still produce a block (we use
+        -- the ticked ledger state). However, we probably don't /want/ to
+        -- produce a block in this case; we are most likely missing blocks
+        -- on our chain.
+        trace $ TraceNoLedgerView currentSlot err
+        exitEarly
+      Right lv ->
+        return lv
+
+  trace $ TraceLedgerView currentSlot
+  pure ledgerView
 
 {-------------------------------------------------------------------------------
   TxSubmission integration

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
@@ -572,7 +572,13 @@ forkBlockForging IS{..} (MkBlockForging blockForgingM) =
 
   go :: BlockForging m blk -> SlotNo -> WithEarlyExit m ()
   go blockForging currentSlot = do
-    trace blockForging $ TraceStartLeadershipCheck currentSlot
+    let trace :: TraceForgeEvent blk -> WithEarlyExit m ()
+        trace =
+          lift
+            . traceWith (forgeTracer tracers)
+            . TraceLabelCreds (forgeLabel blockForging)
+
+    trace $ TraceStartLeadershipCheck currentSlot
 
     -- Figure out which block to connect to
     --
@@ -587,10 +593,10 @@ forkBlockForging IS{..} (MkBlockForging blockForgingM) =
       case eBlkCtx of
         Right blkCtx -> return blkCtx
         Left failure -> do
-          trace blockForging failure
+          trace failure
           exitEarly
 
-    trace blockForging $ TraceBlockContext currentSlot bcBlockNo bcPrevPoint
+    trace $ TraceBlockContext currentSlot bcBlockNo bcPrevPoint
 
     -- Get forker corresponding to bcPrevPoint
     --
@@ -601,12 +607,12 @@ forkBlockForging IS{..} (MkBlockForging blockForgingM) =
     (txs, txssz, proof, snapSize, tickedLedgerState, forgingOnTopOf) <-
       ChainDB.withReadOnlyForkerAtPoint chainDB (SpecificPoint bcPrevPoint) $ \case
         Left _ -> do
-          trace blockForging $ TraceNoLedgerState currentSlot bcPrevPoint
+          trace $ TraceNoLedgerState currentSlot bcPrevPoint
           exitEarly
         Right forker -> do
           unticked <- lift $ atomically $ LedgerDB.roforkerGetLedgerState forker
 
-          trace blockForging $ TraceLedgerState currentSlot bcPrevPoint
+          trace $ TraceLedgerState currentSlot bcPrevPoint
 
           -- We require the ticked ledger view in order to construct the ticked
           -- 'ChainDepState'.
@@ -625,12 +631,12 @@ forkBlockForging IS{..} (MkBlockForging blockForgingM) =
                 -- the ticked ledger state). However, we probably don't /want/ to
                 -- produce a block in this case; we are most likely missing a blocks
                 -- on our chain.
-                trace blockForging $ TraceNoLedgerView currentSlot err
+                trace $ TraceNoLedgerView currentSlot err
                 exitEarly
               Right lv ->
                 return lv
 
-          trace blockForging $ TraceLedgerView currentSlot
+          trace $ TraceLedgerView currentSlot
 
           -- Tick the 'ChainDepState' for the 'SlotNo' we're producing a block for. We
           -- only need the ticked 'ChainDepState' to check the whether we're a leader.
@@ -658,18 +664,18 @@ forkBlockForging IS{..} (MkBlockForging blockForgingM) =
                   tickedChainDepState
             case shouldForge of
               ForgeStateUpdateError err -> do
-                trace blockForging $ TraceForgeStateUpdateError currentSlot err
+                trace $ TraceForgeStateUpdateError currentSlot err
                 exitEarly
               CannotForge cannotForge -> do
-                trace blockForging $ TraceNodeCannotForge currentSlot cannotForge
+                trace $ TraceNodeCannotForge currentSlot cannotForge
                 exitEarly
               NotLeader -> do
-                trace blockForging $ TraceNodeNotLeader currentSlot
+                trace $ TraceNodeNotLeader currentSlot
                 exitEarly
               ShouldForge p -> return p
 
           -- At this point we have established that we are indeed slot leader
-          trace blockForging $ TraceNodeIsLeader currentSlot
+          trace $ TraceNodeIsLeader currentSlot
 
           -- Tick the ledger state for the 'SlotNo' we're producing a block for
           let tickedLedgerState :: Ticked LedgerState blk DiffMK
@@ -681,7 +687,7 @@ forkBlockForging IS{..} (MkBlockForging blockForgingM) =
                   (ledgerState unticked)
 
           _ <- evaluate tickedLedgerState
-          trace blockForging $ TraceForgeTickedLedgerState currentSlot bcPrevPoint
+          trace $ TraceForgeTickedLedgerState currentSlot bcPrevPoint
 
           -- Get a snapshot of the mempool that is consistent with the ledger
           --
@@ -712,7 +718,7 @@ forkBlockForging IS{..} (MkBlockForging blockForgingM) =
           _ <- evaluate (length txs)
           _ <- evaluate mempoolHash
 
-          trace blockForging $ TraceForgingMempoolSnapshot currentSlot bcPrevPoint mempoolHash mempoolSlotNo
+          trace $ TraceForgingMempoolSnapshot currentSlot bcPrevPoint mempoolHash mempoolSlotNo
 
           pure
             ( txs
@@ -736,7 +742,7 @@ forkBlockForging IS{..} (MkBlockForging blockForgingM) =
           txs
           proof
 
-    trace blockForging $
+    trace $
       TraceForgedBlock
         currentSlot
         forgingOnTopOf
@@ -767,9 +773,9 @@ forkBlockForging IS{..} (MkBlockForging blockForgingM) =
                 <$> ChainDB.getIsInvalidBlock chainDB
         case isInvalid of
           Nothing ->
-            trace blockForging $ TraceDidntAdoptBlock currentSlot newBlock
+            trace $ TraceDidntAdoptBlock currentSlot newBlock
           Just reason -> do
-            trace blockForging $ TraceForgedInvalidBlock currentSlot newBlock reason
+            trace $ TraceForgedInvalidBlock currentSlot newBlock reason
             -- We just produced a block that is invalid according to the
             -- ledger in the ChainDB, while the mempool said it is valid.
             -- There is an inconsistency between the two!
@@ -793,13 +799,7 @@ forkBlockForging IS{..} (MkBlockForging blockForgingM) =
       -- assert this here because the ability to extract transactions from a
       -- block, i.e., the @HasTxs@ class, is not implementable by all blocks,
       -- e.g., @DualBlock@.
-      trace blockForging $ TraceAdoptedBlock currentSlot newBlock txs
-
-  trace :: BlockForging m blk -> TraceForgeEvent blk -> WithEarlyExit m ()
-  trace blockForging =
-    lift
-      . traceWith (forgeTracer tracers)
-      . TraceLabelCreds (forgeLabel blockForging)
+      trace $ TraceAdoptedBlock currentSlot newBlock txs
 
 -- | Context required to forge a block
 data BlockContext blk = BlockContext

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
@@ -601,16 +601,7 @@ forkBlockForging IS{..} (MkBlockForging blockForgingM) =
 
           ledgerView <- getLedgerView trace cfg currentSlot unticked
 
-          -- Tick the 'ChainDepState' for the 'SlotNo' we're producing a block for. We
-          -- only need the ticked 'ChainDepState' to check the whether we're a leader.
-          -- This is much cheaper than ticking the entire 'ExtLedgerState'.
-          let tickedChainDepState :: Ticked (ChainDepState (BlockProtocol blk))
-              tickedChainDepState =
-                tickChainDepState
-                  (configConsensus cfg)
-                  ledgerView
-                  currentSlot
-                  (headerStateChainDep (headerState unticked))
+          let tickedChainDepState = getTickedChainDepState cfg currentSlot unticked ledgerView
 
           -- Check if we are the leader
           proof <- do
@@ -921,6 +912,23 @@ getLedgerView trace cfg currentSlot unticked = do
 
   trace $ TraceLedgerView currentSlot
   pure ledgerView
+
+getTickedChainDepState ::
+  RunNode blk =>
+  TopLevelConfig blk ->
+  SlotNo ->
+  ExtLedgerState blk EmptyMK ->
+  LedgerView (BlockProtocol blk) ->
+  Ticked (ChainDepState (BlockProtocol blk))
+getTickedChainDepState cfg currentSlot unticked ledgerView =
+  -- Tick the 'ChainDepState' for the 'SlotNo' we're producing a block for. We
+  -- only need the ticked 'ChainDepState' to check whether we're a leader.
+  -- This is much cheaper than ticking the entire 'ExtLedgerState'.
+  tickChainDepState
+    (configConsensus cfg)
+    ledgerView
+    currentSlot
+    (headerStateChainDep (headerState unticked))
 
 {-------------------------------------------------------------------------------
   TxSubmission integration

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
@@ -5,7 +5,6 @@
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
 
 module Ouroboros.Consensus.NodeKernel
   ( -- * Node kernel
@@ -38,7 +37,6 @@ import qualified Control.Concurrent.Class.MonadSTM.Strict as StrictSTM
 import Control.DeepSeq (force)
 import Control.Monad
 import qualified Control.Monad.Class.MonadTimer.SI as SI
-import Control.Monad.Except
 import Control.ResourceRegistry
 import Control.Tracer
 import Data.Bifunctor (second)
@@ -49,27 +47,19 @@ import Data.Function (on)
 import Data.Functor ((<&>))
 import Data.Hashable (Hashable)
 import Data.List.NonEmpty (NonEmpty)
-import qualified Data.List.NonEmpty as NE
-import Data.Maybe (isJust)
-import Data.Proxy
 import Data.Set (Set)
 import qualified Data.Text as Text
 import Data.Void (Void)
 import Ouroboros.Consensus.Block hiding (blockMatchesHeader)
-import qualified Ouroboros.Consensus.Block as Block
 import Ouroboros.Consensus.BlockchainTime
 import Ouroboros.Consensus.Config
-import Ouroboros.Consensus.Forecast
 import Ouroboros.Consensus.Genesis.Governor (gddWatcher)
 import Ouroboros.Consensus.HeaderValidation
 import Ouroboros.Consensus.Ledger.Abstract
 import Ouroboros.Consensus.Ledger.Extended
 import Ouroboros.Consensus.Ledger.SupportsMempool
 import Ouroboros.Consensus.Ledger.SupportsPeerSelection
-import Ouroboros.Consensus.Ledger.SupportsProtocol
-import Ouroboros.Consensus.Ledger.Tables.Utils (forgetLedgerTables)
 import Ouroboros.Consensus.Mempool
-import Ouroboros.Consensus.Mempool.API (TxMeasureWithDiffTime)
 import qualified Ouroboros.Consensus.MiniProtocol.BlockFetch.ClientInterface as BlockFetchClientInterface
 import Ouroboros.Consensus.MiniProtocol.ChainSync.Client
   ( ChainSyncClientHandle (..)
@@ -93,18 +83,14 @@ import Ouroboros.Consensus.Node.Genesis
   )
 import Ouroboros.Consensus.Node.Run
 import Ouroboros.Consensus.Node.Tracers
+import Ouroboros.Consensus.NodeKernel.Forge (forge)
 import Ouroboros.Consensus.Protocol.Abstract
 import Ouroboros.Consensus.Storage.ChainDB.API
-  ( AddBlockResult (..)
-  , ChainDB
+  ( ChainDB
   )
 import qualified Ouroboros.Consensus.Storage.ChainDB.API as ChainDB
-import qualified Ouroboros.Consensus.Storage.ChainDB.API.Types.InvalidBlockPunishment as InvalidBlockPunishment
 import Ouroboros.Consensus.Storage.ChainDB.Init (InitChainDB)
 import qualified Ouroboros.Consensus.Storage.ChainDB.Init as InitChainDB
-import Ouroboros.Consensus.Storage.LedgerDB
-import qualified Ouroboros.Consensus.Storage.LedgerDB as LedgerDB
-import Ouroboros.Consensus.Util (whenJust)
 import Ouroboros.Consensus.Util.AnchoredFragment
   ( preferAnchoredCandidate
   )
@@ -115,10 +101,6 @@ import Ouroboros.Consensus.Util.LeakyBucket
   )
 import Ouroboros.Consensus.Util.Orphans ()
 import Ouroboros.Consensus.Util.STM
-import Ouroboros.Network.AnchoredFragment
-  ( AnchoredFragment
-  , AnchoredSeq (..)
-  )
 import qualified Ouroboros.Network.AnchoredFragment as AF
 import Ouroboros.Network.Block (castTip, tipFromHeader)
 import Ouroboros.Network.BlockFetch
@@ -139,7 +121,6 @@ import Ouroboros.Network.PeerSharing
   , ps_POLICY_PEER_SHARE_MAX_PEERS
   , ps_POLICY_PEER_SHARE_STICKY_TIME
   )
-import Ouroboros.Network.Protocol.LocalStateQuery.Type (Target (..))
 import Ouroboros.Network.TxSubmission.Inbound.V1
   ( TxSubmissionInitDelay
   , TxSubmissionMempoolWriter
@@ -560,7 +541,16 @@ forkBlockForging IS{..} (MkBlockForging blockForgingM) =
     blockForgingMLabel
     finalize
     ( \bf -> knownSlotWatcher btime $
-        \currentSlot -> withEarlyExit_ $ go bf currentSlot
+        \currentSlot ->
+          withEarlyExit_ $
+            forge
+              (forgeTracer tracers)
+              (forgeStateInfoTracer tracers)
+              cfg
+              chainDB
+              mempool
+              bf
+              currentSlot
     )
  where
   label :: String
@@ -570,423 +560,6 @@ forkBlockForging IS{..} (MkBlockForging blockForgingM) =
     bf <- blockForgingM
     labelThisThread $ Text.unpack $ forgeLabel bf
     pure bf
-
-  go :: BlockForging m blk -> SlotNo -> WithEarlyExit m ()
-  go blockForging currentSlot = do
-    let trace :: TraceForgeEvent blk -> WithEarlyExit m ()
-        trace =
-          lift
-            . traceWith (forgeTracer tracers)
-            . TraceLabelCreds (forgeLabel blockForging)
-
-    trace $ TraceStartLeadershipCheck currentSlot
-
-    BlockContext{bcBlockNo, bcPrevPoint} <- getBlockContext trace chainDB currentSlot
-    trace $ TraceBlockContext currentSlot bcBlockNo bcPrevPoint
-
-    -- Get forker corresponding to bcPrevPoint
-    --
-    -- This might fail if, in between choosing 'bcPrevPoint' and this call to
-    -- 'ChainDB.withReadOnlyForkerAtPoint', we switched to a fork where 'bcPrevPoint'
-    -- is no longer on our chain. When that happens, we simply give up on the
-    -- chance to produce a block.
-    (txs, txssz, proof, snapSize, tickedLedgerState, forgingOnTopOf) <-
-      ChainDB.withReadOnlyForkerAtPoint chainDB (SpecificPoint bcPrevPoint) $ \case
-        Left _ -> do
-          trace $ TraceNoLedgerState currentSlot bcPrevPoint
-          exitEarly
-        Right forker -> do
-          unticked <- lift $ atomically $ LedgerDB.roforkerGetLedgerState forker
-
-          trace $ TraceLedgerState currentSlot bcPrevPoint
-
-          ledgerView <- getLedgerView trace cfg currentSlot unticked
-
-          tickedChainDepState <- getTickedChainDepState cfg currentSlot unticked ledgerView
-
-          proof <-
-            getIsLeaderProof
-              trace
-              (forgeStateInfoTracer tracers)
-              blockForging
-              cfg
-              currentSlot
-              tickedChainDepState
-
-          tickedLedgerState <- getTickedLedgerState trace cfg currentSlot bcPrevPoint unticked
-
-          traceForgingMempoolSnapshot trace mempool currentSlot bcPrevPoint
-
-          (txs, txssz, snapSize) <- getTransactionsToForge cfg mempool currentSlot tickedLedgerState forker
-
-          pure
-            ( txs
-            , txssz
-            , proof
-            , snapSize
-            , forgetLedgerTables tickedLedgerState
-            , ledgerTipPoint (ledgerState unticked)
-            )
-
-    -- Actually produce the block
-    newBlock <-
-      lift $
-        Block.forgeBlock
-          blockForging
-          cfg
-          bcBlockNo
-          currentSlot
-          Nothing -- No PerasCert for now
-          tickedLedgerState
-          txs
-          proof
-
-    trace $
-      TraceForgedBlock
-        currentSlot
-        forgingOnTopOf
-        newBlock
-        snapSize
-        txssz
-
-    addBlockToChainDB trace chainDB mempool currentSlot txs newBlock
-
--- | Context required to forge a block
-data BlockContext blk = BlockContext
-  { bcBlockNo :: !BlockNo
-  -- ^ the block number of the block to be forged
-  , bcPrevPoint :: !(Point blk)
-  -- ^ the point of /the predecessor of/ the block
-  --
-  -- Note that a block/header stores the hash of its predecessor but not the
-  -- slot.
-  }
-
--- | Figure out which block to connect to
---
--- Normally this will be the current block at the tip, but it may be the
--- /previous/ block, if there were multiple slot leaders
-getBlockContext ::
-  (IOLike m, RunNode blk) =>
-  (TraceForgeEvent blk -> WithEarlyExit m ()) ->
-  ChainDB m blk ->
-  SlotNo ->
-  WithEarlyExit m (BlockContext blk)
-getBlockContext trace chainDB currentSlot = do
-  eBlkCtx <-
-    lift $
-      atomically $
-        mkCurrentBlockContext currentSlot
-          <$> ChainDB.getCurrentChain chainDB
-  case eBlkCtx of
-    Right blkCtx -> return blkCtx
-    Left failure -> do
-      trace failure
-      exitEarly
-
--- | Create the 'BlockContext' from the header of the previous block
-blockContextFromPrevHeader ::
-  HasHeader (Header blk) =>
-  Header blk -> BlockContext blk
-blockContextFromPrevHeader hdr =
-  -- Recall that an EBB has the same block number as its predecessor, so this
-  -- @succ@ is even correct when @hdr@ is an EBB.
-  BlockContext (succ (blockNo hdr)) (headerPoint hdr)
-
--- | Determine the 'BlockContext' for a block about to be forged from the
--- current slot, ChainDB chain fragment, and ChainDB tip block number
---
--- The 'bcPrevPoint' will either refer to the header at the tip of the current
--- chain or, in case there is already a block in this slot (e.g. another node
--- was also elected leader and managed to produce a block before us), the tip's
--- predecessor. If the chain is empty, then it will refer to the chain's anchor
--- point, which may be genesis.
-mkCurrentBlockContext ::
-  forall blk.
-  RunNode blk =>
-  -- | the current slot, i.e. the slot of the block about to be forged
-  SlotNo ->
-  -- | the current chain fragment
-  --
-  -- Recall that the anchor point is the tip of the ImmutableDB.
-  AnchoredFragment (Header blk) ->
-  -- | the event records the cause of the failure
-  Either (TraceForgeEvent blk) (BlockContext blk)
-mkCurrentBlockContext currentSlot c = case c of
-  Empty AF.AnchorGenesis ->
-    -- The chain is entirely empty.
-    Right $ BlockContext (expectedFirstBlockNo (Proxy @blk)) GenesisPoint
-  Empty (AF.Anchor anchorSlot anchorHash anchorBlockNo) ->
-    let p :: Point blk = BlockPoint anchorSlot anchorHash
-     in if anchorSlot < currentSlot
-          then Right $ BlockContext (succ anchorBlockNo) p
-          else Left $ TraceSlotIsImmutable currentSlot p anchorBlockNo
-  c' :> hdr -> case blockSlot hdr `compare` currentSlot of
-    -- The block at the tip of our chain has a slot number /before/ the
-    -- current slot number. This is the common case, and we just want to
-    -- connect our new block to the block at the tip.
-    LT -> Right $ blockContextFromPrevHeader hdr
-    -- The block at the tip of our chain has a slot that lies in the
-    -- future. Although the chain DB should not contain blocks from the
-    -- future, if the volatile DB contained such blocks on startup
-    -- (due to a node clock misconfiguration) this invariant may be
-    -- violated. See: https://github.com/IntersectMBO/ouroboros-consensus/blob/main/docs/website/contents/for-developers/HandlingBlocksFromTheFuture.md#handling-blocks-from-the-future
-    -- Also note that if the
-    -- system is under heavy load, it is possible (though unlikely) that
-    -- one or more slots have passed after @currentSlot@ that we got from
-    -- @onSlotChange@ and before we queried the chain DB for the block
-    -- at its tip. At the moment, we simply don't produce a block if this
-    -- happens.
-
-    -- TODO: We may wish to produce a block here anyway, treating this
-    -- as similar to the @EQ@ case below, but we should be careful:
-    --
-    -- 1. We should think about what slot number to use.
-    -- 2. We should be careful to distinguish between the case where we
-    --    need to drop a block from the chain and where we don't.
-    -- 3. We should be careful about slot numbers and EBBs.
-    -- 4. We should probably not produce a block if the system is under
-    --    very heavy load (e.g., if a lot of blocks have been produced
-    --    after @currentTime@).
-    --
-    -- See <https://github.com/IntersectMBO/ouroboros-network/issues/1462>
-    GT -> Left $ TraceBlockFromFuture currentSlot (blockSlot hdr)
-    -- The block at the tip has the same slot as the block we're going to
-    -- produce (@currentSlot@).
-    EQ ->
-      Right $
-        if isJust (headerIsEBB hdr)
-          -- We allow forging a block that is the successor of an EBB in the
-          -- same slot.
-          then blockContextFromPrevHeader hdr
-          -- If @hdr@ is not an EBB, then forge an alternative to @hdr@: same
-          -- block no and same predecessor.
-          else BlockContext (blockNo hdr) $ castPoint $ AF.headPoint c'
-
--- | Add a forged block to the ChainDB, tracing whether it was adopted, and
--- removing its transactions from the mempool if it turned out to be invalid.
-addBlockToChainDB ::
-  (IOLike m, RunNode blk) =>
-  (TraceForgeEvent blk -> WithEarlyExit m ()) ->
-  ChainDB m blk ->
-  Mempool m blk ->
-  SlotNo ->
-  [Validated (GenTx blk)] ->
-  blk ->
-  WithEarlyExit m ()
-addBlockToChainDB trace chainDB mempool currentSlot txs newBlock = do
-  let noPunish = InvalidBlockPunishment.noPunishment -- no way to punish yourself
-  -- Make sure that if an async exception is thrown while a block is
-  -- added to the chain db, we will remove txs from the mempool.
-
-  -- 'addBlockAsync' is a non-blocking action, so `mask_` would suffice,
-  -- but the finalizer is a blocking operation, hence we need to use
-  -- 'uninterruptibleMask_' to make sure that async exceptions do not
-  -- interrupt it.
-  uninterruptibleMask_ $ do
-    result <- lift $ ChainDB.addBlockAsync chainDB noPunish newBlock
-    -- Block until we have processed the block
-    mbCurTip <- lift $ atomically $ ChainDB.blockProcessed result
-
-    -- Check whether we adopted our block
-    when (mbCurTip /= SuccesfullyAddedBlock (blockPoint newBlock)) $ do
-      isInvalid <-
-        lift $
-          atomically $
-            ($ blockHash newBlock) . forgetFingerprint
-              <$> ChainDB.getIsInvalidBlock chainDB
-      case isInvalid of
-        Nothing ->
-          trace $ TraceDidntAdoptBlock currentSlot newBlock
-        Just reason -> do
-          trace $ TraceForgedInvalidBlock currentSlot newBlock reason
-          -- We just produced a block that is invalid according to the
-          -- ledger in the ChainDB, while the mempool said it is valid.
-          -- There is an inconsistency between the two!
-          --
-          -- Remove all the transactions in that block, otherwise we'll
-          -- run the risk of forging the same invalid block again. This
-          -- means that we'll throw away some good transactions in the
-          -- process.
-          whenJust
-            (NE.nonEmpty (map (txId . txForgetValidated) txs))
-            (lift . removeTxsEvenIfValid mempool)
-      exitEarly
-
-    -- We successfully produced /and/ adopted a block
-    --
-    -- NOTE: we are tracing the transactions we retrieved from the Mempool,
-    -- not the transactions actually /in the block/.
-    -- The transactions in the block should be a prefix of the transactions
-    -- in the mempool. If this is not the case, this is a bug.
-    -- Unfortunately, we can't
-    -- assert this here because the ability to extract transactions from a
-    -- block, i.e., the @HasTxs@ class, is not implementable by all blocks,
-    -- e.g., @DualBlock@.
-    trace $ TraceAdoptedBlock currentSlot newBlock txs
-
--- | Obtain the ticked ledger view for 'currentSlot', required in order to
--- construct the ticked 'ChainDepState'.
-getLedgerView ::
-  (IOLike m, RunNode blk) =>
-  (TraceForgeEvent blk -> WithEarlyExit m ()) ->
-  TopLevelConfig blk ->
-  SlotNo ->
-  ExtLedgerState blk EmptyMK ->
-  WithEarlyExit m (LedgerView (BlockProtocol blk))
-getLedgerView trace cfg currentSlot unticked = do
-  ledgerView <-
-    case runExcept $
-      forecastFor
-        ( ledgerViewForecastAt
-            (configLedger cfg)
-            (ledgerState unticked)
-        )
-        currentSlot of
-      Left err -> do
-        -- There are so many empty slots between the tip of our chain and the
-        -- current slot that we cannot get an ledger view anymore In
-        -- principle, this is no problem; we can still produce a block (we use
-        -- the ticked ledger state). However, we probably don't /want/ to
-        -- produce a block in this case; we are most likely missing blocks
-        -- on our chain.
-        trace $ TraceNoLedgerView currentSlot err
-        exitEarly
-      Right lv ->
-        return lv
-
-  trace $ TraceLedgerView currentSlot
-  pure ledgerView
-
--- | Tick the 'ChainDepState' for the 'SlotNo' we're producing a block for. We
--- only need the ticked 'ChainDepState' to check whether we're a leader.
--- This is much cheaper than ticking the entire 'ExtLedgerState'.
-getTickedChainDepState ::
-  (IOLike m, RunNode blk) =>
-  TopLevelConfig blk ->
-  SlotNo ->
-  ExtLedgerState blk EmptyMK ->
-  LedgerView (BlockProtocol blk) ->
-  WithEarlyExit m (Ticked (ChainDepState (BlockProtocol blk)))
-getTickedChainDepState cfg currentSlot unticked ledgerView =
-  pure $
-    tickChainDepState
-      (configConsensus cfg)
-      ledgerView
-      currentSlot
-      (headerStateChainDep (headerState unticked))
-
--- | Check whether we are leader for 'currentSlot', given the ticked
--- 'ChainDepState', and obtain the leadership proof if so.
-getIsLeaderProof ::
-  (IOLike m, RunNode blk) =>
-  (TraceForgeEvent blk -> WithEarlyExit m ()) ->
-  Tracer m (TraceLabelCreds (ForgeStateInfo blk)) ->
-  BlockForging m blk ->
-  TopLevelConfig blk ->
-  SlotNo ->
-  Ticked (ChainDepState (BlockProtocol blk)) ->
-  WithEarlyExit m (IsLeader (BlockProtocol blk))
-getIsLeaderProof trace forgeStateInfoTracer' blockForging cfg currentSlot tickedChainDepState = do
-  proof <- do
-    shouldForge <-
-      lift $
-        checkShouldForge
-          blockForging
-          ( contramap
-              (TraceLabelCreds (forgeLabel blockForging))
-              forgeStateInfoTracer'
-          )
-          cfg
-          currentSlot
-          tickedChainDepState
-    case shouldForge of
-      ForgeStateUpdateError err -> do
-        trace $ TraceForgeStateUpdateError currentSlot err
-        exitEarly
-      CannotForge cannotForge -> do
-        trace $ TraceNodeCannotForge currentSlot cannotForge
-        exitEarly
-      NotLeader -> do
-        trace $ TraceNodeNotLeader currentSlot
-        exitEarly
-      ShouldForge p -> return p
-
-  -- At this point we have established that we are indeed slot leader
-  trace $ TraceNodeIsLeader currentSlot
-  pure proof
-
--- | Tick the ledger state for the 'SlotNo' we're producing a block for
-getTickedLedgerState ::
-  (IOLike m, RunNode blk) =>
-  (TraceForgeEvent blk -> WithEarlyExit m ()) ->
-  TopLevelConfig blk ->
-  SlotNo ->
-  Point blk ->
-  ExtLedgerState blk EmptyMK ->
-  WithEarlyExit m (Ticked LedgerState blk DiffMK)
-getTickedLedgerState trace cfg currentSlot bcPrevPoint unticked = do
-  let tickedLedgerState =
-        applyChainTick
-          OmitLedgerEvents
-          (configLedger cfg)
-          currentSlot
-          (ledgerState unticked)
-
-  _ <- evaluate tickedLedgerState
-  trace $ TraceForgeTickedLedgerState currentSlot bcPrevPoint
-  pure tickedLedgerState
-
--- TODO(bladyjoker): Why is this needed? Can we remove it?
---
--- NOTE: It is possible that due to adoption of new blocks the /current/
--- ledger will have changed. This doesn't matter: we will produce a block
--- that fits onto the ledger we got above; if the ledger in the meantime
--- changes, the block we produce here may or may not be adopted, but it
--- won't be invalid.
-traceForgingMempoolSnapshot ::
-  IOLike m =>
-  (TraceForgeEvent blk -> WithEarlyExit m ()) ->
-  Mempool m blk ->
-  SlotNo ->
-  Point blk ->
-  WithEarlyExit m ()
-traceForgingMempoolSnapshot trace mempool currentSlot bcPrevPoint = do
-  (mempoolHash, mempoolSlotNo) <- lift $ atomically $ do
-    snap <- getSnapshot mempool -- only used for its tip-like information
-    pure (castHash $ snapshotStateHash snap, snapshotSlotNo snap)
-
-  _ <- evaluate mempoolHash
-
-  trace $ TraceForgingMempoolSnapshot currentSlot bcPrevPoint mempoolHash mempoolSlotNo
-
--- | Get a consistent snapshot of the mempool for the given ticked ledger state
--- and select transactions up to block capacity.
-getTransactionsToForge ::
-  (IOLike m, RunNode blk) =>
-  TopLevelConfig blk ->
-  Mempool m blk ->
-  SlotNo ->
-  Ticked LedgerState blk DiffMK ->
-  ReadOnlyForker m l blk ->
-  WithEarlyExit m ([Validated (GenTx blk)], TxMeasureWithDiffTime blk, MempoolSize)
-getTransactionsToForge cfg mempool currentSlot tickedLedgerState forker = lift $ do
-  mempoolSnapshot <-
-    getSnapshotFor
-      mempool
-      currentSlot
-      tickedLedgerState
-      (roforkerReadTables forker)
-
-  let (txs, txssz) =
-        snapshotTake mempoolSnapshot $
-          blockCapacityTxMeasure (configLedger cfg) tickedLedgerState
-  -- NB respect the capacity of the ledger state we're extending,
-  -- which is /not/ 'snapshotLedgerState'
-
-  _ <- evaluate (length txs)
-
-  pure (txs, txssz, snapshotMempoolSize mempoolSnapshot)
 
 {-------------------------------------------------------------------------------
   TxSubmission integration

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
@@ -614,16 +614,7 @@ forkBlockForging IS{..} (MkBlockForging blockForgingM) =
 
           tickedLedgerState <- getTickedLedgerState trace cfg currentSlot bcPrevPoint unticked
 
-          -- Get a snapshot of the mempool that is consistent with the ledger
-          --
-          -- NOTE: It is possible that due to adoption of new blocks the
-          -- /current/ ledger will have changed. This doesn't matter: we will
-          -- produce a block that fits onto the ledger we got above; if the
-          -- ledger in the meantime changes, the block we produce here may or
-          -- may not be adopted, but it won't be invalid.
-          (mempoolHash, mempoolSlotNo) <- lift $ atomically $ do
-            snap <- getSnapshot mempool -- only used for its tip-like information
-            pure (castHash $ snapshotStateHash snap, snapshotSlotNo snap)
+          traceForgingMempoolSnapshot trace mempool currentSlot bcPrevPoint
 
           mempoolSnapshot <-
             lift $
@@ -641,9 +632,6 @@ forkBlockForging IS{..} (MkBlockForging blockForgingM) =
 
           -- force the mempool's computation before the tracer event
           _ <- evaluate (length txs)
-          _ <- evaluate mempoolHash
-
-          trace $ TraceForgingMempoolSnapshot currentSlot bcPrevPoint mempoolHash mempoolSlotNo
 
           pure
             ( txs
@@ -961,6 +949,29 @@ getTickedLedgerState trace cfg currentSlot bcPrevPoint unticked = do
   _ <- evaluate tickedLedgerState
   trace $ TraceForgeTickedLedgerState currentSlot bcPrevPoint
   pure tickedLedgerState
+
+-- TODO(bladyjoker): Why is this needed? Can we remove it?
+--
+-- NOTE: It is possible that due to adoption of new blocks the /current/
+-- ledger will have changed. This doesn't matter: we will produce a block
+-- that fits onto the ledger we got above; if the ledger in the meantime
+-- changes, the block we produce here may or may not be adopted, but it
+-- won't be invalid.
+traceForgingMempoolSnapshot ::
+  IOLike m =>
+  (TraceForgeEvent blk -> WithEarlyExit m ()) ->
+  Mempool m blk ->
+  SlotNo ->
+  Point blk ->
+  WithEarlyExit m ()
+traceForgingMempoolSnapshot trace mempool currentSlot bcPrevPoint = do
+  (mempoolHash, mempoolSlotNo) <- lift $ atomically $ do
+    snap <- getSnapshot mempool -- only used for its tip-like information
+    pure (castHash $ snapshotStateHash snap, snapshotSlotNo snap)
+
+  _ <- evaluate mempoolHash
+
+  trace $ TraceForgingMempoolSnapshot currentSlot bcPrevPoint mempoolHash mempoolSlotNo
 
 {-------------------------------------------------------------------------------
   TxSubmission integration

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
@@ -603,33 +603,14 @@ forkBlockForging IS{..} (MkBlockForging blockForgingM) =
 
           let tickedChainDepState = getTickedChainDepState cfg currentSlot unticked ledgerView
 
-          -- Check if we are the leader
-          proof <- do
-            shouldForge <-
-              lift $
-                checkShouldForge
-                  blockForging
-                  ( contramap
-                      (TraceLabelCreds (forgeLabel blockForging))
-                      (forgeStateInfoTracer tracers)
-                  )
-                  cfg
-                  currentSlot
-                  tickedChainDepState
-            case shouldForge of
-              ForgeStateUpdateError err -> do
-                trace $ TraceForgeStateUpdateError currentSlot err
-                exitEarly
-              CannotForge cannotForge -> do
-                trace $ TraceNodeCannotForge currentSlot cannotForge
-                exitEarly
-              NotLeader -> do
-                trace $ TraceNodeNotLeader currentSlot
-                exitEarly
-              ShouldForge p -> return p
-
-          -- At this point we have established that we are indeed slot leader
-          trace $ TraceNodeIsLeader currentSlot
+          proof <-
+            getIsLeaderProof
+              trace
+              (forgeStateInfoTracer tracers)
+              blockForging
+              cfg
+              currentSlot
+              tickedChainDepState
 
           -- Tick the ledger state for the 'SlotNo' we're producing a block for
           let tickedLedgerState :: Ticked LedgerState blk DiffMK
@@ -929,6 +910,46 @@ getTickedChainDepState cfg currentSlot unticked ledgerView =
     ledgerView
     currentSlot
     (headerStateChainDep (headerState unticked))
+
+-- | Check whether we are leader for 'currentSlot', given the ticked
+-- 'ChainDepState', and obtain the leadership proof if so.
+getIsLeaderProof ::
+  (IOLike m, RunNode blk) =>
+  (TraceForgeEvent blk -> WithEarlyExit m ()) ->
+  Tracer m (TraceLabelCreds (ForgeStateInfo blk)) ->
+  BlockForging m blk ->
+  TopLevelConfig blk ->
+  SlotNo ->
+  Ticked (ChainDepState (BlockProtocol blk)) ->
+  WithEarlyExit m (IsLeader (BlockProtocol blk))
+getIsLeaderProof trace forgeStateInfoTracer' blockForging cfg currentSlot tickedChainDepState = do
+  proof <- do
+    shouldForge <-
+      lift $
+        checkShouldForge
+          blockForging
+          ( contramap
+              (TraceLabelCreds (forgeLabel blockForging))
+              forgeStateInfoTracer'
+          )
+          cfg
+          currentSlot
+          tickedChainDepState
+    case shouldForge of
+      ForgeStateUpdateError err -> do
+        trace $ TraceForgeStateUpdateError currentSlot err
+        exitEarly
+      CannotForge cannotForge -> do
+        trace $ TraceNodeCannotForge currentSlot cannotForge
+        exitEarly
+      NotLeader -> do
+        trace $ TraceNodeNotLeader currentSlot
+        exitEarly
+      ShouldForge p -> return p
+
+  -- At this point we have established that we are indeed slot leader
+  trace $ TraceNodeIsLeader currentSlot
+  pure proof
 
 {-------------------------------------------------------------------------------
   TxSubmission integration

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
@@ -612,17 +612,7 @@ forkBlockForging IS{..} (MkBlockForging blockForgingM) =
               currentSlot
               tickedChainDepState
 
-          -- Tick the ledger state for the 'SlotNo' we're producing a block for
-          let tickedLedgerState :: Ticked LedgerState blk DiffMK
-              tickedLedgerState =
-                applyChainTick
-                  OmitLedgerEvents
-                  (configLedger cfg)
-                  currentSlot
-                  (ledgerState unticked)
-
-          _ <- evaluate tickedLedgerState
-          trace $ TraceForgeTickedLedgerState currentSlot bcPrevPoint
+          tickedLedgerState <- getTickedLedgerState trace cfg currentSlot bcPrevPoint unticked
 
           -- Get a snapshot of the mempool that is consistent with the ledger
           --
@@ -950,6 +940,27 @@ getIsLeaderProof trace forgeStateInfoTracer' blockForging cfg currentSlot ticked
   -- At this point we have established that we are indeed slot leader
   trace $ TraceNodeIsLeader currentSlot
   pure proof
+
+-- | Tick the ledger state for the 'SlotNo' we're producing a block for
+getTickedLedgerState ::
+  (IOLike m, RunNode blk) =>
+  (TraceForgeEvent blk -> WithEarlyExit m ()) ->
+  TopLevelConfig blk ->
+  SlotNo ->
+  Point blk ->
+  ExtLedgerState blk EmptyMK ->
+  WithEarlyExit m (Ticked LedgerState blk DiffMK)
+getTickedLedgerState trace cfg currentSlot bcPrevPoint unticked = do
+  let tickedLedgerState =
+        applyChainTick
+          OmitLedgerEvents
+          (configLedger cfg)
+          currentSlot
+          (ledgerState unticked)
+
+  _ <- evaluate tickedLedgerState
+  trace $ TraceForgeTickedLedgerState currentSlot bcPrevPoint
+  pure tickedLedgerState
 
 {-------------------------------------------------------------------------------
   TxSubmission integration

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
@@ -735,56 +735,7 @@ forkBlockForging IS{..} (MkBlockForging blockForgingM) =
         snapSize
         txssz
 
-    -- Add the block to the chain DB
-    let noPunish = InvalidBlockPunishment.noPunishment -- no way to punish yourself
-    -- Make sure that if an async exception is thrown while a block is
-    -- added to the chain db, we will remove txs from the mempool.
-
-    -- 'addBlockAsync' is a non-blocking action, so `mask_` would suffice,
-    -- but the finalizer is a blocking operation, hence we need to use
-    -- 'uninterruptibleMask_' to make sure that async exceptions do not
-    -- interrupt it.
-    uninterruptibleMask_ $ do
-      result <- lift $ ChainDB.addBlockAsync chainDB noPunish newBlock
-      -- Block until we have processed the block
-      mbCurTip <- lift $ atomically $ ChainDB.blockProcessed result
-
-      -- Check whether we adopted our block
-      when (mbCurTip /= SuccesfullyAddedBlock (blockPoint newBlock)) $ do
-        isInvalid <-
-          lift $
-            atomically $
-              ($ blockHash newBlock) . forgetFingerprint
-                <$> ChainDB.getIsInvalidBlock chainDB
-        case isInvalid of
-          Nothing ->
-            trace $ TraceDidntAdoptBlock currentSlot newBlock
-          Just reason -> do
-            trace $ TraceForgedInvalidBlock currentSlot newBlock reason
-            -- We just produced a block that is invalid according to the
-            -- ledger in the ChainDB, while the mempool said it is valid.
-            -- There is an inconsistency between the two!
-            --
-            -- Remove all the transactions in that block, otherwise we'll
-            -- run the risk of forging the same invalid block again. This
-            -- means that we'll throw away some good transactions in the
-            -- process.
-            whenJust
-              (NE.nonEmpty (map (txId . txForgetValidated) txs))
-              (lift . removeTxsEvenIfValid mempool)
-        exitEarly
-
-      -- We successfully produced /and/ adopted a block
-      --
-      -- NOTE: we are tracing the transactions we retrieved from the Mempool,
-      -- not the transactions actually /in the block/.
-      -- The transactions in the block should be a prefix of the transactions
-      -- in the mempool. If this is not the case, this is a bug.
-      -- Unfortunately, we can't
-      -- assert this here because the ability to extract transactions from a
-      -- block, i.e., the @HasTxs@ class, is not implementable by all blocks,
-      -- e.g., @DualBlock@.
-      trace $ TraceAdoptedBlock currentSlot newBlock txs
+    addBlockToChainDB trace chainDB mempool currentSlot txs newBlock
 
 -- | Context required to forge a block
 data BlockContext blk = BlockContext
@@ -897,6 +848,68 @@ mkCurrentBlockContext currentSlot c = case c of
           -- If @hdr@ is not an EBB, then forge an alternative to @hdr@: same
           -- block no and same predecessor.
           else BlockContext (blockNo hdr) $ castPoint $ AF.headPoint c'
+
+-- | Add a forged block to the ChainDB, tracing whether it was adopted, and
+-- removing its transactions from the mempool if it turned out to be invalid.
+addBlockToChainDB ::
+  (IOLike m, RunNode blk) =>
+  (TraceForgeEvent blk -> WithEarlyExit m ()) ->
+  ChainDB m blk ->
+  Mempool m blk ->
+  SlotNo ->
+  [Validated (GenTx blk)] ->
+  blk ->
+  WithEarlyExit m ()
+addBlockToChainDB trace chainDB mempool currentSlot txs newBlock = do
+  let noPunish = InvalidBlockPunishment.noPunishment -- no way to punish yourself
+  -- Make sure that if an async exception is thrown while a block is
+  -- added to the chain db, we will remove txs from the mempool.
+
+  -- 'addBlockAsync' is a non-blocking action, so `mask_` would suffice,
+  -- but the finalizer is a blocking operation, hence we need to use
+  -- 'uninterruptibleMask_' to make sure that async exceptions do not
+  -- interrupt it.
+  uninterruptibleMask_ $ do
+    result <- lift $ ChainDB.addBlockAsync chainDB noPunish newBlock
+    -- Block until we have processed the block
+    mbCurTip <- lift $ atomically $ ChainDB.blockProcessed result
+
+    -- Check whether we adopted our block
+    when (mbCurTip /= SuccesfullyAddedBlock (blockPoint newBlock)) $ do
+      isInvalid <-
+        lift $
+          atomically $
+            ($ blockHash newBlock) . forgetFingerprint
+              <$> ChainDB.getIsInvalidBlock chainDB
+      case isInvalid of
+        Nothing ->
+          trace $ TraceDidntAdoptBlock currentSlot newBlock
+        Just reason -> do
+          trace $ TraceForgedInvalidBlock currentSlot newBlock reason
+          -- We just produced a block that is invalid according to the
+          -- ledger in the ChainDB, while the mempool said it is valid.
+          -- There is an inconsistency between the two!
+          --
+          -- Remove all the transactions in that block, otherwise we'll
+          -- run the risk of forging the same invalid block again. This
+          -- means that we'll throw away some good transactions in the
+          -- process.
+          whenJust
+            (NE.nonEmpty (map (txId . txForgetValidated) txs))
+            (lift . removeTxsEvenIfValid mempool)
+      exitEarly
+
+    -- We successfully produced /and/ adopted a block
+    --
+    -- NOTE: we are tracing the transactions we retrieved from the Mempool,
+    -- not the transactions actually /in the block/.
+    -- The transactions in the block should be a prefix of the transactions
+    -- in the mempool. If this is not the case, this is a bug.
+    -- Unfortunately, we can't
+    -- assert this here because the ability to extract transactions from a
+    -- block, i.e., the @HasTxs@ class, is not implementable by all blocks,
+    -- e.g., @DualBlock@.
+    trace $ TraceAdoptedBlock currentSlot newBlock txs
 
 {-------------------------------------------------------------------------------
   TxSubmission integration

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
@@ -580,22 +580,7 @@ forkBlockForging IS{..} (MkBlockForging blockForgingM) =
 
     trace $ TraceStartLeadershipCheck currentSlot
 
-    -- Figure out which block to connect to
-    --
-    -- Normally this will be the current block at the tip, but it may be the
-    -- /previous/ block, if there were multiple slot leaders
-    BlockContext{bcBlockNo, bcPrevPoint} <- do
-      eBlkCtx <-
-        lift $
-          atomically $
-            mkCurrentBlockContext currentSlot
-              <$> ChainDB.getCurrentChain chainDB
-      case eBlkCtx of
-        Right blkCtx -> return blkCtx
-        Left failure -> do
-          trace failure
-          exitEarly
-
+    BlockContext{bcBlockNo, bcPrevPoint} <- getBlockContext trace chainDB currentSlot
     trace $ TraceBlockContext currentSlot bcBlockNo bcPrevPoint
 
     -- Get forker corresponding to bcPrevPoint
@@ -811,6 +796,28 @@ data BlockContext blk = BlockContext
   -- Note that a block/header stores the hash of its predecessor but not the
   -- slot.
   }
+
+-- | Figure out which block to connect to
+--
+-- Normally this will be the current block at the tip, but it may be the
+-- /previous/ block, if there were multiple slot leaders
+getBlockContext ::
+  (IOLike m, RunNode blk) =>
+  (TraceForgeEvent blk -> WithEarlyExit m ()) ->
+  ChainDB m blk ->
+  SlotNo ->
+  WithEarlyExit m (BlockContext blk)
+getBlockContext trace chainDB currentSlot = do
+  eBlkCtx <-
+    lift $
+      atomically $
+        mkCurrentBlockContext currentSlot
+          <$> ChainDB.getCurrentChain chainDB
+  case eBlkCtx of
+    Right blkCtx -> return blkCtx
+    Left failure -> do
+      trace failure
+      exitEarly
 
 -- | Create the 'BlockContext' from the header of the previous block
 blockContextFromPrevHeader ::

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel.hs
@@ -69,6 +69,7 @@ import Ouroboros.Consensus.Ledger.SupportsPeerSelection
 import Ouroboros.Consensus.Ledger.SupportsProtocol
 import Ouroboros.Consensus.Ledger.Tables.Utils (forgetLedgerTables)
 import Ouroboros.Consensus.Mempool
+import Ouroboros.Consensus.Mempool.API (TxMeasureWithDiffTime)
 import qualified Ouroboros.Consensus.MiniProtocol.BlockFetch.ClientInterface as BlockFetchClientInterface
 import Ouroboros.Consensus.MiniProtocol.ChainSync.Client
   ( ChainSyncClientHandle (..)
@@ -601,7 +602,7 @@ forkBlockForging IS{..} (MkBlockForging blockForgingM) =
 
           ledgerView <- getLedgerView trace cfg currentSlot unticked
 
-          let tickedChainDepState = getTickedChainDepState cfg currentSlot unticked ledgerView
+          tickedChainDepState <- getTickedChainDepState cfg currentSlot unticked ledgerView
 
           proof <-
             getIsLeaderProof
@@ -616,28 +617,13 @@ forkBlockForging IS{..} (MkBlockForging blockForgingM) =
 
           traceForgingMempoolSnapshot trace mempool currentSlot bcPrevPoint
 
-          mempoolSnapshot <-
-            lift $
-              getSnapshotFor
-                mempool
-                currentSlot
-                tickedLedgerState
-                (roforkerReadTables forker)
-
-          let (txs, txssz) =
-                snapshotTake mempoolSnapshot $
-                  blockCapacityTxMeasure (configLedger cfg) tickedLedgerState
-          -- NB respect the capacity of the ledger state we're extending,
-          -- which is /not/ 'snapshotLedgerState'
-
-          -- force the mempool's computation before the tracer event
-          _ <- evaluate (length txs)
+          (txs, txssz, snapSize) <- getTransactionsToForge cfg mempool currentSlot tickedLedgerState forker
 
           pure
             ( txs
             , txssz
             , proof
-            , snapshotMempoolSize mempoolSnapshot
+            , snapSize
             , forgetLedgerTables tickedLedgerState
             , ledgerTipPoint (ledgerState unticked)
             )
@@ -872,22 +858,23 @@ getLedgerView trace cfg currentSlot unticked = do
   trace $ TraceLedgerView currentSlot
   pure ledgerView
 
+-- | Tick the 'ChainDepState' for the 'SlotNo' we're producing a block for. We
+-- only need the ticked 'ChainDepState' to check whether we're a leader.
+-- This is much cheaper than ticking the entire 'ExtLedgerState'.
 getTickedChainDepState ::
-  RunNode blk =>
+  (IOLike m, RunNode blk) =>
   TopLevelConfig blk ->
   SlotNo ->
   ExtLedgerState blk EmptyMK ->
   LedgerView (BlockProtocol blk) ->
-  Ticked (ChainDepState (BlockProtocol blk))
+  WithEarlyExit m (Ticked (ChainDepState (BlockProtocol blk)))
 getTickedChainDepState cfg currentSlot unticked ledgerView =
-  -- Tick the 'ChainDepState' for the 'SlotNo' we're producing a block for. We
-  -- only need the ticked 'ChainDepState' to check whether we're a leader.
-  -- This is much cheaper than ticking the entire 'ExtLedgerState'.
-  tickChainDepState
-    (configConsensus cfg)
-    ledgerView
-    currentSlot
-    (headerStateChainDep (headerState unticked))
+  pure $
+    tickChainDepState
+      (configConsensus cfg)
+      ledgerView
+      currentSlot
+      (headerStateChainDep (headerState unticked))
 
 -- | Check whether we are leader for 'currentSlot', given the ticked
 -- 'ChainDepState', and obtain the leadership proof if so.
@@ -972,6 +959,34 @@ traceForgingMempoolSnapshot trace mempool currentSlot bcPrevPoint = do
   _ <- evaluate mempoolHash
 
   trace $ TraceForgingMempoolSnapshot currentSlot bcPrevPoint mempoolHash mempoolSlotNo
+
+-- | Get a consistent snapshot of the mempool for the given ticked ledger state
+-- and select transactions up to block capacity.
+getTransactionsToForge ::
+  (IOLike m, RunNode blk) =>
+  TopLevelConfig blk ->
+  Mempool m blk ->
+  SlotNo ->
+  Ticked LedgerState blk DiffMK ->
+  ReadOnlyForker m l blk ->
+  WithEarlyExit m ([Validated (GenTx blk)], TxMeasureWithDiffTime blk, MempoolSize)
+getTransactionsToForge cfg mempool currentSlot tickedLedgerState forker = lift $ do
+  mempoolSnapshot <-
+    getSnapshotFor
+      mempool
+      currentSlot
+      tickedLedgerState
+      (roforkerReadTables forker)
+
+  let (txs, txssz) =
+        snapshotTake mempoolSnapshot $
+          blockCapacityTxMeasure (configLedger cfg) tickedLedgerState
+  -- NB respect the capacity of the ledger state we're extending,
+  -- which is /not/ 'snapshotLedgerState'
+
+  _ <- evaluate (length txs)
+
+  pure (txs, txssz, snapshotMempoolSize mempoolSnapshot)
 
 {-------------------------------------------------------------------------------
   TxSubmission integration

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel/Forge.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel/Forge.hs
@@ -1,0 +1,486 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+-- | Run one leadership check and, if we are leader, forge and adopt a block.
+--
+-- This is spawned once per forge-credentials thread by
+-- 'Ouroboros.Consensus.NodeKernel.forkBlockForging'.
+module Ouroboros.Consensus.NodeKernel.Forge
+  ( forge
+  ) where
+
+import Control.Monad
+import Control.Monad.Except
+import Control.Tracer
+import qualified Data.List.NonEmpty as NE
+import Data.Maybe (isJust)
+import Data.Proxy
+import Ouroboros.Consensus.Block hiding (blockMatchesHeader)
+import qualified Ouroboros.Consensus.Block as Block
+import Ouroboros.Consensus.Config
+import Ouroboros.Consensus.Forecast
+import Ouroboros.Consensus.HeaderValidation
+  ( BasicEnvelopeValidation (..)
+  , HeaderState (..)
+  , headerStateChainDep
+  )
+import Ouroboros.Consensus.Ledger.Abstract
+import Ouroboros.Consensus.Ledger.Extended
+import Ouroboros.Consensus.Ledger.SupportsMempool
+import Ouroboros.Consensus.Ledger.SupportsProtocol
+import Ouroboros.Consensus.Ledger.Tables.Utils (forgetLedgerTables)
+import Ouroboros.Consensus.Mempool
+import Ouroboros.Consensus.Mempool.API (TxMeasureWithDiffTime)
+import Ouroboros.Consensus.Node.Run
+import Ouroboros.Consensus.Node.Tracers
+import Ouroboros.Consensus.Protocol.Abstract
+import Ouroboros.Consensus.Storage.ChainDB.API
+  ( AddBlockResult (..)
+  , ChainDB
+  )
+import qualified Ouroboros.Consensus.Storage.ChainDB.API as ChainDB
+import qualified Ouroboros.Consensus.Storage.ChainDB.API.Types.InvalidBlockPunishment as InvalidBlockPunishment
+import Ouroboros.Consensus.Storage.LedgerDB
+import qualified Ouroboros.Consensus.Storage.LedgerDB as LedgerDB
+import Ouroboros.Consensus.Util (whenJust)
+import Ouroboros.Consensus.Util.EarlyExit
+import Ouroboros.Consensus.Util.IOLike
+import Ouroboros.Consensus.Util.Orphans ()
+import Ouroboros.Consensus.Util.STM
+import Ouroboros.Network.AnchoredFragment
+  ( AnchoredFragment
+  , AnchoredSeq (..)
+  )
+import qualified Ouroboros.Network.AnchoredFragment as AF
+import Ouroboros.Network.Protocol.LocalStateQuery.Type (Target (..))
+
+forge ::
+  forall m blk.
+  (IOLike m, RunNode blk) =>
+  Tracer m (TraceLabelCreds (TraceForgeEvent blk)) ->
+  Tracer m (TraceLabelCreds (ForgeStateInfo blk)) ->
+  TopLevelConfig blk ->
+  ChainDB m blk ->
+  Mempool m blk ->
+  BlockForging m blk ->
+  SlotNo ->
+  WithEarlyExit m ()
+forge forgeEventTracer forgeStateInfoTracer cfg chainDB mempool blockForging currentSlot = do
+  let trace :: TraceForgeEvent blk -> WithEarlyExit m ()
+      trace =
+        lift
+          . traceWith forgeEventTracer
+          . TraceLabelCreds (forgeLabel blockForging)
+
+  trace $ TraceStartLeadershipCheck currentSlot
+
+  BlockContext{bcBlockNo, bcPrevPoint} <- getBlockContext trace chainDB currentSlot
+  trace $ TraceBlockContext currentSlot bcBlockNo bcPrevPoint
+
+  -- Get forker corresponding to bcPrevPoint
+  --
+  -- This might fail if, in between choosing 'bcPrevPoint' and this call to
+  -- 'ChainDB.withReadOnlyForkerAtPoint', we switched to a fork where 'bcPrevPoint'
+  -- is no longer on our chain. When that happens, we simply give up on the
+  -- chance to produce a block.
+  (txs, txssz, proof, snapSize, tickedLedgerState, forgingOnTopOf) <-
+    ChainDB.withReadOnlyForkerAtPoint chainDB (SpecificPoint bcPrevPoint) $ \case
+      Left _ -> do
+        trace $ TraceNoLedgerState currentSlot bcPrevPoint
+        exitEarly
+      Right forker -> do
+        unticked <- lift $ atomically $ LedgerDB.roforkerGetLedgerState forker
+
+        trace $ TraceLedgerState currentSlot bcPrevPoint
+
+        ledgerView <- getLedgerView trace cfg currentSlot unticked
+
+        let tickedChainDepState = getTickedChainDepState cfg currentSlot unticked ledgerView
+
+        proof <-
+          getIsLeaderProof
+            trace
+            forgeStateInfoTracer
+            blockForging
+            cfg
+            currentSlot
+            tickedChainDepState
+
+        tickedLedgerState <- getTickedLedgerState trace cfg currentSlot bcPrevPoint unticked
+
+        traceForgingMempoolSnapshot trace mempool currentSlot bcPrevPoint
+
+        (txs, txssz, snapSize) <- getTransactionsToForge cfg mempool currentSlot tickedLedgerState forker
+
+        pure
+          ( txs
+          , txssz
+          , proof
+          , snapSize
+          , forgetLedgerTables tickedLedgerState
+          , ledgerTipPoint (ledgerState unticked)
+          )
+
+  -- Actually produce the block
+  newBlock <-
+    lift $
+      Block.forgeBlock
+        blockForging
+        cfg
+        bcBlockNo
+        currentSlot
+        Nothing -- No PerasCert for now
+        tickedLedgerState
+        txs
+        proof
+
+  trace $
+    TraceForgedBlock
+      currentSlot
+      forgingOnTopOf
+      newBlock
+      snapSize
+      txssz
+
+  addBlockToChainDB trace chainDB mempool currentSlot txs newBlock
+
+-- | Context required to forge a block
+data BlockContext blk = BlockContext
+  { bcBlockNo :: !BlockNo
+  -- ^ the block number of the block to be forged
+  , bcPrevPoint :: !(Point blk)
+  -- ^ the point of /the predecessor of/ the block
+  --
+  -- Note that a block/header stores the hash of its predecessor but not the
+  -- slot.
+  }
+
+-- | Figure out which block to connect to
+--
+-- Normally this will be the current block at the tip, but it may be the
+-- /previous/ block, if there were multiple slot leaders
+getBlockContext ::
+  (IOLike m, RunNode blk) =>
+  (TraceForgeEvent blk -> WithEarlyExit m ()) ->
+  ChainDB m blk ->
+  SlotNo ->
+  WithEarlyExit m (BlockContext blk)
+getBlockContext trace chainDB currentSlot = do
+  eBlkCtx <-
+    lift $
+      atomically $
+        mkCurrentBlockContext currentSlot
+          <$> ChainDB.getCurrentChain chainDB
+  case eBlkCtx of
+    Right blkCtx -> return blkCtx
+    Left failure -> do
+      trace failure
+      exitEarly
+
+-- | Create the 'BlockContext' from the header of the previous block
+blockContextFromPrevHeader ::
+  HasHeader (Header blk) =>
+  Header blk -> BlockContext blk
+blockContextFromPrevHeader hdr =
+  -- Recall that an EBB has the same block number as its predecessor, so this
+  -- @succ@ is even correct when @hdr@ is an EBB.
+  BlockContext (succ (blockNo hdr)) (headerPoint hdr)
+
+-- | Determine the 'BlockContext' for a block about to be forged from the
+-- current slot, ChainDB chain fragment, and ChainDB tip block number
+--
+-- The 'bcPrevPoint' will either refer to the header at the tip of the current
+-- chain or, in case there is already a block in this slot (e.g. another node
+-- was also elected leader and managed to produce a block before us), the tip's
+-- predecessor. If the chain is empty, then it will refer to the chain's anchor
+-- point, which may be genesis.
+mkCurrentBlockContext ::
+  forall blk.
+  RunNode blk =>
+  -- | the current slot, i.e. the slot of the block about to be forged
+  SlotNo ->
+  -- | the current chain fragment
+  --
+  -- Recall that the anchor point is the tip of the ImmutableDB.
+  AnchoredFragment (Header blk) ->
+  -- | the event records the cause of the failure
+  Either (TraceForgeEvent blk) (BlockContext blk)
+mkCurrentBlockContext currentSlot c = case c of
+  Empty AF.AnchorGenesis ->
+    -- The chain is entirely empty.
+    Right $ BlockContext (expectedFirstBlockNo (Proxy @blk)) GenesisPoint
+  Empty (AF.Anchor anchorSlot anchorHash anchorBlockNo) ->
+    let p :: Point blk = BlockPoint anchorSlot anchorHash
+     in if anchorSlot < currentSlot
+          then Right $ BlockContext (succ anchorBlockNo) p
+          else Left $ TraceSlotIsImmutable currentSlot p anchorBlockNo
+  c' :> hdr -> case blockSlot hdr `compare` currentSlot of
+    -- The block at the tip of our chain has a slot number /before/ the
+    -- current slot number. This is the common case, and we just want to
+    -- connect our new block to the block at the tip.
+    LT -> Right $ blockContextFromPrevHeader hdr
+    -- The block at the tip of our chain has a slot that lies in the
+    -- future. Although the chain DB should not contain blocks from the
+    -- future, if the volatile DB contained such blocks on startup
+    -- (due to a node clock misconfiguration) this invariant may be
+    -- violated. See: https://github.com/IntersectMBO/ouroboros-consensus/blob/main/docs/website/contents/for-developers/HandlingBlocksFromTheFuture.md#handling-blocks-from-the-future
+    -- Also note that if the
+    -- system is under heavy load, it is possible (though unlikely) that
+    -- one or more slots have passed after @currentSlot@ that we got from
+    -- @onSlotChange@ and before we queried the chain DB for the block
+    -- at its tip. At the moment, we simply don't produce a block if this
+    -- happens.
+
+    -- TODO: We may wish to produce a block here anyway, treating this
+    -- as similar to the @EQ@ case below, but we should be careful:
+    --
+    -- 1. We should think about what slot number to use.
+    -- 2. We should be careful to distinguish between the case where we
+    --    need to drop a block from the chain and where we don't.
+    -- 3. We should be careful about slot numbers and EBBs.
+    -- 4. We should probably not produce a block if the system is under
+    --    very heavy load (e.g., if a lot of blocks have been produced
+    --    after @currentTime@).
+    --
+    -- See <https://github.com/IntersectMBO/ouroboros-network/issues/1462>
+    GT -> Left $ TraceBlockFromFuture currentSlot (blockSlot hdr)
+    -- The block at the tip has the same slot as the block we're going to
+    -- produce (@currentSlot@).
+    EQ ->
+      Right $
+        if isJust (headerIsEBB hdr)
+          -- We allow forging a block that is the successor of an EBB in the
+          -- same slot.
+          then blockContextFromPrevHeader hdr
+          -- If @hdr@ is not an EBB, then forge an alternative to @hdr@: same
+          -- block no and same predecessor.
+          else BlockContext (blockNo hdr) $ castPoint $ AF.headPoint c'
+
+-- | Add a forged block to the ChainDB, tracing whether it was adopted, and
+-- removing its transactions from the mempool if it turned out to be invalid.
+addBlockToChainDB ::
+  (IOLike m, RunNode blk) =>
+  (TraceForgeEvent blk -> WithEarlyExit m ()) ->
+  ChainDB m blk ->
+  Mempool m blk ->
+  SlotNo ->
+  [Validated (GenTx blk)] ->
+  blk ->
+  WithEarlyExit m ()
+addBlockToChainDB trace chainDB mempool currentSlot txs newBlock = do
+  let noPunish = InvalidBlockPunishment.noPunishment -- no way to punish yourself
+  -- Make sure that if an async exception is thrown while a block is
+  -- added to the chain db, we will remove txs from the mempool.
+
+  -- 'addBlockAsync' is a non-blocking action, so `mask_` would suffice,
+  -- but the finalizer is a blocking operation, hence we need to use
+  -- 'uninterruptibleMask_' to make sure that async exceptions do not
+  -- interrupt it.
+  uninterruptibleMask_ $ do
+    result <- lift $ ChainDB.addBlockAsync chainDB noPunish newBlock
+    -- Block until we have processed the block
+    mbCurTip <- lift $ atomically $ ChainDB.blockProcessed result
+
+    -- Check whether we adopted our block
+    when (mbCurTip /= SuccesfullyAddedBlock (blockPoint newBlock)) $ do
+      isInvalid <-
+        lift $
+          atomically $
+            ($ blockHash newBlock) . forgetFingerprint
+              <$> ChainDB.getIsInvalidBlock chainDB
+      case isInvalid of
+        Nothing ->
+          trace $ TraceDidntAdoptBlock currentSlot newBlock
+        Just reason -> do
+          trace $ TraceForgedInvalidBlock currentSlot newBlock reason
+          -- We just produced a block that is invalid according to the
+          -- ledger in the ChainDB, while the mempool said it is valid.
+          -- There is an inconsistency between the two!
+          --
+          -- Remove all the transactions in that block, otherwise we'll
+          -- run the risk of forging the same invalid block again. This
+          -- means that we'll throw away some good transactions in the
+          -- process.
+          whenJust
+            (NE.nonEmpty (map (txId . txForgetValidated) txs))
+            (lift . removeTxsEvenIfValid mempool)
+      exitEarly
+
+    -- We successfully produced /and/ adopted a block
+    --
+    -- NOTE: we are tracing the transactions we retrieved from the Mempool,
+    -- not the transactions actually /in the block/.
+    -- The transactions in the block should be a prefix of the transactions
+    -- in the mempool. If this is not the case, this is a bug.
+    -- Unfortunately, we can't
+    -- assert this here because the ability to extract transactions from a
+    -- block, i.e., the @HasTxs@ class, is not implementable by all blocks,
+    -- e.g., @DualBlock@.
+    trace $ TraceAdoptedBlock currentSlot newBlock txs
+
+-- | Obtain the ticked ledger view for 'currentSlot', required in order to
+-- construct the ticked 'ChainDepState'.
+getLedgerView ::
+  (IOLike m, RunNode blk) =>
+  (TraceForgeEvent blk -> WithEarlyExit m ()) ->
+  TopLevelConfig blk ->
+  SlotNo ->
+  ExtLedgerState blk EmptyMK ->
+  WithEarlyExit m (LedgerView (BlockProtocol blk))
+getLedgerView trace cfg currentSlot unticked = do
+  ledgerView <-
+    case runExcept $
+      forecastFor
+        ( ledgerViewForecastAt
+            (configLedger cfg)
+            (ledgerState unticked)
+        )
+        currentSlot of
+      Left err -> do
+        -- There are so many empty slots between the tip of our chain and the
+        -- current slot that we cannot get a ledger view anymore. In
+        -- principle, this is no problem; we can still produce a block (we use
+        -- the ticked ledger state). However, we probably don't /want/ to
+        -- produce a block in this case; we are most likely missing blocks
+        -- on our chain.
+        trace $ TraceNoLedgerView currentSlot err
+        exitEarly
+      Right lv ->
+        return lv
+
+  trace $ TraceLedgerView currentSlot
+  pure ledgerView
+
+-- | Tick the 'ChainDepState' for the 'SlotNo' we're producing a block for. We
+-- only need the ticked 'ChainDepState' to check whether we're a leader.
+-- This is much cheaper than ticking the entire 'ExtLedgerState'.
+getTickedChainDepState ::
+  RunNode blk =>
+  TopLevelConfig blk ->
+  SlotNo ->
+  ExtLedgerState blk EmptyMK ->
+  LedgerView (BlockProtocol blk) ->
+  Ticked (ChainDepState (BlockProtocol blk))
+getTickedChainDepState cfg currentSlot unticked ledgerView =
+  tickChainDepState
+    (configConsensus cfg)
+    ledgerView
+    currentSlot
+    (headerStateChainDep (headerState unticked))
+
+-- | Check whether we are leader for 'currentSlot', given the ticked
+-- 'ChainDepState', and obtain the leadership proof if so.
+getIsLeaderProof ::
+  (IOLike m, RunNode blk) =>
+  (TraceForgeEvent blk -> WithEarlyExit m ()) ->
+  Tracer m (TraceLabelCreds (ForgeStateInfo blk)) ->
+  BlockForging m blk ->
+  TopLevelConfig blk ->
+  SlotNo ->
+  Ticked (ChainDepState (BlockProtocol blk)) ->
+  WithEarlyExit m (IsLeader (BlockProtocol blk))
+getIsLeaderProof trace forgeStateInfoTracer blockForging cfg currentSlot tickedChainDepState = do
+  proof <- do
+    shouldForge <-
+      lift $
+        checkShouldForge
+          blockForging
+          ( contramap
+              (TraceLabelCreds (forgeLabel blockForging))
+              forgeStateInfoTracer
+          )
+          cfg
+          currentSlot
+          tickedChainDepState
+    case shouldForge of
+      ForgeStateUpdateError err -> do
+        trace $ TraceForgeStateUpdateError currentSlot err
+        exitEarly
+      CannotForge cannotForge -> do
+        trace $ TraceNodeCannotForge currentSlot cannotForge
+        exitEarly
+      NotLeader -> do
+        trace $ TraceNodeNotLeader currentSlot
+        exitEarly
+      ShouldForge p -> return p
+
+  -- At this point we have established that we are indeed slot leader
+  trace $ TraceNodeIsLeader currentSlot
+  pure proof
+
+-- | Tick the ledger state for the 'SlotNo' we're producing a block for
+getTickedLedgerState ::
+  (IOLike m, RunNode blk) =>
+  (TraceForgeEvent blk -> WithEarlyExit m ()) ->
+  TopLevelConfig blk ->
+  SlotNo ->
+  Point blk ->
+  ExtLedgerState blk EmptyMK ->
+  WithEarlyExit m (Ticked LedgerState blk DiffMK)
+getTickedLedgerState trace cfg currentSlot bcPrevPoint unticked = do
+  let tickedLedgerState =
+        applyChainTick
+          OmitLedgerEvents
+          (configLedger cfg)
+          currentSlot
+          (ledgerState unticked)
+
+  _ <- evaluate tickedLedgerState
+  trace $ TraceForgeTickedLedgerState currentSlot bcPrevPoint
+  pure tickedLedgerState
+
+-- | Get a snapshot of the mempool that is consistent with the ledger, and
+-- trace it.
+--
+-- NOTE: It is possible that due to adoption of new blocks the /current/
+-- ledger will have changed. This doesn't matter: we will produce a block
+-- that fits onto the ledger we got above; if the ledger in the meantime
+-- changes, the block we produce here may or may not be adopted, but it
+-- won't be invalid.
+traceForgingMempoolSnapshot ::
+  IOLike m =>
+  (TraceForgeEvent blk -> WithEarlyExit m ()) ->
+  Mempool m blk ->
+  SlotNo ->
+  Point blk ->
+  WithEarlyExit m ()
+traceForgingMempoolSnapshot trace mempool currentSlot bcPrevPoint = do
+  (mempoolHash, mempoolSlotNo) <- lift $ atomically $ do
+    snap <- getSnapshot mempool -- only used for its tip-like information
+    pure (castHash $ snapshotStateHash snap, snapshotSlotNo snap)
+
+  _ <- evaluate mempoolHash
+
+  trace $ TraceForgingMempoolSnapshot currentSlot bcPrevPoint mempoolHash mempoolSlotNo
+
+-- | Get a consistent snapshot of the mempool for the given ticked ledger state
+-- and select transactions up to block capacity.
+getTransactionsToForge ::
+  (IOLike m, RunNode blk) =>
+  TopLevelConfig blk ->
+  Mempool m blk ->
+  SlotNo ->
+  Ticked LedgerState blk DiffMK ->
+  ReadOnlyForker m l blk ->
+  WithEarlyExit m ([Validated (GenTx blk)], TxMeasureWithDiffTime blk, MempoolSize)
+getTransactionsToForge cfg mempool currentSlot tickedLedgerState forker = lift $ do
+  mempoolSnapshot <-
+    getSnapshotFor
+      mempool
+      currentSlot
+      tickedLedgerState
+      (roforkerReadTables forker)
+
+  let (txs, txssz) =
+        snapshotTake mempoolSnapshot $
+          blockCapacityTxMeasure (configLedger cfg) tickedLedgerState
+  -- NB respect the capacity of the ledger state we're extending,
+  -- which is /not/ 'snapshotLedgerState'
+
+  _ <- evaluate (length txs)
+
+  pure (txs, txssz, snapshotMempoolSize mempoolSnapshot)

--- a/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel/Forge.hs
+++ b/ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel/Forge.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
@@ -87,7 +86,7 @@ forge forgeEventTracer forgeStateInfoTracer cfg chainDB mempool blockForging cur
   -- 'ChainDB.withReadOnlyForkerAtPoint', we switched to a fork where 'bcPrevPoint'
   -- is no longer on our chain. When that happens, we simply give up on the
   -- chance to produce a block.
-  (txs, txssz, proof, snapSize, tickedLedgerState, forgingOnTopOf) <-
+  (fbArgs, txssz, snapSize, forgingOnTopOf) <-
     ChainDB.withReadOnlyForkerAtPoint chainDB (SpecificPoint bcPrevPoint) $ \case
       Left _ -> do
         trace $ TraceNoLedgerState currentSlot bcPrevPoint
@@ -116,27 +115,25 @@ forge forgeEventTracer forgeStateInfoTracer cfg chainDB mempool blockForging cur
 
         (txs, txssz, snapSize) <- getTransactionsToForge cfg mempool currentSlot tickedLedgerState forker
 
+        let fbArgs =
+              Block.ForgeBlockArgs
+                { Block.fbConfig = cfg
+                , Block.fbCurrentBlockNo = bcBlockNo
+                , Block.fbCurrentSlotNo = currentSlot
+                , Block.fbPerasCert = Nothing -- No PerasCert for now
+                , Block.fbCurrentTickedLedgerState = forgetLedgerTables tickedLedgerState
+                , Block.fbTxs = txs
+                , Block.fbIsLeader = proof
+                }
         pure
-          ( txs
+          ( fbArgs
           , txssz
-          , proof
           , snapSize
-          , forgetLedgerTables tickedLedgerState
           , ledgerTipPoint (ledgerState unticked)
           )
 
   -- Actually produce the block
-  newBlock <-
-    lift $
-      Block.forgeBlock
-        blockForging
-        cfg
-        bcBlockNo
-        currentSlot
-        Nothing -- No PerasCert for now
-        tickedLedgerState
-        txs
-        proof
+  newBlock <- lift $ Block.forgeBlock blockForging fbArgs
 
   trace $
     TraceForgedBlock
@@ -146,7 +143,7 @@ forge forgeEventTracer forgeStateInfoTracer cfg chainDB mempool blockForging cur
       snapSize
       txssz
 
-  addBlockToChainDB trace chainDB mempool currentSlot txs newBlock
+  addBlockToChainDB trace chainDB mempool currentSlot (fbTxs fbArgs) newBlock
 
 -- | Context required to forge a block
 data BlockContext blk = BlockContext

--- a/ouroboros-consensus-diffusion/src/unstable-diffusion-testlib/Test/ThreadNet/Network.hs
+++ b/ouroboros-consensus-diffusion/src/unstable-diffusion-testlib/Test/ThreadNet/Network.hs
@@ -879,17 +879,9 @@ runThreadNetwork
           <$> allocate registry (const (ChainDB.openDB chainDbArgs)) ChainDB.closeDB
 
       let customForgeBlock ::
-            BlockForging m blk ->
-            TopLevelConfig blk ->
-            BlockNo ->
-            SlotNo ->
-            Maybe (PerasCert blk) ->
-            TickedLedgerState blk mk ->
-            [Validated (GenTx blk)] ->
-            IsLeader (BlockProtocol blk) ->
-            m blk
-          customForgeBlock origBlockForging cfg' currentBno currentSlot mbPerasCert tickedLdgSt txs prf = do
-            let currentEpoch = HFF.futureSlotToEpoch future currentSlot
+            BlockForging m blk -> ForgeBlockArgs blk -> m blk
+          customForgeBlock origBlockForging args@ForgeBlockArgs{..} = do
+            let currentEpoch = HFF.futureSlotToEpoch future fbCurrentSlotNo
 
             -- EBBs are only ever possible in the first era
             let inFirstEra = HFF.futureEpochInFirstEra future currentEpoch
@@ -901,7 +893,7 @@ runThreadNetwork
                   EpochSize y = epochSize0
 
             let p :: Point blk
-                p = castPoint $ getTip tickedLdgSt
+                p = castPoint $ getTip fbCurrentTickedLedgerState
 
             let needEBB = inFirstEra && NotOrigin ebbSlot > pointSlot p
             case mbForgeEbbEnv <* guard needEBB of
@@ -909,17 +901,11 @@ runThreadNetwork
                 -- no EBB needed, forge without making one
                 forgeBlock
                   origBlockForging
-                  cfg'
-                  currentBno
-                  currentSlot
-                  mbPerasCert
-                  (forgetLedgerTables tickedLdgSt)
-                  txs
-                  prf
+                  args
               Just forgeEbbEnv -> do
                 -- The EBB shares its BlockNo with its predecessor (if
                 -- there is one)
-                let ebbBno = case currentBno of
+                let ebbBno = case fbCurrentBlockNo of
                       -- We assume this invariant:
                       --
                       -- If forging of EBBs is enabled then the node
@@ -941,14 +927,14 @@ runThreadNetwork
                 -- if it is valid, we retick to the /same/ slot
                 let apply = applyLedgerBlock OmitLedgerEvents (configLedger pInfoConfig)
                     tables = emptyLedgerTables -- EBBs need no input tables
-                tickedLdgSt' <- case Exc.runExcept $ apply ebb (tickedLdgSt `withLedgerTables` tables) of
+                tickedLdgSt' <- case Exc.runExcept $ apply ebb (fbCurrentTickedLedgerState `withLedgerTables` tables) of
                   Left e -> Exn.throw $ JitEbbError @blk e
                   Right st ->
                     pure $
                       applyChainTick
                         OmitLedgerEvents
                         (configLedger pInfoConfig)
-                        currentSlot
+                        fbCurrentSlotNo
                         (forgetLedgerTables st)
 
                 -- forge the block usings the ledger state that includes
@@ -956,13 +942,7 @@ runThreadNetwork
                 blk <-
                   forgeBlock
                     origBlockForging
-                    cfg'
-                    currentBno
-                    currentSlot
-                    mbPerasCert
-                    (forgetLedgerTables tickedLdgSt')
-                    txs
-                    prf
+                    args{fbCurrentTickedLedgerState = forgetLedgerTables tickedLdgSt'}
 
                 -- If the EBB or the subsequent block is invalid, then the
                 -- ChainDB will reject it as invalid, and

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator/A.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator/A.hs
@@ -365,31 +365,25 @@ type instance CannotForge BlockA = Void
 type instance ForgeStateInfo BlockA = ()
 type instance ForgeStateUpdateError BlockA = Void
 
-forgeBlockA ::
-  TopLevelConfig BlockA ->
-  BlockNo ->
-  SlotNo ->
-  TickedLedgerState BlockA mk ->
-  [GenTx BlockA] ->
-  IsLeader (BlockProtocol BlockA) ->
-  BlockA
-forgeBlockA tlc bno sno (TickedLedgerStateA st) _txs _ =
+forgeBlockA :: ForgeBlockArgs BlockA -> BlockA
+forgeBlockA ForgeBlockArgs{..} =
   BlkA
     { blkA_header =
         HdrA
           { hdrA_fields =
               HeaderFields
-                { headerFieldHash = Lazy.toStrict . B.encode $ unSlotNo sno
-                , headerFieldSlot = sno
-                , headerFieldBlockNo = bno
+                { headerFieldHash = Lazy.toStrict . B.encode $ unSlotNo fbCurrentSlotNo
+                , headerFieldSlot = fbCurrentSlotNo
+                , headerFieldBlockNo = fbCurrentBlockNo
                 }
-          , hdrA_prev = ledgerTipHash st
+          , hdrA_prev = ledgerTipHash lst
           }
-    , blkA_body = Map.findWithDefault [] sno (lcfgA_forgeTxs ledgerConfig)
+    , blkA_body = Map.findWithDefault [] fbCurrentSlotNo (lcfgA_forgeTxs ledgerConfig)
     }
  where
+  TickedLedgerStateA lst = fbCurrentTickedLedgerState
   ledgerConfig :: PartialLedgerConfig BlockA
-  ledgerConfig = snd $ configLedger tlc
+  ledgerConfig = snd $ configLedger fbConfig
 
 blockForgingA :: Monad m => BlockForging m BlockA
 blockForgingA =
@@ -398,9 +392,7 @@ blockForgingA =
     , canBeLeader = ()
     , updateForgeState = \_ _ _ -> return $ ForgeStateUpdated ()
     , checkCanForge = \_ _ _ _ _ -> return ()
-    , forgeBlock = \cfg bno slot _mbPerasCert st txs proof ->
-        return $
-          forgeBlockA cfg bno slot st (fmap txForgetValidated txs) proof
+    , forgeBlock = return . forgeBlockA
     , finalize = return ()
     }
 

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator/B.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/HardFork/Combinator/B.hs
@@ -314,27 +314,22 @@ type instance CannotForge BlockB = Void
 type instance ForgeStateInfo BlockB = ()
 type instance ForgeStateUpdateError BlockB = Void
 
-forgeBlockB ::
-  TopLevelConfig BlockB ->
-  BlockNo ->
-  SlotNo ->
-  TickedLedgerState BlockB mk ->
-  [GenTx BlockB] ->
-  IsLeader (BlockProtocol BlockB) ->
-  BlockB
-forgeBlockB _ bno sno (TickedLedgerStateB st) _txs _ =
+forgeBlockB :: ForgeBlockArgs BlockB -> BlockB
+forgeBlockB ForgeBlockArgs{..} =
   BlkB
     { blkB_header =
         HdrB
           { hdrB_fields =
               HeaderFields
-                { headerFieldHash = Lazy.toStrict . B.encode $ unSlotNo sno
-                , headerFieldSlot = sno
-                , headerFieldBlockNo = bno
+                { headerFieldHash = Lazy.toStrict . B.encode $ unSlotNo fbCurrentSlotNo
+                , headerFieldSlot = fbCurrentSlotNo
+                , headerFieldBlockNo = fbCurrentBlockNo
                 }
-          , hdrB_prev = ledgerTipHash st
+          , hdrB_prev = ledgerTipHash lst
           }
     }
+ where
+  TickedLedgerStateB lst = fbCurrentTickedLedgerState
 
 blockForgingB :: Monad m => BlockForging m BlockB
 blockForgingB =
@@ -343,9 +338,7 @@ blockForgingB =
     , canBeLeader = ()
     , updateForgeState = \_ _ _ -> return $ ForgeStateUpdated ()
     , checkCanForge = \_ _ _ _ _ -> return ()
-    , forgeBlock = \cfg bno slot _mbPerasCert st txs proof ->
-        return $
-          forgeBlockB cfg bno slot st (fmap txForgetValidated txs) proof
+    , forgeBlock = return . forgeBlockB
     , finalize = return ()
     }
 

--- a/ouroboros-consensus.cabal
+++ b/ouroboros-consensus.cabal
@@ -1113,6 +1113,7 @@ library diffusion
     Ouroboros.Consensus.Node.RethrowPolicy
     Ouroboros.Consensus.Node.Tracers
     Ouroboros.Consensus.NodeKernel
+    Ouroboros.Consensus.NodeKernel.Forge
 
   reexported-modules:
     Ouroboros.Consensus.Block,

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Block/Forging.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Block/Forging.hs
@@ -21,6 +21,9 @@ module Ouroboros.Consensus.Block.Forging
 
     -- * 'UpdateInfo'
   , UpdateInfo (..)
+
+    -- * 'ForgeBlockArgs'
+  , ForgeBlockArgs (..)
   ) where
 
 import Control.Tracer (Tracer, traceWith)
@@ -119,30 +122,8 @@ data BlockForging m blk = BlockForging
   -- to see whether we can actually forge a block.
   --
   -- When 'CannotForge' is returned, we don't call 'forgeBlock'.
-  , forgeBlock ::
-      TopLevelConfig blk ->
-      BlockNo -> -- Current block number
-      SlotNo -> -- Current slot number
-      Maybe (PerasCert blk) -> -- Optional Peras certificate to include
-      TickedLedgerState blk EmptyMK -> -- Current ledger state
-      [Validated (GenTx blk)] -> -- Transactions to include
-      IsLeader (BlockProtocol blk) -> -- Proof we are leader
-      m blk
+  , forgeBlock :: ForgeBlockArgs blk -> m blk
   -- ^ Forge a block
-  --
-  -- The function is passed the prefix of the mempool that will fit within
-  -- a valid block; this is a set of transactions that is guaranteed to be
-  -- consistent with the ledger state (also provided as an argument) and
-  -- with each other (when applied in order). All of them should be
-  -- included in the forged block, since the mempool ensures they can fit.
-  --
-  -- NOTE: do not refer to the consensus or ledger config in the closure,
-  -- because they might contain an @EpochInfo Identity@, which will be
-  -- incorrect when used as part of the hard fork combinator. Use the
-  -- given 'TopLevelConfig' instead, as it is guaranteed to be correct
-  -- even when used as part of the hard fork combinator.
-  --
-  -- PRECONDITION: 'checkCanForge' returned @Right ()@.
   , finalize :: m ()
   -- ^ Clean up any unmanaged resources.
   --
@@ -245,3 +226,42 @@ forgeStateUpdateInfoFromUpdateInfo ::
 forgeStateUpdateInfoFromUpdateInfo = \case
   Updated info -> ForgeStateUpdated info
   UpdateFailed err -> ForgeStateUpdateFailed err
+
+{-------------------------------------------------------------------------------
+  ForgeBlockArgs
+-------------------------------------------------------------------------------}
+
+-- | Arguments to 'forgeBlock' aggregated into a single record.
+data ForgeBlockArgs blk = ForgeBlockArgs
+  { fbConfig :: !(TopLevelConfig blk)
+  -- ^ The node's top-level config.
+  , fbCurrentBlockNo :: !BlockNo
+  -- ^ The block number of the block to be forged.
+  , fbCurrentSlotNo :: !SlotNo
+  -- ^ The slot number of the block to be forged.
+  , fbPerasCert :: !(Maybe (PerasCert blk))
+  -- ^ Optional Peras certificate to include in the forged block
+  --
+  -- For 'blk' that supports Peras 'Nothing' means no certificate.
+  -- For 'blk' that doesn't support Peras it's always 'Nothing'.
+  , fbCurrentTickedLedgerState :: !(TickedLedgerState blk EmptyMK)
+  -- ^ The current ledger state ticked to 'fbCurrentSlotNo'.
+  , fbTxs :: ![Validated (GenTx blk)]
+  -- ^ The transactions to include in the forged block.
+  --
+  -- The function is passed the prefix of the mempool that will fit within
+  -- a valid block; this is a set of transactions that is guaranteed to be
+  -- consistent with the ledger state 'fbCurrentTickedLedgerState' and
+  -- with each other (when applied in order). All of them should be
+  -- included in the forged block, since the mempool ensures they can fit.
+  --
+  -- NOTE: do not refer to the consensus or ledger config in the closure,
+  -- because they might contain an @EpochInfo Identity@, which will be
+  -- incorrect when used as part of the hard fork combinator. Use the
+  -- given 'fbConfig' instead, as it is guaranteed to be correct
+  -- even when used as part of the hard fork combinator.
+  --
+  -- PRECONDITION: 'checkCanForge' returned @Right ()@.
+  , fbIsLeader :: !(IsLeader (BlockProtocol blk))
+  -- ^ Proof that the node is the slot leader.
+  }

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Embed/Unary.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Embed/Unary.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE InstanceSigs #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE QuantifiedConstraints #-}
 {-# LANGUAGE RankNTypes #-}
@@ -492,16 +493,28 @@ instance Functor m => Isomorphic (BlockForging m) where
               )
               (inject' (Proxy @(WrapIsLeader blk)) isLeader)
               (inject' (Proxy @(WrapForgeStateInfo blk)) forgeStateInfo)
-      , forgeBlock = \cfg bno sno mbPerasCert tickedLgrSt txs isLeader ->
-          project' (Proxy @(I blk))
-            <$> forgeBlock
-              (inject cfg)
-              bno
-              sno
-              (injectPerasCert mbPerasCert)
-              (getFlipTickedLedgerState (inject (FlipTickedLedgerState tickedLgrSt)))
-              (inject' (Proxy @(WrapValidatedGenTx blk)) <$> txs)
-              (inject' (Proxy @(WrapIsLeader blk)) isLeader)
+      , forgeBlock =
+          \ForgeBlockArgs
+             { fbConfig
+             , fbCurrentBlockNo
+             , fbCurrentSlotNo
+             , fbPerasCert
+             , fbCurrentTickedLedgerState
+             , fbTxs
+             , fbIsLeader
+             } ->
+              project' (Proxy @(I blk))
+                <$> forgeBlock
+                  ForgeBlockArgs
+                    { fbConfig = inject fbConfig
+                    , fbCurrentBlockNo = fbCurrentBlockNo
+                    , fbCurrentSlotNo = fbCurrentSlotNo
+                    , fbPerasCert = injectPerasCert fbPerasCert
+                    , fbCurrentTickedLedgerState =
+                        getFlipTickedLedgerState (inject (FlipTickedLedgerState fbCurrentTickedLedgerState))
+                    , fbTxs = inject' (Proxy @(WrapValidatedGenTx blk)) <$> fbTxs
+                    , fbIsLeader = inject' (Proxy @(WrapIsLeader blk)) fbIsLeader
+                    }
       }
    where
     injectPerasCert :: Maybe (PerasCert blk) -> Maybe (PerasCert (HardForkBlock '[blk]))
@@ -542,16 +555,28 @@ instance Functor m => Isomorphic (BlockForging m) where
               (projTickedChainDepSt tickedChainDepSt)
               (project' (Proxy @(WrapIsLeader blk)) isLeader)
               (project' (Proxy @(WrapForgeStateInfo blk)) forgeStateInfo)
-      , forgeBlock = \cfg bno sno mbPerasCert tickedLgrSt txs isLeader ->
-          inject' (Proxy @(I blk))
-            <$> forgeBlock
-              (project cfg)
-              bno
-              sno
-              (projectPerasCert mbPerasCert)
-              (getFlipTickedLedgerState (project (FlipTickedLedgerState tickedLgrSt)))
-              (project' (Proxy @(WrapValidatedGenTx blk)) <$> txs)
-              (project' (Proxy @(WrapIsLeader blk)) isLeader)
+      , forgeBlock =
+          \ForgeBlockArgs
+             { fbConfig
+             , fbCurrentBlockNo
+             , fbCurrentSlotNo
+             , fbPerasCert
+             , fbCurrentTickedLedgerState
+             , fbTxs
+             , fbIsLeader
+             } ->
+              inject' (Proxy @(I blk))
+                <$> forgeBlock
+                  ForgeBlockArgs
+                    { fbConfig = project fbConfig
+                    , fbCurrentBlockNo = fbCurrentBlockNo
+                    , fbCurrentSlotNo = fbCurrentSlotNo
+                    , fbPerasCert = projectPerasCert fbPerasCert
+                    , fbCurrentTickedLedgerState =
+                        getFlipTickedLedgerState (project (FlipTickedLedgerState fbCurrentTickedLedgerState))
+                    , fbTxs = project' (Proxy @(WrapValidatedGenTx blk)) <$> fbTxs
+                    , fbIsLeader = project' (Proxy @(WrapIsLeader blk)) fbIsLeader
+                    }
       }
    where
     projectPerasCert :: Maybe (PerasCert (HardForkBlock '[blk])) -> Maybe (PerasCert blk)

--- a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Forging.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/Forging.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -307,135 +308,124 @@ hardForkForgeBlock ::
   forall m xs empty.
   (CanHardFork xs, Monad m) =>
   OptNP empty (BlockForging m) xs ->
-  TopLevelConfig (HardForkBlock xs) ->
-  BlockNo ->
-  SlotNo ->
-  Maybe (PerasCert (HardForkBlock xs)) ->
-  TickedLedgerState (HardForkBlock xs) EmptyMK ->
-  [Validated (GenTx (HardForkBlock xs))] ->
-  HardForkIsLeader xs ->
+  ForgeBlockArgs (HardForkBlock xs) ->
   m (HardForkBlock xs)
-hardForkForgeBlock
-  blockForging
-  cfg
-  bno
-  sno
-  mbPerasCert
-  (TickedHardForkLedgerState transition ledgerState)
-  txs
-  isLeader =
-    fmap (HardForkBlock . OneEraBlock)
-      $ hsequence
-      $ hizipWith3
-        forgeBlockOne
-        cfgs
-        (OptNP.toNP blockForging)
-      -- We know both NSs must be from the same era, because they were all
-      -- produced from the same 'BlockForging'. Unfortunately, we can't enforce
-      -- it statically.
-      $ Match.mustMatchNS
-        "IsLeader"
-        (getOneEraIsLeader isLeader)
-      $ injectValidatedTxs ledgerState
-   where
-    cfgs = distribTopLevelConfig ei cfg
-    ei =
-      State.epochInfoPrecomputedTransitionInfo
-        (hardForkLedgerConfigShape (configLedger cfg))
-        transition
-        ledgerState
+hardForkForgeBlock blockForging ForgeBlockArgs{..} =
+  fmap (HardForkBlock . OneEraBlock)
+    $ hsequence
+    $ hizipWith3
+      forgeBlockOne
+      cfgs
+      (OptNP.toNP blockForging)
+    -- We know both NSs must be from the same era, because they were all
+    -- produced from the same 'BlockForging'. Unfortunately, we can't enforce
+    -- it statically.
+    $ Match.mustMatchNS
+      "IsLeader"
+      (getOneEraIsLeader fbIsLeader)
+    $ injectValidatedTxs ledgerState
+ where
+  TickedHardForkLedgerState transition ledgerState = fbCurrentTickedLedgerState
+  cfgs = distribTopLevelConfig ei fbConfig
+  ei =
+    State.epochInfoPrecomputedTransitionInfo
+      (hardForkLedgerConfigShape (configLedger fbConfig))
+      transition
+      ledgerState
 
-    missingBlockForgingImpossible :: EraIndex xs -> String
-    missingBlockForgingImpossible eraIndex =
-      "impossible: current era lacks block forging but we have an IsLeader proof "
-        <> show eraIndex
+  missingBlockForgingImpossible :: EraIndex xs -> String
+  missingBlockForgingImpossible eraIndex =
+    "impossible: current era lacks block forging but we have an IsLeader proof "
+      <> show eraIndex
 
-    -- If we crossed an era boundary in this forge, the transactions were
-    -- revalidated against the tip in the new era so:
-    --
-    --  * Re-matching them MUST leave them in the right era via returning
-    --    'ReapplyTxs'.
-    --
-    --  * There should be no rejected-by-untranslatable transactions.
-    --
-    -- Otherwise there is a bug.
-    injectValidatedTxs ::
-      State.HardForkState f xs ->
-      NS (Product f ([] :.: WrapValidatedGenTx)) xs
-    injectValidatedTxs st =
-      case rematchValidatedTxs getHardForkValidatedGenTx st $ map (\x -> (x, (), ())) txs of
-        ([], hfs) ->
-          hmap
-            ( \case
-                Pair _ ApplyTxs{} ->
-                  error
-                    "Impossible! we have translated the txs to the current era, but they should already be in this era!"
-                Pair a (ReapplyTxs b) -> Pair a $ Comp $ map (\(x, (), ()) -> x) b
-            )
-            $ State.tip hfs
-        (_ : _, _) ->
-          error
-            "Impossible! some transactions were rejected as untranslatable by rematchValidatedTxs but all of them have been translated and applied just now."
-
-    -- If we crossed an era boundary in this forge, and we are supposed to
-    -- include a Peras certificate in this block, we must ensure that the
-    -- certificate being passed to us (i.e., the latest certificate seen) is
-    -- from the same era as the block being forged. Otherwise, we drop it
-    -- (treating it as absent), since inter-era certificate inclusion is not
-    -- supported for now. In the unlikely event of recovering from a cooldown
-    -- period that crosses an era boundary, one should jumpstart the voting
-    -- process again via the same type of governance action that started this
-    -- process in the first place, but in the new era.
-    injectPerasCertIfSameEra ::
-      Index xs blk ->
-      PerasCert (HardForkBlock xs) ->
-      Maybe (PerasCert blk)
-    injectPerasCertIfSameEra index hardForkPerasCert =
-      case ( Match.matchNS
-               (getIndex index)
-               (getOneEraPerasCert hardForkPerasCert)
-           ) of
-        -- The Peras certificate is from a different era than the block being
-        -- forged, so we drop it (treating it as absent).
-        Left _mismatch ->
-          Nothing
-        -- The Peras certificate is from the same era as the block being forged,
-        -- so we keep it and pass it down to the current era's 'forgeBlock'.
-        Right nsPair ->
-          hcollapse $
-            hmap (\(Pair Refl (WrapPerasCert cert)) -> K (Just cert)) $
-              nsPair
-
-    -- \| Unwraps all the layers needed for SOP and call 'forgeBlock'.
-    forgeBlockOne ::
-      Index xs blk ->
-      TopLevelConfig blk ->
-      (Maybe :.: BlockForging m) blk ->
-      Product
-        WrapIsLeader
-        ( Product
-            (FlipTickedLedgerState EmptyMK)
-            ([] :.: WrapValidatedGenTx)
-        )
-        blk ->
-      m blk
-    forgeBlockOne
-      index
-      cfg'
-      (Comp mBlockForging')
-      ( Pair
-          (WrapIsLeader isLeader')
-          (Pair (FlipTickedLedgerState ledgerState') (Comp txs'))
-        ) =
-        forgeBlock
-          ( fromMaybe
-              (error (missingBlockForgingImpossible (eraIndexFromIndex index)))
-              mBlockForging'
+  -- If we crossed an era boundary in this forge, the transactions were
+  -- revalidated against the tip in the new era so:
+  --
+  --  * Re-matching them MUST leave them in the right era via returning
+  --    'ReapplyTxs'.
+  --
+  --  * There should be no rejected-by-untranslatable transactions.
+  --
+  -- Otherwise there is a bug.
+  injectValidatedTxs ::
+    State.HardForkState f xs ->
+    NS (Product f ([] :.: WrapValidatedGenTx)) xs
+  injectValidatedTxs st =
+    case rematchValidatedTxs getHardForkValidatedGenTx st $ map (\x -> (x, (), ())) fbTxs of
+      ([], hfs) ->
+        hmap
+          ( \case
+              Pair _ ApplyTxs{} ->
+                error
+                  "Impossible! we have translated the txs to the current era, but they should already be in this era!"
+              Pair a (ReapplyTxs b) -> Pair a $ Comp $ map (\(x, (), ()) -> x) b
           )
-          cfg'
-          bno
-          sno
-          (mbPerasCert >>= injectPerasCertIfSameEra index)
-          ledgerState'
-          (map unwrapValidatedGenTx txs')
-          isLeader'
+          $ State.tip hfs
+      (_ : _, _) ->
+        error
+          "Impossible! some transactions were rejected as untranslatable by rematchValidatedTxs but all of them have been translated and applied just now."
+
+  -- If we crossed an era boundary in this forge, and we are supposed to
+  -- include a Peras certificate in this block, we must ensure that the
+  -- certificate being passed to us (i.e., the latest certificate seen) is
+  -- from the same era as the block being forged. Otherwise, we drop it
+  -- (treating it as absent), since inter-era certificate inclusion is not
+  -- supported for now. In the unlikely event of recovering from a cooldown
+  -- period that crosses an era boundary, one should jumpstart the voting
+  -- process again via the same type of governance action that started this
+  -- process in the first place, but in the new era.
+  injectPerasCertIfSameEra ::
+    Index xs blk ->
+    PerasCert (HardForkBlock xs) ->
+    Maybe (PerasCert blk)
+  injectPerasCertIfSameEra index hardForkPerasCert =
+    case ( Match.matchNS
+             (getIndex index)
+             (getOneEraPerasCert hardForkPerasCert)
+         ) of
+      -- The Peras certificate is from a different era than the block being
+      -- forged, so we drop it (treating it as absent).
+      Left _mismatch ->
+        Nothing
+      -- The Peras certificate is from the same era as the block being forged,
+      -- so we keep it and pass it down to the current era's 'forgeBlock'.
+      Right nsPair ->
+        hcollapse $
+          hmap (\(Pair Refl (WrapPerasCert cert)) -> K (Just cert)) $
+            nsPair
+
+  -- \| Unwraps all the layers needed for SOP and call 'forgeBlock'.
+  forgeBlockOne ::
+    Index xs blk ->
+    TopLevelConfig blk ->
+    (Maybe :.: BlockForging m) blk ->
+    Product
+      WrapIsLeader
+      ( Product
+          (FlipTickedLedgerState EmptyMK)
+          ([] :.: WrapValidatedGenTx)
+      )
+      blk ->
+    m blk
+  forgeBlockOne
+    index
+    cfg'
+    (Comp mBlockForging')
+    ( Pair
+        (WrapIsLeader isLeader')
+        (Pair (FlipTickedLedgerState ledgerState') (Comp txs'))
+      ) =
+      forgeBlock
+        ( fromMaybe
+            (error (missingBlockForgingImpossible (eraIndexFromIndex index)))
+            mBlockForging'
+        )
+        ForgeBlockArgs
+          { fbConfig = cfg'
+          , fbCurrentBlockNo = fbCurrentBlockNo
+          , fbCurrentSlotNo = fbCurrentSlotNo
+          , fbPerasCert = fbPerasCert >>= injectPerasCertIfSameEra index
+          , fbCurrentTickedLedgerState = ledgerState'
+          , fbTxs = map unwrapValidatedGenTx txs'
+          , fbIsLeader = isLeader'
+          }

--- a/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Ledger/Forge.hs
+++ b/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Ledger/Forge.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Ouroboros.Consensus.Mock.Ledger.Forge
@@ -8,13 +9,13 @@ module Ouroboros.Consensus.Mock.Ledger.Forge
   ) where
 
 import Cardano.Binary (toCBOR)
-import Cardano.Crypto.Hash (HashAlgorithm, hashWithSerialiser)
+import Cardano.Crypto.Hash (hashWithSerialiser)
 import Codec.Serialise (Serialise (..), serialise)
 import qualified Data.ByteString.Lazy as Lazy
-import Data.Typeable (Typeable)
 import Ouroboros.Consensus.Block
 import Ouroboros.Consensus.Config
 import Ouroboros.Consensus.Ledger.Abstract
+import Ouroboros.Consensus.Ledger.SupportsMempool (LedgerSupportsMempool (txForgetValidated))
 import Ouroboros.Consensus.Mock.Ledger.Block
 import Ouroboros.Consensus.Protocol.Abstract
 import Ouroboros.Network.SizeInBytes
@@ -36,36 +37,27 @@ newtype ForgeExt c ext = ForgeExt
   }
 
 forgeSimple ::
-  forall c ext mk.
-  (HashAlgorithm (SimpleHash c), Typeable c, Typeable ext) =>
+  forall c ext.
+  MockProtocolSpecific c ext =>
   ForgeExt c ext ->
-  TopLevelConfig (SimpleBlock c ext) ->
-  -- | Current block number
-  BlockNo ->
-  -- | Current slot number
-  SlotNo ->
-  -- | Current ledger
-  TickedLedgerState (SimpleBlock c ext) mk ->
-  -- | Txs to include
-  [GenTx (SimpleBlock c ext)] ->
-  IsLeader (BlockProtocol (SimpleBlock c ext)) ->
+  ForgeBlockArgs (SimpleBlock c ext) ->
   SimpleBlock c ext
-forgeSimple ForgeExt{forgeExt} cfg curBlock curSlot tickedLedger txs proof =
-  forgeExt cfg proof $
+forgeSimple ForgeExt{forgeExt} ForgeBlockArgs{..} =
+  forgeExt fbConfig fbIsLeader $
     SimpleBlock
       { simpleHeader = mkSimpleHeader encode stdHeader ()
       , simpleBody = body
       }
  where
   body :: SimpleBody
-  body = SimpleBody{simpleTxs = map simpleGenTx txs}
+  body = SimpleBody{simpleTxs = (simpleGenTx . txForgetValidated) <$> fbTxs}
 
   stdHeader :: SimpleStdHeader c ext
   stdHeader =
     SimpleStdHeader
-      { simplePrev = castHash $ getTipHash tickedLedger
-      , simpleSlotNo = curSlot
-      , simpleBlockNo = curBlock
+      { simplePrev = castHash $ getTipHash fbCurrentTickedLedgerState
+      , simpleSlotNo = fbCurrentSlotNo
+      , simpleBlockNo = fbCurrentBlockNo
       , simpleBodyHash = hashWithSerialiser toCBOR body
       , simpleBodySize = bodySize
       }

--- a/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Node.hs
+++ b/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Node.hs
@@ -20,7 +20,6 @@ import qualified Data.Map.Strict as Map
 import Data.Void (Void)
 import Ouroboros.Consensus.Block
 import Ouroboros.Consensus.Config
-import Ouroboros.Consensus.Ledger.SupportsMempool (txForgetValidated)
 import Ouroboros.Consensus.Ledger.SupportsProtocol
 import Ouroboros.Consensus.Mock.Ledger
 import Ouroboros.Consensus.Mock.Node.Abstract
@@ -103,16 +102,7 @@ simpleBlockForging aCanBeLeader aForgeExt =
     , canBeLeader = aCanBeLeader
     , updateForgeState = \_ _ _ -> return $ ForgeStateUpdated ()
     , checkCanForge = \_ _ _ _ _ -> return ()
-    , forgeBlock = \cfg bno slot _mbPerasCert lst txs proof ->
-        return $
-          forgeSimple
-            aForgeExt
-            cfg
-            bno
-            slot
-            lst
-            (map txForgetValidated txs)
-            proof
+    , forgeBlock = return . forgeSimple aForgeExt
     , finalize = pure ()
     }
  where

--- a/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Node/PBFT.hs
+++ b/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Node/PBFT.hs
@@ -17,7 +17,6 @@ import qualified Ouroboros.Consensus.HardFork.History as HardFork
 import Ouroboros.Consensus.HeaderValidation
 import Ouroboros.Consensus.Ledger.Extended
 import Ouroboros.Consensus.Ledger.Peras (initPerasState)
-import Ouroboros.Consensus.Ledger.SupportsMempool (txForgetValidated)
 import Ouroboros.Consensus.Mock.Ledger
 import Ouroboros.Consensus.Node.ProtocolInfo
 import Ouroboros.Consensus.NodeId (CoreNodeId (..))
@@ -113,15 +112,6 @@ pbftBlockForging canBeLeader =
             canBeLeader
             slot
             tickedPBftState
-    , forgeBlock = \cfg slot bno _mbPerasCert lst txs proof ->
-        return $
-          forgeSimple
-            forgePBftExt
-            cfg
-            slot
-            bno
-            lst
-            (map txForgetValidated txs)
-            proof
+    , forgeBlock = return . forgeSimple forgePBftExt
     , finalize = pure ()
     }

--- a/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Node/Praos.hs
+++ b/ouroboros-consensus/src/unstable-mock-block/Ouroboros/Consensus/Mock/Node/Praos.hs
@@ -21,7 +21,6 @@ import qualified Ouroboros.Consensus.HardFork.History as HardFork
 import Ouroboros.Consensus.HeaderValidation
 import Ouroboros.Consensus.Ledger.Extended
 import Ouroboros.Consensus.Ledger.Peras (initPerasState)
-import Ouroboros.Consensus.Ledger.SupportsMempool (txForgetValidated)
 import Ouroboros.Consensus.Mock.Ledger
 import Ouroboros.Consensus.Mock.Protocol.Praos
 import Ouroboros.Consensus.Node.ProtocolInfo
@@ -140,16 +139,11 @@ praosBlockForging cid initHotKey = do
               . second forgeStateUpdateInfoFromUpdateInfo
               . evolveKey sno
       , checkCanForge = \_ _ _ _ _ -> return ()
-      , forgeBlock = \cfg bno sno _mbPerasCert tickedLedgerSt txs isLeader -> do
+      , forgeBlock = \fbArgs -> do
           hotKey <- readMVar varHotKey
           return $
             forgeSimple
               (forgePraosExt hotKey)
-              cfg
-              bno
-              sno
-              tickedLedgerSt
-              (map txForgetValidated txs)
-              isLeader
+              fbArgs
       , finalize = pure ()
       }


### PR DESCRIPTION
# Description

Entirely mechanical refactor that borrows quality of life improvements from the `leios-prototype` branch and prepares that part of the code base for future Leios PRs.

All work is done in incremental commits for easier read and review.

DONE
- [x] Refactors Forge into a separate `Ouroboros.Consensus.NodeKernel.Forge` module and extracts all 'forge steps' into separate functions
   - Rationale: NodeKernel has grown too big, to avoid growth and facilitate reuse (for example `db-synthesizer`) it made sense to extract forge exclusive logic into a separate module. Additionally, to facilitate flow comprehension and prepare for additional instrumentation (noise), the logical 'steps' have been extracted into separate functions.
- [x] Refactors `forgeBlock` to use `ForgeBlockArgs`
  - Rationale: Makes tracing the flow of various 'forgeBlock's straightforward, reduces noise,
makes partial application obvious and consolidates documentation at one place.