### PR TITLE
[DO-NOT-MERGE] LeiosDB denormalization attempts

### DIFF
--- a/ouroboros-consensus.cabal
+++ b/ouroboros-consensus.cabal
@@ -103,6 +103,7 @@ library
     LeiosDemoDb.InMemory
     LeiosDemoDb.SQLite
     LeiosDemoDb.Trace
+    LeiosDemoDb.WithCallTrace
     LeiosDemoException
     LeiosDemoLogic
     LeiosDemoLogic.Announcements
@@ -1070,6 +1071,7 @@ benchmark leios-db-bench
   main-is: Main.hs
   ghc-options: -with-rtsopts=-N4
   build-depends:
+    aeson,
     async,
     base >=4.14 && <4.23,
     bytestring,

--- a/ouroboros-consensus/bench/leios-db-bench/Main.hs
+++ b/ouroboros-consensus/bench/leios-db-bench/Main.hs
@@ -24,6 +24,15 @@
 -- All data is deterministic (no QuickCheck generators), so runs are stable and
 -- comparable across refactors.
 --
+-- Every DB call is wrapped via 'LeiosDbWithCallTrace' and the resulting
+-- 'SomeJsonCallTrace' events (start + end with duration\/allocation) are
+-- written as JSON lines to @leios-db-bench-trace.jsonl@ in the working
+-- directory.
+--
+-- The call trace forms a tree rooted at a single \"LeiosDBBench\" context
+-- created in 'main'.  Each role (fetch-client-N, fetch-server-M, etc.) is a
+-- child span of that root, and individual DB calls are grandchildren.
+--
 -- Usage:
 --
 -- @
@@ -33,26 +42,25 @@ module Main (main) where
 
 import Cardano.Slotting.Slot (SlotNo (..))
 import Control.Concurrent.Async (async, mapConcurrently_, wait)
+import Control.Concurrent.MVar (newMVar, withMVar)
 import Control.Monad (forM, forM_, when)
 import Control.Monad.Class.MonadTime.SI (diffTime, getMonotonicTime)
 import Control.Tracer (debugTracer, (>$<))
+import qualified Data.Aeson as Aeson
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as BS8
+import qualified Data.ByteString.Lazy as BSL
 import Data.IORef (IORef, atomicModifyIORef', newIORef)
 import Data.Time.Clock (DiffTime)
 import qualified Data.Vector.Strict as V
 import LeiosDemoDb
-  ( LeiosDbConnection
-  , LeiosDbHandle (..)
-  , leiosDbBatchRetrieveTxs
-  , leiosDbGarbageCollect
-  , leiosDbInsertEbBody
-  , leiosDbInsertEbPoint
-  , leiosDbInsertTxs
-  , leiosDbLookupEbBody
-  , leiosDbLookupEbClosure
+  ( LeiosDbHandle (..)
   , newLeiosDBSQLite
   , withLeiosDb
+  )
+import LeiosDemoDb.WithCallTrace
+  ( LeiosDbWithCallTrace (..)
+  , newLeiosDbWithCallTrace
   )
 import LeiosDemoTypes
   ( BytesSize
@@ -62,7 +70,16 @@ import LeiosDemoTypes
   , TxHash (..)
   , leiosEbBytesSize
   )
-import System.IO (hFlush, stdout)
+import LeiosUtils.CallTrace
+  ( CallCtx
+  , CallTrace
+  , SomeJsonCallTrace (..)
+  , callTrace
+  , callTraceSameThreadVia
+  , callTraceToObject
+  , rootCallCtx
+  )
+import System.IO (Handle, IOMode (..), hFlush, stdout, withFile)
 import System.IO.Temp (withSystemTempDirectory)
 
 main :: IO ()
@@ -84,10 +101,15 @@ main = do
       , ""
       , "Runs: 1 warmup + " <> show numRuns <> " timed"
       , ""
+      , "Trace output: leios-db-bench-trace.jsonl"
+      , ""
       ]
-  withSystemTempDirectory "leios-db-bench" $ \tmpDir -> do
-    env <- setupBenchEnv tmpDir
-    runBench (benchConcurrentAll env)
+  withFile "leios-db-bench-trace.jsonl" WriteMode $ \traceFile -> do
+    tracer <- newTracer traceFile
+    rootCtx <- rootCallCtx "LeiosDBBench"
+    withSystemTempDirectory "leios-db-bench" $ \tmpDir -> do
+      env <- setupBenchEnv tmpDir tracer rootCtx
+      runBench (benchConcurrentAll env)
 
 -- * Configuration
 
@@ -123,15 +145,16 @@ numRuns = 5
 
 -- | All production roles running concurrently against one DB handle.
 benchConcurrentAll :: BenchEnv -> IO ()
-benchConcurrentAll BenchEnv{beDb = db, bePoints = points, beWriterIdx = writerIdxRef} = do
+benchConcurrentAll BenchEnv{beDb = db, bePoints = points, beWriterIdx = writerIdxRef, beTracer = tracer, beRootCtx = rootCtx} = do
   startIdx <-
     atomicModifyIORef'
       writerIdxRef
       (\n -> (n + numFetchClients * ebsPerClient, n))
-  cs <- async (chainSelReader db points)
-  gc <- async (gcTicker db)
-  clients <- forM (clientRanges startIdx) $ \range -> async (fetchClient db range)
-  mapConcurrently_ (fetchServer db points) [0 .. numFetchServers - 1]
+  cs <- async (chainSelReader db tracer rootCtx points)
+  gc <- async (gcTicker db tracer rootCtx)
+  clients <- forM (zip [0 ..] (clientRanges startIdx)) $ \(i, range) ->
+    async (fetchClient db tracer rootCtx i range)
+  mapConcurrently_ (fetchServer db tracer rootCtx points) [0 .. numFetchServers - 1]
   wait cs >> wait gc
   forM_ clients wait
  where
@@ -142,33 +165,40 @@ benchConcurrentAll BenchEnv{beDb = db, bePoints = points, beWriterIdx = writerId
     ]
 
 -- | Mirrors a fetch client: inserts fresh EBs with full TX payloads.
-fetchClient :: LeiosDbHandle IO -> [Int] -> IO ()
-fetchClient db range =
-  withLeiosDb db $ \c ->
-    forM_ range (insertOneEb c)
+fetchClient :: LeiosDbHandle IO -> Tracer -> CallCtx IO -> Int -> [Int] -> IO ()
+fetchClient db tracer rootCtx clientIdx range =
+  callTrace (jsonTracer tracer) rootCtx ("fetch-client-" <> show clientIdx) "fetch-client" () $ \roleCtx ->
+    withLeiosDb db $ \c -> do
+      let wct = newLeiosDbWithCallTrace tracer c
+      forM_ range (insertOneEb wct roleCtx)
 
 -- | Mirrors chain-selection's block-apply path: repeated
 -- 'leiosDbLookupEbClosure' for the tx closure of each certified EB.
-chainSelReader :: LeiosDbHandle IO -> [LeiosPoint] -> IO ()
-chainSelReader db points =
-  withLeiosDb db $ \c ->
-    forM_ (take numChainSelReads (cycle points)) $ \p ->
-      leiosDbLookupEbClosure c p.pointEbHash
+chainSelReader :: LeiosDbHandle IO -> Tracer -> CallCtx IO -> [LeiosPoint] -> IO ()
+chainSelReader db tracer rootCtx points =
+  callTrace (jsonTracer tracer) rootCtx "chain-sel-reader" "chain-sel-reader" () $ \roleCtx ->
+    withLeiosDb db $ \c -> do
+      let wct = newLeiosDbWithCallTrace tracer c
+      forM_ (take numChainSelReads (cycle points)) $ \p ->
+        wct.leiosDbLookupEbClosure roleCtx p.pointEbHash
 
 -- | Fires periodic garbage-collect calls. Handle-level operation; touches
 -- every table when implemented (currently a no-op backend-side, but the
 -- call path is realistic).
-gcTicker :: LeiosDbHandle IO -> IO ()
-gcTicker db =
-  forM_ [1 .. numGcTicks] $ \i ->
-    leiosDbGarbageCollect db (SlotNo (fromIntegral (i * 10)))
+gcTicker :: LeiosDbHandle IO -> Tracer -> CallCtx IO -> IO ()
+gcTicker db tracer rootCtx =
+  callTrace (jsonTracer tracer) rootCtx "gc-ticker" "gc-ticker" () $ \_ ->
+    forM_ [1 .. numGcTicks] $ \i ->
+      leiosDbGarbageCollect db (SlotNo (fromIntegral (i * 10)))
 
 -- | Mirrors a fetch server: looks up EB bodies and retrieves TX batches.
-fetchServer :: LeiosDbHandle IO -> [LeiosPoint] -> Int -> IO ()
-fetchServer db points i =
-  withLeiosDb db $ \c -> do
-    forM_ ebPoints $ \p -> leiosDbLookupEbBody c p.pointEbHash
-    forM_ txPoints $ \p -> leiosDbBatchRetrieveTxs c p.pointEbHash sampleOffsets
+fetchServer :: LeiosDbHandle IO -> Tracer -> CallCtx IO -> [LeiosPoint] -> Int -> IO ()
+fetchServer db tracer rootCtx points i =
+  callTrace (jsonTracer tracer) rootCtx ("fetch-server-" <> show i) "fetch-server" () $ \roleCtx ->
+    withLeiosDb db $ \c -> do
+      let wct = newLeiosDbWithCallTrace tracer c
+      forM_ ebPoints $ \p -> wct.leiosDbLookupEbBody roleCtx p.pointEbHash
+      forM_ txPoints $ \p -> wct.leiosDbBatchRetrieveTxs roleCtx p.pointEbHash sampleOffsets
  where
   sampleOffsets = [0, 10 .. txsPerEb - 1]
   ebPoints = take 30 $ drop (i * 30) (cycle points)
@@ -183,22 +213,45 @@ data BenchEnv = BenchEnv
   , beWriterIdx :: !(IORef Int)
   -- ^ Monotonically increasing counter so each benchmark iteration allocates
   -- a fresh range of EB indices for writers (avoids duplicate-key errors).
+  , beTracer :: !Tracer
+  -- ^ Serialised JSON-line sink for call trace events.
+  , beRootCtx :: !(CallCtx IO)
+  -- ^ Single root context for the entire benchmark run.
   }
 
 -- | Create a fresh SQLite DB and insert 'numPrePopulatedEbs' complete EBs.
 -- This setup cost is not included in the timed measurements.
-setupBenchEnv :: FilePath -> IO BenchEnv
-setupBenchEnv tmpDir = do
+setupBenchEnv :: FilePath -> Tracer -> CallCtx IO -> IO BenchEnv
+setupBenchEnv tmpDir tracer rootCtx = do
   db <- newLeiosDBSQLite (show >$< debugTracer) (tmpDir <> "/bench.db")
   putStr "Inserting EBs: " >> hFlush stdout
-  forM_ [0 .. numPrePopulatedEbs - 1] $ \i -> do
-    withLeiosDb db (`insertOneEb` i)
-    when (i `mod` (numPrePopulatedEbs `div` 10) == numPrePopulatedEbs `div` 10 - 1) $
-      putStr (show (i + 1) <> " ") >> hFlush stdout
-  putStrLn "done"
-  let points = [genPoint i | i <- [0 .. numPrePopulatedEbs - 1]]
-  writerIdx <- newIORef numPrePopulatedEbs
-  pure $ BenchEnv db points writerIdx
+  callTraceSameThreadVia (const ()) (jsonTracer tracer) rootCtx "setup" () $ \setupCtx -> do
+    forM_ [0 .. numPrePopulatedEbs - 1] $ \i -> do
+      withLeiosDb db $ \c -> do
+        let wct = newLeiosDbWithCallTrace tracer c
+        insertOneEb wct setupCtx i
+      when (i `mod` (numPrePopulatedEbs `div` 10) == numPrePopulatedEbs `div` 10 - 1) $
+        putStr (show (i + 1) <> " ") >> hFlush stdout
+    putStrLn "done"
+    let points = [genPoint i | i <- [0 .. numPrePopulatedEbs - 1]]
+    writerIdx <- newIORef numPrePopulatedEbs
+    pure $ BenchEnv db points writerIdx tracer rootCtx
+
+-- * Tracer
+
+-- | Thread-safe sink that serialises 'SomeJsonCallTrace' events as JSON lines.
+type Tracer = SomeJsonCallTrace -> IO ()
+
+newTracer :: Handle -> IO Tracer
+newTracer h = do
+  lock <- newMVar ()
+  pure $ \(SomeJsonCallTrace ct) ->
+    withMVar lock $ \() ->
+      BSL.hPut h (Aeson.encode (Aeson.Object (callTraceToObject ct)) <> BSL.singleton 0x0a)
+
+-- | Adapt a 'Tracer' into the form expected by 'callTrace' \/ 'callTraceSameThreadVia'.
+jsonTracer :: (Aeson.ToJSON a, Aeson.ToJSON r) => Tracer -> CallTrace a r -> IO ()
+jsonTracer tracer ct = tracer (SomeJsonCallTrace ct)
 
 -- * Timing
 
@@ -236,8 +289,8 @@ showTime t
 -- * DB helpers
 
 -- | Insert one complete EB (point + body + all TXs) by index.
-insertOneEb :: Monad m => LeiosDbConnection m -> Int -> m ()
-insertOneEb conn ebIdx = do
+insertOneEb :: LeiosDbWithCallTrace IO -> CallCtx IO -> Int -> IO ()
+insertOneEb wct ctx ebIdx = do
   let point = genPoint ebIdx
       eb = genEb ebIdx
       txs =
@@ -245,9 +298,9 @@ insertOneEb conn ebIdx = do
         | txIdx <- [0 .. txsPerEb - 1]
         , let h = genTxHash ebIdx txIdx
         ]
-  leiosDbInsertEbPoint conn point (leiosEbBytesSize eb)
-  _ <- leiosDbInsertEbBody conn point eb
-  _ <- leiosDbInsertTxs conn txs
+  wct.leiosDbInsertEbPoint ctx point (leiosEbBytesSize eb)
+  _ <- wct.leiosDbInsertEbBody ctx point eb
+  _ <- wct.leiosDbInsertTxs ctx txs
   pure ()
 
 -- * Deterministic data generation

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoDb/SQLite.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoDb/SQLite.hs
@@ -599,6 +599,10 @@ sql_schema =
     , "  PRIMARY KEY (ebHashBytes, txOffset)"
     , ");"
     , "CREATE INDEX idx_ebTxs_pending ON ebTxs(txHashBytes) WHERE txBytes IS NULL;"
+    , -- Covering index for lookupEbBody: SELECT txHashBytes, txBytesSize … WHERE ebHashBytes = ?
+      -- All needed columns are in the index so SQLite never touches the main table rows
+      -- (which carry txBytes blobs up to 16 KiB each).
+      "CREATE INDEX idx_ebTxs_body ON ebTxs(ebHashBytes, txOffset, txHashBytes, txBytesSize);"
     ]
 
 sql_scan_ebs :: String

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoDb/SQLite.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoDb/SQLite.hs
@@ -38,7 +38,6 @@ import qualified Control.Monad.Class.MonadThrow as MonadThrow
 import Control.Tracer (Tracer, traceWith)
 import Data.Bifunctor (first)
 import Data.ByteString (ByteString)
-import qualified Data.ByteString as BS
 import qualified Data.ByteString.Builder as BB
 import qualified Data.ByteString.Lazy as BSL
 import Data.Int (Int64)
@@ -131,8 +130,6 @@ data Stmts = Stmts
   , stInitMissingCount :: !DB.Statement
   , stInsertTx :: !DB.Statement
   , stDecrMissingCount :: !DB.Statement
-  , stInsertMissingTxs :: !DB.Statement
-  , stDeleteMissingTxs :: !DB.Statement
   , stFindCompleteEbs :: !DB.Statement
   , stMarkNotifiedEbs :: !DB.Statement
   , stMarkPointNotified :: !DB.Statement
@@ -159,8 +156,6 @@ prepareStmts db = do
   stInitMissingCount <- dbPrepare db (fromString sql_init_missing_tx_count)
   stInsertTx <- dbPrepare db (fromString sql_insert_tx)
   stDecrMissingCount <- dbPrepare db (fromString sql_decrement_missing_tx_count)
-  stInsertMissingTxs <- dbPrepare db (fromString sql_insert_missing_txs)
-  stDeleteMissingTxs <- dbPrepare db (fromString sql_delete_missing_txs)
   stFindCompleteEbs <- dbPrepare db (fromString sql_find_complete_ebs)
   stMarkNotifiedEbs <- dbPrepare db (fromString sql_mark_notified_ebs)
   stMarkPointNotified <- dbPrepare db (fromString sql_mark_point_notified)
@@ -181,8 +176,6 @@ finalizeStmts Stmts{..} = do
   dbFinalize stInitMissingCount
   dbFinalize stInsertTx
   dbFinalize stDecrMissingCount
-  dbFinalize stInsertMissingTxs
-  dbFinalize stDeleteMissingTxs
   dbFinalize stFindCompleteEbs
   dbFinalize stMarkNotifiedEbs
   dbFinalize stMarkPointNotified
@@ -333,15 +326,9 @@ sqlInsertEbBody tracer conn notify point eb = do
         "ebTxs"
         (show point.pointEbHash <> "@" <> show txOffset)
         stInsertEbTxsRow
-    -- Record which of this body's txs we still lack, then count them. Both in
-    -- this transaction, so an arrival can never see the rows without the count
-    -- or the other way round.
-    useStmt stInsertMissingTxs $ do
-      dbBindBlob stInsertMissingTxs 1 point.pointEbHash.ebHashBytes
-      dbStep1 stInsertMissingTxs
-    -- Initialize missingTxCount and read the resulting value via
-    -- @RETURNING missingTxCount@. Only /this/ point's row can have
-    -- transitioned to 0 as a consequence of the insert above.
+    -- Initialize missingTxCount from the NULL txBytes rows just inserted,
+    -- reading the result via @RETURNING missingTxCount@. Only /this/ point's
+    -- row can have transitioned to 0 as a consequence of the body insert above.
     missingCount <- useStmt stInitMissingCount $ do
       dbBindBlob stInitMissingCount 1 point.pointEbHash.ebHashBytes
       dbBindBlob stInitMissingCount 2 point.pointEbHash.ebHashBytes
@@ -350,8 +337,8 @@ sqlInsertEbBody tracer conn notify point eb = do
     if missingCount == 0
       then do
         useStmt stMarkPointNotified $ do
-          dbBindInt64 stMarkPointNotified 1 (fromIntegral $ unSlotNo point.pointSlotNo)
-          dbBindBlob stMarkPointNotified 2 point.pointEbHash.ebHashBytes
+          dbBindBlob stMarkPointNotified 1 point.pointEbHash.ebHashBytes
+          dbBindInt64 stMarkPointNotified 2 (fromIntegral $ unSlotNo point.pointSlotNo)
           dbStep1 stMarkPointNotified
         pure [point]
       else pure []
@@ -364,7 +351,6 @@ sqlInsertEbBody tracer conn notify point eb = do
   Conn{connStmts} = conn
   Stmts
     { stInsertEbTxsRow
-    , stInsertMissingTxs
     , stInitMissingCount
     , stMarkPointNotified
     } = connStmts
@@ -390,31 +376,24 @@ sqlInsertTxs ::
   [(TxHash, ByteString)] ->
   IO CompletedEbs
 sqlInsertTxs _tracer conn notify txs = do
-  -- Skip txs already persisted in 'txs'. Under mempool backlog,
+  -- Skip txs whose ebTxs rows are already filled. Under mempool backlog,
   -- successive forges (or overlapping peer EBs) re-present the same tx
-  -- hashes; attempting the INSERT and catching a constraint violation
-  -- still pays the bind + PK-lookup + reset cost per row.
+  -- hashes; attempting the UPDATE and finding 0 changed rows still pays
+  -- the bind + scan + reset cost per row.
   missing <- Set.fromList <$> sqlFilterMissingTxs conn (map fst txs)
   completed <- dbWithWriteTransaction conn $ do
-    -- 'dbStepInsert' still handles the rare race where a concurrent
-    -- writer inserted the same hash between the filter above and the
-    -- INSERT below.
+    -- Decrement before filling: the decrement subquery selects ebTxs rows
+    -- WHERE txBytes IS NULL, so it must run before the fill overwrites them.
+    -- A concurrent writer that beat us leaves both steps as no-ops.
     forM_ (novel missing) $ \(txHash, txBytes) -> do
-      let txBytesSize = fromIntegral $ BS.length txBytes
-          txHashBytes = let MkTxHash bytes = txHash in bytes
-      inserted <- useStmt stInsertTx $ do
-        dbBindBlob stInsertTx 1 txHashBytes
-        dbBindBlob stInsertTx 2 txBytes
-        dbBindInt64 stInsertTx 3 txBytesSize
-        dbStepInsert stInsertTx
-      when inserted $ do
-        useStmt stDecrMissingCount $ do
-          dbBindBlob stDecrMissingCount 1 txHashBytes
-          dbStep1 stDecrMissingCount
-        -- Strictly after the decrement, which reads these rows.
-        useStmt stDeleteMissingTxs $ do
-          dbBindBlob stDeleteMissingTxs 1 txHashBytes
-          dbStep1 stDeleteMissingTxs
+      let txHashBytes = let MkTxHash bytes = txHash in bytes
+      useStmt stDecrMissingCount $ do
+        dbBindBlob stDecrMissingCount 1 txHashBytes
+        dbStep1 stDecrMissingCount
+      useStmt stInsertTx $ do
+        dbBindBlob stInsertTx 1 txBytes
+        dbBindBlob stInsertTx 2 txHashBytes
+        dbStep1 stInsertTx
     -- Find newly-complete EBs (missingTxCount reached 0)
     completed <- useStmt stFindCompleteEbs $ do
       let loop acc =
@@ -436,7 +415,6 @@ sqlInsertTxs _tracer conn notify txs = do
   Stmts
     { stInsertTx
     , stDecrMissingCount
-    , stDeleteMissingTxs
     , stFindCompleteEbs
     , stMarkNotifiedEbs
     } = connStmts
@@ -444,7 +422,7 @@ sqlInsertTxs _tracer conn notify txs = do
 
 -- | Retrieve tx bytes for a batch of @(ebHash, txOffset)@ points. Passes
 -- the offsets list as a JSON int array bound to a single parameter;
--- SQLite's 'json_each' virtual table joins it against 'ebTxs' + 'txs'.
+-- SQLite's 'json_each' virtual table joins it against 'ebTxs' via its PK.
 --
 -- No temp tables, no attached databases, no per-item INSERT round-trips.
 -- Works on strictly read-only connections.
@@ -466,15 +444,15 @@ sqlBatchRetrieveTxs conn ebHash offsets =
       DB.Row -> do
         offset <- fromIntegral <$> DB.columnInt64 stmt 0
         txHash <- MkTxHash <$> DB.columnBlob stmt 1
-        -- Column 2 is from LEFT JOIN, NULL if tx not in txs table
+        -- Column 2 is txBytes, NULL if the tx has not yet arrived
         txBytes <- DB.columnBlob stmt 2
         let mbTxBytes = if txBytes == mempty then Nothing else Just txBytes
         loop ((offset, txHash, mbTxBytes) : acc)
 
--- | Batch-filter tx hashes against @txs@: passes txHashes as a JSON array
--- of hex strings; SQL decodes with @unhex()@ so index lookups on
--- @txs.txHashBytes@ still fire. Used internally by 'sqlInsertTxs' to skip
--- already-persisted txs.
+-- | Batch-filter tx hashes against @ebTxs@: passes txHashes as a JSON array
+-- of hex strings; SQL decodes with @unhex()@ so the partial index
+-- @idx_ebTxs_pending@ still fires. Used internally by 'sqlInsertTxs' to skip
+-- txs whose 'ebTxs' rows are already filled.
 sqlFilterMissingTxs :: Conn -> [TxHash] -> IO [TxHash]
 sqlFilterMissingTxs conn txHashes =
   dbWithTransaction db $ useStmt stmt $ do
@@ -503,18 +481,16 @@ truncateLeiosDbAfterSlot dbPath (SlotNo slot) =
   deletes =
     unlines
       [ "DELETE FROM ebTxs WHERE ebHashBytes IN (" <> droppedHashes <> ");"
-      , "DELETE FROM ebsMissingTxs WHERE ebHashBytes IN (" <> droppedHashes <> ");"
       , "DELETE FROM ebs WHERE ebSlot > " <> show slot <> ";"
       ]
 
   -- The EBs whose bodies the truncation drops.
   --
   -- 'ebs' holds one row per announcement, so the same EB hash can appear at
-  -- several slots. 'ebTxs' and 'ebsMissingTxs' hold one copy per hash and carry
-  -- no slot. So an EB announced at slot 5 and again at slot 15 keeps its body
-  -- when the cut is at slot 10. That is what the EXCEPT does: take the hashes
-  -- announced after the cut, then remove the ones also announced at or before
-  -- it.
+  -- several slots. 'ebTxs' holds one copy per hash and carries no slot. So an
+  -- EB announced at slot 5 and again at slot 15 keeps its body when the cut is
+  -- at slot 10. That is what the EXCEPT does: take the hashes announced after
+  -- the cut, then remove the ones also announced at or before it.
   droppedHashes =
     "SELECT ebHashBytes FROM ebs WHERE ebSlot > "
       <> show slot
@@ -523,12 +499,12 @@ truncateLeiosDbAfterSlot dbPath (SlotNo slot) =
 
 -- | Delete the transactions that no EB references.
 --
+-- No-op after denormalisation: tx bytes live directly in 'ebTxs' rows, so
+-- there is no separate 'txs' table to prune.
+--
 -- For internal tooling.
-deleteDanglingTxs :: HasCallStack => FilePath -> IO ()
-deleteDanglingTxs dbPath =
-  withExistingLeiosDbFile dbPath $ \db ->
-    dbExec db . fromString $
-      "DELETE FROM txs WHERE txHashBytes NOT IN (SELECT txHashBytes FROM ebTxs)"
+deleteDanglingTxs :: FilePath -> IO ()
+deleteDanglingTxs _dbPath = pure ()
 
 -- | Shrink a LeiosDb file to the space its rows need.
 --
@@ -584,7 +560,6 @@ sqlLookupEbClosure :: Conn -> EbHash -> IO (Maybe [(TxHash, ByteString)])
 sqlLookupEbClosure conn ebHash =
   dbWithTransaction db $ useStmt stmt $ do
     dbBindBlob stmt 1 (ebHashBytes ebHash)
-    -- FIXME(bladyjoker): This should have a SlotNo as the second part of the key
     loop []
  where
   Conn{connDb = db, connStmts = Stmts{stLookupEbClosure = stmt}} = conn
@@ -612,27 +587,18 @@ sql_schema =
     , "  ebBytesSize INTEGER NOT NULL,"
     , -- NULL = body not downloaded, >0 = txs missing, 0 = just completed, <0 = notified
       "  missingTxCount INTEGER,"
-    , "  PRIMARY KEY (ebSlot, ebHashBytes)"
+    , "  PRIMARY KEY (ebHashBytes, ebSlot)"
     , ");"
-    , "CREATE INDEX idx_ebs_ebHashBytes ON ebs(ebHashBytes);"
+    , "CREATE INDEX idx_ebs_complete ON ebs(ebHashBytes) WHERE missingTxCount = 0;"
     , "CREATE TABLE ebTxs ("
     , "  ebHashBytes BLOB NOT NULL,"
     , "  txOffset INTEGER NOT NULL,"
     , "  txHashBytes BLOB NOT NULL,"
     , "  txBytesSize INTEGER NOT NULL,"
+    , "  txBytes BLOB,"
     , "  PRIMARY KEY (ebHashBytes, txOffset)"
     , ");"
-    , "CREATE TABLE ebsMissingTxs ("
-    , "  txHashBytes BLOB NOT NULL,"
-    , "  ebHashBytes BLOB NOT NULL,"
-    , "  PRIMARY KEY (txHashBytes, ebHashBytes)"
-    , ");"
-    , "CREATE INDEX idx_ebsMissingTxs_ebHashBytes ON ebsMissingTxs(ebHashBytes);"
-    , "CREATE TABLE txs ("
-    , "  txHashBytes BLOB NOT NULL PRIMARY KEY,"
-    , "  txBytes BLOB NOT NULL,"
-    , "  txBytesSize INTEGER NOT NULL"
-    , ");"
+    , "CREATE INDEX idx_ebTxs_pending ON ebTxs(txHashBytes) WHERE txBytes IS NULL;"
     ]
 
 sql_scan_ebs :: String
@@ -677,18 +643,23 @@ sql_insert_ebBody =
   "INSERT INTO ebTxs (ebHashBytes, txOffset, txHashBytes, txBytesSize) VALUES (?, ?, ?, ?)\n\
   \"
 
+-- | Fill in tx bytes for every ebTxs row that references this tx and does not
+-- yet have them. Parameter 1 = txBytes, parameter 2 = txHashBytes.
+-- Uses @sqlite3_changes()@ on return to detect whether any rows were actually
+-- filled (0 means a concurrent writer beat us or the tx is unreferenced).
 sql_insert_tx :: String
 sql_insert_tx =
-  "INSERT INTO txs (txHashBytes, txBytes, txBytesSize) VALUES (?, ?, ?)\n\
+  "UPDATE ebTxs SET txBytes = ? WHERE txHashBytes = ? AND txBytes IS NULL\n\
   \"
 
 -- | Batch-filter txHashes via JSON1. Parameter is a JSON array of hex
 -- strings; 'unhex(je.value)' decodes back into a BLOB comparable against
--- the indexed @txs.txHashBytes@ column.
+-- the indexed @ebTxs.txHashBytes@ column. Returns only hashes for which at
+-- least one @ebTxs@ row still has @txBytes IS NULL@.
 sql_filter_missing_txs_json :: String
 sql_filter_missing_txs_json =
-  "SELECT unhex(je.value) FROM json_each(?) je\n\
-  \WHERE NOT EXISTS (SELECT 1 FROM txs t WHERE t.txHashBytes = unhex(je.value))\n\
+  "SELECT DISTINCT unhex(je.value) FROM json_each(?) je\n\
+  \WHERE EXISTS (SELECT 1 FROM ebTxs e WHERE e.txHashBytes = unhex(je.value) AND e.txBytes IS NULL)\n\
   \"
 
 -- | Find EBs that are now complete (missingTxCount reached 0).
@@ -704,53 +675,29 @@ sql_mark_notified_ebs =
 
 -- | Decrement missingTxCount for every EB still /waiting/ on the given txHash.
 --
--- Uses 'ebsMissingTxs' rather than 'ebTxs', which makes this more efficient
--- than a full scan of 'ebTxs' in the average case.
---
--- Must be paired with 'sql_delete_missing_txs' in the same transaction.
+-- Reads 'ebTxs' directly via 'idx_ebTxs_pending' (a partial index on
+-- @txHashBytes WHERE txBytes IS NULL@). Must run /before/ 'sql_insert_tx'
+-- fills those rows, or the subquery returns nothing.
 --
 -- Parameter 1: txHashBytes
 sql_decrement_missing_tx_count :: String
 sql_decrement_missing_tx_count =
   "UPDATE ebs SET missingTxCount = missingTxCount - 1\n\
-  \WHERE ebHashBytes IN (SELECT ebHashBytes FROM ebsMissingTxs WHERE txHashBytes = ?)\n\
-  \"
-
--- | Retire the waiting rows for a tx that has just landed.
--- Parameter 1: txHashBytes
-sql_delete_missing_txs :: String
-sql_delete_missing_txs =
-  "DELETE FROM ebsMissingTxs WHERE txHashBytes = ?"
-
--- | Record which of a freshly-inserted body's txs we do not yet hold.
---
--- One anti-join over the EB's own 'ebTxs' range -- the same work
--- 'sql_init_missing_tx_count' used to do to produce a count, now materialised so
--- that the arrival side reads the rows instead of recomputing them. Paying it
--- here rather than on every tx arrival is what earns the index removal: this
--- runs once per body, against ~4.7 times per tx for the old reverse lookup.
---
--- Parameter 1: ebHashBytes
-sql_insert_missing_txs :: String
-sql_insert_missing_txs =
-  "INSERT OR IGNORE INTO ebsMissingTxs (txHashBytes, ebHashBytes)\n\
-  \SELECT e.txHashBytes, e.ebHashBytes FROM ebTxs e\n\
-  \LEFT JOIN txs t ON e.txHashBytes = t.txHashBytes\n\
-  \WHERE e.ebHashBytes = ? AND t.txHashBytes IS NULL\n\
+  \WHERE ebHashBytes IN (SELECT DISTINCT ebHashBytes FROM ebTxs WHERE txHashBytes = ? AND txBytes IS NULL)\n\
   \"
 
 -- | Initialize missingTxCount after EB body is inserted, returning the
--- resulting count. Counts ebTxs entries that don't yet have a corresponding
--- tx in the txs table. The RETURNING clause lets the caller detect the
--- special case @missingTxCount = 0@ (all referenced txs already present) with
--- a PK lookup on the row that was just touched, instead of a full-table
--- scan via 'sql_find_complete_ebs'.
+-- resulting count. Counts 'ebTxs' rows for this EB whose @txBytes@ is still
+-- NULL (i.e. not yet filled by a tx arrival). The PK prefix @ebHashBytes@
+-- makes this efficient without an extra index. The RETURNING clause lets the
+-- caller detect @missingTxCount = 0@ (all txs already present) immediately,
+-- without a follow-up scan via 'sql_find_complete_ebs'.
 --
--- Parameters: 1 = ebHashBytes, 2 = ebHashBytes, 3 = ebSlot
+-- Parameters: 1 = ebHashBytes (subquery), 2 = ebHashBytes (WHERE), 3 = ebSlot
 sql_init_missing_tx_count :: String
 sql_init_missing_tx_count =
   "UPDATE ebs SET missingTxCount = (\n\
-  \    SELECT COUNT(*) FROM ebsMissingTxs WHERE ebHashBytes = ?\n\
+  \    SELECT COUNT(*) FROM ebTxs WHERE ebHashBytes = ? AND txBytes IS NULL\n\
   \) WHERE ebHashBytes = ? AND ebSlot = ?\n\
   \RETURNING missingTxCount\n\
   \"
@@ -759,30 +706,29 @@ sql_init_missing_tx_count =
 -- variant of 'sql_mark_notified_ebs'; used by 'sqlInsertEbBody' when the
 -- body's arrival is what completed the closure.
 --
--- Parameters: 1 = ebSlot, 2 = ebHashBytes
+-- Parameters: 1 = ebHashBytes, 2 = ebSlot
 sql_mark_point_notified :: String
 sql_mark_point_notified =
-  "UPDATE ebs SET missingTxCount = -1 WHERE ebSlot = ? AND ebHashBytes = ?"
+  "UPDATE ebs SET missingTxCount = -1 WHERE ebHashBytes = ? AND ebSlot = ?"
 
 -- | Batch retrieve of tx bytes for a batch of @(ebHash, offset)@ points.
 -- @?1@ is the ebHash blob (all offsets belong to the same EB); @?2@ is a
 -- JSON int array of offsets. The join uses ebTxs' PK
--- @(ebHashBytes, txOffset)@, so index lookups still fire.
+-- @(ebHashBytes, txOffset)@, so index lookups still fire. @txBytes@ is NULL
+-- for any offset whose tx has not yet arrived.
 sql_retrieve_from_ebTxs_json :: String
 sql_retrieve_from_ebTxs_json =
-  "SELECT je.value, e.txHashBytes, t.txBytes\n\
+  "SELECT je.value, e.txHashBytes, e.txBytes\n\
   \FROM json_each(?2) je\n\
   \JOIN ebTxs e ON e.ebHashBytes = ?1 AND e.txOffset = je.value\n\
-  \LEFT JOIN txs t ON e.txHashBytes = t.txHashBytes\n\
   \ORDER BY je.value ASC\n\
   \"
 
 sql_lookup_eb_closure :: String
 sql_lookup_eb_closure =
   unlines
-    [ "SELECT ebTx.txHashBytes, tx.txBytes"
-    , "FROM ebTxs as ebTx"
-    , "LEFT JOIN txs as tx ON ebTx.txHashBytes = tx.txHashBytes"
+    [ "SELECT ebTx.txHashBytes, ebTx.txBytes"
+    , "FROM ebTxs AS ebTx"
     , "WHERE ebTx.ebHashBytes = ?"
     , "ORDER BY ebTx.txOffset ASC"
     ]

--- a/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoDb/WithCallTrace.hs
+++ b/ouroboros-consensus/src/ouroboros-consensus/LeiosDemoDb/WithCallTrace.hs
@@ -1,0 +1,101 @@
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE NamedFieldPuns #-}
+
+-- | Wrapper around 'LeiosDbConnection' that records each call via
+-- 'LeiosUtils.CallTrace'.  Every endpoint takes an explicit 'CallCtx' as its
+-- first argument so callers can compose calls into a structured trace tree.
+module LeiosDemoDb.WithCallTrace
+  ( LeiosDbWithCallTrace (..)
+  , newLeiosDbWithCallTrace
+  ) where
+
+import Cardano.Slotting.Slot (SlotNo)
+import Control.Concurrent.Class.MonadSTM.Strict (MonadSTM)
+import Control.Monad.Class.MonadTime.SI (MonadMonotonicTime)
+import Data.ByteString (ByteString)
+import LeiosDemoDb.Common (CompletedEbs, LeiosDbConnection (..))
+import LeiosDemoTypes (BytesSize, EbHash, LeiosEb, LeiosPoint, TxHash)
+import LeiosUtils.CallTrace
+  ( CallCtx
+  , MonadAllocationCounter
+  , SomeJsonCallTrace (..)
+  , callTraceSameThreadVia
+  )
+
+-- | A mirror of 'LeiosDbConnection' where each endpoint takes an explicit
+-- 'CallCtx' so that call timing and allocation can be recorded via
+-- 'LeiosUtils.CallTrace'.
+--
+-- Construct via 'newLeiosDbWithCallTrace', which wraps an existing
+-- 'LeiosDbConnection' and forwards all calls to it while emitting
+-- 'SomeJsonCallTrace' events to the supplied sink.
+data LeiosDbWithCallTrace m = LeiosDbWithCallTrace
+  { leiosDbInsertEbPoint :: CallCtx m -> LeiosPoint -> BytesSize -> m ()
+  , leiosDbLookupEbBody :: CallCtx m -> EbHash -> m [(TxHash, BytesSize)]
+  , leiosDbInsertEbBody :: CallCtx m -> LeiosPoint -> LeiosEb -> m CompletedEbs
+  , leiosDbInsertTxs :: CallCtx m -> [(TxHash, ByteString)] -> m CompletedEbs
+  , leiosDbBatchRetrieveTxs :: CallCtx m -> EbHash -> [Int] -> m [(Int, TxHash, Maybe ByteString)]
+  , leiosDbLookupEbClosure :: CallCtx m -> EbHash -> m (Maybe [(TxHash, ByteString)])
+  , leiosDbScanEbPoints :: CallCtx m -> m [(SlotNo, EbHash)]
+  , leiosDbScanCompleteEbClosuresNotOlderThanSlot :: CallCtx m -> SlotNo -> m [LeiosPoint]
+  }
+
+-- | Wrap a 'LeiosDbConnection' so that every call is bracketed by
+-- 'CallStart'\/'CallEnd' events forwarded to @emit@.
+--
+-- The call argument recorded in each trace event is a 'String' built from
+-- 'show' on the relevant inputs (e.g. the 'EbHash' or 'LeiosPoint').
+-- The result is projected to @()@ so no 'ToJSON' instance is needed on the
+-- (often large) return values.
+newLeiosDbWithCallTrace ::
+  (MonadSTM m, MonadMonotonicTime m, MonadAllocationCounter m) =>
+  -- | Sink for trace events; called once at call-start and once at call-end.
+  (SomeJsonCallTrace -> m ()) ->
+  LeiosDbConnection m ->
+  LeiosDbWithCallTrace m
+newLeiosDbWithCallTrace emit conn =
+  LeiosDbWithCallTrace
+    { leiosDbInsertEbPoint = \ctx point size ->
+        go ctx "leios-db-insert-eb-point" (show point) $
+          \_ -> connInsertEbPoint point size
+    , leiosDbLookupEbBody = \ctx ebHash ->
+        go ctx "leios-db-lookup-eb-body" (show ebHash) $
+          \_ -> connLookupEbBody ebHash
+    , leiosDbInsertEbBody = \ctx point eb ->
+        go ctx "leios-db-insert-eb-body" (show point) $
+          \_ -> connInsertEbBody point eb
+    , leiosDbInsertTxs = \ctx txs ->
+        go ctx "leios-db-insert-txs" (show (length txs) <> " txs") $
+          \_ -> connInsertTxs txs
+    , leiosDbBatchRetrieveTxs = \ctx ebHash offsets ->
+        go ctx "leios-db-batch-retrieve-txs" (show ebHash) $
+          \_ -> connBatchRetrieveTxs ebHash offsets
+    , leiosDbLookupEbClosure = \ctx ebHash ->
+        go ctx "leios-db-lookup-eb-closure" (show ebHash) $
+          \_ -> connLookupEbClosure ebHash
+    , leiosDbScanEbPoints = \ctx ->
+        go ctx "leios-db-scan-eb-points" "()" $
+          \_ -> connScanEbPoints
+    , leiosDbScanCompleteEbClosuresNotOlderThanSlot = \ctx slotNo ->
+        go ctx "leios-db-scan-complete-eb-closures-not-older-than-slot" (show slotNo) $
+          \_ -> connScanComplete slotNo
+    }
+ where
+  LeiosDbConnection
+    { leiosDbInsertEbPoint = connInsertEbPoint
+    , leiosDbLookupEbBody = connLookupEbBody
+    , leiosDbInsertEbBody = connInsertEbBody
+    , leiosDbInsertTxs = connInsertTxs
+    , leiosDbBatchRetrieveTxs = connBatchRetrieveTxs
+    , leiosDbLookupEbClosure = connLookupEbClosure
+    , leiosDbScanEbPoints = connScanEbPoints
+    , leiosDbScanCompleteEbClosuresNotOlderThanSlot = connScanComplete
+    } = conn
+  go ctx callName arg action =
+    callTraceSameThreadVia
+      (const ())
+      (\ct -> emit (SomeJsonCallTrace ct))
+      ctx
+      callName
+      arg
+      action


### PR DESCRIPTION
This is almost entirely vibed to get some preliminary data.

TLDR; Denormalization helped based on the (calltrace augmented) leios-db-bench runs. However, genie also raised the "contention" issue that is inherent to SQLite, all write are serialized, so writers have to wait (even the ones that could in principle proceed independently). 

At https://github.com/IntersectMBO/ouroboros-consensus/pull/2288/commits/75d5d203f4f9772999cce7b54c4f7cb019415c87

```
  ┌─────────────────────────────┬──────────┬────────────┬─────────────┐
  │            Call             │ orig p50 │ denorm p50 │      Δ      │
  ├─────────────────────────────┼──────────┼────────────┼─────────────┤
  │ leios-db-insert-txs         │ 0.219 ms │ 0.159 ms   │ −27% ✓      │
  ├─────────────────────────────┼──────────┼────────────┼─────────────┤
  │ leios-db-batch-retrieve-txs │ 0.353 ms │ 0.319 ms   │ −10% ✓      │
  ├─────────────────────────────┼──────────┼────────────┼─────────────┤
  │ leios-db-lookup-eb-closure  │ 1.110 ms │ 1.072 ms   │ −3% (noise) │
  ├─────────────────────────────┼──────────┼────────────┼─────────────┤
  │ leios-db-insert-eb-point    │ 0.014 ms │ 0.015 ms   │ +6% (noise) │
  ├─────────────────────────────┼──────────┼────────────┼─────────────┤
  │ leios-db-insert-eb-body     │ 0.395 ms │ 0.455 ms   │ +15% ✗      │
  ├─────────────────────────────┼──────────┼────────────┼─────────────┤
  │ leios-db-lookup-eb-body     │ 0.062 ms │ 0.176 ms   │ +185% ✗     │
  └─────────────────────────────┴──────────┴────────────┴─────────────┘

  The 400-run picture confirms the earlier 5-run result:

  Wins: insert-txs (−27%) and batch-retrieve-txs (−10%) are clearly faster — tx bytes now live next to the hash rows, avoiding the join.

  Regression: lookup-eb-body is the standout loser (+185% on p50, 0.062→0.176ms) — it only needs hash+size but now SQLite has to read past the (potentially
  large) txBytes blob in every row it scans. insert-eb-body is also slightly slower (+15%), probably due to the same wider row penalty on write.

  The lookup-eb-body regression is the one to watch — it's the hot read path for serving downstream peers. Worth considering a covering index on
  (ebHashBytes, txOffset, txHashBytes, txBytesSize) to let that query be satisfied from the index alone without touching the main table rows.
```

And then at https://github.com/IntersectMBO/ouroboros-consensus/pull/2288/commits/4c54964aacd83a9b40607f502a54b32d0cc74c01

```
● Here's the three-way comparison with the covering index:

  ┌─────────────────────────────┬──────────┬────────────┬────────────┬─────────────┬─────────────┐
  │            Call             │ orig p50 │ denorm p50 │ +index p50 │ orig→denorm │ denorm→+idx │
  ├─────────────────────────────┼──────────┼────────────┼────────────┼─────────────┼─────────────┤
  │ leios-db-lookup-eb-body     │ 0.062 ms │ 0.176 ms   │ 0.058 ms   │ +185%       │ -67%        │
  ├─────────────────────────────┼──────────┼────────────┼────────────┼─────────────┼─────────────┤
  │ leios-db-insert-eb-body     │ 0.395 ms │ 0.455 ms   │ 0.469 ms   │ +15%        │ +3%         │
  ├─────────────────────────────┼──────────┼────────────┼────────────┼─────────────┼─────────────┤
  │ leios-db-insert-txs         │ 0.219 ms │ 0.159 ms   │ 0.152 ms   │ -27%        │ -5%         │
  ├─────────────────────────────┼──────────┼────────────┼────────────┼─────────────┼─────────────┤
  │ leios-db-lookup-eb-closure  │ 1.110 ms │ 1.072 ms   │ 1.053 ms   │ -3%         │ -2%         │
  ├─────────────────────────────┼──────────┼────────────┼────────────┼─────────────┼─────────────┤
  │ leios-db-batch-retrieve-txs │ 0.353 ms │ 0.319 ms   │ 0.332 ms   │ -10%        │ +4%         │
  ├─────────────────────────────┼──────────┼────────────┼────────────┼─────────────┼─────────────┤
  │ leios-db-insert-eb-point    │ 0.014 ms │ 0.015 ms   │ 0.014 ms   │ +6%         │ -5%         │
  └─────────────────────────────┴──────────┴────────────┴────────────┴─────────────┴─────────────┘

  The covering index fully resolves the lookup-eb-body regression — from a 185% slowdown back to slightly faster than the original (0.058ms vs 0.062ms).
  The insert-eb-body cost is slightly higher (+15%) due to maintaining the additional index on write, which is the expected trade-off. All other calls are
  within noise.
```

The contention argument

```
● Yes, there are clear contention issues. The data tells a clean story:

  Strong evidence of SQLite write-lock contention:

  - leios-db-insert-eb-point has a 2407× p99/p50 ratio — the most extreme signal. p50 is 0.014ms (essentially free), but p99 hits 34ms and max 79ms. This
  is a textbook SQLite exclusive-lock wait: the call is trivial when the lock is free, and expensive when another writer holds it.
  - leios-db-insert-eb-body and leios-db-insert-txs have ratios of 25× and 83× respectively — same pattern, masked slightly because those calls do more
  real work.
  - Histogram confirms it's bimodal: 81% of insert-eb-point calls finish in <0.02ms (uncontended), but ~4% take >10ms (waited for the write lock). That gap
  between the two modes is pure lock-wait time.
  
  Reads are much healthier:

  - lookup-eb-body: 5.9× ratio — modest, reads don't block each other in WAL mode
  - lookup-eb-closure: 2.5× ratio — nearly contention-free

  Per-thread is symmetric — no single client is being starved; all three fetch-clients see similar p99s, so it's fair round-robin lock acquisition, not
  starvation.
  
  Root cause: SQLite allows only one writer at a time (even in WAL mode). With 3 concurrent fetch-clients all calling INSERT OR IGNORE in a tight loop,
  they queue for the exclusive write lock, which shows up as these spikes on the first write call in each EB insertion sequence (insert-eb-point).
```